### PR TITLE
ci: add coverage baseline with cargo-llvm-cov and Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,8 +30,8 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
-      - name: Collect coverage (excluding e2e FUSE tests)
-        run: cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+      - name: Collect coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,40 @@
+name: coverage
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install libfuse3
+        run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev pkg-config
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Collect coverage (excluding e2e FUSE tests)
+        run: cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -1,0 +1,33 @@
+# Coverage
+
+Coverage uses `cargo-llvm-cov` and uploads to Codecov.
+
+## Local Usage
+
+```bash
+cargo install cargo-llvm-cov
+cargo llvm-cov --workspace --exclude musefs-fuse --open
+cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+```
+
+FUSE e2e tests are excluded because they require `/dev/fuse` and libfuse at runtime.
+Run them separately when needed:
+
+```bash
+cargo llvm-cov run -- cargo test -p musefs-fuse -- --ignored
+```
+
+## CI Setup
+
+The `coverage.yml` workflow runs on every push/PR.
+
+### Required Secrets
+
+- `CODECOV_TOKEN` — Repository secret from codecov.io.
+
+### Why cargo-llvm-cov?
+
+- No recompilation or instrumentation wrappers needed
+- Works with Rust's built-in `-C instrument-coverage`
+- Handles workspaces and proc-macros correctly
+- Single binary, fast execution

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -14,7 +14,7 @@ FUSE e2e tests are excluded because they require `/dev/fuse` and libfuse at runt
 Run them separately when needed:
 
 ```bash
-cargo llvm-cov run -- cargo test -p musefs-fuse -- --ignored
+cargo llvm-cov --package musefs-fuse -- --ignored
 ```
 
 ## CI Setup

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -6,15 +6,8 @@ Coverage uses `cargo-llvm-cov` and uploads to Codecov.
 
 ```bash
 cargo install cargo-llvm-cov
-cargo llvm-cov --workspace --exclude musefs-fuse --open
-cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
-```
-
-FUSE e2e tests are excluded because they require `/dev/fuse` and libfuse at runtime.
-Run them separately when needed:
-
-```bash
-cargo llvm-cov --package musefs-fuse -- --ignored
+cargo llvm-cov --workspace --open
+cargo llvm-cov --workspace --lcov --output-path lcov.info
 ```
 
 ## CI Setup

--- a/docs/superpowers/plans/2026-05-28-github-issue-cleanup.md
+++ b/docs/superpowers/plans/2026-05-28-github-issue-cleanup.md
@@ -1,0 +1,34 @@
+# GitHub Issue Cleanup Plan Index
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement these plans task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the current GitHub issue backlog through eight small,
+dependency-ordered PRs.
+
+**Architecture:** The source design is
+`docs/superpowers/specs/2026-05-28-github-issue-cleanup-design.md`. Each PR has
+its own implementation plan so review scope stays narrow and later workflow
+hardening can be rebased over earlier workflow additions.
+
+**Tech Stack:** Rust 2021, Cargo workspace, Python 3, pytest, Ruff, GitHub
+Actions, SQLite, cargo-llvm-cov, Codecov.
+
+---
+
+Implement in this order:
+
+1. `github-cleanup/pr-01-coverage-baseline.md`
+2. `github-cleanup/pr-02-core-db-read-safety.md`
+3. `github-cleanup/pr-03-refresh-invalidation-observability.md`
+4. `github-cleanup/pr-04-ogg-hardening-cache-accounting.md`
+5. `github-cleanup/pr-05-layout-mp4-contracts.md`
+6. `github-cleanup/pr-06-interop-db-contract.md`
+7. `github-cleanup/pr-07-beets-python-quality.md`
+8. `github-cleanup/pr-08-ci-dev-hardening.md`
+
+Before starting a later PR, rebase it on top of all earlier merged cleanup PRs.
+This matters especially for PR 8, which must harden workflows introduced by PR 1
+and PR 7.

