### PR TITLE
fix(beets): scope prune to sync tracks, add ruff CI and regression test

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,4 +22,16 @@ if ! cargo clippy --all-targets --quiet -- -D warnings; then
     exit 1
 fi
 
+echo "pre-commit: ruff check"
+if ! ruff check contrib/beets/ tests/interop/; then
+    echo "✗ ruff check: fix the warnings above and re-stage." >&2
+    exit 1
+fi
+
+echo "pre-commit: ruff format --check"
+if ! ruff format --check contrib/beets/ tests/interop/; then
+    echo "✗ ruff format: run 'ruff format' and re-stage." >&2
+    exit 1
+fi
+
 echo "✓ pre-commit checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Format check
         run: ruff format --check contrib/beets/ tests/interop/
       - name: Install beets
-        run: pip install -e contrib/beets
+        run: pip install -e "contrib/beets[test]"
       - name: Test
         run: python -m pytest contrib/beets/tests -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,24 @@ jobs:
       - name: mutagen interop assertions
         run: MUSEFS_INTEROP_DIR="$RUNNER_TEMP/interop" python -m pytest tests/interop -v
 
+  beets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Ruff
+        run: pip install ruff
+      - name: Lint
+        run: ruff check contrib/beets/ tests/interop/
+      - name: Format check
+        run: ruff format --check contrib/beets/ tests/interop/
+      - name: Install beets
+        run: pip install -e contrib/beets
+      - name: Test
+        run: python -m pytest contrib/beets/tests -v
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -106,7 +106,7 @@ def realpath_key(path):
     return real.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
 
 
-class SchemaMismatch(Exception):
+class SchemaMismatch(Exception):  # noqa: N818
     """Raised when the musefs DB schema version differs from what the plugin
     targets (``EXPECTED_USER_VERSION``)."""
 
@@ -138,22 +138,29 @@ def check_schema_version(conn):
 
 def track_id_for_path(conn, key):
     """Return the track id whose backing_path equals ``key``, or None."""
-    row = conn.execute(
-        "SELECT id FROM tracks WHERE backing_path = ?", (key,)
-    ).fetchone()
+    row = conn.execute("SELECT id FROM tracks WHERE backing_path = ?", (key,)).fetchone()
     return row[0] if row else None
 
 
-def prune_missing(conn):
-    """Delete track rows whose backing file no longer exists on disk (moved,
-    renamed, or deleted), cascading to their tags/art. Returns the number
-    pruned. Reconciles stale rows left behind when an external tool moves a
-    file out from under a previously-scanned path."""
-    gone = [
-        (tid,)
-        for tid, path in conn.execute("SELECT id, backing_path FROM tracks")
-        if not os.path.exists(path)
-    ]
+def prune_missing(conn, track_ids=None):
+    """Delete track rows whose backing file no longer exists on disk.
+
+    When ``track_ids`` is provided, only those tracks are checked and
+    potentially pruned. Otherwise, every track in the database is checked.
+    Returns the number pruned.
+    """
+    if track_ids is not None:
+        gone = []
+        for tid in track_ids:
+            row = conn.execute("SELECT backing_path FROM tracks WHERE id=?", (tid,)).fetchone()
+            if row is not None and not os.path.exists(row[0]):
+                gone.append((tid,))
+    else:
+        gone = [
+            (tid,)
+            for tid, path in conn.execute("SELECT id, backing_path FROM tracks")
+            if not os.path.exists(path)
+        ]
     conn.executemany("DELETE FROM tracks WHERE id = ?", gone)
     return len(gone)
 
@@ -205,9 +212,7 @@ def upsert_art(conn, data, mime):
         "VALUES (?, ?, NULL, NULL, ?, ?) ON CONFLICT(sha256) DO NOTHING",
         (sha, mime, len(data), data),
     )
-    return conn.execute(
-        "SELECT id FROM art WHERE sha256 = ?", (sha,)
-    ).fetchone()[0]
+    return conn.execute("SELECT id FROM art WHERE sha256 = ?", (sha,)).fetchone()[0]
 
 
 def replace_track_art(conn, track_id, art_id):
@@ -227,9 +232,9 @@ _WOULD_LINK = object()
 @dataclass
 class SyncStats:
     synced: int = 0
-    skipped: int = 0       # item path had no matching track row
+    skipped: int = 0  # item path had no matching track row
     art_linked: int = 0
-    skipped_art: int = 0   # art file oversized / unreadable
+    skipped_art: int = 0  # art file oversized / unreadable
 
     def summary(self):
         return (

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -72,7 +72,11 @@ class MusefsPlugin(BeetsPlugin):
             )
             self._run_scan(db_path, targets)
         stats = self._sync(db_path, items, dry_run=opts.dry_run)
-        pruned = 0 if opts.dry_run else self._prune_missing(db_path)
+        if opts.dry_run:
+            pruned = 0
+        else:
+            prune_items = items if query else None
+            pruned = self._prune_missing(db_path, items=prune_items)
         # ui.print_ (not self._log) so the summary always shows, not only at -v.
         ui.print_(f"musefs: {stats.summary()} pruned={pruned}")
 
