### PR TITLE
fix(ogg): guard full VorbisComment value length and bound Ogg index cache charge

### DIFF
--- a/docs/OGG_INVARIANT.md
+++ b/docs/OGG_INVARIANT.md
@@ -1,0 +1,25 @@
+# Ogg Invariant
+
+Original Ogg packet payload bytes are preserved during synthesis. Ogg page
+sequence numbers and CRCs may be patched intentionally.
+
+## Rationale
+
+Ogg synthesis regenerates the logical bitstream headers (page granule positions,
+packet boundaries) to embed synthesized tags and cover art. Audio packets are
+passed through unchanged. This means:
+
+- Audio payload bytes are always preserved (tested via property tests and
+  mutagen interop).
+- Page sequence numbers are re-numbered to account for the changed header page
+  count.
+- CRCs are recomputed for any page whose content changed (headers only).
+- VorbisComments are rebuilt from the DB tag store, with cover art injected as
+  `METADATA_BLOCK_PICTURE` base64 values (Opus/Vorbis) or native FLAC PICTURE
+  blocks (OggFLAC).
+
+## Verified By
+
+- `proptest_ogg` property tests (crate feature `fuzzing`)
+- `read_at` integration tests that compare source and synthesized audio payloads
+- Mutagen interop tests that verify ecosystem readers can parse the output

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -13,6 +13,9 @@ use crate::facade::Mode;
 use crate::mapping::{tags_to_inputs, track_art_to_inputs};
 use crate::ogg_index::{build_index, serve, OggPageIndex};
 
+const OGG_AVG_PAGE_BYTES: u64 = 8192;
+const OGG_INDEX_BYTES_PER_PAGE: u64 = 100;
+
 /// A fully resolved synthesized file: its segment layout, total size, the
 /// content version it was built from, and where the backing audio lives.
 #[derive(Debug)]
@@ -336,7 +339,16 @@ impl HeaderCache {
                 Segment::Inline(b) => b.len() as u64,
                 _ => 0,
             })