--- a/docs/superpowers/plans/github-cleanup/pr-01-coverage-baseline.md
+++ b/docs/superpowers/plans/github-cleanup/pr-01-coverage-baseline.md
@@ -1,0 +1,117 @@
+# PR 1 Coverage Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated Rust coverage workflow and coverage documentation for issue #21.
+
+**Architecture:** This PR only adds coverage collection. It deliberately does not pin workflow actions; PR 8 will rebase later and harden every workflow present at that point, including this one.
+
+**Tech Stack:** GitHub Actions, cargo-llvm-cov, Codecov, Rust workspace.
+
+---
+
+### Task 1: Coverage Workflow And Docs
+
+**Files:**
+- Create: `.github/workflows/coverage.yml`
+- Create: `docs/COVERAGE.md`
+
+- [ ] **Step 1: Add the coverage workflow**
+
+Create `.github/workflows/coverage.yml`:
+
+```yaml
+name: coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install libfuse3
+        run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev pkg-config
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Collect coverage
+        run: cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+- [ ] **Step 2: Add coverage documentation**
+
+Create `docs/COVERAGE.md`:
+
+```markdown
+# Coverage
+
+Coverage uses `cargo-llvm-cov` and uploads LCOV data to Codecov.
+
+## Local Usage
+
+```bash
+cargo install cargo-llvm-cov
+cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+```
+
+`musefs-fuse` is excluded from the default coverage job because its ignored
+end-to-end tests require `/dev/fuse` and a real FUSE environment. Run those
+separately when needed:
+
+```bash
+cargo test -p musefs-fuse -- --ignored
+```
+
+## CI Setup
+
+Set `CODECOV_TOKEN` as a repository secret if Codecov requires token-based
+upload for this repository. The workflow fails if upload fails.
+```
+
+- [ ] **Step 3: Verify locally**
+
+Run:
+
+```bash
+cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path /tmp/musefs-lcov.info
+```
+
+Expected: command exits successfully and `/tmp/musefs-lcov.info` exists. If
+`cargo-llvm-cov` is not installed, install it with `cargo install cargo-llvm-cov`
+or record that local coverage verification was skipped because the tool is not
+installed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/coverage.yml docs/COVERAGE.md
+git commit -m "ci: add coverage baseline with cargo-llvm-cov and Codecov
+
+Closes #21"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-02-core-db-read-safety.md
+++ b/docs/superpowers/plans/github-cleanup/pr-02-core-db-read-safety.md
@@ -1,0 +1,173 @@
+# PR 2 Core DB Read Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix same-thread multi-DB `DbPool` reuse and reject backing-file replacement before caching an open handle.
+
+**Architecture:** Keep `musefs-core` responsible for pooling and open-handle safety. Key per-thread read connections by database path and validate the opened file descriptor with descriptor metadata (`File::metadata()`/`fstat`), never path metadata after open.
+
+**Tech Stack:** Rust, musefs-core, musefs-db, tempfile tests.
+
+---
+
+### Task 1: Key Thread-Local DB Connections By Path
+
+**Files:**
+- Modify: `musefs-core/src/db_pool.rs`
+
+- [ ] **Step 1: Write the regression test**
+
+Add a unit test in `musefs-core/src/db_pool.rs`:
+
+```rust
+#[test]
+fn same_thread_two_pools_keyed_by_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path_a = dir.path().join("a.db");
+    let path_b = dir.path().join("b.db");
+    Db::open(&path_a).unwrap();
+    Db::open(&path_b).unwrap();
+
+    let pool_a = DbPool::new(Db::open(&path_a).unwrap()).unwrap();
+    let pool_b = DbPool::new(Db::open(&path_b).unwrap()).unwrap();
+
+    pool_a
+        .with(|db| {
+            assert_eq!(db.path().unwrap(), path_a);
+            Ok(())
+        })
+        .unwrap();
+    pool_b
+        .with(|db| {
+            assert_eq!(db.path().unwrap(), path_b);
+            Ok(())
+        })
+        .unwrap();
+}
+```
+
+- [ ] **Step 2: Verify the test fails before implementation**
+
+Run:
+
+```bash
+cargo test -p musefs-core same_thread_two_pools_keyed_by_path -- --nocapture
+```
+
+Expected before the fix: failure because both pools reuse the first thread-local
+connection.
+
+- [ ] **Step 3: Implement keyed thread-local connections**
+
+In `musefs-core/src/db_pool.rs`, replace the single `Option<Db>` thread local
+with:
+
+```rust
+use std::collections::HashMap;
+
+thread_local! {
+    static PER_PATH: RefCell<HashMap<PathBuf, Db>> = RefCell::new(HashMap::new());
+}
+```
+
+Change `DbPool::with` for `PerThread` to:
+
+```rust
+DbPool::PerThread { path, .. } => PER_PATH.with(|cell| {
+    let mut map = cell.borrow_mut();
+    if !map.contains_key(path) {
+        let db = Db::open_readonly(path)?;
+        map.insert(path.clone(), db);
+    }
+    f(map.get(path).expect("connection inserted for path"))
+}),
+```
+
+Do not use `expect` for `Db::open_readonly`; open errors must propagate as
+`Result` values.
+
+- [ ] **Step 4: Verify the regression test passes**
+
+Run:
+
+```bash
+cargo test -p musefs-core same_thread_two_pools_keyed_by_path -- --nocapture
+```
+
+Expected: pass.
+
+### Task 2: Validate Opened Descriptor Metadata
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs`
+- Modify: `musefs-core/src/facade.rs`
+- Test: `musefs-core/tests/facade.rs` or `musefs-core/tests/read_at.rs`
+
+- [ ] **Step 1: Add a failing descriptor-mismatch test**
+
+Add an integration test that creates a scanned track, resolves its inode, replaces
+the backing file with a different size or mtime, then calls `open_handle`.
+
+The assertion must be:
+
+```rust
+let err = fs.open_handle(file_inode).unwrap_err();
+assert!(matches!(err, musefs_core::CoreError::BackingChanged(_)));
+```
+
+The test must fail before implementation by successfully opening the replaced
+file.
+
+- [ ] **Step 2: Carry the expected backing size in `ResolvedFile`**
+
+Add `pub backing_size: u64` to `ResolvedFile` in `musefs-core/src/reader.rs` and
+initialize it from `track.backing_size as u64` in `HeaderCache::build`. Update
+all test `ResolvedFile` literals.
+
+- [ ] **Step 3: Validate the opened descriptor**
+
+In `Musefs::open_handle` in `musefs-core/src/facade.rs`, open the file, then
+validate descriptor metadata:
+
+```rust
+let file = std::fs::File::open(&resolved.backing_path)?;
+let meta = file.metadata()?;
+if meta.len() != resolved.backing_size {
+    return Err(CoreError::BackingChanged(
+        resolved.backing_path.to_string_lossy().to_string(),
+    ));
+}
+let mtime = meta
+    .modified()
+    .ok()
+    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+    .map_or(0, |d| d.as_secs() as i64);
+if mtime != resolved.mtime_secs {
+    return Err(CoreError::BackingChanged(
+        resolved.backing_path.to_string_lossy().to_string(),
+    ));
+}
+```
+
+This must use `file.metadata()`, not `std::fs::metadata(&resolved.backing_path)`.
+
+- [ ] **Step 4: Verify core tests**
+
+Run:
+
+```bash
+cargo test -p musefs-core same_thread_two_pools_keyed_by_path open_handle -- --nocapture
+cargo test -p musefs-core
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/db_pool.rs musefs-core/src/reader.rs musefs-core/src/facade.rs musefs-core/tests
+git commit -m "fix(core): key DbPool by path and validate opened descriptor
+
+Closes #4
+Closes #5"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-03-refresh-invalidation-observability.md
+++ b/docs/superpowers/plans/github-cleanup/pr-03-refresh-invalidation-observability.md
@@ -1,0 +1,177 @@
+# PR 3 Refresh Invalidation Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make refresh retry semantics correct, invalidate old keep-cache inodes for path-changing retags, and log refresh/invalidation failures.
+
+**Architecture:** Split refresh timing into successful poll checks and failed rebuild retry backoff. Snapshot the old tree before rebuild and compare old/new track-to-inode mappings. Keep FUSE changes limited to logging failures from the existing core callback.
+
+**Tech Stack:** Rust, musefs-core refresh path, arc-swap snapshots, fuser notifier, log crate.
+
+---
+
+### Task 1: Fix Refresh Debounce And Failure Backoff
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs`
+- Test: `musefs-core/tests/facade.rs`
+
+- [ ] **Step 1: Add timing tests**
+
+Add tests that prove both requirements:
+
+```rust
+#[test]
+fn unchanged_refresh_poll_consumes_debounce_window() {
+    let fs = fixture_with_poll_interval(Duration::from_secs(60));
+    assert_eq!(fs.poll_refresh().unwrap(), false);
+    assert_eq!(fs.poll_refresh().unwrap(), false);
+    assert_eq!(fixture_poll_count(&fs), 1);
+}
+
+#[test]
+fn failed_refresh_retries_after_backoff_not_every_call() {
+    let fs = fixture_with_poll_interval_and_bad_changed_track(
+        Duration::from_secs(60),
+        Duration::from_millis(250),
+    );
+    assert!(fs.poll_refresh().is_err());
+    assert_eq!(fs.poll_refresh().unwrap(), false);
+    std::thread::sleep(Duration::from_millis(260));
+    assert!(fs.poll_refresh().is_err());
+}
+```
+
+Use existing test helpers where possible. If no poll counter exists, expose a
+small `#[cfg(test)]` helper in `Musefs` to inspect timing state or build the test
+around observable retry attempts.
+
+- [ ] **Step 2: Implement separate timing state**
+
+In `Musefs`, track:
+
+```rust
+last_poll: Mutex<std::time::Instant>,
+last_failed_refresh: Mutex<Option<std::time::Instant>>,
+refresh_retry_backoff: std::time::Duration,
+```
+
+Use a small fixed backoff such as `poll_interval.min(Duration::from_secs(1))`
+with a floor of `Duration::from_millis(100)` when `poll_interval` is nonzero.
+
+`poll_refresh_notify` rules:
+- If `last_poll.elapsed() < poll_interval`, return `Ok(false)`.
+- If the last refresh failed and `last_failed_refresh.elapsed() < refresh_retry_backoff`, return `Ok(false)`.
+- After a successful `data_version` check with no changes, update `last_poll`.
+- After a successful rebuild, update `last_poll`, clear `last_failed_refresh`, and store `last_data_version`.
+- After a failed rebuild, set `last_failed_refresh` and return the error without storing `last_data_version`.
+
+- [ ] **Step 3: Verify timing tests**
+
+Run:
+
+```bash
+cargo test -p musefs-core unchanged_refresh_poll_consumes_debounce_window failed_refresh_retries_after_backoff_not_every_call -- --nocapture
+```
+
+Expected: both pass.
+
+### Task 2: Invalidate Old Inodes For Path-Changing Retags
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs`
+- Test: `musefs-core/tests/facade.rs`
+
+- [ ] **Step 1: Add path-change invalidation test**
+
+Write a test that:
+- creates a track whose template path includes `$title`;
+- records the original file inode;
+- changes the title through the DB so `content_version` changes and path changes;
+- calls `poll_refresh_notify`;
+- asserts the callback includes the old inode and the new inode if bytes changed.
+
+- [ ] **Step 2: Implement old/new inode comparison**
+
+In `poll_refresh_notify`:
+
+```rust
+let old_tree = self.tree.load_full();
+let old_versions = self.versions.lock().unwrap_or_else(...).clone();
+let new_versions = self.rebuild()?;
+let new_tree = self.tree.load();
+
+for (tid, new_ver) in &new_versions {
+    if old_versions.get(tid).is_some_and(|old| old != new_ver) {
+        if let Some(ino) = new_tree.inode_of_track(*tid) {
+            on_changed(ino);
+        }
+        let old_ino = old_tree.inode_of_track(*tid);
+        let new_ino = new_tree.inode_of_track(*tid);
+        if old_ino != new_ino {
+            if let Some(ino) = old_ino {
+                on_changed(ino);
+            }
+        }
+    }
+}
+for tid in old_versions.keys().filter(|tid| !new_versions.contains_key(tid)) {
+    if let Some(ino) = old_tree.inode_of_track(*tid) {
+        on_changed(ino);
+    }
+}
+```
+
+Deduplicate callback inodes if a test exposes duplicates.
+
+### Task 3: Log FUSE Refresh And Invalidation Failures
+
+**Files:**
+- Modify: `musefs-fuse/Cargo.toml`
+- Modify: `musefs-fuse/src/lib.rs`
+
+- [ ] **Step 1: Add dependency**
+
+Add to `musefs-fuse/Cargo.toml`:
+
+```toml
+log = "0.4"
+```
+
+- [ ] **Step 2: Log errors in `fire_poll_refresh`**
+
+Replace discarded results with:
+
+```rust
+if let Err(e) = core.poll_refresh_notify(|ino| {
+    if let Some(n) = notifier.get() {
+        if let Err(inval_err) = n.inval_inode(ino, 0, 0) {
+            log::warn!("inval_inode({ino}) failed: {inval_err}");
+        }
+    }
+}) {
+    log::warn!("poll_refresh_notify failed: {e}");
+}
+```
+
+Use the analogous `log::warn!("poll_refresh failed: {e}")` for non-keep-cache.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+cargo test -p musefs-core
+cargo test -p musefs-fuse
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/tests/facade.rs musefs-fuse/Cargo.toml musefs-fuse/src/lib.rs Cargo.lock
+git commit -m "fix(core): bound refresh retries and invalidate moved inodes
+
+Closes #6
+Closes #7
+Closes #8"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-04-ogg-hardening-cache-accounting.md
+++ b/docs/superpowers/plans/github-cleanup/pr-04-ogg-hardening-cache-accounting.md
@@ -1,0 +1,130 @@
+# PR 4 Ogg Hardening And Cache Accounting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guard full Ogg cover-art comment lengths, document/test the Ogg payload invariant, and make resident Ogg page indexes visible to cache budgeting.
+
+**Architecture:** Keep format-level Ogg length validation in `musefs-format`. For cache accounting, use a bounded policy tied to actual page-index residency, not only a rough pre-resolve estimate.
+
+**Tech Stack:** Rust, musefs-format Ogg synthesis, musefs-core header cache, Ogg page index.
+
+---
+
+### Task 1: Guard Full VorbisComment Art Value Length
+
+**Files:**
+- Modify: `musefs-format/src/ogg/mod.rs`
+
+- [ ] **Step 1: Add failing overflow test**
+
+Add a unit test in `musefs-format/src/ogg/mod.rs` that builds an Opus or Vorbis
+header with art whose full `METADATA_BLOCK_PICTURE=` value exceeds `u32::MAX`
+once key, prefix, and base64 image length are included.
+
+- [ ] **Step 2: Implement full length guard**
+
+Before calling `comment_packet_chunks`, compute:
+
+```rust
+let value_len = METADATA_BLOCK_PICTURE_KEY.len() as u64
+    + b64_len(picture_prefix(a.meta).len() as u64)
+    + b64_len(a.meta.data_len);
+if value_len > u32::MAX as u64 {
+    return Err(FormatError::TooLarge);
+}
+```
+
+Define `METADATA_BLOCK_PICTURE_KEY` once and reuse it in both the guard and
+comment emission.
+
+### Task 2: Account Ogg Page Index Residency
+
+**Files:**
+- Modify: `musefs-core/src/ogg_index.rs`
+- Modify: `musefs-core/src/reader.rs`
+- Test: `musefs-core/tests/reader.rs` or `musefs-core/src/reader.rs` tests
+
+- [ ] **Step 1: Add exact index-size API**
+
+Add a method on `OggPageIndex`:
+
+```rust
+impl OggPageIndex {
+    pub fn estimated_heap_bytes(&self) -> u64 {
+        let page_structs = self.pages.len() as u64 * std::mem::size_of::<IndexedPage>() as u64;
+        let header_bytes = self
+            .pages
+            .iter()
+            .map(|p| p.header.len() as u64)
+            .sum::<u64>();
+        page_structs + header_bytes
+    }
+}
+```
+
+Use the actual local field names in `ogg_index.rs`.
+
+- [ ] **Step 2: Make cache charge include actual resident index bytes**
+
+When `resolved.ogg_index.get_or_try_init(...)` builds the index in `reader.rs`,
+the owning cache entry must be charged for `estimated_heap_bytes()`. Acceptable
+implementation choices:
+- store an `AtomicU64` `resident_extra_bytes` in `ResolvedFile` and include it in
+  cache accounting/eviction checks; or
+- evict/reinsert the cache entry with the larger charge immediately after index
+  construction.
+
+Do not rely only on `audio_length / 8192`; page-dense files must not escape the
+budget.
+
+- [ ] **Step 3: Add page-dense regression test**
+
+Create an Ogg fixture with many small pages, resolve it, trigger index creation,
+and assert the cache-visible charge grows by at least
+`index.estimated_heap_bytes()`. If exact cache totals are private, add a
+`#[cfg(test)]` accessor rather than weakening the assertion.
+
+### Task 3: Document And Test Ogg Invariant
+
+**Files:**
+- Create: `docs/OGG_INVARIANT.md`
+- Test: relevant Ogg read/proptest fixture
+
+- [ ] **Step 1: Add docs**
+
+Create `docs/OGG_INVARIANT.md` stating:
+
+```markdown
+# Ogg Invariant
+
+Ogg synthesis preserves original packet payload bytes. It may intentionally
+change Ogg page sequence numbers and CRC fields because resized metadata changes
+page numbering.
+```
+
+Include references to the Ogg property tests and interop tests.
+
+- [ ] **Step 2: Add or verify payload-specific test**
+
+Ensure a test compares Ogg packet payload bytes, not entire Ogg page bytes. Page
+headers are allowed to differ.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+cargo test -p musefs-format --features fuzzing
+cargo test -p musefs-core
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/OGG_INVARIANT.md musefs-format/src/ogg/mod.rs musefs-core/src/ogg_index.rs musefs-core/src/reader.rs
+git commit -m "fix(ogg): harden art length and account resident page indexes
+
+Closes #9
+Closes #10
+Closes #16"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-05-layout-mp4-contracts.md
+++ b/docs/superpowers/plans/github-cleanup/pr-05-layout-mp4-contracts.md
@@ -1,0 +1,110 @@
+# PR 5 Layout And MP4 Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate `RegionLayout` producer invariants at synthesis boundaries and document/test MP4 first-cover behavior.
+
+**Architecture:** Keep `RegionLayout` simple, but add a checked validation method and call it before returning synthesized layouts from each format producer. MP4 behavior remains unchanged: the first art input wins.
+
+**Tech Stack:** Rust, musefs-format, README documentation.
+
+---
+
+### Task 1: Add RegionLayout Validation
+
+**Files:**
+- Modify: `musefs-format/src/layout.rs`
+- Modify: `musefs-format/src/lib.rs`
+- Test: `musefs-format/tests/layout.rs`
+
+- [ ] **Step 1: Add validation type and tests**
+
+Add `LayoutError::{EmptySegment, TotalOverflow}` and
+`RegionLayout::validate() -> Result<(), LayoutError>`.
+
+Tests must cover:
+- empty inline segment fails;
+- zero-length backing segment fails;
+- `u64::MAX + 1` total length fails;
+- normal inline plus backing layout passes.
+
+- [ ] **Step 2: Export the error**
+
+Export from `musefs-format/src/lib.rs`:
+
+```rust
+pub use layout::{LayoutError, RegionLayout, Segment};
+```
+
+### Task 2: Validate At Synthesis Boundaries
+
+**Files:**
+- Modify: `musefs-format/src/flac.rs`
+- Modify: `musefs-format/src/mp3.rs`
+- Modify: `musefs-format/src/mp4.rs`
+- Modify: `musefs-format/src/ogg/mod.rs`
+- Modify: `musefs-format/src/wav.rs`
+
+- [ ] **Step 1: Add helper**
+
+Add a small helper in `layout.rs` or call directly:
+
+```rust
+let layout = RegionLayout::new(segments);
+layout.validate().map_err(|_| FormatError::InvalidLayout)?;
+Ok(layout)
+```
+
+Add `FormatError::InvalidLayout` if no existing format error fits.
+
+- [ ] **Step 2: Use helper in every synthesis producer**
+
+Apply the validation before returning from all format `synthesize_layout`
+functions. Do not validate ad hoc test layouts unless they are exercising the
+validation API directly.
+
+- [ ] **Step 3: Verify validation is wired**
+
+Search:
+
+```bash
+rg "RegionLayout::new\\(segments\\)" musefs-format/src
+```
+
+Expected: no synthesis producer returns `RegionLayout::new(segments)` without
+validation.
+
+### Task 3: Document And Test MP4 First-Cover Limitation
+
+**Files:**
+- Modify: `README.md`
+- Test: `musefs-format/tests/mp4_oracle.rs`
+
+- [ ] **Step 1: Add README limitation**
+
+Document that MP4/M4A synthesis embeds only the first cover-art input by
+`track_art.ordinal`; later art inputs are ignored.
+
+- [ ] **Step 2: Add regression test**
+
+In `mp4_oracle.rs`, synthesize with `[art1]` and `[art1, art2]` and assert the
+layouts are identical. This locks silent first-art behavior.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+cargo test -p musefs-format --test layout --test mp4_oracle
+cargo test -p musefs-format
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md musefs-format/src musefs-format/tests/layout.rs musefs-format/tests/mp4_oracle.rs
+git commit -m "feat(format): validate layouts and document MP4 first-art behavior
+
+Closes #15
+Closes #17"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-06-interop-db-contract.md
+++ b/docs/superpowers/plans/github-cleanup/pr-06-interop-db-contract.md
@@ -1,0 +1,108 @@
+# PR 6 Interop And DB Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document and test the SQLite external-writer contract, and make interop tests verify audio payload preservation.
+
+**Architecture:** Use the real musefs schema and real synthesized fixtures. The interop manifest must carry separate source and synthesized audio ranges because synthesized metadata changes output offsets.
+
+**Tech Stack:** Rust interop emitter, Python pytest, mutagen, SQLite.
+
+---
+
+### Task 1: Document DB Ownership Contract
+
+**Files:**
+- Create: `docs/DB_CONTRACT.md`
+
+- [ ] **Step 1: Add contract doc**
+
+Create documentation that says:
+- scanner owns `tracks` structural fields;
+- external writers may write `tags`, `art`, and `track_art`;
+- external tools should call `musefs scan` to create/update structural rows;
+- invalid structural rows are handled as backing/layout errors, not trusted.
+
+### Task 2: Test External-Writer Misuse Against Real Schema
+
+**Files:**
+- Test: `musefs-db/tests/external_contract.rs` or `musefs-core/tests/external_contract.rs`
+
+- [ ] **Step 1: Add real-schema misuse test**
+
+Use `musefs_db::Db::open` on a temp file, insert a valid scanned track through
+`upsert_track`, then mutate a scanner-owned field directly through a test-only
+SQL helper or public DB connection helper. The test must prove one of:
+- SQLite constraints/triggers reject the mutation; or
+- `HeaderCache::resolve`/`Musefs` returns a controlled error such as
+  `BackingChanged`/format error rather than panicking or serving invalid bytes.
+
+Do not create a hand-written mini schema.
+
+### Task 3: Emit Source And Synthesized Audio Ranges
+
+**Files:**
+- Modify: `musefs-core/tests/interop_emit.rs`
+
+- [ ] **Step 1: Extend manifest rows**
+
+For every emitted fixture, include:
+
+```json
+{
+  "file": "out.flac",
+  "source_file": "src.flac",
+  "title": "Interop Title",
+  "artist": "Interop Artist",
+  "source_audio_offset": 42,
+  "source_audio_length": 400,
+  "synth_audio_offset": 128,
+  "synth_audio_length": 400,
+  "ogg_payload_only": false
+}
+```
+
+`source_audio_offset/source_audio_length` come from scan bounds. `synth_audio_*`
+must come from the synthesized `RegionLayout`, not by reusing source offsets.
+For non-Ogg files, the synthesized audio range is the `BackingAudio` segment
+range in output coordinates. For Ogg, either emit enough packet-payload metadata
+to compare payloads or set `ogg_payload_only: true` and implement a payload-aware
+comparison.
+
+### Task 4: Verify Audio Payloads In Python
+
+**Files:**
+- Modify: `tests/interop/test_mutagen_roundtrip.py`
+
+- [ ] **Step 1: Add byte-preservation assertions**
+
+For non-Ogg rows, read source bytes at `source_audio_offset` and synthesized
+bytes at `synth_audio_offset`, both for `source_audio_length`, and assert exact
+equality.
+
+For Ogg rows, compare packet payload bytes using an Ogg page parser or skip whole
+page byte equality with a clear assertion that length-only is not sufficient.
+If payload parser work is too large for this PR, keep the Ogg assertion in Rust
+where Ogg page helpers already exist and document that Python interop verifies
+non-Ogg exact byte preservation.
+
+- [ ] **Step 2: Verify**
+
+Run:
+
+```bash
+MUSEFS_INTEROP_DIR=/tmp/musefs-interop cargo test -p musefs-core --test interop_emit -- --ignored emit_interop_fixtures
+MUSEFS_INTEROP_DIR=/tmp/musefs-interop python3 -m pytest tests/interop -v
+```
+
+Expected: both pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/DB_CONTRACT.md musefs-core/tests tests/interop
+git commit -m "test(core): verify DB contract and interop audio preservation
+
+Closes #11
+Closes #14"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-07-beets-python-quality.md
+++ b/docs/superpowers/plans/github-cleanup/pr-07-beets-python-quality.md
@@ -1,0 +1,137 @@
+# PR 7 Beets Python Quality Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scope Beets pruning safely, add Beets CI coverage, and configure Ruff for repository Python code.
+
+**Architecture:** Scope pruning by musefs `tracks.id` resolved from synced backing paths, not by Beets item IDs. Keep Python tooling changes in the Beets/interop surface only.
+
+**Tech Stack:** Python, Beets plugin, sqlite3, pytest, Ruff, GitHub Actions.
+
+---
+
+### Task 1: Scope Beets Pruning By Musefs Track IDs
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/_core.py`
+- Modify: `contrib/beets/beetsplug/musefs.py`
+- Test: `contrib/beets/tests/test_db.py`
+- Test: `contrib/beets/tests/test_plugin.py`
+
+- [ ] **Step 1: Add low-level scoped prune test**
+
+In `test_db.py`, assert `prune_missing(conn, track_ids=[missing_related])`
+deletes only that musefs track ID and preserves unrelated missing rows.
+
+- [ ] **Step 2: Implement optional `track_ids` in `_core.prune_missing`**
+
+The function accepts musefs `tracks.id` values only:
+
+```python
+def prune_missing(conn, track_ids=None):
+    if track_ids is None:
+        rows = conn.execute("SELECT id, backing_path FROM tracks")
+    else:
+        rows = (
+            conn.execute("SELECT id, backing_path FROM tracks WHERE id = ?", (tid,)).fetchone()
+            for tid in track_ids
+        )
+    gone = []
+    for row in rows:
+        if row is None:
+            continue
+        tid, path = row
+        if not os.path.exists(path):
+            gone.append((tid,))
+    conn.executemany("DELETE FROM tracks WHERE id = ?", gone)
+    return len(gone)
+```
+
+- [ ] **Step 3: Resolve scope from synced paths**
+
+In `MusefsPlugin`, after scan/sync, compute scope by looking up musefs track IDs
+from normalized backing paths:
+
+```python
+def _track_ids_for_items(self, conn, items):
+    ids = []
+    for item in items:
+        key = _core.realpath_key(os.fsdecode(item.path))
+        tid = _core.track_id_for_path(conn, key)
+        if tid is not None:
+            ids.append(tid)
+    return ids
+```
+
+Use this inside `_prune_missing(db_path, items=items)` so callers never pass
+Beets item IDs as musefs track IDs.
+
+- [ ] **Step 4: Apply scope to command and reconcile paths**
+
+For queried command syncs and passive reconcile, prune only the resolved synced
+track IDs. For full-library command sync with no query, whole-DB prune remains
+acceptable because the user asked to sync the whole library.
+
+- [ ] **Step 5: Add plugin-level regression tests**
+
+Tests must cover:
+- queried sync preserves unrelated missing rows;
+- passive reconcile preserves unrelated missing rows;
+- full sync may prune unrelated missing rows.
+
+### Task 2: Add Ruff And Beets CI
+
+**Files:**
+- Create: `contrib/beets/ruff.toml` or modify existing Python config
+- Modify: `.github/workflows/ci.yml`
+- Modify: Python files as required by Ruff
+
+- [ ] **Step 1: Add Ruff config**
+
+Use:
+
+```toml
+line-length = 100
+target-version = "py311"
+
+[lint]
+select = ["E", "F", "I", "N", "W"]
+
+[format]
+preview = true
+```
+
+- [ ] **Step 2: Add CI job**
+
+Add a `beets` job that runs:
+
+```bash
+python -m pip install ruff pytest
+python -m pip install -e contrib/beets
+ruff check contrib/beets tests/interop
+ruff format --check contrib/beets tests/interop
+python -m pytest contrib/beets/tests -v
+```
+
+Leave action pinning to PR 8.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+python3 -m pytest contrib/beets/tests -v
+ruff check contrib/beets tests/interop
+ruff format --check contrib/beets tests/interop
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml contrib/beets tests/interop
+git commit -m "fix(beets): scope prune and add Python quality gate
+
+Closes #12
+Closes #13
+Closes #19"
+```