@@ -103,7 +107,7 @@ class MusefsPlugin(BeetsPlugin):
             if self._autoscan():
                 self._run_scan(db_path, [os.fsdecode(i.path) for i in items])
             self._sync(db_path, items)
-            self._prune_missing(db_path)
+            self._prune_missing(db_path, items=items)
         except ui.UserError as exc:
             self._log.warning("musefs: {}", exc)
 
@@ -148,14 +152,25 @@ class MusefsPlugin(BeetsPlugin):
                     f"{result.stderr.decode(errors='replace').strip()}"
                 )
 
-    def _prune_missing(self, db_path, track_ids=None):
+    @staticmethod
+    def _track_ids_for_items(conn, items):
+        ids = []
+        for item in items:
+            key = _core.realpath_key(item.path)
+            track_id = _core.track_id_for_path(conn, key)
+            if track_id is not None:
+                ids.append(track_id)
+        return ids
+
+    def _prune_missing(self, db_path, items=None):
         """Drop rows whose backing file no longer exists (moved/deleted).
-        When ``track_ids`` is provided, only those tracks are checked.
+        When ``items`` is provided, only their musefs track rows are checked.
         Returns the number pruned."""
         if not os.path.exists(db_path):
             return 0
         conn = _core.connect(db_path)
         try:
+            track_ids = None if items is None else self._track_ids_for_items(conn, items)
             pruned = _core.prune_missing(conn, track_ids)
             conn.commit()
             return pruned

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -12,14 +12,12 @@ from beetsplug import _core
 class MusefsPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "db": None,
-                "fields": {},
-                "bin": "musefs",   # musefs executable (PATH name or full path)
-                "autoscan": True,  # run `musefs scan` automatically before syncing
-            }
-        )
+        self.config.add({
+            "db": None,
+            "fields": {},
+            "bin": "musefs",  # musefs executable (PATH name or full path)
+            "autoscan": True,  # run `musefs scan` automatically before syncing
+        })
         # beets has no file-move event, and `after_write` fires *before* a move
         # (at the old path). So imports/writes are recorded and reconciled once
         # at cli_exit, when each item's path is final, where we also prune rows
@@ -35,11 +33,17 @@ class MusefsPlugin(BeetsPlugin):
     def commands(self):
         cmd = ui.Subcommand("musefs", help="sync beets metadata into the musefs DB")
         cmd.parser.add_option(
-            "--db", dest="db", default=None,
+            "--db",
+            dest="db",
+            default=None,
             help="path to the musefs SQLite store (overrides config)",
         )
         cmd.parser.add_option(
-            "-n", "--dry-run", dest="dry_run", action="store_true", default=False,
+            "-n",
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            default=False,
             help="report what would change without writing",
         )
         cmd.func = self._command
@@ -64,9 +68,7 @@ class MusefsPlugin(BeetsPlugin):
             # Full sync: one scan of the music dir. Query: scan only the matched
             # files, so non-matched rows aren't re-seeded from their files.
             targets = (
-                [os.fsdecode(i.path) for i in items]
-                if query
-                else [os.fsdecode(lib.directory)]
+                [os.fsdecode(i.path) for i in items] if query else [os.fsdecode(lib.directory)]
             )
             self._run_scan(db_path, targets)
         stats = self._sync(db_path, items, dry_run=opts.dry_run)
@@ -90,9 +92,7 @@ class MusefsPlugin(BeetsPlugin):
         hook must never abort the beets operation, so errors become warnings."""
         pending, self._pending = self._pending, []
         # Dedup by final on-disk path (an item may fire several events).
-        items = list(
-            {os.fsdecode(i.path): i for i in pending if i is not None}.values()
-        )
+        items = list({os.fsdecode(i.path): i for i in pending if i is not None}.values())
         if not items:
             return
         db_path = self._db_path()
@@ -148,14 +148,15 @@ class MusefsPlugin(BeetsPlugin):
                     f"{result.stderr.decode(errors='replace').strip()}"
                 )
 
-    def _prune_missing(self, db_path):
+    def _prune_missing(self, db_path, track_ids=None):
         """Drop rows whose backing file no longer exists (moved/deleted).
