### PR TITLE
fix(mutants): scratch dir must be outside the repo; don't fail discovery on survivors

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -55,6 +55,27 @@ jobs:
           fi
           cargo mutants --in-diff mutants.diff -j1
 
+  canary:
+    # Per-PR: exercise the REAL scripts/mutants.sh pipeline (out-of-repo scratch,
+    # source-tree copy, --output dir, report) cheaply via --check on the smallest
+    # crate. Catches the copy-recursion / output-dir class of bugs the --list
+    # smoke test can't (list mode neither copies the tree nor creates output).
+    # cargo-check only, no test runs, so it stays fast.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants
+      - name: Canary (check-only) run of the harness
+        run: MUTANTS_CANARY=1 scripts/mutants.sh musefs-db
+
   full:
     # Scheduled or manually dispatched: full per-crate campaign.
     if: github.event_name != 'pull_request'

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -6,32 +6,38 @@
 # see the remediation tracking doc).
 #
 # Usage: scripts/mutants.sh [crate ...]   (default: all three in-scope crates)
-# Env:   MUTANTS_TMP  scratch PARENT dir off the /tmp tmpfs (default: ./.mutants-tmp).
-#                     cargo-mutants builds inside a unique child we create here;
-#                     a caller-provided parent is never deleted, only our children.
+# Env:   MUTANTS_TMP  scratch PARENT dir, MUST be OUTSIDE this repo (default: the
+#                     system temp dir). cargo-mutants copies the source tree into
+#                     a build dir under TMPDIR, so a scratch dir inside the repo
+#                     gets copied into itself recursively ("File name too long").
+#                     On a host whose /tmp is too small (e.g. a tmpfs), point this
+#                     at a roomy directory outside the repo.
 #        MUTANTS_LIST set to 1 to only enumerate mutants (no build/run)
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-# Scratch parent. If the caller supplied MUTANTS_TMP we treat it as a shared
-# parent and must NOT remove it on exit (could be /tmp or another shared dir);
-# we only ever remove the unique children we mktemp inside it. Our own default
-# repo-local parent we do clean up.
-if [ -n "${MUTANTS_TMP:-}" ]; then
-  SCRATCH_PARENT="$MUTANTS_TMP"; OWN_PARENT=0
-else
-  SCRATCH_PARENT="$ROOT/.mutants-tmp"; OWN_PARENT=1
-fi
+# Scratch parent. cargo-mutants copies the source tree into a build dir under
+# TMPDIR, so the scratch parent MUST live OUTSIDE this repo — a dir inside the
+# tree gets copied into itself recursively until the path overflows
+# ("File name too long"). Default to the system temp dir; honor MUTANTS_TMP only
+# if it points outside the repo. We never delete the parent (it may be shared,
+# e.g. /tmp) — only the unique per-crate children we mktemp inside it.
+SCRATCH_PARENT="${MUTANTS_TMP:-${TMPDIR:-/tmp}}"
+case "$SCRATCH_PARENT" in
+  "$ROOT" | "$ROOT"/*)
+    echo "mutants: scratch dir must be outside the repo ($ROOT); cargo-mutants" \
+         "copies the tree into it. Set MUTANTS_TMP to a roomy path outside the repo." >&2
+    exit 1
+    ;;
+esac
 mkdir -p "$SCRATCH_PARENT"
 CREATED_TMPS=()
 cleanup() {
-  # Remove every per-crate scratch child we created, even on abnormal exit and
-  # even when the caller owns SCRATCH_PARENT (OWN_PARENT=0).
+  # Remove only the unique per-crate scratch children we created (never the
+  # possibly-shared parent), even on abnormal exit.
   [ "${#CREATED_TMPS[@]}" -gt 0 ] && rm -rf "${CREATED_TMPS[@]}"
-  # Remove the parent only if we created it.
-  [ "$OWN_PARENT" = 1 ] && rm -rf "$SCRATCH_PARENT"
 }
 trap cleanup EXIT
 
@@ -66,6 +72,14 @@ run_crate() {
   TMPDIR="$tmp" cargo mutants "${args[@]}"
   local rc=$?
   rm -rf "$tmp"
+  # Discovery run: surviving/timed-out mutants are the expected output, not a
+  # failure. If cargo-mutants produced its report dir the crate ran fine, so
+  # return success regardless of exit code; only a genuine error (no report,
+  # e.g. a baseline build failure) propagates. The PR --in-diff gate calls
+  # cargo-mutants directly and still fails on survivors.
+  if [ -d "$out/mutants.out" ]; then
+    return 0
+  fi
   return "$rc"
 }
 

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -12,7 +12,10 @@
 #                     gets copied into itself recursively ("File name too long").
 #                     On a host whose /tmp is too small (e.g. a tmpfs), point this
 #                     at a roomy directory outside the repo.
-#        MUTANTS_LIST set to 1 to only enumerate mutants (no build/run)
+#        MUTANTS_LIST   set to 1 to only enumerate mutants (no build/run)
+#        MUTANTS_CANARY set to 1 to cargo-CHECK mutants without running tests
+#                       (--check): a fast CI canary that still exercises the real
+#                       source-copy + scratch + output pipeline.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -68,6 +71,7 @@ run_crate() {
   echo "== mutants: $crate (scratch: $tmp) =="
   local args=(-p "$crate" --jobs 1 --output "$out")
   [ "${MUTANTS_LIST:-0}" = "1" ] && args+=(--list)
+  [ "${MUTANTS_CANARY:-0}" = "1" ] && args+=(--check)
   args+=("$@")
   TMPDIR="$tmp" cargo mutants "${args[@]}"
   local rc=$?


### PR DESCRIPTION
## Summary

The second dispatched **Mutants → `full`** run ([#26631326086](https://github.com/Sohex/musefs/actions/runs/26631326086)) got past the output-dir fix (PR #43) — it found the mutants (62 db / 353 core / 1237 format) — then all three legs died with:

```
Failed to copy …/.mutants-tmp/<crate>.XXX/cargo-mutants-…tmp/.mutants-tmp/<crate>.XXX/cargo-mutants-…tmp/…(repeating)… File name too long (os error 36)
```

**Root cause:** `scripts/mutants.sh` pointed `TMPDIR` at a repo-local `.mutants-tmp/`. cargo-mutants copies the **source tree** into its build dir under `TMPDIR`, so a scratch dir *inside* the repo gets copied into itself recursively until the path overflows. My original "keep scratch off the small /tmp tmpfs" rationale wrongly put it *inside the repo*.

## Fix
- **Scratch parent must be outside the repo.** Default to the system temp dir (`$TMPDIR`/`/tmp`, fine on CI runners). `MUTANTS_TMP` is still honored but now **rejected with a clear error if it points inside the repo**. Dropped the repo-local default and the now-moot `OWN_PARENT` cleanup branch (we only ever remove the per-crate `mktemp` children, never the shared parent).
- **Discovery `full` runs no longer go red just because mutants survive.** Surviving/timed-out mutants are the *expected* output of a discovery campaign. If cargo-mutants produced its `mutants.out/` report dir, the crate is treated as success; only a genuine error (no report — e.g. a baseline build failure) fails the job. The PR `--in-diff` gate calls cargo-mutants directly and **still fails on survivors** (the regression gate is unaffected).

## Test Plan
- [x] `bash -n scripts/mutants.sh` clean
- [x] In-repo `MUTANTS_TMP` rejected with exit 1 + clear message
- [x] `MUTANTS_LIST=1 scripts/mutants.sh musefs-db` lists mutants, exit 0, no `.mutants-tmp/` left in repo
- [ ] **After merge:** re-dispatch Mutants → `full`; legs should copy to an out-of-repo scratch, run to completion, upload reports, and stay green even with survivors

### Known follow-up (not in this PR)
`musefs-format` has 1237 mutants; an uncapped serial (`--jobs 1`) run is long (~hours). If a leg approaches GitHub's 6h job limit we can sub-shard the matrix or add a generous `--timeout`. Watch the first successful run's duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight "canary" mutation check run in CI for pull requests to exercise the mutation pipeline cheaply.
* **Bug Fixes**
  * Ensure scratch/temp directories are placed outside the repository and default to the system temp location.
  * Simplified cleanup to remove only per-run temp children.
  * Updated success detection to rely on generated mutation reports when present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->