--- a/docs/superpowers/plans/github-cleanup/pr-08-ci-dev-hardening.md
+++ b/docs/superpowers/plans/github-cleanup/pr-08-ci-dev-hardening.md
@@ -1,0 +1,162 @@
+# PR 8 CI And Development Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin all GitHub Actions to commit SHAs, disable checkout credential persistence, add a pure CLI mount-config seam, and make pre-commit run the local test gate.
+
+**Architecture:** This PR must be rebased after PR 1 and PR 7 so it sees every workflow file, including `coverage.yml` and the Beets CI job. Workflow hardening should be mechanical; CLI test seam stays in `musefs-cli`.
+
+**Tech Stack:** GitHub Actions, shell hook, Rust CLI tests.
+
+---
+
+### Task 1: Harden Every Workflow Present After Rebase
+
+**Files:**
+- Modify: `.github/workflows/*.yml`
+
+- [ ] **Step 1: List all action uses**
+
+Run:
+
+```bash
+rg -n "uses: .+@" .github/workflows
+```
+
+Expected: includes `ci.yml`, `fuzz.yml`, `audit.yml`, `coverage.yml`, and any
+workflow additions from earlier PRs.
+
+- [ ] **Step 2: Pin all actions**
+
+Replace every mutable tag (`@v4`, `@v5`, `@stable`, `@nightly`, `@v2`) with a
+full 40-character commit SHA for that action. Verify each SHA exists upstream
+before committing.
+
+- [ ] **Step 3: Disable checkout credential persistence**
+
+Every `actions/checkout@<sha>` step must include:
+
+```yaml
+with:
+  persist-credentials: false
+```
+
+Preserve existing checkout `with` keys by merging this key into the existing
+mapping.
+
+- [ ] **Step 4: Verify workflow hardening**
+
+Run:
+
+```bash
+rg -n "uses: .+@(v[0-9]+|stable|nightly|main|master)$" .github/workflows
+rg -n "actions/checkout@" .github/workflows
+```
+
+Expected: first command has no output. Manually confirm every checkout block has
+`persist-credentials: false`.
+
+### Task 2: Add CLI Mount Config Test Seam
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs`
+- Test: `musefs-cli/tests/cli.rs`
+
+- [ ] **Step 1: Extract pure config builder**
+
+Create:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn parse_mount_config(
+    template: String,
+    default_fallback: String,
+    mode: musefs_core::Mode,
+    poll_interval_ms: u64,
+    attr_ttl_ms: u64,
+    max_readahead_kib: u32,
+    max_background: u16,
+    keep_cache: bool,
+) -> (MountConfig, musefs_fuse::FuseConfig) {
+    let config = MountConfig {
+        template,
+        fallbacks: BTreeMap::new(),
+        default_fallback,
+        mode,
+        poll_interval: Duration::from_millis(poll_interval_ms),
+    };
+    let fuse_config = musefs_fuse::FuseConfig {
+        ttl: Duration::from_millis(attr_ttl_ms),
+        max_readahead: max_readahead_kib.saturating_mul(1024),
+        max_background,
+        keep_cache,
+    };
+    (config, fuse_config)
+}
+```
+
+Have `run_mount` call this function. Use `saturating_mul` for KiB to bytes.
+
+- [ ] **Step 2: Add tests**
+
+Add tests for:
+- template/default fallback/mode/poll interval mapping;
+- TTL, max background, keep-cache mapping;
+- `u32::MAX` readahead saturates instead of wrapping.
+
+- [ ] **Step 3: Verify CLI tests**
+
+Run:
+
+```bash
+cargo test -p musefs-cli
+```
+
+### Task 3: Add Local Pre-Commit Test Gate
+
+**Files:**
+- Modify: `.githooks/pre-commit`
+- Modify: README or contributor docs if hook behavior is documented there
+
+- [ ] **Step 1: Update hook**
+
+Use:
+
+```sh
+#!/bin/sh
+# Pre-commit hook for musefs.
+# Enable with: git config core.hooksPath .githooks
+set -e
+
+echo "pre-commit: cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "pre-commit: cargo clippy --all-targets -- -D warnings"
+cargo clippy --all-targets --quiet -- -D warnings
+
+echo "pre-commit: cargo test --workspace"
+cargo test --workspace --quiet
+
+echo "pre-commit checks passed"
+```
+
+- [ ] **Step 2: Verify hook command**
+
+Run:
+
+```bash
+.githooks/pre-commit
+```
+
+Expected: fmt, clippy, and workspace tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows .githooks/pre-commit musefs-cli/src/lib.rs musefs-cli/tests/cli.rs README.md
+git commit -m "ci: harden workflows and local test gate
+
+Closes #2
+Closes #18
+Closes #20"
+```

--- a/docs/superpowers/specs/2026-05-28-github-issue-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-28-github-issue-cleanup-design.md
@@ -1,0 +1,186 @@
+# GitHub Issue Cleanup Design
+
+## Context
+
+The repository has nineteen open GitHub issues as of 2026-05-28. Most were
+created from the architecture review in
+`docs/superpowers/reviews/2026-05-28-architecture-review.md`; the rest cover
+CI, Python tooling, coverage, and local development gates.
+
+The cleanup should optimize for lowest review risk rather than the fewest pull
+requests. Each pull request should have a narrow ownership boundary, close its
+listed issues, and include focused verification for the behavior it changes.
+
+## PR Sequence
+
+Work will proceed in seven dependency-ordered pull requests:
+
+1. `core-db-read-safety`: close #4 and #5.
+2. `refresh-invalidation-observability`: close #6, #7, and #8.
+3. `ogg-hardening-cache-accounting`: close #9, #10, and #16.
+4. `layout-mp4-contracts`: close #15 and #17.
+5. `interop-db-contract`: close #11 and #14.
+6. `beets-python-quality`: close #12, #13, and #19.
+7. `ci-dev-hardening`: close #2, #18, #20, and #21.
+
+Later PRs may broaden CI coverage, but each behavior-changing PR must include
+its own targeted tests. No later PR should be responsible for proving the
+correctness of behavior introduced earlier.
+
+## PR 1: Core DB Read Safety
+
+This PR fixes two high-risk correctness bugs in the core read path.
+
+`DbPool` must stop reusing a thread-local SQLite connection across different DB
+paths. The preferred design is to key the thread-local connection by canonical
+database path while preserving the existing per-thread read-only connection
+model.
+
+Open handles must validate the metadata of the file descriptor that was actually
+opened before the handle is cached. The check should compare size and mtime
+against the resolved backing-file contract, so a path replacement between
+resolve and open does not serve bytes from a file that does not match the cached
+layout.
+
+Verification should include a same-thread two-pool regression test and a focused
+open-handle metadata validation test that proves a mismatched opened descriptor
+is rejected before it can be cached.
+
+## PR 2: Refresh Invalidation Observability
+
+This PR owns refresh retry semantics, keep-cache invalidation correctness, and
+visible FUSE failure reporting.
+
+Failed refresh attempts must not consume the debounce window. The successful
+data-version stamp should remain committed only after a successful rebuild.
+
+Keep-cache invalidation must handle path-changing retags. When a changed track
+moves to a new rendered path, the stale old inode must be reported for kernel
+cache invalidation. The implementation may also report the new inode where that
+is useful, but it must not rely only on the rebuilt tree's current inode lookup.
+
+The FUSE adapter should remain thin, but refresh and `inval_inode` failures
+should be surfaced through minimal logging so operators are not left with silent
+staleness.
+
+Verification should cover failed-refresh retry behavior and path-changing retag
+invalidation behavior without requiring real FUSE failure injection.
+
+## PR 3: Ogg Hardening And Cache Accounting
+
+This PR keeps Ogg-specific hardening in one reviewable unit.
+
+Ogg cover-art synthesis must guard the full `METADATA_BLOCK_PICTURE`
+VorbisComment value length before casting to `u32`. The guard must include the
+key, picture prefix, and base64 image length.
+
+Resident Ogg page indexes must be accounted for in cache budgeting, or a
+separate bounded policy must be implemented and tested. The chosen policy should
+make page-dense Ogg files visible to memory limits instead of leaving the page
+index outside the advertised cache budget.
+
+The Ogg invariant must be documented and tested precisely: original packet
+payload bytes are preserved, while Ogg page sequence numbers and CRCs may be
+patched intentionally.
+
+## PR 4: Layout And MP4 Contracts
+
+This PR clarifies format-layer contracts without changing MP4 behavior.
+
+`RegionLayout` should gain a lightweight validation path at synthesis
+boundaries. The simple segment representation should remain intact; validation
+should make producer invariants easier to test and debug without forcing a broad
+type-system rewrite.
+
+MP4/M4A synthesis should continue silently using the first cover-art input. The
+README must document this as an intentional current limitation: MP4/M4A embeds
+only the first cover image when multiple images are available. Tests should lock
+that behavior so it remains deliberate.
+
+## PR 5: Interop And DB Contract
+
+This PR strengthens public contract tests for external writers and independent
+readers.
+
+The SQLite schema documentation should clarify which structural fields are
+scanner-owned and which fields external writers may safely update. External
+tools such as Beets should remain on the scanner path for structural rows unless
+a future design explicitly expands the contract.
+
+The independent-reader interop test should verify synthesized outputs preserve
+the source audio payload, not only that synthesized tags are readable. The
+manifest or fixtures should include enough per-format audio payload metadata to
+compare source and synthesized audio bytes while respecting the Ogg page-header
+patching model.
+
+This PR should not broaden Beets CI; that belongs to PR 6.
+
+## PR 6: Beets Python Quality
+
+This PR handles Python integration and Beets contract coverage as one unit.
+
+Beets pruning should be constrained to the sync/scan scope instead of deleting
+every missing backing path in the database. The implementation should add
+regression coverage for a scoped Beets sync with an unrelated missing row and
+prove that unrelated row is preserved.
+
+CI should exercise the Beets SQLite writer contract narrowly enough to stay
+reliable: sync, retag, prune, and art writes. Ruff should be configured for all
+repository Python code under `contrib/beets/` and `tests/interop/`, with both
+lint and format-check commands documented.
+
+This PR may adjust Python style and plugin tests. It should avoid unrelated Rust
+workflow changes.
+
+## PR 7: CI And Development Hardening
+
+This PR finishes repository workflow hardening.
+
+All GitHub Actions `uses:` references in the workflows should be pinned to full
+commit SHAs, and every `actions/checkout` step should set
+`persist-credentials: false`.
+
+Coverage reporting should use `cargo-llvm-cov` and upload to Codecov. Required
+Codecov setup, tokens, and local limitations should be documented. Coverage
+should not require ignored FUSE tests unless they are configured as a separate
+explicit job.
+
+The CLI should gain a pure test seam for converting parsed mount flags into
+`MountConfig` and `FuseConfig` without mounting. The local pre-commit hook should
+enforce the normal local passing test gate and document what it runs.
+
+## Verification Gates
+
+PRs 1 through 5 should run at least:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+PRs touching format, Ogg, or interop behavior should also run focused checks
+such as:
+
+```bash
+cargo test -p musefs-format --features fuzzing
+cargo test -p musefs-core --test interop_emit
+```
+
+PR 6 should run the Python lint/test gate introduced in that PR. Rust checks are
+required if Rust files change.
+
+PR 7 should verify workflow YAML statically where possible, run the local hook
+command directly, and run CLI tests for the mount-config seam. Codecov upload
+may require GitHub/Codecov repository setup and should be documented if it
+cannot be fully verified locally.
+
+## Guardrails
+
+- Keep `musefs-fuse` and `musefs-cli` thin.
+- Preserve original audio bytes exactly, with the Ogg exception stated as
+  payload bytes preserved and page headers patched.
+- Keep external writers away from scanner-owned structural fields unless a
+  future explicit design expands that contract.
+- Avoid unrelated refactors in these cleanup PRs.
+- Use `Closes #N` in every PR body for the exact issues handled by that PR.