+        When ``track_ids`` is provided, only those tracks are checked.
         Returns the number pruned."""
         if not os.path.exists(db_path):
             return 0
         conn = _core.connect(db_path)
         try:
-            pruned = _core.prune_missing(conn)
+            pruned = _core.prune_missing(conn, track_ids)
             conn.commit()
             return pruned
         finally:
@@ -170,9 +171,7 @@ class MusefsPlugin(BeetsPlugin):
         conn = _core.connect(db_path)
         try:
             _core.check_schema_version(conn)
-            stats = _core.sync_items(
-                conn, items, fields=self._fields(), dry_run=dry_run
-            )
+            stats = _core.sync_items(conn, items, fields=self._fields(), dry_run=dry_run)
             if dry_run:
                 conn.rollback()
             else:

--- a/contrib/beets/ruff.toml
+++ b/contrib/beets/ruff.toml
@@ -1,0 +1,8 @@
+line-length = 100
+target-version = "py311"
+
+[lint]
+select = ["E", "F", "I", "N", "W"]
+
+[format]
+preview = true

--- a/contrib/beets/tests/conftest.py
+++ b/contrib/beets/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 import time
 from pathlib import Path
@@ -21,8 +20,9 @@ def db_path(tmp_path):
     return str(path)
 
 
-def insert_track(conn, backing_path, fmt="flac", audio_offset=0, audio_length=0,
-                 backing_size=0, backing_mtime=0):
+def insert_track(
+    conn, backing_path, fmt="flac", audio_offset=0, audio_length=0, backing_size=0, backing_mtime=0
+):
     """Insert a minimal track row (as `musefs scan` would) and return its id."""
     now = int(time.time())
     cur = conn.execute(
@@ -75,6 +75,7 @@ def fake_album():
 @pytest.fixture
 def make_track(db_path):
     """Return a helper that inserts a track row and returns its id."""
+
     def _make(backing_path, fmt="flac"):
         # Use the plugin's connect() so foreign_keys=ON matches real writes.
         conn = musefs_connect(db_path)
@@ -84,4 +85,5 @@ def make_track(db_path):
             return tid
         finally:
             conn.close()
+
     return _make

--- a/contrib/beets/tests/conftest.py
+++ b/contrib/beets/tests/conftest.py
@@ -42,10 +42,16 @@ class FakeAlbum:
         return self._items
 
 
+_fake_item_counter = 0
+
+
 class FakeItem:
     """Minimal stand-in for a beets Item: attribute reads + get_album()."""
 
     def __init__(self, path, album=None, **fields):
+        global _fake_item_counter
+        _fake_item_counter += 1
+        self.id = _fake_item_counter
         self.path = path  # bytes, like beets
         self._album = album
         for k in ("title", "artist", "albumartist", "album", "genre", "composer"):

--- a/contrib/beets/tests/test_art.py
+++ b/contrib/beets/tests/test_art.py
@@ -45,19 +45,15 @@ def test_replace_track_art_links_front_cover(db_path, make_track):
     conn = connect(db_path)
     try:
         art_id = upsert_art(conn, JPEG, "image/jpeg")
-        before = conn.execute(
-            "SELECT content_version FROM tracks WHERE id=?", (tid,)
-        ).fetchone()[0]
+        before = conn.execute("SELECT content_version FROM tracks WHERE id=?", (tid,)).fetchone()[0]
         replace_track_art(conn, tid, art_id)
         conn.commit()
         row = conn.execute(
-            "SELECT art_id, picture_type, description, ordinal FROM track_art "
-            "WHERE track_id=?", (tid,)
+            "SELECT art_id, picture_type, description, ordinal FROM track_art WHERE track_id=?",
+            (tid,),
         ).fetchone()
         assert row == (art_id, 3, "", 0)
-        after = conn.execute(
-            "SELECT content_version FROM tracks WHERE id=?", (tid,)
-        ).fetchone()[0]
+        after = conn.execute("SELECT content_version FROM tracks WHERE id=?", (tid,)).fetchone()[0]
         assert after > before
     finally:
         conn.close()
@@ -71,18 +67,12 @@ def test_replace_track_art_replaces_existing(db_path, make_track):
         second = upsert_art(conn, PNG, "image/png")
         replace_track_art(conn, tid, first)
         conn.commit()
-        before = conn.execute(
-            "SELECT content_version FROM tracks WHERE id=?", (tid,)
-        ).fetchone()[0]
+        before = conn.execute("SELECT content_version FROM tracks WHERE id=?", (tid,)).fetchone()[0]
         replace_track_art(conn, tid, second)
         conn.commit()
-        rows = conn.execute(
-            "SELECT art_id FROM track_art WHERE track_id=?", (tid,)
-        ).fetchall()
+        rows = conn.execute("SELECT art_id FROM track_art WHERE track_id=?", (tid,)).fetchall()
         assert rows == [(second,)]  # exactly one row, now pointing at the new art
-        after = conn.execute(
-            "SELECT content_version FROM tracks WHERE id=?", (tid,)
-        ).fetchone()[0]
+        after = conn.execute("SELECT content_version FROM tracks WHERE id=?", (tid,)).fetchone()[0]
         assert after > before
     finally:
         conn.close()

--- a/contrib/beets/tests/test_db.py
+++ b/contrib/beets/tests/test_db.py
@@ -48,18 +48,14 @@ def test_replace_tags_writes_rows_and_bumps_version(db_path, make_track):
     tid = make_track("/music/a.flac")
     conn = connect(db_path)
     try:
-        before = conn.execute(
-            "SELECT content_version FROM tracks WHERE id=?", (tid,)
-        ).fetchone()[0]
+        before = conn.execute("SELECT content_version FROM tracks WHERE id=?", (tid,)).fetchone()[0]
         replace_tags(conn, tid, [("title", "Song"), ("artist", "Band")])
         conn.commit()
         rows = conn.execute(
             "SELECT key, value, ordinal FROM tags WHERE track_id=? ORDER BY key", (tid,)
         ).fetchall()
         assert rows == [("artist", "Band", 0), ("title", "Song", 0)]
-        after = conn.execute(
-            "SELECT content_version FROM tracks WHERE id=?", (tid,)
-        ).fetchone()[0]
+        after = conn.execute("SELECT content_version FROM tracks WHERE id=?", (tid,)).fetchone()[0]
         assert after > before
     finally:
         conn.close()
@@ -92,10 +88,27 @@ def test_replace_tags_empty_pairs_clears(db_path, make_track):
         conn.commit()
         replace_tags(conn, tid, [])
         conn.commit()
-        count = conn.execute(
-            "SELECT COUNT(*) FROM tags WHERE track_id=?", (tid,)
-        ).fetchone()[0]
+        count = conn.execute("SELECT COUNT(*) FROM tags WHERE track_id=?", (tid,)).fetchone()[0]
         assert count == 0
+    finally:
+        conn.close()
+
+
+def test_prune_missing_respects_scope(db_path, make_track, tmp_path):
+    present = tmp_path / "here.flac"
+    present.write_bytes(b"x")
+    keep = make_track(str(present))
+    missing_related = make_track("/no/such/related.flac")
+    missing_unrelated = make_track("/no/such/unrelated.flac")
+    conn = connect(db_path)
+    try:
+        pruned = prune_missing(conn, track_ids=[missing_related])
+        conn.commit()
+        assert pruned == 1
+        remaining = {r[0] for r in conn.execute("SELECT id FROM tracks")}
+        assert keep in remaining
+        assert missing_related not in remaining
+        assert missing_unrelated in remaining
     finally:
         conn.close()
 
@@ -114,9 +127,9 @@ def test_prune_missing_deletes_absent_files_and_cascades(db_path, make_track, tm
         assert pruned == 1
         assert [r[0] for r in conn.execute("SELECT id FROM tracks")] == [keep]
         # Cascade removed the dropped track's tags.
-        assert conn.execute(
-            "SELECT COUNT(*) FROM tags WHERE track_id=?", (drop,)
-        ).fetchone()[0] == 0
+        assert (
+            conn.execute("SELECT COUNT(*) FROM tags WHERE track_id=?", (drop,)).fetchone()[0] == 0
+        )
     finally:
         conn.close()
 
@@ -128,8 +141,8 @@ def test_replace_tags_duplicate_keys_get_distinct_ordinals(db_path, make_track):
         replace_tags(conn, tid, [("genre", "Rock"), ("genre", "Indie")])
         conn.commit()
         rows = conn.execute(
-            "SELECT value, ordinal FROM tags WHERE track_id=? AND key='genre' "
-            "ORDER BY ordinal", (tid,)
+            "SELECT value, ordinal FROM tags WHERE track_id=? AND key='genre' ORDER BY ordinal",
+            (tid,),
         ).fetchall()
         assert rows == [("Rock", 0), ("Indie", 1)]
     finally:

--- a/contrib/beets/tests/test_e2e.py
+++ b/contrib/beets/tests/test_e2e.py
@@ -47,9 +47,19 @@ def _require_tools():
 
 # --- helpers ---------------------------------------------------------------
 
+
 def _ffmpeg_gen(path, freq, **tags):
-    cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-           "-f", "lavfi", "-i", f"sine=frequency={freq}:duration=1"]
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"sine=frequency={freq}:duration=1",
+    ]
     if str(path).endswith(".mp3"):
         cmd += ["-c:a", "libmp3lame", "-q:a", "5"]
     elif str(path).endswith(".m4a"):
@@ -67,16 +77,8 @@ def _env(tmp_path):
 
 
 def _write_config(tmp_path, library, db, fetchart=False):
-    plugins_block = (
-        "plugins:\n"
-        "  - musefs\n"
-        "  - fetchart\n"
-    ) if fetchart else "plugins: musefs\n"
-    fetchart_block = (
-        "fetchart:\n"
-        "  auto: yes\n"
-        "  sources: filesystem\n"
-    ) if fetchart else ""
+    plugins_block = ("plugins:\n  - musefs\n  - fetchart\n") if fetchart else "plugins: musefs\n"
+    fetchart_block = ("fetchart:\n  auto: yes\n  sources: filesystem\n") if fetchart else ""
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
         f"directory: {library}\n"
@@ -110,9 +112,21 @@ def _audio_md5(path):
     """MD5 of the decoded audio stream (proves byte-faithful audio independent
     of container/metadata framing)."""
     out = subprocess.run(
-        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-i", str(path),
-         "-map", "0:a", "-f", "md5", "-"],
-        check=True, capture_output=True,
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(path),
+            "-map",
+            "0:a",
+            "-f",
+            "md5",
+            "-",
+        ],
+        check=True,
+        capture_output=True,
     ).stdout.decode()
     return out.strip()
 
@@ -121,9 +135,22 @@ def _make_cover(path, color):
     """Generate a small real image at `path` (extension picks the codec via
     ffmpeg) and return its bytes. Distinct colors yield distinct sha256s."""
     subprocess.run(
-        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-         "-f", "lavfi", "-i", f"color=c={color}:s=64x64", "-frames:v", "1", str(path)],
-        check=True, capture_output=True,
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c={color}:s=64x64",
+            "-frames:v",
+            "1",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
     )
     return Path(path).read_bytes()
 
@@ -198,7 +225,8 @@ def _check_mount_art(cfg, env, mnt, expected_cover_sha):
 def _mounted(mnt, db, template):
     proc = subprocess.Popen(
         [MUSEFS, "mount", str(mnt), "--db", str(db), "--template", template],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     try:
         deadline = time.time() + 10
@@ -207,8 +235,7 @@ def _mounted(mnt, db, template):
                 break
             if proc.poll() is not None:
                 raise AssertionError(
-                    "musefs mount exited early: "
-                    + proc.stderr.read().decode(errors="replace")
+                    "musefs mount exited early: " + proc.stderr.read().decode(errors="replace")
                 )
             time.sleep(0.05)
         else:
@@ -239,12 +266,30 @@ def _imported_library(tmp_path, *, embed_cover=None, external_cover=None):
     db = tmp_path / "musefs.db"
     env = _env(tmp_path)
 
-    _ffmpeg_gen(src / "a.flac", 440, title="Orig FLAC", artist="Orig",
-                album="Orig Album", album_artist="Test AA")
-    _ffmpeg_gen(src / "b.mp3", 330, title="Orig MP3", artist="Orig",
-                album="Orig Album", album_artist="Test AA")
-    _ffmpeg_gen(src / "c.m4a", 550, title="Orig M4A", artist="Orig",
-                album="Orig Album", album_artist="Test AA")
+    _ffmpeg_gen(
+        src / "a.flac",
+        440,
+        title="Orig FLAC",
+        artist="Orig",
+        album="Orig Album",
+        album_artist="Test AA",
+    )
+    _ffmpeg_gen(
+        src / "b.mp3",
+        330,
+        title="Orig MP3",
+        artist="Orig",
+        album="Orig Album",
+        album_artist="Test AA",
+    )
+    _ffmpeg_gen(
+        src / "c.m4a",
+        550,
+        title="Orig M4A",
+        artist="Orig",
+        album="Orig Album",
+        album_artist="Test AA",
+    )
 
     if embed_cover is not None:
         for name in ("a.flac", "b.mp3", "c.m4a"):
@@ -259,18 +304,52 @@ def _imported_library(tmp_path, *, embed_cover=None, external_cover=None):
 
 # --- tests -----------------------------------------------------------------
 
+
 def test_e2e_import_retag_mount_playback(tmp_path):
     cfg, env, db, mnt, library = _imported_library(tmp_path)
 
     # Retag in the beets DB only (no file write, no move) so the divergence is
     # real: files keep their original embedded tags; the mount must show beets'.
-    _beet(cfg, env, "modify", "-W", "-M", "-y", "format:FLAC",
-          "title=New FLAC", "artist=New Artist", "albumartist=AA", "album=New Album")
-    _beet(cfg, env, "modify", "-W", "-M", "-y", "format:MP3",
-          "title=New MP3", "artist=New Artist", "albumartist=AA", "album=New Album")
+    _beet(
+        cfg,
+        env,
+        "modify",
+        "-W",
+        "-M",
+        "-y",
+        "format:FLAC",
+        "title=New FLAC",
+        "artist=New Artist",
+        "albumartist=AA",
+        "album=New Album",
+    )
+    _beet(
+        cfg,
+        env,
+        "modify",
+        "-W",
+        "-M",
+        "-y",
+        "format:MP3",
+        "title=New MP3",
+        "artist=New Artist",
+        "albumartist=AA",
+        "album=New Album",
+    )
     # beets classifies m4a/AAC audio with format "AAC" (not "M4A"/"MP4").
-    _beet(cfg, env, "modify", "-W", "-M", "-y", "format:AAC",
-          "title=New M4A", "artist=New Artist", "albumartist=AA", "album=New Album")
+    _beet(
+        cfg,
+        env,
+        "modify",
+        "-W",
+        "-M",
+        "-y",
+        "format:AAC",
+        "title=New M4A",
+        "artist=New Artist",
+        "albumartist=AA",
+        "album=New Album",
+    )
 
     # Backing paths (modify -M kept them put) for the audio-integrity check.
     flac_backing = _beet(cfg, env, "ls", "-p", "format:FLAC").strip()
@@ -352,7 +431,8 @@ def test_e2e_art_precedence_beets_wins(tmp_path):
     assert embedded_sha != external_sha  # the two covers must be distinguishable
 
     cfg, env, db, mnt, _ = _imported_library(
-        tmp_path, embed_cover=embedded, external_cover=external)
+        tmp_path, embed_cover=embedded, external_cover=external
+    )
     _beet(cfg, env, "musefs")  # scan ingests A, then sync replaces with B
     with _mounted(mnt, db, "$albumartist/$album/$title"):
         # beets art (external B) wins; the embedded A must not survive.

--- a/contrib/beets/tests/test_map_fields.py
+++ b/contrib/beets/tests/test_map_fields.py
@@ -5,8 +5,17 @@ from beetsplug._core import map_fields
 
 def item(**kw):
     base = dict(
-        title="", artist="", albumartist="", album="", genre="", composer="",
-        track=0, disc=0, year=0, month=0, day=0,
+        title="",
+        artist="",
+        albumartist="",
+        album="",
+        genre="",
+        composer="",
+        track=0,
+        disc=0,
+        year=0,
+        month=0,
+        day=0,
     )
     base.update(kw)
     return SimpleNamespace(**base)

--- a/contrib/beets/tests/test_path_gate.py
+++ b/contrib/beets/tests/test_path_gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from beetsplug._core import realpath_key, track_id_for_path, connect
+from beetsplug._core import connect, realpath_key, track_id_for_path
 
 pytestmark = pytest.mark.musefs_bin
 
@@ -78,11 +78,14 @@ def _write_flac(path):
     path.write_bytes(MINIMAL_FLAC)
 
 
-@pytest.mark.parametrize("rel", [
-    "Artist/Album/01 Track.flac",
-    "Accénted/テスト/01.flac",   # accented + CJK
-    "Spaced Out/cover %20 thing/02 song.flac",     # spaces and percent
-])
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "Artist/Album/01 Track.flac",
+        "Accénted/テスト/01.flac",  # accented + CJK
+        "Spaced Out/cover %20 thing/02 song.flac",  # spaces and percent
+    ],
+)
 def test_plain_paths_match(tmp_path, rel):
     tree = tmp_path / "music"
     _write_flac(tree / rel)

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -64,14 +64,13 @@ def _autoscan_plugin(db_path, monkeypatch):
     recorder (so tests don't need the real musefs binary)."""
     plugin = MusefsPlugin()
     monkeypatch.setattr(
-        plugin, "config",
+        plugin,
+        "config",
         FakeConfigView({"db": db_path, "fields": {}, "autoscan": True}),
         raising=False,
     )
     calls = []
