### PR TITLE
fix(mutants): create --output parent dir before running cargo-mutants

### DIFF
--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -48,6 +48,11 @@ OUT_ROOT="$ROOT/mutants-out"
 run_crate() {
   local crate="$1"; shift
   local out="$OUT_ROOT/$crate"
+  # cargo-mutants' --output does a plain mkdir of the leaf, not mkdir -p, so the
+  # parent must already exist (a real run fails with "create output parent
+  # directory ... No such file or directory" otherwise; --list never creates it,
+  # which is why the list-only smoke test missed this).
+  mkdir -p "$out"
   local tmp
   tmp="$(mktemp -d "$SCRATCH_PARENT/${crate}.XXXXXX")" || {
     echo "mutants: mktemp -d failed under $SCRATCH_PARENT" >&2


### PR DESCRIPTION
## Summary

The first dispatched **Mutants → `full`** run ([#26630913421](https://github.com/Sohex/musefs/actions/runs/26630913421)) failed on all three crate legs in ~90s:

```
Error: create output parent directory "…/mutants-out/<crate>"
Caused by: No such file or directory (os error 2)
```

`scripts/mutants.sh` passes `--output mutants-out/<crate>`, but cargo-mutants does a plain `mkdir` of the leaf (not `mkdir -p`), so it fails when the `mutants-out/` parent doesn't exist. Fix: `mkdir -p "$out"` in `run_crate` before invoking cargo-mutants.

**Why the Phase 1 smoke test missed it:** the local check used `MUTANTS_LIST=1` → `--list`, and cargo-mutants doesn't create an output dir in list mode — the only path the smoke test couldn't exercise is the one that broke.

## Test Plan
- [x] `bash -n scripts/mutants.sh` clean
- [x] `MUTANTS_LIST=1 scripts/mutants.sh musefs-db` exit 0; `mutants-out/musefs-db` now created and is gitignored
- [ ] **After merge:** re-dispatch Mutants → `full`; the campaign should proceed past output-dir creation into the real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the mutation testing script would fail due to missing output directories. The script now automatically creates necessary parent directories before execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->