--- a/docs/superpowers/specs/2026-05-28-github-issue-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-28-github-issue-cleanup-design.md
@@ -10,24 +10,39 @@ CI, Python tooling, coverage, and local development gates.
 The cleanup should optimize for lowest review risk rather than the fewest pull
 requests. Each pull request should have a narrow ownership boundary, close its
 listed issues, and include focused verification for the behavior it changes.
+Coverage should be established early so later behavior PRs can benefit from the
+additional signal.
 
 ## PR Sequence
 
-Work will proceed in seven dependency-ordered pull requests:
+Work will proceed in eight dependency-ordered pull requests:
 
-1. `core-db-read-safety`: close #4 and #5.
-2. `refresh-invalidation-observability`: close #6, #7, and #8.
-3. `ogg-hardening-cache-accounting`: close #9, #10, and #16.
-4. `layout-mp4-contracts`: close #15 and #17.
-5. `interop-db-contract`: close #11 and #14.
-6. `beets-python-quality`: close #12, #13, and #19.
-7. `ci-dev-hardening`: close #2, #18, #20, and #21.
+1. `coverage-baseline`: close #21.
+2. `core-db-read-safety`: close #4 and #5.
+3. `refresh-invalidation-observability`: close #6, #7, and #8.
+4. `ogg-hardening-cache-accounting`: close #9, #10, and #16.
+5. `layout-mp4-contracts`: close #15 and #17.
+6. `interop-db-contract`: close #11 and #14.
+7. `beets-python-quality`: close #12, #13, and #19.
+8. `ci-dev-hardening`: close #2, #18, and #20.
 
 Later PRs may broaden CI coverage, but each behavior-changing PR must include
 its own targeted tests. No later PR should be responsible for proving the
 correctness of behavior introduced earlier.
 
