### PR TITLE
ci: pin actions to commit SHAs, add test gate to pre-commit, extract parse_mount_config

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,6 +22,12 @@ if ! cargo clippy --all-targets --quiet -- -D warnings; then
     exit 1
 fi
 
+echo "pre-commit: cargo test --workspace"
+if ! cargo test --workspace --quiet; then
+    echo "✗ tests: fix the failures above and re-stage." >&2
+    exit 1
+fi
+
 echo "pre-commit: ruff check"
 if ! ruff check contrib/beets/ tests/interop/; then
     echo "✗ ruff check: fix the warnings above and re-stage." >&2

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,9 @@ jobs:
       issues: write
       checks: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Install libfuse3
         run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -38,10 +40,12 @@ jobs:
     # then reads them back with mutagen. Builds only musefs-core, so no libfuse.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.x'
       - name: Install mutagen + pytest
@@ -54,8 +58,10 @@ jobs:
   beets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.x'
       - name: Install Ruff
@@ -72,10 +78,12 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Install libfuse3
         run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: FUSE end-to-end tests
         run: cargo test -p musefs-fuse -- --ignored

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
+        uses: taiki-e/install-action@6ed6112eb9893c58dd600eebccdf6e77ab7bfa9c
         with:
           tool: cargo-llvm-cov
       - name: Collect coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,22 +18,24 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Install libfuse3
         run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev pkg-config
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a
         with:
           tool: cargo-llvm-cov
       - name: Collect coverage
         run: cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
         with:
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,9 +23,13 @@ jobs:
     # Per-PR: build all targets + a few seconds each to catch broken targets.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: 'fuzz'
       - name: Install cargo-fuzz
@@ -49,9 +53,13 @@ jobs:
       matrix:
         target: [flac, mp3, mp4, ogg, wav, ogg_page, b64, vorbiscomment]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           workspaces: 'fuzz'
       - name: Install cargo-fuzz
@@ -63,7 +71,7 @@ jobs:
       # restore-keys prefix to restore the most recent prior corpus, so coverage
       # accumulates across scheduled runs.
       - name: Restore corpus
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: fuzz/corpus/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
@@ -76,7 +84,7 @@ jobs:
         run: cargo +nightly fuzz cmin ${{ matrix.target }} -- -max_len=131072
       - name: Upload crashes
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         target: 90%
         threshold: 5%
+        informational: true
 
 ignore:
   - "docs/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 90%
+        threshold: 5%
+
+ignore:
+  - "docs/**"
+  - "fuzz/**"
+  - ".github/**"
+  - ".githooks/**"
+  - "contrib/**"
+  - "tests/interop/**"

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -113,6 +113,35 @@ pub fn run_scan(db_path: &Path, backing_dir: &Path, revalidate: bool) -> Result<
     Ok(())
 }
 
+/// Parse mount CLI flags into `MountConfig` and `FuseConfig`. Pure function —
+/// no DB access, no mounting. Exported for unit testing.
+#[allow(clippy::too_many_arguments)]
+pub fn parse_mount_config(
+    template: String,
+    default_fallback: String,
+    mode: musefs_core::Mode,
+    poll_interval_ms: u64,
+    attr_ttl_ms: u64,
+    max_readahead_kib: u32,
+    max_background: u16,
+    keep_cache: bool,
+) -> (MountConfig, musefs_fuse::FuseConfig) {
+    let config = MountConfig {
+        template,
+        fallbacks: BTreeMap::new(),
+        default_fallback,
+        mode,
+        poll_interval: std::time::Duration::from_millis(poll_interval_ms),
+    };
+    let fuse_config = musefs_fuse::FuseConfig {
+        ttl: std::time::Duration::from_millis(attr_ttl_ms),
+        max_readahead: max_readahead_kib.saturating_mul(1024),
+        max_background,
+        keep_cache,
+    };
+    (config, fuse_config)
+}
+
 /// Build a `Musefs` from the DB at `db_path` and mount it (blocking) at
 /// `mountpoint`.
 #[allow(clippy::too_many_arguments)]
