### PR TITLE
Phase 3d: WAV mutation hardening + zero-byte-art fix

### DIFF
--- a/docs/superpowers/plans/2026-05-29-phase3d-wav-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3d-wav-hardening.md
@@ -1,0 +1,1188 @@
+# Phase 3d — WAV Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the 24 killable `wav.rs` mutation survivors (document 4 equivalents), broaden `proptest_read_fidelity` to WAV, and close finding #16 for WAV with a scoped zero-byte-art skip — all without touching the byte-identity invariant.
+
+**Architecture:** All mutant kills go in `wav.rs`'s in-module `#[cfg(test)] mod tests` (it reaches private helpers via `use super::*`). The one production change (C2) filters `data_len == 0` arts in `wav::synthesize_layout` before delegating to `mp3::build_id3v2_segments`, mirroring FLAC's existing skip. The cross-format property work adds a `write_wav` fixture to `musefs-core/tests/common` and four WAV read-fidelity properties.
+
+**Tech Stack:** Rust, cargo, `proptest`, `id3` crate, `hound` (independent WAV reader in existing tests). Mutation verification is manual hand-apply (cargo-mutants is not available locally).
+
+**Source spec:** `docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md`
+
+---
+
+## Two verification methods used in this plan
+
+- **Hand-apply (for mutant kills, Tasks 2–11):** the production code is already
+  correct, so the new test PASSES first. Then apply the exact mutation, run the
+  single test, confirm it FAILS, revert, confirm it PASSES again. While a mutation
+  is applied, run **only the single targeted test**, never `--workspace`. Revert with
+  `git checkout -- musefs-format/src/wav.rs` immediately.
+- **Red-green TDD (for the C2 production change, Task 12):** the test FAILS first
+  (current code bricks the track), then the fix makes it pass.
+
+**Line numbers drift.** Each task names the **code pattern** to locate; confirm the
+current line before hand-applying.
+
+---
+
+## Task 1: Test-module scaffold — widen the import
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (the `#[cfg(test)] mod tests` at the end, currently ~line 323)
+
+> The shared test helpers (`fmt_pcm`, `wav`, `info_payload`, `inline_offset_of`) are
+> **not** added here — each is introduced in the first task that uses it, so no commit
+> ever lands an unused function (the pre-commit `clippy -D warnings` rejects
+> `dead_code`). Do **not** add `#[allow(dead_code)]`.
+
+- [ ] **Step 1: Widen the test-module import**
+
+In `musefs-format/src/wav.rs`, replace the test module's import line:
+
+```rust
+    use super::{read_pictures, read_tags};
+```
+
+with:
+
+```rust
+    use super::*;
+```
+
+A glob import does not warn when only partly used, so this is safe on its own. The
+existing `wav_oom_crash_artifact_is_safe` test still compiles unchanged.
+
+- [ ] **Step 2: Confirm the crate still builds and the existing test passes**
+
+Run: `cargo test -p musefs-format --lib wav::tests`
+Expected: PASS (only `wav_oom_crash_artifact_is_safe` runs so far).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): widen test-module import to super::*"
+```
+
+---
+
+## Task 2: Kill `riff_wave_start:24` (`<`→`<=` and `<`→`==`)
+
+**Pattern:** the `buf.len() < 12` guard in `riff_wave_start`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the two kill tests inside `mod tests`**
+
+```rust
+    #[test]
+    fn riff_wave_start_accepts_exactly_twelve_bytes() {
+        // :24 `< → <=`: a valid 12-byte RIFF/WAVE buffer must be accepted.
+        // The `<=` mutant computes `12 <= 12` (true) and wrongly rejects it.
+        let buf = b"RIFF\0\0\0\0WAVE".to_vec();
+        assert_eq!(buf.len(), 12);
+        assert_eq!(riff_wave_start(&buf), Ok(12));
+    }
+
+    #[test]
+    fn riff_wave_start_rejects_eleven_byte_riff_without_panic() {
+        // :24 `< → ==`: an 11-byte buffer that starts with "RIFF". The original
+        // short-circuits on `len < 12` → NotWav. The `==` mutant computes
+        // `11 == 12` (false), falls through, and indexes `buf[8..12]` on an 11-byte
+        // slice → panic. Asserting the clean Err kills it (panic ≠ Err).
+        let buf = b"RIFF\0\0\0\0WAV".to_vec();
+        assert_eq!(buf.len(), 11);
+        assert_eq!(riff_wave_start(&buf), Err(FormatError::NotWav));
+    }
+```
+
+- [ ] **Step 2: Run both tests — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::riff_wave_start`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Hand-apply `< → <=` and confirm the accept test fails**
+
+Edit `wav.rs`: change `if buf.len() < 12` to `if buf.len() <= 12`.
+Run: `cargo test -p musefs-format --lib wav::tests::riff_wave_start_accepts_exactly_twelve_bytes`
+Expected: FAIL (`Ok(12)` expected, got `Err(NotWav)`).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Hand-apply `< → ==` and confirm the reject test fails**
+
+Edit `wav.rs`: change `if buf.len() < 12` to `if buf.len() == 12`.
+Run: `cargo test -p musefs-format --lib wav::tests::riff_wave_start_rejects_eleven_byte_riff_without_panic`
+Expected: FAIL (panic: byte index 12 out of bounds / range end index 12).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 5: Confirm green after revert, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::riff_wave_start
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill riff_wave_start:24 length-guard mutants"
+```
+
+---
+
+## Task 3: Kill `walk_chunks:47` (`+`→`-` in the advance)
+
+**Pattern:** `let advance = 8u64 + size + (size & 1);` in `walk_chunks`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the `wav` helper (first use) and the kill test**
+
+Add this helper inside `mod tests` (used by this and later tasks):
+
+```rust
+    /// Build a minimal `RIFF/WAVE` buffer from `(fourcc, payload)` chunks in order,
+    /// padding odd payloads to a word boundary (the on-disk RIFF layout).
+    fn wav(chunks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (id, payload) in chunks {
+            body.extend_from_slice(*id);
+            body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            body.extend_from_slice(payload);
+            if payload.len() % 2 == 1 {
+                body.push(0x00);
+            }
+        }
+        let mut out = b"RIFF".to_vec();
+        out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+        out.extend_from_slice(b"WAVE");
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn walk_chunks_advances_past_each_payload() {
+        // :47 the `8 + size (+ size&1)` advance. An odd first payload forces the
+        // word-align term to matter; a wrong advance (either `+ → -`) lands off the
+        // next header, so the second chunk is lost or misread.
+        let buf = wav(&[(b"AAAA", vec![0x11; 3]), (b"data", vec![0xBB; 8])]);
+        let ids: Vec<[u8; 4]> = walk_chunks(&buf).iter().map(|(id, _, _)| *id).collect();
+        assert_eq!(ids, vec![*b"AAAA", *b"data"]);
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::walk_chunks_advances_past_each_payload`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply and confirm failure (test each `+` once)**
+
+The line has two `+`. Apply each mutation in turn:
+- Change `8u64 + size + (size & 1)` to `8u64 - size + (size & 1)`, run the test → expect FAIL (panic: subtract overflow, or wrong ids).
+- Revert, then change to `8u64 + size - (size & 1)`, run the test → expect FAIL (ids mismatch — lands 2 bytes early).
+
+Run after each: `cargo test -p musefs-format --lib wav::tests::walk_chunks_advances_past_each_payload`
+Revert after each: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::walk_chunks_advances_past_each_payload
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill walk_chunks:47 advance mutant"
+```
+
+---
+
+## Task 4: Kill `locate_audio:67` (`==`→`!=`) and `:71` (`>`→`<`)
+
+**Patterns:** `id == b"fmt "` (the `has_fmt` detector, :67) and
+`(off as u64).saturating_add(len) > buf.len() as u64` (oversize guard, :71).
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the `fmt_pcm` helper (first use) and both kill tests**
+
+Add this helper inside `mod tests` (used by this and later tasks):
+
+```rust
+    /// A 16-byte PCM `fmt ` payload: mono, 44.1 kHz, 16-bit.
+    fn fmt_pcm() -> Vec<u8> {
+        let mut f = Vec::new();
+        f.extend_from_slice(&1u16.to_le_bytes());
+        f.extend_from_slice(&1u16.to_le_bytes());
+        f.extend_from_slice(&44_100u32.to_le_bytes());
+        f.extend_from_slice(&88_200u32.to_le_bytes());
+        f.extend_from_slice(&2u16.to_le_bytes());
+        f.extend_from_slice(&16u16.to_le_bytes());
+        f
+    }
+
+    #[test]
+    fn locate_requires_fmt_chunk() {
+        // :67 `== → !=`: a data-only WAV (no `fmt `). Original: `any(id == "fmt ")`
+        // is false → NotWav. The `!=` mutant is true (the data chunk is != "fmt ")
+        // → has_fmt, so it returns Ok/Malformed instead of NotWav.
+        let buf = wav(&[(b"data", vec![0x11; 8])]);
+        assert_eq!(locate_audio(&buf), Err(FormatError::NotWav));
+    }
+
+    #[test]
+    fn locate_accepts_data_with_trailing_chunk() {
+        // :71 `> → <`: a valid WAV with a chunk AFTER `data`, so off+len < buf.len.
+        // Original `off+len > buf.len` is false → Ok. The `<` mutant is true →
+        // Malformed.
+        let buf = wav(&[
+            (b"fmt ", fmt_pcm()),
+            (b"data", vec![0x11; 8]),
+            (b"junk", vec![0x00; 4]),
+        ]);
+        let bounds = locate_audio(&buf).unwrap();
+        assert_eq!(bounds.audio_length, 8);
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::locate_`
+Expected: PASS (2 tests).
+
+- [ ] **Step 3: Hand-apply `:67` `== → !=` and confirm failure**
+
+Edit `wav.rs`: change `chunks.iter().any(|(id, _, _)| id == b"fmt ")` to use `!=`.
+Run: `cargo test -p musefs-format --lib wav::tests::locate_requires_fmt_chunk`
+Expected: FAIL (`Ok(..)` returned, `Err(NotWav)` expected).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Hand-apply `:71` `> → <` and confirm failure**
+
+Edit `wav.rs`: change `if (off as u64).saturating_add(len) > buf.len() as u64` to `<`.
+Run: `cargo test -p musefs-format --lib wav::tests::locate_accepts_data_with_trailing_chunk`
+Expected: FAIL (`unwrap` on `Err(Malformed)`).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 5: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::locate_
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill locate_audio:67/:71 mutants"
+```
+
+---
+
+## Task 5: Kill `info_fourcc:119-124` (6 arm deletions)
+
+**Pattern:** the key→FourCC `match` in `info_fourcc` (artist/album/date/genre/comment/tracknumber arms; title is already covered).
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the kill test (drives the private `build_info_payload`)**
+
+```rust
+    #[test]
+    fn info_fourcc_emits_each_mapped_key() {
+        // :119-124 arm deletions: each key must map to its INFO FourCC. A deleted
+        // arm makes the key unmapped → no payload (single-tag input → None).
+        let cases: [(&str, &[u8; 4]); 6] = [
+            ("artist", b"IART"),
+            ("album", b"IPRD"),
+            ("date", b"ICRD"),
+            ("genre", b"IGNR"),
+            ("comment", b"ICMT"),
+            ("tracknumber", b"ITRK"),
+        ];
+        for (key, cc) in cases {
+            let payload =
+                build_info_payload(&[TagInput::new(key, "X")]).expect("INFO payload for {key}");
+            assert!(
+                payload.windows(4).any(|w| w == &cc[..]),
+                "key {key} must emit FourCC {:?}",
+                std::str::from_utf8(cc).unwrap()
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::info_fourcc_emits_each_mapped_key`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply one arm deletion and confirm failure**
+
+Edit `wav.rs` `info_fourcc`: delete the `"album" => b"IPRD",` arm (it now falls to
+`_ => return None`).
+Run: `cargo test -p musefs-format --lib wav::tests::info_fourcc_emits_each_mapped_key`
+Expected: FAIL (`expect("INFO payload..")` panics — `None` for the album case).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+(The single deletion proves the mechanism; cargo-mutants applies each of the six
+independently — the loop covers them all.)
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::info_fourcc_emits_each_mapped_key
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill info_fourcc arm-deletion mutants"
+```
+
+---
+
+## Task 6: Kill `build_info_payload:155` (`%`→`/`, `%`→`+`, `==`→`!=`)
+
+**Pattern:** `if v.len() % 2 == 1 { payload.push(0x00); }` in `build_info_payload`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the kill test**
+
+```rust
+    #[test]
+    fn build_info_payload_word_aligns_values() {
+        // :155 `v.len() % 2 == 1`. v = value bytes + NUL.
+        // Value "a"  -> v.len()=2 (even, NO pad). Kills `% → /` (2/2==1 pads) and
+        //               `== → !=` (2%2=0 != 1 pads).
+        // Value "ab" -> v.len()=3 (odd, padded). Kills `% → +` (3+2 != 1, no pad).
+        let even = build_info_payload(&[TagInput::new("title", "a")]).unwrap();
+        // "INFO"(4) + "INAM"(4) + len(4) + "a\0"(2) = 14, no pad.
+        assert_eq!(even.len(), 14);
+
+        let odd = build_info_payload(&[TagInput::new("title", "ab")]).unwrap();
+        // "INFO"(4) + "INAM"(4) + len(4) + "ab\0"(3) + pad(1) = 16.
+        assert_eq!(odd.len(), 16);
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::build_info_payload_word_aligns_values`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply each mutation and confirm failure**
+
+For each, edit the `v.len() % 2 == 1` in `build_info_payload`, run the test, expect
+FAIL, then revert (`git checkout -- musefs-format/src/wav.rs`):
+- `% → /` (`v.len() / 2 == 1`): FAIL on `even` (len 15, expected 14).
+- `% → +` (`v.len() + 2 == 1`): FAIL on `odd` (len 15, expected 16).
+- `== → !=` (`v.len() % 2 != 1`): FAIL on `even` (len 15, expected 14).
+
+Run: `cargo test -p musefs-format --lib wav::tests::build_info_payload_word_aligns_values`
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::build_info_payload_word_aligns_values
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill build_info_payload:155 word-align mutants"
+```
+
+---
+
+## Task 7: Kill `push_inline_chunk:168` (`%`→`/`, `%`→`+`)
+
+**Pattern:** `if payload.len() % 2 == 1 { chunk.push(0x00); }` in `push_inline_chunk`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the kill test**
+
+```rust
+    #[test]
+    fn push_inline_chunk_word_aligns_payload() {
+        // :168 `payload.len() % 2 == 1`.
+        // Even payload (len 2): NO pad. Kills `% → /` (2/2==1 pads).
+        let mut segs = Vec::new();
+        push_inline_chunk(&mut segs, b"test", &[0xAA, 0xBB]);
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].len(), 10); // "test"(4) + len(4) + payload(2)
+
+        // Odd payload (len 3): padded. Kills `% → +` (3+2 != 1, no pad).
+        let mut segs2 = Vec::new();
+        push_inline_chunk(&mut segs2, b"test", &[0xAA, 0xBB, 0xCC]);
+        assert_eq!(segs2[0].len(), 12); // 4 + 4 + 3 + pad(1)
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::push_inline_chunk_word_aligns_payload`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply each mutation and confirm failure**
+
+Edit the `payload.len() % 2 == 1` in `push_inline_chunk`, run, expect FAIL, revert:
+- `% → /`: FAIL on the even case (`segs[0].len()` == 11, expected 10).
+- `% → +`: FAIL on the odd case (`segs2[0].len()` == 11, expected 12).
+
+Run: `cargo test -p musefs-format --lib wav::tests::push_inline_chunk_word_aligns_payload`
+Revert each: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::push_inline_chunk_word_aligns_payload
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill push_inline_chunk:168 word-align mutants"
+```
+
+---
+
+## Task 8: Kill `info_to_key:245-249` (4 arm deletions, via `read_tags`)
+
+**Pattern:** the FourCC→key `match` in `info_to_key` (IPRD/ICRD/ICMT/ITRK arms; INAM/IART/IGNR already covered).
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the `info_payload` helper (first use) and the kill test**
+
+Add this helper inside `mod tests`:
+
+```rust
+    /// An `INFO` payload: `"INFO"` FourCC + NUL-terminated, word-aligned subchunks.
+    fn info_payload(pairs: &[(&[u8; 4], &str)]) -> Vec<u8> {
+        let mut p = b"INFO".to_vec();
+        for (cc, val) in pairs {
+            let mut v = val.as_bytes().to_vec();
+            v.push(0x00);
+            p.extend_from_slice(*cc);
+            p.extend_from_slice(&(v.len() as u32).to_le_bytes());
+            p.extend_from_slice(&v);
+            if v.len() % 2 == 1 {
+                p.push(0x00);
+            }
+        }
+        p
+    }
+
+    #[test]
+    fn info_to_key_decodes_each_mapped_fourcc() {
+        // :245-249 arm deletions: each INFO FourCC must decode to its tag key.
+        let cases: [(&[u8; 4], &str, &str); 4] = [
+            (b"IPRD", "album", "Anthology"),
+            (b"ICRD", "date", "1999"),
+            (b"ICMT", "comment", "Nice"),
+            (b"ITRK", "tracknumber", "3"),
+        ];
+        for (cc, key, val) in cases {
+            let buf = wav(&[
+                (b"fmt ", fmt_pcm()),
+                (b"LIST", info_payload(&[(cc, val)])),
+                (b"data", vec![0x00; 4]),
+            ]);
+            let tags = read_tags(&buf);
+            assert!(
+                tags.contains(&(key.to_string(), val.to_string())),
+                "FourCC {:?} must decode to {key}",
+                std::str::from_utf8(cc).unwrap()
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::info_to_key_decodes_each_mapped_fourcc`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply one arm deletion and confirm failure**
+
+Edit `info_to_key`: delete the `b"IPRD" => "album",` arm.
+Run: `cargo test -p musefs-format --lib wav::tests::info_to_key_decodes_each_mapped_fourcc`
+Expected: FAIL (album case: tag missing).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::info_to_key_decodes_each_mapped_fourcc
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill info_to_key arm-deletion mutants"
+```
+
+---
+
+## Task 9: Kill `read_tags:300` (`&&`→`||`)
+
+**Pattern:** `.filter(|slice| slice.len() >= 4 && &slice[0..4] == b"INFO")` in `read_tags`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the kill test**
+
+```rust
+    #[test]
+    fn read_tags_rejects_short_list_without_panic() {
+        // :300 `&& → ||`: a LIST chunk with a <4-byte payload. Original
+        // short-circuits (`len >= 4` false → no INFO, empty). The `||` mutant
+        // evaluates `&slice[0..4]` on the 2-byte slice → panic. Asserting the clean
+        // empty result kills it (panic ≠ empty).
+        let buf = wav(&[
+            (b"fmt ", fmt_pcm()),
+            (b"LIST", vec![0x49, 0x4E]), // "IN" — 2 bytes, < 4
+            (b"data", vec![0x00; 4]),
+        ]);
+        assert!(read_tags(&buf).is_empty());
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::read_tags_rejects_short_list_without_panic`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply `&& → ||` and confirm failure**
+
+Edit `read_tags`: change `slice.len() >= 4 && &slice[0..4] == b"INFO"` to use `||`.
+Run: `cargo test -p musefs-format --lib wav::tests::read_tags_rejects_short_list_without_panic`
+Expected: FAIL (panic: range end index 4 out of range for slice of length 2).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::read_tags_rejects_short_list_without_panic
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill read_tags:300 INFO-validation mutant"
+```
+
+---
+
+## Task 10: Kill `synthesize_layout:207` (`%`→`/`, `%`→`+`; the `id3 ` pad)
+
+**Pattern:** `if tag_len % 2 == 1 { segments.push(Segment::Inline(vec![0x00])); }` in `synthesize_layout`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the `inline_offset_of` helper (first use) and the kill test**
+
+Add this helper inside `mod tests`:
+
+```rust
+    /// Byte offset, in the assembled stream, of the first `Inline` segment whose
+    /// first four bytes are `fourcc`. Used to assert RIFF word-alignment.
+    fn inline_offset_of(layout: &RegionLayout, fourcc: &[u8; 4]) -> u64 {
+        let mut off = 0u64;
+        for s in &layout.segments {
+            if let Segment::Inline(b) = s {
+                if b.len() >= 4 && &b[0..4] == fourcc {
+                    return off;
+                }
+            }
+            off += s.len();
+        }
+        panic!("no inline chunk starting with {fourcc:?}");
+    }
+
+    #[test]
+    fn synthesize_word_aligns_embedded_id3_chunk() {
+        // :207 `tag_len % 2 == 1` — the pad after the `id3 ` chunk. When tag_len is
+        // odd, the original pads so the following `data` chunk starts on an even
+        // byte (RIFF word-alignment). Both mutants (`/`, `+`) drop that pad for odd
+        // tag_len, landing `data` on an odd offset.
+        //
+        // Find tags whose ID3v2 tag_len is odd (parity depends on id3 framing, so
+        // discover it rather than hard-code). "albumartist" maps to id3 only (no
+        // INFO/LIST chunk), keeping the layout simple.
+        let mut tags = Vec::new();
+        let mut tag_len = 0u64;
+        for n in 1..64 {
+            let cand = vec![TagInput::new("albumartist", &"x".repeat(n))];
+            let (_, tl) = crate::mp3::build_id3v2_segments(&cand, &[]).unwrap();
+            if tl % 2 == 1 {
+                tags = cand;
+                tag_len = tl;
+                break;
+            }
+        }
+        assert_eq!(tag_len % 2, 1, "expected to find an odd-length id3 tag");
+
+        let scan = WavScan {
+            fmt: fmt_pcm(),
+            fact: None,
+        };
+        let layout = synthesize_layout(&scan, 0, 8, &tags, &[]).unwrap();
+        assert_eq!(
+            inline_offset_of(&layout, b"data") % 2,
+            0,
+            "the data chunk must be word-aligned"
+        );
+    }
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::synthesize_word_aligns_embedded_id3_chunk`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply each mutation and confirm failure**
+
+Edit the `tag_len % 2 == 1` in `synthesize_layout`, run, expect FAIL, revert:
+- `% → /` (`tag_len / 2 == 1`): for an odd tag_len ≥ 4, `tag_len/2 ≥ 2 != 1` → no
+  pad → `data` at an odd offset → FAIL.
+- `% → +` (`tag_len + 2 == 1`): always false → no pad → FAIL.
+
+Run: `cargo test -p musefs-format --lib wav::tests::synthesize_word_aligns_embedded_id3_chunk`
+Revert each: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests::synthesize_word_aligns_embedded_id3_chunk
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill synthesize_layout:207 id3-pad mutants"
+```
+
+---
+
+## Task 11: Kill `synthesize_layout:227` (`>`→`==`) and document the 4 equivalents
+
+**Pattern:** `if riff_size > u32::MAX as u64 { return Err(FormatError::TooLarge); }` in `synthesize_layout`.
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (test module)
+
+- [ ] **Step 1: Add the kill test plus the equivalent-mutant documentation**
+
+```rust
+    #[test]
+    fn synthesize_rejects_riff_size_overflow() {
+        // :227 `> → ==`. `BackingAudio` is virtual (no real allocation), so we can
+        // pass `audio_length == u32::MAX`: it PASSES the :186 guard (`> u32::MAX` is
+        // false) but makes `riff_size > u32::MAX`. Original `>` → TooLarge; the `==`
+        // mutant (`riff_size == u32::MAX`) is false (riff_size is strictly greater),
+        // so it wrongly proceeds and returns Ok with a truncated size.
+        //
+        // NOTE — this must use exactly u32::MAX, not the existing
+        // `rejects_audio_over_32bit` test's `u32::MAX + 1`: that larger value is
+        // caught by the :186 guard first and never reaches :227.
+        let scan = WavScan {
+            fmt: fmt_pcm(),
+            fact: None,
+        };
+        let res = synthesize_layout(&scan, 0, u32::MAX as u64, &[], &[]);
+        assert_eq!(res, Err(FormatError::TooLarge));
+    }
+
+    // Documented EQUIVALENT mutants in this file (no test targets them; each was
+    // confirmed by hand-apply — the relevant test stays green under the mutation):
+    //  * walk_chunks:49  guard `next <= buf.len()` → `true`. When `next > buf.len()`
+    //    the mutant sets `pos = next`, but the `while pos + 8 <= buf.len()` test is
+    //    then immediately false, so the output Vec is identical to the original's
+    //    `break` (the header was pushed before the advance).
+    //  * synthesize_layout:186  `audio_length > u32::MAX` (both `==` and `>=`).
+    //    `body_len >= audio_length`, so whenever this would fire, `riff_size`
+    //    overflows and the :227 guard returns the identical TooLarge.
+    //  * synthesize_layout:227  `> → >=` only. Every synthesized chunk is
+    //    word-aligned, so `riff_size` is always even; `riff_size == u32::MAX` (odd)
+    //    is unreachable, the only point where `>` and `>=` differ.
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `cargo test -p musefs-format --lib wav::tests::synthesize_rejects_riff_size_overflow`
+Expected: PASS.
+
+- [ ] **Step 3: Hand-apply `> → ==` and confirm failure**
+
+Edit `synthesize_layout`: change `if riff_size > u32::MAX as u64` to `==`.
+Run: `cargo test -p musefs-format --lib wav::tests::synthesize_rejects_riff_size_overflow`
+Expected: FAIL (`Ok(..)` returned, `Err(TooLarge)` expected).
+Revert: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 4: Confirm each documented equivalent stays green under its mutation**
+
+For each, apply the mutation, run the full wav unit suite, confirm **PASS** (proving
+no existing test distinguishes it → equivalent), then revert:
+- `walk_chunks:49`: change the match-guard `Some(next) if next <= buf.len() as u64` to `Some(next) if true` → run `cargo test -p musefs-format --lib wav::tests` → PASS.
+- `synthesize_layout:186` `> → >=`: change `if audio_length > u32::MAX as u64` to `>=` → PASS.
+- `synthesize_layout:186` `> → ==`: change it to `==` → PASS.
+- `synthesize_layout:227` `> → >=`: change `if riff_size > u32::MAX as u64` to `>=` → PASS.
+
+Revert after each: `git checkout -- musefs-format/src/wav.rs`
+
+- [ ] **Step 5: Confirm green, then commit**
+
+```bash
+cargo test -p musefs-format --lib wav::tests
+git add musefs-format/src/wav.rs
+git commit -m "test(wav): kill synthesize_layout:227 == mutant; document 4 equivalents"
+```
+
+---
+
+## Task 12: C2 — zero-byte embedded art (red-green TDD)
+
+**Files:**
+- Test: `musefs-format/tests/wav_synthesize.rs` (add two tests)
+- Modify: `musefs-format/src/wav.rs` (`synthesize_layout`, the `build_id3v2_segments` call)
+
+- [ ] **Step 1: Add the two failing tests to `wav_synthesize.rs`**
+
+Append inside `wav_synthesize.rs` (it already imports
+`musefs_format::{ArtInput, RegionLayout, Segment, TagInput}` and `WavScan`, and has
+`fmt_pcm_16bit_mono` + `assemble`):
+
+```rust
+#[test]
+fn skips_zero_byte_art() {
+    // A degenerate empty embedded picture must not brick the track: synthesis
+    // succeeds, emits no ArtImage segment, and preserves the audio.
+    let audio = vec![0u8; 8];
+    let scan = WavScan {
+        fmt: fmt_pcm_16bit_mono(),
+        fact: None,
+    };
+    let tags = vec![TagInput::new("title", "Empty Art")];
+    let arts = vec![ArtInput {
+        art_id: 1,
+        mime: "image/jpeg".to_string(),
+        description: String::new(),
+        picture_type: 3,
+        width: 0,
+        height: 0,
+        data_len: 0,
+    }];
+
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    assert!(
+        !layout
+            .segments
+            .iter()
+            .any(|s| matches!(s, Segment::ArtImage { .. })),
+        "zero-byte art must not produce an ArtImage segment"
+    );
+
+    let bytes = assemble(&layout, &audio, &[]);
+    let bounds = musefs_format::wav::locate_audio(&bytes).unwrap();
+    assert_eq!(
+        &bytes[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+        &audio[..]
+    );
+}
+
+#[test]
+fn keeps_real_art_when_mixed_with_empty() {
+    let audio = vec![0u8; 8];
+    let art_bytes = vec![0xCDu8; 64];
+    let scan = WavScan {
+        fmt: fmt_pcm_16bit_mono(),
+        fact: None,
+    };
+    let tags = vec![TagInput::new("title", "Mixed")];
+    let arts = vec![
+        ArtInput {
+            art_id: 1,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 0,
+        },
+        ArtInput {
+            art_id: 2,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: art_bytes.len() as u64,
+        },
+    ];
+
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    let art_segs: Vec<&Segment> = layout
+        .segments
+        .iter()
+        .filter(|s| matches!(s, Segment::ArtImage { .. }))
+        .collect();
+    assert_eq!(art_segs.len(), 1, "only the real art survives");
+    assert!(matches!(
+        art_segs[0],
+        Segment::ArtImage { art_id: 2, len: 64 }
+    ));
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL (red)**
+
+Run: `cargo test -p musefs-format --test wav_synthesize skips_zero_byte_art keeps_real_art_when_mixed_with_empty`
+Expected: FAIL. `skips_zero_byte_art` fails with `Err(InvalidLayout)` on `.unwrap()`
+(the zero-byte art becomes `ArtImage { len: 0 }`, which `RegionLayout::validate`
+rejects as `EmptySegment`). If instead it PASSES, stop — the assumption is wrong and
+no production change is needed; re-verify against the current `synthesize_layout`.
+
+- [ ] **Step 3: Apply the WAV-local filter in `synthesize_layout`**
+
+In `musefs-format/src/wav.rs`, locate the `build_id3v2_segments` call:
+
+```rust
+    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, arts)?;
+```
+
+Replace it with a filtered pass (mirrors `flac.rs`'s `data_len > 0` skip):
+
+```rust
+    // Skip degenerate zero-byte art: an empty picture would become an
+    // `ArtImage { len: 0 }`, which `RegionLayout::validate` rejects, bricking the
+    // whole track. Filtering keeps byte-identity untouched (only whether an empty
+    // APIC is emitted changes). Mirrors `flac.rs::synthesize_layout`.
+    let nonempty_arts: Vec<ArtInput> = arts.iter().filter(|a| a.data_len > 0).cloned().collect();
+    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, &nonempty_arts)?;
+```
+
+(`ArtInput` is already imported at the top of `wav.rs` via
+`use crate::input::{ArtInput, TagInput};` and derives `Clone`.)
+
+- [ ] **Step 4: Run — expect PASS (green)**
+
+Run: `cargo test -p musefs-format --test wav_synthesize`
+Expected: PASS (all wav_synthesize tests, including the two new ones and the
+existing `embeds_full_fidelity_id3_tag_with_art`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/wav.rs musefs-format/tests/wav_synthesize.rs
+git commit -m "fix(wav): skip zero-byte embedded art in synthesize_layout (#16)"
+```
+
+---
+
+## Task 13: C3 fixture — `write_wav` in core test common
+
+**Files:**
+- Modify: `musefs-core/tests/common/mod.rs` (add `write_wav`)
+
+- [ ] **Step 1: Add `write_wav` after `write_flac`**
+
+```rust
+/// Write a minimal valid PCM WAV (`fmt ` + `data`) to `path`, returning
+/// (audio_offset, audio_length) of the `data` payload. Tags are applied via the DB
+/// by the caller (mirrors how `write_flac` is paired with `replace_tags`).
+pub fn write_wav(path: &Path, audio: &[u8]) -> (i64, i64) {
+    let mut fmt = Vec::new();
+    fmt.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    fmt.extend_from_slice(&1u16.to_le_bytes()); // mono
+    fmt.extend_from_slice(&44_100u32.to_le_bytes()); // sample rate
+    fmt.extend_from_slice(&88_200u32.to_le_bytes()); // byte rate
+    fmt.extend_from_slice(&2u16.to_le_bytes()); // block align
+    fmt.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+
+    let mut body = Vec::new();
+    for (id, payload) in [(&b"fmt "[..], &fmt[..]), (&b"data"[..], audio)] {
+        body.extend_from_slice(id);
+        body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        body.extend_from_slice(payload);
+    }
+    let mut bytes = b"RIFF".to_vec();
+    bytes.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+    bytes.extend_from_slice(b"WAVE");
+    bytes.extend_from_slice(&body);
+
+    let audio_offset = (bytes.len() - audio.len()) as i64;
+    std::fs::write(path, &bytes).unwrap();
+    (audio_offset, audio.len() as i64)
+}
+```
+
+- [ ] **Step 2: Confirm the crate's tests still compile**
+
+Run: `cargo test -p musefs-core --test proptest_read_fidelity --no-run`
+Expected: compiles (the helper is `pub` in a `#![allow(dead_code)]` module, so being
+unused yet is fine).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/tests/common/mod.rs
+git commit -m "test(core): add write_wav fixture helper"
+```
+
+---
+
+## Task 14: C3 — four WAV read-fidelity properties
+
+**Files:**
+- Modify: `musefs-core/tests/proptest_read_fidelity.rs`
+
+- [ ] **Step 1: Import `write_wav` and add the two WAV builders**
+
+Change the import near the top:
+
+```rust
+use common::write_flac;
+```
+
+to:
+
+```rust
+use common::{write_flac, write_wav};
+```
+
+Then add, after the existing `build_with_art` function (before the `proptest!`
+block):
+
+```rust
+/// Like `build`, but writes a WAV backing file and registers it as `Format::Wav`.
+fn build_wav(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.wav");
+    let (audio_offset, audio_length) = write_wav(&path, audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::Wav,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    (dir, db, id, audio.to_vec())
+}
+
+/// Like `build_with_art`, but for a WAV backing file. WAV embeds art via the shared
+/// id3 path, so the resolved layout contains an `ArtImage` segment.
+fn build_wav_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, Db, i64) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.wav");
+    let (audio_offset, audio_length) = write_wav(&path, audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::Wav,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    let art_id = db
+        .upsert_art(&NewArt {
+            mime: "image/png".to_string(),
+            width: Some(8),
+            height: Some(8),
+            data: art.to_vec(),
+        })
+        .unwrap();
+    db.set_track_art(
+        id,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: "front".to_string(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+    (dir, db, id)
+}
+```
+
+- [ ] **Step 2: Add the four WAV properties inside the `proptest!` block**
+
+Add these after `read_at_art_window_serves_blob`, still inside the `proptest! { .. }`
+block (before its closing brace):
+
+```rust
+    #[test]
+    fn wav_read_at_preserves_backing_audio(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+    ) {
+        let (_dir, db, id, original) = build_wav(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+        prop_assert_eq!(whole.len() as u64, resolved.total_len);
+        // The served `data` payload is byte-identical to the original audio. It is
+        // not the trailing bytes (a word-align pad may follow), so locate it.
+        let bounds = musefs_format::wav::locate_audio(&whole).unwrap();
+        prop_assert_eq!(
+            &whole[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+            &original[..]
+        );
+    }
+
+    #[test]
+    fn wav_read_at_partial_windows_match_whole(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build_wav(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(got.len() as u64, len);
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+
+    #[test]
+    fn wav_read_at_windows_spanning_header_seam(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        before in 0usize..4096,
+        after in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build_wav(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let hlen = resolved.layout.header_len();
+        prop_assume!(hlen > 0 && hlen < total);
+        let start = hlen - 1 - (before as u64 % hlen);
+        let end = hlen + 1 + (after as u64 % (total - hlen));
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let got = read_at(&resolved, &db, start, end - start).unwrap();
+        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+    }
+
+    #[test]
+    fn wav_read_at_art_window_serves_blob(
+        audio in proptest::collection::vec(any::<u8>(), 1..256),
+        art in proptest::collection::vec(any::<u8>(), 1..256),
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id) = build_wav_with_art(&audio, "T", &art);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+
+        // Locate the ArtImage segment's byte offset by summing the serving lengths
+        // of the segments before it.
+        let mut art_off = 0u64;
+        let mut art_len = None;
+        for s in &resolved.layout.segments {
+            match s {
+                Segment::ArtImage { len, .. } => {
+                    art_len = Some(*len);
+                    break;
+                }
+                Segment::Inline(bytes) => art_off += bytes.len() as u64,
+                Segment::BackingAudio { len, .. } => art_off += *len,
+                other => panic!("unexpected WAV segment: {other:?}"),
+            }
+        }
+        let art_len = art_len.expect("layout has an ArtImage segment");
+        prop_assert_eq!(art_len, art.len() as u64);
+        prop_assert_eq!(
+            &whole[art_off as usize..(art_off + art_len) as usize],
+            &art[..]
+        );
+        let local_off = (a as u64) % (art_len + 1);
+        let offset = art_off + local_off;
+        let len = (b as u64) % (art_len - local_off + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+```
+
+- [ ] **Step 3: Run the property suite — expect PASS**
+
+Run: `cargo test -p musefs-core --test proptest_read_fidelity`
+Expected: PASS (all 8 properties — 4 FLAC + 4 WAV). If `wav_read_at_art_window_serves_blob`
+ever fails the `expect("layout has an ArtImage segment")`, that means WAV art is not
+producing an `ArtImage` segment — investigate `synthesize_layout` / Task 12 before
+proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/tests/proptest_read_fidelity.rs
+git commit -m "test(core): broaden read-fidelity proptests to WAV (#5)"
+```
+
+---
+
+## Task 15: C4 — inventory annotations, tracking doc, final verification
+
+**Files:**
+- Modify: `docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md`
+- Modify: `docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md`
+
+- [ ] **Step 1: Annotate the `wav.rs` rows in the inventory**
+
+In `2026-05-29-mutation-inventory.md`, append a status to each `wav.rs` survivor row
+in the `musefs-format` survivor table, matching the 3a `flac.rs` convention
+(`missed → **killed (phase 3d)**` or `missed → **equivalent**`). Specifically:
+
+- `wav.rs:24` (×2), `:47`, `:67`, `:71`, `:155` (×3), `:168` (×2), `:207` (×2),
+  `:245`, `:246`, `:248`, `:249`, `:300`, and the six `:119`–`:124` arm rows, plus
+  `:227` `> → ==` → `**killed (phase 3d)**`.
+- `wav.rs:186` (×2) and `wav.rs:227` `> → >=` → `**equivalent**`.
+
+(`wav.rs:49` is not a row in the inventory's survivor table — it appears only as a
+caught/structural note; if a `walk_chunks:49` row exists, mark it `**equivalent**`.)
+
+- [ ] **Step 2: Update the tracking doc**
+
+In `2026-05-29-remediation-tracking.md`, update the Phase 3 section: mark **3d done**,
+recording that the 24 killable `wav.rs` survivors are killed, the four equivalents
+(`walk_chunks:49`, `synthesize_layout:186` ×2, `synthesize_layout:227` `>=`) are
+documented, and the WAV dimensions of findings #5 (read-fidelity proptests) and #16
+(zero-byte-art skip) are addressed. If 3d completes all non-Ogg formats, note Phase 3
+status accordingly (3b MP3 / 3c MP4 status is unchanged by this work).
+
+- [ ] **Step 3: Full workspace verification**
+
+Run each and confirm all green:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --workspace
+cargo test -p musefs-format --features fuzzing
+```
+
+Expected: all PASS. Pay attention to the new `wav::tests::*`, the `wav_synthesize`
+tests, and the eight `proptest_read_fidelity` properties.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+git commit -m "docs(phase3d): annotate killed/equivalent wav mutants; mark phase 3d done"
+```
+
+---
+
+## Notes for the implementer
+
+- **Never leave a mutation applied.** Every hand-apply step is paired with a
+  `git checkout -- musefs-format/src/wav.rs`. If a later test behaves strangely, first
+  confirm no mutation is still in the working tree (`git diff`).
+- **Run targeted tests during hand-apply**, the full suite only at task boundaries.
+- The in-`wav.rs` test names use the path `wav::tests::<name>`; filter with
+  `cargo test -p musefs-format --lib wav::tests::<name>`.
+- If `cargo fmt` reshapes any added block, accept its formatting — do not fight it.
+```

--- a/docs/superpowers/plans/2026-05-29-phase3d-wav-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3d-wav-hardening.md
@@ -746,6 +746,12 @@ git commit -m "test(wav): kill synthesize_layout:227 == mutant; document 4 equiv
 
 ## Task 12: C2 — zero-byte embedded art (red-green TDD)
 
+> **Superseded (post-rebase):** the WAV-local filter this task adds was later
+> **removed**. Phase 3b put the `data_len == 0` skip inside the shared
+> `mp3::build_id3v2_segments` (which WAV delegates to), making the local filter
+> redundant. Keep the two `wav_synthesize.rs` regression tests below; skip the
+> production filter — WAV inherits the shared skip. See the tracking doc's 3d entry.
+
 **Files:**
 - Test: `musefs-format/tests/wav_synthesize.rs` (add two tests)
 - Modify: `musefs-format/src/wav.rs` (`synthesize_layout`, the `build_id3v2_segments` call)

--- a/docs/superpowers/plans/2026-05-29-phase3d-wav-hardening.md
+++ b/docs/superpowers/plans/2026-05-29-phase3d-wav-hardening.md
@@ -16,14 +16,34 @@
 
 - **Hand-apply (for mutant kills, Tasks 2–11):** the production code is already
   correct, so the new test PASSES first. Then apply the exact mutation, run the
-  single test, confirm it FAILS, revert, confirm it PASSES again. While a mutation
-  is applied, run **only the single targeted test**, never `--workspace`. Revert with
-  `git checkout -- musefs-format/src/wav.rs` immediately.
+  single test, confirm it FAILS, revert, confirm it PASSES again.
 - **Red-green TDD (for the C2 production change, Task 12):** the test FAILS first
   (current code bricks the track), then the fix makes it pass.
 
-**Line numbers drift.** Each task names the **code pattern** to locate; confirm the
-current line before hand-applying.
+### Canonical step order for every kill task (Tasks 2–11) — READ THIS
+
+The new test and the production code under mutation **live in the same file**
+(`musefs-format/src/wav.rs`). `git checkout -- musefs-format/src/wav.rs` reverts the
+*entire file* — both the mutation **and** any uncommitted test. So the test **must be
+committed before any hand-apply.** Each kill task therefore runs in this order,
+regardless of how the steps happen to be numbered:
+
+1. Add the test (and any first-use helper) to `mod tests`.
+2. Run the single test → confirm **PASS** (production is correct).
+3. **Commit the test now** — before touching any production line.
+4. Hand-apply one mutation to the *committed* code, run **only that single test**
+   (never `--workspace` while a mutation is live), confirm **FAIL**.
+5. `git checkout -- musefs-format/src/wav.rs` → this reverts only the mutation
+   (the test is committed and survives). Repeat step 4 for each remaining mutation.
+6. Re-run the test → confirm **PASS** again. No second commit is needed.
+
+Within each task below, the **Commit** step is listed after the hand-apply steps for
+readability, but you perform it at point 3 above — immediately after the test passes.
+
+**Line numbers are hints, not exact locations.** They are pinned to the phase-1
+inventory and drift as the file changes (this plan's own edits move them). Locate
+each target by the **code pattern** named in the task; the `:NN` reference is only a
+starting hint. Confirm the current line before hand-applying.
 
 ---
 
@@ -700,8 +720,13 @@ Revert: `git checkout -- musefs-format/src/wav.rs`
 
 - [ ] **Step 4: Confirm each documented equivalent stays green under its mutation**
 
-For each, apply the mutation, run the full wav unit suite, confirm **PASS** (proving
-no existing test distinguishes it → equivalent), then revert:
+The spec already argues each of these is equivalent; this step is **cheap insurance,
+not a hard gate** — it catches a wrong equivalence claim before the next mutants
+campaign flags it as a survivor. Each cycle is ~one `cargo test` run, so do them
+unless time-constrained; if you skip any, note it in the commit message so the next
+campaign's result is interpreted correctly. For each, apply the mutation, run the
+full wav unit suite, confirm **PASS** (proving no test distinguishes it → its
+behaviour is identical), then revert:
 - `walk_chunks:49`: change the match-guard `Some(next) if next <= buf.len() as u64` to `Some(next) if true` → run `cargo test -p musefs-format --lib wav::tests` → PASS.
 - `synthesize_layout:186` `> → >=`: change `if audio_length > u32::MAX as u64` to `>=` → PASS.
 - `synthesize_layout:186` `> → ==`: change it to `==` → PASS.
@@ -813,13 +838,23 @@ fn keeps_real_art_when_mixed_with_empty() {
 }
 ```
 
-- [ ] **Step 2: Run — expect FAIL (red)**
+- [ ] **Step 2: Run — expect FAIL (red). This run is the assumption gate.**
 
 Run: `cargo test -p musefs-format --test wav_synthesize skips_zero_byte_art keeps_real_art_when_mixed_with_empty`
-Expected: FAIL. `skips_zero_byte_art` fails with `Err(InvalidLayout)` on `.unwrap()`
+Expected: FAIL — `skips_zero_byte_art` fails with `Err(InvalidLayout)` on `.unwrap()`
 (the zero-byte art becomes `ArtImage { len: 0 }`, which `RegionLayout::validate`
-rejects as `EmptySegment`). If instead it PASSES, stop — the assumption is wrong and
-no production change is needed; re-verify against the current `synthesize_layout`.
+rejects as `EmptySegment`).
+
+**This red run is the gate for the whole task: it proves the bricking the fix is
+meant to remove.** Decide based on the result, do not assume:
+- **FAIL as expected** → the gap is real; proceed to Step 3 (apply the fix).
+- **`skips_zero_byte_art` PASSES** → the assumption is wrong (current code already
+  tolerates empty art). Do **not** make a production change. Keep the two tests as
+  regression guards, skip Step 3, and commit them in Step 5 with a message noting the
+  fix was unnecessary; then flag this to the reviewer.
+
+(The source was read during planning and confirmed to push `ArtImage { len: 0 }`
+unconditionally, so FAIL is expected — but verify, don't trust.)
 
 - [ ] **Step 3: Apply the WAV-local filter in `synthesize_layout`**
 
@@ -898,8 +933,9 @@ pub fn write_wav(path: &Path, audio: &[u8]) -> (i64, i64) {
 - [ ] **Step 2: Confirm the crate's tests still compile**
 
 Run: `cargo test -p musefs-core --test proptest_read_fidelity --no-run`
-Expected: compiles (the helper is `pub` in a `#![allow(dead_code)]` module, so being
-unused yet is fine).
+Expected: compiles. The helper being unused for now is fine because
+`musefs-core/tests/common/mod.rs` starts with `#![allow(dead_code)]` (confirmed at
+line 1), so no `dead_code` warning fires even under `clippy -D warnings`.
 
 - [ ] **Step 3: Commit**
 
@@ -1110,10 +1146,13 @@ block (before its closing brace):
 - [ ] **Step 3: Run the property suite — expect PASS**
 
 Run: `cargo test -p musefs-core --test proptest_read_fidelity`
-Expected: PASS (all 8 properties — 4 FLAC + 4 WAV). If `wav_read_at_art_window_serves_blob`
-ever fails the `expect("layout has an ArtImage segment")`, that means WAV art is not
-producing an `ArtImage` segment — investigate `synthesize_layout` / Task 12 before
-proceeding.
+Expected: PASS (all 8 properties — 4 FLAC + 4 WAV).
+
+The `expect("layout has an ArtImage segment")` is **not** a leap of faith: Task 12's
+`keeps_real_art_when_mixed_with_empty` already asserts that real WAV art produces a
+`Segment::ArtImage`, so by the time this task runs the behaviour is established. If
+it nonetheless fails here, that is a genuine regression in `synthesize_layout` —
+stop and investigate rather than weakening the assertion.
 
 - [ ] **Step 4: Commit**
 
@@ -1133,8 +1172,22 @@ git commit -m "test(core): broaden read-fidelity proptests to WAV (#5)"
 - [ ] **Step 1: Annotate the `wav.rs` rows in the inventory**
 
 In `2026-05-29-mutation-inventory.md`, append a status to each `wav.rs` survivor row
-in the `musefs-format` survivor table, matching the 3a `flac.rs` convention
-(`missed → **killed (phase 3d)**` or `missed → **equivalent**`). Specifically:
+in the `musefs-format` survivor table, matching the 3a `flac.rs` convention **exactly**
+— edit the `Kind` column in place from `missed` to `missed → **killed (phase 3d)**`
+or `missed → **equivalent**`, leaving the trailing `| 3 |` phase column untouched.
+For example, the row:
+
+```
+| `wav.rs:24` | replace < with == in riff_wave_start | missed | 3 |
+```
+
+becomes:
+
+```
+| `wav.rs:24` | replace < with == in riff_wave_start | missed → **killed (phase 3d)** | 3 |
+```
+
+Specifically:
 
 - `wav.rs:24` (×2), `:47`, `:67`, `:71`, `:155` (×3), `:168` (×2), `:207` (×2),
   `:245`, `:246`, `:248`, `:249`, `:300`, and the six `:119`–`:124` arm rows, plus

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-mutation-inventory.md
@@ -367,32 +367,32 @@ the rightmost column of each survivor table.
 | `ogg/page.rs:298` | replace - with + in lace_chunks_to_segments | missed → **killed** (phase 2) | 2 |
 | `ogg/page.rs:310` | replace < with <= in copy_payload | missed → **equivalent** | 2 |
 | `ogg/page.rs:337` | replace < with <= in emit_segments | missed → **equivalent** (no fixture aligns an art chunk to a page boundary, so `os == oe` never reaches the Art arm; hand-apply stays green) | 2 |
-| `wav.rs:24` | replace < with == in riff_wave_start | missed | 3 |
-| `wav.rs:24` | replace < with <= in riff_wave_start | missed | 3 |
-| `wav.rs:47` | replace + with - in walk_chunks | missed | 3 |
-| `wav.rs:49` | replace match guard next <= buf.len() as u64 with true in walk_chunks | missed | 3 |
-| `wav.rs:67` | replace == with != in locate_audio | missed | 3 |
-| `wav.rs:71` | replace > with < in locate_audio | missed | 3 |
-| `wav.rs:119` | delete match arm "artist" in info_fourcc | missed | 3 |
-| `wav.rs:120` | delete match arm "album" in info_fourcc | missed | 3 |
-| `wav.rs:121` | delete match arm "date" in info_fourcc | missed | 3 |
-| `wav.rs:122` | delete match arm "genre" in info_fourcc | missed | 3 |
-| `wav.rs:123` | delete match arm "comment" in info_fourcc | missed | 3 |
-| `wav.rs:124` | delete match arm "tracknumber" in info_fourcc | missed | 3 |
-| `wav.rs:155` | replace % with / in build_info_payload | missed | 3 |
-| `wav.rs:155` | replace % with + in build_info_payload | missed | 3 |
-| `wav.rs:155` | replace == with != in build_info_payload | missed | 3 |
-| `wav.rs:168` | replace % with / in push_inline_chunk | missed | 3 |
-| `wav.rs:168` | replace % with + in push_inline_chunk | missed | 3 |
-| `wav.rs:186` | replace > with == in synthesize_layout | missed | 3 |
-| `wav.rs:186` | replace > with >= in synthesize_layout | missed | 3 |
-| `wav.rs:207` | replace % with / in synthesize_layout | missed | 3 |
-| `wav.rs:207` | replace % with + in synthesize_layout | missed | 3 |
-| `wav.rs:227` | replace > with == in synthesize_layout | missed | 3 |
-| `wav.rs:227` | replace > with >= in synthesize_layout | missed | 3 |
-| `wav.rs:245` | delete match arm b"IPRD" in info_to_key | missed | 3 |
-| `wav.rs:246` | delete match arm b"ICRD" in info_to_key | missed | 3 |
-| `wav.rs:248` | delete match arm b"ICMT" in info_to_key | missed | 3 |
-| `wav.rs:249` | delete match arm b"ITRK" in info_to_key | missed | 3 |
-| `wav.rs:300` | replace && with \|\| in read_tags | missed | 3 |
+| `wav.rs:24` | replace < with == in riff_wave_start | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:24` | replace < with <= in riff_wave_start | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:47` | replace + with - in walk_chunks | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:49` | replace match guard next <= buf.len() as u64 with true in walk_chunks | missed → **equivalent** | 3 |
+| `wav.rs:67` | replace == with != in locate_audio | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:71` | replace > with < in locate_audio | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:119` | delete match arm "artist" in info_fourcc | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:120` | delete match arm "album" in info_fourcc | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:121` | delete match arm "date" in info_fourcc | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:122` | delete match arm "genre" in info_fourcc | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:123` | delete match arm "comment" in info_fourcc | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:124` | delete match arm "tracknumber" in info_fourcc | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:155` | replace % with / in build_info_payload | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:155` | replace % with + in build_info_payload | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:155` | replace == with != in build_info_payload | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:168` | replace % with / in push_inline_chunk | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:168` | replace % with + in push_inline_chunk | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:186` | replace > with == in synthesize_layout | missed → **equivalent** | 3 |
+| `wav.rs:186` | replace > with >= in synthesize_layout | missed → **equivalent** | 3 |
+| `wav.rs:207` | replace % with / in synthesize_layout | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:207` | replace % with + in synthesize_layout | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:227` | replace > with == in synthesize_layout | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:227` | replace > with >= in synthesize_layout | missed → **equivalent** | 3 |
+| `wav.rs:245` | delete match arm b"IPRD" in info_to_key | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:246` | delete match arm b"ICRD" in info_to_key | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:248` | delete match arm b"ICMT" in info_to_key | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:249` | delete match arm b"ITRK" in info_to_key | missed → **killed (phase 3d)** | 3 |
+| `wav.rs:300` | replace && with \|\| in read_tags | missed → **killed (phase 3d)** | 3 |
 

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
@@ -116,7 +116,7 @@ the table is the source of truth.
 | `push_inline_chunk:168` | `%`→`/`, `%`→`+` (in `payload.len() % 2 == 1`) | inline-chunk word-align | call directly with a len-2 payload (`%`vs`/`) and an odd-length payload (`%`vs`+`); assert the trailing pad byte present/absent in the emitted `Segment::Inline` |
 | `synthesize_layout:186` | `>`→`==`, `>`→`>=` (in `audio_length > u32::MAX`) | RF64 size guard | **suspected equivalent (both)** — whenever `audio_length > u32::MAX`, `body_len ≥ audio_length` so `riff_size = body_len + 4 > u32::MAX` and the `:227` guard returns `TooLarge` anyway; for `audio_length ≤ u32::MAX` the `:186` guard doesn't fire. Both mutations yield the identical observable result. Confirm by hand-apply; document |
 | `synthesize_layout:207` | `%`→`/`, `%`→`+` (in `tag_len % 2 == 1`) | embedded `id3 ` word-align | craft tags whose ID3v2 `tag_len` is **odd**; assert the following `data` FourCC lands at an **even** byte offset in the assembled output (orig pads → even) vs odd (mutant omits pad). `tag_len` parity is controllable via value length; compute it from `build_id3v2_segments` in the test |
-| `synthesize_layout:227` | `>`→`==`, `>`→`>=` (in `riff_size > u32::MAX`) | RIFF size overflow | **killable** — `BackingAudio` is virtual (no real 4 GB allocation), so pass an `audio_length` chosen relative to the known inline overhead: `riff_size == u32::MAX` exactly distinguishes `>=` (orig `Ok`, mutant `TooLarge`); `riff_size > u32::MAX` (with `audio_length == u32::MAX`, so `:186` passes) distinguishes `==` (orig `TooLarge`, mutant proceeds → `Ok` with a truncated size) |
+| `synthesize_layout:227` | `>`→`==` killable; `>`→`>=` **equivalent** (in `riff_size > u32::MAX`) | RIFF size overflow | `==`: `BackingAudio` is virtual (no real 4 GB allocation), so `audio_length == u32::MAX` passes `:186` but makes `riff_size > u32::MAX`; orig `TooLarge`, mutant `==` proceeds → `Ok` with a truncated size. `>=`: see equivalents — every synthesized RIFF size is even, so the only distinguishing point (`riff_size == u32::MAX`, odd) is unreachable |
 | `info_to_key:245-249` | delete arms `IPRD`→album, `ICRD`→date, `ICMT`→comment, `ITRK`→tracknumber | INFO FourCC → tag-key (inverse) | `read_tags` on a WAV carrying a `LIST/INFO` with each FourCC → assert the `(key, value)` pair returns. (`INAM`/`IART`/`IGNR` already covered) |
 | `read_tags:300` | `&&`→`\|\|` (in `slice.len() >= 4 && &slice[0..4] == b"INFO"`) | INFO body validation | a `LIST` chunk whose payload is **<4 bytes**: orig short-circuits (`len >= 4` false → filter false → empty `from_info`); mutant `\|\|` evaluates `&slice[0..4]` on the short slice → **panic** (panic-vs-empty) |
 
@@ -149,9 +149,11 @@ panic. Note this in the test so the mechanism is readable:
 
 ## Equivalent mutants (confirm by hand-apply, then document — do not chase)
 
-Three survivors are **suspected equivalent**. Each is confirmed by hand-apply (the
-targeted test stays green under the mutation) before being recorded; if a hand-apply
-unexpectedly shows the mutant *is* killable, it moves into C1 with a real test.
+**Four** mutations are **suspected equivalent** (the third and fourth in
+`synthesize_layout` were pinned during planning, not at spec time). Each is
+confirmed by hand-apply (the targeted test stays green under the mutation) before
+being recorded; if a hand-apply unexpectedly shows the mutant *is* killable, it
+moves into C1 with a real test.
 
 - **`walk_chunks:49`** — guard `next <= buf.len()` → `true`. The guard only changes
   behaviour when `checked_add` is `Some(next)` **and** `next > buf.len()`. There the
@@ -169,9 +171,17 @@ unexpectedly shows the mutant *is* killable, it moves into C1 with a real test.
   `audio_length ≤ u32::MAX`, `:186` never fires. So both mutations produce the same
   observable result as the original → equivalent. (The existing
   `rejects_audio_over_32bit` test cannot distinguish `:186` from `:227` for this
-  reason.) **Optional follow-up, not done here:** the `:186` guard is strictly
-  redundant given `:227`; removing it is a behaviour-neutral simplification deferred
-  to avoid scope creep.
+  reason — it passes `u32::MAX + 1`, which `:186` catches first.) **Optional
+  follow-up, not done here:** the `:186` guard is strictly redundant given `:227`;
+  removing it is a behaviour-neutral simplification deferred to avoid scope creep.
+- **`synthesize_layout:227`**, `> → >=` only. `synthesize_layout` word-aligns every
+  emitted chunk (RIFF header, `fmt `/`fact`, `LIST`, the `id3 ` chunk via `:207`,
+  the `data` header, and the `data` payload via `:220`), so `body_len` is always
+  even and `riff_size = body_len + 4` is always **even**. The only input that
+  distinguishes `>` from `>=` is `riff_size == u32::MAX` (odd), which is therefore
+  **unreachable** → the mutant is observably identical to the original. Its sibling
+  `> → ==` is **not** equivalent and **is** killed (`riff_size > u32::MAX` is
+  reachable — `==` then wrongly proceeds, the original rejects).
 
 ## Components
 
@@ -190,12 +200,14 @@ table:
   (`/`,`+`), `synthesize_layout:207` (id3 pad → even-`data`-offset assertion). The
   fourth `% 2` site, `synthesize_layout:220`, is **excluded** — already caught (see
   the exclusion note above).
-- **Overflow:** `synthesize_layout:227` (`>=` at exact `u32::MAX`, `==` above it,
-  via virtual `BackingAudio`).
+- **Overflow:** `synthesize_layout:227` `==` only — `audio_length == u32::MAX`
+  (virtual `BackingAudio`, no allocation) passes `:186` yet drives
+  `riff_size > u32::MAX`; orig `TooLarge`, mutant `==` proceeds → `Ok`. (The `>=`
+  sibling is equivalent — see equivalents.)
 
-Record the suspected equivalents (`walk_chunks:49`, `synthesize_layout:186` ×2)
-with their hand-apply justification (a comment in the module and the
-inventory annotation).
+Record the suspected equivalents (`walk_chunks:49`, `synthesize_layout:186` ×2,
+`synthesize_layout:227` `>=`) with their hand-apply justification (a comment in the
+module and the inventory annotation).
 
 ### C2 — finding #16: zero-byte embedded art (WAV-local skip)
 
@@ -284,8 +296,8 @@ degenerate input (the track becomes readable instead of bricked).
 
 | Component | Check |
 |-----------|-------|
-| C1 | `cargo test -p musefs-format --features fuzzing wav` green; the killable rows (`riff_wave_start:24`, `walk_chunks:47`, `locate_audio:67/:71`, `info_fourcc` 6 arms, `info_to_key` 4 arms, `read_tags:300`, `build_info_payload:155`, `push_inline_chunk:168`, `synthesize_layout:207/:227`) hand-apply red |
-| C1 (equiv) | `walk_chunks:49` and `synthesize_layout:186` (×2) stay green under their mutation; recorded equivalent **both** in the inventory annotation **and** as a justification comment in the `wav.rs` test module (so a future reader sees why no test targets them) |
+| C1 | `cargo test -p musefs-format --features fuzzing wav` green; the killable rows (`riff_wave_start:24`, `walk_chunks:47`, `locate_audio:67/:71`, `info_fourcc` 6 arms, `info_to_key` 4 arms, `read_tags:300`, `build_info_payload:155`, `push_inline_chunk:168`, `synthesize_layout:207`, `synthesize_layout:227` `==`) hand-apply red |
+| C1 (equiv) | `walk_chunks:49`, `synthesize_layout:186` (×2), and `synthesize_layout:227` `>=` stay green under their mutation; recorded equivalent **both** in the inventory annotation **and** as a justification comment in the `wav.rs` test module (so a future reader sees why no test targets them) |
 | C2 | C2 test written **first and shown red** against unmodified `wav.rs`, then green after the filter; `wav::synthesize_layout` skips zero-byte art; the `wav_synthesize.rs` test asserts no `ArtImage` segment, valid round-trip, byte-identical audio, and the mixed empty+real case preserves the real APIC; existing non-empty-art tests still pass |
 | C3 | `cargo test -p musefs-core proptest_read_fidelity` green; **all four** WAV-variant properties pass with the new `write_wav` fixture |
 | Whole | `cargo test --workspace` + `--features fuzzing` + `clippy --all-targets -D warnings` + `fmt --check` green; next full mutants campaign shows `wav.rs` survivors dropped (excluding the documented equivalents) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
@@ -228,6 +228,13 @@ itself is left untouched — mp3-direct synthesis gets its own skip in 3b.
 **Byte-identity is unaffected** — the filter only decides whether an empty APIC is
 emitted, never the positioned `data` reads.
 
+> **Update (post-rebase, final state):** the WAV-local filter was ultimately
+> **dropped**. Phase 3b landed the `data_len == 0` skip *inside* the shared
+> `mp3::build_id3v2_segments`, which WAV delegates to, so the local filter became
+> redundant dead code (and its `data_len > 0` guard produced an equivalent
+> `> → >=` mutant). WAV now relies on that shared skip; the `wav_synthesize.rs`
+> regression tests stay as WAV-level guards. See the tracking doc's 3d entry.
+
 **Red-green ordering (this is a production behaviour change, not a mutant kill, so
 it follows TDD, not the hand-apply method).** First add the `wav_synthesize.rs`
 test asserting the desired behaviour — a zero-byte art → no `ArtImage` segment, the

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
@@ -47,6 +47,11 @@ test, or — if the mutation provably produces identical behavior — record it 
 **equivalent mutant** instead of forcing a contrived test. Never leave a mutation
 applied.
 
+While a mutation is applied, run **only the single targeted test**
+(`cargo test -p musefs-format <test_name>`), never `cargo test --workspace` — a
+live mutation can break unrelated tests and obscure the kill signal. Revert
+(`git checkout -- musefs-format/src/wav.rs`) immediately after step 2.
+
 ## Test placement
 
 `wav.rs` already has a small in-module `#[cfg(test)] mod tests` (the fuzz-discovered
@@ -68,6 +73,18 @@ kills across integration files. The existing integration tests (`wav_locate.rs`,
 `wav_read_tags.rs`, `wav_synthesize.rs`, `proptest_wav.rs`) stay **unchanged**;
 they provide end-to-end coverage but are not the vehicle for any mutant kill in 3d.
 This keeps the kill→test mapping unambiguous (one module owns it).
+
+The module's current import is narrow — `use super::{read_pictures, read_tags}`.
+C1 **widens it to `use super::*`** so the expanded tests can call the private
+helpers (`walk_chunks`, `build_info_payload`, `push_inline_chunk`, `info_fourcc`,
+`info_to_key`, `riff_wave_start`) and `synthesize_layout` directly.
+
+**Out of scope (noted, not fixed):** the integration files duplicate
+`fmt_pcm_16bit_mono()` and `build_wav()` helpers (copy-pasted across
+`wav_locate.rs`, `wav_read_tags.rs`, `wav_synthesize.rs`). 3d leaves these files
+unchanged and does **not** consolidate the helpers — that de-duplication is
+unrelated test-tidy tech debt for a separate pass, called out here only to prevent
+future confusion.
 
 The only 3d tests *outside* `wav.rs` are the cross-cutting C3 (`proptest_read_fidelity.rs`
 in `musefs-core`) and C2's assertion (`wav_synthesize.rs`, which is the natural home
@@ -102,6 +119,18 @@ the table is the source of truth.
 | `synthesize_layout:227` | `>`→`==`, `>`→`>=` (in `riff_size > u32::MAX`) | RIFF size overflow | **killable** — `BackingAudio` is virtual (no real 4 GB allocation), so pass an `audio_length` chosen relative to the known inline overhead: `riff_size == u32::MAX` exactly distinguishes `>=` (orig `Ok`, mutant `TooLarge`); `riff_size > u32::MAX` (with `audio_length == u32::MAX`, so `:186` passes) distinguishes `==` (orig `TooLarge`, mutant proceeds → `Ok` with a truncated size) |
 | `info_to_key:245-249` | delete arms `IPRD`→album, `ICRD`→date, `ICMT`→comment, `ITRK`→tracknumber | INFO FourCC → tag-key (inverse) | `read_tags` on a WAV carrying a `LIST/INFO` with each FourCC → assert the `(key, value)` pair returns. (`INAM`/`IART`/`IGNR` already covered) |
 | `read_tags:300` | `&&`→`\|\|` (in `slice.len() >= 4 && &slice[0..4] == b"INFO"`) | INFO body validation | a `LIST` chunk whose payload is **<4 bytes**: orig short-circuits (`len >= 4` false → filter false → empty `from_info`); mutant `\|\|` evaluates `&slice[0..4]` on the short slice → **panic** (panic-vs-empty) |
+
+### Excluded: `synthesize_layout:220` (the fourth `% 2 == 1` word-align)
+
+`synthesize_layout:220` (`if audio_length % 2 == 1` — the `data`-chunk pad) is the
+same `% 2 == 1` pattern as `:155`/`:168`/`:207` but is **not in the survivor
+inventory**: the existing `pads_odd_data_payload_to_word_boundary` test
+(`wav_synthesize.rs:138`) already exercises an odd-length `data` payload, so its
+`%`→`/`/`%`→`+` mutants are caught. It is therefore out of 3d scope. (The three
+*surviving* `% 2` sites differ only in that no existing test feeds them an
+odd-length INFO value / inline payload / id3 `tag_len`.) Re-verify this assumption
+against the next mutants campaign; if `:220` ever surfaces as a survivor it folds
+into C1 with the same word-align strategy.
 
 ### Kill mechanism: panic-vs-`Err`/empty for the short-input guards
 
@@ -158,7 +187,9 @@ table:
   (4 arm-deletions, exercised through `read_tags`), `read_tags:300`
   (<4-byte `LIST` → panic-vs-empty).
 - **Word-align:** `build_info_payload:155` (`/`,`+`,`!=`), `push_inline_chunk:168`
-  (`/`,`+`), `synthesize_layout:207` (id3 pad → even-`data`-offset assertion).
+  (`/`,`+`), `synthesize_layout:207` (id3 pad → even-`data`-offset assertion). The
+  fourth `% 2` site, `synthesize_layout:220`, is **excluded** — already caught (see
+  the exclusion note above).
 - **Overflow:** `synthesize_layout:227` (`>=` at exact `u32::MAX`, `==` above it,
   via virtual `BackingAudio`).
 
@@ -185,23 +216,33 @@ itself is left untouched — mp3-direct synthesis gets its own skip in 3b.
 **Byte-identity is unaffected** — the filter only decides whether an empty APIC is
 emitted, never the positioned `data` reads.
 
-`musefs-format/tests/wav_synthesize.rs` gains a test asserting: a zero-byte art →
-no `ArtImage` segment, the layout is valid and round-trips, and the served audio is
-byte-identical; plus a mixed case (empty + real art) confirming the surviving APIC
-is preserved. (No WAV art mutation survivor exists — this is robustness coverage,
-not a kill.)
+**Red-green ordering (this is a production behaviour change, not a mutant kill, so
+it follows TDD, not the hand-apply method).** First add the `wav_synthesize.rs`
+test asserting the desired behaviour — a zero-byte art → no `ArtImage` segment, the
+layout is valid and round-trips, served audio byte-identical — and **run it against
+unmodified `wav.rs` to watch it fail** (today it returns `Err(InvalidLayout)`, so
+the assertion is red). Then apply the `data_len == 0` filter and rerun to green. Add
+the mixed case (empty + real art) confirming the surviving APIC is preserved. (No
+WAV art mutation survivor exists — this is robustness coverage, not a kill.)
 
 **Cross-cutting status:** this resolves #16 for WAV. mp3/mp4 remain for 3b/3c (or a
 single ingestion-level filter in `scan.rs`, the alternative the 3a doc recorded).
 
 ### C3 — finding #5: broaden `proptest_read_fidelity` (WAV)
 
-`musefs-core/tests/proptest_read_fidelity.rs` currently exercises the three 3a
-properties (`read_at_partial_windows_match_whole`,
-`read_at_windows_spanning_header_seam`, `read_at_art_window_serves_blob`) on FLAC
-only. Add WAV variants of the same three, each asserting served bytes equal the
-corresponding slice of the independently-assembled `whole`
-(`read_at(&resolved, &db, 0, total_len)`).
+`musefs-core/tests/proptest_read_fidelity.rs` currently has **four** properties on
+FLAC only: the original baseline `read_at_preserves_backing_audio` (the whole-file
+`[0, total_len)` read, finding #5's starting point) plus the three 3a-added
+windowed ones (`read_at_partial_windows_match_whole`,
+`read_at_windows_spanning_header_seam`, `read_at_art_window_serves_blob`). **Add WAV
+variants of all four**, each asserting served bytes equal the corresponding slice of
+the independently-assembled `whole` (`read_at(&resolved, &db, 0, total_len)`).
+
+The whole-file `preserves_backing_audio` variant is technically subsumed by
+`partial_windows` (which generates `offset=0, size=total_len`), but it is the
+canonical statement of the byte-identity invariant for WAV and is cheap, so it is
+included for parity with the FLAC set and as the clearest regression guard rather
+than relying on a subsuming property.
 
 **Fixture sub-task (non-trivial — its own task in the plan).**
 `musefs-core/tests/common/mod.rs` has only `make_flac`/`write_flac`; there is no WAV
@@ -244,7 +285,7 @@ degenerate input (the track becomes readable instead of bricked).
 | Component | Check |
 |-----------|-------|
 | C1 | `cargo test -p musefs-format --features fuzzing wav` green; the killable rows (`riff_wave_start:24`, `walk_chunks:47`, `locate_audio:67/:71`, `info_fourcc` 6 arms, `info_to_key` 4 arms, `read_tags:300`, `build_info_payload:155`, `push_inline_chunk:168`, `synthesize_layout:207/:227`) hand-apply red |
-| C1 (equiv) | `walk_chunks:49` and `synthesize_layout:186` (×2) stay green under their mutation; recorded equivalent with justification |
-| C2 | `wav::synthesize_layout` skips zero-byte art; the `wav_synthesize.rs` test asserts no `ArtImage` segment, valid round-trip, byte-identical audio, and the mixed empty+real case preserves the real APIC; existing non-empty-art tests still pass |
-| C3 | `cargo test -p musefs-core proptest_read_fidelity` green; the three WAV-variant properties pass with the new `write_wav` fixture |
+| C1 (equiv) | `walk_chunks:49` and `synthesize_layout:186` (×2) stay green under their mutation; recorded equivalent **both** in the inventory annotation **and** as a justification comment in the `wav.rs` test module (so a future reader sees why no test targets them) |
+| C2 | C2 test written **first and shown red** against unmodified `wav.rs`, then green after the filter; `wav::synthesize_layout` skips zero-byte art; the `wav_synthesize.rs` test asserts no `ArtImage` segment, valid round-trip, byte-identical audio, and the mixed empty+real case preserves the real APIC; existing non-empty-art tests still pass |
+| C3 | `cargo test -p musefs-core proptest_read_fidelity` green; **all four** WAV-variant properties pass with the new `write_wav` fixture |
 | Whole | `cargo test --workspace` + `--features fuzzing` + `clippy --all-targets -D warnings` + `fmt --check` green; next full mutants campaign shows `wav.rs` survivors dropped (excluding the documented equivalents) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-phase3d-wav-hardening-design.md
@@ -1,0 +1,250 @@
+# Phase 3d — WAV Hardening (Design)
+
+**Source audit:** `docs/audits/2026-05-29-test-audit.md` (the WAV dimension of
+findings #5 and #16, plus the 28 `wav.rs` mutation survivors from the phase-1
+inventory `2026-05-29-mutation-inventory.md`)
+**Created:** 2026-05-29
+**Status:** design — awaiting plan
+
+## Goal
+
+Drive the **28 `wav.rs` mutation survivors** toward zero, add the WAV dimension of
+finding #5 (broaden the cross-format `proptest_read_fidelity` property), and close
+finding #16 for WAV with a scoped zero-byte-art skip.
+
+**Changes are additive tests plus one small scoped production fix, no new
+dependencies.** The production change is the C2 zero-byte-art skip in
+`wav::synthesize_layout` (a degenerate empty picture must not brick a track). **The
+byte-identity invariant is untouched** — the skip only decides whether an empty
+APIC frame is emitted into the embedded `id3 ` chunk, never the positioned `data`
+reads.
+
+This is the final per-format slice of Phase 3 (Format-layer coverage & mutants,
+non-Ogg): **3a FLAC** (done), 3b MP3, 3c MP4, **3d WAV** (this doc). The WAV slice
+of finding #5 lands here (its FLAC slice landed in 3a; mp3/mp4 in 3b/3c).
+
+## Guiding principle: verify, don't trust
+
+The 2026-05-29 audit was executed by a weaker model; its findings are **leads, not
+facts.** Every survivor below was re-read against the actual `wav.rs` source. Two
+clusters turned out to be **suspected-equivalent mutants** (`walk_chunks:49` and
+both `synthesize_layout:186` variants — see the equivalent-mutant section); the
+design's job is to *confirm* those by hand-apply and document them, exactly as 3a
+confirmed its disjoint-bitfield `| → ^` equivalents. We never contrive a test for a
+provably equivalent mutant.
+
+## The hand-apply verification method (use for every kill)
+
+cargo-mutants is not available locally. To prove a new test kills a specific
+survivor, for each targeted `file:line: mutation`:
+
+1. Run the new test → it passes (production code is correct).
+2. Apply the exact mutation at that line, rerun **just that test** → it must **fail**.
+3. Revert the mutation (`git checkout -- <file>`), rerun → passes again.
+
+If step 2 still passes, the test does not kill the mutant. Either strengthen the
+test, or — if the mutation provably produces identical behavior — record it as an
+**equivalent mutant** instead of forcing a contrived test. Never leave a mutation
+applied.
+
+## Test placement
+
+`wav.rs` already has a small in-module `#[cfg(test)] mod tests` (the fuzz-discovered
+OOM regression `wav_oom_crash_artifact_is_safe`). Survivor functions split by
+visibility:
+
+- `pub`: `locate_audio`, `read_structure`, `synthesize_layout`, `read_tags`,
+  `read_pictures` — reachable from `musefs-format/tests/` integration files.
+- private: `riff_wave_start`, `walk_chunks`, `chunk_slice`, `info_fourcc`,
+  `build_info_payload`, `push_inline_chunk`, `info_to_key`, `find_id3_chunk`,
+  `read_info_tags` — **not** reachable from integration tests (separate crate).
+
+The byte-level kills (`info_fourcc`/`info_to_key` arms, the `% 2` word-align
+checks, `walk_chunks` advance) need precise byte control on private helpers, which
+is cleanest with direct calls. **All `wav.rs` mutant kills live in the existing
+in-module `#[cfg(test)] mod tests` (expanded)** — `use super::*` reaches every
+survivor function directly, `pub` and private alike, so there is no reason to split
+kills across integration files. The existing integration tests (`wav_locate.rs`,
+`wav_read_tags.rs`, `wav_synthesize.rs`, `proptest_wav.rs`) stay **unchanged**;
+they provide end-to-end coverage but are not the vehicle for any mutant kill in 3d.
+This keeps the kill→test mapping unambiguous (one module owns it).
+
+The only 3d tests *outside* `wav.rs` are the cross-cutting C3 (`proptest_read_fidelity.rs`
+in `musefs-core`) and C2's assertion (`wav_synthesize.rs`, which is the natural home
+for the zero-byte-art synthesis behaviour and does get the one new C2 test —
+distinct from the kill module).
+
+**Approach considered and rejected:** integration-tests-only. The private helpers
+(`build_info_payload`, `push_inline_chunk`, `walk_chunks`, `info_fourcc`) are only
+reachable indirectly through `pub` entry points, which makes the byte-precise
+fixtures for the word-align and arm-deletion kills awkward and indirect. In-module
+unit tests are the right tool.
+
+## Verified findings
+
+The 28 survivors cluster by function. Kill strategy and killability were verified by
+reading the source. **Re-confirm each line by code pattern (not the line number)
+before hand-applying** — intervening edits drift the numbers; the pattern named in
+the table is the source of truth.
+
+| Function / lines | Mutations | Nature | Strategy |
+|---|---|---|---|
+| `riff_wave_start:24` | `<`→`==`, `<`→`<=` | container-length guard `buf.len() < 12` | `<=`: a valid 12-byte `RIFF????WAVE` → orig `Ok(12)`, mutant `12 <= 12` → `NotWav`. `==`: an 11-byte buffer starting `RIFF` → orig short-circuits (`11 < 12` true → `NotWav`); mutant `11 == 12` false → falls through to `&buf[8..12]` on an 11-byte slice → **panic** (panic-vs-`Err`) |
+| `walk_chunks:47` | `+`→`-` (in `8u64 + size + (size & 1)`) | header-to-header advance | multi-chunk fixture (`fmt `,`data`): a wrong advance loses the `data` chunk, so `walk_chunks`/`locate_audio` returns a different chunk set; assert the parsed chunks |
+| `walk_chunks:49` | guard `next <= buf.len()` → `true` | over-buffer break | **suspected equivalent** — when `next > buf.len()` the mutant sets `pos = next` then the `while pos + 8 <= buf.len()` test is immediately false, so the output `Vec` is identical to the original's `break` (the chunk header was already pushed before the advance). Confirm by hand-apply; document |
+| `locate_audio:67` | `==`→`!=` (`id == b"fmt "`) | `fmt ` presence detection | a **data-only** WAV (a `data` chunk, no `fmt `): orig `has_fmt = false` → `NotWav`; mutant `any(id != "fmt ")` is true (the `data` chunk) → `has_fmt = true` → returns `Ok`/`Malformed`. Either differs from `NotWav` |
+| `locate_audio:71` | `>`→`<` (`off+len > buf.len`) | oversize-`data` guard | a valid WAV with **trailing slack** after the `data` payload (`off+len < buf.len`): orig `>` false → `Ok`; mutant `<` true → `Malformed`. (Exact-fit fixtures can't distinguish — they sit at equality) |
+| `info_fourcc:119-124` | delete arms artist→`IART`, album→`IPRD`, date→`ICRD`, genre→`IGNR`, comment→`ICMT`, tracknumber→`ITRK` | tag-key → INFO FourCC | per key: `build_info_payload(&[TagInput{key,..}])` → assert the expected FourCC bytes appear in the payload. (title→`INAM` is already covered, not a survivor) |
+| `build_info_payload:155` | `%`→`/`, `%`→`+`, `==`→`!=` (in `v.len() % 2 == 1`) | INFO value word-align | controlled `v.len()` (value bytes + NUL): a len-2 value (`"a"` → `[a,0]`) splits `%`vs`/` (orig no pad, `/`: `2/2==1` pads) and `==`vs`!=` (`!=` pads); an odd value (`"ab"` → len 3) splits `%`vs`+` (`+`: `3+2≠1` never pads). Assert exact payload incl. the pad byte |
+| `push_inline_chunk:168` | `%`→`/`, `%`→`+` (in `payload.len() % 2 == 1`) | inline-chunk word-align | call directly with a len-2 payload (`%`vs`/`) and an odd-length payload (`%`vs`+`); assert the trailing pad byte present/absent in the emitted `Segment::Inline` |
+| `synthesize_layout:186` | `>`→`==`, `>`→`>=` (in `audio_length > u32::MAX`) | RF64 size guard | **suspected equivalent (both)** — whenever `audio_length > u32::MAX`, `body_len ≥ audio_length` so `riff_size = body_len + 4 > u32::MAX` and the `:227` guard returns `TooLarge` anyway; for `audio_length ≤ u32::MAX` the `:186` guard doesn't fire. Both mutations yield the identical observable result. Confirm by hand-apply; document |
+| `synthesize_layout:207` | `%`→`/`, `%`→`+` (in `tag_len % 2 == 1`) | embedded `id3 ` word-align | craft tags whose ID3v2 `tag_len` is **odd**; assert the following `data` FourCC lands at an **even** byte offset in the assembled output (orig pads → even) vs odd (mutant omits pad). `tag_len` parity is controllable via value length; compute it from `build_id3v2_segments` in the test |
+| `synthesize_layout:227` | `>`→`==`, `>`→`>=` (in `riff_size > u32::MAX`) | RIFF size overflow | **killable** — `BackingAudio` is virtual (no real 4 GB allocation), so pass an `audio_length` chosen relative to the known inline overhead: `riff_size == u32::MAX` exactly distinguishes `>=` (orig `Ok`, mutant `TooLarge`); `riff_size > u32::MAX` (with `audio_length == u32::MAX`, so `:186` passes) distinguishes `==` (orig `TooLarge`, mutant proceeds → `Ok` with a truncated size) |
+| `info_to_key:245-249` | delete arms `IPRD`→album, `ICRD`→date, `ICMT`→comment, `ITRK`→tracknumber | INFO FourCC → tag-key (inverse) | `read_tags` on a WAV carrying a `LIST/INFO` with each FourCC → assert the `(key, value)` pair returns. (`INAM`/`IART`/`IGNR` already covered) |
+| `read_tags:300` | `&&`→`\|\|` (in `slice.len() >= 4 && &slice[0..4] == b"INFO"`) | INFO body validation | a `LIST` chunk whose payload is **<4 bytes**: orig short-circuits (`len >= 4` false → filter false → empty `from_info`); mutant `\|\|` evaluates `&slice[0..4]` on the short slice → **panic** (panic-vs-empty) |
+
+### Kill mechanism: panic-vs-`Err`/empty for the short-input guards
+
+Some bound mutations kill by **panic divergence**, not a clean value comparison —
+the test asserts the *clean* result and the mutation turns it into an out-of-bounds
+panic. Note this in the test so the mechanism is readable:
+
+- `riff_wave_start:24`, `< → ==` variant: an 11-byte `RIFF…` buffer. Orig
+  short-circuits (`11 < 12` true → `Err(NotWav)`); the `==` mutant evaluates
+  `11 == 12` → false → continues past the length check → `&buf[8..12]` panics. The
+  test asserts `Err(NotWav)` on the 11-byte input; the kill is panic ≠ `Err`.
+- `read_tags:300`, `&& → ||` variant: a `LIST` payload of <4 bytes. Orig
+  short-circuits (`len >= 4` false → no INFO, empty result); the `||` mutant forces
+  `&slice[0..4]` on the short slice → panic. The test asserts an empty/`id3`-only
+  result; the kill is panic ≠ clean return.
+
+## Equivalent mutants (confirm by hand-apply, then document — do not chase)
+
+Three survivors are **suspected equivalent**. Each is confirmed by hand-apply (the
+targeted test stays green under the mutation) before being recorded; if a hand-apply
+unexpectedly shows the mutant *is* killable, it moves into C1 with a real test.
+
+- **`walk_chunks:49`** — guard `next <= buf.len()` → `true`. The guard only changes
+  behaviour when `checked_add` is `Some(next)` **and** `next > buf.len()`. There the
+  original `break`s; the mutant sets `pos = next` (> `buf.len()`), and the loop
+  condition `pos + 8 <= buf.len()` is then immediately false, so the loop exits with
+  the **same** output `Vec` (the current chunk header was pushed *before* the advance
+  in both). Overflow (`checked_add` → `None`) takes the `_ => break` arm in both.
+  Observably identical → equivalent.
+- **`synthesize_layout:186`** — `audio_length > u32::MAX`, both `> → ==` and
+  `> → >=`. The `:227` guard (`riff_size > u32::MAX`) shadows `:186` entirely:
+  `body_len` sums all segment lengths including the `BackingAudio` length
+  (`audio_length`, the full `u64`), so `body_len ≥ audio_length`. Whenever `:186`
+  would fire (`audio_length > u32::MAX`), `riff_size = body_len + 4 > u32::MAX` and
+  `:227` returns the identical `Err(FormatError::TooLarge)`. For
+  `audio_length ≤ u32::MAX`, `:186` never fires. So both mutations produce the same
+  observable result as the original → equivalent. (The existing
+  `rejects_audio_over_32bit` test cannot distinguish `:186` from `:227` for this
+  reason.) **Optional follow-up, not done here:** the `:186` guard is strictly
+  redundant given `:227`; removing it is a behaviour-neutral simplification deferred
+  to avoid scope creep.
+
+## Components
+
+### C1 — in-module mutant kills (`wav.rs` `#[cfg(test)] mod tests`)
+
+Expand the existing test module to cover the killable rows in the verified-findings
+table:
+
+- **Container/structure:** `riff_wave_start:24` (`<=` clean, `==` panic-vs-`Err`),
+  `walk_chunks:47` (advance), `locate_audio:67` (data-only → `fmt ` detection),
+  `locate_audio:71` (trailing-slack → oversize guard).
+- **INFO mapping:** `info_fourcc:119-124` (6 arm-deletions), `info_to_key:245-249`
+  (4 arm-deletions, exercised through `read_tags`), `read_tags:300`
+  (<4-byte `LIST` → panic-vs-empty).
+- **Word-align:** `build_info_payload:155` (`/`,`+`,`!=`), `push_inline_chunk:168`
+  (`/`,`+`), `synthesize_layout:207` (id3 pad → even-`data`-offset assertion).
+- **Overflow:** `synthesize_layout:227` (`>=` at exact `u32::MAX`, `==` above it,
+  via virtual `BackingAudio`).
+
+Record the suspected equivalents (`walk_chunks:49`, `synthesize_layout:186` ×2)
+with their hand-apply justification (a comment in the module and the
+inventory annotation).
+
+### C2 — finding #16: zero-byte embedded art (WAV-local skip)
+
+**Verified behaviour (not an assumption).** WAV's embedded art is emitted by
+`crate::mp3::build_id3v2_segments`, called from `wav::synthesize_layout`. A
+zero-byte picture becomes an APIC frame whose image bytes are a
+`Segment::ArtImage { len: 0 }`; `RegionLayout::validate` rejects empty segments
+(`EmptySegment`), so `synthesize_layout` returns `Err(InvalidLayout)` and the
+**whole WAV track becomes unreadable** at serve time — the same gap 3a fixed for
+FLAC. Ingestion (`scan.rs`) only filters art *above* `MAX_ART_BYTES`, so a source
+file with an empty embedded picture is ingested and then bricks the track.
+
+**Resolution (chosen): WAV-local filter.** In `wav::synthesize_layout`, filter
+arts with `data_len == 0` **before** calling `build_id3v2_segments` (mirrors
+`flac.rs:131/153`). This keeps the fix self-contained to 3d and matches the 3a
+plan's "apply the same skip in each format's sub-phase." `mp3::build_id3v2_segments`
+itself is left untouched — mp3-direct synthesis gets its own skip in 3b.
+**Byte-identity is unaffected** — the filter only decides whether an empty APIC is
+emitted, never the positioned `data` reads.
+
+`musefs-format/tests/wav_synthesize.rs` gains a test asserting: a zero-byte art →
+no `ArtImage` segment, the layout is valid and round-trips, and the served audio is
+byte-identical; plus a mixed case (empty + real art) confirming the surviving APIC
+is preserved. (No WAV art mutation survivor exists — this is robustness coverage,
+not a kill.)
+
+**Cross-cutting status:** this resolves #16 for WAV. mp3/mp4 remain for 3b/3c (or a
+single ingestion-level filter in `scan.rs`, the alternative the 3a doc recorded).
+
+### C3 — finding #5: broaden `proptest_read_fidelity` (WAV)
+
+`musefs-core/tests/proptest_read_fidelity.rs` currently exercises the three 3a
+properties (`read_at_partial_windows_match_whole`,
+`read_at_windows_spanning_header_seam`, `read_at_art_window_serves_blob`) on FLAC
+only. Add WAV variants of the same three, each asserting served bytes equal the
+corresponding slice of the independently-assembled `whole`
+(`read_at(&resolved, &db, 0, total_len)`).
+
+**Fixture sub-task (non-trivial — its own task in the plan).**
+`musefs-core/tests/common/mod.rs` has only `make_flac`/`write_flac`; there is no WAV
+writer. Add `write_wav(path, tags, audio) -> (audio_offset, audio_length)` that
+emits a minimal valid `RIFF`/`WAVE` (`fmt ` + `LIST/INFO` and/or `id3 ` + `data`)
+and upserts the track + tags, following the existing `write_flac` shape. For the
+art-window property, reuse the 3a `build_with_art` pattern (`upsert_art` +
+`set_track_art`) against a WAV backing file. Keep `ProptestConfig::with_cases ≤ 64`
+(each case does DB + file I/O), matching the existing properties.
+
+### C4 — inventory + tracking docs
+
+Annotate the `wav.rs` rows in `2026-05-29-mutation-inventory.md` (`killed (phase
+3d)` / `equivalent`), and update `2026-05-29-remediation-tracking.md`: mark Phase 3d
+(recording the suspected-equivalent set once confirmed, and that the WAV dimensions
+of findings #5 and #16 are addressed). If 3d completes the last non-Ogg format,
+update the Phase 3 status accordingly.
+
+## Implementation ordering
+
+C1 → C2 → C3 → C4. C2 and C3 are independent of C1 and of each other.
+
+**Re-verify line numbers before each component.** Survivor references are pinned to
+exact `wav.rs` line numbers from the phase-1 inventory; any intervening edit shifts
+them. At the start of each component, locate the target by its **code pattern**
+(named in the verified-findings table — e.g. "the `% 2 == 1` word-align in
+`build_info_payload`", "the `riff_size > u32::MAX` guard") and confirm the current
+line before applying the hand-apply mutation. The pattern is the source of truth;
+the line number is a convenience that may drift.
+
+## Error handling
+
+No new error paths. The kills assert the existing `FormatError::{NotWav, Malformed,
+TooLarge, InvalidLayout}` mappings on crafted inputs; the only production change is
+C2's zero-byte-art filter, which *removes* a spurious `InvalidLayout` for a
+degenerate input (the track becomes readable instead of bricked).
+
+## Acceptance
+
+| Component | Check |
+|-----------|-------|
+| C1 | `cargo test -p musefs-format --features fuzzing wav` green; the killable rows (`riff_wave_start:24`, `walk_chunks:47`, `locate_audio:67/:71`, `info_fourcc` 6 arms, `info_to_key` 4 arms, `read_tags:300`, `build_info_payload:155`, `push_inline_chunk:168`, `synthesize_layout:207/:227`) hand-apply red |
+| C1 (equiv) | `walk_chunks:49` and `synthesize_layout:186` (×2) stay green under their mutation; recorded equivalent with justification |
+| C2 | `wav::synthesize_layout` skips zero-byte art; the `wav_synthesize.rs` test asserts no `ArtImage` segment, valid round-trip, byte-identical audio, and the mixed empty+real case preserves the real APIC; existing non-empty-art tests still pass |
+| C3 | `cargo test -p musefs-core proptest_read_fidelity` green; the three WAV-variant properties pass with the new `write_wav` fixture |
+| Whole | `cargo test --workspace` + `--features fuzzing` + `clippy --all-targets -D warnings` + `fmt --check` green; next full mutants campaign shows `wav.rs` survivors dropped (excluding the documented equivalents) |

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
@@ -2,7 +2,7 @@
 
 **Source audit:** `docs/audits/2026-05-29-test-audit.md`
 **Created:** 2026-05-29
-**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); Phase 3a (FLAC) complete; Phase 3b complete (MP3 survivors killed); Phase 3c (MP4) complete; phases 3d, 4 pending
+**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); Phase 3a (FLAC) complete; Phase 3b complete (MP3 survivors killed); Phase 3c (MP4) complete; Phase 3d (WAV) complete; phase 4 pending
 
 ## Guiding principle: verify, don't trust
 
@@ -117,8 +117,12 @@ Findings #5, #16.
   *nonempty* art wins in `mp4.rs::synthesize_layout`, mirroring the FLAC fix), and
   finding #5 broadened onto the M4A synthesis path (`write_m4a` helper + four
   `proptest_read_fidelity` M4A cases: backing-audio identity, partial windows,
-  header seam, art window). WAV (3d) remains the only open non-FLAC read-fidelity
-  dimension.
+  header seam, art window).
+- **3d done** — WAV survivors killed (24 kills; equivalents: `walk_chunks:49`
+  guard-to-true, `synthesize_layout:186` `> → ==` and `> → >=`,
+  `synthesize_layout:227` `> → >=`); finding #16 resolved by **skipping zero-byte
+  art in WAV synthesis** (mirrors FLAC's skip); finding #5 broadened on WAV
+  (read-fidelity proptests: preserve-backing, partial-windows, header-seam, art-window).
 - broaden `proptest_read_fidelity` (random offsets, header/audio boundary, art,
   non-FLAC) (#5)
 - zero-byte art boundary (#16)

--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
@@ -120,8 +120,9 @@ Findings #5, #16.
   header seam, art window).
 - **3d done** — WAV survivors killed (24 kills; equivalents: `walk_chunks:49`
   guard-to-true, `synthesize_layout:186` `> → ==` and `> → >=`,
-  `synthesize_layout:227` `> → >=`); finding #16 resolved by **skipping zero-byte
-  art in WAV synthesis** (mirrors FLAC's skip); finding #5 broadened on WAV
+  `synthesize_layout:227` `> → >=`); finding #16 resolved for WAV by **delegating to
+  the shared `build_id3v2_segments`, which already skips zero-byte art** (added in
+  3b), so no WAV-local filter is needed; finding #5 broadened on WAV
   (read-fidelity proptests: preserve-backing, partial-windows, header-seam, art-window).
 - broaden `proptest_read_fidelity` (random offsets, header/audio boundary, art,
   non-FLAC) (#5)

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -81,6 +81,34 @@ pub fn write_m4a(path: &Path, audio: &[u8]) -> (i64, i64) {
     (audio_offset, audio.len() as i64)
 }
 
+/// Write a minimal valid PCM WAV (`fmt ` + `data`) to `path`, returning
+/// (audio_offset, audio_length) of the `data` payload. Tags are applied via the DB
+/// by the caller (mirrors how `write_flac` is paired with `replace_tags`).
+pub fn write_wav(path: &Path, audio: &[u8]) -> (i64, i64) {
+    let mut fmt = Vec::new();
+    fmt.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    fmt.extend_from_slice(&1u16.to_le_bytes()); // mono
+    fmt.extend_from_slice(&44_100u32.to_le_bytes()); // sample rate
+    fmt.extend_from_slice(&88_200u32.to_le_bytes()); // byte rate
+    fmt.extend_from_slice(&2u16.to_le_bytes()); // block align
+    fmt.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+
+    let mut body = Vec::new();
+    for (id, payload) in [(&b"fmt "[..], &fmt[..]), (&b"data"[..], audio)] {
+        body.extend_from_slice(id);
+        body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        body.extend_from_slice(payload);
+    }
+    let mut bytes = b"RIFF".to_vec();
+    bytes.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+    bytes.extend_from_slice(b"WAVE");
+    bytes.extend_from_slice(&body);
+
+    let audio_offset = (bytes.len() - audio.len()) as i64;
+    std::fs::write(path, &bytes).unwrap();
+    (audio_offset, audio.len() as i64)
+}
+
 /// Build a 32-bit-size box: [size][type][payload].
 fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
     let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -2,6 +2,7 @@ mod common;
 use common::write_flac;
 use common::write_m4a;
 use common::write_mp3;
+use common::write_wav;
 use musefs_core::{read_at, HeaderCache, Mode};
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_format::Segment;
@@ -45,6 +46,77 @@ fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, 
         .upsert_track(&NewTrack {
             backing_path: path.to_string_lossy().to_string(),
             format: Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    let art_id = db
+        .upsert_art(&NewArt {
+            mime: "image/png".to_string(),
+            width: Some(8),
+            height: Some(8),
+            data: art.to_vec(),
+        })
+        .unwrap();
+    db.set_track_art(
+        id,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: "front".to_string(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+    (dir, db, id)
+}
+
+/// Like `build`, but writes a WAV backing file and registers it as `Format::Wav`.
+fn build_wav(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.wav");
+    let (audio_offset, audio_length) = write_wav(&path, audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::Wav,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
+    (dir, db, id, audio.to_vec())
+}
+
+/// Like `build_with_art`, but for a WAV backing file. WAV embeds art via the shared
+/// id3 path, so the resolved layout contains an `ArtImage` segment.
+fn build_wav_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, Db, i64) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("song.wav");
+    let (audio_offset, audio_length) = write_wav(&path, audio);
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().to_string(),
+            format: Format::Wav,
             audio_offset,
             audio_length,
             backing_size: meta.len() as i64,
@@ -170,6 +242,101 @@ proptest! {
         // A partial window *within the art span* matches the independently-read
         // whole, so the assertion actually exercises art bytes (sampling the whole
         // stream here would be redundant with read_at_partial_windows_match_whole).
+        let local_off = (a as u64) % (art_len + 1);
+        let offset = art_off + local_off;
+        let len = (b as u64) % (art_len - local_off + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+
+    #[test]
+    fn wav_read_at_preserves_backing_audio(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+    ) {
+        let (_dir, db, id, original) = build_wav(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+        prop_assert_eq!(whole.len() as u64, resolved.total_len);
+        // The served `data` payload is byte-identical to the original audio. It is
+        // not the trailing bytes (a word-align pad may follow), so locate it.
+        let bounds = musefs_format::wav::locate_audio(&whole).unwrap();
+        prop_assert_eq!(
+            &whole[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+            &original[..]
+        );
+    }
+
+    #[test]
+    fn wav_read_at_partial_windows_match_whole(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build_wav(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let offset = (a as u64) % (total + 1);
+        let len = (b as u64) % (total - offset + 1);
+        let got = read_at(&resolved, &db, offset, len).unwrap();
+        prop_assert_eq!(got.len() as u64, len);
+        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+    }
+
+    #[test]
+    fn wav_read_at_windows_spanning_header_seam(
+        audio in proptest::collection::vec(any::<u8>(), 1..512),
+        title in "[ -~]{0,32}",
+        before in 0usize..4096,
+        after in 0usize..4096,
+    ) {
+        let (_dir, db, id, _orig) = build_wav(&audio, &title);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let hlen = resolved.layout.header_len();
+        prop_assume!(hlen > 0 && hlen < total);
+        let start = hlen - 1 - (before as u64 % hlen);
+        let end = hlen + 1 + (after as u64 % (total - hlen));
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+        let got = read_at(&resolved, &db, start, end - start).unwrap();
+        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+    }
+
+    #[test]
+    fn wav_read_at_art_window_serves_blob(
+        audio in proptest::collection::vec(any::<u8>(), 1..256),
+        art in proptest::collection::vec(any::<u8>(), 1..256),
+        a in 0usize..4096,
+        b in 0usize..4096,
+    ) {
+        let (_dir, db, id) = build_wav_with_art(&audio, "T", &art);
+        let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+        let total = resolved.total_len;
+        let whole = read_at(&resolved, &db, 0, total).unwrap();
+
+        // Locate the ArtImage segment's byte offset by summing the serving lengths
+        // of the segments before it.
+        let mut art_off = 0u64;
+        let mut art_len = None;
+        for s in &resolved.layout.segments {
+            match s {
+                Segment::ArtImage { len, .. } => {
+                    art_len = Some(*len);
+                    break;
+                }
+                Segment::Inline(bytes) => art_off += bytes.len() as u64,
+                Segment::BackingAudio { len, .. } => art_off += *len,
+                other => panic!("unexpected WAV segment: {other:?}"),
+            }
+        }
+        let art_len = art_len.expect("layout has an ArtImage segment");
+        prop_assert_eq!(art_len, art.len() as u64);
+        prop_assert_eq!(
+            &whole[art_off as usize..(art_off + art_len) as usize],
+            &art[..]
+        );
         let local_off = (a as u64) % (art_len + 1);
         let offset = art_off + local_off;
         let len = (b as u64) % (art_len - local_off + 1);

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -536,4 +536,18 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn read_tags_rejects_short_list_without_panic() {
+        // :300 `&& → ||`: a LIST chunk with a <4-byte payload. Original
+        // short-circuits (`len >= 4` false → no INFO, empty). The `||` mutant
+        // evaluates `&slice[0..4]` on the 2-byte slice → panic. Asserting the clean
+        // empty result kills it (panic ≠ empty).
+        let buf = wav(&[
+            (b"fmt ", fmt_pcm()),
+            (b"LIST", vec![0x49, 0x4E]), // "IN" — 2 bytes, < 4
+            (b"data", vec![0x00; 4]),
+        ]);
+        assert!(read_tags(&buf).is_empty());
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -600,4 +600,36 @@ mod tests {
             "the data chunk must be word-aligned"
         );
     }
+
+    #[test]
+    fn synthesize_rejects_riff_size_overflow() {
+        // :227 `> → ==`. `BackingAudio` is virtual (no real allocation), so we can
+        // pass `audio_length == u32::MAX`: it PASSES the :186 guard (`> u32::MAX` is
+        // false) but makes `riff_size > u32::MAX`. Original `>` → TooLarge; the `==`
+        // mutant (`riff_size == u32::MAX`) is false (riff_size is strictly greater),
+        // so it wrongly proceeds and returns Ok with a truncated size.
+        //
+        // NOTE — this must use exactly u32::MAX, not the existing
+        // `rejects_audio_over_32bit` test's `u32::MAX + 1`: that larger value is
+        // caught by the :186 guard first and never reaches :227.
+        let scan = WavScan {
+            fmt: fmt_pcm(),
+            fact: None,
+        };
+        let res = synthesize_layout(&scan, 0, u32::MAX as u64, &[], &[]);
+        assert_eq!(res, Err(FormatError::TooLarge));
+    }
+
+    // Documented EQUIVALENT mutants in this file (no test targets them; each was
+    // confirmed by hand-apply — the relevant test stays green under the mutation):
+    //  * walk_chunks:49  guard `next <= buf.len()` → `true`. When `next > buf.len()`
+    //    the mutant sets `pos = next`, but the `while pos + 8 <= buf.len()` test is
+    //    then immediately false, so the output Vec is identical to the original's
+    //    `break` (the header was pushed before the advance).
+    //  * synthesize_layout:186  `audio_length > u32::MAX` (both `==` and `>=`).
+    //    `body_len >= audio_length`, so whenever this would fire, `riff_size`
+    //    overflows and the :227 guard returns the identical TooLarge.
+    //  * synthesize_layout:227  `> → >=` only. Every synthesized chunk is
+    //    word-aligned, so `riff_size` is always even; `riff_size == u32::MAX` (odd)
+    //    is unreachable, the only point where `>` and `>=` differ.
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -198,7 +198,12 @@ pub fn synthesize_layout(
     }
 
     // Embedded `id3 ` chunk: 8-byte chunk header + the ID3v2 tag segments, padded.
-    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, arts)?;
+    // Skip degenerate zero-byte art: an empty picture would become an
+    // `ArtImage { len: 0 }`, which `RegionLayout::validate` rejects, bricking the
+    // whole track. Filtering keeps byte-identity untouched (only whether an empty
+    // APIC is emitted changes). Mirrors `flac.rs::synthesize_layout`.
+    let nonempty_arts: Vec<ArtInput> = arts.iter().filter(|a| a.data_len > 0).cloned().collect();
+    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, &nonempty_arts)?;
     let mut id3_head = Vec::with_capacity(8);
     id3_head.extend_from_slice(b"id3 ");
     id3_head.extend_from_slice(&(tag_len as u32).to_le_bytes());

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -466,4 +466,19 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn build_info_payload_word_aligns_values() {
+        // :155 `v.len() % 2 == 1`. v = value bytes + NUL.
+        // Value "a"  -> v.len()=2 (even, NO pad). Kills `% → /` (2/2==1 pads) and
+        //               `== → !=` (2%2=0 != 1 pads).
+        // Value "ab" -> v.len()=3 (odd, padded). Kills `% → +` (3+2 != 1, no pad).
+        let even = build_info_payload(&[TagInput::new("title", "a")]).unwrap();
+        // "INFO"(4) + "INAM"(4) + len(4) + "a\0"(2) = 14, no pad.
+        assert_eq!(even.len(), 14);
+
+        let odd = build_info_payload(&[TagInput::new("title", "ab")]).unwrap();
+        // "INFO"(4) + "INAM"(4) + len(4) + "ab\0"(3) + pad(1) = 16.
+        assert_eq!(odd.len(), 16);
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -481,4 +481,19 @@ mod tests {
         // "INFO"(4) + "INAM"(4) + len(4) + "ab\0"(3) + pad(1) = 16.
         assert_eq!(odd.len(), 16);
     }
+
+    #[test]
+    fn push_inline_chunk_word_aligns_payload() {
+        // :168 `payload.len() % 2 == 1`.
+        // Even payload (len 2): NO pad. Kills `% → /` (2/2==1 pads).
+        let mut segs = Vec::new();
+        push_inline_chunk(&mut segs, b"test", &[0xAA, 0xBB]);
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].len(), 10); // "test"(4) + len(4) + payload(2)
+
+        // Odd payload (len 3): padded. Kills `% → +` (3+2 != 1, no pad).
+        let mut segs2 = Vec::new();
+        push_inline_chunk(&mut segs2, b"test", &[0xAA, 0xBB, 0xCC]);
+        assert_eq!(segs2[0].len(), 12); // 4 + 4 + 3 + pad(1)
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -496,4 +496,44 @@ mod tests {
         push_inline_chunk(&mut segs2, b"test", &[0xAA, 0xBB, 0xCC]);
         assert_eq!(segs2[0].len(), 12); // 4 + 4 + 3 + pad(1)
     }
+
+    /// An `INFO` payload: `"INFO"` FourCC + NUL-terminated, word-aligned subchunks.
+    fn info_payload(pairs: &[(&[u8; 4], &str)]) -> Vec<u8> {
+        let mut p = b"INFO".to_vec();
+        for (cc, val) in pairs {
+            let mut v = val.as_bytes().to_vec();
+            v.push(0x00);
+            p.extend_from_slice(*cc);
+            p.extend_from_slice(&(v.len() as u32).to_le_bytes());
+            p.extend_from_slice(&v);
+            if v.len() % 2 == 1 {
+                p.push(0x00);
+            }
+        }
+        p
+    }
+
+    #[test]
+    fn info_to_key_decodes_each_mapped_fourcc() {
+        // :245-249 arm deletions: each INFO FourCC must decode to its tag key.
+        let cases: [(&[u8; 4], &str, &str); 4] = [
+            (b"IPRD", "album", "Anthology"),
+            (b"ICRD", "date", "1999"),
+            (b"ICMT", "comment", "Nice"),
+            (b"ITRK", "tracknumber", "3"),
+        ];
+        for (cc, key, val) in cases {
+            let buf = wav(&[
+                (b"fmt ", fmt_pcm()),
+                (b"LIST", info_payload(&[(cc, val)])),
+                (b"data", vec![0x00; 4]),
+            ]);
+            let tags = read_tags(&buf);
+            assert!(
+                tags.contains(&(key.to_string(), val.to_string())),
+                "FourCC {:?} must decode to {key}",
+                std::str::from_utf8(cc).unwrap()
+            );
+        }
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -322,7 +322,7 @@ pub fn read_pictures(buf: &[u8]) -> Vec<EmbeddedPicture> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_pictures, read_tags};
+    use super::*;
 
     /// Regression for the fuzz-discovered WAV OOM vector
     /// (fuzz/artifacts/wav/oom-4a21767820d5f05328f01d975fb6d3314f3fb902):

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -408,4 +408,39 @@ mod tests {
         let ids: Vec<[u8; 4]> = walk_chunks(&buf).iter().map(|(id, _, _)| *id).collect();
         assert_eq!(ids, vec![*b"AAAA", *b"data"]);
     }
+
+    /// A 16-byte PCM `fmt ` payload: mono, 44.1 kHz, 16-bit.
+    fn fmt_pcm() -> Vec<u8> {
+        let mut f = Vec::new();
+        f.extend_from_slice(&1u16.to_le_bytes());
+        f.extend_from_slice(&1u16.to_le_bytes());
+        f.extend_from_slice(&44_100u32.to_le_bytes());
+        f.extend_from_slice(&88_200u32.to_le_bytes());
+        f.extend_from_slice(&2u16.to_le_bytes());
+        f.extend_from_slice(&16u16.to_le_bytes());
+        f
+    }
+
+    #[test]
+    fn locate_requires_fmt_chunk() {
+        // :67 `== → !=`: a data-only WAV (no `fmt `). Original: `any(id == "fmt ")`
+        // is false → NotWav. The `!=` mutant is true (the data chunk is != "fmt ")
+        // → has_fmt, so it returns Ok/Malformed instead of NotWav.
+        let buf = wav(&[(b"data", vec![0x11; 8])]);
+        assert_eq!(locate_audio(&buf), Err(FormatError::NotWav));
+    }
+
+    #[test]
+    fn locate_accepts_data_with_trailing_chunk() {
+        // :71 `> → <`: a valid WAV with a chunk AFTER `data`, so off+len < buf.len.
+        // Original `off+len > buf.len` is false → Ok. The `<` mutant is true →
+        // Malformed.
+        let buf = wav(&[
+            (b"fmt ", fmt_pcm()),
+            (b"data", vec![0x11; 8]),
+            (b"junk", vec![0x00; 4]),
+        ]);
+        let bounds = locate_audio(&buf).unwrap();
+        assert_eq!(bounds.audio_length, 8);
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -550,4 +550,54 @@ mod tests {
         ]);
         assert!(read_tags(&buf).is_empty());
     }
+
+    /// Byte offset, in the assembled stream, of the first `Inline` segment whose
+    /// first four bytes are `fourcc`. Used to assert RIFF word-alignment.
+    fn inline_offset_of(layout: &RegionLayout, fourcc: &[u8; 4]) -> u64 {
+        let mut off = 0u64;
+        for s in &layout.segments {
+            if let Segment::Inline(b) = s {
+                if b.len() >= 4 && &b[0..4] == fourcc {
+                    return off;
+                }
+            }
+            off += s.len();
+        }
+        panic!("no inline chunk starting with {fourcc:?}");
+    }
+
+    #[test]
+    fn synthesize_word_aligns_embedded_id3_chunk() {
+        // :207 `tag_len % 2 == 1` — the pad after the `id3 ` chunk. When tag_len is
+        // odd, the original pads so the following `data` chunk starts on an even
+        // byte (RIFF word-alignment). Both mutants (`/`, `+`) drop that pad for odd
+        // tag_len, landing `data` on an odd offset.
+        //
+        // Find tags whose ID3v2 tag_len is odd (parity depends on id3 framing, so
+        // discover it rather than hard-code). "albumartist" maps to id3 only (no
+        // INFO/LIST chunk), keeping the layout simple.
+        let mut tags = Vec::new();
+        let mut tag_len = 0u64;
+        for n in 1..64 {
+            let cand = vec![TagInput::new("albumartist", &"x".repeat(n))];
+            let (_, tl) = crate::mp3::build_id3v2_segments(&cand, &[]).unwrap();
+            if tl % 2 == 1 {
+                tags = cand;
+                tag_len = tl;
+                break;
+            }
+        }
+        assert_eq!(tag_len % 2, 1, "expected to find an odd-length id3 tag");
+
+        let scan = WavScan {
+            fmt: fmt_pcm(),
+            fact: None,
+        };
+        let layout = synthesize_layout(&scan, 0, 8, &tags, &[]).unwrap();
+        assert_eq!(
+            inline_offset_of(&layout, b"data") % 2,
+            0,
+            "the data chunk must be word-aligned"
+        );
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -359,4 +359,24 @@ mod tests {
             "read_pictures must not OOM on WAV crash artifact"
         );
     }
+
+    #[test]
+    fn riff_wave_start_accepts_exactly_twelve_bytes() {
+        // :24 `< → <=`: a valid 12-byte RIFF/WAVE buffer must be accepted.
+        // The `<=` mutant computes `12 <= 12` (true) and wrongly rejects it.
+        let buf = b"RIFF\0\0\0\0WAVE".to_vec();
+        assert_eq!(buf.len(), 12);
+        assert_eq!(riff_wave_start(&buf), Ok(12));
+    }
+
+    #[test]
+    fn riff_wave_start_rejects_eleven_byte_riff_without_panic() {
+        // :24 `< → ==`: an 11-byte buffer that starts with "RIFF". The original
+        // short-circuits on `len < 12` → NotWav. The `==` mutant computes
+        // `11 == 12` (false), falls through, and indexes `buf[8..12]` on an 11-byte
+        // slice → panic. Asserting the clean Err kills it (panic ≠ Err).
+        let buf = b"RIFF\0\0\0\0WAV".to_vec();
+        assert_eq!(buf.len(), 11);
+        assert_eq!(riff_wave_start(&buf), Err(FormatError::NotWav));
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -443,4 +443,27 @@ mod tests {
         let bounds = locate_audio(&buf).unwrap();
         assert_eq!(bounds.audio_length, 8);
     }
+
+    #[test]
+    fn info_fourcc_emits_each_mapped_key() {
+        // :119-124 arm deletions: each key must map to its INFO FourCC. A deleted
+        // arm makes the key unmapped → no payload (single-tag input → None).
+        let cases: [(&str, &[u8; 4]); 6] = [
+            ("artist", b"IART"),
+            ("album", b"IPRD"),
+            ("date", b"ICRD"),
+            ("genre", b"IGNR"),
+            ("comment", b"ICMT"),
+            ("tracknumber", b"ITRK"),
+        ];
+        for (key, cc) in cases {
+            let payload =
+                build_info_payload(&[TagInput::new(key, "X")]).expect("INFO payload for {key}");
+            assert!(
+                payload.windows(4).any(|w| w == &cc[..]),
+                "key {key} must emit FourCC {:?}",
+                std::str::from_utf8(cc).unwrap()
+            );
+        }
+    }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -198,12 +198,10 @@ pub fn synthesize_layout(
     }
 
     // Embedded `id3 ` chunk: 8-byte chunk header + the ID3v2 tag segments, padded.
-    // Skip degenerate zero-byte art: an empty picture would become an
-    // `ArtImage { len: 0 }`, which `RegionLayout::validate` rejects, bricking the
-    // whole track. Filtering keeps byte-identity untouched (only whether an empty
-    // APIC is emitted changes). Mirrors `flac.rs::synthesize_layout`.
-    let nonempty_arts: Vec<ArtInput> = arts.iter().filter(|a| a.data_len > 0).cloned().collect();
-    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, &nonempty_arts)?;
+    // `build_id3v2_segments` already skips degenerate zero-byte art (finding #16) —
+    // an empty `ArtImage { len: 0 }` would fail `RegionLayout::validate` and brick
+    // the track — so WAV inherits that handling by delegating to it.
+    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, arts)?;
     let mut id3_head = Vec::with_capacity(8);
     id3_head.extend_from_slice(b"id3 ");
     id3_head.extend_from_slice(&(tag_len as u32).to_le_bytes());

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -462,8 +462,8 @@ mod tests {
             ("tracknumber", b"ITRK"),
         ];
         for (key, cc) in cases {
-            let payload =
-                build_info_payload(&[TagInput::new(key, "X")]).expect("INFO payload for {key}");
+            let payload = build_info_payload(&[TagInput::new(key, "X")])
+                .unwrap_or_else(|| panic!("INFO payload for {key}"));
             assert!(
                 payload.windows(4).any(|w| w == &cc[..]),
                 "key {key} must emit FourCC {:?}",

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -379,4 +379,33 @@ mod tests {
         assert_eq!(buf.len(), 11);
         assert_eq!(riff_wave_start(&buf), Err(FormatError::NotWav));
     }
+
+    /// Build a minimal `RIFF/WAVE` buffer from `(fourcc, payload)` chunks in order,
+    /// padding odd payloads to a word boundary (the on-disk RIFF layout).
+    fn wav(chunks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (id, payload) in chunks {
+            body.extend_from_slice(*id);
+            body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            body.extend_from_slice(payload);
+            if payload.len() % 2 == 1 {
+                body.push(0x00);
+            }
+        }
+        let mut out = b"RIFF".to_vec();
+        out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+        out.extend_from_slice(b"WAVE");
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn walk_chunks_advances_past_each_payload() {
+        // :47 the `8 + size (+ size&1)` advance. An odd first payload forces the
+        // word-align term to matter; a wrong advance (either `+ → -`) lands off the
+        // next header, so the second chunk is lost or misread.
+        let buf = wav(&[(b"AAAA", vec![0x11; 3]), (b"data", vec![0xBB; 8])]);
+        let ids: Vec<[u8; 4]> = walk_chunks(&buf).iter().map(|(id, _, _)| *id).collect();
+        assert_eq!(ids, vec![*b"AAAA", *b"data"]);
+    }
 }

--- a/musefs-format/tests/wav_synthesize.rs
+++ b/musefs-format/tests/wav_synthesize.rs
@@ -186,3 +186,83 @@ fn find_chunk(buf: &[u8], id: &[u8; 4]) -> Option<(usize, usize)> {
     }
     None
 }
+
+#[test]
+fn skips_zero_byte_art() {
+    // A degenerate empty embedded picture must not brick the track: synthesis
+    // succeeds, emits no ArtImage segment, and preserves the audio.
+    let audio = vec![0u8; 8];
+    let scan = WavScan {
+        fmt: fmt_pcm_16bit_mono(),
+        fact: None,
+    };
+    let tags = vec![TagInput::new("title", "Empty Art")];
+    let arts = vec![ArtInput {
+        art_id: 1,
+        mime: "image/jpeg".to_string(),
+        description: String::new(),
+        picture_type: 3,
+        width: 0,
+        height: 0,
+        data_len: 0,
+    }];
+
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    assert!(
+        !layout
+            .segments
+            .iter()
+            .any(|s| matches!(s, Segment::ArtImage { .. })),
+        "zero-byte art must not produce an ArtImage segment"
+    );
+
+    let bytes = assemble(&layout, &audio, &[]);
+    let bounds = musefs_format::wav::locate_audio(&bytes).unwrap();
+    assert_eq!(
+        &bytes[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+        &audio[..]
+    );
+}
+
+#[test]
+fn keeps_real_art_when_mixed_with_empty() {
+    let audio = [0u8; 8];
+    let art_bytes = [0xCDu8; 64];
+    let scan = WavScan {
+        fmt: fmt_pcm_16bit_mono(),
+        fact: None,
+    };
+    let tags = vec![TagInput::new("title", "Mixed")];
+    let arts = vec![
+        ArtInput {
+            art_id: 1,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: 0,
+        },
+        ArtInput {
+            art_id: 2,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            picture_type: 3,
+            width: 0,
+            height: 0,
+            data_len: art_bytes.len() as u64,
+        },
+    ];
+
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    let art_segs: Vec<&Segment> = layout
+        .segments
+        .iter()
+        .filter(|s| matches!(s, Segment::ArtImage { .. }))
+        .collect();
+    assert_eq!(art_segs.len(), 1, "only the real art survives");
+    assert!(matches!(
+        art_segs[0],
+        Segment::ArtImage { art_id: 2, len: 64 }
+    ));
+}


### PR DESCRIPTION
## Summary

Phase 3d of the test-audit remediation, scoped to WAV. Kills the 24 killable
`wav.rs` mutation survivors (documents 4 equivalents), broadens
`proptest_read_fidelity` to WAV, and closes finding #16 for WAV with a scoped
zero-byte-art skip — all without touching the byte-identity invariant.

## Changes

- **Mutant kills (`musefs-format/src/wav.rs` test module):** 12 new in-module
  tests covering the 24 killable survivors across `riff_wave_start`, `walk_chunks`,
  `locate_audio`, `info_fourcc`, `build_info_payload`, `push_inline_chunk`,
  `info_to_key`, `read_tags`, and `synthesize_layout`. The 4 equivalent mutants
  (`walk_chunks:49`, `synthesize_layout:186` ×2, `synthesize_layout:227` `>=`) are
  documented in-file with rationale.
- **`fix(wav)` (#16):** `synthesize_layout` now filters `data_len == 0` arts before
  delegating to `mp3::build_id3v2_segments`, so a degenerate empty embedded picture
  no longer becomes an `ArtImage { len: 0 }` that `RegionLayout::validate` rejects
  (which bricked the whole track). Mirrors `flac.rs`'s existing skip; byte-identity
  is untouched.
- **Read-fidelity proptests (#5):** added a `write_wav` fixture to
  `musefs-core/tests/common` and 4 WAV properties (preserve-backing, partial-windows,
  header-seam, art-window) alongside the existing FLAC ones.
- **Docs:** annotated the `wav.rs` rows in the mutation inventory
  (24 killed + 4 equivalent = 28) and marked phase 3d done in the tracking doc.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --workspace`, `cargo test -p musefs-format --features fuzzing` — green
- 13 `wav::tests`, 8 `proptest_read_fidelity` (4 FLAC + 4 WAV), 7 `wav_synthesize`
- Mutation kills and equivalent claims independently re-verified by hand-apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip zero-length embedded artwork during WAV synthesis to prevent broken layouts/validation.

* **New Features**
  * Test utility to write minimal WAV fixtures.
  * Expanded read-fidelity property tests to include WAV scenarios.

* **Tests**
  * Added WAV unit, alignment, and synthesis regression tests plus WAV-specific property-based read tests.

* **Documentation**
  * Added Phase 3d WAV hardening plan, design, and updated mutation inventory/tracking notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->