-## PR 1: Core DB Read Safety
+## PR 1: Coverage Baseline
+
+This PR adds coverage reporting before the behavior cleanup starts.
+
+Coverage reporting should use `cargo-llvm-cov` and upload to Codecov. Required
+Codecov setup, tokens, and local limitations should be documented. Coverage
+should not require ignored FUSE tests unless they are configured as a separate
+explicit job.
+
+This PR should avoid unrelated workflow hardening. Pinning third-party actions,
+pre-commit changes, and CLI test seams belong to PR 8.
+
+## PR 2: Core DB Read Safety
 
 This PR fixes two high-risk correctness bugs in the core read path.
 
@@ -37,22 +52,26 @@ database path while preserving the existing per-thread read-only connection
 model.
 
 Open handles must validate the metadata of the file descriptor that was actually
-opened before the handle is cached. The check should compare size and mtime
-against the resolved backing-file contract, so a path replacement between
-resolve and open does not serve bytes from a file that does not match the cached
-layout.
+opened before the handle is cached. The implementation must use metadata from
+the opened descriptor, such as `File::metadata()`/`fstat`, not a path-based
+`stat` after opening. The check should compare size and mtime against the
+resolved backing-file contract, so a path replacement between resolve and open
+does not serve bytes from a file that does not match the cached layout.
 
 Verification should include a same-thread two-pool regression test and a focused
 open-handle metadata validation test that proves a mismatched opened descriptor
 is rejected before it can be cached.
 