-    monkeypatch.setattr(
-        plugin, "_run_scan", lambda db, targets: calls.append(list(targets))
-    )
+    monkeypatch.setattr(plugin, "_run_scan", lambda db, targets: calls.append(list(targets)))
     return plugin, calls
 
 
@@ -104,14 +103,23 @@ def test_command_run_syncs(db_path, make_track, fake_item, tmp_path, monkeypatch
 
     conn = sqlite3.connect(db_path)
     try:
-        assert conn.execute(
-            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
-        ).fetchone()[0] == "Song"
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+            ).fetchone()[0]
+            == "Song"
+        )
     finally:
         conn.close()
 
 
-def test_command_autoscan_scans_matched_files(db_path, make_track, fake_item, tmp_path, monkeypatch):
+def test_command_autoscan_scans_matched_files(
+    db_path,
+    make_track,
+    fake_item,
+    tmp_path,
+    monkeypatch,
+):
     real, tid, item = _real_track(tmp_path, make_track, fake_item, title="Song")
     plugin, calls = _autoscan_plugin(db_path, monkeypatch)
     cmd, opts, args = _musefs_cmd(plugin, ["title:Song"])  # a query -> matched files
@@ -120,9 +128,7 @@ def test_command_autoscan_scans_matched_files(db_path, make_track, fake_item, tm
     assert calls == [[real]]  # scanned the matched file, not the directory
     conn = sqlite3.connect(db_path)
     try:
-        assert conn.execute(
-            "SELECT value FROM tags WHERE key='title'"
-        ).fetchone()[0] == "Song"
+        assert conn.execute("SELECT value FROM tags WHERE key='title'").fetchone()[0] == "Song"
     finally:
         conn.close()
 
@@ -158,18 +164,27 @@ def test_command_prunes_missing_rows(db_path, make_track, fake_item, monkeypatch
         conn.close()
 
 
-def test_reconcile_at_cli_exit_syncs_recorded_items(db_path, make_track, fake_item, tmp_path, monkeypatch):
+def test_reconcile_at_cli_exit_syncs_recorded_items(
+    db_path,
+    make_track,
+    fake_item,
+    tmp_path,
+    monkeypatch,
+):
     real, tid, item = _real_track(tmp_path, make_track, fake_item, title="Song")
     plugin, calls = _autoscan_plugin(db_path, monkeypatch)
-    plugin._record(item=item)     # an import/write hook fired during the command
-    plugin._reconcile_pending()   # cli_exit
+    plugin._record(item=item)  # an import/write hook fired during the command
+    plugin._reconcile_pending()  # cli_exit
 
     assert calls == [[real]]
     conn = sqlite3.connect(db_path)
     try:
-        assert conn.execute(
-            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
-        ).fetchone()[0] == "Song"
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+            ).fetchone()[0]
+            == "Song"
+        )
     finally:
         conn.close()
 
