### PR TITLE
Phase 3a: FLAC hardening — mutation kills, broadened read fidelity, zero-byte art fix

### DIFF
--- a/docs/superpowers/plans/2026-05-29-phase3a-flac-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3a-flac-hardening.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Kill the 45 `flac.rs` mutation survivors with additive in-module tests, broaden `proptest_read_fidelity` on FLAC (finding #5), and add the zero-byte embedded-art boundary test (finding #16) — no production logic changes (one possible scoped exception from the C5 spike).
+**Goal:** Kill the 45 `flac.rs` mutation survivors with additive in-module tests, broaden `proptest_read_fidelity` on FLAC (finding #5), and make FLAC synthesis skip zero-byte embedded art so it never bricks a track (finding #16). One small scoped production change (the zero-byte-art skip, Task 7); everything else is additive tests. Byte-identity for audio is untouched.
 
 **Architecture:** All `flac.rs` kills live in one new `#[cfg(test)] mod tests` inside `musefs-format/src/flac.rs`, which can call `pub`, `pub(crate)`, and private helpers directly via `use super::*` and builds byte-precise fixtures with small independent local helpers (it cannot use `musefs-format/tests/common`). The cross-cutting findings live in their own integration files: #5 in `musefs-core/tests/proptest_read_fidelity.rs`, #16 in `musefs-format/tests/synthesize_art.rs`.
 
@@ -83,9 +83,9 @@ mod tests {
         let data = [0x11u8, 0x22, 0x33, 0x44, 0x55];
         assert_eq!(read_u32_be(&data, 0).unwrap(), 0x1122_3344);
         // pins :224 (`+` -> `*`): at pos=1 the second byte is data[2]=0x33, not data[1].
+        // pins :219 (`>` -> `==`/`>=`): pos+4 == len (5) is valid, so this unwrap must
+        // succeed — a mutated bound returns Err here and the unwrap panics.
         assert_eq!(read_u32_be(&data, 1).unwrap(), 0x2233_4455);
-        // pins :219 (`>` -> `==`/`>=`): pos+4 == len is valid (not an error).
-        assert!(read_u32_be(&data, 1).is_ok());
         assert_eq!(read_u32_be(&data, 2), Err(FormatError::Malformed));
     }
 
@@ -489,11 +489,9 @@ Kills `synthesize_layout:155` (`> → >=`).
 ```rust
     #[test]
     fn synthesize_layout_picture_block_size_boundary_is_inclusive() {
-        // body_len = picture_body_framing(art).len() + art.data_len, and the framing
-        // is 32 fixed bytes + mime.len() + desc.len(). With mime "image/png" (9) and
-        // an empty description, framing = 41. The guard rejects body_len > 0x00FF_FFFF.
+        // body_len = picture_body_framing(art).len() + art.data_len. The guard at
+        // flac.rs:155 rejects body_len > 0x00FF_FFFF (FLAC's 24-bit block length).
         let scan = FlacScan { audio_offset: 0, audio_length: 0, preserved: vec![] };
-        let framing_len = 32u64 + "image/png".len() as u64; // 41
         let mk = |data_len: u64| ArtInput {
             art_id: 1,
             mime: "image/png".to_string(),
@@ -503,12 +501,17 @@ Kills `synthesize_layout:155` (`> → >=`).
             height: 0,
             data_len,
         };
-        // body_len == 0x00FF_FFFF exactly: original `>` accepts; `>=` mutant rejects.
+        // Derive the exact framing length from production rather than hardcoding it
+        // (it is independent of the data_len *value* — that field is always 4 bytes).
+        // This keeps the boundary correct regardless of the framing's field count.
+        let framing_len = picture_body_framing(&mk(0)).len() as u64;
+        let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
+        // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
         // (data_len is only a count; no large allocation occurs.)
-        assert!(synthesize_layout(&scan, &[], &[mk(0x00FF_FFFF - framing_len)]).is_ok());
+        assert!(synthesize_layout(&scan, &[], &[mk(at_limit)]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
         assert_eq!(
-            synthesize_layout(&scan, &[], &[mk(0x00FF_FFFF - framing_len + 1)]),
+            synthesize_layout(&scan, &[], &[mk(at_limit + 1)]),
             Err(FormatError::TooLarge)
         );
     }
@@ -519,8 +522,9 @@ Kills `synthesize_layout:155` (`> → >=`).
 ```bash
 cargo test -p musefs-format --features fuzzing flac::tests::synthesize_layout_picture_block_size_boundary_is_inclusive
 ```
-Expected: pass. (If `picture_body_framing` ever changes its fixed size, recompute
-`framing_len`; the test asserts the inclusive boundary, not a magic file size.)
+Expected: pass. (`framing_len` is computed from `picture_body_framing` at runtime,
+so the test stays correct if the framing's fixed-field count ever changes; it
+asserts the inclusive boundary, not a magic file size.)
 
 - [ ] **Step 3: Hand-apply-verify**
 
@@ -648,19 +652,38 @@ fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, 
     ) {
         let (_dir, db, id) = build_with_art(&audio, "T", &art);
         let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
-        prop_assert!(resolved
-            .layout
-            .segments
-            .iter()
-            .any(|s| matches!(s, Segment::ArtImage { .. })));
         let total = resolved.total_len;
         let whole = read_at(&resolved, &db, 0, total).unwrap();
+
+        // Locate the ArtImage segment's exact byte offset in the assembled stream by
+        // summing the serving lengths of the segments before it. (Asserting the blob
+        // appears at this precise offset is robust; a `windows().any()` search would
+        // false-positive when a tiny blob coincidentally matches audio bytes.)
+        let mut art_off = 0u64;
+        let mut art_len = None;
+        for s in &resolved.layout.segments {
+            match s {
+                Segment::ArtImage { len, .. } => {
+                    art_len = Some(*len);
+                    break;
+                }
+                Segment::Inline(bytes) => art_off += bytes.len() as u64,
+                Segment::BackingAudio { len, .. } => art_off += *len,
+                other => panic!("unexpected FLAC segment: {other:?}"),
+            }
+        }
+        let art_len = art_len.expect("layout has an ArtImage segment");
+        prop_assert_eq!(art_len, art.len() as u64);
+        // The art blob is served verbatim at its segment offset.
+        prop_assert_eq!(
+            &whole[art_off as usize..(art_off + art_len) as usize],
+            &art[..]
+        );
+        // A partial window over the art region matches the independently-read whole.
         let offset = (a as u64) % (total + 1);
         let len = (b as u64) % (total - offset + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
         prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
-        // the art blob appears verbatim in the assembled output (it is served, not dropped).
-        prop_assert!(whole.windows(art.len()).any(|w| w == &art[..]));
     }
 ```
 
@@ -682,68 +705,134 @@ git commit -m "test(read): broaden proptest_read_fidelity — partial/seam/art w
 
 ---
 
-## Task 7: zero-byte embedded-art boundary (finding #16) — spike-first
+## Task 7: zero-byte embedded-art is skipped at synthesis (finding #16)
+
+This is the one **production change** in 3a: a degenerate picture with no image data
+must not be emitted. Today `synthesize_layout` builds `Segment::ArtImage { len: 0 }`,
+which `RegionLayout::validate` (layout.rs:102, `EmptySegment`) rejects → `synthesize_layout`
+returns `Err(FormatError::InvalidLayout)` → the whole track becomes unreadable. And
+ingestion (`scan.rs:162`) only filters art *above* `MAX_ART_BYTES`, so a source file
+with an empty PICTURE block reaches synthesis. Fix: skip zero-length art in the FLAC
+synthesizer so the track still serves. Byte-identity is unaffected (metadata framing
+only). TDD: write the failing test, then make the change.
 
 **Files:**
-- Modify (tests only): `musefs-format/tests/synthesize_art.rs`.
+- Test: `musefs-format/tests/synthesize_art.rs`.
+- Modify (production): `musefs-format/src/flac.rs` — `synthesize_layout` (the
+  `num_blocks` computation at line 129 and the `for art in arts` loop at line 149).
 
-- [ ] **Step 1: Add the zero-byte-art test (the spike)**
+- [ ] **Step 1: Write the failing tests**
 
 `cover(art_id, data_len)` and `fixture()` already exist in this file. Add:
 
 ```rust
 #[test]
-fn zero_byte_art_synthesizes_and_round_trips() {
+fn zero_byte_art_is_skipped_so_the_track_still_serves() {
     let (file, audio) = fixture();
     let scan = locate_audio(&file).unwrap();
 
+    // A picture with no image data is degenerate; synthesis must skip it rather than
+    // emit an empty PICTURE block (which would fail layout validation and brick the
+    // track).
     let art = cover(7, 0); // data_len == 0
     let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
 
-    // A zero-length PICTURE block: the ArtImage segment carries len 0.
-    assert!(layout
+    // No ArtImage segment was emitted.
+    assert!(!layout
         .segments
         .iter()
-        .any(|s| matches!(s, Segment::ArtImage { art_id: 7, len: 0 })));
+        .any(|s| matches!(s, Segment::ArtImage { .. })));
 
-    let mut art_map = HashMap::new();
-    art_map.insert(7i64, Vec::new());
+    // The track still round-trips: header + verbatim audio (no art bytes needed).
+    let art_map = HashMap::new();
     let assembled = resolve_layout(&layout, &file, &art_map);
     assert_eq!(assembled.len() as u64, layout.total_len());
     assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
 
-    // metaflac reads back exactly one picture with empty data.
+    // metaflac sees a valid FLAC with zero pictures.
+    let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
+    assert_eq!(tag.pictures().count(), 0);
+}
+
+#[test]
+fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
+    // Guards the `is_last` flag: filtering the empty art must not leave the final
+    // real PICTURE block without its last-block bit. metaflac parsing the whole
+    // chain validates that.
+    let (file, _audio) = fixture();
+    let scan = locate_audio(&file).unwrap();
+    let image = vec![0x55u8; 64];
+    let empty = cover(1, 0);
+    let real = cover(2, image.len() as u64);
+    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[empty, real]).unwrap();
+
+    let art_segs: Vec<_> = layout
+        .segments
+        .iter()
+        .filter(|s| matches!(s, Segment::ArtImage { .. }))
+        .collect();
+    assert_eq!(art_segs.len(), 1);
+
+    let mut art_map = HashMap::new();
+    art_map.insert(2i64, image.clone());
+    let assembled = resolve_layout(&layout, &file, &art_map);
     let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
     let pics: Vec<_> = tag.pictures().collect();
     assert_eq!(pics.len(), 1);
-    assert!(pics[0].data.is_empty());
+    assert_eq!(pics[0].data, image);
 }
 ```
 
-- [ ] **Step 2: Run — this is the verification spike**
+- [ ] **Step 2: Run, expect FAIL**
 
 ```bash
-cargo test -p musefs-format --features fuzzing synthesize_art::zero_byte_art_synthesizes_and_round_trips
+cargo test -p musefs-format --features fuzzing synthesize_art::zero_byte_art
+```
+Expected: FAIL — `synthesize_layout(...).unwrap()` panics today because the empty
+`ArtImage` segment trips `RegionLayout::validate` → `Err(FormatError::InvalidLayout)`.
+
+- [ ] **Step 3: Implement the skip in `synthesize_layout`**
+
+In `musefs-format/src/flac.rs`, filter zero-length art **before** counting blocks
+(so `last_index` lands on the true final block) and `continue` past it in the loop.
+
+Change the count line (currently line 129):
+
+```rust
+    // exclude zero-byte art: an empty PICTURE block is meaningless and would fail
+    // layout validation (EmptySegment), making the track unreadable.
+    let nonempty_art = arts.iter().filter(|a| a.data_len > 0).count();
+    let num_blocks = scan.preserved.len() + 1 + nonempty_art; // preserved + VORBIS_COMMENT + pictures
 ```
 
-Two outcomes (record which in Task 8):
+And guard the loop body (currently the `for art in arts {` at line 149), as its
+first statement:
 
-- **PASS** → zero-byte art is a valid zero-length PICTURE block end to end. Done,
-  tests-only. Proceed to Step 3.
-- **FAIL** → a real defect surfaced (e.g. `metaflac` rejects empty picture data, or
-  an off-by-one in `picture_body_framing`/`synthesize_layout` at `data_len == 0`).
-  This is **not** a test artifact. Apply the **C5 contingency**: make a minimal,
-  scoped fix in `musefs-format/src/flac.rs` framing/guard logic (never the
-  positioned audio reads — byte-identity is unaffected), and adjust the assertion to
-  the corrected behavior. If the correct behavior is to *reject* zero-byte art, the
-  test asserts `synthesize_layout(...) == Err(...)` instead and ingestion is the
-  enforcement point. Use `superpowers:systematic-debugging` for the diagnosis.
+```rust
+    for art in arts {
+        if art.data_len == 0 {
+            continue; // skip degenerate empty art (see nonempty_art above)
+        }
+        let framing = picture_body_framing(art);
+        // ... unchanged ...
+    }
+```
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Run, expect PASS (and the existing art tests still pass)**
 
 ```bash
-git add musefs-format/tests/synthesize_art.rs   # plus musefs-format/src/flac.rs if the spike forced a fix
-git commit -m "test(flac): zero-byte embedded-art boundary (#16)"
+cargo test -p musefs-format --features fuzzing synthesize_art
+```
+Expected: all `synthesize_art` tests pass, including the existing
+`art_becomes_an_artimage_segment_and_lengths_are_exact`,
+`metaflac_reads_synthesized_picture`, and `synthesize_errors_on_oversized_picture`
+(non-empty art is unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/flac.rs musefs-format/tests/synthesize_art.rs
+git commit -m "fix(flac): skip zero-byte art at synthesis; boundary test (#16)"
 ```
 
 ---
@@ -772,9 +861,12 @@ In `2026-05-29-remediation-tracking.md`:
 - Top-of-file Status line: add "Phase 3a (FLAC) complete".
 - Under Phase 3, record: 3a done — FLAC survivors killed (equivalents:
   disjoint-bitfield `| → ^` at `:50/:51/:99/:200/:201/:290/:291` and inclusive-bound
-  `> → >=` at `parse_picture_block:237/:245`); finding #16 resolved (record the C5
-  spike outcome); finding #5 broadened on FLAC (partial/seam/art windows), with the
-  non-FLAC dimension tracked into 3b/3c/3d.
+  `> → >=` at `parse_picture_block:237/:245`); finding #16 resolved by **skipping
+  zero-byte art at FLAC synthesis** (small production fix in `flac.rs::synthesize_layout`),
+  with a cross-cutting follow-up noted: apply the same skip to mp3/mp4/ogg/wav
+  synthesis (their sub-phases) or filter empty art once at ingestion (`scan.rs`);
+  finding #5 broadened on FLAC (partial/seam/art windows), with the non-FLAC
+  dimension tracked into 3b/3c/3d.
 
 - [ ] **Step 3: Commit**
 
@@ -804,8 +896,9 @@ equivalents).
 
 ## Notes for the executor
 
-- The **only** possible non-test production change is the C5 contingency (Task 7);
-  every other change is additive tests. Byte-identity for audio is never touched.
+- The **only** production change is the zero-byte-art skip in `flac.rs::synthesize_layout`
+  (Task 7); every other change is additive tests. Byte-identity for audio is never
+  touched (the change only affects whether an empty PICTURE block is emitted).
 - Never leave a hand-applied mutation in the tree — always revert before the next step.
 - If a survivor turns out to be a genuine equivalent the plan did not anticipate,
   record it in Task 8 rather than forcing a contrived test. The plan already marks

--- a/docs/superpowers/plans/2026-05-29-phase3a-flac-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3a-flac-hardening.md
@@ -1,0 +1,815 @@
+# Phase 3a — FLAC Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the 45 `flac.rs` mutation survivors with additive in-module tests, broaden `proptest_read_fidelity` on FLAC (finding #5), and add the zero-byte embedded-art boundary test (finding #16) — no production logic changes (one possible scoped exception from the C5 spike).
+
+**Architecture:** All `flac.rs` kills live in one new `#[cfg(test)] mod tests` inside `musefs-format/src/flac.rs`, which can call `pub`, `pub(crate)`, and private helpers directly via `use super::*` and builds byte-precise fixtures with small independent local helpers (it cannot use `musefs-format/tests/common`). The cross-cutting findings live in their own integration files: #5 in `musefs-core/tests/proptest_read_fidelity.rs`, #16 in `musefs-format/tests/synthesize_art.rs`.
+
+**Tech Stack:** Rust, `cargo test`, `proptest` (existing dev-dep), `tempfile` (existing), `metaflac` (existing dev-dep). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md`
+**Survivor data:** `docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md`
+
+---
+
+## The hand-apply verification method (use in every kill step)
+
+cargo-mutants is not available locally. To prove a new test kills a specific
+survivor, for each targeted `file:line: mutation`:
+
+1. Run the new test → it passes (production code is correct).
+2. Apply the exact mutation at that line, rerun **just that test** → it must **fail**
+   (a failed assertion *or a panic* both count as a kill).
+3. Revert (`git checkout -- <file>`), rerun → passes again.
+
+If step 2 still passes, the test does not kill the mutant. Either strengthen it, or
+— if the mutation provably yields identical behavior — record it as an **equivalent
+mutant** (Task 8). Never leave a mutation applied.
+
+**Re-verify line numbers first.** Survivor line numbers are from the phase-1
+inventory; the test module is appended at the end of `flac.rs`, so the survivor
+lines do not move while you work, but confirm each target by its code pattern
+before hand-applying.
+
+## Equivalent mutants (confirm green under the mutation, then record in Task 8)
+
+Verified by reading the source; do **not** write tests to "kill" these:
+
+- **Disjoint-bitfield `| → ^`** (operands occupy non-overlapping bits, so `|` ≡ `^` ≡ `+`):
+  `parse_blocks:50, :51`; `read_vorbis_comments:200` (the `^` variant), `:201`;
+  `read_pictures:290` (the `^` variant), `:291`; `push_block_header:99`
+  (`0x80 | (block_type & 0x7F)`, bit 7 vs bits 6–0).
+- **Inclusive-bound `> → >=` in `parse_picture_block`** (`:237`, `:245`): the only
+  differing input is `*_end == body.len()`, where the original proceeds and then
+  fails at the *next* `read_u32_be` → `Err(Malformed)`, identical to the mutant's
+  immediate `Err(Malformed)`. Equivalent. (Their `> → ==` siblings **are** killable
+  — see Task 4.)
+
+## Pre-flight (run once before Task 1)
+
+- [ ] **Confirm baseline green on the phase-3a branch**
+
+```bash
+git rev-parse --abbrev-ref HEAD          # expect: phase3a-flac-hardening
+cargo test -p musefs-format --features fuzzing flac
+cargo test -p musefs-core proptest_read_fidelity
+```
+Expected: both green.
+
+---
+
+## Task 1: test module scaffold + `read_u32_be` and `push_block_header` kills
+
+Kills `read_u32_be:219, :224` and `push_block_header:101`. Confirms `:99` equivalent.
+Establishes the local fixture helpers used by Tasks 2–4.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/flac.rs` — append a `#[cfg(test)] mod tests` after `read_pictures` (end of file, line 306).
+
+- [ ] **Step 1: Add the test module scaffold + the first two tests**
+
+Append to `musefs-format/src/flac.rs`. **No fixture helpers yet** — they are
+introduced in the task that first uses them, so every commit stays free of
+`dead_code` warnings (the pre-commit hook runs `clippy -D warnings`).
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_u32_be_assembles_big_endian_and_guards_length() {
+        let data = [0x11u8, 0x22, 0x33, 0x44, 0x55];
+        assert_eq!(read_u32_be(&data, 0).unwrap(), 0x1122_3344);
+        // pins :224 (`+` -> `*`): at pos=1 the second byte is data[2]=0x33, not data[1].
+        assert_eq!(read_u32_be(&data, 1).unwrap(), 0x2233_4455);
+        // pins :219 (`>` -> `==`/`>=`): pos+4 == len is valid (not an error).
+        assert!(read_u32_be(&data, 1).is_ok());
+        assert_eq!(read_u32_be(&data, 2), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn push_block_header_emits_24bit_length_big_endian() {
+        // pins :101 (`>>16` -> `<<16`): high byte 0x12 must land in out[1].
+        let mut out = Vec::new();
+        push_block_header(&mut out, BLOCK_PICTURE, 0x12_3456, false);
+        assert_eq!(out, vec![BLOCK_PICTURE, 0x12, 0x34, 0x56]);
+        // :99 is equivalent, but exercise the is_last/0x80 path anyway.
+        let mut last = Vec::new();
+        push_block_header(&mut last, BLOCK_VORBIS_COMMENT, 0, true);
+        assert_eq!(last, vec![0x80 | BLOCK_VORBIS_COMMENT, 0x00, 0x00, 0x00]);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests, expect PASS**
+
+```bash
+cargo test -p musefs-format --features fuzzing flac::tests::read_u32_be_assembles_big_endian_and_guards_length flac::tests::push_block_header_emits_24bit_length_big_endian
+```
+Expected: both pass.
+
+- [ ] **Step 3: Hand-apply-verify the kills**
+
+- `:219` `pos + 4 > data.len()` → `>=` (and `==`): rerun `read_u32_be_*` → FAIL
+  (the `read_u32_be(&data, 1).is_ok()` assertion). Revert.
+- `:224` `data[pos + 1]` → `data[pos * 1]`: rerun → FAIL (the `0x2233_4455`
+  assertion). Revert.
+- `:101` `(body_len >> 16)` → `(body_len << 16)`: rerun `push_block_header_*` →
+  FAIL (`out[1]` becomes `0x00`). Revert.
+- `:99` `| → ^`: rerun → still PASS (equivalent: `0x80` and `& 0x7F` are disjoint).
+  Note for Task 8. Revert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/flac.rs
+git commit -m "test(flac): read_u32_be + push_block_header kills; test scaffold"
+```
+
+---
+
+## Task 2: `parse_blocks` kills
+
+Kills `parse_blocks:37, :43, :49`. Confirms `:50`/`:51` equivalent.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/flac.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the shared fixture helpers + the tests**
+
+Add inside `mod tests`. The two helpers are defined here (first use) and reused by
+Tasks 3–4:
+
+```rust
+    /// One FLAC metadata block: 4-byte header (last-flag, type, 24-bit BE length)
+    /// + body, built independently of production framing so a mutation in
+    /// `push_block_header` cannot mask a fixture. `len_override` lets a test claim a
+    /// length different from `body.len()`.
+    fn raw_block(block_type: u8, body: &[u8], last: bool, len_override: Option<usize>) -> Vec<u8> {
+        let n = len_override.unwrap_or(body.len());
+        let mut v = vec![(if last { 0x80 } else { 0 }) | (block_type & 0x7F)];
+        v.push((n >> 16) as u8);
+        v.push((n >> 8) as u8);
+        v.push(n as u8);
+        v.extend_from_slice(body);
+        v
+    }
+
+    /// `fLaC` + the given blocks (no audio).
+    fn flac_with(blocks: &[Vec<u8>]) -> Vec<u8> {
+        let mut f = b"fLaC".to_vec();
+        for b in blocks {
+            f.extend_from_slice(b);
+        }
+        f
+    }
+
+    #[test]
+    fn parse_blocks_rejects_short_and_wrong_marker() {
+        // :37 `< -> ==`: 3-byte input -> original short-circuits NotFlac; the mutant
+        // evaluates &data[0..4] on 3 bytes -> panic. Asserting Err(NotFlac) kills it.
+        assert_eq!(parse_blocks(b"fLa"), Err(FormatError::NotFlac));
+        // :37 `< -> <=`: a 4-byte fLaC-only file. Original proceeds then hits the
+        // loop guard -> Malformed; the `<=` mutant short-circuits to NotFlac.
+        assert_eq!(parse_blocks(b"fLaC"), Err(FormatError::Malformed));
+        assert_eq!(parse_blocks(b"XXXX____"), Err(FormatError::NotFlac));
+    }
+
+    #[test]
+    fn parse_blocks_guards_truncated_block_header() {
+        // 5 bytes: marker + 1 header byte. Original: pos+4=8 > 5 -> Malformed.
+        // :43 `+ -> -` (0 > 5 false) and `> -> ==` (8 == 5 false) both fall through
+        // and panic reading data[5..8].
+        assert_eq!(parse_blocks(b"fLaC\x80"), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn parse_blocks_accepts_header_flush_with_end() {
+        // Single last STREAMINFO, empty body, no audio: the final header occupies the
+        // last 4 bytes, so pos+4 == data.len() at the loop guard. Original (`>`)
+        // proceeds and returns audio_offset == len; the :43 `> -> >=` mutant rejects.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        let meta = parse_blocks(&file).unwrap();
+        assert_eq!(meta.audio_offset, 8);
+    }
+
+    #[test]
+    fn parse_blocks_decodes_24bit_length_high_byte() {
+        // STREAMINFO header claims length 0x010000 (high byte set) over an empty body.
+        // Original: len = 65536 -> body_end > data.len() -> Malformed.
+        // :49 `<<16 -> >>16`: (0x01 >> 16) = 0 -> len = 0 -> body fits -> Ok.
+        // (:50/:51 `| -> ^` are equivalent here: the shifted bytes are disjoint.)
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0000))]);
+        assert_eq!(parse_blocks(&file), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn parse_blocks_preserves_structural_blocks() {
+        // Positive decode: a normal STREAMINFO (34-byte body) + audio boundary.
+        let si = vec![0xAA; 34];
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &si, true, None)]);
+        let meta = parse_blocks(&file).unwrap();
+        assert_eq!(meta.audio_offset, 4 + 4 + 34);
+        assert_eq!(meta.preserved.len(), 1);
+        assert_eq!(meta.preserved[0].block_type, BLOCK_STREAMINFO);
+        assert_eq!(meta.preserved[0].body, si);
+    }
+```
+
+- [ ] **Step 2: Run, expect PASS**
+
+```bash
+cargo test -p musefs-format --features fuzzing flac::tests::parse_blocks
+```
+Expected: all five pass.
+
+- [ ] **Step 3: Hand-apply-verify the kills**
+
+- `:37` `< → ==`: `parse_blocks_rejects_short_*` FAILs (panic on `b"fLa"`). Revert.
+- `:37` `< → <=`: same test FAILs (`b"fLaC"` returns NotFlac not Malformed). Revert.
+- `:43` `+ → -`: `parse_blocks_guards_truncated_block_header` FAILs (panic). Revert.
+- `:43` `> → ==`: same test FAILs (panic). Revert.
+- `:43` `> → >=`: `parse_blocks_accepts_header_flush_with_end` FAILs (Malformed). Revert.
+- `:49` `<< → >>`: `parse_blocks_decodes_24bit_length_high_byte` FAILs (returns Ok). Revert.
+- `:50` `| → ^`, `:51` `| → ^`: rerun the whole `parse_blocks` set → still PASS
+  (equivalent). Note for Task 8. Revert each.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/flac.rs
+git commit -m "test(flac): parse_blocks bounds + 24-bit length kills"
+```
+
+---
+
+## Task 3: `read_vorbis_comments` kills
+
+Kills `read_vorbis_comments:188, :193, :199, :200` (`&` and `<<8`), `:204`. Confirms
+`:200` (`^`) and `:201` equivalent.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/flac.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the `vc_body` helper + the tests**
+
+`raw_block`/`flac_with` already exist in the module (Task 2). Add `vc_body` (first
+use here):
+
+```rust
+    /// A VORBIS_COMMENT body: u32-LE vendor length, vendor, u32-LE count, then each
+    /// comment as u32-LE length + bytes.
+    fn vc_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        v.extend_from_slice(vendor.as_bytes());
+        v.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+        for c in comments {
+            v.extend_from_slice(&(c.len() as u32).to_le_bytes());
+            v.extend_from_slice(c.as_bytes());
+        }
+        v
+    }
+
+    #[test]
+    fn read_vorbis_comments_returns_pairs_and_guards_marker() {
+        // Happy path: VC block is the last block with no audio, so body_end == len.
+        // This also pins :204 (`>` -> `==`/`>=`): the mutant would reject (Malformed)
+        // and the unwrap below would panic.
+        let vc = vc_body("v", &["TITLE=Hi", "ARTIST=Me"]);
+        let file = flac_with(&[raw_block(BLOCK_VORBIS_COMMENT, &vc, true, None)]);
+        let got = read_vorbis_comments(&file).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                ("TITLE".to_string(), "Hi".to_string()),
+                ("ARTIST".to_string(), "Me".to_string()),
+            ]
+        );
+        // :188 `< -> ==` and `|| -> &&`: 3-byte input -> original NotFlac via
+        // short-circuit; both mutants force &data[0..4] -> panic.
+        assert_eq!(read_vorbis_comments(b"fLa"), Err(FormatError::NotFlac));
+        // :188 `< -> <=`: 4-byte fLaC -> original Malformed; mutant NotFlac.
+        assert_eq!(read_vorbis_comments(b"fLaC"), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn read_vorbis_comments_guards_block_walk() {
+        // :193 `+ -> -` and `> -> ==`: truncated header -> original Malformed,
+        // mutants fall through and panic.
+        assert_eq!(read_vorbis_comments(b"fLaC\x80"), Err(FormatError::Malformed));
+        // :193 `> -> >=`: a non-VC last block flush with end -> original returns the
+        // empty vec; the `>=` mutant rejects at the loop guard.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        assert_eq!(read_vorbis_comments(&file).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn read_vorbis_comments_decodes_24bit_length() {
+        // :199 `<<16 -> >>16` AND :200 `| -> &`: high length byte set over a short
+        // body. Original len = 0x10000 -> Malformed. `>>16` -> len 0 -> Ok; `&` ->
+        // (0x10000 & 0) -> len 0 -> Ok. Either mutant returns Ok instead of Malformed.
+        let hi = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0000))]);
+        assert_eq!(read_vorbis_comments(&hi), Err(FormatError::Malformed));
+        // :200 `<<8 -> >>8`: mid length byte set, high byte 0. Original len = 0x100
+        // -> Malformed; `>>8` -> len 0 -> Ok.
+        let mid = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x00_0100))]);
+        assert_eq!(read_vorbis_comments(&mid), Err(FormatError::Malformed));
+        // (:200 `| -> ^` and :201 `| -> ^` are equivalent: disjoint shifted bytes.)
+    }
+```
+
+- [ ] **Step 2: Run, expect PASS**
+
+```bash
+cargo test -p musefs-format --features fuzzing flac::tests::read_vorbis_comments
+```
+Expected: all three pass.
+
+- [ ] **Step 3: Hand-apply-verify the kills**
+
+- `:188` `< → ==`, `< → <=`, `|| → &&`: `..._guards_marker` FAILs (panic or wrong error). Revert each.
+- `:204` `> → ==`, `> → >=`: `..._guards_marker` FAILs (the happy unwrap panics). Revert each.
+- `:193` `+ → -`, `> → ==`, `> → >=`: `..._guards_block_walk` FAILs. Revert each.
+- `:199` `<< → >>`, `:200` `| → &`, `:200` `<< → >>`: `..._decodes_24bit_length` FAILs. Revert each.
+- `:200` `| → ^`, `:201` `| → ^`: rerun the set → still PASS (equivalent). Note for Task 8. Revert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/flac.rs
+git commit -m "test(flac): read_vorbis_comments block-walk + length kills"
+```
+
+---
+
+## Task 4: `parse_picture_block` + `read_pictures` kills
+
+Kills `parse_picture_block:237` (`==`), `:245` (`==`), `:261`; `read_pictures:277,
+:283, :289, :290` (`&` and `<<8`), `:294`. Confirms `:237`/`:245` (`>=`),
+`:290` (`^`), `:291` equivalent.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/flac.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the `picture_body` helper + the `parse_picture_block` tests**
+
+`raw_block`/`flac_with` already exist (Task 2). Add `picture_body` (first use here):
+
+```rust
+    /// A FLAC PICTURE block body (big-endian fields), independent of production.
+    fn picture_body(ptype: u32, mime: &str, desc: &str, w: u32, h: u32, data: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&ptype.to_be_bytes());
+        v.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        v.extend_from_slice(mime.as_bytes());
+        v.extend_from_slice(&(desc.len() as u32).to_be_bytes());
+        v.extend_from_slice(desc.as_bytes());
+        v.extend_from_slice(&w.to_be_bytes());
+        v.extend_from_slice(&h.to_be_bytes());
+        v.extend_from_slice(&0u32.to_be_bytes()); // depth
+        v.extend_from_slice(&0u32.to_be_bytes()); // colors
+        v.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        v.extend_from_slice(data);
+        v
+    }
+
+    #[test]
+    fn parse_picture_block_roundtrips_fields() {
+        let body = picture_body(3, "image/png", "desc", 4, 5, b"PIXELS");
+        let p = parse_picture_block(&body).unwrap();
+        assert_eq!(p.picture_type, 3);
+        assert_eq!(p.mime, "image/png");
+        assert_eq!(p.description, "desc");
+        assert_eq!(p.width, 4);
+        assert_eq!(p.height, 5);
+        assert_eq!(p.data, b"PIXELS");
+    }
+
+    #[test]
+    fn parse_picture_block_guards_field_bounds() {
+        // :237 `> -> ==` (mime bound): claim mime_len far past the end. Original
+        // Malformed; the `==` mutant falls through to slice body[8..8+mime_len] -> panic.
+        let mut bad_mime = 3u32.to_be_bytes().to_vec();
+        bad_mime.extend_from_slice(&16u32.to_be_bytes()); // mime_len = 16
+        bad_mime.extend_from_slice(b"ab"); // only 2 bytes present
+        assert_eq!(parse_picture_block(&bad_mime), Err(FormatError::Malformed));
+
+        // :245 `> -> ==` (desc bound): valid mime, then claim desc_len past the end.
+        let mut bad_desc = 3u32.to_be_bytes().to_vec();
+        bad_desc.extend_from_slice(&3u32.to_be_bytes()); // mime_len = 3
+        bad_desc.extend_from_slice(b"png");
+        bad_desc.extend_from_slice(&16u32.to_be_bytes()); // desc_len = 16
+        bad_desc.extend_from_slice(b"x"); // only 1 byte present
+        assert_eq!(parse_picture_block(&bad_desc), Err(FormatError::Malformed));
+
+        // :261 `> -> <` (data bound): a fully valid picture body with TRAILING bytes.
+        // Original ignores the trailing byte (data_end < len, not >) and returns Ok;
+        // the `<` mutant rejects (data_end < len -> Malformed).
+        let mut trailing = picture_body(3, "png", "", 1, 1, b"DA");
+        trailing.push(0xFF); // one extra trailing byte
+        assert!(parse_picture_block(&trailing).is_ok());
+    }
+```
+
+- [ ] **Step 2: Add the `read_pictures` tests**
+
+```rust
+    #[test]
+    fn read_pictures_extracts_and_guards_marker() {
+        // Happy path: one PICTURE block, last, no audio (body_end == len). Pins :294.
+        let pic = picture_body(3, "image/jpeg", "front", 8, 8, b"IMG");
+        let file = flac_with(&[raw_block(BLOCK_PICTURE, &pic, true, None)]);
+        let pics = read_pictures(&file).unwrap();
+        assert_eq!(pics.len(), 1);
+        assert_eq!(pics[0].mime, "image/jpeg");
+        assert_eq!(pics[0].data, b"IMG");
+        // :277 `< -> ==` and `|| -> &&`: 3-byte input -> panic vs NotFlac.
+        assert_eq!(read_pictures(b"fLa"), Err(FormatError::NotFlac));
+        // :277 `< -> <=`: 4-byte fLaC -> Malformed vs NotFlac.
+        assert_eq!(read_pictures(b"fLaC"), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn read_pictures_guards_block_walk_and_length() {
+        // :283 `+ -> -`, `> -> ==`: truncated header.
+        assert_eq!(read_pictures(b"fLaC\x80"), Err(FormatError::Malformed));
+        // :283 `> -> >=`: non-PICTURE last block flush with end -> Ok(empty).
+        let none = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        assert_eq!(read_pictures(&none).unwrap(), Vec::new());
+        // :289 `<<16 -> >>16` and :290 `| -> &`: high length byte over short body.
+        let hi = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0000))]);
+        assert_eq!(read_pictures(&hi), Err(FormatError::Malformed));
+        // :290 `<<8 -> >>8`: mid length byte, high byte 0.
+        let mid = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x00_0100))]);
+        assert_eq!(read_pictures(&mid), Err(FormatError::Malformed));
+    }
+```
+
+- [ ] **Step 3: Run, expect PASS**
+
+```bash
+cargo test -p musefs-format --features fuzzing flac::tests::parse_picture_block flac::tests::read_pictures
+```
+Expected: all four pass.
+
+- [ ] **Step 4: Hand-apply-verify the kills**
+
+- `:237` `> → ==`: `parse_picture_block_guards_field_bounds` FAILs (panic). Revert.
+- `:245` `> → ==`: same test FAILs (panic). Revert.
+- `:261` `> → <`: same test FAILs (`trailing` returns Malformed). Revert.
+- `:237` `> → >=`, `:245` `> → >=`: rerun → still PASS (equivalent — proceeding still
+  hits `Malformed` at the next `read_u32_be`). Note for Task 8. Revert each.
+- `:277` (`< → ==`, `< → <=`, `|| → &&`), `:294` (`> → ==`/`>=`):
+  `read_pictures_extracts_and_guards_marker` FAILs. Revert each.
+- `:283` (`+ → -`, `> → ==`, `> → >=`), `:289` (`<< → >>`), `:290` (`| → &`,
+  `<< → >>`): `read_pictures_guards_block_walk_and_length` FAILs. Revert each.
+- `:290` `| → ^`, `:291` `| → ^`: rerun → still PASS (equivalent). Note for Task 8. Revert.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/flac.rs
+git commit -m "test(flac): parse_picture_block + read_pictures kills"
+```
+
+---
+
+## Task 5: `synthesize_layout` 24-bit `TooLarge` boundary (C3)
+
+Kills `synthesize_layout:155` (`> → >=`).
+
+**Files:**
+- Modify (tests only): `musefs-format/src/flac.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the boundary test**
+
+```rust
+    #[test]
+    fn synthesize_layout_picture_block_size_boundary_is_inclusive() {
+        // body_len = picture_body_framing(art).len() + art.data_len, and the framing
+        // is 32 fixed bytes + mime.len() + desc.len(). With mime "image/png" (9) and
+        // an empty description, framing = 41. The guard rejects body_len > 0x00FF_FFFF.
+        let scan = FlacScan { audio_offset: 0, audio_length: 0, preserved: vec![] };
+        let framing_len = 32u64 + "image/png".len() as u64; // 41
+        let mk = |data_len: u64| ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len,
+        };
+        // body_len == 0x00FF_FFFF exactly: original `>` accepts; `>=` mutant rejects.
+        // (data_len is only a count; no large allocation occurs.)
+        assert!(synthesize_layout(&scan, &[], &[mk(0x00FF_FFFF - framing_len)]).is_ok());
+        // one byte over must still error, pinning the high side of the boundary.
+        assert_eq!(
+            synthesize_layout(&scan, &[], &[mk(0x00FF_FFFF - framing_len + 1)]),
+            Err(FormatError::TooLarge)
+        );
+    }
+```
+
+- [ ] **Step 2: Run, expect PASS**
+
+```bash
+cargo test -p musefs-format --features fuzzing flac::tests::synthesize_layout_picture_block_size_boundary_is_inclusive
+```
+Expected: pass. (If `picture_body_framing` ever changes its fixed size, recompute
+`framing_len`; the test asserts the inclusive boundary, not a magic file size.)
+
+- [ ] **Step 3: Hand-apply-verify**
+
+`:155` `body_len > 0x00FF_FFFF` → `>=`: rerun → FAIL (the `.is_ok()` assertion now
+returns `Err(TooLarge)`). Revert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/flac.rs
+git commit -m "test(flac): synthesize_layout 24-bit picture-size boundary"
+```
+
+---
+
+## Task 6: broaden `proptest_read_fidelity` (finding #5)
+
+**Files:**
+- Modify (tests only): `musefs-core/tests/proptest_read_fidelity.rs`.
+
+- [ ] **Step 1: Add the art-fixture helper + imports**
+
+At the top of the file, extend the `use` lines and add `build_with_art` after the
+existing `build`:
+
+```rust
+use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
+use musefs_format::Segment;
+```
+
+```rust
+/// Like `build`, but also inserts an art blob and links it to the track, so the
+/// resolved layout contains an `ArtImage` segment. Mirrors the insert+link pattern
+/// in `musefs-core/tests/reader.rs::resolve_includes_art_image_segments`.
+fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, Db, i64) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.flac");
+    let (audio_offset, audio_length) = write_flac(&path, &["TITLE=Orig"], audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    let art_id = db
+        .upsert_art(&NewArt {
+            mime: "image/png".to_string(),
+            width: Some(8),
+            height: Some(8),
+            data: art.to_vec(),
+        })
+        .unwrap();
+    db.set_track_art(
+        id,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: "front".to_string(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+    (dir, db, id)
+}
+```
+
+- [ ] **Step 2: Add the three broadened properties inside the existing `proptest! { ... }` block**
+
+```rust
+    #[test]
+    fn read_at_partial_windows_match_whole(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(got.len() as u64, len);
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+
+    #[test]
+    fn read_at_windows_spanning_header_seam(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        before in 0usize..4096,
+        after in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let hlen = resolved.layout.header_len();
+        prop_assume!(hlen > 0 && hlen < total);
+        let start = hlen - 1 - (before as u64 % hlen); // in [0, hlen)
+        let end = hlen + 1 + (after as u64 % (total - hlen)); // in (hlen, total]
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let got = read_at(&resolved, &db, start, end - start).unwrap();
+        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+    }
+
+    #[test]
+    fn read_at_art_window_serves_blob(
+        audio in proptest::collection::vec(any::<u8>(), 1..256),
+        art in proptest::collection::vec(any::<u8>(), 1..256),
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id) = build_with_art(&audio, "T", &art);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        prop_assert!(resolved
+            .layout
+            .segments
+            .iter()
+            .any(|s| matches!(s, Segment::ArtImage { .. })));
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        // the art blob appears verbatim in the assembled output (it is served, not dropped).
+        prop_assert!(whole.windows(art.len()).any(|w| w == &art[..]));
+    }
+```
+
+- [ ] **Step 3: Run, expect PASS**
+
+```bash
+cargo test -p musefs-core proptest_read_fidelity
+```
+Expected: all four properties pass (the original `read_at_preserves_backing_audio`
+plus the three new ones). If `read_at` rejects an in-range zero-length read, that is
+a real bug — investigate before adjusting the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/tests/proptest_read_fidelity.rs
+git commit -m "test(read): broaden proptest_read_fidelity — partial/seam/art windows (#5)"
+```
+
+---
+
+## Task 7: zero-byte embedded-art boundary (finding #16) — spike-first
+
+**Files:**
+- Modify (tests only): `musefs-format/tests/synthesize_art.rs`.
+
+- [ ] **Step 1: Add the zero-byte-art test (the spike)**
+
+`cover(art_id, data_len)` and `fixture()` already exist in this file. Add:
+
+```rust
+#[test]
+fn zero_byte_art_synthesizes_and_round_trips() {
+    let (file, audio) = fixture();
+    let scan = locate_audio(&file).unwrap();
+
+    let art = cover(7, 0); // data_len == 0
+    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
+
+    // A zero-length PICTURE block: the ArtImage segment carries len 0.
+    assert!(layout
+        .segments
+        .iter()
+        .any(|s| matches!(s, Segment::ArtImage { art_id: 7, len: 0 })));
+
+    let mut art_map = HashMap::new();
+    art_map.insert(7i64, Vec::new());
+    let assembled = resolve_layout(&layout, &file, &art_map);
+    assert_eq!(assembled.len() as u64, layout.total_len());
+    assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
+
+    // metaflac reads back exactly one picture with empty data.
+    let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
+    let pics: Vec<_> = tag.pictures().collect();
+    assert_eq!(pics.len(), 1);
+    assert!(pics[0].data.is_empty());
+}
+```
+
+- [ ] **Step 2: Run — this is the verification spike**
+
+```bash
+cargo test -p musefs-format --features fuzzing synthesize_art::zero_byte_art_synthesizes_and_round_trips
+```
+
+Two outcomes (record which in Task 8):
+
+- **PASS** → zero-byte art is a valid zero-length PICTURE block end to end. Done,
+  tests-only. Proceed to Step 3.
+- **FAIL** → a real defect surfaced (e.g. `metaflac` rejects empty picture data, or
+  an off-by-one in `picture_body_framing`/`synthesize_layout` at `data_len == 0`).
+  This is **not** a test artifact. Apply the **C5 contingency**: make a minimal,
+  scoped fix in `musefs-format/src/flac.rs` framing/guard logic (never the
+  positioned audio reads — byte-identity is unaffected), and adjust the assertion to
+  the corrected behavior. If the correct behavior is to *reject* zero-byte art, the
+  test asserts `synthesize_layout(...) == Err(...)` instead and ingestion is the
+  enforcement point. Use `superpowers:systematic-debugging` for the diagnosis.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-format/tests/synthesize_art.rs   # plus musefs-format/src/flac.rs if the spike forced a fix
+git commit -m "test(flac): zero-byte embedded-art boundary (#16)"
+```
+
+---
+
+## Task 8: inventory + tracking doc updates (C6)
+
+**Files:**
+- Modify: `docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md`
+- Modify: `docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md`
+
+- [ ] **Step 1: Annotate the `flac.rs` rows in the inventory**
+
+For each `flac.rs:<line>` row, append the outcome to its `Kind` column, matching the
+Phase 2 convention (`missed → **killed** (phase 3a)` or `missed → **equivalent**`):
+
+- **Equivalent** (do not count as killed):
+  `:50`, `:51` (`| → ^`); `:99` (`| → ^`); `:200` (`| → ^` row only),
+  `:201` (`| → ^`); `:290` (`| → ^` row only), `:291` (`| → ^`);
+  `:237` (`> → >=` row only), `:245` (`> → >=` row only).
+- **Killed (phase 3a):** every other `flac.rs` row, including `:200`/`:290` (`| → &`
+  and `<< → >>` rows), `:237`/`:245` (`> → ==` rows), and `:261`.
+
+- [ ] **Step 2: Mark Phase 3a complete in the tracking doc**
+
+In `2026-05-29-remediation-tracking.md`:
+- Top-of-file Status line: add "Phase 3a (FLAC) complete".
+- Under Phase 3, record: 3a done — FLAC survivors killed (equivalents:
+  disjoint-bitfield `| → ^` at `:50/:51/:99/:200/:201/:290/:291` and inclusive-bound
+  `> → >=` at `parse_picture_block:237/:245`); finding #16 resolved (record the C5
+  spike outcome); finding #5 broadened on FLAC (partial/seam/art windows), with the
+  non-FLAC dimension tracked into 3b/3c/3d.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md \
+        docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+git commit -m "docs(phase3a): record FLAC kills/equivalents; mark phase 3a complete"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] **Full workspace + lint + format**
+
+```bash
+cargo test --workspace
+cargo test -p musefs-format --features fuzzing
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+Expected: all green (the pre-commit hook runs these too).
+
+- [ ] **Open the PR; `mutants.yml` `in-diff` + `canary` run on it.** After merge, the
+next full campaign confirms `flac.rs` survivors dropped (excluding the documented
+equivalents).
+
+## Notes for the executor
+
+- The **only** possible non-test production change is the C5 contingency (Task 7);
+  every other change is additive tests. Byte-identity for audio is never touched.
+- Never leave a hand-applied mutation in the tree — always revert before the next step.
+- If a survivor turns out to be a genuine equivalent the plan did not anticipate,
+  record it in Task 8 rather than forcing a contrived test. The plan already marks
+  the `| → ^` and `parse_picture_block` `> → >=` mutations equivalent.
+- The pre-commit hook runs `cargo fmt --check`, `clippy -D warnings`, `cargo test
+  --workspace`, and `ruff`; keep each commit green.
+```

