### PR TITLE
docs: record all fuzzer-found fixes in CHANGELOG and ROADMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   entry count made `Vec::with_capacity` attempt a multi-gigabyte allocation; the
   pre-allocation is now bounded by the readable byte count. Found by the new
   `vorbiscomment` fuzz target.
+- **MP4 box-bounds integer overflow:** an untrusted 64-bit extended box size made
+  the box-bounds check (`pos + total`) overflow `usize` — a panic in debug and a
+  silent wrap in release that accepted a bogus box length. The addition is now
+  checked. Found by the `mp4` fuzz target.
+- **ID3v2 parsing unbounded allocation (DoS):** the `id3` crate eagerly allocates
+  a frame's declared size (ID3v2.3 frame sizes are plain 32-bit, up to 4 GiB), so
+  a crafted tag could exhaust memory at scan time — via an MP3 or a WAV embedded
+  `id3 ` chunk. Parsing is now gated on validated ID3v2 frame bounds and an
+  ID3v2 tag at offset 0 (the `id3` reader scans forward). Found by the `mp3` and
+  `wav` fuzz targets.
 
 ## [0.2.0] - 2026-05-27
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,9 +97,11 @@ modifying or duplicating the original audio bytes.
   the byte-identical audio guarantee, and tag round-trip — an end-to-end read
   fidelity property, and a `mutagen` interop check that an independent reader
   sees the tags we synthesize. The fuzzers run per-PR (build + smoke) and on a
-  weekly schedule with an accumulating corpus; fuzzing already caught and fixed
-  an OOM/DoS in VorbisComment parsing (unbounded `Vec::with_capacity` on an
-  untrusted count).
+  weekly schedule with an accumulating corpus. Fuzzing already caught and fixed
+  three robustness bugs: an MP4 box-bounds integer overflow (a release-build
+  silent wrap), an `id3`-crate unbounded allocation reachable via MP3 and WAV's
+  embedded `id3 ` chunk, and an unbounded `Vec::with_capacity` in VorbisComment
+  parsing — all DoS-class issues on adversarial files.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #1. The CHANGELOG `Fixed` list and the ROADMAP fuzzing bullet were written early in #1 and only mentioned the VorbisComment OOM. Two more robustness bugs were found and fixed by later fuzzing passes in that PR but never added to the docs:

- **MP4 box-bounds integer overflow** — untrusted 64-bit box size overflowed `usize` (silent wrap in release); now `checked_add`.
- **ID3v2 `id3`-crate unbounded allocation (DoS)** — reachable via MP3 and WAV's embedded `id3 ` chunk; parsing now validates frame bounds and only reads a tag at offset 0.

This PR completes the CHANGELOG `Fixed` entries and generalizes the ROADMAP line to "three robustness bugs." Docs-only; no code change.

## Test plan

- [ ] Docs render correctly; CHANGELOG `Fixed` lists all three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented memory exhaustion vulnerability in Vorbis comment parsing by bounding pre-allocation
  * Fixed integer overflow in MP4 box bounds validation to reject invalid box lengths
  * Prevented unbounded memory allocation in ID3v2 frame parsing with proper validation

* **Documentation**
  * Updated changelog documenting three security and robustness fixes
  * Refreshed roadmap reflecting completed improvements from fuzzing testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->