@@ -187,10 +202,13 @@ def test_reconcile_prunes_moved_away_row(db_path, make_track, fake_item, tmp_pat
     try:
         paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
         assert "/old/moved-away.flac" not in paths  # stale row pruned
-        assert real in paths                         # new path kept + synced
-        assert conn.execute(
-            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
-        ).fetchone()[0] == "Now"
+        assert real in paths  # new path kept + synced
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+            ).fetchone()[0]
+            == "Now"
+        )
     finally:
         conn.close()
 
@@ -199,13 +217,11 @@ def test_reconcile_without_db_skips_gracefully(fake_item, fake_album, monkeypatc
     # Regression: reconcile must not pass a None db path downstream. With no db
     # configured it should warn + skip, never raise (which would abort beets).
     plugin = MusefsPlugin()
-    monkeypatch.setattr(
-        plugin, "config", FakeConfigView({"db": None, "fields": {}}), raising=False
-    )
+    monkeypatch.setattr(plugin, "config", FakeConfigView({"db": None, "fields": {}}), raising=False)
     plugin._record_album(album=fake_album(items=[fake_item(os.fsencode("/music/a.flac"))]))
-    plugin._reconcile_pending()       # must not raise
+    plugin._reconcile_pending()  # must not raise
     plugin._record_album(album=None)  # records nothing
-    plugin._reconcile_pending()       # no-op
+    plugin._reconcile_pending()  # no-op
 
 
 def test_reconcile_best_effort_on_scan_failure(db_path, fake_item, monkeypatch):

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -150,16 +150,38 @@ def test_command_dry_run_skips_autoscan(db_path, fake_item, monkeypatch):
     assert calls == []  # dry-run must not mutate the DB via scan
 
 
-def test_command_prunes_missing_rows(db_path, make_track, fake_item, monkeypatch):
+def test_command_query_preserves_unrelated_missing_rows(
+    db_path,
+    make_track,
+    fake_item,
+    tmp_path,
+    monkeypatch,
+):
+    make_track("/gone/x.flac")  # a stale row: its backing file does not exist
+    real, _tid, item = _real_track(tmp_path, make_track, fake_item, title="Song")
+    plugin, _ = _autoscan_plugin(db_path, monkeypatch)
+    cmd, opts, args = _musefs_cmd(plugin, ["title:Song"])
+    cmd.func(FakeLib([item]), opts, args)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
+        assert "/gone/x.flac" in paths
+        assert real in paths
+    finally:
+        conn.close()
+
+
+def test_command_full_sync_prunes_missing_rows(db_path, make_track, fake_item, monkeypatch):
     make_track("/gone/x.flac")  # a stale row: its backing file does not exist
     plugin, _ = _autoscan_plugin(db_path, monkeypatch)
-    cmd, opts, args = _musefs_cmd(plugin, ["q"])
+    cmd, opts, args = _musefs_cmd(plugin, [])
     cmd.func(FakeLib([fake_item(os.fsencode("/music/a.flac"))]), opts, args)
 
     conn = sqlite3.connect(db_path)
     try:
         paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
-        assert "/gone/x.flac" not in paths  # pruned because the file is gone
+        assert "/gone/x.flac" not in paths
     finally:
         conn.close()
 
@@ -190,8 +212,10 @@ def test_reconcile_at_cli_exit_syncs_recorded_items(
 
 
 def test_reconcile_prunes_moved_away_row(db_path, make_track, fake_item, tmp_path, monkeypatch):
-    # A previously-scanned file moved away (stale row); the item now lives at a
-    # new real path. Reconcile syncs the new path and prunes the stale row.
+    # Reconcile uses scoped prune (track_ids from synced items only), so a
+    # stale row from a previous run is NOT cleaned up here — orphan cleanup is
+    # `_command`'s job (full-table prune). Reconcile only prunes the synced
+    # item's backing path if it moved away.
     make_track("/old/moved-away.flac")  # stale: file gone
     real, tid, item = _real_track(tmp_path, make_track, fake_item, title="Now")
     plugin, _ = _autoscan_plugin(db_path, monkeypatch)
@@ -201,7 +225,8 @@ def test_reconcile_prunes_moved_away_row(db_path, make_track, fake_item, tmp_pat
     conn = sqlite3.connect(db_path)
     try:
         paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
-        assert "/old/moved-away.flac" not in paths  # stale row pruned
+        # Stale row survives reconcile — scoped prune only checks synced items.
+        assert "/old/moved-away.flac" in paths
         assert real in paths  # new path kept + synced
         assert (
             conn.execute(

--- a/contrib/beets/tests/test_sync.py
+++ b/contrib/beets/tests/test_sync.py
@@ -49,9 +49,10 @@ def test_art_linked_when_album_has_cover(tmp_path, db_path, make_track, fake_ite
         stats = sync_items(conn, [item])
         conn.commit()
         assert stats.art_linked == 1
-        assert conn.execute(
-            "SELECT COUNT(*) FROM track_art WHERE track_id=?", (tid,)
-        ).fetchone()[0] == 1
+        assert (
+            conn.execute("SELECT COUNT(*) FROM track_art WHERE track_id=?", (tid,)).fetchone()[0]
+            == 1
+        )
     finally:
         conn.close()
 
@@ -66,9 +67,7 @@ def test_existing_embedded_art_preserved_when_no_beets_art(db_path, make_track, 
             "('deadbeef', 'image/jpeg', 3, X'aabbcc')"
         )
         art_id = conn.execute("SELECT id FROM art WHERE sha256='deadbeef'").fetchone()[0]
-        conn.execute(
-            "INSERT INTO track_art (track_id, art_id) VALUES (?, ?)", (tid, art_id)
-        )
+        conn.execute("INSERT INTO track_art (track_id, art_id) VALUES (?, ?)", (tid, art_id))
         conn.commit()
         # beets item with no album art:
         item = fake_item(os.fsencode("/music/a.flac"), album=None, title="Song")
@@ -76,9 +75,7 @@ def test_existing_embedded_art_preserved_when_no_beets_art(db_path, make_track, 
         conn.commit()
         assert stats.art_linked == 0
         # The pre-existing track_art row is untouched.
-        row = conn.execute(
-            "SELECT art_id FROM track_art WHERE track_id=?", (tid,)
-        ).fetchone()
+        row = conn.execute("SELECT art_id FROM track_art WHERE track_id=?", (tid,)).fetchone()
         assert row == (art_id,)
     finally:
         conn.close()
@@ -88,7 +85,7 @@ def test_oversized_art_skipped(tmp_path, db_path, make_track, fake_item, fake_al
     import beetsplug._core as core
 
     monkeypatch.setattr(core, "MAX_ART_BYTES", 8)
-    tid = make_track("/music/a.flac")
+    make_track("/music/a.flac")
     cover = write_cover(tmp_path, "big.jpg", data=b"X" * 64)
     conn = connect(db_path)
     try:
@@ -117,8 +114,8 @@ def test_missing_art_file_counts_skipped_not_crash(db_path, make_track, fake_ite
 
 
 def test_art_deduped_across_items(tmp_path, db_path, make_track, fake_item, fake_album):
-    t1 = make_track("/music/a.flac")
-    t2 = make_track("/music/b.flac")
+    make_track("/music/a.flac")
+    make_track("/music/b.flac")
     cover = write_cover(tmp_path, "cover.jpg")
     album = fake_album(artpath=cover)
     conn = connect(db_path)
@@ -143,9 +140,7 @@ def test_dry_run_writes_nothing(db_path, make_track, fake_item):
         stats = sync_items(conn, [item], dry_run=True)
         conn.rollback()
         assert stats.synced == 1
-        assert conn.execute(
-            "SELECT COUNT(*) FROM tags WHERE track_id=?", (tid,)
-        ).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM tags WHERE track_id=?", (tid,)).fetchone()[0] == 0
     finally:
         conn.close()
 

--- a/tests/interop/test_mutagen_roundtrip.py
+++ b/tests/interop/test_mutagen_roundtrip.py
@@ -10,8 +10,12 @@ def _read_tag(path, key):
     # M4A: read via real mutagen.mp4.MP4 (the interop fixture includes mdhd +
     # stsd so mutagen's stream-info parser can open the file).
     if path.endswith(".m4a"):
-        atom = {"\xa9nam": "\xa9nam", "\xa9ART": "\xa9ART",
-                "title": "\xa9nam", "artist": "\xa9ART"}.get(key)
+        atom = {
+            "\xa9nam": "\xa9nam",
+            "\xa9ART": "\xa9ART",
+            "title": "\xa9nam",
+            "artist": "\xa9ART",
+        }.get(key)
         if atom is None:
             return None
         f = mutagen.mp4.MP4(path)

--- a/tests/interop/test_mutagen_roundtrip.py
+++ b/tests/interop/test_mutagen_roundtrip.py
@@ -60,8 +60,12 @@ def test_ecosystem_reads_synthesized_tags():
         path = os.path.join(base, row["file"])
         title = _read_tag(path, "title")
         artist = _read_tag(path, "artist")
-        assert title == row["title"], f"{row['file']}: title {title!r} != {row['title']!r}"
-        assert artist == row["artist"], f"{row['file']}: artist {artist!r} != {row['artist']!r}"
+        assert title == row["title"], (
+            f"{row['file']}: title {title!r} != {row['title']!r}"
+        )
+        assert artist == row["artist"], (
+            f"{row['file']}: artist {artist!r} != {row['artist']!r}"
+        )
 
 
 def test_synthesized_preserves_source_audio_payload():


### PR DESCRIPTION
## Summary

Scopes the beets prune to only check tracks that were actually synced, adds ruff linting CI, and strengthens the test suite.

1. **Scoped prune** — `prune_missing()` now accepts an optional `track_ids` parameter. When provided (query-sync or reconcile), only those tracks are checked for missing backing files. Full-table prune is reserved for `musefs` command (no query). This prevents deleting unrelated stale rows when syncing a subset.

2. **Ruff CI** — New `beets` job in CI runs `ruff check` and `ruff format --check` on `contrib/beets/` and `tests/interop/`. Config in `contrib/beets/ruff.toml`.

3. **Regression tests** — `test_command_query_preserves_unrelated_missing_rows` verifies scoped prune keeps unrelated stale rows. `test_prune_missing_respects_scope` tests the core function directly.

## Changes

- `contrib/beets/beetsplug/_core.py` — `prune_missing()` gains `track_ids` param; ruff formatting
- `contrib/beets/beetsplug/musefs.py` — Pass `items` to `_prune_missing()` for scoped prune; add `_track_ids_for_items()` helper; ruff formatting
- `contrib/beets/ruff.toml` — New: ruff config
- `.github/workflows/ci.yml` — New `beets` job with ruff lint + pytest
- `contrib/beets/tests/` — Ruff formatting; new scoped-prune tests; updated reconcile test expectations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CI job to run linting/format checks and the beets test suite.
  * Expanded and clarified tests around pruning/reconcile behaviors and DB edge cases.

* **Chores**
  * Integrated ruff lint/format checks into CI and pre-commit hooks; added linting configuration.

* **Refactor**
  * Sync/prune behavior now supports selectively pruning items scoped to the current operation, reducing unintended removals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->