@@ -130,19 +159,16 @@ pub fn run_mount(
 ) -> Result<()> {
     let db =
         Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
-    let config = MountConfig {
+    let (config, fuse_config) = parse_mount_config(
         template,
-        fallbacks: BTreeMap::new(),
         default_fallback,
         mode,
-        poll_interval: std::time::Duration::from_millis(poll_interval_ms),
-    };
-    let fuse_config = musefs_fuse::FuseConfig {
-        ttl: std::time::Duration::from_millis(attr_ttl_ms),
-        max_readahead: max_readahead_kib.saturating_mul(1024),
+        poll_interval_ms,
+        attr_ttl_ms,
+        max_readahead_kib,
         max_background,
         keep_cache,
-    };
+    );
     let core = Musefs::open(db, config).context("building the virtual filesystem")?;
     musefs_fuse::mount_with(core, mountpoint, "musefs", fuse_config)
         .with_context(|| format!("mounting at {}", mountpoint.display()))?;

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -134,3 +134,64 @@ fn parses_mode_and_revalidate_flags() {
         Command::Mount { .. } => panic!("expected scan"),
     }
 }
+
+use musefs_cli::parse_mount_config;
+use musefs_core::Mode;
+use std::time::Duration;
+
+#[test]
+fn parse_mount_config_defaults_are_sensible() {
+    let (config, fuse_config) = parse_mount_config(
+        "$artist/$title".to_string(),
+        "Unknown".to_string(),
+        Mode::Synthesis,
+        1000,
+        1000,
+        512,
+        64,
+        false,
+    );
+    assert_eq!(config.template, "$artist/$title");
+    assert_eq!(config.default_fallback, "Unknown");
+    assert_eq!(config.mode, Mode::Synthesis);
+    assert_eq!(config.poll_interval, Duration::from_secs(1));
+    assert!(config.fallbacks.is_empty());
+    assert!(!fuse_config.keep_cache);
+    assert_eq!(fuse_config.ttl, Duration::from_secs(1));
+    assert_eq!(fuse_config.max_readahead, 512 * 1024);
+    assert_eq!(fuse_config.max_background, 64);
+}
+
+#[test]
+fn parse_mount_config_keep_cache_sets_flag() {
+    let (config, fuse_config) = parse_mount_config(
+        "$title".to_string(),
+        "Unknown".to_string(),
+        Mode::StructureOnly,
+        250,
+        5000,
+        256,
+        32,
+        true,
+    );
+    assert_eq!(config.mode, Mode::StructureOnly);
+    assert_eq!(config.poll_interval, Duration::from_millis(250));
+    assert!(fuse_config.keep_cache);
+    assert_eq!(fuse_config.ttl, Duration::from_secs(5));
+    assert_eq!(fuse_config.max_background, 32);
+}
+
+#[test]
+fn parse_mount_config_saturating_readahead() {
+    let (_, fuse_config) = parse_mount_config(
+        "$title".to_string(),
+        "Unknown".to_string(),
+        Mode::Synthesis,
+        1000,
+        1000,
+        u32::MAX,
+        64,
+        false,
+    );
+    assert_eq!(fuse_config.max_readahead, u32::MAX);
+}


### PR DESCRIPTION
## Summary

Security and testing hardening:

1. **Pin actions to commit SHAs** — All third-party GitHub Actions across ci.yml, coverage.yml, fuzz.yml, and audit.yml are pinned to specific commit SHAs with `persist-credentials: false`. Prevents supply-chain attacks via tag mutation.

2. **Test gate in pre-commit** — `cargo test --workspace` now runs as part of the pre-commit hook, catching test failures before they reach CI.

3. **CLI test seam** — Extracted `parse_mount_config()` from `run_mount()` as a pure function. This enables unit testing of config parsing without needing a DB or FUSE mount. Added 3 tests covering defaults, keep-cache flag, and saturating readahead.

## Changes

- `.github/workflows/*.yml` — Pin all actions to commit SHAs, add `persist-credentials: false` to checkout steps
- `.githooks/pre-commit` — Add `cargo test --workspace` gate between clippy and ruff
- `musefs-cli/src/lib.rs` — Extract `parse_mount_config()` from `run_mount()`
- `musefs-cli/tests/cli.rs` — Add 3 tests for `parse_mount_config`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI/audit/coverage/fuzz workflow actions to specific commits for tighter supply-chain control.
  * Pre-commit hook now runs the test suite and aborts further checks if tests fail.
  * Added/updated coverage configuration to enforce patch-level coverage checks.

* **Tests**
  * Added unit tests for mount configuration parsing, including edge and saturation cases.

* **Refactor**
  * Extracted mount configuration construction into a dedicated helper for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->