-            .sum();
+            .sum::<u64>()
+            + match track.format {
+                Format::Opus | Format::Vorbis | Format::OggFlac => {
+                    let estimated_pages = (track.audio_length as u64)
+                        .saturating_div(OGG_AVG_PAGE_BYTES)
+                        .max(1);
+                    estimated_pages.saturating_mul(OGG_INDEX_BYTES_PER_PAGE)
+                }
+                _ => 0,
+            };
         Ok(Arc::new(ResolvedFile {
             layout,
             total_len,

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -13,8 +13,15 @@ use crate::facade::Mode;
 use crate::mapping::{tags_to_inputs, track_art_to_inputs};
 use crate::ogg_index::{build_index, serve, OggPageIndex};
 
-const OGG_AVG_PAGE_BYTES: u64 = 8192;
-const OGG_INDEX_BYTES_PER_PAGE: u64 = 100;
+const OGG_MIN_PAGE_BYTES: u64 = 27;
+const OGG_INDEX_BYTES_PER_PAGE: u64 = 128;
+
+fn estimated_ogg_index_bytes(audio_length: u64) -> u64 {
+    let estimated_pages = audio_length
+        .saturating_div(OGG_MIN_PAGE_BYTES)
+        .saturating_add(1);
+    estimated_pages.saturating_mul(OGG_INDEX_BYTES_PER_PAGE)
+}
 
 /// A fully resolved synthesized file: its segment layout, total size, the
 /// content version it was built from, and where the backing audio lives.
@@ -342,10 +349,7 @@ impl HeaderCache {
             .sum::<u64>()
             + match track.format {
                 Format::Opus | Format::Vorbis | Format::OggFlac => {
-                    let estimated_pages = (track.audio_length as u64)
-                        .saturating_div(OGG_AVG_PAGE_BYTES)
-                        .max(1);
-                    estimated_pages.saturating_mul(OGG_INDEX_BYTES_PER_PAGE)
+                    estimated_ogg_index_bytes(track.audio_length as u64)
                 }
                 _ => 0,
             };
@@ -843,6 +847,19 @@ mod cache_bound_tests {
         assert!(shard.get(2).is_some());
         shard.insert(3, entry(0, 60)); // evicts the now-LRU entry
         assert!(shard.get(3).is_some());
+    }
+
+    #[test]
+    fn ogg_index_estimate_accounts_page_dense_files() {
+        assert_eq!(estimated_ogg_index_bytes(0), OGG_INDEX_BYTES_PER_PAGE);
+        assert_eq!(
+            estimated_ogg_index_bytes(OGG_MIN_PAGE_BYTES),
+            OGG_INDEX_BYTES_PER_PAGE * 2
+        );
+        assert!(
+            estimated_ogg_index_bytes(8 * 1024) > OGG_INDEX_BYTES_PER_PAGE * 100,
+            "8 KiB of tiny Ogg pages must cost far more than one average page"
+        );
     }
 
     #[test]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -983,6 +983,37 @@ mod tests {
     }
 
     #[test]
+    fn sum_overflow_art_value_rejected_by_build_packets() {
+        // data_len and prefix individually fit in u32, but the full value
+        // (key + b64(prefix) + b64(data)) exceeds u32::MAX.
+        let meta = crate::input::ArtInput {
+            art_id: 0,
+            mime: "image/png".to_string(),
+            description: "x".repeat(256),
+            data_len: 3_221_225_470, // b64_len = 4_294_967_294 < u32::MAX
+            picture_type: 3,
+            width: 0,
+            height: 0,
+        };
+        let art = OggArt {
+            meta: &meta,
+            image: &[],
+        };
+        let header = OggHeader {
+            codec: Codec::Vorbis,
+            serial: 0,
+            packets: vec![vec![], vec![], vec![]],
+            header_pages: 1,
+            audio_offset: 0,
+        };
+        let result = build_packets_with_art(&header, &[], &[art]);
+        assert!(
+            result.is_err(),
+            "expected Err when key + b64(prefix) + b64(data) overflows u32"
+        );
+    }
+
+    #[test]
     fn picture_prefix_is_3_aligned_and_declares_image_len() {
         let art = crate::input::ArtInput {
             art_id: 1,

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -15,6 +15,8 @@ pub enum Codec {
     OggFlac,
 }
 
+const METADATA_BLOCK_PICTURE_KEY: &[u8] = b"METADATA_BLOCK_PICTURE=";
+
 fn detect_codec(first_packet: &[u8]) -> Result<Codec> {
     if first_packet.len() >= 8 && &first_packet[0..8] == b"OpusHead" {
         Ok(Codec::Opus)
@@ -292,9 +294,16 @@ fn build_packets_with_art(
     match header.codec {
         Codec::Opus | Codec::Vorbis => {
             // VorbisComment value length is a 32-bit field; guard against overflow
-            // for absurdly large images (cover art is far below this).
+            // for absurdly large images (cover art is far below this). The full
+            // value includes the key, base64 of the picture prefix, and base64 of
+            // the image; any one of these alone may fit in u32 but the sum may not.
             for a in arts {
-                if b64_len(a.meta.data_len) > u32::MAX as u64 {
+                let prefix = picture_prefix(a.meta);
+                let b64_prefix_len = b64_len(prefix.len() as u64);
+                let value_len = METADATA_BLOCK_PICTURE_KEY.len() as u64
+                    + b64_prefix_len
+                    + b64_len(a.meta.data_len);
+                if value_len > u32::MAX as u64 {
                     return Err(FormatError::TooLarge);
                 }
             }
@@ -338,13 +347,14 @@ fn comment_packet_chunks(
     let mut head = magic.to_vec();
     head.extend_from_slice(&leading);
 
-    const KEY: &[u8] = b"METADATA_BLOCK_PICTURE=";
     for art in arts {
         let prefix = picture_prefix(art.meta);
         let b64_prefix = b64_encode(&prefix);
-        let value_len = KEY.len() + b64_prefix.len() + b64_len(art.meta.data_len) as usize;
+        let value_len = METADATA_BLOCK_PICTURE_KEY.len()
+            + b64_prefix.len()
+            + b64_len(art.meta.data_len) as usize;
         head.extend_from_slice(&(value_len as u32).to_le_bytes());
-        head.extend_from_slice(KEY);
+        head.extend_from_slice(METADATA_BLOCK_PICTURE_KEY);
         head.extend_from_slice(&b64_prefix);
         chunks.push(PayloadChunk::Bytes(std::mem::take(&mut head)));
         chunks.push(PayloadChunk::Art {
@@ -944,6 +954,32 @@ mod tests {
         assert_eq!(pics.len(), 2);
         assert_eq!(pics[0].data, img_a);
         assert_eq!(pics[1].data, img_b);
+    }
+
+    #[test]
+    fn oversized_full_art_value_rejected_by_build_packets() {
+        let meta = crate::input::ArtInput {
+            art_id: 0,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            data_len: u32::MAX as u64,
+            picture_type: 3,
+            width: 0,
+            height: 0,
+        };
+        let art = OggArt {
+            meta: &meta,
+            image: &[],
+        };
+        let header = OggHeader {
+            codec: Codec::Vorbis,
+            serial: 0,
+            packets: vec![vec![], vec![], vec![]],
+            header_pages: 1,
+            audio_offset: 0,
+        };
+        let result = build_packets_with_art(&header, &[], &[art]);
+        assert!(result.is_err(), "expected Err for oversized art");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two Ogg hardening fixes:

1. **Full VorbisComment value length guard** — The overflow check for art values only validated  against , but the full value includes the key prefix and base64 picture prefix. A large image combined with a long prefix could overflow the 32-bit length field. Now validates the complete value length.

2. **Ogg index cache budget** — The Ogg page index was not accounted for in , so dense Ogg files with many small pages could exceed the LRU byte budget. Adds an estimate based on audio length and minimum page size.

## Changes

-  — Validate full  value length (key + b64 prefix + b64 data); add  test
-  — Add , include it in  for Ogg formats; add  test
-  — Document the Ogg byte-preservation invariant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive notes describing Ogg synthesis invariants, metadata regeneration, and cover art embedding/verification.

* **Bug Fixes**
  * Strengthened validation to reject oversized embedded cover art values in Ogg-based metadata.

* **Chores**
  * Improved cache accounting for synthesized Ogg formats by including estimated index cost for tiny-page streams.

* **Tests**
  * Added unit tests covering art-size overflow scenarios and Ogg index cost estimation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->