### PR TITLE
feat(format): add RegionLayout validation and document MP4 single-art limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ minus a few intentional/noisy groups — lives in the root `Cargo.toml` under
 git config core.hooksPath .githooks
 ```
 
+## Limitations
+
+### MP4/M4A Cover Art
+
+MP4/M4A synthesis embeds only the first cover-art input when multiple images
+are available. This is an intentional current limitation: the MP4 container
+format stores cover art in the `covr` metadata atom, which maps to a single
+`data` item. If multiple cover images are present in the database, only the
+first (earliest `track_art.ordinal`) is embedded.
+
+Tests lock this behavior — see `tests/mp4_oracle.rs`. Future work may
+support multiple covers via additional metadata atoms or a gallery layout.
+
 ## License
 
 Licensed under the [MIT License](LICENSE).

--- a/musefs-format/src/error.rs
+++ b/musefs-format/src/error.rs
@@ -14,6 +14,8 @@ pub enum FormatError {
     NotMp4,
     #[error("not a supported WAV/RIFF file")]
     NotWav,
+    #[error("synthesized region layout violates producer invariants")]
+    InvalidLayout,
 }
 
 pub type Result<T> = std::result::Result<T, FormatError>;

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -178,7 +178,7 @@ pub fn synthesize_layout(
         len: scan.audio_length,
     });
 
-    Ok(RegionLayout::new(segments))
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
 }
 
 /// Read the existing VORBIS_COMMENT block from a complete FLAC file, returning

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -66,6 +66,12 @@ impl RegionLayout {
         RegionLayout { segments }
     }
 
+    pub fn validated(segments: Vec<Segment>) -> Result<RegionLayout, LayoutError> {
+        let layout = RegionLayout::new(segments);
+        layout.validate()?;
+        Ok(layout)
+    }
+
     /// The ordered segments composing the synthesized virtual file.
     pub fn segments(&self) -> &[Segment] {
         &self.segments
@@ -86,13 +92,14 @@ impl RegionLayout {
     }
 
     /// Validate basic producer invariants. Returns `Ok(())` if the layout is
-    /// structurally sound (no empty segments, lengths don't overflow). This is
-    /// a lightweight check — not against schema — for testing and debugging.
+    /// structurally sound (no empty metadata segments, lengths don't overflow).
+    /// Zero-length backing audio is valid for formats that can represent an
+    /// empty media payload.
     pub fn validate(&self) -> Result<(), LayoutError> {
         let mut total: u64 = 0;
         for seg in &self.segments {
             let len = seg.len();
-            if len == 0 {
+            if len == 0 && !matches!(seg, Segment::BackingAudio { .. } | Segment::OggAudio { .. }) {
                 return Err(LayoutError::EmptySegment);
             }
             total = total.checked_add(len).ok_or(LayoutError::TotalOverflow)?;

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -1,3 +1,12 @@
+/// Validation errors discovered in a layout at synthesis time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LayoutError {
+    /// A segment reported zero length.
+    EmptySegment,
+    /// Total length overflowed u64.
+    TotalOverflow,
+}
+
 /// One contiguous run of bytes in a synthesized virtual file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Segment {
@@ -74,5 +83,20 @@ impl RegionLayout {
             .filter(|s| !matches!(s, Segment::BackingAudio { .. } | Segment::OggAudio { .. }))
             .map(Segment::len)
             .sum()
+    }
+
+    /// Validate basic producer invariants. Returns `Ok(())` if the layout is
+    /// structurally sound (no empty segments, lengths don't overflow). This is
+    /// a lightweight check — not against schema — for testing and debugging.
+    pub fn validate(&self) -> Result<(), LayoutError> {
+        let mut total: u64 = 0;
+        for seg in &self.segments {
+            let len = seg.len();
+            if len == 0 {
+                return Err(LayoutError::EmptySegment);
+            }
+            total = total.checked_add(len).ok_or(LayoutError::TotalOverflow)?;
+        }
+        Ok(())
     }
 }

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -14,7 +14,7 @@ pub mod fuzz_check;
 
 pub use error::{FormatError, Result};
 pub use input::{ArtInput, EmbeddedPicture, TagInput};
-pub use layout::{RegionLayout, Segment};
+pub use layout::{LayoutError, RegionLayout, Segment};
 pub use ogg::{Codec, OggHeader, OggScan};
 
 // tagmap is pure &str→key mapping with no byte parsing and is already exercised

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -252,7 +252,7 @@ pub fn synthesize_layout(
         offset: audio_offset,
         len: audio_length,
     });
-    Ok(RegionLayout::new(segments))
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
 }
 
 /// Returns false when `data` begins with an ID3v2 tag whose declared frame sizes

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -667,7 +667,7 @@ pub fn synthesize_layout(
         offset: scan.mdat_payload_offset,
         len: scan.mdat_payload_len,
     });
-    Ok(RegionLayout::new(segments))
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
 }
 
 #[cfg(test)]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -238,7 +238,7 @@ pub fn synthesize_layout(
         len: audio_length,
         seq_delta,
     });
-    Ok(RegionLayout::new(segments))
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
 }
 
 /// Build the FLAC PICTURE block *body prefix* (everything before the image data:

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -233,7 +233,7 @@ pub fn synthesize_layout(
     header.extend_from_slice(b"WAVE");
     segments.insert(0, Segment::Inline(header));
 
-    Ok(RegionLayout::new(segments))
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
 }
 
 /// RIFF `INFO` subchunk FourCC -> canonical (lowercase) tag key. Inverse of

--- a/musefs-format/tests/layout.rs
+++ b/musefs-format/tests/layout.rs
@@ -45,7 +45,19 @@ fn valid_layout_passes_validation() {
 }
 
 #[test]
-fn empty_backing_segment_fails_validation() {
+fn empty_backing_segment_passes_validation() {
     let layout = RegionLayout::new(vec![Segment::BackingAudio { offset: 0, len: 0 }]);
-    assert_eq!(layout.validate(), Err(LayoutError::EmptySegment));
+    assert!(layout.validate().is_ok());
+}
+
+#[test]
+fn total_overflow_detected() {
+    let layout = RegionLayout::new(vec![
+        Segment::BackingAudio {
+            offset: 0,
+            len: u64::MAX,
+        },
+        Segment::BackingAudio { offset: 0, len: 1 },
+    ]);
+    assert_eq!(layout.validate(), Err(LayoutError::TotalOverflow));
 }

--- a/musefs-format/tests/layout.rs
+++ b/musefs-format/tests/layout.rs
@@ -1,4 +1,4 @@
-use musefs_format::{RegionLayout, Segment};
+use musefs_format::{LayoutError, RegionLayout, Segment};
 
 #[test]
 fn lengths_sum_segments_and_exclude_audio_from_header() {
@@ -24,4 +24,28 @@ fn segment_len_reports_each_variant() {
     assert_eq!(Segment::Inline(vec![1, 2, 3]).len(), 3);
     assert_eq!(Segment::ArtImage { art_id: 1, len: 42 }.len(), 42);
     assert_eq!(Segment::BackingAudio { offset: 0, len: 9 }.len(), 9);
+}
+
+#[test]
+fn empty_single_segment_layout_fails_validation() {
+    let layout = RegionLayout::new(vec![Segment::Inline(vec![])]);
+    assert_eq!(layout.validate(), Err(LayoutError::EmptySegment));
+}
+
+#[test]
+fn valid_layout_passes_validation() {
+    let layout = RegionLayout::new(vec![
+        Segment::Inline(b"header".to_vec()),
+        Segment::BackingAudio {
+            offset: 0,
+            len: 100,
+        },
+    ]);
+    assert!(layout.validate().is_ok());
+}
+
+#[test]
+fn empty_backing_segment_fails_validation() {
+    let layout = RegionLayout::new(vec![Segment::BackingAudio { offset: 0, len: 0 }]);
+    assert_eq!(layout.validate(), Err(LayoutError::EmptySegment));
 }

--- a/musefs-format/tests/mp4_oracle.rs
+++ b/musefs-format/tests/mp4_oracle.rs
@@ -3,7 +3,7 @@
 //! samples read through OUR patched chunk offsets are byte-identical to the
 //! originals — proving the offset surgery.
 
-use musefs_format::{mp4, RegionLayout, Segment, TagInput};
+use musefs_format::{mp4, ArtInput, RegionLayout, Segment, TagInput};
 use std::io::Cursor;
 
 fn materialize(layout: &RegionLayout, backing: &[u8]) -> Vec<u8> {
@@ -69,4 +69,35 @@ fn synthesized_m4a_decodes_via_independent_parser() {
     let tags = mp4::read_tags(&synth);
     assert!(tags.contains(&("title".into(), "Rewritten".into())));
     assert!(tags.contains(&("artist".into(), "AA".into())));
+}
+
+#[test]
+fn m4a_synthesis_uses_only_first_cover_art() {
+    let original = std::fs::read("tests/fixtures/sample.m4a").unwrap();
+    let scan = mp4::read_structure(&original).unwrap();
+
+    let art1 = ArtInput {
+        art_id: 1,
+        mime: "image/jpeg".to_string(),
+        description: "cover".to_string(),
+        picture_type: 3,
+        width: 0,
+        height: 0,
+        data_len: 100,
+    };
+    let art2 = ArtInput {
+        art_id: 2,
+        mime: "image/png".to_string(),
+        description: "back".to_string(),
+        picture_type: 0,
+        width: 0,
+        height: 0,
+        data_len: 200,
+    };
+
+    let layout_single = mp4::synthesize_layout(&scan, &[], std::slice::from_ref(&art1)).unwrap();
+    let layout_both = mp4::synthesize_layout(&scan, &[], &[art1, art2]).unwrap();
+
+    // Both layouts must be identical — the second art input is ignored.
+    assert_eq!(layout_single, layout_both);
 }

--- a/musefs-format/tests/mp4_oracle.rs
+++ b/musefs-format/tests/mp4_oracle.rs
@@ -95,9 +95,15 @@ fn m4a_synthesis_uses_only_first_cover_art() {
         data_len: 200,
     };
 
+    let layout_no_art = mp4::synthesize_layout(&scan, &[], &[]).unwrap();
     let layout_single = mp4::synthesize_layout(&scan, &[], std::slice::from_ref(&art1)).unwrap();
     let layout_both = mp4::synthesize_layout(&scan, &[], &[art1, art2]).unwrap();
 
+    // art1 must actually change the layout compared to no-art.
+    assert_ne!(
+        layout_no_art, layout_single,
+        "first art input must alter the layout"
+    );
     // Both layouts must be identical — the second art input is ignored.
     assert_eq!(layout_single, layout_both);
 }


### PR DESCRIPTION
## Summary

Adds structural validation to  and documents the MP4 cover-art limitation.

1. **Layout validation** —  checks that no non-backing segment is empty and total length doesn't overflow u64. All format synthesizers now use this instead of .

2. **MP4 single-art limitation** — MP4/M4A only embeds the first cover-art input (the  atom maps to a single data item). Documented in README and locked by a test that verifies single-art and multi-art produce identical layouts.

## Changes

-  — Add  enum,  method,  constructor
- , , , ,  — Switch from  to 
-  — Add  variant
-  — Tests for empty segment, valid layout, empty backing, total overflow
-  — Test locking single-art behavior
-  — Document MP4 cover-art limitation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect and report invalid audio-file layouts during synthesis, improving error handling for malformed segment layouts.

* **Documentation**
  * Documented MP4/M4A cover-art limitation: synthesis currently embeds only the first available cover image.

* **Tests**
  * Added tests covering layout validation behavior and MP4/M4A cover-art synthesis to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->