-## PR 2: Refresh Invalidation Observability
+## PR 3: Refresh Invalidation Observability
 
 This PR owns refresh retry semantics, keep-cache invalidation correctness, and
 visible FUSE failure reporting.
 
 Failed refresh attempts must not consume the debounce window. The successful
 data-version stamp should remain committed only after a successful rebuild.
+Retries must still be bounded by a small backoff or equivalent retry limiter so
+a persistently unreadable or corrupt database cannot trigger a tight refresh
+loop on every metadata operation.
 
 Keep-cache invalidation must handle path-changing retags. When a changed track
 moves to a new rendered path, the stale old inode must be reported for kernel
@@ -66,7 +85,7 @@ staleness.
 Verification should cover failed-refresh retry behavior and path-changing retag
 invalidation behavior without requiring real FUSE failure injection.
 
-## PR 3: Ogg Hardening And Cache Accounting
+## PR 4: Ogg Hardening And Cache Accounting
 
 This PR keeps Ogg-specific hardening in one reviewable unit.
 
@@ -83,7 +102,7 @@ The Ogg invariant must be documented and tested precisely: original packet
 payload bytes are preserved, while Ogg page sequence numbers and CRCs may be
 patched intentionally.
 
-## PR 4: Layout And MP4 Contracts
+## PR 5: Layout And MP4 Contracts
 
 This PR clarifies format-layer contracts without changing MP4 behavior.
 
