### PR TITLE
Phase 3c: MP4 hardening — mutation kills, zero-byte art fix, M4A read fidelity

### DIFF
--- a/docs/superpowers/plans/2026-05-29-phase3c-mp4-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3c-mp4-hardening.md
@@ -1,0 +1,808 @@
+# Phase 3c — MP4 Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the 44 `mp4.rs` mutation survivors (40 missed + 4 timeout) with additive in-module tests — hand-apply-verifying every kill and recording the 4 infinite-loop survivors as timeout-detected — with no production logic change expected.
+
+**Architecture:** Extend `mp4.rs`'s existing `#[cfg(test)] mod tests` (already `use super::*`, 30 tests). Call the private survivor fns (`box_header`, `read_box`, `child_boxes`, `read_structure_from`, `read_freeform`, `read_tags`, `read_pictures`, `build_udta`, `patch_chunk_offsets`, `synthesize_layout`) directly with byte-precise box/atom fixtures built by the existing local helpers (`bx`, `mk_mp4`, `mk_mp4_co64`, `soun_trak`, `data_atom`, `mp4_with_ilst`, `inline_head`, `find_moov_in_head`) plus the production `boxed`. Hand-apply-verify each kill; record the timeouts. Byte-identity invariant untouched (no audio-read path is changed).
+
+**Tech Stack:** Rust, `cargo test`, `proptest` + `id3` + `metaflac` (existing dev-deps). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3c-mp4-hardening-design.md`
+**Survivor data:** `docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md`
+
+---
+
+## The hand-apply verification method (use in every kill step)
+
+cargo-mutants is not available locally. For each targeted `function: construct: mutation`:
+
+1. Run the new test → it passes (production is correct).
+2. **Locate the construct by its code pattern** (inventory line numbers are
+   approximate — never trust the raw number), apply the exact mutation, rerun
+   **just that test** → it must **fail** (a failed assertion *or* a panic).
+3. Revert (`git checkout -- musefs-format/src/mp4.rs`), rerun → passes again.
+
+If step 2 still passes: strengthen the test, or — if the mutation provably yields
+identical behavior — record it as an **equivalent mutant**. Never leave a mutation
+applied.
+
+## Timeout survivors are the exception (do NOT hand-apply)
+
+The 4 timeout survivors (`BoxRef::end` ×3, `read_structure_from`'s `pos += total`)
+make a box-walk non-terminating — hand-applying them **hangs the test run**.
+For these: confirm a covering walk test exists (by reading it), then record them as
+**timeout-detected** in the inventory (Task 7). Never apply them locally.
+
+## Equivalent mutants
+
+**MP4 has none to pre-record.** Every multi-byte field uses `from_be_bytes`, so there
+is no disjoint-bitfield `|→^` site. The only `|` mutants are the bool `|=`
+dup-accumulators in `read_structure_from`, which are killable (Task 2). If a kill
+attempt during implementation proves a mutant equivalent, record it then with the
+hand-apply evidence; otherwise record none.
+
+## Pre-flight (run once before Task 1)
+
+- [ ] **Confirm baseline green on the phase-3c branch**
+
+```bash
+git rev-parse --abbrev-ref HEAD          # expect: worktree-phase3c-mp4-hardening
+cargo test -p musefs-format --features fuzzing --lib mp4
+```
+Expected: green — `running 31 tests` (the `--lib mp4` filter matches the 30
+`mp4::tests` plus one substring-matching test from another module), 0 failed.
+
+---
+
+## Task 1: C1 — box primitives (`box_header`, `read_box`, `BoxRef::end`)
+
+Kills `box_header`'s `<→<=` size bound and `read_box`'s size-0 `-→+`/`-→/`.
+Confirms (does not apply) the three `BoxRef::end` timeouts.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/mp4.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the box-primitive tests**
+
+Append inside `mod tests`:
+
+```rust
+    #[test]
+    fn box_header_accepts_empty_payload_box() {
+        // total_len == header_len (an 8-byte box, no payload) must be accepted.
+        // `< -> <=` would make the equal case reject.
+        let mut h = 8u32.to_be_bytes().to_vec();
+        h.extend_from_slice(b"free");
+        let bh = box_header(&h, 1000).unwrap();
+        assert_eq!(bh.header_len, 8);
+        assert_eq!(bh.total_len, 8);
+    }
+
+    #[test]
+    fn read_box_size0_extends_to_end_from_offset() {
+        // A size-0 box ("extends to EOF") at pos > 0: total_len must be
+        // buf.len() - pos. `- -> +` (buf.len() + pos) and `- -> /` (buf.len() / pos)
+        // both diverge. The box is placed at pos = 8 with pos + 8 <= buf.len() so the
+        // be_u32 size read and the kind slice both succeed BEFORE the size-0 branch.
+        let mut buf = bx(b"free", b""); // 8-byte box at pos 0
+        buf.extend_from_slice(&0u32.to_be_bytes()); // size32 = 0 at pos 8
+        buf.extend_from_slice(b"mdat"); // kind at pos 12..16
+        buf.extend_from_slice(b"AUDIOPAYLOAD"); // 12 payload bytes
+        assert_eq!(buf.len(), 28);
+        let b = read_box(&buf, 8).unwrap();
+        assert_eq!(&b.kind, b"mdat");
+        assert_eq!(b.total_len, buf.len() - 8); // 20
+    }
+```
+
+- [ ] **Step 2: Run the two tests — confirm green**
+
+```bash
+cargo test -p musefs-format --features fuzzing --lib \
+  mp4::tests::box_header_accepts_empty_payload_box \
+  mp4::tests::read_box_size0_extends_to_end_from_offset
+```
+Expected: PASS (2 passed).
+
+- [ ] **Step 3: Hand-apply-verify each kill**
+
+For each row: apply the mutation, run the named test, confirm FAIL, then
+`git checkout -- musefs-format/src/mp4.rs`.
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
+| `box_header`: `if total_len < header_len` | `<` → `<=` | `box_header_accepts_empty_payload_box` (8 ≤ 8 → `Malformed`, unwrap panics) |
+| `read_box`: `0 => (8usize, (buf.len() - pos) as u64)` | `-` → `+` | `read_box_size0_extends_to_end_from_offset` (end > buf.len() → `Malformed`) |
+| same line | `-` → `/` | `read_box_size0_extends_to_end_from_offset` (total 3 < header 8 → `Malformed`) |
+
+- [ ] **Step 4: Confirm the `BoxRef::end` timeouts are covered (do NOT apply)**
+
+Read `walks_top_level_boxes` — it calls `child_boxes` over a 2-box buffer, whose
+loop advances with `pos = b.end()`. `BoxRef::end -> 0` and `+ -> *` pin `pos` at 0
+→ non-terminating. **Do not hand-apply** (it hangs). These three (`-> 0`, `-> 1`,
+`+ -> *`) are recorded as timeout-detected in Task 7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs
+git commit -m "$(cat <<'EOF'
+test(mp4): phase 3c C1 — box-primitive mutation kills
+
+box_header empty-payload boundary (< -> <=); read_box size-0 arithmetic
+(- -> +/ /). BoxRef::end timeouts confirmed covered by walks_top_level_boxes.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: C2 — `read_structure_from` structural walk
+
+Kills the `remaining` `-→+`, the `moof`-arm delete, and the three dup `|=→&=`.
+Confirms (does not apply) the `pos += total` timeout. All via `std::io::Cursor`.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/mp4.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the structural-walk tests**
+
+```rust
+    #[test]
+    fn read_structure_from_rejects_box_overrunning_eof() {
+        // box_header's `remaining` arg is `file_len - pos`. Inflating the mdat box's
+        // declared size past the bytes remaining must be rejected. `- -> +` inflates
+        // `remaining` to `file_len + pos`, wrongly accepting the overrun (returns Ok).
+        let mut buf = mk_mp4(true, b"AUDIO", &[0]); // [ftyp][moov][mdat], mdat last
+        let scan = read_structure(&buf).unwrap();
+        let mdat_start = (scan.mdat_payload_offset - scan.mdat_header.len() as u64) as usize;
+        let real = u32::from_be_bytes(buf[mdat_start..mdat_start + 4].try_into().unwrap());
+        buf[mdat_start..mdat_start + 4].copy_from_slice(&(real + 100).to_be_bytes());
+        let mut cur = std::io::Cursor::new(buf.clone());
+        assert!(read_structure_from(&mut cur, buf.len() as u64).is_err());
+    }
+
+    #[test]
+    fn read_structure_from_rejects_moof() {
+        // A `moof` (fragmented MP4) top-level box must be rejected via the seeking
+        // path. Deleting the `b"moof"` match arm drops it to `_ => {}` and accepts.
+        let mut buf = mk_mp4(true, b"AUDIO", &[0]);
+        buf.extend(bx(b"moof", b"\x00\x00\x00\x00"));
+        let mut cur = std::io::Cursor::new(buf.clone());
+        assert!(read_structure_from(&mut cur, buf.len() as u64).is_err());
+    }
+
+    #[test]
+    fn read_structure_from_rejects_duplicate_top_level_boxes() {
+        // Each `dup |= X.replace(..).is_some()` accumulates a duplicate. `|= -> &=`
+        // can never set `dup` (it starts false), so a duplicate box is wrongly
+        // accepted. One duplicated box per kind isolates each of the three `|=` lines.
+        let dup = |extra: Vec<u8>| {
+            let mut buf = mk_mp4(true, b"AUDIO", &[0]);
+            buf.extend(extra);
+            let mut cur = std::io::Cursor::new(buf.clone());
+            read_structure_from(&mut cur, buf.len() as u64).is_err()
+        };
+        assert!(dup(bx(b"ftyp", b"M4A isom")), "duplicate ftyp must reject"); // ftyp |= line
+        // duplicate moov: reuse the moov from a fresh fixture so it is structurally valid.
+        let extra_moov = {
+            let other = mk_mp4(true, b"AUDIO", &[0]);
+            let s = read_structure(&other).unwrap();
+            s.moov
+        };
+        assert!(dup(extra_moov), "duplicate moov must reject"); // moov |= line
+        assert!(dup(bx(b"mdat", b"Y")), "duplicate mdat must reject"); // mdat |= line
+    }
+```
+
+- [ ] **Step 2: Run the three tests — confirm green**
+
+```bash
+cargo test -p musefs-format --features fuzzing --lib \
+  mp4::tests::read_structure_from_rejects_box_overrunning_eof \
+  mp4::tests::read_structure_from_rejects_moof \
+  mp4::tests::read_structure_from_rejects_duplicate_top_level_boxes
+```
+Expected: PASS (3 passed).
+
+- [ ] **Step 3: Hand-apply-verify each kill**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
+| `read_structure_from`: `box_header(&hdr, file_len - pos)?` | `-` → `+` | `..._rejects_box_overrunning_eof` (mutant accepts → returns Ok) |
+| `read_structure_from`: `b"moof" => return Err(FormatError::NotMp4.into()),` | delete arm | `..._rejects_moof` (mutant ignores moov → returns Ok) |
+| `read_structure_from`: `dup |= ftyp.replace((pos, bh)).is_some(),` | `\|=` → `&=` | `..._rejects_duplicate_top_level_boxes` (1st `assert!` — dup ftyp) |
+| `read_structure_from`: `dup |= moov.replace((pos, bh)).is_some(),` | `\|=` → `&=` | `..._rejects_duplicate_top_level_boxes` (2nd `assert!` — dup moov) |
+| `read_structure_from`: `dup |= mdat.replace((pos, bh)).is_some(),` | `\|=` → `&=` | `..._rejects_duplicate_top_level_boxes` (3rd `assert!` — dup mdat) |
+
+After each: `git checkout -- musefs-format/src/mp4.rs`.
+
+- [ ] **Step 4: Confirm the `pos += total` timeout is covered (do NOT apply)**
+
+Read `read_structure_from_matches_buffer_path` — it walks every top-level box via
+`pos += total`. `+= -> *=` keeps `pos` at 0 (`0 *= total`) → non-terminating.
+**Do not hand-apply** (it hangs). Recorded as timeout-detected in Task 7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs
+git commit -m "$(cat <<'EOF'
+test(mp4): phase 3c C2 — read_structure_from walk kills
+
+remaining `file_len - pos` (- -> +), moof-arm reject, and the three dup
+`|= -> &=` accumulators. pos += total timeout confirmed covered.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: C3 — metadata read (`read_freeform`, `read_tags`, `read_pictures`)
+
+Kills the length-guard boundaries, the `||`/`&&` short-circuits, the trkn/disk
+branches, and the PNG `data`-type arm.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/mp4.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the metadata-read tests**
+
+```rust
+    #[test]
+    fn read_freeform_accepts_minimal_name_and_data() {
+        // name payload == 4 (empty name) and data payload == 8 (empty value) is the
+        // boundary of `np.len() < 4 || dp.len() < 8`. Both operands at the boundary,
+        // so flipping EITHER `<` to `==`/`<=` makes that side true -> None.
+        let name_body = 0u32.to_be_bytes().to_vec(); // exactly 4 bytes
+        let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
+        data.extend_from_slice(&0u32.to_be_bytes()); // locale -> dp.len() == 8
+        let mut inner = boxed(b"name", &name_body);
+        inner.extend(boxed(b"data", &data));
+        let (key, value) = read_freeform(&inner).unwrap();
+        assert_eq!(key, ""); // empty name, not in vocabulary -> verbatim ""
+        assert_eq!(value, "");
+    }
+
+    #[test]
+    fn read_freeform_short_name_returns_none() {
+        // name payload 3 bytes (< 4) with a valid 8-byte data payload. `|| -> &&`
+        // makes `true && false == false`, falling through to `&np[4..]` (out of bounds
+        // -> panic).
+        let name_body = vec![0u8, 0, 0]; // 3 bytes
+        let mut data = 1u32.to_be_bytes().to_vec();
+        data.extend_from_slice(&0u32.to_be_bytes());
+        let mut inner = boxed(b"name", &name_body);
+        inner.extend(boxed(b"data", &data));
+        assert!(read_freeform(&inner).is_none());
+    }
+
+    #[test]
+    fn read_freeform_mean_payload_exactly_4_uses_empty_mean() {
+        // mean payload == 4 (FullBox prefix, empty mean). `p.len() >= 4` must take the
+        // utf8 branch (mean ""), so the vocabulary does NOT fold the iTunes name.
+        // `>= -> <` falls to the default "com.apple.iTunes" mean and wrongly folds.
+        let mean_body = vec![0u8, 0, 0, 0]; // exactly 4 bytes
+        let mut name_body = 0u32.to_be_bytes().to_vec();
+        name_body.extend_from_slice(b"MusicBrainz Album Id");
+        let mut data = 1u32.to_be_bytes().to_vec();
+        data.extend_from_slice(&0u32.to_be_bytes());
+        data.extend_from_slice(b"abc-123");
+        let mut inner = boxed(b"mean", &mean_body);
+        inner.extend(boxed(b"name", &name_body));
+        inner.extend(boxed(b"data", &data));
+        let (key, value) = read_freeform(&inner).unwrap();
+        assert_eq!(key, "MusicBrainz Album Id"); // empty mean -> not folded
+        assert_eq!(value, "abc-123");
+    }
+
+    #[test]
+    fn read_tags_data_payload_exactly_8_is_read() {
+        // A `data` payload of exactly 8 bytes (type+locale, empty value) is the
+        // boundary of `dp.len() < 8`. The (empty) value must be read; `< -> ==`/`<= `
+        // would skip it.
+        let atoms = bx(b"\xa9nam", &data_atom(1, b"")); // dp.len() == 8
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(read_tags(&buf).contains(&("title".into(), "".into())));
+    }
+
+    #[test]
+    fn read_tags_disk_exact_4_byte_value_yields_discnumber() {
+        // disk atom, value exactly 4 bytes: `kind == disk` (== branch) `&&`
+        // `value.len() >= 4` (>= branch). Kills `== -> !=` (mutant skips a real disk)
+        // and `>= -> <` (mutant skips the boundary length).
+        let atoms = bx(b"disk", &data_atom(0, &[0, 0, 0, 2])); // disc 2, value len 4
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(read_tags(&buf).contains(&("discnumber".into(), "2".into())));
+    }
+
+    #[test]
+    fn read_tags_disk_short_value_is_skipped() {
+        // disk with a value shorter than 4 bytes: the guard is false. `&& -> ||`
+        // makes it true and indexes value[2]/value[3] out of bounds (panic).
+        let atoms = bx(b"disk", &data_atom(0, &[0, 0])); // value len 2
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(!read_tags(&buf).iter().any(|(k, _)| k == "discnumber"));
+    }
+
+    #[test]
+    fn read_tags_trkn_short_value_is_skipped() {
+        // trkn with a value shorter than 4 bytes: `kind == trkn && value.len() >= 4`
+        // is false. `&& -> ||` makes it true and indexes value[2]/value[3] (panic).
+        let atoms = bx(b"trkn", &data_atom(0, &[0, 0])); // value len 2
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(!read_tags(&buf).iter().any(|(k, _)| k == "tracknumber"));
+    }
+
+    #[test]
+    fn read_pictures_data_payload_exactly_8_is_read() {
+        // covr/data payload of exactly 8 bytes (type+locale, empty image) is the
+        // boundary of `dp.len() < 8`; the (empty) picture must be read.
+        let buf = mp4_with_ilst(&bx(b"covr", &data_atom(13, b"")), true);
+        let pics = read_pictures(&buf);
+        assert_eq!(pics.len(), 1);
+        assert_eq!(pics[0].mime, "image/jpeg");
+        assert!(pics[0].data.is_empty());
+    }
+
+    #[test]
+    fn read_pictures_recognizes_png() {
+        // A covr `data` atom with type code 14 is PNG. Deleting the `14 =>` match arm
+        // drops it to `_ => continue` and yields no picture.
+        let png = [0x89, b'P', b'N', b'G', 1, 2, 3];
+        let buf = mp4_with_ilst(&bx(b"covr", &data_atom(14, &png)), false);
+        let pics = read_pictures(&buf);
+        assert_eq!(pics.len(), 1);
+        assert_eq!(pics[0].mime, "image/png");
+        assert_eq!(pics[0].data, png);
+    }
+```
+
+- [ ] **Step 2: Run the C3 tests — confirm green**
+
+```bash
+cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_freeform
+cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_tags
+cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_pictures
+```
+Expected: each PASS (the new tests plus the pre-existing `read_*` tests).
+
+- [ ] **Step 3: Hand-apply-verify each kill**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
+| `read_freeform`: `if np.len() < 4 \|\| dp.len() < 8` (the `np.len()` `<`) | `<` → `==` | `read_freeform_accepts_minimal_name_and_data` |
+| same `<` | `<` → `<=` | `read_freeform_accepts_minimal_name_and_data` |
+| `read_freeform`: same line (the `dp.len()` `<`) | `<` → `==` | `read_freeform_accepts_minimal_name_and_data` |
+| same `<` | `<` → `<=` | `read_freeform_accepts_minimal_name_and_data` |
+| `read_freeform`: the `\|\|` on that line | `\|\|` → `&&` | `read_freeform_short_name_returns_none` (panics on `np[4..]`) |
+| `read_freeform`: `if p.len() >= 4` (mean) | `>=` → `<` | `read_freeform_mean_payload_exactly_4_uses_empty_mean` |
+| `read_tags`: `if dp.len() < 8` | `<` → `==` | `read_tags_data_payload_exactly_8_is_read` |
+| same `<` | `<` → `<=` | `read_tags_data_payload_exactly_8_is_read` |
+| `read_tags`: `&atom.kind == b"trkn" && value.len() >= 4` (the `&&`) | `&&` → `\|\|` | `read_tags_trkn_short_value_is_skipped` (panics) |
+| `read_tags`: `&atom.kind == b"disk" && value.len() >= 4` (the `==`) | `==` → `!=` | `read_tags_disk_exact_4_byte_value_yields_discnumber` |
+| same line (the `&&`) | `&&` → `\|\|` | `read_tags_disk_short_value_is_skipped` (panics) |
+| same line (the `>=`) | `>=` → `<` | `read_tags_disk_exact_4_byte_value_yields_discnumber` |
+| `read_pictures`: `if dp.len() < 8` | `<` → `==` | `read_pictures_data_payload_exactly_8_is_read` |
+| same `<` | `<` → `<=` | `read_pictures_data_payload_exactly_8_is_read` |
+| `read_pictures`: `14 => "image/png",` | delete arm | `read_pictures_recognizes_png` |
+
+After each: `git checkout -- musefs-format/src/mp4.rs`.
+
+> Note: the `trkn`/`disk` `&& -> ||` and `read_freeform` `|| -> &&` kills are
+> **panics** (out-of-bounds slice), which count as kills per the verification method.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs
+git commit -m "$(cat <<'EOF'
+test(mp4): phase 3c C3 — metadata-read mutation kills
+
+read_freeform/read_tags/read_pictures length-guard boundaries, the ||/&&
+short-circuits, the trkn/disk branches, and the PNG data-type arm.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: C4a — `build_udta`
+
+Kills the png type-code `==→!=`, the covr/data size arithmetic `+→-/*`, and the
+`udta_size > u32::MAX` guard (`>→>=`) via a cheap `data_len` boundary.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/mp4.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the build_udta tests**
+
+```rust
+    #[test]
+    fn build_udta_png_art_uses_type_code_14() {
+        // PNG art => covr/data type code 14; JPEG => 13. `== -> !=` flips them.
+        for (mime, expected) in [("image/png", 14u32), ("image/jpeg", 13u32)] {
+            let art = ArtInput {
+                art_id: 1,
+                mime: mime.into(),
+                description: String::new(),
+                picture_type: 3,
+                width: 0,
+                height: 0,
+                data_len: 10,
+            };
+            let (prefix, _) = build_udta(&[TagInput::new("title", "T")], Some(&art)).unwrap();
+            // covr layout: [covr_size u32]["covr"][data_size u32]["data"][type u32][locale u32]
+            let cpos = prefix.windows(4).position(|w| w == b"covr").expect("covr");
+            assert_eq!(&prefix[cpos + 8..cpos + 12], b"data");
+            let type_code = u32::from_be_bytes(prefix[cpos + 12..cpos + 16].try_into().unwrap());
+            assert_eq!(type_code, expected, "mime {mime}");
+        }
+    }
+
+    #[test]
+    fn build_udta_art_box_sizes_are_exact() {
+        // data_size = 8 + 8 + data_len; covr_size = 8 + data_size. The `+ -> -`/`+ -> *`
+        // mutations change the emitted box sizes.
+        let art = ArtInput {
+            art_id: 1,
+            mime: "image/jpeg".into(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 10,
+        };
+        let (prefix, _) = build_udta(&[TagInput::new("title", "T")], Some(&art)).unwrap();
+        let cpos = prefix.windows(4).position(|w| w == b"covr").expect("covr");
+        let covr_size = u32::from_be_bytes(prefix[cpos - 4..cpos].try_into().unwrap());
+        let data_size = u32::from_be_bytes(prefix[cpos + 4..cpos + 8].try_into().unwrap());
+        assert_eq!(data_size, 8 + 8 + 10); // 26
+        assert_eq!(covr_size, 8 + data_size); // 34
+    }
+
+    #[test]
+    fn build_udta_udta_size_exactly_u32_max_is_ok() {
+        // The guard is `udta_size > u32::MAX` (strict). udta_size == u32::MAX must be
+        // accepted; `> -> >=` rejects the exact boundary. data_len is reserved as a
+        // number (no image bytes), so the boundary is cheap to hit.
+        fn art(data_len: u64) -> ArtInput {
+            ArtInput {
+                art_id: 1,
+                mime: "image/jpeg".into(),
+                description: String::new(),
+                picture_type: 3,
+                width: 0,
+                height: 0,
+                data_len,
+            }
+        }
+        // Derive the fixed overhead: with data_len 0, udta_size == overhead.
+        let (p0, _) = build_udta(&[TagInput::new("title", "T")], Some(&art(0))).unwrap();
+        let overhead = u32::from_be_bytes(p0[0..4].try_into().unwrap()) as u64;
+        let max_len = u32::MAX as u64 - overhead;
+
+        let (p_max, art_len) =
+            build_udta(&[TagInput::new("title", "T")], Some(&art(max_len))).unwrap();
+        assert_eq!(art_len, max_len);
+        assert_eq!(u32::from_be_bytes(p_max[0..4].try_into().unwrap()), u32::MAX);
+
+        assert!(matches!(
+            build_udta(&[TagInput::new("title", "T")], Some(&art(max_len + 1))),
+            Err(FormatError::TooLarge)
+        ));
+    }
+```
+
+- [ ] **Step 2: Run the build_udta tests — confirm green**
+
+```bash
+cargo test -p musefs-format --features fuzzing --lib mp4::tests::build_udta
+```
+Expected: PASS (the new tests plus the pre-existing `build_udta_*`).
+
+- [ ] **Step 3: Hand-apply-verify each kill**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
+| `build_udta`: `let type_code: u32 = if a.mime == "image/png"` | `==` → `!=` | `build_udta_png_art_uses_type_code_14` |
+| `build_udta`: `let data_size = 8 + 8 + a.data_len;` (first `+`) | `+` → `-` | `build_udta_art_box_sizes_are_exact` |
+| same line (either `+`) | `+` → `*` | `build_udta_art_box_sizes_are_exact` |
+| `build_udta`: `let covr_size = 8 + data_size;` | `+` → `*` | `build_udta_art_box_sizes_are_exact` |
+| `build_udta`: `if udta_size > u32::MAX as u64` | `>` → `>=` | `build_udta_udta_size_exactly_u32_max_is_ok` (boundary rejected → unwrap panics) |
+
+After each: `git checkout -- musefs-format/src/mp4.rs`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs
+git commit -m "$(cat <<'EOF'
+test(mp4): phase 3c C4a — build_udta mutation kills
+
+png type-code (== -> !=), covr/data size arithmetic (+ -> -/*), and the
+udta_size > u32::MAX guard via a cheap data_len boundary.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: C4b — `patch_chunk_offsets`
+
+Kills all 9 survivors: the `:595` stco overflow/underflow guard (5), the `:590`
+bounds check (2), and the `:601` co64 `v < 0` (2).
+
+**Files:**
+- Modify (tests only): `musefs-format/src/mp4.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the patch_chunk_offsets tests**
+
+```rust
+    #[test]
+    fn patch_chunk_offsets_stco_overflow_and_underflow_boundaries() {
+        // kept = a single soun trak with one stco entry (offset 0). v = 0 + delta is
+        // guarded by `v < 0 || v > u32::MAX`. Boundary deltas pin every guard mutant;
+        // delta 0 (accepted) also pins the `:590` `+ -> *` bound at i = 0.
+        let mut k = soun_trak();
+        assert!(patch_chunk_offsets(&mut k, 0).is_ok()); // v == 0
+
+        let mut k = soun_trak();
+        assert!(patch_chunk_offsets(&mut k, u32::MAX as i64).is_ok()); // v == u32::MAX
+
+        let mut k = soun_trak();
+        assert!(matches!(
+            patch_chunk_offsets(&mut k, u32::MAX as i64 + 1), // v == u32::MAX + 1
+            Err(FormatError::TooLarge)
+        ));
+
+        let mut k = soun_trak();
+        assert!(matches!(
+            patch_chunk_offsets(&mut k, -1), // v == -1
+            Err(FormatError::TooLarge)
+        ));
+    }
+
+    #[test]
+    fn patch_chunk_offsets_rejects_count_past_table() {
+        // stco declares 2 entries but only 1 entry's bytes are present (followed by an
+        // unrelated `free` box for padding). `pos + entry > start + len` must reject
+        // the 2nd entry. `+ -> -` shrinks the bound and reads into the `free` box
+        // instead of erroring (returns Ok).
+        let mut stco = vec![0u8; 4]; // version/flags
+        stco.extend_from_slice(&2u32.to_be_bytes()); // count = 2 (a lie)
+        stco.extend_from_slice(&0u32.to_be_bytes()); // only 1 entry present
+        let stbl = bx(b"stbl", &[bx(b"stco", &stco), bx(b"free", &[0u8; 8])].concat());
+        let mut kept = bx(b"trak", &bx(b"mdia", &bx(b"minf", &stbl)));
+        assert!(matches!(
+            patch_chunk_offsets(&mut kept, 0),
+            Err(FormatError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn patch_chunk_offsets_co64_zero_offset_is_ok() {
+        // co64 path guard is `v < 0`. offset 0 + delta 0 => v == 0 must be accepted;
+        // `< -> ==`/`<= ` reject the boundary.
+        let mut co64 = vec![0u8; 4]; // version/flags
+        co64.extend_from_slice(&1u32.to_be_bytes()); // count 1
+        co64.extend_from_slice(&0u64.to_be_bytes()); // offset 0
+        let stbl = bx(b"stbl", &bx(b"co64", &co64));
+        let mut kept = bx(b"trak", &bx(b"mdia", &bx(b"minf", &stbl)));
+        assert!(patch_chunk_offsets(&mut kept, 0).is_ok());
+    }
+```
+
+- [ ] **Step 2: Run the patch_chunk_offsets tests — confirm green**
+
+```bash
+cargo test -p musefs-format --features fuzzing --lib mp4::tests::patch_chunk_offsets
+```
+Expected: PASS (3 passed).
+
+- [ ] **Step 3: Hand-apply-verify each kill**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
+| `patch_chunk_offsets`: `if pos + entry > start + len` | `+` (pos+entry) → `-` | `patch_chunk_offsets_rejects_count_past_table` (mutant returns Ok) |
+| same `+` (pos+entry) | `+` → `*` | `patch_chunk_offsets_stco_overflow_and_underflow_boundaries` (delta 0 → `Malformed` at i=0) |
+| `patch_chunk_offsets`: `if v < 0 \|\| v > u32::MAX as i64` (the `v < 0`) | `<` → `==` | `..._stco_overflow_and_underflow_boundaries` (delta 0: 0 == 0 → `TooLarge`) |
+| same `<` | `<` → `<=` | `..._stco_overflow_and_underflow_boundaries` (delta 0: 0 ≤ 0 → `TooLarge`) |
+| same line (the `\|\|`) | `\|\|` → `&&` | `..._stco_overflow_and_underflow_boundaries` (delta u32::MAX+1 wrongly accepted → not Err) |
+| same line (the `v > u32::MAX`) | `>` → `==` | `..._stco_overflow_and_underflow_boundaries` (delta u32::MAX: == → `TooLarge`) |
+| same `>` | `>` → `>=` | `..._stco_overflow_and_underflow_boundaries` (delta u32::MAX: ≥ → `TooLarge`) |
+| `patch_chunk_offsets`: co64 `if v < 0` | `<` → `==` | `patch_chunk_offsets_co64_zero_offset_is_ok` (0 == 0 → `Malformed`) |
+| same co64 `<` | `<` → `<=` | `patch_chunk_offsets_co64_zero_offset_is_ok` (0 ≤ 0 → `Malformed`) |
+
+After each: `git checkout -- musefs-format/src/mp4.rs`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs
+git commit -m "$(cat <<'EOF'
+test(mp4): phase 3c C4b — patch_chunk_offsets mutation kills
+
+stco overflow/underflow guard, the count-past-table bounds check, and the
+co64 v < 0 boundary.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: C4c — `synthesize_layout`
+
+Kills the `new_moov_size > u32::MAX` guard (`>→==`, `>→>=`) via a cheap `data_len`
+boundary driven through the full synthesis path.
+
+**Files:**
+- Modify (tests only): `musefs-format/src/mp4.rs` `#[cfg(test)] mod tests`.
+
+- [ ] **Step 1: Add the synthesize_layout test**
+
+```rust
+    #[test]
+    fn synthesize_new_moov_size_exactly_u32_max_is_ok() {
+        // `if new_moov_size > u32::MAX` is strict. new_moov_size == u32::MAX must be
+        // accepted; `> -> ==`/`>= ` reject the exact boundary. data_len (the art size)
+        // is reserved as a number, so the boundary is cheap. new_moov_size == overhead
+        // + data_len, so probe overhead with data_len 0 first.
+        fn art(data_len: u64) -> ArtInput {
+            ArtInput {
+                art_id: 1,
+                mime: "image/jpeg".into(),
+                description: String::new(),
+                picture_type: 3,
+                width: 0,
+                height: 0,
+                data_len,
+            }
+        }
+        let buf = mk_mp4(true, b"AUDIO", &[0]);
+        let scan = read_structure(&buf).unwrap();
+
+        let layout0 =
+            synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art(0)]).unwrap();
+        let head0 = inline_head(&layout0);
+        let overhead = find_moov_in_head(&head0).total_len as u64; // == new_moov_size at data_len 0
+        let max_len = u32::MAX as u64 - overhead;
+
+        assert!(
+            synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art(max_len)]).is_ok()
+        );
+        assert!(matches!(
+            synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art(max_len + 1)]),
+            Err(FormatError::TooLarge)
+        ));
+    }
+```
+
+- [ ] **Step 2: Run the test — confirm green**
+
+```bash
+cargo test -p musefs-format --features fuzzing --lib \
+  mp4::tests::synthesize_new_moov_size_exactly_u32_max_is_ok
+```
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply-verify each kill**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
+| `synthesize_layout`: `if new_moov_size > u32::MAX as u64` | `>` → `==` | `synthesize_new_moov_size_exactly_u32_max_is_ok` (boundary → `TooLarge`, unwrap/is_ok panics) |
+| same `>` | `>` → `>=` | `synthesize_new_moov_size_exactly_u32_max_is_ok` |
+
+After each: `git checkout -- musefs-format/src/mp4.rs`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs
+git commit -m "$(cat <<'EOF'
+test(mp4): phase 3c C4c — synthesize_layout mutation kills
+
+new_moov_size > u32::MAX guard (> -> ==/>=) via a cheap data_len boundary
+driven through the full synthesis path.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: C5 — inventory + tracking docs
+
+Annotate the killed/timeout-detected survivors and mark Phase 3c complete.
+
+**Files:**
+- Modify: `docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md`
+- Modify: `docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md`
+
+- [ ] **Step 1: Annotate the `mp4.rs` rows in the inventory**
+
+In `2026-05-29-mutation-inventory.md`, edit the 44 `mp4.rs` survivor rows
+(`mp4.rs:35` … `mp4.rs:638`) in the `musefs-format` survivor table. For each
+**missed** row, change the `Kind` cell `missed` → `missed → **killed** (phase 3c)`.
+For the 4 **timeout** rows (`mp4.rs:35` ×3 = `BoxRef::end`; `mp4.rs:285` =
+`read_structure_from`'s `pos += total`), change `timeout` →
+`timeout → **timeout-detected**` (matching the Phase 2 `ogg/page.rs` convention).
+Record that the only `|` mutants (`read_structure_from` `|= -> &=`) are **killed**,
+not equivalent — no mp4.rs mutant is recorded as equivalent.
+
+- [ ] **Step 2: Mark Phase 3c complete in the tracking doc**
+
+In `2026-05-29-remediation-tracking.md`:
+- Update the `**Status:**` line to note Phase 3c (MP4) complete.
+- In the **Phase 3** section, mark the MP4 slice complete (mirror how 3a/3b are
+  annotated), noting WAV (3d) remains and that the non-FLAC read-fidelity dimension
+  of finding #5 is still tracked separately.
+
+- [ ] **Step 3: Run the full workspace suite + lints (acceptance gate)**
+
+```bash
+cargo test --workspace
+cargo test -p musefs-format --features fuzzing
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+Expected: all green. (The pre-commit hook also runs these.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md \
+        docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+git commit -m "$(cat <<'EOF'
+docs(phase3c): record MP4 kills + mark phase complete
+
+Annotate the 44 mp4.rs survivors (40 missed -> killed, 4 timeout ->
+timeout-detected) and mark Phase 3c complete in the tracking doc. No mp4.rs
+mutant is equivalent (the |= dup-accumulators are killed).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Coverage map (every survivor → its kill)
+
+| Survivor(s) | Task | Test |
+|---|---|---|
+| `BoxRef::end:35` ×3 (`→0`,`→1`,`+→*`) | 1 | timeout-detected (covered by `walks_top_level_boxes`) |
+| `box_header:75` `<→<=` | 1 | `box_header_accepts_empty_payload_box` |
+| `read_box:105` `-→+`, `-→/` | 1 | `read_box_size0_extends_to_end_from_offset` |
+| `read_structure_from:276` `-→+` | 2 | `read_structure_from_rejects_box_overrunning_eof` |
+| `read_structure_from:279` `moof` arm | 2 | `read_structure_from_rejects_moof` |
+| `read_structure_from:280/281/282` `|=→&=` ×3 | 2 | `read_structure_from_rejects_duplicate_top_level_boxes` |
+| `read_structure_from:285` `+=→*=` | 2 | timeout-detected (covered by `read_structure_from_matches_buffer_path`) |
+| `read_freeform:337` `<→==`/`<→<=` ×4, `||→&&` | 3 | `read_freeform_accepts_minimal_name_and_data`, `read_freeform_short_name_returns_none` |
+| `read_freeform:354` `>=→<` | 3 | `read_freeform_mean_payload_exactly_4_uses_empty_mean` |
+| `read_tags:388` `<→==`/`<→<=` | 3 | `read_tags_data_payload_exactly_8_is_read` |
+| `read_tags:396` `&&→||` | 3 | `read_tags_trkn_short_value_is_skipped` |
+| `read_tags:401` `==→!=`, `&&→||`, `>=→<` | 3 | `read_tags_disk_exact_4_byte_value_yields_discnumber`, `read_tags_disk_short_value_is_skipped` |
+| `read_pictures:428` `<→==`/`<→<=` | 3 | `read_pictures_data_payload_exactly_8_is_read` |
+| `read_pictures:433` arm `14` | 3 | `read_pictures_recognizes_png` |
+| `build_udta:539` `==→!=` | 4 | `build_udta_png_art_uses_type_code_14` |
+| `build_udta:540` `+→-`/`+→*` ×3, `:541` `+→*` | 4 | `build_udta_art_box_sizes_are_exact` |
+| `build_udta:566` `>→>=` | 4 | `build_udta_udta_size_exactly_u32_max_is_ok` |
+| `patch_chunk_offsets:590` `+→-`, `+→*` | 5 | `..._rejects_count_past_table`, `..._stco_overflow_and_underflow_boundaries` |
+| `patch_chunk_offsets:595` `<→==`/`<→<=`, `||→&&`, `>→==`/`>→>=` | 5 | `patch_chunk_offsets_stco_overflow_and_underflow_boundaries` |
+| `patch_chunk_offsets:601` `<→==`/`<→<=` | 5 | `patch_chunk_offsets_co64_zero_offset_is_ok` |
+| `synthesize_layout:638` `>→==`/`>→>=` | 6 | `synthesize_new_moov_size_exactly_u32_max_is_ok` |
+
+40 missed killed by tests; 4 timeouts recorded. Total survivors addressed: 44.

--- a/docs/superpowers/plans/2026-05-29-phase3c-mp4-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3c-mp4-hardening.md
@@ -372,7 +372,16 @@ cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_pictures
 ```
 Expected: each PASS (the new tests plus the pre-existing `read_*` tests).
 
-- [ ] **Step 3: Hand-apply-verify each kill**
+Hand-apply-verify in three per-function sub-batches (Steps 3a–3c). 15 mutations
+total; keeping them grouped by function bounds the apply/revert cycle and the
+risk of leaving a stray edit. **After every single mutation:**
+`git checkout -- musefs-format/src/mp4.rs`, then rerun the named test to confirm it
+is green again before applying the next.
+
+> Note: the `trkn`/`disk` `&& -> ||` and `read_freeform` `|| -> &&` kills are
+> **panics** (out-of-bounds slice), which count as kills per the verification method.
+
+- [ ] **Step 3a: Hand-apply-verify the `read_freeform` group (6 mutations)**
 
 | Construct (locate by pattern) | Mutation | Test that must FAIL |
 |---|---|---|
@@ -382,20 +391,31 @@ Expected: each PASS (the new tests plus the pre-existing `read_*` tests).
 | same `<` | `<` → `<=` | `read_freeform_accepts_minimal_name_and_data` |
 | `read_freeform`: the `\|\|` on that line | `\|\|` → `&&` | `read_freeform_short_name_returns_none` (panics on `np[4..]`) |
 | `read_freeform`: `if p.len() >= 4` (mean) | `>=` → `<` | `read_freeform_mean_payload_exactly_4_uses_empty_mean` |
+
+Run between mutations: `cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_freeform`
+
+- [ ] **Step 3b: Hand-apply-verify the `read_tags` group (6 mutations)**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
 | `read_tags`: `if dp.len() < 8` | `<` → `==` | `read_tags_data_payload_exactly_8_is_read` |
 | same `<` | `<` → `<=` | `read_tags_data_payload_exactly_8_is_read` |
 | `read_tags`: `&atom.kind == b"trkn" && value.len() >= 4` (the `&&`) | `&&` → `\|\|` | `read_tags_trkn_short_value_is_skipped` (panics) |
 | `read_tags`: `&atom.kind == b"disk" && value.len() >= 4` (the `==`) | `==` → `!=` | `read_tags_disk_exact_4_byte_value_yields_discnumber` |
 | same line (the `&&`) | `&&` → `\|\|` | `read_tags_disk_short_value_is_skipped` (panics) |
 | same line (the `>=`) | `>=` → `<` | `read_tags_disk_exact_4_byte_value_yields_discnumber` |
+
+Run between mutations: `cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_tags`
+
+- [ ] **Step 3c: Hand-apply-verify the `read_pictures` group (3 mutations)**
+
+| Construct (locate by pattern) | Mutation | Test that must FAIL |
+|---|---|---|
 | `read_pictures`: `if dp.len() < 8` | `<` → `==` | `read_pictures_data_payload_exactly_8_is_read` |
 | same `<` | `<` → `<=` | `read_pictures_data_payload_exactly_8_is_read` |
 | `read_pictures`: `14 => "image/png",` | delete arm | `read_pictures_recognizes_png` |
 
-After each: `git checkout -- musefs-format/src/mp4.rs`.
-
-> Note: the `trkn`/`disk` `&& -> ||` and `read_freeform` `|| -> &&` kills are
-> **panics** (out-of-bounds slice), which count as kills per the verification method.
+Run between mutations: `cargo test -p musefs-format --features fuzzing --lib mp4::tests::read_pictures`
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md
@@ -274,50 +274,50 @@ the rightmost column of each survivor table.
 | `mp3.rs:356` | replace > with >= in id3v2_alloc_safe | missed → **killed** (phase 3b) | 3 |
 | `mp3.rs:356` | replace - with + in id3v2_alloc_safe | missed → **killed** (phase 3b) | 3 |
 | `mp3.rs:362` | replace >= with < in id3v2_alloc_safe | missed → **killed** (phase 3b) | 3 |
-| `mp4.rs:35` | replace BoxRef::end -> usize with 0 | timeout | 3 |
-| `mp4.rs:35` | replace BoxRef::end -> usize with 1 | timeout | 3 |
-| `mp4.rs:35` | replace + with * in BoxRef::end | timeout | 3 |
-| `mp4.rs:75` | replace < with <= in box_header | missed | 3 |
-| `mp4.rs:105` | replace - with + in read_box | missed | 3 |
-| `mp4.rs:105` | replace - with / in read_box | missed | 3 |
-| `mp4.rs:276` | replace - with + in read_structure_from | missed | 3 |
-| `mp4.rs:279` | delete match arm b"moof" in read_structure_from | missed | 3 |
-| `mp4.rs:280` | replace \|= with &= in read_structure_from | missed | 3 |
-| `mp4.rs:281` | replace \|= with &= in read_structure_from | missed | 3 |
-| `mp4.rs:282` | replace \|= with &= in read_structure_from | missed | 3 |
-| `mp4.rs:285` | replace += with *= in read_structure_from | timeout | 3 |
-| `mp4.rs:337` | replace < with == in read_freeform | missed | 3 |
-| `mp4.rs:337` | replace < with <= in read_freeform | missed | 3 |
-| `mp4.rs:337` | replace \|\| with && in read_freeform | missed | 3 |
-| `mp4.rs:337` | replace < with == in read_freeform | missed | 3 |
-| `mp4.rs:337` | replace < with <= in read_freeform | missed | 3 |
-| `mp4.rs:354` | replace >= with < in read_freeform | missed | 3 |
-| `mp4.rs:388` | replace < with == in read_tags | missed | 3 |
-| `mp4.rs:388` | replace < with <= in read_tags | missed | 3 |
-| `mp4.rs:396` | replace && with \|\| in read_tags | missed | 3 |
-| `mp4.rs:401` | replace == with != in read_tags | missed | 3 |
-| `mp4.rs:401` | replace && with \|\| in read_tags | missed | 3 |
-| `mp4.rs:401` | replace >= with < in read_tags | missed | 3 |
-| `mp4.rs:428` | replace < with == in read_pictures | missed | 3 |
-| `mp4.rs:428` | replace < with <= in read_pictures | missed | 3 |
-| `mp4.rs:433` | delete match arm 14 in read_pictures | missed | 3 |
-| `mp4.rs:539` | replace == with != in build_udta | missed | 3 |
-| `mp4.rs:540` | replace + with - in build_udta | missed | 3 |
-| `mp4.rs:540` | replace + with * in build_udta | missed | 3 |
-| `mp4.rs:540` | replace + with * in build_udta | missed | 3 |
-| `mp4.rs:541` | replace + with * in build_udta | missed | 3 |
-| `mp4.rs:566` | replace > with >= in build_udta | missed | 3 |
-| `mp4.rs:590` | replace + with - in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:590` | replace + with * in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:595` | replace < with == in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:595` | replace < with <= in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:595` | replace \|\| with && in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:595` | replace > with == in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:595` | replace > with >= in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:601` | replace < with == in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:601` | replace < with <= in patch_chunk_offsets | missed | 3 |
-| `mp4.rs:638` | replace > with == in synthesize_layout | missed | 3 |
-| `mp4.rs:638` | replace > with >= in synthesize_layout | missed | 3 |
+| `mp4.rs:35` | replace BoxRef::end -> usize with 0 | timeout → **timeout-detected** | 3 |
+| `mp4.rs:35` | replace BoxRef::end -> usize with 1 | timeout → **timeout-detected** | 3 |
+| `mp4.rs:35` | replace + with * in BoxRef::end | timeout → **timeout-detected** | 3 |
+| `mp4.rs:75` | replace < with <= in box_header | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:105` | replace - with + in read_box | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:105` | replace - with / in read_box | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:276` | replace - with + in read_structure_from | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:279` | delete match arm b"moof" in read_structure_from | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:280` | replace \|= with &= in read_structure_from | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:281` | replace \|= with &= in read_structure_from | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:282` | replace \|= with &= in read_structure_from | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:285` | replace += with *= in read_structure_from | timeout → **timeout-detected** | 3 |
+| `mp4.rs:337` | replace < with == in read_freeform | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:337` | replace < with <= in read_freeform | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:337` | replace \|\| with && in read_freeform | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:337` | replace < with == in read_freeform | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:337` | replace < with <= in read_freeform | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:354` | replace >= with < in read_freeform | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:388` | replace < with == in read_tags | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:388` | replace < with <= in read_tags | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:396` | replace && with \|\| in read_tags | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:401` | replace == with != in read_tags | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:401` | replace && with \|\| in read_tags | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:401` | replace >= with < in read_tags | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:428` | replace < with == in read_pictures | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:428` | replace < with <= in read_pictures | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:433` | delete match arm 14 in read_pictures | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:539` | replace == with != in build_udta | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:540` | replace + with - in build_udta | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:540` | replace + with * in build_udta | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:540` | replace + with * in build_udta | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:541` | replace + with * in build_udta | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:566` | replace > with >= in build_udta | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:590` | replace + with - in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:590` | replace + with * in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:595` | replace < with == in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:595` | replace < with <= in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:595` | replace \|\| with && in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:595` | replace > with == in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:595` | replace > with >= in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:601` | replace < with == in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:601` | replace < with <= in patch_chunk_offsets | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:638` | replace > with == in synthesize_layout | missed → **killed** (phase 3c) | 3 |
+| `mp4.rs:638` | replace > with >= in synthesize_layout | missed → **killed** (phase 3c) | 3 |
 | `ogg/b64.rs:26` | replace - with + in b64_window | missed → **killed** (phase 2) | 2 |
 | `ogg/b64.rs:26` | replace - with / in b64_window | missed → **killed** (phase 2) | 2 |
 | `ogg/b64.rs:26` | replace / with * in b64_window | missed → **killed** (phase 2) | 2 |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3c-mp4-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3c-mp4-hardening-design.md
@@ -61,7 +61,7 @@ test and recorded as caught-by-timeout.
 
 ## Test placement
 
-`mp4.rs` **already has** a `#[cfg(test)] mod tests` (31 tests, already
+`mp4.rs` **already has** a `#[cfg(test)] mod tests` (30 tests, already
 `use super::*`, with local fixture helpers `bx`, `mk_mp4`, `mk_mp4_co64`,
 `soun_trak`, `mp4_with_ilst`, `data_atom`, `inline_head`, `first_stco`,
 `first_co64`, plus direct use of the production `boxed`/`text_atom`/etc.). 3c
@@ -144,9 +144,15 @@ multi-box walk path" — never an apply-and-rerun (which would hang the suite).
 
 ### C1 — box primitives (`box_header`, `read_box`, `BoxRef::end`)
 
-In-module unit tests: `box_header` with an empty-payload box (`size == header_len`,
-e.g. an 8-byte box) must return Ok (kills `<→<=`); a size-0 box parsed at a nonzero
-`pos` asserts `total_len == buf.len() - pos` (kills `read_box`'s `-→+`/`-→/`).
+In-module unit tests: `box_header` with an empty-payload box (`total_len ==
+header_len`, e.g. an 8-byte box) must return Ok (kills `<→<=`); a size-0 box parsed
+at a nonzero `pos` asserts `total_len == buf.len() - pos` (kills `read_box`'s
+`-→+`/`-→/`). **Buffer layout for the size-0 kill must be explicit:** place the box
+at a `pos` with `pos + 8 <= buf.len()` (so the `be_u32` size read and the `kind`
+slice both succeed *before* the size-0 branch — otherwise the test fails on a
+`Malformed` from the bounds check rather than on the mutated arithmetic), with the
+four size bytes at `pos` zeroed; then assert the exact `total_len == buf.len() -
+pos` so `-→+` (`buf.len() + pos`) and `-→/` (`buf.len() / pos`) both diverge.
 Confirm an existing multi-box walk test covers the `BoxRef::end` timeouts; record
 the three as timeout-detected.
 
@@ -197,12 +203,22 @@ forced.
 
 ## Test budget (for chunking the plan)
 
-Rough new/strengthened-test counts so the plan can split into bite-sized tasks:
+Rough new/strengthened-test counts so the plan can split into bite-sized tasks.
+**These counts assume boundary-pair tests each kill multiple mutants** — e.g. a
+single `patch_chunk_offsets` test that drives one patched offset to *both* `0` and
+`u32::MAX` exercises all five mutants on `v < 0 || v > u32::MAX` at once, and one
+oversize-by-one variant covers the corresponding `==`/`>=`/`&&`. Without that
+sharing the counts would be roughly double. (Mirrors 3b's "several branches share a
+base fixture mutated minimally.")
 
-- C1 box primitives: ~3–4 tests (+ confirm/record 3 timeouts).
-- C2 `read_structure_from`: ~4–5 tests (over-large box, `moof`, dup ×3; + confirm/record 1 timeout).
-- C3 metadata read: ~10–12 tests (the bulk of the `<`/`||`/`&&`/arm survivors).
-- C4 synthesis: ~10–12 tests (png type, size arithmetic, the two `u32::MAX` guards, stco/co64 bounds).
+- C1 box primitives (~3 missed survivors): ~3–4 tests (+ confirm/record 3 timeouts).
+- C2 `read_structure_from` (~5 missed survivors): ~4–5 tests (over-large box, `moof`, dup ×3; + confirm/record 1 timeout).
+- C3 metadata read (~12 missed survivors): ~10–12 tests (the bulk of the `<`/`||`/`&&`/arm survivors).
+- C4 synthesis (**17 missed survivors** — `build_udta` 6, `patch_chunk_offsets` 9,
+  `synthesize_layout` 2): ~12–14 tests. This is the densest component; the plan
+  should split it per-function (a `build_udta` task, a `patch_chunk_offsets` task,
+  a `synthesize_layout` task) and lean on boundary-pair tests, or the count creeps
+  toward one-test-per-mutant.
 
 Total ≈ 30–40 new/strengthened tests, plus 4 timeout records.
 

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3c-mp4-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3c-mp4-hardening-design.md
@@ -1,0 +1,230 @@
+# Phase 3c — MP4 Hardening (Design)
+
+**Source audit:** `docs/audits/2026-05-29-test-audit.md` (the `mp4.rs` mutation
+survivors from the phase-1 inventory)
+**Created:** 2026-05-29
+**Status:** design — awaiting plan
+
+## Goal
+
+Drive the **44 `mp4.rs` mutation survivors** (40 missed + 4 timeout) toward zero
+with additive tests, killing the killable ones, documenting genuine equivalents,
+and recording the 4 infinite-loop survivors as **timeout-detected**.
+
+**All changes are additive tests; no new dependencies.** No production logic change
+is expected (these are coverage gaps). The one contingency: if a survivor in a
+bounds check (`patch_chunk_offsets`, `box_header`, the `u32::MAX` size guards)
+turns out to mark a real off-by-one, it gets a small scoped fix — flagged, not
+assumed (mirrors 3a's #16 handling and 3b's `id3v2_alloc_safe` contingency). The
+byte-identity invariant is untouched either way: nothing here touches the
+positioned `mdat`-payload reads.
+
+This is the third slice of Phase 3 (Format-layer coverage & mutants, non-Ogg):
+3a FLAC (merged, #47), 3b MP3 (in flight), **3c MP4** (this doc), 3d WAV. 3c
+carries no cross-cutting findings — finding #5/#16 were resolved for FLAC in 3a;
+the non-FLAC read-fidelity dimension of #5 is tracked separately and is **out of
+scope here** (per the 3b decision).
+
+## Guiding principle: verify, don't trust
+
+The 2026-05-29 audit was executed by a weaker model; its findings are **leads, not
+facts.** Every survivor below was re-read against the actual `mp4.rs` source on the
+3c base (`main` @ `895b910`, with 3a merged). Two consequences surfaced:
+
+1. **Line numbers in the inventory are approximate** (captured at CI sha
+   `81d6d845d`). They happen to line up closely with current `main` for `mp4.rs`,
+   but **locate every target by its code construct, never by the raw line
+   number.** Re-confirm before each kill.
+2. **MP4 has no manual shift-OR bit-decode sites.** `be_u32`/`be_u64` use
+   `u32::from_be_bytes`/`u64::from_be_bytes`, so — unlike MP3 (3b) and FLAC (3a) —
+   there is **no `|→^` disjoint-bitfield equivalence question.** The only `|`
+   mutants are the bool `|=` dup-accumulators in `read_structure_from`, which are
+   **killable** (see the equivalence section).
+
+## The hand-apply verification method (use for every kill)
+
+cargo-mutants is not available locally. For each targeted `function: construct: mutation`:
+
+1. Run the new test → it passes (production code is correct).
+2. Locate the construct by pattern, apply the exact mutation, rerun **just that
+   test** → it must **fail** (a failed assertion *or* a panic both count).
+3. Revert (`git checkout -- musefs-format/src/mp4.rs`), rerun → passes again.
+
+If step 2 still passes, strengthen the test, or — if the mutation provably yields
+identical behavior — record it as an **equivalent mutant** instead of contriving a
+test. Never leave a mutation applied.
+
+**Timeout survivors are the exception** (see the timeout section): they cannot be
+hand-applied locally because the mutation makes a walk loop non-terminating (the
+test would hang rather than fail). They are confirmed by reasoning + a covering
+test and recorded as caught-by-timeout.
+
+## Test placement
+
+`mp4.rs` **already has** a `#[cfg(test)] mod tests` (31 tests, already
+`use super::*`, with local fixture helpers `bx`, `mk_mp4`, `mk_mp4_co64`,
+`soun_trak`, `mp4_with_ilst`, `data_atom`, `inline_head`, `first_stco`,
+`first_co64`, plus direct use of the production `boxed`/`text_atom`/etc.). 3c
+**extends that module** — it can call every private survivor fn (`box_header`,
+`read_box`, `child_boxes`, `read_structure_from`, `read_freeform`, `read_tags`,
+`read_pictures`, `build_udta`, `patch_chunk_offsets`, `synthesize_layout`)
+directly with byte-precise fixtures. The existing integration files under
+`musefs-format/tests/` stay unchanged; all 3c kills live in the in-module test
+module so the kill→test mapping is unambiguous.
+
+## Verified findings
+
+The 44 survivors cluster by function (line numbers approximate — locate by
+construct):
+
+| Function | Constructs with survivors | Kill approach |
+|----------|---------------------------|---------------|
+| `BoxRef::end` | whole-fn (`→0`/`→1`), `start + total_len` (`+→*`) | **timeout** — stalls the `child_boxes` walk; covering walk test + record |
+| `box_header` | `total_len < header_len` size bound (`<→<=`) | empty-payload box (`total_len == header_len`) must parse Ok |
+| `read_box` | size-0 `(buf.len() - pos)` (`-→+`, `-→/`) | size-0 box at `pos > 0`: `total_len == buf.len() - pos` |
+| `read_structure_from` | `remaining` arg `file_len - pos` (`-→+`); `moof` arm delete; dup `\|=` ×3 (`\|=→&=`); `pos += total` (`+=→*=`) | over-large box rejected; `moof` file rejected; duplicate ftyp/moov/mdat rejected; `pos +=` is **timeout** |
+| `read_freeform` | `np.len() < 4 \|\| dp.len() < 8` (`<→==`/`<=`, `\|\|→&&`); mean `p.len() >= 4` (`>=→<`) | exact-length name/data fixtures; one-side-true `\|\|` fixture |
+| `read_tags` | `dp.len() < 8` (`<→==`/`<=`); `trkn`/`disk` branch (`&&→\|\|`, `==→!=`, `>=→<`) | exact 8-byte data; `trkn`/`disk` with value len exactly 4 and <4 |
+| `read_pictures` | `dp.len() < 8` (`<→==`/`<=`); `data`-type arm `14` delete | exact 8-byte data; **PNG** cover (type 14) recognized as `image/png` |
+| `build_udta` | png `a.mime == "image/png"` (`==→!=`); covr/data size `+→-/*`; `udta_size > u32::MAX` (`>→>=`) | png→type 14 / jpeg→type 13; exact emitted box sizes; `u32::MAX` boundary via `art_len` |
+| `patch_chunk_offsets` | bounds `pos + entry > start + len` (`+→-/*`); stco `v < 0 \|\| v > u32::MAX` (`<→==`/`<=`, `\|\|→&&`, `>→==`/`>=`); co64 `v < 0` (`<→==`/`<=`) | delta driving `v` to exactly `0` / `u32::MAX` and one past each |
+| `synthesize_layout` | `new_moov_size > u32::MAX` (`>→==`/`>=`) | `u32::MAX` boundary via `art_len` |
+
+### The `u32::MAX` size guards are cheaply testable
+
+`build_udta:566` (`udta_size > u32::MAX`) and `synthesize_layout:638`
+(`new_moov_size > u32::MAX`) look untestable (a 4 GiB tag region), but **are not**:
+`build_udta` *reserves* the art region from `art.data_len` (a `u64`) without ever
+holding the image bytes (see the existing `build_udta_with_art_reserves_size_without_image`
+test). So an `ArtInput` with a large `data_len` drives `udta_size`/`new_moov_size`
+to exactly `u32::MAX` (must be Ok) and one byte past (must be `TooLarge`) without
+allocating anything. That boundary pair kills both `>→==` and `>→>=`.
+
+## Equivalent mutants
+
+**MP4 has essentially none.** Because every multi-byte field is decoded with
+`from_be_bytes` (no hand-rolled `(a<<16)|(b<<8)|c`), the disjoint-bitfield `|→^`
+equivalence that dominated 3a/3b **does not arise**. The only `|` mutants in the
+inventory are the three bool dup-accumulators in `read_structure_from`:
+
+```rust
+dup |= ftyp.replace((pos, bh)).is_some(),   // and the moov / mdat lines
+```
+
+`|=→&=` here is **killable**, not equivalent: `dup` starts `false`, and `&=` can
+never set it `true`, so a file with a duplicate box (where the correct `|=`
+accumulates `true` and rejects with `NotMp4`) is wrongly accepted under `&=`. One
+duplicate-ftyp / duplicate-moov / duplicate-mdat fixture kills each line. **No
+mutant is recorded as equivalent** unless a kill attempt proves otherwise during
+implementation (recorded then, with the hand-apply evidence).
+
+## Timeout survivors → timeout-detected
+
+Four survivors are **infinite-loop mutations**: they make a box-walk stop
+advancing `pos`, so the loop never terminates and cargo-mutants times out rather
+than classifying caught/missed. Per the Phase 2 convention they are recorded as
+**timeout-detected** (cargo-mutants' own per-mutant timeout kills a non-terminating
+mutant in CI). No production change; verified by reasoning + a confirmed covering
+test, **not** by running the hang locally.
+
+- `BoxRef::end` `→0`, `→1`, `+→*`: `child_boxes` advances with `pos = b.end()`. A
+  zero/constant/`start*total_len` end pins `pos` at `0` (or fails to advance), so
+  any walk over a ≥2-box buffer hangs. **Covering tests already exist**
+  (`walks_top_level_boxes`, `find_box_and_nested_path`, the `locate`/`read_tags`
+  paths). Confirm one walks ≥2 boxes; record.
+- `read_structure_from:285` `pos += total` → `pos *= total`: `pos` starts `0`, so
+  `0 *= total` stays `0` forever. **Covered** by `read_structure_from_matches_buffer_path`
+  / `_never_reads_mdat_payload` / `_handles_largesize_mdat`. Confirm one walks past
+  the first box; record.
+
+The plan's verification step for these is "confirm a covering test exercises the
+multi-box walk path" — never an apply-and-rerun (which would hang the suite).
+
+## Components
+
+### C1 — box primitives (`box_header`, `read_box`, `BoxRef::end`)
+
+In-module unit tests: `box_header` with an empty-payload box (`size == header_len`,
+e.g. an 8-byte box) must return Ok (kills `<→<=`); a size-0 box parsed at a nonzero
+`pos` asserts `total_len == buf.len() - pos` (kills `read_box`'s `-→+`/`-→/`).
+Confirm an existing multi-box walk test covers the `BoxRef::end` timeouts; record
+the three as timeout-detected.
+
+### C2 — `read_structure_from` structural walk
+
+Cursor-fed fixtures (reuse the `read_structure_from_*` idiom): a file whose second
+top-level box declares a size larger than the bytes remaining must error (kills the
+`remaining` `-→+`); a file carrying a `moof` top-level box must be rejected via the
+seeking path (kills the `moof`-arm delete); files with a duplicated `ftyp` / `moov`
+/ `mdat` must each be rejected (kills the three `|=→&=`). Confirm a covering walk
+test for the `pos += total` timeout; record.
+
+### C3 — metadata read (`read_freeform`, `read_tags`, `read_pictures`)
+
+Byte-precise atom fixtures: name/data payloads at exactly the guarded lengths
+(`np.len() == 4` vs `3`; `dp.len() == 8` vs `7`) pin the `<` boundaries; a fixture
+where one side of `np.len() < 4 || dp.len() < 8` is true and the other false kills
+`||→&&`; a `mean` payload of exactly 4 bytes pins `>=→<`. For `read_tags`: a
+`trkn`/`disk` atom with value length exactly 4 (parsed) vs <4 (skipped) kills the
+`&&→||`/`>=→<`/`==→!=` on those branches; an 8-byte `data` boundary pins the length
+guard. For `read_pictures`: a **PNG** cover atom (`data` type `14`) must yield
+`image/png` (kills the arm-`14` delete), a JPEG (`13`) yields `image/jpeg`, and an
+8-byte `data` boundary pins the length guard.
+
+### C4 — synthesis (`build_udta`, `patch_chunk_offsets`, `synthesize_layout`)
+
+`build_udta`: a PNG `ArtInput` emits a `covr/data` atom with type code `14`, a JPEG
+with `13` (kills `==→!=`); assert the exact emitted `covr_size`/`data_size` (kills
+the `+→-/*` size arithmetic); an `art_len` driving `udta_size` to exactly
+`u32::MAX` is Ok, one past is `TooLarge` (kills `>→>=`/`>→==`). `patch_chunk_offsets`:
+craft a `stbl` with `stco`/`co64` entries and a `delta` that drives a patched offset
+to exactly `0` and exactly `u32::MAX` (Ok) versus `-1` and `u32::MAX + 1`
+(`Malformed`/`TooLarge`) — kills the `v < 0 || v > u32::MAX` mutants and the co64
+`v < 0`; an entry count one past the table bound kills `pos + entry > start + len`.
+`synthesize_layout`: the `art_len` `u32::MAX` boundary kills `new_moov_size`'s
+`>→>=`/`>→==`. Reuse `mk_mp4`/`mk_mp4_co64`/`first_stco`/`first_co64`.
+
+### C5 — inventory + tracking docs
+
+Annotate the `mp4.rs` rows in
+`docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md`
+(`missed → **killed** (phase 3c)` / `timeout → **timeout-detected**`, matching the
+Phase 2 convention), and mark Phase 3c complete in
+`docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md`
+(Status line + Phase 3 section). Record the empty equivalent set (note the
+`|=→&=` are killable, not equivalent) and any production fix the contingency
+forced.
+
+## Test budget (for chunking the plan)
+
+Rough new/strengthened-test counts so the plan can split into bite-sized tasks:
+
+- C1 box primitives: ~3–4 tests (+ confirm/record 3 timeouts).
+- C2 `read_structure_from`: ~4–5 tests (over-large box, `moof`, dup ×3; + confirm/record 1 timeout).
+- C3 metadata read: ~10–12 tests (the bulk of the `<`/`||`/`&&`/arm survivors).
+- C4 synthesis: ~10–12 tests (png type, size arithmetic, the two `u32::MAX` guards, stco/co64 bounds).
+
+Total ≈ 30–40 new/strengthened tests, plus 4 timeout records.
+
+## Implementation ordering
+
+C1 → C2 → C3 → C4 → C5. C1–C4 are independent; do C4 last because it is the
+largest and reuses fixture idioms from C1–C3.
+
+## Error handling
+
+No new error paths. Tests assert the existing `FormatError::{Malformed, NotMp4,
+TooLarge, InvalidLayout}` mappings and the leniency contracts of `read_tags` /
+`read_pictures` (skip-and-continue, never error) on crafted inputs. If a bound
+survivor reveals a real off-by-one, the scoped fix stays within `mp4.rs` framing /
+validation (never the positioned `mdat` reads).
+
+## Acceptance
+
+| Component | Check |
+|-----------|-------|
+| C1 | `box_header` empty-payload boundary red under `<→<=`; `read_box` size-0 red under `-→+`/`-→/`; 3 `BoxRef::end` timeouts have a confirmed multi-box covering test and are recorded |
+| C2 | over-large-box, `moof`-reject, and dup-ftyp/moov/mdat tests red under the `remaining` `-→+`, the `moof`-arm delete, and the three `\|=→&=`; `pos += total` timeout covered + recorded |
+| C3 | `read_freeform`/`read_tags`/`read_pictures` length-guard, `\|\|→&&`/`&&→\|\|`, trkn/disk, and PNG-arm mutations hand-apply red |
+| C4 | `build_udta` png-type + size-arithmetic + `u32::MAX`-guard red; `patch_chunk_offsets` overflow/underflow/bounds red; `synthesize_layout` `u32::MAX`-guard red |
+| Whole | `cargo test --workspace` + `--features fuzzing` + `clippy -D warnings` + `fmt --check` green; inventory/tracking docs updated; next full mutants campaign shows `mp4.rs` survivors dropped (excluding the documented timeouts) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
@@ -113,7 +113,12 @@ Findings #5, #16.
   `read_structure_from`, `read_freeform`, `read_tags`, `read_pictures`,
   `build_udta`, `patch_chunk_offsets`, `synthesize_layout`. The `|` mutants
   (`read_structure_from` `|= → &=` dup-accumulators) are killed, not equivalent.
-  Finding #5 non-FLAC read-fidelity dimension still tracked separately.
+  Finding #16 resolved for MP4 by **skipping zero-byte art at synthesis** (the first
+  *nonempty* art wins in `mp4.rs::synthesize_layout`, mirroring the FLAC fix), and
+  finding #5 broadened onto the M4A synthesis path (`write_m4a` helper + four
+  `proptest_read_fidelity` M4A cases: backing-audio identity, partial windows,
+  header seam, art window). WAV (3d) remains the only open non-FLAC read-fidelity
+  dimension.
 - broaden `proptest_read_fidelity` (random offsets, header/audio boundary, art,
   non-FLAC) (#5)
 - zero-byte art boundary (#16)
@@ -122,7 +127,8 @@ Findings #5, #16.
   `synchsafe_decode` and v2.2 24-bit decode (note: disjoint `| → &` are killed,
   not equivalent). Production change: finding #16 zero-byte-art skip applied to
   `mp3.rs::build_id3v2_segments` (mirrors the FLAC fix; also covers the WAV `id3 `
-  chunk, which shares this builder). #16 still open for mp4/ogg. Finding #5: the
+  chunk, which shares this builder). #16 still open for ogg (mp4 closed in 3c).
+  Finding #5: the
   MP3 read-fidelity dimension is now done — added `write_mp3` to the core test
   harness and ported the four `proptest_read_fidelity` invariants (whole-audio,
   partial windows, header seam, art window) to MP3; the WAV/MP4 dimensions land in

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
@@ -2,7 +2,7 @@
 
 **Source audit:** `docs/audits/2026-05-29-test-audit.md`
 **Created:** 2026-05-29
-**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); Phase 3a (FLAC) complete; Phase 3b complete (MP3 survivors killed); phases 3c/3d, 4 pending
+**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); Phase 3a (FLAC) complete; Phase 3b complete (MP3 survivors killed); Phase 3c (MP4) complete; phases 3d, 4 pending
 
 ## Guiding principle: verify, don't trust
 
@@ -108,6 +108,12 @@ Findings #5, #16.
   (their sub-phases) or filter empty art once at ingestion (`scan.rs`); finding #5
   broadened on FLAC (partial/seam/art windows), with the non-FLAC dimension tracked
   into 3b/3c/3d.
+- **3c done** — MP4 survivors killed (40 missed → killed, 4 timeout →
+  timeout-detected; no equivalents). Covers `box_header`, `read_box`,
+  `read_structure_from`, `read_freeform`, `read_tags`, `read_pictures`,
+  `build_udta`, `patch_chunk_offsets`, `synthesize_layout`. The `|` mutants
+  (`read_structure_from` `|= → &=` dup-accumulators) are killed, not equivalent.
+  Finding #5 non-FLAC read-fidelity dimension still tracked separately.
 - broaden `proptest_read_fidelity` (random offsets, header/audio boundary, art,
   non-FLAC) (#5)
 - zero-byte art boundary (#16)

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -70,6 +70,17 @@ pub fn write_mp3(path: &Path, audio: &[u8]) -> (i64, i64) {
     (audio_offset, audio.len() as i64)
 }
 
+/// Write a minimal moov-first M4A (see `minimal_m4a`) to `path`, returning
+/// (audio_offset, audio_length) for the verbatim trailing `mdat` payload. M4A
+/// synthesis re-scans the file's structural boxes and serves the mdat payload
+/// verbatim, so the stored bounds need only satisfy the reader's size guard.
+pub fn write_m4a(path: &Path, audio: &[u8]) -> (i64, i64) {
+    let bytes = minimal_m4a(audio);
+    let audio_offset = (bytes.len() - audio.len()) as i64;
+    std::fs::write(path, &bytes).unwrap();
+    (audio_offset, audio.len() as i64)
+}
+
 /// Build a 32-bit-size box: [size][type][payload].
 fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
     let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();
@@ -123,5 +134,18 @@ pub fn minimal_m4a(mdat_payload: &[u8]) -> Vec<u8> {
     let moov = bx(b"moov", &[bx(b"mvhd", &[0u8; 8]), trak, udta].concat());
     let ftyp = bx(b"ftyp", b"M4A isom");
     let mdat = bx(b"mdat", mdat_payload);
-    [ftyp, moov, mdat].concat()
+    let mut out = [ftyp, moov, mdat].concat();
+    // Point the single `stco` chunk offset at the real `mdat` payload start. A real
+    // M4A's chunk offsets are absolute file positions; leaving it 0 means a retag
+    // that shrinks the `moov` patches the offset below zero and synthesis fails
+    // (TooLarge). With the true offset, the patched value lands at the new payload
+    // position. The first `stco` occurrence is the box type (it precedes `mdat`).
+    let mdat_payload_offset = (out.len() - mdat_payload.len()) as u32;
+    let stco = out
+        .windows(4)
+        .position(|w| w == b"stco")
+        .expect("stco present");
+    let entry = stco + 4 + 4 + 4; // past "stco" type + version/flags + entry count
+    out[entry..entry + 4].copy_from_slice(&mdat_payload_offset.to_be_bytes());
+    out
 }

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::write_flac;
+use common::write_m4a;
 use common::write_mp3;
 use musefs_core::{read_at, HeaderCache, Mode};
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
@@ -327,6 +328,173 @@ proptest! {
                 Segment::Inline(bytes) => art_off += bytes.len() as u64,
                 Segment::BackingAudio { len, .. } => art_off += *len,
                 other => panic!("unexpected MP3 segment: {other:?}"),
+            }
+        }
+        let art_len = art_len.expect("layout has an ArtImage segment");
+        prop_assert_eq!(art_len, art.len() as u64);
+        prop_assert_eq!(
+            &whole[art_off as usize..(art_off + art_len) as usize],
+            &art[..]
+        );
+        let local_off = (a as u64) % (art_len + 1);
+        let offset = art_off + local_off;
+        let len = (b as u64) % (art_len - local_off + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+}
+
+fn build_m4a(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.m4a");
+    let (audio_offset, audio_length) = write_m4a(&path, audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::M4a,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    (dir, db, id, audio.to_vec())
+}
+
+fn build_m4a_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, Db, i64) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.m4a");
+    let (audio_offset, audio_length) = write_m4a(&path, audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::M4a,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    let art_id = db
+        .upsert_art(&NewArt {
+            mime: "image/png".to_string(),
+            width: Some(8),
+            height: Some(8),
+            data: art.to_vec(),
+        })
+        .unwrap();
+    db.set_track_art(
+        id,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: "front".to_string(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+    (dir, db, id)
+}
+
+// Finding #5, non-FLAC dimension: the same read-fidelity invariants over the M4A
+// synthesis path (rebuilt `moov` + verbatim `mdat` payload, plus a `covr` art
+// window). Mirrors the FLAC/MP3 blocks above; the WAV dimension lands in its own
+// phase.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn read_at_preserves_backing_audio_m4a(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+    ) {
+        let (_dir, db, id, original) = build_m4a(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+        prop_assert_eq!(whole.len() as u64, resolved.total_len);
+        let served_audio = &whole[resolved.layout.header_len() as usize..];
+        prop_assert_eq!(served_audio, &original[..]);
+    }
+
+    #[test]
+    fn read_at_partial_windows_match_whole_m4a(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build_m4a(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(got.len() as u64, len);
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+
+    #[test]
+    fn read_at_windows_spanning_header_seam_m4a(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        before in 0usize..4096,
+        after in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build_m4a(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let hlen = resolved.layout.header_len();
+        prop_assume!(hlen > 0 && hlen < total);
+        let start = hlen - 1 - (before as u64 % hlen); // in [0, hlen)
+        let end = hlen + 1 + (after as u64 % (total - hlen)); // in (hlen, total]
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let got = read_at(&resolved, &db, start, end - start).unwrap();
+        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+    }
+
+    #[test]
+    fn read_at_art_window_serves_blob_m4a(
+        audio in proptest::collection::vec(any::<u8>(), 1..256),
+        art in proptest::collection::vec(any::<u8>(), 1..256),
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id) = build_m4a_with_art(&audio, "T", &art);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+
+        // Locate the ArtImage segment's exact byte offset by summing the serving
+        // lengths of the segments before it (see the FLAC variant for why a
+        // byte-search would false-positive).
+        let mut art_off = 0u64;
+        let mut art_len = None;
+        for s in &resolved.layout.segments {
+            match s {
+                Segment::ArtImage { len, .. } => {
+                    art_len = Some(*len);
+                    break;
+                }
+                Segment::Inline(bytes) => art_off += bytes.len() as u64,
+                Segment::BackingAudio { len, .. } => art_off += *len,
+                other => panic!("unexpected M4A segment: {other:?}"),
             }
         }
         let art_len = art_len.expect("layout has an ArtImage segment");

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1393,4 +1393,31 @@ mod tests {
         assert_eq!(from_stream.mdat_header.len(), 16); // largesize header
         assert_eq!(from_stream.mdat_payload_len, payload.len() as u64);
     }
+
+    #[test]
+    fn box_header_accepts_empty_payload_box() {
+        // total_len == header_len (an 8-byte box, no payload) must be accepted.
+        // `< -> <=` would make the equal case reject.
+        let mut h = 8u32.to_be_bytes().to_vec();
+        h.extend_from_slice(b"free");
+        let bh = box_header(&h, 1000).unwrap();
+        assert_eq!(bh.header_len, 8);
+        assert_eq!(bh.total_len, 8);
+    }
+
+    #[test]
+    fn read_box_size0_extends_to_end_from_offset() {
+        // A size-0 box ("extends to EOF") at pos > 0: total_len must be
+        // buf.len() - pos. `- -> +` (buf.len() + pos) and `- -> /` (buf.len() / pos)
+        // both diverge. The box is placed at pos = 8 with pos + 8 <= buf.len() so the
+        // be_u32 size read and the kind slice both succeed BEFORE the size-0 branch.
+        let mut buf = bx(b"free", b""); // 8-byte box at pos 0
+        buf.extend_from_slice(&0u32.to_be_bytes()); // size32 = 0 at pos 8
+        buf.extend_from_slice(b"mdat"); // kind at pos 12..16
+        buf.extend_from_slice(b"AUDIOPAYLOAD"); // 12 payload bytes
+        assert_eq!(buf.len(), 28);
+        let b = read_box(&buf, 8).unwrap();
+        assert_eq!(&b.kind, b"mdat");
+        assert_eq!(b.total_len, buf.len() - 8); // 20
+    }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1708,4 +1708,43 @@ mod tests {
         let mut kept = bx(b"trak", &bx(b"mdia", &bx(b"minf", &stbl)));
         assert!(patch_chunk_offsets(&mut kept, 0).is_ok());
     }
+
+    #[test]
+    fn synthesize_new_moov_size_exactly_u32_max_is_ok() {
+        // `if new_moov_size > u32::MAX` is strict. new_moov_size == u32::MAX must be
+        // accepted; `> -> ==`/`>= ` reject the exact boundary. data_len (the art size)
+        // is reserved as a number, so the boundary is cheap.
+        fn art(data_len: u64) -> ArtInput {
+            ArtInput {
+                art_id: 1,
+                mime: "image/jpeg".into(),
+                description: String::new(),
+                picture_type: 3,
+                width: 0,
+                height: 0,
+                data_len,
+            }
+        }
+        let buf = mk_mp4(true, b"AUDIO", &[0]);
+        let scan = read_structure(&buf).unwrap();
+        let tags = [TagInput::new("title", "T")];
+
+        // Synthesize once with a 1-byte art. The head is [ftyp][moov], where the moov
+        // box header declares new_moov_size = overhead + 1. The actual moov bytes in the
+        // head are new_moov_size - 1 (the art is a separate ArtImage segment). So the
+        // head length = ftyp.len() + (overhead + 1 - 1) = ftyp.len() + overhead.
+        let layout1 = synthesize_layout(&scan, &tags, &[art(1)]).unwrap();
+        let head_len = inline_head(&layout1).len();
+        let overhead = (head_len as u64) - (scan.ftyp.len() as u64);
+        let max_len = u32::MAX as u64 - overhead;
+
+        assert!(max_len > 0, "overhead {overhead} must be < u32::MAX");
+        // Boundary accepted
+        assert!(synthesize_layout(&scan, &tags, &[art(max_len)]).is_ok());
+        // Boundary+1 rejected
+        assert!(matches!(
+            synthesize_layout(&scan, &tags, &[art(max_len + 1)]),
+            Err(FormatError::TooLarge)
+        ));
+    }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1652,4 +1652,60 @@ mod tests {
             Err(FormatError::TooLarge)
         ));
     }
+
+    #[test]
+    fn patch_chunk_offsets_stco_overflow_and_underflow_boundaries() {
+        // kept = a single soun trak with one stco entry (offset 0). v = 0 + delta is
+        // guarded by `v < 0 || v > u32::MAX`. Boundary deltas pin every guard mutant;
+        // delta 0 (accepted) also pins the `:590` `+ -> *` bound at i = 0.
+        let mut k = soun_trak();
+        assert!(patch_chunk_offsets(&mut k, 0).is_ok()); // v == 0
+
+        let mut k = soun_trak();
+        assert!(patch_chunk_offsets(&mut k, u32::MAX as i64).is_ok()); // v == u32::MAX
+
+        let mut k = soun_trak();
+        assert!(matches!(
+            patch_chunk_offsets(&mut k, u32::MAX as i64 + 1), // v == u32::MAX + 1
+            Err(FormatError::TooLarge)
+        ));
+
+        let mut k = soun_trak();
+        assert!(matches!(
+            patch_chunk_offsets(&mut k, -1), // v == -1
+            Err(FormatError::TooLarge)
+        ));
+    }
+
+    #[test]
+    fn patch_chunk_offsets_rejects_count_past_table() {
+        // stco declares 2 entries but only 1 entry's bytes are present (followed by an
+        // unrelated `free` box for padding). `pos + entry > start + len` must reject
+        // the 2nd entry. `+ -> -` shrinks the bound and reads into the `free` box
+        // instead of erroring (returns Ok).
+        let mut stco = vec![0u8; 4]; // version/flags
+        stco.extend_from_slice(&2u32.to_be_bytes()); // count = 2 (a lie)
+        stco.extend_from_slice(&0u32.to_be_bytes()); // only 1 entry present
+        let stbl = bx(
+            b"stbl",
+            &[bx(b"stco", &stco), bx(b"free", &[0u8; 8])].concat(),
+        );
+        let mut kept = bx(b"trak", &bx(b"mdia", &bx(b"minf", &stbl)));
+        assert!(matches!(
+            patch_chunk_offsets(&mut kept, 0),
+            Err(FormatError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn patch_chunk_offsets_co64_zero_offset_is_ok() {
+        // co64 path guard is `v < 0`. offset 0 + delta 0 => v == 0 must be accepted;
+        // `< -> ==`/`<= ` reject the boundary.
+        let mut co64 = vec![0u8; 4]; // version/flags
+        co64.extend_from_slice(&1u32.to_be_bytes()); // count 1
+        co64.extend_from_slice(&0u64.to_be_bytes()); // offset 0
+        let stbl = bx(b"stbl", &bx(b"co64", &co64));
+        let mut kept = bx(b"trak", &bx(b"mdia", &bx(b"minf", &stbl)));
+        assert!(patch_chunk_offsets(&mut kept, 0).is_ok());
+    }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1420,4 +1420,50 @@ mod tests {
         assert_eq!(&b.kind, b"mdat");
         assert_eq!(b.total_len, buf.len() - 8); // 20
     }
+
+    #[test]
+    fn read_structure_from_rejects_box_overrunning_eof() {
+        // box_header's `remaining` arg is `file_len - pos`. Inflating the mdat box's
+        // declared size past the bytes remaining must be rejected. `- -> +` inflates
+        // `remaining` to `file_len + pos`, wrongly accepting the overrun (returns Ok).
+        let mut buf = mk_mp4(true, b"AUDIO", &[0]); // [ftyp][moov][mdat], mdat last
+        let scan = read_structure(&buf).unwrap();
+        let mdat_start = (scan.mdat_payload_offset - scan.mdat_header.len() as u64) as usize;
+        let real = u32::from_be_bytes(buf[mdat_start..mdat_start + 4].try_into().unwrap());
+        buf[mdat_start..mdat_start + 4].copy_from_slice(&(real + 100).to_be_bytes());
+        let mut cur = std::io::Cursor::new(buf.clone());
+        assert!(read_structure_from(&mut cur, buf.len() as u64).is_err());
+    }
+
+    #[test]
+    fn read_structure_from_rejects_moof() {
+        // A `moof` (fragmented MP4) top-level box must be rejected via the seeking
+        // path. Deleting the `b"moof"` match arm drops it to `_ => {}` and accepts.
+        let mut buf = mk_mp4(true, b"AUDIO", &[0]);
+        buf.extend(bx(b"moof", b"\x00\x00\x00\x00"));
+        let mut cur = std::io::Cursor::new(buf.clone());
+        assert!(read_structure_from(&mut cur, buf.len() as u64).is_err());
+    }
+
+    #[test]
+    fn read_structure_from_rejects_duplicate_top_level_boxes() {
+        // Each `dup |= X.replace(..).is_some()` accumulates a duplicate. `|= -> &=`
+        // can never set `dup` (it starts false), so a duplicate box is wrongly
+        // accepted. One duplicated box per kind isolates each of the three `|=` lines.
+        let dup = |extra: Vec<u8>| {
+            let mut buf = mk_mp4(true, b"AUDIO", &[0]);
+            buf.extend(extra);
+            let mut cur = std::io::Cursor::new(buf.clone());
+            read_structure_from(&mut cur, buf.len() as u64).is_err()
+        };
+        assert!(dup(bx(b"ftyp", b"M4A isom")), "duplicate ftyp must reject"); // ftyp |= line
+                                                                              // duplicate moov: reuse the moov from a fresh fixture so it is structurally valid.
+        let extra_moov = {
+            let other = mk_mp4(true, b"AUDIO", &[0]);
+            let s = read_structure(&other).unwrap();
+            s.moov
+        };
+        assert!(dup(extra_moov), "duplicate moov must reject"); // moov |= line
+        assert!(dup(bx(b"mdat", b"Y")), "duplicate mdat must reject"); // mdat |= line
+    }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1574,4 +1574,82 @@ mod tests {
         assert_eq!(pics[0].mime, "image/png");
         assert_eq!(pics[0].data, png);
     }
+
+    #[test]
+    fn build_udta_png_art_uses_type_code_14() {
+        // PNG art => covr/data type code 14; JPEG => 13. `== -> !=` flips them.
+        for (mime, expected) in [("image/png", 14u32), ("image/jpeg", 13u32)] {
+            let art = ArtInput {
+                art_id: 1,
+                mime: mime.into(),
+                description: String::new(),
+                picture_type: 3,
+                width: 0,
+                height: 0,
+                data_len: 10,
+            };
+            let (prefix, _) = build_udta(&[TagInput::new("title", "T")], Some(&art)).unwrap();
+            // covr layout: [covr_size u32]["covr"][data_size u32]["data"][type u32][locale u32]
+            let cpos = prefix.windows(4).position(|w| w == b"covr").expect("covr");
+            assert_eq!(&prefix[cpos + 8..cpos + 12], b"data");
+            let type_code = u32::from_be_bytes(prefix[cpos + 12..cpos + 16].try_into().unwrap());
+            assert_eq!(type_code, expected, "mime {mime}");
+        }
+    }
+
+    #[test]
+    fn build_udta_art_box_sizes_are_exact() {
+        // data_size = 8 + 8 + data_len; covr_size = 8 + data_size. The `+ -> -`/`+ -> *`
+        // mutations change the emitted box sizes.
+        let art = ArtInput {
+            art_id: 1,
+            mime: "image/jpeg".into(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 10,
+        };
+        let (prefix, _) = build_udta(&[TagInput::new("title", "T")], Some(&art)).unwrap();
+        let cpos = prefix.windows(4).position(|w| w == b"covr").expect("covr");
+        let covr_size = u32::from_be_bytes(prefix[cpos - 4..cpos].try_into().unwrap());
+        let data_size = u32::from_be_bytes(prefix[cpos + 4..cpos + 8].try_into().unwrap());
+        assert_eq!(data_size, 8 + 8 + 10); // 26
+        assert_eq!(covr_size, 8 + data_size); // 34
+    }
+
+    #[test]
+    fn build_udta_udta_size_exactly_u32_max_is_ok() {
+        // The guard is `udta_size > u32::MAX` (strict). udta_size == u32::MAX must be
+        // accepted; `> -> >=` rejects the exact boundary. data_len is reserved as a
+        // number (no image bytes), so the boundary is cheap to hit.
+        fn art(data_len: u64) -> ArtInput {
+            ArtInput {
+                art_id: 1,
+                mime: "image/jpeg".into(),
+                description: String::new(),
+                picture_type: 3,
+                width: 0,
+                height: 0,
+                data_len,
+            }
+        }
+        // Derive the fixed overhead: with data_len 0, udta_size == overhead.
+        let (p0, _) = build_udta(&[TagInput::new("title", "T")], Some(&art(0))).unwrap();
+        let overhead = u32::from_be_bytes(p0[0..4].try_into().unwrap()) as u64;
+        let max_len = u32::MAX as u64 - overhead;
+
+        let (p_max, art_len) =
+            build_udta(&[TagInput::new("title", "T")], Some(&art(max_len))).unwrap();
+        assert_eq!(art_len, max_len);
+        assert_eq!(
+            u32::from_be_bytes(p_max[0..4].try_into().unwrap()),
+            u32::MAX
+        );
+
+        assert!(matches!(
+            build_udta(&[TagInput::new("title", "T")], Some(&art(max_len + 1))),
+            Err(FormatError::TooLarge)
+        ));
+    }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1466,4 +1466,112 @@ mod tests {
         assert!(dup(extra_moov), "duplicate moov must reject"); // moov |= line
         assert!(dup(bx(b"mdat", b"Y")), "duplicate mdat must reject"); // mdat |= line
     }
+
+    #[test]
+    fn read_freeform_accepts_minimal_name_and_data() {
+        // name payload == 4 (empty name) and data payload == 8 (empty value) is the
+        // boundary of `np.len() < 4 || dp.len() < 8`. Both operands at the boundary,
+        // so flipping EITHER `<` to `==`/`<=` makes that side true -> None.
+        let name_body = 0u32.to_be_bytes().to_vec(); // exactly 4 bytes
+        let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
+        data.extend_from_slice(&0u32.to_be_bytes()); // locale -> dp.len() == 8
+        let mut inner = boxed(b"name", &name_body);
+        inner.extend(boxed(b"data", &data));
+        let (key, value) = read_freeform(&inner).unwrap();
+        assert_eq!(key, ""); // empty name, not in vocabulary -> verbatim ""
+        assert_eq!(value, "");
+    }
+
+    #[test]
+    fn read_freeform_short_name_returns_none() {
+        // name payload 3 bytes (< 4) with a valid 8-byte data payload. `|| -> &&`
+        // makes `true && false == false`, falling through to `&np[4..]` (out of bounds
+        // -> panic).
+        let name_body = vec![0u8, 0, 0]; // 3 bytes
+        let mut data = 1u32.to_be_bytes().to_vec();
+        data.extend_from_slice(&0u32.to_be_bytes());
+        let mut inner = boxed(b"name", &name_body);
+        inner.extend(boxed(b"data", &data));
+        assert!(read_freeform(&inner).is_none());
+    }
+
+    #[test]
+    fn read_freeform_mean_payload_exactly_4_uses_empty_mean() {
+        // mean payload == 4 (FullBox prefix, empty mean). `p.len() >= 4` must take the
+        // utf8 branch (mean ""), so the vocabulary does NOT fold the iTunes name.
+        // `>= -> <` falls to the default "com.apple.iTunes" mean and wrongly folds.
+        let mean_body = vec![0u8, 0, 0, 0]; // exactly 4 bytes
+        let mut name_body = 0u32.to_be_bytes().to_vec();
+        name_body.extend_from_slice(b"MusicBrainz Album Id");
+        let mut data = 1u32.to_be_bytes().to_vec();
+        data.extend_from_slice(&0u32.to_be_bytes());
+        data.extend_from_slice(b"abc-123");
+        let mut inner = boxed(b"mean", &mean_body);
+        inner.extend(boxed(b"name", &name_body));
+        inner.extend(boxed(b"data", &data));
+        let (key, value) = read_freeform(&inner).unwrap();
+        assert_eq!(key, "MusicBrainz Album Id"); // empty mean -> not folded
+        assert_eq!(value, "abc-123");
+    }
+
+    #[test]
+    fn read_tags_data_payload_exactly_8_is_read() {
+        // A `data` payload of exactly 8 bytes (type+locale, empty value) is the
+        // boundary of `dp.len() < 8`. The (empty) value must be read; `< -> ==`/`<= `
+        // would skip it.
+        let atoms = bx(b"\xa9nam", &data_atom(1, b"")); // dp.len() == 8
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(read_tags(&buf).contains(&("title".into(), String::new())));
+    }
+
+    #[test]
+    fn read_tags_disk_exact_4_byte_value_yields_discnumber() {
+        // disk atom, value exactly 4 bytes: `kind == disk` (== branch) `&&`
+        // `value.len() >= 4` (>= branch). Kills `== -> !=` (mutant skips a real disk)
+        // and `>= -> <` (mutant skips the boundary length).
+        let atoms = bx(b"disk", &data_atom(0, &[0, 0, 0, 2])); // disc 2, value len 4
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(read_tags(&buf).contains(&("discnumber".into(), "2".into())));
+    }
+
+    #[test]
+    fn read_tags_disk_short_value_is_skipped() {
+        // disk with a value shorter than 4 bytes: the guard is false. `&& -> ||`
+        // makes it true and indexes value[2]/value[3] out of bounds (panic).
+        let atoms = bx(b"disk", &data_atom(0, &[0, 0])); // value len 2
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(!read_tags(&buf).iter().any(|(k, _)| k == "discnumber"));
+    }
+
+    #[test]
+    fn read_tags_trkn_short_value_is_skipped() {
+        // trkn with a value shorter than 4 bytes: `kind == trkn && value.len() >= 4`
+        // is false. `&& -> ||` makes it true and indexes value[2]/value[3] (panic).
+        let atoms = bx(b"trkn", &data_atom(0, &[0, 0])); // value len 2
+        let buf = mp4_with_ilst(&atoms, true);
+        assert!(!read_tags(&buf).iter().any(|(k, _)| k == "tracknumber"));
+    }
+
+    #[test]
+    fn read_pictures_data_payload_exactly_8_is_read() {
+        // covr/data payload of exactly 8 bytes (type+locale, empty image) is the
+        // boundary of `dp.len() < 8`; the (empty) picture must be read.
+        let buf = mp4_with_ilst(&bx(b"covr", &data_atom(13, b"")), true);
+        let pics = read_pictures(&buf);
+        assert_eq!(pics.len(), 1);
+        assert_eq!(pics[0].mime, "image/jpeg");
+        assert!(pics[0].data.is_empty());
+    }
+
+    #[test]
+    fn read_pictures_recognizes_png() {
+        // A covr `data` atom with type code 14 is PNG. Deleting the `14 =>` match arm
+        // drops it to `_ => continue` and yields no picture.
+        let png = [0x89, b'P', b'N', b'G', 1, 2, 3];
+        let buf = mp4_with_ilst(&bx(b"covr", &data_atom(14, &png)), false);
+        let pics = read_pictures(&buf);
+        assert_eq!(pics.len(), 1);
+        assert_eq!(pics[0].mime, "image/png");
+        assert_eq!(pics[0].data, png);
+    }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -627,7 +627,10 @@ pub fn synthesize_layout(
         }
     }
 
-    let art = arts.first();
+    // Skip zero-byte art (mirrors flac.rs finding #16): an empty ArtImage segment
+    // fails layout validation (EmptySegment), making the track unreadable. Pick the
+    // first art with real bytes rather than merely the first art.
+    let art = arts.iter().find(|a| a.data_len > 0);
     let (udta_prefix, art_len) = build_udta(tags, art)?;
     let udta_total = udta_prefix.len() as u64 + art_len;
 
@@ -1162,6 +1165,73 @@ mod tests {
         assert!(matches!(segs[1], Segment::ArtImage { art_id: 7, len: 50 }));
         assert!(matches!(segs[2], Segment::Inline(_))); // mdat header
         assert!(matches!(segs.last().unwrap(), Segment::BackingAudio { .. }));
+    }
+
+    #[test]
+    fn synthesize_skips_zero_length_art() {
+        // A zero-byte art must be skipped at synthesis (mirrors flac.rs finding
+        // #16): an ArtImage { len: 0 } segment fails layout validation
+        // (EmptySegment), making the track unreadable. The track must still
+        // synthesize with its tags, just without a cover-art segment or covr box.
+        let buf = mk_mp4(false, b"AUDIODATA", &[0]);
+        let scan = read_structure(&buf).unwrap();
+        let art = ArtInput {
+            art_id: 7,
+            mime: "image/jpeg".into(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 0,
+        };
+        let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
+        let segs = layout.segments();
+        assert!(
+            !segs.iter().any(|s| matches!(s, Segment::ArtImage { .. })),
+            "zero-byte art must not emit an ArtImage segment"
+        );
+        let Segment::Inline(head) = &segs[0] else {
+            panic!("first segment should be the inline head");
+        };
+        assert!(
+            head.windows(4).all(|w| w != b"covr"),
+            "no covr box should be emitted for zero-byte art"
+        );
+        assert!(matches!(segs.last().unwrap(), Segment::BackingAudio { .. }));
+    }
+
+    #[test]
+    fn synthesize_picks_first_nonempty_art() {
+        // With a zero-byte art ahead of a real one, the real art must still be
+        // served (the first nonempty art wins, not merely the first art).
+        let buf = mk_mp4(false, b"AUDIODATA", &[0]);
+        let scan = read_structure(&buf).unwrap();
+        let empty = ArtInput {
+            art_id: 1,
+            mime: "image/jpeg".into(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 0,
+        };
+        let real = ArtInput {
+            art_id: 9,
+            mime: "image/png".into(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 40,
+        };
+        let layout =
+            synthesize_layout(&scan, &[TagInput::new("title", "T")], &[empty, real]).unwrap();
+        let segs = layout.segments();
+        assert!(
+            segs.iter()
+                .any(|s| matches!(s, Segment::ArtImage { art_id: 9, len: 40 })),
+            "the first nonempty art must be served"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 3c of the test-audit remediation: harden the MP4 (`mp4.rs`) format layer.

## Mutation kills (C1–C5)
Additive in-module tests killing the 44 `mp4.rs` survivors from the phase-1 inventory — **40 missed → killed**, **4 timeout → timeout-detected** (the `BoxRef::end` ×3 and `read_structure_from`'s `pos += total` non-terminating walks). No equivalents. Covers `box_header`, `read_box`, `read_structure_from`, `read_freeform`, `read_tags`, `read_pictures`, `build_udta`, `patch_chunk_offsets`, `synthesize_layout`. Each kill was hand-apply-verified (mutate → named test fails → revert).

## Finding #16 — zero-byte art skip for MP4
`synthesize_layout` used `arts.first()`, so a leading zero-byte art emitted an `ArtImage { len: 0 }` segment that fails layout validation (`EmptySegment`), making the track unreadable. Now picks the first art with real bytes, mirroring the FLAC fix. Guarded by `synthesize_skips_zero_length_art` / `synthesize_picks_first_nonempty_art`.

## Finding #5 — M4A read-fidelity proptest
Added `write_m4a` to the core test harness and ported the four read-fidelity invariants (whole-audio identity, partial windows, header seam, art window) to the M4A synthesis path, mirroring the FLAC/MP3 blocks. `minimal_m4a` now points its `stco` chunk offset at the real `mdat` payload position (real M4A offsets are absolute) — with offset 0 a retag that shrank the `moov` patched the offset below zero and synthesis failed (`TooLarge`).

WAV (3d) is now the only remaining non-FLAC read-fidelity dimension.

## Invariant
No audio-read path changed; the byte-identical invariant is untouched. The only production change is the one-line art-selection fix in `synthesize_layout`.

## Verification
`cargo test --workspace`, `cargo test -p musefs-format --features fuzzing`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all green (enforced by the pre-commit hook on every commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio synthesis to skip empty cover art instead of generating empty art segments in MP4 files.

* **Tests**
  * Expanded test coverage for MP4 file format validation and synthesis boundary cases.
  * Added property-based tests for M4A audio read fidelity, including art image handling.

* **Documentation**
  * Updated test mutation inventory and completion tracking for MP4 hardening work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->