### PR TITLE
test(core): deflake debounce-window poll test

### DIFF
--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -376,6 +376,19 @@ impl Musefs {
         self.force_rebuild_error.store(fail, Ordering::Release);
     }
 
+    /// Backdates `last_poll` so the next `poll_refresh` is past the debounce
+    /// window, letting tests cross the window deterministically without sleeping.
+    #[doc(hidden)]
+    pub fn expire_poll_debounce_for_test(&self) {
+        let past = std::time::Instant::now()
+            .checked_sub(self.poll_interval)
+            .unwrap_or_else(std::time::Instant::now);
+        *self
+            .last_poll
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = past;
+    }
+
     pub fn lookup(&self, parent: u64, name: &str) -> Option<u64> {
         self.tree.load().lookup(parent, name)
     }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -382,7 +382,7 @@ impl Musefs {
     pub fn expire_poll_debounce_for_test(&self) {
         let past = std::time::Instant::now()
             .checked_sub(self.poll_interval)
-            .unwrap_or_else(std::time::Instant::now);
+            .expect("poll_interval exceeds monotonic clock base; cannot backdate last_poll");
         *self
             .last_poll
             .lock()

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -477,12 +477,15 @@ fn unchanged_refresh_poll_consumes_debounce_window() {
         )
         .unwrap();
     }
+    // A generous interval keeps the DB-mutation gap below reliably within the
+    // debounce window; the window is crossed via the test hook, not a sleep, so
+    // the assertions don't race wall-clock jitter on a loaded CI runner.
     let cfg = MountConfig {
-        poll_interval: std::time::Duration::from_millis(100),
+        poll_interval: std::time::Duration::from_secs(30),
         ..config()
     };
     let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(150));
+    fs.expire_poll_debounce_for_test();
     assert!(!fs.poll_refresh().unwrap());
     {
         let db2 = musefs_db::Db::open(&db_path).unwrap();
@@ -506,7 +509,7 @@ fn unchanged_refresh_poll_consumes_debounce_window() {
         !fs.poll_refresh().unwrap(),
         "unchanged poll should have reset the debounce window"
     );
-    std::thread::sleep(std::time::Duration::from_millis(150));
+    fs.expire_poll_debounce_for_test();
     assert!(fs.poll_refresh().unwrap());
 }
 


### PR DESCRIPTION
## What

Fixes the flaky `unchanged_refresh_poll_consumes_debounce_window` test that failed the **CI** check on `main`.

## Root cause

The test exercised `poll_refresh`'s debounce window using real wall-clock sleeps with only a ~50ms margin (100ms interval, 150ms sleeps). The key assertion — that a DB change polled immediately after a no-op poll gets debounced — depended on a DB mutation (`open` + `upsert_track` + `replace_tags`) completing within the 100ms window. Under CI load that work overran the window, so the second poll actually ran, detected the change, and returned `true` instead of the expected `false`. It passed every time locally and only failed under CI load.

## Fix

Made the test deterministic instead of timing-dependent:

- Added a `#[doc(hidden)]` test hook `expire_poll_debounce_for_test()` that backdates `last_poll`, mirroring the existing `force_rebuild_errors_for_test` convention.
- Rewrote the test to use a 30s poll interval (so the DB-mutation gap is reliably *inside* the window) and cross the window via the hook rather than `sleep`. No wall-clock races, and it runs faster.

## Verification

- 30/30 passes under full CPU saturation (`yes` on all cores).
- Full `cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` pass (via pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and determinism by removing wall-clock sleep dependencies in polling debounce tests; introduced a test-only mechanism to expire the debounce window so tests run faster and consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sohex/musefs/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->