--- a/docs/superpowers/plans/2026-05-29-phase3a-flac-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3a-flac-hardening.md
@@ -490,7 +490,7 @@ Kills `synthesize_layout:155` (`> → >=`).
     #[test]
     fn synthesize_layout_picture_block_size_boundary_is_inclusive() {
         // body_len = picture_body_framing(art).len() + art.data_len. The guard at
-        // flac.rs:155 rejects body_len > 0x00FF_FFFF (FLAC's 24-bit block length).
+        // flac.rs rejects body_len > 0x00FF_FFFF (FLAC's 24-bit block length).
         let scan = FlacScan { audio_offset: 0, audio_length: 0, preserved: vec![] };
         let mk = |data_len: u64| ArtInput {
             art_id: 1,

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md
@@ -159,51 +159,51 @@ the rightmost column of each survivor table.
 
 | File:line | Mutation | Kind | Phase |
 |-----------|----------|------|------:|
-| `flac.rs:37` | replace < with == in parse_blocks | missed | 3 |
-| `flac.rs:37` | replace < with <= in parse_blocks | missed | 3 |
-| `flac.rs:43` | replace + with - in parse_blocks | missed | 3 |
-| `flac.rs:43` | replace > with == in parse_blocks | missed | 3 |
-| `flac.rs:43` | replace > with >= in parse_blocks | missed | 3 |
-| `flac.rs:49` | replace << with >> in parse_blocks | missed | 3 |
-| `flac.rs:50` | replace \| with ^ in parse_blocks | missed | 3 |
-| `flac.rs:51` | replace \| with ^ in parse_blocks | missed | 3 |
-| `flac.rs:99` | replace \| with ^ in push_block_header | missed | 3 |
-| `flac.rs:101` | replace >> with << in push_block_header | missed | 3 |
-| `flac.rs:155` | replace > with >= in synthesize_layout | missed | 3 |
-| `flac.rs:188` | replace < with == in read_vorbis_comments | missed | 3 |
-| `flac.rs:188` | replace < with <= in read_vorbis_comments | missed | 3 |
-| `flac.rs:188` | replace \|\| with && in read_vorbis_comments | missed | 3 |
-| `flac.rs:193` | replace + with - in read_vorbis_comments | missed | 3 |
-| `flac.rs:193` | replace > with == in read_vorbis_comments | missed | 3 |
-| `flac.rs:193` | replace > with >= in read_vorbis_comments | missed | 3 |
-| `flac.rs:199` | replace << with >> in read_vorbis_comments | missed | 3 |
-| `flac.rs:200` | replace \| with & in read_vorbis_comments | missed | 3 |
-| `flac.rs:200` | replace \| with ^ in read_vorbis_comments | missed | 3 |
-| `flac.rs:200` | replace << with >> in read_vorbis_comments | missed | 3 |
-| `flac.rs:201` | replace \| with ^ in read_vorbis_comments | missed | 3 |
-| `flac.rs:204` | replace > with == in read_vorbis_comments | missed | 3 |
-| `flac.rs:204` | replace > with >= in read_vorbis_comments | missed | 3 |
-| `flac.rs:219` | replace > with == in read_u32_be | missed | 3 |
-| `flac.rs:219` | replace > with >= in read_u32_be | missed | 3 |
-| `flac.rs:224` | replace + with * in read_u32_be | missed | 3 |
-| `flac.rs:237` | replace > with == in parse_picture_block | missed | 3 |
-| `flac.rs:237` | replace > with >= in parse_picture_block | missed | 3 |
-| `flac.rs:245` | replace > with == in parse_picture_block | missed | 3 |
-| `flac.rs:245` | replace > with >= in parse_picture_block | missed | 3 |
-| `flac.rs:261` | replace > with < in parse_picture_block | missed | 3 |
-| `flac.rs:277` | replace < with == in read_pictures | missed | 3 |
-| `flac.rs:277` | replace < with <= in read_pictures | missed | 3 |
-| `flac.rs:277` | replace \|\| with && in read_pictures | missed | 3 |
-| `flac.rs:283` | replace + with - in read_pictures | missed | 3 |
-| `flac.rs:283` | replace > with == in read_pictures | missed | 3 |
-| `flac.rs:283` | replace > with >= in read_pictures | missed | 3 |
-| `flac.rs:289` | replace << with >> in read_pictures | missed | 3 |
-| `flac.rs:290` | replace \| with & in read_pictures | missed | 3 |
-| `flac.rs:290` | replace \| with ^ in read_pictures | missed | 3 |
-| `flac.rs:290` | replace << with >> in read_pictures | missed | 3 |
-| `flac.rs:291` | replace \| with ^ in read_pictures | missed | 3 |
-| `flac.rs:294` | replace > with == in read_pictures | missed | 3 |
-| `flac.rs:294` | replace > with >= in read_pictures | missed | 3 |
+| `flac.rs:37` | replace < with == in parse_blocks | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:37` | replace < with <= in parse_blocks | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:43` | replace + with - in parse_blocks | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:43` | replace > with == in parse_blocks | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:43` | replace > with >= in parse_blocks | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:49` | replace << with >> in parse_blocks | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:50` | replace \| with ^ in parse_blocks | missed → **equivalent** | 3 |
+| `flac.rs:51` | replace \| with ^ in parse_blocks | missed → **equivalent** | 3 |
+| `flac.rs:99` | replace \| with ^ in push_block_header | missed → **equivalent** | 3 |
+| `flac.rs:101` | replace >> with << in push_block_header | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:155` | replace > with >= in synthesize_layout | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:188` | replace < with == in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:188` | replace < with <= in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:188` | replace \|\| with && in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:193` | replace + with - in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:193` | replace > with == in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:193` | replace > with >= in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:199` | replace << with >> in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:200` | replace \| with & in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:200` | replace \| with ^ in read_vorbis_comments | missed → **equivalent** | 3 |
+| `flac.rs:200` | replace << with >> in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:201` | replace \| with ^ in read_vorbis_comments | missed → **equivalent** | 3 |
+| `flac.rs:204` | replace > with == in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:204` | replace > with >= in read_vorbis_comments | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:219` | replace > with == in read_u32_be | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:219` | replace > with >= in read_u32_be | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:224` | replace + with * in read_u32_be | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:237` | replace > with == in parse_picture_block | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:237` | replace > with >= in parse_picture_block | missed → **equivalent** | 3 |
+| `flac.rs:245` | replace > with == in parse_picture_block | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:245` | replace > with >= in parse_picture_block | missed → **equivalent** | 3 |
+| `flac.rs:261` | replace > with < in parse_picture_block | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:277` | replace < with == in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:277` | replace < with <= in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:277` | replace \|\| with && in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:283` | replace + with - in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:283` | replace > with == in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:283` | replace > with >= in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:289` | replace << with >> in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:290` | replace \| with & in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:290` | replace \| with ^ in read_pictures | missed → **equivalent** | 3 |
+| `flac.rs:290` | replace << with >> in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:291` | replace \| with ^ in read_pictures | missed → **equivalent** | 3 |
+| `flac.rs:294` | replace > with == in read_pictures | missed → **killed** (phase 3a) | 3 |
+| `flac.rs:294` | replace > with >= in read_pictures | missed → **killed** (phase 3a) | 3 |
 | `mp3.rs:16` | replace << with >> in synchsafe_decode | missed | 3 |
 | `mp3.rs:17` | replace \| with & in synchsafe_decode | missed | 3 |
 | `mp3.rs:17` | replace \| with ^ in synchsafe_decode | missed | 3 |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
@@ -13,12 +13,12 @@ dimensions finding #5 calls out (partial reads, header/audio boundary spanning,
 art-segment serving), and add the zero-byte embedded-art boundary test (finding
 #16).
 
-**Changes are additive: tests only, no new dependencies** — with one possible
-exception. The C5 zero-byte-art spike could surface a genuine production bug in the
-FLAC framing/guard logic; if so it gets a small, scoped fix (see C5). **Either way
-the byte-identity invariant is untouched** — no change in 3a touches the positioned
-audio reads, only metadata-block framing. (Phase 2 needed one named constant; 3a
-needs none unless the spike forces a fix.)
+**Changes are additive tests plus one small scoped production fix, no new
+dependencies.** The production change is the C5 zero-byte-art skip in
+`flac.rs::synthesize_layout` (a degenerate empty picture must not brick a track).
+**The byte-identity invariant is untouched** — no change in 3a touches the
+positioned audio reads, only whether an empty metadata-block is emitted. (Phase 2
+needed one named constant; 3a needs the zero-byte-art skip.)
 
 This is the first slice of Phase 3 (Format-layer coverage & mutants, non-Ogg),
 which is decomposed into per-format sub-phases: **3a FLAC** (this doc), 3b MP3,
@@ -212,33 +212,33 @@ matching the existing property) since each case does DB + file I/O.
 Non-FLAC formats are deferred to 3b/3c/3d (their fixtures don't exist in
 `musefs-core/tests/common` yet); 3a does not add `write_mp3/mp4/wav`.
 
-### C5 — Finding #16: zero-byte embedded art
+### C5 — Finding #16: zero-byte embedded art (skip at synthesis)
 
-Extend `musefs-format/tests/synthesize_art.rs`: synthesize a picture with
-`data_len == 0` and assert the boundary behavior. Pins the `data_len == 0` edge
-that the survivor bounds (`parse_picture_block:261`, the `data_end > body.len()`
-guard) depend on.
+**Verified behavior (not an assumption).** Today `synthesize_layout` builds
+`Segment::ArtImage { len: 0 }` for zero-byte art, which `RegionLayout::validate`
+(`layout.rs:102`, `EmptySegment`) rejects → `synthesize_layout` returns
+`Err(FormatError::InvalidLayout)`. Ingestion (`scan.rs:162`) only filters art
+*above* `MAX_ART_BYTES`, so a source file with an empty PICTURE block is ingested
+and then makes the **whole track unreadable** at serve time. That is a real
+robustness gap.
 
-**Unverified assumption + contingency (verify-don't-trust).** The spec *expects*
-zero-length art to be a valid zero-length PICTURE block: `ArtImage { len: 0 }`, the
-layout round-trips, and `metaflac` reads a picture with empty `data`. This is
-**not yet verified** — `metaflac` might reject empty picture data, or
-`picture_body_framing` / `synthesize_layout` might have an off-by-one at
-`data_len == 0`. The plan's **first C5 step is a verification spike** (write the
-test, observe actual behavior) with two branches:
+**Resolution (chosen): skip zero-byte art at FLAC synthesis.** `synthesize_layout`
+filters arts with `data_len == 0` **before** computing `num_blocks`/`last_index`
+(so the FLAC `is_last` flag lands on the true final block) and `continue`s past them
+in the emit loop. The track then serves normally without the empty picture. This is
+a small, scoped production change in `musefs-format/src/flac.rs`; **byte-identity is
+unaffected** — it only decides whether an empty PICTURE metadata block is emitted,
+never the positioned audio reads.
 
-- **Assumption holds:** assert the round-trip + `metaflac` empty-data read. Pure
-  test addition, no production change — the "tests-only" claim stands.
-- **Assumption fails (production bug surfaced):** this is a real defect, not a test
-  artifact. Fix it as a **scoped production change** to the framing/guard logic in
-  `flac.rs` (e.g. the length-field emit or the `data_end` bound) and document the
-  exception to "tests-only" in the inventory. **The byte-identity invariant is
-  unaffected either way** — the fix touches metadata-block framing, never the
-  positioned audio reads. If the correct behavior turns out to be *rejecting*
-  zero-byte art (`Err(...)`), the test asserts that error instead, and ingestion's
-  art handling is noted as the enforcement point.
+`musefs-format/tests/synthesize_art.rs` asserts: zero-byte art → no `ArtImage`
+segment, the layout is valid and round-trips, and `metaflac` reads **zero** pictures;
+plus a mixed case (empty + real art) confirming the surviving PICTURE block keeps its
+last-block flag.
 
-Either branch is acceptable; the spike decides which, and 3a records the outcome.
+**Cross-cutting follow-up (noted, not done in 3a):** the same degenerate-art skip
+applies to mp3/mp4/ogg/wav synthesis — handle it in each format's sub-phase, or
+filter empty art once at ingestion (`scan.rs`, add `&& !p.data.is_empty()`). 3a
+fixes FLAC and records the follow-up.
 
 ### C6 — inventory + tracking docs
 
@@ -273,5 +273,5 @@ Malformed, TooLarge}` mappings on crafted inputs; nothing in production changes.
 | C2 | listed `read_vorbis_comments`/`parse_picture_block`/`read_pictures` mutations hand-apply red; `| → ^` rows recorded equivalent |
 | C3 | boundary test at `0x00FF_FFFF` passes; `> → >=` hand-apply red |
 | C4 | `cargo test -p musefs-core proptest_read_fidelity` green; the three named properties (`read_at_partial_windows_match_whole`, `read_at_windows_spanning_header_seam`, `read_at_art_window_serves_blob`) pass with the art fixture |
-| C5 | spike resolved and outcome recorded: either the zero-byte-art round-trip + `metaflac` empty-data read passes (tests-only), or the scoped framing/guard fix lands with the test asserting the corrected behavior |
+| C5 | `synthesize_layout` skips zero-byte art; the synthesize_art tests assert no `ArtImage` segment, valid round-trip, `metaflac` reads 0 pictures, and the mixed empty+real case keeps the last-block flag; existing non-empty-art tests still pass |
 | Whole | `cargo test --workspace` + `--features fuzzing` + `clippy -D warnings` + `fmt --check` green; next full mutants campaign shows `flac.rs` survivors dropped (excluding documented equivalents) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
@@ -1,0 +1,187 @@
+# Phase 3a — FLAC Hardening (Design)
+
+**Source audit:** `docs/audits/2026-05-29-test-audit.md` (findings #5, #16, plus the
+`flac.rs` mutation survivors from the phase-1 inventory)
+**Created:** 2026-05-29
+**Status:** design — awaiting plan
+
+## Goal
+
+Close the FLAC unit-test gaps and drive the **45 `flac.rs` mutation survivors**
+toward zero, broaden the cross-format read-fidelity property test along the
+dimensions finding #5 calls out (partial reads, header/audio boundary spanning,
+art-segment serving), and add the zero-byte embedded-art boundary test (finding
+#16).
+
+**All changes are additive: tests only. No production logic changes and no new
+dependencies**, so the byte-identity invariant is untouched. (Phase 2 needed one
+named constant; 3a needs none.)
+
+This is the first slice of Phase 3 (Format-layer coverage & mutants, non-Ogg),
+which is decomposed into per-format sub-phases: **3a FLAC** (this doc), 3b MP3,
+3c MP4, 3d WAV. Findings #5 and #16 are cross-cutting but small, so they ride with
+3a; the non-FLAC dimension of #5 lands incrementally in 3b/3c/3d when each format's
+fixtures get built.
+
+## Guiding principle: verify, don't trust
+
+The 2026-05-29 audit was executed by a weaker model; its findings are **leads, not
+facts.** Every survivor below was re-read against the actual `flac.rs` source, and
+several turned out to be **provably equivalent mutants** (see the equivalent-mutant
+section). We document those rather than contrive tests for them.
+
+## The hand-apply verification method (use for every kill)
+
+cargo-mutants is not available locally. To prove a new test kills a specific
+survivor, for each targeted `file:line: mutation`:
+
+1. Run the new test → it passes (production code is correct).
+2. Apply the exact mutation at that line, rerun **just that test** → it must **fail**.
+3. Revert the mutation (`git checkout -- <file>`), rerun → passes again.
+
+If step 2 still passes, the test does not kill the mutant. Either strengthen the
+test, or — if the mutation provably produces identical behavior — record it as an
+**equivalent mutant** instead of forcing a contrived test. Never leave a mutation
+applied.
+
+## Test placement
+
+`flac.rs` has no test module today. Survivor functions split by visibility:
+
+- `pub`: `synthesize_layout`, `read_vorbis_comments`, `read_pictures` — reachable
+  from `musefs-format/tests/` integration files.
+- `pub(crate)` / private: `parse_blocks`, `push_block_header`, `read_u32_be`,
+  `parse_picture_block` — **not** reachable from integration tests (separate crate).
+
+The bit-level kills need precise byte control, which is cleanest with direct calls.
+So the bulk of 3a lives in a new `#[cfg(test)] mod tests` inside `flac.rs` (mirrors
+Phase 2's in-module tests in `page.rs`/`mod.rs`/`b64.rs`), with the `pub`-function
+work strengthening the existing `flac_pictures.rs` / `read_comments.rs` integration
+tests where they already exercise the path.
+
+**Approach considered and rejected:** integration-tests-only. The private helpers
+(`parse_blocks`, `read_u32_be`, `parse_picture_block`) are only reachable
+indirectly through `pub` entry points, which makes the byte-precise fixtures for
+the bit-op kills awkward and indirect. In-module unit tests are the right tool.
+
+## Verified findings
+
+The 45 survivors cluster by function. Kill strategy and killability were verified
+by reading the source.
+
+| Function | Survivor lines | Nature | Strategy |
+|----------|----------------|--------|----------|
+| `read_u32_be` | :219 (`>`→`==`/`>=`), :224 (`+`→`*` on the index) | bounds + byte-index | in-module: 4 distinct bytes pin the BE assembly; short slice pins the bound |
+| `parse_blocks` | :37 (`<`→`==`/`<=`), :43 (`+`→`-`, `>`→`==`/`>=`), :49 (`<<16`→`>>16`) | header/length decode | crafted fixtures incl. malformed-path (see "shift kills") |
+| `push_block_header` | :101 (`>>16`→`<<16`) | 24-bit length emit | in-module: `body_len = 0x123456`, assert emitted bytes |
+| `synthesize_layout` | :155 (`>`→`>=`) | 24-bit TooLarge guard | exact-boundary test at `body_len == 0x00FF_FFFF` |
+| `read_vorbis_comments` | :188 (`<`→`==`/`<=`, `\|\|`→`&&`), :193 (`+`→`-`, `>`→`==`/`>=`), :199 (`<<16`→`>>16`), :200 (`\|`→`&`, `<<8`→`>>8`), :204 (`>`→`==`/`>=`) | block-walk + length decode | crafted fixtures + malformed-path |
+| `parse_picture_block` | :237 (`>`→`==`/`>=`), :245 (`>`→`==`/`>=`), :261 (`>`→`<`) | mime/desc/data bounds | in-module: picture bodies truncated at each boundary |
+| `read_pictures` | :277 (`<`→`==`/`<=`, `\|\|`→`&&`), :283 (`+`→`-`, `>`→`==`/`>=`), :289 (`<<16`→`>>16`), :290 (`\|`→`&`, `<<8`→`>>8`), :294 (`>`→`==`/`>=`) | block-walk + length decode | crafted fixtures + malformed-path |
+
+### "Shift kills" technique (`<<16`/`<<8` → `>>`)
+
+The 24-bit length decode reads bytes that are normally zero in small fixtures, so
+the existing happy-path tests can't observe a flipped shift. Killing them does
+**not** require 64 KB bodies: set the high (or mid) length byte nonzero and assert
+the **malformed vs parsed** divergence. E.g. a STREAMINFO header with length bytes
+`[0x01, 0x00, 0x00]` (= 0x010000) over a short body: the original computes
+`len = 65536` → `body_end > data.len()` → `Err(Malformed)`; the `>>16` mutant
+computes `len = 0` → body fits → `Ok`. The Err/Ok split kills the mutant with a
+tiny fixture.
+
+## Equivalent mutants (do not chase — document)
+
+The 24-bit length decode `(b1 << 16) | (b2 << 8) | b3` shifts each byte into a
+**disjoint** bit range (23–16, 15–8, 7–0). For disjoint operands, `|` ≡ `^` ≡ `+`,
+so the following `| → ^` mutations produce byte-identical results and are
+**equivalent**:
+
+- `parse_blocks`: `:50`, `:51`
+- `read_vorbis_comments`: `:200` (the `\| → ^` variant), `:201`
+- `read_pictures`: `:290` (the `\| → ^` variant), `:291`
+
+Likewise `push_block_header:99` — `(if is_last {0x80} else {0}) | (block_type &
+0x7F)` ORs bit 7 with a value masked to bits 6–0 (disjoint), so its `| → ^` is
+**equivalent**.
+
+The sibling `| → &` mutations on the same lines (`:200`, `:290`) are **not**
+equivalent (AND of disjoint ranges = 0) and **are** killed. Each equivalence is
+re-confirmed by hand-apply (the test stays green under `^`) before being recorded.
+
+## Components
+
+### C1 — byte-decode helper kills (in-module `#[cfg(test)] mod tests`)
+
+`read_u32_be` (:219, :224), `parse_blocks` (:37, :43, :49 + record :50/:51 equiv),
+`push_block_header` (:101 killed, :99 equiv). Fixtures: distinct-byte BE values,
+truncated headers, and the shift-kill malformed fixtures.
+
+### C2 — VORBIS_COMMENT + picture parsing kills
+
+`read_vorbis_comments` (:188, :193, :199, :200 `&`, :204; record :200 `^`/:201
+equiv), `parse_picture_block` (:237, :245, :261), `read_pictures` (:277, :283,
+:289, :290 `&`, :294; record :290 `^`/:291 equiv). In-module for the private
+`parse_picture_block`; strengthen `flac_pictures.rs` / `read_comments.rs` for the
+`pub` walkers where they already build real fixtures.
+
+### C3 — `synthesize_layout:155` boundary
+
+`> → >=` on the 24-bit `TooLarge` guard. The existing
+`synthesize_errors_on_oversized_picture` test uses `data_len` well over the limit,
+so `>` and `>=` both fire — it can't distinguish them. Add a test at
+`body_len == 0x00FF_FFFF` exactly (`data_len = 0x00FF_FFFF - framing.len()`):
+original returns `Ok` (boundary is inclusive-valid), `>=` mutant returns
+`Err(TooLarge)`.
+
+### C4 — Finding #5: broaden `proptest_read_fidelity` (FLAC)
+
+`musefs-core/tests/proptest_read_fidelity.rs` today reads only `[0, total_len)`
+with no art. Broaden, on FLAC:
+
+- **Partial reads:** random `(offset, size)` windows; assert the served bytes equal
+  the corresponding slice of an independently-assembled whole.
+- **Header/audio boundary spanning:** windows straddling `header_len` (the
+  Inline→BackingAudio seam).
+- **Art-segment serving:** build a track with embedded art (an `ArtImage` segment)
+  and assert partial reads across the art window serve the blob bytes correctly.
+
+Non-FLAC formats are deferred to 3b/3c/3d (their fixtures don't exist in
+`musefs-core/tests/common` yet).
+
+### C5 — Finding #16: zero-byte embedded art
+
+Extend `musefs-format/tests/synthesize_art.rs`: synthesize a picture with
+`data_len == 0` and assert the boundary behavior — a valid zero-length PICTURE
+block (the `ArtImage` segment has `len: 0`, the layout round-trips, and
+`metaflac` reads a picture with empty data). Pins the `data_len == 0` edge that
+the survivor bounds (`parse_picture_block:261`, the `data_end > body.len()` guard)
+depend on.
+
+### C6 — inventory + tracking docs
+
+Annotate the `flac.rs` rows in `2026-05-29-mutation-inventory.md` (`killed (phase
+3a)` / `equivalent`), and mark Phase 3a complete in `2026-05-29-remediation-tracking.md`
+(recording the equivalent set and that findings #5/#16 are addressed for FLAC, with
+non-FLAC #5 coverage tracked into 3b/3c/3d).
+
+## Implementation ordering
+
+C1 → C2 → C3 (the in-`flac.rs` kills, building the test module incrementally) →
+C4, C5 (independent of each other and of C1–C3) → C6 (wrap-up).
+
+## Error handling
+
+No new error paths. The kills assert the existing `FormatError::{NotFlac,
+Malformed, TooLarge}` mappings on crafted inputs; nothing in production changes.
+
+## Acceptance
+
+| Component | Check |
+|-----------|-------|
+| C1 | `cargo test -p musefs-format --features fuzzing flac` green; :219/:224/:37/:43/:49/:101 hand-apply red; :50/:51/:99 stay green under `^` (equivalent) |
+| C2 | listed `read_vorbis_comments`/`parse_picture_block`/`read_pictures` mutations hand-apply red; `| → ^` rows recorded equivalent |
+| C3 | boundary test at `0x00FF_FFFF` passes; `> → >=` hand-apply red |
+| C4 | `cargo test -p musefs-core proptest_read_fidelity` green; partial-read / boundary / art windows covered |
+| C5 | zero-byte art test passes; round-trips via `metaflac` |
+| Whole | `cargo test --workspace` + `--features fuzzing` + `clippy -D warnings` + `fmt --check` green; next full mutants campaign shows `flac.rs` survivors dropped (excluding documented equivalents) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
@@ -13,9 +13,12 @@ dimensions finding #5 calls out (partial reads, header/audio boundary spanning,
 art-segment serving), and add the zero-byte embedded-art boundary test (finding
 #16).
 
-**All changes are additive: tests only. No production logic changes and no new
-dependencies**, so the byte-identity invariant is untouched. (Phase 2 needed one
-named constant; 3a needs none.)
+**Changes are additive: tests only, no new dependencies** — with one possible
+exception. The C5 zero-byte-art spike could surface a genuine production bug in the
+FLAC framing/guard logic; if so it gets a small, scoped fix (see C5). **Either way
+the byte-identity invariant is untouched** — no change in 3a touches the positioned
+audio reads, only metadata-block framing. (Phase 2 needed one named constant; 3a
+needs none unless the spike forces a fix.)
 
 This is the first slice of Phase 3 (Format-layer coverage & mutants, non-Ogg),
 which is decomposed into per-format sub-phases: **3a FLAC** (this doc), 3b MP3,
@@ -54,10 +57,18 @@ applied.
   `parse_picture_block` — **not** reachable from integration tests (separate crate).
 
 The bit-level kills need precise byte control, which is cleanest with direct calls.
-So the bulk of 3a lives in a new `#[cfg(test)] mod tests` inside `flac.rs` (mirrors
-Phase 2's in-module tests in `page.rs`/`mod.rs`/`b64.rs`), with the `pub`-function
-work strengthening the existing `flac_pictures.rs` / `read_comments.rs` integration
-tests where they already exercise the path.
+**All `flac.rs` mutant kills live in one new `#[cfg(test)] mod tests` inside
+`flac.rs`** (mirrors Phase 2's in-module tests in `page.rs`/`mod.rs`/`b64.rs`). A
+`#[cfg(test)] mod tests` with `use super::*` can call every survivor function
+directly — `pub`, `pub(crate)`, and private alike — so there is no reason to split
+kills across integration files. The existing integration tests (`flac_pictures.rs`,
+`read_comments.rs`, `layout.rs`, `locate.rs`, `proptest_flac.rs`) stay **unchanged**;
+they provide end-to-end coverage but are not the vehicle for any mutant kill in 3a.
+This keeps the kill→test mapping unambiguous (one module owns it) and avoids
+redundant or gap-prone work across files.
+
+The only 3a tests *outside* `flac.rs` are the cross-cutting C4 (`proptest_read_fidelity.rs`,
+in `musefs-core`) and C5 (`synthesize_art.rs`, in `musefs-format/tests`).
 
 **Approach considered and rejected:** integration-tests-only. The private helpers
 (`parse_blocks`, `read_u32_be`, `parse_picture_block`) are only reachable
@@ -78,6 +89,23 @@ by reading the source.
 | `read_vorbis_comments` | :188 (`<`→`==`/`<=`, `\|\|`→`&&`), :193 (`+`→`-`, `>`→`==`/`>=`), :199 (`<<16`→`>>16`), :200 (`\|`→`&`, `<<8`→`>>8`), :204 (`>`→`==`/`>=`) | block-walk + length decode | crafted fixtures + malformed-path |
 | `parse_picture_block` | :237 (`>`→`==`/`>=`), :245 (`>`→`==`/`>=`), :261 (`>`→`<`) | mime/desc/data bounds | in-module: picture bodies truncated at each boundary |
 | `read_pictures` | :277 (`<`→`==`/`<=`, `\|\|`→`&&`), :283 (`+`→`-`, `>`→`==`/`>=`), :289 (`<<16`→`>>16`), :290 (`\|`→`&`, `<<8`→`>>8`), :294 (`>`→`==`/`>=`) | block-walk + length decode | crafted fixtures + malformed-path |
+
+### Kill mechanism: panic-vs-`Err` for the short-input guards
+
+Some bound mutations kill by **panic-vs-`Err` divergence**, not a clean value
+comparison — the test must assert the *clean* `Err` and the mutation turns it into
+an out-of-bounds panic. Note this in the test so the mechanism is readable:
+
+- `parse_blocks:37` / `read_vorbis_comments:188` / `read_pictures:277`,
+  `< → ==` variant: with a **3-byte** input the original short-circuits
+  (`len < 4` true → `Err(NotFlac)`); the `==` mutant evaluates `3 == 4` → false →
+  falls through to `&data[0..4]` → **panic**. The test asserts `Err(NotFlac)` on a
+  3-byte input; the kill is panic ≠ Err.
+- The `< → <=` variant of the same lines kills cleanly by value: a **4-byte**
+  `fLaC`-only input gives original `Err(Malformed)` (loop reaches `pos+4 > len`)
+  vs. mutant `Err(NotFlac)` (`4 <= 4` short-circuits).
+- The `|| → &&` variant (`:188`, `:277`) likewise kills via panic-vs-`Err` on a
+  3-byte input (`&&` forces evaluation of `data[0..4]`).
 
 ### "Shift kills" technique (`<<16`/`<<8` → `>>`)
 
@@ -121,9 +149,10 @@ truncated headers, and the shift-kill malformed fixtures.
 
 `read_vorbis_comments` (:188, :193, :199, :200 `&`, :204; record :200 `^`/:201
 equiv), `parse_picture_block` (:237, :245, :261), `read_pictures` (:277, :283,
-:289, :290 `&`, :294; record :290 `^`/:291 equiv). In-module for the private
-`parse_picture_block`; strengthen `flac_pictures.rs` / `read_comments.rs` for the
-`pub` walkers where they already build real fixtures.
+:289, :290 `&`, :294; record :290 `^`/:291 equiv). **All in-module** — the test
+module calls `read_vorbis_comments`/`read_pictures` (`pub`) and `parse_picture_block`
+(`pub(crate)`) directly via `use super::*`, with crafted FLAC byte arrays. The
+existing `flac_pictures.rs` / `read_comments.rs` integration tests are not touched.
 
 ### C3 — `synthesize_layout:155` boundary
 
@@ -136,27 +165,71 @@ original returns `Ok` (boundary is inclusive-valid), `>=` mutant returns
 
 ### C4 — Finding #5: broaden `proptest_read_fidelity` (FLAC)
 
-`musefs-core/tests/proptest_read_fidelity.rs` today reads only `[0, total_len)`
-with no art. Broaden, on FLAC:
+`musefs-core/tests/proptest_read_fidelity.rs` today has one property
+(`read_at_preserves_backing_audio`) that reads only `[0, total_len)` with no art.
+Broaden on FLAC with these named properties, each asserting served bytes equal the
+corresponding slice of an independently-assembled `whole` (the existing
+`read_at(&resolved, &db, 0, total_len)` output is the reference):
 
-- **Partial reads:** random `(offset, size)` windows; assert the served bytes equal
-  the corresponding slice of an independently-assembled whole.
-- **Header/audio boundary spanning:** windows straddling `header_len` (the
-  Inline→BackingAudio seam).
-- **Art-segment serving:** build a track with embedded art (an `ArtImage` segment)
-  and assert partial reads across the art window serve the blob bytes correctly.
+- **`read_at_partial_windows_match_whole`** — strategy: `offset in 0..=total_len`,
+  `size in 0..=(total_len - offset)` (or clamp `offset+size` to `total_len`); assert
+  `read_at(.., offset, size) == whole[offset..offset+size]` and the returned length
+  equals `size`. Covers arbitrary partial reads, empty reads, and tail reads.
+- **`read_at_windows_spanning_header_seam`** — strategy: pick windows that straddle
+  `resolved.layout.header_len()` (e.g. `start in 0..header_len`, `end in
+  header_len..total_len`); assert equality with `whole[start..end]`. Pins the
+  Inline→BackingAudio seam.
+- **`read_at_art_window_serves_blob`** — uses the new art fixture (below); strategy:
+  windows overlapping the `ArtImage` segment's byte range; assert the served bytes
+  match the inserted art blob at the right offsets and that audio after the art is
+  still byte-identical.
+
+**Art-fixture sub-task (non-trivial — its own task in the plan).** `write_flac`
+produces tags only; there is no art helper. Add `build_with_art(...)` in this test
+file that, after `upsert_track` + `replace_tags`:
+
+1. `let art_id = db.upsert_art(&NewArt { mime: "image/jpeg".into(), width: Some(8),
+   height: Some(8), data: <blob> })?;`
+2. `db.set_track_art(track_id, &[TrackArt { art_id, picture_type: 3, description:
+   "front".into(), ordinal: 0 }])?;`
+
+`HeaderCache::resolve` then emits an `ArtImage` segment via
+`mapping::track_art_to_inputs`, and `read_at` serves the blob through
+`db.read_art_chunk`. **Reference the existing `musefs-core/tests/reader.rs` and
+`tests/read_at.rs`**, which already insert and link art this way — follow their
+pattern rather than inventing one. Keep `ProptestConfig::with_cases` modest (≤64,
+matching the existing property) since each case does DB + file I/O.
 
 Non-FLAC formats are deferred to 3b/3c/3d (their fixtures don't exist in
-`musefs-core/tests/common` yet).
+`musefs-core/tests/common` yet); 3a does not add `write_mp3/mp4/wav`.
 
 ### C5 — Finding #16: zero-byte embedded art
 
 Extend `musefs-format/tests/synthesize_art.rs`: synthesize a picture with
-`data_len == 0` and assert the boundary behavior — a valid zero-length PICTURE
-block (the `ArtImage` segment has `len: 0`, the layout round-trips, and
-`metaflac` reads a picture with empty data). Pins the `data_len == 0` edge that
-the survivor bounds (`parse_picture_block:261`, the `data_end > body.len()` guard)
-depend on.
+`data_len == 0` and assert the boundary behavior. Pins the `data_len == 0` edge
+that the survivor bounds (`parse_picture_block:261`, the `data_end > body.len()`
+guard) depend on.
+
+**Unverified assumption + contingency (verify-don't-trust).** The spec *expects*
+zero-length art to be a valid zero-length PICTURE block: `ArtImage { len: 0 }`, the
+layout round-trips, and `metaflac` reads a picture with empty `data`. This is
+**not yet verified** — `metaflac` might reject empty picture data, or
+`picture_body_framing` / `synthesize_layout` might have an off-by-one at
+`data_len == 0`. The plan's **first C5 step is a verification spike** (write the
+test, observe actual behavior) with two branches:
+
+- **Assumption holds:** assert the round-trip + `metaflac` empty-data read. Pure
+  test addition, no production change — the "tests-only" claim stands.
+- **Assumption fails (production bug surfaced):** this is a real defect, not a test
+  artifact. Fix it as a **scoped production change** to the framing/guard logic in
+  `flac.rs` (e.g. the length-field emit or the `data_end` bound) and document the
+  exception to "tests-only" in the inventory. **The byte-identity invariant is
+  unaffected either way** — the fix touches metadata-block framing, never the
+  positioned audio reads. If the correct behavior turns out to be *rejecting*
+  zero-byte art (`Err(...)`), the test asserts that error instead, and ingestion's
+  art handling is noted as the enforcement point.
+
+Either branch is acceptable; the spike decides which, and 3a records the outcome.
 
 ### C6 — inventory + tracking docs
 
@@ -170,6 +243,14 @@ non-FLAC #5 coverage tracked into 3b/3c/3d).
 C1 → C2 → C3 (the in-`flac.rs` kills, building the test module incrementally) →
 C4, C5 (independent of each other and of C1–C3) → C6 (wrap-up).
 
+**Re-verify line numbers before each component.** All survivor references are
+pinned to exact `flac.rs` line numbers from the phase-1 inventory; any intervening
+edit shifts them. At the start of each component, locate the target by its **code
+pattern** (named in the verified-findings table — e.g. "the `<< 16` in the 24-bit
+length decode", "the `data_end > body.len()` guard in `parse_picture_block`") and
+confirm the current line before applying the hand-apply mutation. The pattern is
+the source of truth; the line number is a convenience that may drift.
+
 ## Error handling
 
 No new error paths. The kills assert the existing `FormatError::{NotFlac,
@@ -182,6 +263,6 @@ Malformed, TooLarge}` mappings on crafted inputs; nothing in production changes.
 | C1 | `cargo test -p musefs-format --features fuzzing flac` green; :219/:224/:37/:43/:49/:101 hand-apply red; :50/:51/:99 stay green under `^` (equivalent) |
 | C2 | listed `read_vorbis_comments`/`parse_picture_block`/`read_pictures` mutations hand-apply red; `| → ^` rows recorded equivalent |
 | C3 | boundary test at `0x00FF_FFFF` passes; `> → >=` hand-apply red |
-| C4 | `cargo test -p musefs-core proptest_read_fidelity` green; partial-read / boundary / art windows covered |
-| C5 | zero-byte art test passes; round-trips via `metaflac` |
+| C4 | `cargo test -p musefs-core proptest_read_fidelity` green; the three named properties (`read_at_partial_windows_match_whole`, `read_at_windows_spanning_header_seam`, `read_at_art_window_serves_blob`) pass with the art fixture |
+| C5 | spike resolved and outcome recorded: either the zero-byte-art round-trip + `metaflac` empty-data read passes (tests-only), or the scoped framing/guard fix lands with the test asserting the corrected behavior |
 | Whole | `cargo test --workspace` + `--features fuzzing` + `clippy -D warnings` + `fmt --check` green; next full mutants campaign shows `flac.rs` survivors dropped (excluding documented equivalents) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3a-flac-hardening-design.md
@@ -87,7 +87,7 @@ by reading the source.
 | `push_block_header` | :101 (`>>16`→`<<16`) | 24-bit length emit | in-module: `body_len = 0x123456`, assert emitted bytes |
 | `synthesize_layout` | :155 (`>`→`>=`) | 24-bit TooLarge guard | exact-boundary test at `body_len == 0x00FF_FFFF` |
 | `read_vorbis_comments` | :188 (`<`→`==`/`<=`, `\|\|`→`&&`), :193 (`+`→`-`, `>`→`==`/`>=`), :199 (`<<16`→`>>16`), :200 (`\|`→`&`, `<<8`→`>>8`), :204 (`>`→`==`/`>=`) | block-walk + length decode | crafted fixtures + malformed-path |
-| `parse_picture_block` | :237 (`>`→`==`/`>=`), :245 (`>`→`==`/`>=`), :261 (`>`→`<`) | mime/desc/data bounds | in-module: picture bodies truncated at each boundary |
+| `parse_picture_block` | :237 (`>`→`==` kill; `>=` **equiv**), :245 (`>`→`==` kill; `>=` **equiv**), :261 (`>`→`<`) | mime/desc/data bounds | in-module: over-length field → panic kills `==`; trailing-byte body kills `:261`; `>=` equivalent (see below) |
 | `read_pictures` | :277 (`<`→`==`/`<=`, `\|\|`→`&&`), :283 (`+`→`-`, `>`→`==`/`>=`), :289 (`<<16`→`>>16`), :290 (`\|`→`&`, `<<8`→`>>8`), :294 (`>`→`==`/`>=`) | block-walk + length decode | crafted fixtures + malformed-path |
 
 ### Kill mechanism: panic-vs-`Err` for the short-input guards
@@ -134,8 +134,17 @@ Likewise `push_block_header:99` — `(if is_last {0x80} else {0}) | (block_type 
 **equivalent**.
 
 The sibling `| → &` mutations on the same lines (`:200`, `:290`) are **not**
-equivalent (AND of disjoint ranges = 0) and **are** killed. Each equivalence is
-re-confirmed by hand-apply (the test stays green under `^`) before being recorded.
+equivalent (AND of disjoint ranges = 0) and **are** killed.
+
+**Inclusive-bound `> → >=` in `parse_picture_block` (`:237`, `:245`) are also
+equivalent** (refinement found during planning). The only input that distinguishes
+`>` from `>=` is `*_end == body.len()`; there the original proceeds and immediately
+fails at the *next* `read_u32_be` (zero bytes remain) → `Err(Malformed)`, identical
+to the mutant's direct `Err(Malformed)`. Their `> → ==` siblings remain killable
+(an `*_end > len` input makes `==` fall through to an out-of-bounds slice → panic).
+
+Each equivalence is re-confirmed by hand-apply (the test stays green under the
+mutation) before being recorded.
 
 ## Components
 

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
@@ -2,7 +2,7 @@
 
 **Source audit:** `docs/audits/2026-05-29-test-audit.md`
 **Created:** 2026-05-29
-**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); phases 3–4 pending
+**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); Phase 3a (FLAC) complete; phases 3b–3d, 4 pending
 
 ## Guiding principle: verify, don't trust
 
@@ -96,10 +96,18 @@ P1 + all Ogg-related P2 + Ogg mutant kills. Findings #1, #2, #3, #4, #8, #14
 - EOS preservation, reframed from "FLAG_EOS handling" (#14)
 - kill surviving `ogg/` + `ogg_index` mutants (from phase-1 inventory)
 
-### Phase 3 — Format-layer coverage & mutants (non-Ogg)  ⟶ STATUS: pending
+### Phase 3 — Format-layer coverage & mutants (non-Ogg)  ⟶ STATUS: in progress
 
 Findings #5, #16.
 
+- **3a done** — FLAC survivors killed (equivalents: disjoint-bitfield `| → ^` at
+  `:50/:51/:99/:200/:201/:290/:291` and inclusive-bound `> → >=` at
+  `parse_picture_block:237/:245`); finding #16 resolved by **skipping zero-byte art
+  at FLAC synthesis** (small production fix in `flac.rs::synthesize_layout`), with a
+  cross-cutting follow-up noted: apply the same skip to mp3/mp4/ogg/wav synthesis
+  (their sub-phases) or filter empty art once at ingestion (`scan.rs`); finding #5
+  broadened on FLAC (partial/seam/art windows), with the non-FLAC dimension tracked
+  into 3b/3c/3d.
 - broaden `proptest_read_fidelity` (random offsets, header/audio boundary, art,
   non-FLAC) (#5)
 - zero-byte art boundary (#16)

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -1,7 +1,8 @@
 mod common;
 use common::write_flac;
 use musefs_core::{read_at, HeaderCache, Mode};
-use musefs_db::{Db, Format, NewTrack, Tag};
+use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
+use musefs_format::Segment;
 use proptest::prelude::*;
 
 fn build(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
@@ -29,6 +30,52 @@ fn build(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
     (dir, db, id, audio.to_vec())
 }
 
+/// Like `build`, but also inserts an art blob and links it to the track, so the
+/// resolved layout contains an `ArtImage` segment. Mirrors the insert+link pattern
+/// in `musefs-core/tests/reader.rs::resolve_includes_art_image_segments`.
+fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, Db, i64) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.flac");
+    let (audio_offset, audio_length) = write_flac(&path, &["TITLE=Orig"], audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    let art_id = db
+        .upsert_art(&NewArt {
+            mime: "image/png".to_string(),
+            width: Some(8),
+            height: Some(8),
+            data: art.to_vec(),
+        })
+        .unwrap();
+    db.set_track_art(
+        id,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: "front".to_string(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+    (dir, db, id)
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(64))]
 
@@ -43,5 +90,85 @@ proptest! {
         prop_assert_eq!(whole.len() as u64, resolved.total_len);
         let served_audio = &whole[resolved.layout.header_len() as usize..];
         prop_assert_eq!(served_audio, &original[..]);
+    }
+
+    #[test]
+    fn read_at_partial_windows_match_whole(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(got.len() as u64, len);
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+
+    #[test]
+    fn read_at_windows_spanning_header_seam(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        before in 0usize..4096,
+        after in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let hlen = resolved.layout.header_len();
+        prop_assume!(hlen > 0 && hlen < total);
+        let start = hlen - 1 - (before as u64 % hlen); // in [0, hlen)
+        let end = hlen + 1 + (after as u64 % (total - hlen)); // in (hlen, total]
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let got = read_at(&resolved, &db, start, end - start).unwrap();
+        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+    }
+
+    #[test]
+    fn read_at_art_window_serves_blob(
+        audio in proptest::collection::vec(any::<u8>(), 1..256),
+        art in proptest::collection::vec(any::<u8>(), 1..256),
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id) = build_with_art(&audio, "T", &art);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+
+        // Locate the ArtImage segment's exact byte offset in the assembled stream by
+        // summing the serving lengths of the segments before it. (Asserting the blob
+        // appears at this precise offset is robust; a `windows().any()` search would
+        // false-positive when a tiny blob coincidentally matches audio bytes.)
+        let mut art_off = 0u64;
+        let mut art_len = None;
+        for s in &resolved.layout.segments {
+            match s {
+                Segment::ArtImage { len, .. } => {
+                    art_len = Some(*len);
+                    break;
+                }
+                Segment::Inline(bytes) => art_off += bytes.len() as u64,
+                Segment::BackingAudio { len, .. } => art_off += *len,
+                other => panic!("unexpected FLAC segment: {other:?}"),
+            }
+        }
+        let art_len = art_len.expect("layout has an ArtImage segment");
+        prop_assert_eq!(art_len, art.len() as u64);
+        // The art blob is served verbatim at its segment offset.
+        prop_assert_eq!(
+            &whole[art_off as usize..(art_off + art_len) as usize],
+            &art[..]
+        );
+        // A partial window over the art region matches the independently-read whole.
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
     }
 }

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -165,9 +165,12 @@ proptest! {
             &whole[art_off as usize..(art_off + art_len) as usize],
             &art[..]
         );
-        // A partial window over the art region matches the independently-read whole.
-        let offset = (a as u64) % (total + 1);
-        let len = (b as u64) % (total - offset + 1);
+        // A partial window *within the art span* matches the independently-read
+        // whole, so the assertion actually exercises art bytes (sampling the whole
+        // stream here would be redundant with read_at_partial_windows_match_whole).
+        let local_off = (a as u64) % (art_len + 1);
+        let offset = art_off + local_off;
+        let len = (b as u64) % (art_len - local_off + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
         prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
     }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -469,4 +469,88 @@ mod tests {
         assert_eq!(read_vorbis_comments(&mid), Err(FormatError::Malformed));
         // (:200 `| -> ^` and :201 `| -> ^` are equivalent: disjoint shifted bytes.)
     }
+
+    /// A FLAC PICTURE block body (big-endian fields), independent of production.
+    fn picture_body(ptype: u32, mime: &str, desc: &str, w: u32, h: u32, data: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&ptype.to_be_bytes());
+        v.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        v.extend_from_slice(mime.as_bytes());
+        v.extend_from_slice(&(desc.len() as u32).to_be_bytes());
+        v.extend_from_slice(desc.as_bytes());
+        v.extend_from_slice(&w.to_be_bytes());
+        v.extend_from_slice(&h.to_be_bytes());
+        v.extend_from_slice(&0u32.to_be_bytes()); // depth
+        v.extend_from_slice(&0u32.to_be_bytes()); // colors
+        v.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        v.extend_from_slice(data);
+        v
+    }
+
+    #[test]
+    fn parse_picture_block_roundtrips_fields() {
+        let body = picture_body(3, "image/png", "desc", 4, 5, b"PIXELS");
+        let p = parse_picture_block(&body).unwrap();
+        assert_eq!(p.picture_type, 3);
+        assert_eq!(p.mime, "image/png");
+        assert_eq!(p.description, "desc");
+        assert_eq!(p.width, 4);
+        assert_eq!(p.height, 5);
+        assert_eq!(p.data, b"PIXELS");
+    }
+
+    #[test]
+    fn parse_picture_block_guards_field_bounds() {
+        // :237 `> -> ==` (mime bound): claim mime_len far past the end. Original
+        // Malformed; the `==` mutant falls through to slice body[8..8+mime_len] -> panic.
+        let mut bad_mime = 3u32.to_be_bytes().to_vec();
+        bad_mime.extend_from_slice(&16u32.to_be_bytes()); // mime_len = 16
+        bad_mime.extend_from_slice(b"ab"); // only 2 bytes present
+        assert_eq!(parse_picture_block(&bad_mime), Err(FormatError::Malformed));
+
+        // :245 `> -> ==` (desc bound): valid mime, then claim desc_len past the end.
+        let mut bad_desc = 3u32.to_be_bytes().to_vec();
+        bad_desc.extend_from_slice(&3u32.to_be_bytes()); // mime_len = 3
+        bad_desc.extend_from_slice(b"png");
+        bad_desc.extend_from_slice(&16u32.to_be_bytes()); // desc_len = 16
+        bad_desc.extend_from_slice(b"x"); // only 1 byte present
+        assert_eq!(parse_picture_block(&bad_desc), Err(FormatError::Malformed));
+
+        // :261 `> -> <` (data bound): a fully valid picture body with TRAILING bytes.
+        // Original ignores the trailing byte (data_end < len, not >) and returns Ok;
+        // the `<` mutant rejects (data_end < len -> Malformed).
+        let mut trailing = picture_body(3, "png", "", 1, 1, b"DA");
+        trailing.push(0xFF); // one extra trailing byte
+        assert!(parse_picture_block(&trailing).is_ok());
+    }
+
+    #[test]
+    fn read_pictures_extracts_and_guards_marker() {
+        // Happy path: one PICTURE block, last, no audio (body_end == len). Pins :294.
+        let pic = picture_body(3, "image/jpeg", "front", 8, 8, b"IMG");
+        let file = flac_with(&[raw_block(BLOCK_PICTURE, &pic, true, None)]);
+        let pics = read_pictures(&file).unwrap();
+        assert_eq!(pics.len(), 1);
+        assert_eq!(pics[0].mime, "image/jpeg");
+        assert_eq!(pics[0].data, b"IMG");
+        // :277 `< -> ==` and `|| -> &&`: 3-byte input -> panic vs NotFlac.
+        assert_eq!(read_pictures(b"fLa"), Err(FormatError::NotFlac));
+        // :277 `< -> <=`: 4-byte fLaC -> Malformed vs NotFlac.
+        assert_eq!(read_pictures(b"fLaC"), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn read_pictures_guards_block_walk_and_length() {
+        // :283 `+ -> -`, `> -> ==`: truncated header.
+        assert_eq!(read_pictures(b"fLaC\x80"), Err(FormatError::Malformed));
+        // :283 `> -> >=`: non-PICTURE last block flush with end -> Ok(empty).
+        let none = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        assert_eq!(read_pictures(&none).unwrap(), Vec::new());
+        // :289 `<<16 -> >>16` and :290 `| -> &`: high length byte over short body.
+        let hi = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0000))]);
+        assert_eq!(read_pictures(&hi), Err(FormatError::Malformed));
+        // :290 `<<8 -> >>8`: mid length byte, high byte 0.
+        let mid = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x00_0100))]);
+        assert_eq!(read_pictures(&mid), Err(FormatError::Malformed));
+    }
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -405,4 +405,68 @@ mod tests {
         assert_eq!(meta.preserved[0].block_type, BLOCK_STREAMINFO);
         assert_eq!(meta.preserved[0].body, si);
     }
+
+    /// A VORBIS_COMMENT body: u32-LE vendor length, vendor, u32-LE count, then each
+    /// comment as u32-LE length + bytes.
+    fn vc_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        v.extend_from_slice(vendor.as_bytes());
+        v.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+        for c in comments {
+            v.extend_from_slice(&(c.len() as u32).to_le_bytes());
+            v.extend_from_slice(c.as_bytes());
+        }
+        v
+    }
+
+    #[test]
+    fn read_vorbis_comments_returns_pairs_and_guards_marker() {
+        // Happy path: VC block is the last block with no audio, so body_end == len.
+        // This also pins :204 (`>` -> `==`/`>=`): the mutant would reject (Malformed)
+        // and the unwrap below would panic.
+        let vc = vc_body("v", &["TITLE=Hi", "ARTIST=Me"]);
+        let file = flac_with(&[raw_block(BLOCK_VORBIS_COMMENT, &vc, true, None)]);
+        let got = read_vorbis_comments(&file).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                ("title".to_string(), "Hi".to_string()),
+                ("artist".to_string(), "Me".to_string()),
+            ]
+        );
+        // :188 `< -> ==` and `|| -> &&`: 3-byte input -> original NotFlac via
+        // short-circuit; both mutants force &data[0..4] -> panic.
+        assert_eq!(read_vorbis_comments(b"fLa"), Err(FormatError::NotFlac));
+        // :188 `< -> <=`: 4-byte fLaC -> original Malformed; mutant NotFlac.
+        assert_eq!(read_vorbis_comments(b"fLaC"), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn read_vorbis_comments_guards_block_walk() {
+        // :193 `+ -> -` and `> -> ==`: truncated header -> original Malformed,
+        // mutants fall through and panic.
+        assert_eq!(
+            read_vorbis_comments(b"fLaC\x80"),
+            Err(FormatError::Malformed)
+        );
+        // :193 `> -> >=`: a non-VC last block flush with end -> original returns the
+        // empty vec; the `>=` mutant rejects at the loop guard.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        assert_eq!(read_vorbis_comments(&file).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn read_vorbis_comments_decodes_24bit_length() {
+        // :199 `<<16 -> >>16` AND :200 `| -> &`: high length byte set over a short
+        // body. Original len = 0x10000 -> Malformed. `>>16` -> len 0 -> Ok; `&` ->
+        // (0x10000 & 0) -> len 0 -> Ok. Either mutant returns Ok instead of Malformed.
+        let hi = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0000))]);
+        assert_eq!(read_vorbis_comments(&hi), Err(FormatError::Malformed));
+        // :200 `<<8 -> >>8`: mid length byte set, high byte 0. Original len = 0x100
+        // -> Malformed; `>>8` -> len 0 -> Ok.
+        let mid = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x00_0100))]);
+        assert_eq!(read_vorbis_comments(&mid), Err(FormatError::Malformed));
+        // (:200 `| -> ^` and :201 `| -> ^` are equivalent: disjoint shifted bytes.)
+    }
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -304,3 +304,31 @@ pub fn read_pictures(data: &[u8]) -> Result<Vec<EmbeddedPicture>> {
     }
     Ok(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_u32_be_assembles_big_endian_and_guards_length() {
+        let data = [0x11u8, 0x22, 0x33, 0x44, 0x55];
+        assert_eq!(read_u32_be(&data, 0).unwrap(), 0x1122_3344);
+        // pins :224 (`+` -> `*`): at pos=1 the second byte is data[2]=0x33, not data[1].
+        // pins :219 (`>` -> `==`/`>=`): pos+4 == len (5) is valid, so this unwrap must
+        // succeed — a mutated bound returns Err here and the unwrap panics.
+        assert_eq!(read_u32_be(&data, 1).unwrap(), 0x2233_4455);
+        assert_eq!(read_u32_be(&data, 2), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn push_block_header_emits_24bit_length_big_endian() {
+        // pins :101 (`>>16` -> `<<16`): high byte 0x12 must land in out[1].
+        let mut out = Vec::new();
+        push_block_header(&mut out, BLOCK_PICTURE, 0x12_3456, false);
+        assert_eq!(out, vec![BLOCK_PICTURE, 0x12, 0x34, 0x56]);
+        // :99 is equivalent, but exercise the is_last/0x80 path anyway.
+        let mut last = Vec::new();
+        push_block_header(&mut last, BLOCK_VORBIS_COMMENT, 0, true);
+        assert_eq!(last, vec![0x80 | BLOCK_VORBIS_COMMENT, 0x00, 0x00, 0x00]);
+    }
+}

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -553,4 +553,37 @@ mod tests {
         let mid = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x00_0100))]);
         assert_eq!(read_pictures(&mid), Err(FormatError::Malformed));
     }
+
+    #[test]
+    fn synthesize_layout_picture_block_size_boundary_is_inclusive() {
+        // body_len = picture_body_framing(art).len() + art.data_len. The guard at
+        // flac.rs:155 rejects body_len > 0x00FF_FFFF (FLAC's 24-bit block length).
+        let scan = FlacScan {
+            audio_offset: 0,
+            audio_length: 0,
+            preserved: vec![],
+        };
+        let mk = |data_len: u64| ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len,
+        };
+        // Derive the exact framing length from production rather than hardcoding it
+        // (it is independent of the data_len *value* — that field is always 4 bytes).
+        // This keeps the boundary correct regardless of the framing's field count.
+        let framing_len = picture_body_framing(&mk(0)).len() as u64;
+        let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
+                                                  // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
+                                                  // (data_len is only a count; no large allocation occurs.)
+        assert!(synthesize_layout(&scan, &[], &[mk(at_limit)]).is_ok());
+        // one byte over must still error, pinning the high side of the boundary.
+        assert_eq!(
+            synthesize_layout(&scan, &[], &[mk(at_limit + 1)]),
+            Err(FormatError::TooLarge)
+        );
+    }
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -331,4 +331,78 @@ mod tests {
         push_block_header(&mut last, BLOCK_VORBIS_COMMENT, 0, true);
         assert_eq!(last, vec![0x80 | BLOCK_VORBIS_COMMENT, 0x00, 0x00, 0x00]);
     }
+
+    /// One FLAC metadata block: 4-byte header (last-flag, type, 24-bit BE length)
+    /// + body, built independently of production framing so a mutation in
+    ///   `push_block_header` cannot mask a fixture. `len_override` lets a test claim a
+    ///   length different from `body.len()`.
+    fn raw_block(block_type: u8, body: &[u8], last: bool, len_override: Option<usize>) -> Vec<u8> {
+        let n = len_override.unwrap_or(body.len());
+        let mut v = vec![(if last { 0x80 } else { 0 }) | (block_type & 0x7F)];
+        v.push((n >> 16) as u8);
+        v.push((n >> 8) as u8);
+        v.push(n as u8);
+        v.extend_from_slice(body);
+        v
+    }
+
+    /// `fLaC` + the given blocks (no audio).
+    fn flac_with(blocks: &[Vec<u8>]) -> Vec<u8> {
+        let mut f = b"fLaC".to_vec();
+        for b in blocks {
+            f.extend_from_slice(b);
+        }
+        f
+    }
+
+    #[test]
+    fn parse_blocks_rejects_short_and_wrong_marker() {
+        // :37 `< -> ==`: 3-byte input -> original short-circuits NotFlac; the mutant
+        // evaluates &data[0..4] on 3 bytes -> panic. Asserting Err(NotFlac) kills it.
+        assert_eq!(parse_blocks(b"fLa"), Err(FormatError::NotFlac));
+        // :37 `< -> <=`: a 4-byte fLaC-only file. Original proceeds then hits the
+        // loop guard -> Malformed; the `<=` mutant short-circuits to NotFlac.
+        assert_eq!(parse_blocks(b"fLaC"), Err(FormatError::Malformed));
+        assert_eq!(parse_blocks(b"XXXX____"), Err(FormatError::NotFlac));
+    }
+
+    #[test]
+    fn parse_blocks_guards_truncated_block_header() {
+        // 5 bytes: marker + 1 header byte. Original: pos+4=8 > 5 -> Malformed.
+        // :43 `+ -> -` (0 > 5 false) and `> -> ==` (8 == 5 false) both fall through
+        // and panic reading data[5..8].
+        assert_eq!(parse_blocks(b"fLaC\x80"), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn parse_blocks_accepts_header_flush_with_end() {
+        // Single last STREAMINFO, empty body, no audio: the final header occupies the
+        // last 4 bytes, so pos+4 == data.len() at the loop guard. Original (`>`)
+        // proceeds and returns audio_offset == len; the :43 `> -> >=` mutant rejects.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        let meta = parse_blocks(&file).unwrap();
+        assert_eq!(meta.audio_offset, 8);
+    }
+
+    #[test]
+    fn parse_blocks_decodes_24bit_length_high_byte() {
+        // STREAMINFO header claims length 0x010000 (high byte set) over an empty body.
+        // Original: len = 65536 -> body_end > data.len() -> Malformed.
+        // :49 `<<16 -> >>16`: (0x01 >> 16) = 0 -> len = 0 -> body fits -> Ok.
+        // (:50/:51 `| -> ^` are equivalent here: the shifted bytes are disjoint.)
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0000))]);
+        assert_eq!(parse_blocks(&file), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn parse_blocks_preserves_structural_blocks() {
+        // Positive decode: a normal STREAMINFO (34-byte body) + audio boundary.
+        let si = vec![0xAA; 34];
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &si, true, None)]);
+        let meta = parse_blocks(&file).unwrap();
+        assert_eq!(meta.audio_offset, 4 + 4 + 34);
+        assert_eq!(meta.preserved.len(), 1);
+        assert_eq!(meta.preserved[0].block_type, BLOCK_STREAMINFO);
+        assert_eq!(meta.preserved[0].body, si);
+    }
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -126,7 +126,10 @@ pub fn synthesize_layout(
     tags: &[TagInput],
     arts: &[ArtInput],
 ) -> Result<RegionLayout> {
-    let num_blocks = scan.preserved.len() + 1 + arts.len(); // preserved + VORBIS_COMMENT + pictures
+    // exclude zero-byte art: an empty PICTURE block is meaningless and would fail
+    // layout validation (EmptySegment), making the track unreadable.
+    let nonempty_art = arts.iter().filter(|a| a.data_len > 0).count();
+    let num_blocks = scan.preserved.len() + 1 + nonempty_art; // preserved + VORBIS_COMMENT + pictures
     let last_index = num_blocks - 1;
 
     let mut segments: Vec<Segment> = Vec::new();
@@ -147,6 +150,9 @@ pub fn synthesize_layout(
     idx += 1;
 
     for art in arts {
+        if art.data_len == 0 {
+            continue; // skip degenerate empty art (see nonempty_art above)
+        }
         let framing = picture_body_framing(art);
         let body_len = framing.len() as u64 + art.data_len;
         // FLAC metadata block lengths are 24-bit (max ~16 MiB). Ingestion caps art

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -155,6 +155,14 @@ fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
     let mut art_map = HashMap::new();
     art_map.insert(2i64, image.clone());
     let assembled = resolve_layout(&layout, &file, &art_map);
+
+    // Re-parse the synthesized chain: locate_audio follows the last-block flag, so
+    // if the empty art were miscounted (leaving the final real block without its
+    // last-block bit) the walk would run past the metadata into the audio frames
+    // and fail. This pins the `data_len > 0` filter against `>= 0`.
+    let rescan = locate_audio(&assembled).expect("synthesized FLAC must parse");
+    assert_eq!(rescan.audio_offset, layout.header_len());
+
     let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
     let pics: Vec<_> = tag.pictures().collect();
     assert_eq!(pics.len(), 1);

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -104,3 +104,59 @@ fn synthesize_errors_on_oversized_picture() {
         Err(FormatError::TooLarge)
     );
 }
+
+#[test]
+fn zero_byte_art_is_skipped_so_the_track_still_serves() {
+    let (file, audio) = fixture();
+    let scan = locate_audio(&file).unwrap();
+
+    // A picture with no image data is degenerate; synthesis must skip it rather than
+    // emit an empty PICTURE block (which would fail layout validation and brick the
+    // track).
+    let art = cover(7, 0); // data_len == 0
+    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
+
+    // No ArtImage segment was emitted.
+    assert!(!layout
+        .segments
+        .iter()
+        .any(|s| matches!(s, Segment::ArtImage { .. })));
+
+    // The track still round-trips: header + verbatim audio (no art bytes needed).
+    let art_map = HashMap::new();
+    let assembled = resolve_layout(&layout, &file, &art_map);
+    assert_eq!(assembled.len() as u64, layout.total_len());
+    assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
+
+    // metaflac sees a valid FLAC with zero pictures.
+    let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
+    assert_eq!(tag.pictures().count(), 0);
+}
+
+#[test]
+fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
+    // Guards the `is_last` flag: filtering the empty art must not leave the final
+    // real PICTURE block without its last-block bit. metaflac parsing the whole
+    // chain validates that.
+    let (file, _audio) = fixture();
+    let scan = locate_audio(&file).unwrap();
+    let image = vec![0x55u8; 64];
+    let empty = cover(1, 0);
+    let real = cover(2, image.len() as u64);
+    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[empty, real]).unwrap();
+
+    let art_segs: Vec<_> = layout
+        .segments
+        .iter()
+        .filter(|s| matches!(s, Segment::ArtImage { .. }))
+        .collect();
+    assert_eq!(art_segs.len(), 1);
+
+    let mut art_map = HashMap::new();
+    art_map.insert(2i64, image.clone());
+    let assembled = resolve_layout(&layout, &file, &art_map);
+    let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
+    let pics: Vec<_> = tag.pictures().collect();
+    assert_eq!(pics.len(), 1);
+    assert_eq!(pics[0].data, image);
+}


### PR DESCRIPTION
## Summary

Phase 3a of the test-audit remediation: harden the FLAC format layer. Kills the `flac.rs` mutation survivors with additive in-module tests, broadens `proptest_read_fidelity` on FLAC (finding #5), and makes FLAC synthesis skip zero-byte embedded art so a degenerate PICTURE block can never brick a track (finding #16).

The **only** production change is the zero-byte-art skip in `flac.rs::synthesize_layout`; everything else is additive tests and docs. Byte-identity for audio is untouched.

## Changes

- **Tests (`flac.rs` `#[cfg(test)] mod tests`)** — kills across `read_u32_be`, `push_block_header`, `parse_blocks`, `read_vorbis_comments`, `parse_picture_block`, `read_pictures`, and the `synthesize_layout` 24-bit picture-size boundary. Documented equivalents (disjoint-bitfield `| → ^`; inclusive-bound `> → >=` in `parse_picture_block`) are left untested by design.
- **`fix(flac)`** — `synthesize_layout` excludes zero-length art from the block count and `continue`s past it in the loop, so an empty PICTURE block is never emitted (it would otherwise fail `RegionLayout::validate` → `InvalidLayout` and make the whole track unreadable). Covered by two new `synthesize_art` tests.
- **`proptest_read_fidelity`** — three new properties: partial windows match the whole, windows spanning the header/audio seam, and art-window serving from the blob store.
- **docs** — design spec + implementation plan; mutation inventory annotated (`killed (phase 3a)` / `equivalent`); tracking doc marks Phase 3a complete with the cross-cutting follow-up (apply the same zero-byte-art skip to mp3/mp4/ogg/wav, or filter once at ingestion).

## Verification

- `cargo test --workspace` — green
- `cargo test -p musefs-format --features fuzzing` — green
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Mutation kills hand-verified by apply→test→revert; claimed equivalents confirmed to survive.

## Follow-up

The zero-byte-art skip is FLAC-only; mp3/mp4/ogg/wav synthesis (sub-phases 3b–3d) should get the same skip or filter empty art once at ingestion (`scan.rs`). Finding #5's non-FLAC dimension is tracked into 3b/3c/3d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FLAC synthesis now omits zero-byte embedded artwork to prevent invalid/ unreadable tracks.

* **Tests**
  * Significantly expanded FLAC unit and property tests, including synthesis and partial-read fidelity checks.
  * Added synthesis tests ensuring empty-art is filtered and valid art round-trips correctly.

* **Documentation**
  * Added Phase 3a FLAC hardening plan, updated mutation inventory and remediation tracking with per-mutation statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->