### PR TITLE
docs: mark all test-audit remediation phases complete

### DIFF
--- a/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
+++ b/docs/superpowers/specs/test-audit-remediation/2026-05-29-remediation-tracking.md
@@ -2,7 +2,7 @@
 
 **Source audit:** `docs/audits/2026-05-29-test-audit.md`
 **Created:** 2026-05-29
-**Status:** Phase 1 complete (harness merged, inventory filled from CI run 26632110192); Phase 2 complete (Ogg hardening); Phase 3a (FLAC) complete; Phase 3b complete (MP3 survivors killed); Phase 3c (MP4) complete; Phase 3d (WAV) complete; Phase 4a (core hardening) complete; Phase 4b (db hardening) complete — campaign 26668141596 confirmed 53 caught / 1 missed (known equivalent) / 0 timeout / 8 unviable (tooling limits), no survivor sweep needed
+**Status:** **ALL PHASES COMPLETE.** Phase 1 (harness merged, inventory filled from CI run 26632110192); Phase 2 (Ogg hardening); Phase 3a (FLAC), 3b (MP3), 3c (MP4), 3d (WAV); Phase 4a (core hardening) and 4b (db hardening) — db campaign 26668141596 confirmed 53 caught / 1 missed (known equivalent) / 0 timeout / 8 unviable (tooling limits), no survivor sweep needed. Audit doc (`docs/audits/2026-05-29-test-audit.md`) marked Phase 4 complete in #53.
 
 ## Guiding principle: verify, don't trust
 
@@ -96,7 +96,7 @@ P1 + all Ogg-related P2 + Ogg mutant kills. Findings #1, #2, #3, #4, #8, #14
 - EOS preservation, reframed from "FLAG_EOS handling" (#14)
 - kill surviving `ogg/` + `ogg_index` mutants (from phase-1 inventory)
 
-### Phase 3 — Format-layer coverage & mutants (non-Ogg)  ⟶ STATUS: in progress
+### Phase 3 — Format-layer coverage & mutants (non-Ogg)  ⟶ STATUS: complete
 
 Findings #5, #16.
 
@@ -139,7 +139,7 @@ Findings #5, #16.
   partial windows, header seam, art window) to MP3; the WAV/MP4 dimensions land in
   their own phases.
 
-### Phase 4 — Core & DB coverage & mutants  ⟶ STATUS: in progress
+### Phase 4 — Core & DB coverage & mutants  ⟶ STATUS: complete
 
 Findings #9, #10, #11, #12, #15.
 


### PR DESCRIPTION
Final status flip for the test-audit remediation tracking doc now that every phase is merged (Phase 1–3 + 4a #51 + 4b #52, audit doc #53).

- Top **Status** line → **ALL PHASES COMPLETE**, with the db campaign summary.
- Phase 3 and Phase 4 section markers flipped from `STATUS: in progress` to `STATUS: complete`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated audit remediation tracking documentation to reflect completion of Phase 1, Phase 3, and Phase 4, including database campaign outcome information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->