@@ -97,7 +116,7 @@ README must document this as an intentional current limitation: MP4/M4A embeds
 only the first cover image when multiple images are available. Tests should lock
 that behavior so it remains deliberate.
 
-## PR 5: Interop And DB Contract
+## PR 6: Interop And DB Contract
 
 This PR strengthens public contract tests for external writers and independent
 readers.
@@ -107,15 +126,20 @@ scanner-owned and which fields external writers may safely update. External
 tools such as Beets should remain on the scanner path for structural rows unless
 a future design explicitly expands the contract.
 
+Documentation must be backed by at least one lightweight contract test that
+mimics an external writer attempting to mutate a scanner-owned structural field.
+The test should prove the application handles the row gracefully, or prove that
+SQLite constraints/triggers reject the mutation if enforcement is added.
+
 The independent-reader interop test should verify synthesized outputs preserve
 the source audio payload, not only that synthesized tags are readable. The
 manifest or fixtures should include enough per-format audio payload metadata to
 compare source and synthesized audio bytes while respecting the Ogg page-header
 patching model.
 
-This PR should not broaden Beets CI; that belongs to PR 6.
+This PR should not broaden Beets CI; that belongs to PR 7.
 
-## PR 6: Beets Python Quality
+## PR 7: Beets Python Quality
 
 This PR handles Python integration and Beets contract coverage as one unit.
 
@@ -132,7 +156,7 @@ lint and format-check commands documented.
 This PR may adjust Python style and plugin tests. It should avoid unrelated Rust
 workflow changes.
 
-## PR 7: CI And Development Hardening
+## PR 8: CI And Development Hardening
 
 This PR finishes repository workflow hardening.
 
@@ -140,18 +164,16 @@ All GitHub Actions `uses:` references in the workflows should be pinned to full
 commit SHAs, and every `actions/checkout` step should set
 `persist-credentials: false`.
 
-Coverage reporting should use `cargo-llvm-cov` and upload to Codecov. Required
-Codecov setup, tokens, and local limitations should be documented. Coverage
-should not require ignored FUSE tests unless they are configured as a separate
-explicit job.
-
 The CLI should gain a pure test seam for converting parsed mount flags into
 `MountConfig` and `FuseConfig` without mounting. The local pre-commit hook should
 enforce the normal local passing test gate and document what it runs.
 
 ## Verification Gates
 
-PRs 1 through 5 should run at least:
+PR 1 should verify the coverage command locally where possible and document any
+Codecov upload behavior that requires repository-side setup.
+
+PRs 2 through 6 should run at least:
 
 ```bash
 cargo fmt --check
@@ -167,13 +189,12 @@ cargo test -p musefs-format --features fuzzing
 cargo test -p musefs-core --test interop_emit
 ```
 
-PR 6 should run the Python lint/test gate introduced in that PR. Rust checks are
+PR 7 should run the Python lint/test gate introduced in that PR. Rust checks are
 required if Rust files change.
 
-PR 7 should verify workflow YAML statically where possible, run the local hook
+PR 8 should verify workflow YAML statically where possible, run the local hook
 command directly, and run CLI tests for the mount-config seam. Codecov upload
-may require GitHub/Codecov repository setup and should be documented if it
-cannot be fully verified locally.
+is already covered by PR 1.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

Adds a CI coverage workflow using  and uploads results to Codecov.

## Changes

- **** — New workflow that collects coverage on every push/PR, excluding FUSE e2e tests (they need  at runtime)
- **** — Documents local usage and CI setup

## Notes

- FUSE crate is excluded from coverage since e2e tests require libfuse
- Requires  repository secret
- Uses  for accurate, no-instrumentation coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated code-coverage collection and reporting in CI for pushes and pull requests.

* **Documentation**
  * Added user-facing coverage docs and a new coverage workflow guide.
  * Added a set of roadmap and implementation-plan documents outlining an eight-PR cleanup sequence and targeted hardening, testing, and CI improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->