### PR TITLE
SP0 measurement-foundation harness + per-format bench coverage

### DIFF
--- a/docs/superpowers/plans/2026-05-30-optimization-sp0a-corpus-and-benches.md
+++ b/docs/superpowers/plans/2026-05-30-optimization-sp0a-corpus-and-benches.md
@@ -1,0 +1,1177 @@
+# SP0a — Corpus generator & compute bench suite — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a synthetic music-library generator plus scan/refresh/read benchmarks with comparable reporting, so optimization sub-projects SP1–SP4 are validated against numbers. No production code paths change except an additive metrics field.
+
+**Architecture:** A bench/test-support corpus generator lives in `musefs-core/tests/common/` (already shared by both integration tests and benches via `#[path]`). It writes deterministic backing files using the existing byte builders. Scan/refresh timings are `#[ignore]`d integration tests that print a comparable table (Criterion's resampling does not fit a 100k-file scan); the read path stays in the Criterion bench, generalized to consume the generator and add a concurrent variant. This is the first plan of SP0; the passthrough latency-injection FUSE is a separate plan (SP0b).
+
+**Tech Stack:** Rust, `criterion` 0.8 (read bench, `harness = false`), `#[ignore]`d std tests with `--nocapture` (scan/refresh timing), `tempfile`, `musefs_db::Db`, `musefs_core::{scan_directory, revalidate, Musefs, MountConfig, Mode, VirtualTree}`. Linux `/proc/self/status` for RSS.
+
+**Scope note (read before starting):** This plan delivers the `ci`, `large-compute`, and `bandwidth` tiers, real-mount runs (point `MUSEFS_BENCH_DIR` at any filesystem), and the `custom` / real-library modes — everything that does **not** need `/dev/fuse`. Deterministic latency injection (passthrough FUSE) and the fsync counter are SP0b. Reporting therefore shows `fsyncs: n/a` for these runs; SP0b fills that column.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-optimization-pass/SP0-measurement-foundation.md`
+
+---
+
+## File structure
+
+- Create `musefs-core/tests/common/corpus.rs` — tiers, params, env parsing, deterministic generation.
+- Create `musefs-core/tests/common/report.rs` — `RunReport`, peak-RSS, table printer.
+- Modify `musefs-core/tests/common/mod.rs` — declare the two new submodules; add the moov-at-end M4A builder.
+- Create `musefs-core/tests/bench_ingest.rs` — `#[ignore]`d timed `scan_directory` / `revalidate` reports.
+- Create `musefs-core/tests/bench_refresh.rs` — `#[ignore]`d timed `poll_refresh` reports (1 vs N changed tracks).
+- Modify `musefs-core/benches/read_throughput.rs` — consume the generator; add a concurrent read+walk group.
+
+Module resolution note: Rust resolves `mod corpus;` / `mod report;` relative to the **real** path of `mod.rs` (`musefs-core/tests/common/`), so the submodule files work identically whether `mod.rs` is compiled as a test (`tests/common/mod.rs`) or `#[path]`-included by a bench. Each bench/test binary is its own crate, so `#[path]`-including `common` in several of them is fine (the existing `read_throughput` bench already does this).
+
+---
+
+## Task 1: moov-at-end M4A builder
+
+The generator's format mix must include an M4A whose `moov` follows `mdat` (the SP1 bounded-read hard case). Only a moov-**first** builder (`minimal_m4a`) exists today. The MP4 reader's `locate` finds boxes by scanning top-level atoms, so order does not matter to parsing — verified against `musefs-format/src/mp4.rs`.
+
+**Files:**
+- Modify: `musefs-core/tests/common/mod.rs` (append after `minimal_m4a`, end of file ~line 179)
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (new — exercises `tests/common` helpers through the public scan path)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+mod common;
+
+use common::write_m4a_moov_last;
+use musefs_db::Db;
+use musefs_core::scan_directory;
+
+#[test]
+fn moov_last_m4a_scans_as_one_track() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_off, _len) = write_m4a_moov_last(&dir.path().join("a.m4a"), &[0x11u8; 256]);
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(stats.scanned, 1, "moov-at-end M4A should probe & ingest");
+    assert_eq!(stats.skipped, 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke moov_last -- --nocapture`
+Expected: FAIL — `cannot find function write_m4a_moov_last in module common`.
+
+- [ ] **Step 3: Implement the builder**
+
+Append to `musefs-core/tests/common/mod.rs`. It reuses the existing private `bx` / `m4a_data_atom` helpers and mirrors `minimal_m4a`, but emits `[ftyp, mdat, moov]` and patches the `stco` chunk offset to the (now earlier) `mdat` payload start:
+
+```rust
+/// Build a minimal valid M4A with `moov` AFTER `mdat` (the SP1 bounded-read hard
+/// case). Same box contents as `minimal_m4a`; only top-level order differs. The
+/// MP4 reader locates boxes by scanning, so order does not affect parsing.
+pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
+    let ilst_atoms = [
+        bx(b"\xa9nam", &m4a_data_atom(1, b"Orig M4A")),
+        bx(b"\xa9ART", &m4a_data_atom(1, b"Orig Artist")),
+    ]
+    .concat();
+    let ilst = bx(b"ilst", &ilst_atoms);
+
+    let mut meta_hdlr = vec![0u8; 8];
+    meta_hdlr.extend_from_slice(b"mdir");
+    meta_hdlr.extend_from_slice(b"appl");
+    meta_hdlr.extend_from_slice(&[0u8; 9]);
+    let mut meta = vec![0u8; 4];
+    meta.extend(bx(b"hdlr", &meta_hdlr));
+    meta.extend(ilst);
+    let udta = bx(b"udta", &bx(b"meta", &meta));
+
+    let mut soun_hdlr = vec![0u8; 8];
+    soun_hdlr.extend_from_slice(b"soun");
+    soun_hdlr.extend_from_slice(&[0u8; 12]);
+    let mut stco = vec![0u8; 4];
+    stco.extend_from_slice(&1u32.to_be_bytes());
+    stco.extend_from_slice(&0u32.to_be_bytes());
+    let minf = bx(b"minf", &bx(b"stbl", &bx(b"stco", &stco)));
+    let trak = bx(
+        b"trak",
+        &bx(b"mdia", &[bx(b"hdlr", &soun_hdlr), minf].concat()),
+    );
+    let moov = bx(b"moov", &[bx(b"mvhd", &[0u8; 8]), trak, udta].concat());
+    let ftyp = bx(b"ftyp", b"M4A isom");
+    let mdat = bx(b"mdat", mdat_payload);
+
+    // Order: ftyp, mdat, moov. The mdat payload starts right after ftyp + mdat header.
+    let mut out = [ftyp, mdat, moov].concat();
+    let mdat_payload_offset = {
+        // ftyp len + mdat header (8) is where the payload begins.
+        let ftyp_len = 8 + b"M4A isom".len();
+        (ftyp_len + 8) as u32
+    };
+    let stco = out
+        .windows(4)
+        .position(|w| w == b"stco")
+        .expect("stco present");
+    let entry = stco + 4 + 4 + 4;
+    out[entry..entry + 4].copy_from_slice(&mdat_payload_offset.to_be_bytes());
+    out
+}
+
+/// Write a moov-at-end M4A to `path`, returning (audio_offset, audio_length) of
+/// the verbatim `mdat` payload.
+pub fn write_m4a_moov_last(path: &std::path::Path, audio: &[u8]) -> (i64, i64) {
+    let bytes = minimal_m4a_moov_last(audio);
+    let ftyp_len = 8 + b"M4A isom".len();
+    let audio_offset = (ftyp_len + 8) as i64;
+    std::fs::write(path, &bytes).unwrap();
+    (audio_offset, audio.len() as i64)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke moov_last -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/common/mod.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "test(core): add moov-at-end M4A builder for the corpus generator"
+```
+
+---
+
+## Task 2: Corpus params, tiers, and env parsing
+
+**Files:**
+- Create: `musefs-core/tests/common/corpus.rs`
+- Modify: `musefs-core/tests/common/mod.rs` (add `pub mod corpus;` near the top, after the `use` line)
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+use common::corpus::{CorpusParams, Tier};
+
+#[test]
+fn tier_presets_have_expected_shape() {
+    let ci = CorpusParams::for_tier(Tier::Ci);
+    assert_eq!(ci.track_count(), 200);
+    assert_eq!(ci.art_bytes_per_track, 0, "ci omits embedded art");
+
+    let lc = CorpusParams::for_tier(Tier::LargeCompute);
+    assert_eq!(lc.track_count(), 100_000);
+    assert!(lc.art_bytes_per_track > 0, "large-compute embeds a cover");
+
+    let bw = CorpusParams::for_tier(Tier::Bandwidth);
+    assert!(bw.bytes_per_track >= 1_000_000, "bandwidth uses realistic payloads");
+}
+
+#[test]
+fn env_overrides_apply_over_tier() {
+    std::env::set_var("MUSEFS_BENCH_TIER", "ci");
+    std::env::set_var("MUSEFS_BENCH_ALBUMS", "3");
+    std::env::set_var("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
+    let p = CorpusParams::from_env();
+    std::env::remove_var("MUSEFS_BENCH_ALBUMS");
+    std::env::remove_var("MUSEFS_BENCH_TRACKS_PER_ALBUM");
+    std::env::remove_var("MUSEFS_BENCH_TIER");
+    assert_eq!(p.albums, 3);
+    assert_eq!(p.tracks_per_album, 4);
+    assert_eq!(p.track_count(), 12);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke tier_presets -- --nocapture`
+Expected: FAIL — `unresolved import common::corpus`.
+
+- [ ] **Step 3: Implement params + tiers + env parsing**
+
+Add to `musefs-core/tests/common/mod.rs` (after `use std::path::Path;`):
+
+```rust
+pub mod corpus;
+```
+
+Create `musefs-core/tests/common/corpus.rs`:
+
+```rust
+//! Deterministic synthetic-library generator for the SP0 bench harness.
+//! Shared by `#[ignore]`d timing tests and the read Criterion bench.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Tier {
+    Ci,
+    LargeCompute,
+    Bandwidth,
+    Custom,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    Flac,
+    Mp3,
+    M4aMoovFirst,
+    M4aMoovLast,
+    Wav,
+}
+
+#[derive(Clone, Debug)]
+pub struct CorpusParams {
+    pub albums: usize,
+    pub tracks_per_album: usize,
+    /// Audio payload bytes per track (file size = payload + format front + art).
+    pub bytes_per_track: usize,
+    /// Embedded cover bytes per track (0 = no embedded art). One shared cover
+    /// per album, so the content-addressed `art` table dedups across the album.
+    pub art_bytes_per_track: usize,
+    /// Round-robin formats. Default `[Flac]`.
+    pub format_mix: Vec<Format>,
+    pub seed: u64,
+}
+
+impl CorpusParams {
+    pub fn track_count(&self) -> usize {
+        self.albums * self.tracks_per_album
+    }
+
+    pub fn for_tier(t: Tier) -> Self {
+        match t {
+            // ~200 tracks, tiny, no art — runs in seconds.
+            Tier::Ci => CorpusParams {
+                albums: 20,
+                tracks_per_album: 10,
+                bytes_per_track: 4 * 1024,
+                art_bytes_per_track: 0,
+                format_mix: vec![Format::Flac],
+                seed: 1,
+            },
+            // 100k tracks, ~8 KB payload + one shared ~30 KB cover/album (deduped).
+            Tier::LargeCompute => CorpusParams {
+                albums: 10_000,
+                tracks_per_album: 10,
+                bytes_per_track: 8 * 1024,
+                art_bytes_per_track: 30 * 1024,
+                format_mix: vec![Format::Flac],
+                seed: 1,
+            },
+            // ~1k tracks, realistic payload — real-mount throughput.
+            Tier::Bandwidth => CorpusParams {
+                albums: 100,
+                tracks_per_album: 10,
+                bytes_per_track: 30 * 1024 * 1024,
+                art_bytes_per_track: 200 * 1024,
+                format_mix: vec![Format::Flac],
+                seed: 1,
+            },
+            // Defaults equal to ci; every dimension is env-overridable.
+            Tier::Custom => CorpusParams::for_tier(Tier::Ci),
+        }
+    }
+
+    /// Read `MUSEFS_BENCH_TIER` (default `ci`) then apply any `MUSEFS_BENCH_*`
+    /// overrides. `MUSEFS_BENCH_FORMAT_MIX` is a comma list of
+    /// flac|mp3|m4a|m4a-last|wav.
+    pub fn from_env() -> Self {
+        let tier = match std::env::var("MUSEFS_BENCH_TIER").as_deref() {
+            Ok("large-compute") => Tier::LargeCompute,
+            Ok("bandwidth") => Tier::Bandwidth,
+            Ok("custom") => Tier::Custom,
+            _ => Tier::Ci,
+        };
+        let mut p = CorpusParams::for_tier(tier);
+        if let Some(v) = env_usize("MUSEFS_BENCH_ALBUMS") {
+            p.albums = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_TRACKS_PER_ALBUM") {
+            p.tracks_per_album = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_BYTES_PER_TRACK") {
+            p.bytes_per_track = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_ART_PER_ALBUM") {
+            p.art_bytes_per_track = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_SEED") {
+            p.seed = v as u64;
+        }
+        if let Ok(mix) = std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
+            let parsed: Vec<Format> = mix
+                .split(',')
+                .filter_map(|s| match s.trim() {
+                    "flac" => Some(Format::Flac),
+                    "mp3" => Some(Format::Mp3),
+                    "m4a" => Some(Format::M4aMoovFirst),
+                    "m4a-last" => Some(Format::M4aMoovLast),
+                    "wav" => Some(Format::Wav),
+                    _ => None,
+                })
+                .collect();
+            if !parsed.is_empty() {
+                p.format_mix = parsed;
+            }
+        }
+        p
+    }
+}
+
+fn env_usize(key: &str) -> Option<usize> {
+    std::env::var(key).ok().and_then(|s| s.parse().ok())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke tier_presets -- --nocapture`
+Run: `cargo test -p musefs-core --test common_corpus_smoke env_overrides -- --nocapture`
+Expected: PASS both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/common/mod.rs musefs-core/tests/common/corpus.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "test(core): corpus params, tier presets, and env overrides"
+```
+
+---
+
+## Task 3: Deterministic generation (FLAC, with optional embedded art)
+
+**Files:**
+- Modify: `musefs-core/tests/common/corpus.rs` (add `generate` + helpers)
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+use common::corpus::{generate, Format};
+use musefs_db::Db as Db2; // alias to avoid clashing with the Task-1 `Db` import
+
+#[test]
+fn generate_is_deterministic_and_scans_all_tracks() {
+    let p = CorpusParams {
+        albums: 2,
+        tracks_per_album: 3,
+        bytes_per_track: 512,
+        art_bytes_per_track: 64,
+        format_mix: vec![Format::Flac],
+        seed: 7,
+    };
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    let files_a = generate(a.path(), &p);
+    let files_b = generate(b.path(), &p);
+    assert_eq!(files_a.len(), 6);
+    // Determinism: same relative names and identical bytes for the first file.
+    let first_a = std::fs::read(&files_a[0]).unwrap();
+    let first_b = std::fs::read(&files_b[0]).unwrap();
+    assert_eq!(first_a, first_b, "same (params, seed) => identical bytes");
+
+    let db = Db2::open_in_memory().unwrap();
+    let stats = musefs_core::scan_directory(&db, a.path()).unwrap();
+    assert_eq!(stats.scanned, 6);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke generate_is_deterministic -- --nocapture`
+Expected: FAIL — `cannot find function generate`.
+
+- [ ] **Step 3: Implement generation**
+
+Append to `musefs-core/tests/common/corpus.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// Deterministic filler audio: a seedable byte ramp (content is irrelevant —
+/// `BackingAudio` is served verbatim and probing reads only headers).
+fn filler(seed: u64, idx: usize, len: usize) -> Vec<u8> {
+    let base = seed.wrapping_add(idx as u64).wrapping_mul(2654435761);
+    (0..len).map(|i| (base.wrapping_add(i as u64) & 0xFF) as u8).collect()
+}
+
+/// One shared cover per album so the content-addressed `art` table dedups.
+fn cover(seed: u64, album: usize, len: usize) -> Vec<u8> {
+    filler(seed ^ 0xC0FFEE, album.wrapping_mul(101).wrapping_add(1), len)
+}
+
+/// A FLAC with STREAMINFO + comments + (optionally) a PICTURE block + audio.
+/// Mirrors `tests/common/scan.rs`'s `flac_with_picture` layout.
+fn flac_bytes(comments: &[String], art: Option<&[u8]>, audio: &[u8]) -> Vec<u8> {
+    use super::{flac_block, streaminfo_body, vorbis_comment_body};
+    let refs: Vec<&str> = comments.iter().map(|s| s.as_str()).collect();
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    let last_meta = art.is_none();
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("musefs-bench", &refs), last_meta));
+    if let Some(img) = art {
+        let mut body = Vec::new();
+        body.extend_from_slice(&3u32.to_be_bytes()); // picture type: front cover
+        body.extend_from_slice(&(b"image/png".len() as u32).to_be_bytes());
+        body.extend_from_slice(b"image/png");
+        body.extend_from_slice(&0u32.to_be_bytes()); // description len
+        body.extend_from_slice(&0u32.to_be_bytes()); // width
+        body.extend_from_slice(&0u32.to_be_bytes()); // height
+        body.extend_from_slice(&0u32.to_be_bytes()); // depth
+        body.extend_from_slice(&0u32.to_be_bytes()); // colors
+        body.extend_from_slice(&(img.len() as u32).to_be_bytes());
+        body.extend_from_slice(img);
+        out.extend_from_slice(&flac_block(6, &body, true));
+    }
+    out.extend_from_slice(audio);
+    out
+}
+
+/// Generate the corpus into `dir` (created if missing). Layout is
+/// `dir/album-{a}/track-{t}.{ext}`. Returns created file paths in stable order.
+pub fn generate(dir: &Path, p: &CorpusParams) -> Vec<PathBuf> {
+    std::fs::create_dir_all(dir).unwrap();
+    let mut paths = Vec::with_capacity(p.track_count());
+    let mut idx = 0usize;
+    for album in 0..p.albums {
+        let adir = dir.join(format!("album-{album:05}"));
+        std::fs::create_dir_all(&adir).unwrap();
+        let art_blob = (p.art_bytes_per_track > 0)
+            .then(|| cover(p.seed, album, p.art_bytes_per_track));
+        for track in 0..p.tracks_per_album {
+            let fmt = p.format_mix[idx % p.format_mix.len()];
+            let audio = filler(p.seed, idx, p.bytes_per_track);
+            let comments = vec![
+                format!("ARTIST=Artist {album:05}"),
+                format!("ALBUM=Album {album:05}"),
+                format!("TITLE=Track {track:03}"),
+            ];
+            let path = generate_one(&adir, idx, fmt, &comments, art_blob.as_deref(), &audio);
+            paths.push(path);
+            idx += 1;
+        }
+    }
+    paths
+}
+
+fn generate_one(
+    adir: &Path,
+    idx: usize,
+    fmt: Format,
+    comments: &[String],
+    art: Option<&[u8]>,
+    audio: &[u8],
+) -> PathBuf {
+    match fmt {
+        Format::Flac => {
+            let path = adir.join(format!("track-{idx:06}.flac"));
+            std::fs::write(&path, flac_bytes(comments, art, audio)).unwrap();
+            path
+        }
+        Format::Mp3 => {
+            let path = adir.join(format!("track-{idx:06}.mp3"));
+            super::write_mp3(&path, audio);
+            path
+        }
+        Format::M4aMoovFirst => {
+            let path = adir.join(format!("track-{idx:06}.m4a"));
+            super::write_m4a(&path, audio);
+            path
+        }
+        Format::M4aMoovLast => {
+            let path = adir.join(format!("track-{idx:06}.m4a"));
+            super::write_m4a_moov_last(&path, audio);
+            path
+        }
+        Format::Wav => {
+            let path = adir.join(format!("track-{idx:06}.wav"));
+            super::write_wav(&path, audio);
+            path
+        }
+    }
+}
+```
+
+Note: non-FLAC formats here carry tags via the DB at scan time the same way the existing builders do; embedded art is only generated for FLAC (the only builder with a picture block). This is sufficient — the default mix is FLAC-only and art exercises the FLAC synthesis path.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke generate_is_deterministic -- --nocapture`
+Expected: PASS (6 files, identical first-file bytes, all 6 scanned).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/common/corpus.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "test(core): deterministic corpus generation with optional FLAC art"
+```
+
+---
+
+## Task 4: Target resolution (generate vs real-library) + DB path
+
+**Files:**
+- Modify: `musefs-core/tests/common/corpus.rs` (add `Target` + `prepare`)
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (add case)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+use common::corpus::prepare;
+
+#[test]
+fn prepare_generates_when_no_library_set() {
+    std::env::remove_var("MUSEFS_BENCH_LIBRARY");
+    let scratch = tempfile::tempdir().unwrap();
+    std::env::set_var("MUSEFS_BENCH_DIR", scratch.path());
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: 2,
+        bytes_per_track: 128,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 3,
+    };
+    let t = prepare(&p);
+    std::env::remove_var("MUSEFS_BENCH_DIR");
+    assert!(t.corpus_dir.exists());
+    assert!(!t.is_real_library);
+    // DB path is separate from the corpus dir.
+    assert_ne!(t.db_path, t.corpus_dir);
+    let db = Db2::open(&t.db_path).unwrap();
+    let stats = musefs_core::scan_directory(&db, &t.corpus_dir).unwrap();
+    assert_eq!(stats.scanned, 2);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke prepare_generates -- --nocapture`
+Expected: FAIL — `cannot find function prepare`.
+
+- [ ] **Step 3: Implement target resolution**
+
+Append to `musefs-core/tests/common/corpus.rs`:
+
+```rust
+/// Where the corpus and DB live for a run, and whether it was generated.
+pub struct Target {
+    pub corpus_dir: PathBuf,
+    pub db_path: PathBuf,
+    pub is_real_library: bool,
+    /// Held to keep a tempdir alive for the run when one was created.
+    _scratch: Option<tempfile::TempDir>,
+}
+
+/// Resolve the run target:
+/// - `MUSEFS_BENCH_LIBRARY` set -> scan that real directory in place (never
+///   written to); DB goes to `MUSEFS_BENCH_DB` or a fresh tempfile.
+/// - else generate the corpus under `MUSEFS_BENCH_DIR` (or a tempdir) and put
+///   the DB alongside under a separate `musefs-bench.db` name.
+pub fn prepare(p: &CorpusParams) -> Target {
+    if let Ok(lib) = std::env::var("MUSEFS_BENCH_LIBRARY") {
+        let scratch = tempfile::tempdir().unwrap();
+        let db_path = std::env::var("MUSEFS_BENCH_DB")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| scratch.path().join("musefs-bench.db"));
+        return Target {
+            corpus_dir: PathBuf::from(lib),
+            db_path,
+            is_real_library: true,
+            _scratch: Some(scratch),
+        };
+    }
+    let (corpus_dir, scratch) = match std::env::var("MUSEFS_BENCH_DIR") {
+        Ok(d) => (PathBuf::from(d), None),
+        Err(_) => {
+            let s = tempfile::tempdir().unwrap();
+            (s.path().to_path_buf(), Some(s))
+        }
+    };
+    generate(&corpus_dir, p);
+    let db_path = std::env::var("MUSEFS_BENCH_DB")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| corpus_dir.join("musefs-bench.db"));
+    Target {
+        corpus_dir,
+        db_path,
+        is_real_library: false,
+        _scratch: scratch,
+    }
+}
+```
+
+Add `tempfile` is already a dev-dependency, so it is in scope for test/bench code.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke prepare_generates -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/common/corpus.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "test(core): target resolution for generated vs real-library runs"
+```
+
+---
+
+## Task 5: Reporting (peak RSS + comparable table)
+
+**Files:**
+- Create: `musefs-core/tests/common/report.rs`
+- Modify: `musefs-core/tests/common/mod.rs` (add `pub mod report;`)
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (add case)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+use common::report::{peak_rss_kib, RunReport};
+
+#[test]
+fn report_renders_a_row() {
+    let r = RunReport {
+        label: "scan".into(),
+        tier: "ci".into(),
+        storage: "tempfs".into(),
+        wall_ms: 1234,
+        opens: 200,
+        preads: 200,
+        fsyncs: None,
+        peak_rss_kib: Some(50_000),
+    };
+    let line = r.row();
+    assert!(line.contains("scan"));
+    assert!(line.contains("ci"));
+    assert!(line.contains("n/a"), "fsyncs None renders as n/a");
+    // RSS is readable and positive on Linux.
+    assert!(peak_rss_kib().unwrap_or(1) > 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke report_renders -- --nocapture`
+Expected: FAIL — `unresolved import common::report`.
+
+- [ ] **Step 3: Implement reporting**
+
+Add to `musefs-core/tests/common/mod.rs`:
+
+```rust
+pub mod report;
+```
+
+Create `musefs-core/tests/common/report.rs`:
+
+```rust
+//! Comparable run reporting for the SP0 bench harness.
+
+/// One measured run. `fsyncs`/`peak_rss_kib` are `None` when not applicable
+/// (e.g. fsyncs need the SP0b passthrough FS; RSS is meaningful only in-process).
+pub struct RunReport {
+    pub label: String,
+    pub tier: String,
+    pub storage: String,
+    pub wall_ms: u128,
+    pub opens: u64,
+    pub preads: u64,
+    pub fsyncs: Option<u64>,
+    pub peak_rss_kib: Option<u64>,
+}
+
+impl RunReport {
+    pub fn header() -> String {
+        format!(
+            "{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+            "label", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib"
+        )
+    }
+
+    pub fn row(&self) -> String {
+        let opt = |v: Option<u64>| v.map(|x| x.to_string()).unwrap_or_else(|| "n/a".into());
+        format!(
+            "{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+            self.label,
+            self.tier,
+            self.storage,
+            self.wall_ms,
+            self.opens,
+            self.preads,
+            opt(self.fsyncs),
+            opt(self.peak_rss_kib),
+        )
+    }
+}
+
+/// Peak resident set size (high-water mark) in KiB, from `/proc/self/status`
+/// `VmHWM`. Linux only; `None` elsewhere or if unreadable.
+pub fn peak_rss_kib() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
+            return rest.trim().trim_end_matches(" kB").trim().parse().ok();
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke report_renders -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/common/mod.rs musefs-core/tests/common/report.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "test(core): comparable run reporting (peak RSS + table row)"
+```
+
+---
+
+## Task 6: Scan/ingest timing bench (`#[ignore]`d)
+
+**Files:**
+- Create: `musefs-core/tests/bench_ingest.rs`
+
+- [ ] **Step 1: Write the test (an `#[ignore]`d timing harness)**
+
+Create `musefs-core/tests/bench_ingest.rs`:
+
+```rust
+mod common;
+
+use std::time::Instant;
+
+use common::corpus::{prepare, CorpusParams};
+use common::report::{peak_rss_kib, RunReport};
+use musefs_core::{metrics, revalidate, scan_directory};
+use musefs_db::Db;
+
+fn storage_label(t: &common::corpus::Target) -> String {
+    if t.is_real_library {
+        "real-lib".into()
+    } else if std::env::var("MUSEFS_BENCH_DIR").is_ok() {
+        "env-dir".into()
+    } else {
+        "tempfs".into()
+    }
+}
+
+#[test]
+#[ignore = "SP0 timing harness; run with --ignored --nocapture"]
+fn bench_cold_scan_and_revalidate() {
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    let target = prepare(&params);
+    let storage = storage_label(&target);
+
+    let db = Db::open(&target.db_path).unwrap();
+
+    metrics::reset();
+    let t0 = Instant::now();
+    let stats = scan_directory(&db, &target.corpus_dir).unwrap();
+    let scan_ms = t0.elapsed().as_millis();
+    let s = metrics::snapshot();
+
+    // Second pass: revalidate should skip unchanged files (cheap).
+    metrics::reset();
+    let t1 = Instant::now();
+    let _ = revalidate(&db, &target.corpus_dir).unwrap();
+    let reval_ms = t1.elapsed().as_millis();
+
+    println!("\n{}", RunReport::header());
+    println!(
+        "{}",
+        RunReport {
+            label: "scan".into(),
+            tier: tier.clone(),
+            storage: storage.clone(),
+            wall_ms: scan_ms,
+            opens: s.opens,
+            preads: s.preads,
+            fsyncs: None,
+            peak_rss_kib: peak_rss_kib(),
+        }
+        .row()
+    );
+    println!(
+        "{}",
+        RunReport {
+            label: "revalidate".into(),
+            tier,
+            storage,
+            wall_ms: reval_ms,
+            opens: 0,
+            preads: 0,
+            fsyncs: None,
+            peak_rss_kib: peak_rss_kib(),
+        }
+        .row()
+    );
+    println!("scanned={} skipped={}\n", stats.scanned, stats.skipped);
+    assert!(stats.scanned > 0);
+}
+```
+
+Note: the `metrics` counters instrument the **serve** path
+(`read_at`/`open_handle`/`read_segments`), not the scan path — so `opens`/`preads`
+read ≈0 during a pure scan even with `--features metrics`. The SP1-relevant
+signals in this bench are **`wall_ms`** and **`peak_rss_kib`**; the latter
+captures SP1's whole-file-`fs::read` memory spike (the headline SP1 problem).
+Reporting the ≈0 serve counters is intentional and harmless. (Per-file scan I/O
+counting is added in SP1 when `scan.rs` is being modified, not here.)
+
+- [ ] **Step 2: Run it (ci tier) to verify it runs and reports**
+
+Run: `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture`
+Expected: PASS, prints a two-row table; `scanned` equals the ci track count (200) on a fresh tempfs run. `wall_ms` and `rss_kib` are populated; `opens`/`preads` are ≈0 (see note above).
+
+- [ ] **Step 3: Verify it does nothing under a normal test run**
+
+Run: `cargo test -p musefs-core --test bench_ingest`
+Expected: `0 passed; ... 1 ignored` — it stays out of the default suite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/tests/bench_ingest.rs
+git commit -m "test(core): SP0 cold-scan + revalidate timing harness"
+```
+
+---
+
+## Task 7: Refresh timing bench (`#[ignore]`d, 1 vs N changed)
+
+This records the baseline SP2 attacks: a full tree rebuild after touching 1 vs N tracks. Mutate tags through a second `Db` connection on the same file (bumps `data_version` whole-DB + `content_version` via triggers), then time `poll_refresh`. Disable debounce with `poll_interval = ZERO`.
+
+**Files:**
+- Create: `musefs-core/tests/bench_refresh.rs`
+
+- [ ] **Step 1: Write the `#[ignore]`d harness**
+
+Create `musefs-core/tests/bench_refresh.rs`:
+
+```rust
+mod common;
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use common::corpus::{prepare, CorpusParams};
+use common::report::RunReport;
+use musefs_core::{scan_directory, Mode, Musefs, MountConfig};
+use musefs_db::Db;
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$album/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: Duration::ZERO, // no debounce: each poll actually polls
+    }
+}
+
+/// Re-tag `count` tracks via a separate connection, then time the refresh.
+fn time_refresh(db_path: &std::path::Path, fs: &Musefs, count: usize) -> u128 {
+    let writer = Db::open(db_path).unwrap();
+    let tracks = writer.list_tracks().unwrap();
+    for t in tracks.iter().take(count) {
+        // Append a tag so content_version + data_version bump.
+        writer
+            .replace_tags(
+                t.id,
+                &[musefs_db::Tag::new("COMMENT", "bench-touch", 0)],
+            )
+            .unwrap();
+    }
+    let t0 = Instant::now();
+    fs.poll_refresh();
+    t0.elapsed().as_millis()
+}
+
+#[test]
+#[ignore = "SP0 timing harness; run with --ignored --nocapture"]
+fn bench_refresh_one_vs_many() {
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    let target = prepare(&params);
+
+    let db = Db::open(&target.db_path).unwrap();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let one_ms = time_refresh(&target.db_path, &fs, 1);
+    let many = (params.track_count() / 2).max(1);
+    let many_ms = time_refresh(&target.db_path, &fs, many);
+
+    println!("\n{}", RunReport::header());
+    for (label, ms) in [("refresh-1", one_ms), ("refresh-N", many_ms)] {
+        println!(
+            "{}",
+            RunReport {
+                label: label.into(),
+                tier: tier.clone(),
+                storage: "tempfs".into(),
+                wall_ms: ms,
+                opens: 0,
+                preads: 0,
+                fsyncs: None,
+                peak_rss_kib: None,
+            }
+            .row()
+        );
+    }
+    println!("touched_many={many}\n");
+}
+```
+
+Note: this assumes `Db::list_tracks`, `Db::replace_tags`, and `musefs_db::Tag::new` are public (confirmed in `musefs-db/src/tracks.rs` / `tags.rs` / `models.rs`). If `musefs_db::Tag` is not re-exported at the crate root, use `musefs_db::models::Tag`.
+
+- [ ] **Step 2: Run it (ci tier)**
+
+Run: `cargo test -p musefs-core --test bench_refresh -- --ignored --nocapture`
+Expected: PASS, prints `refresh-1` and `refresh-N` rows. On ci both are small and similar (the current rebuild is full — that is the SP2 baseline).
+
+- [ ] **Step 3: Verify ignored in normal runs**
+
+Run: `cargo test -p musefs-core --test bench_refresh`
+Expected: `0 passed; ... 1 ignored`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/tests/bench_refresh.rs
+git commit -m "test(core): SP0 refresh timing harness (1 vs N changed)"
+```
+
+---
+
+## Task 8: Generalize the read bench + add a concurrent variant
+
+**Files:**
+- Modify: `musefs-core/benches/read_throughput.rs`
+
+- [ ] **Step 1: Replace the bench body to consume the generator and add concurrency**
+
+Rewrite `musefs-core/benches/read_throughput.rs` as:
+
+```rust
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::thread;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use musefs_core::{scan_directory, Mode, Musefs, MountConfig, VirtualTree};
+
+#[path = "../tests/common/mod.rs"]
+mod common;
+use common::corpus::{generate, CorpusParams, Format};
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$album/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+    }
+}
+
+/// A small generated corpus with a few MB of audio per track, scanned into an
+/// in-memory DB and mounted. Returns the fs plus all file inodes.
+fn fixture(bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: tracks,
+        bytes_per_track,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 42,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    generate(dir.path(), &p);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Arc::new(Musefs::open(db, config()).unwrap());
+
+    // Walk the single album dir to collect file inodes.
+    let album = fs.lookup(VirtualTree::ROOT, "Artist 00000").unwrap();
+    let sub = fs.readdir(album).unwrap()[0].1; // Album 00000 dir
+    let inodes: Vec<u64> = fs.readdir(sub).unwrap().into_iter().map(|(_, ino, _)| ino).collect();
+    // Keep the tempdir alive for the duration of the bench by leaking it.
+    std::mem::forget(dir);
+    (fs, inodes)
+}
+
+fn bench_sequential_read(c: &mut Criterion) {
+    let (fs, inodes) = fixture(4 * 1024 * 1024, 1);
+    let inode = inodes[0];
+    let size = fs.getattr(inode).unwrap().size;
+    let mut group = c.benchmark_group("sequential_read");
+    group.throughput(Throughput::Bytes(size));
+    let chunk = 128 * 1024u64;
+    group.bench_function("flac_128k_chunks", |b| {
+        b.iter(|| {
+            let mut off = 0u64;
+            while off < size {
+                let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
+                if got.is_empty() {
+                    break;
+                }
+                off += got.len() as u64;
+            }
+        });
+    });
+    group.finish();
+}
+
+fn bench_concurrent_read_and_walk(c: &mut Criterion) {
+    // M reader threads streaming distinct files + one metadata walker, sharing
+    // one Arc<Musefs>. Exercises handles/size_cache mutex contention (SP3).
+    let m = std::env::var("MUSEFS_BENCH_READERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| num_streams());
+    let (fs, inodes) = fixture(1024 * 1024, m.max(2));
+
+    let mut group = c.benchmark_group("concurrent_read_walk");
+    group.bench_function(format!("m{m}_plus_walker"), |b| {
+        b.iter(|| {
+            let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            // Walker thread: loop lookups/getattrs over the inodes.
+            let walker = {
+                let fs = Arc::clone(&fs);
+                let inodes = inodes.clone();
+                let stop = Arc::clone(&stop);
+                thread::spawn(move || {
+                    while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                        for &ino in &inodes {
+                            let _ = std::hint::black_box(fs.getattr(ino));
+                        }
+                    }
+                })
+            };
+            let readers: Vec<_> = (0..m)
+                .map(|i| {
+                    let fs = Arc::clone(&fs);
+                    let ino = inodes[i % inodes.len()];
+                    thread::spawn(move || {
+                        // open_handle + per-handle reads exercise the `handles`
+                        // mutex (SP3); the walker's getattr exercises `size_cache`.
+                        let fh = fs.open_handle(ino).unwrap();
+                        let size = fs.getattr(ino).unwrap().size;
+                        let mut off = 0u64;
+                        while off < size {
+                            let got = fs.read(ino, fh, off, 128 * 1024).unwrap();
+                            if got.is_empty() {
+                                break;
+                            }
+                            off += got.len() as u64;
+                        }
+                        fs.release_handle(fh);
+                    })
+                })
+                .collect();
+            for r in readers {
+                r.join().unwrap();
+            }
+            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            walker.join().unwrap();
+        });
+    });
+    group.finish();
+}
+
+fn num_streams() -> usize {
+    std::thread::available_parallelism().map(|n| n.get() * 2).unwrap_or(4)
+}
+
+criterion_group!(benches, bench_sequential_read, bench_concurrent_read_and_walk);
+criterion_main!(benches);
+```
+
+- [ ] **Step 2: Run the bench (quick smoke)**
+
+Run: `cargo bench -p musefs-core --bench read_throughput -- --warm-up-time 1 --measurement-time 2`
+Expected: both `sequential_read/flac_128k_chunks` and `concurrent_read_walk/mN_plus_walker` report timings without panicking.
+
+- [ ] **Step 3: Confirm the workspace still builds/tests clean**
+
+Run: `cargo test -p musefs-core`
+Expected: all existing tests PASS; the new `#[ignore]`d benches stay ignored.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/benches/read_throughput.rs
+git commit -m "bench(core): drive read bench from the corpus generator; add concurrent read+walk"
+```
+
+---
+
+## Task 9: Document the harness in the spec directory README
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-30-optimization-pass/README.md` (status table + a short "How to run SP0a" section)
+
+- [ ] **Step 1: Update the SP0 status row and add run instructions**
+
+In the Status table, change the SP0 row to `Harness (SP0a) implemented; SP0b pending`. Append a section:
+
+```markdown
+## Running the SP0a harness
+
+```bash
+# Read throughput + concurrent read/walk (Criterion):
+cargo bench -p musefs-core --bench read_throughput
+
+# Cold scan + revalidate timing (prints a table):
+cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
+
+# Refresh timing, 1 vs N changed tracks:
+cargo test -p musefs-core --test bench_refresh -- --ignored --nocapture
+
+# Scale / storage knobs (any of the timing/bench commands above):
+MUSEFS_BENCH_TIER=large-compute \
+MUSEFS_BENCH_DIR=/mnt/ssd/musefs-bench \
+  cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
+
+# Run against a real library (never written to; DB goes to MUSEFS_BENCH_DB or a tempfile):
+MUSEFS_BENCH_LIBRARY=/srv/music \
+MUSEFS_BENCH_DB=/tmp/musefs-bench.db \
+  cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+git commit -m "docs: record SP0a harness and how to run it"
+```
+
+---
+
+## Self-review notes (for the executor)
+
+- **Spec coverage:** corpus generator with tiers + custom + real-library (Tasks 2–4), scan/refresh/read benches incl. concurrent (Tasks 6–8), comparable reporting (Task 5), moov-at-end fixture (Task 1). Deferred to SP0b per the scope note: passthrough-FUSE latency injection, the fsync counter/column, and the `ssd`-smoke + latency-effect + fsync-direction acceptance criteria (all FUSE-dependent).
+- **Determinism gate:** Task 3 asserts identical bytes for a fixed (params, seed).
+- **No-regression gate:** Tasks 6–8 keep all `#[ignore]`d so the default `cargo test` is unchanged; Task 8 Step 3 confirms the existing suite stays green.
+- **Reproducibility threshold (spec acceptance):** Criterion already reports medians + variance for the read benches; defining the explicit `ci` regression percentage is a one-line policy choice the user makes when wiring CI — flagged here, not blocking.
+- **Type consistency:** `CorpusParams`, `Tier`, `Format`, `Target`, `RunReport`, `generate`, `prepare`, `peak_rss_kib` are used with identical signatures across tasks.
+```

--- a/docs/superpowers/plans/2026-05-30-optimization-sp0a-corpus-and-benches.md
+++ b/docs/superpowers/plans/2026-05-30-optimization-sp0a-corpus-and-benches.md
@@ -157,6 +157,11 @@ Append to `musefs-core/tests/common_corpus_smoke.rs`:
 ```rust
 use common::corpus::{CorpusParams, Tier};
 
+/// Serializes tests that mutate process-global `MUSEFS_BENCH_*` env vars —
+/// cargo runs all tests in one binary across threads, so concurrent
+/// set_var/remove_var would race. Every env-touching test locks this first.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn tier_presets_have_expected_shape() {
     let ci = CorpusParams::for_tier(Tier::Ci);
@@ -173,6 +178,7 @@ fn tier_presets_have_expected_shape() {
 
 #[test]
 fn env_overrides_apply_over_tier() {
+    let _g = ENV_LOCK.lock().unwrap();
     std::env::set_var("MUSEFS_BENCH_TIER", "ci");
     std::env::set_var("MUSEFS_BENCH_ALBUMS", "3");
     std::env::set_var("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
@@ -353,7 +359,7 @@ Append to `musefs-core/tests/common_corpus_smoke.rs`:
 
 ```rust
 use common::corpus::{generate, Format};
-use musefs_db::Db as Db2; // alias to avoid clashing with the Task-1 `Db` import
+// `Db` is already imported at the top of this file (Task 1).
 
 #[test]
 fn generate_is_deterministic_and_scans_all_tracks() {
@@ -375,7 +381,7 @@ fn generate_is_deterministic_and_scans_all_tracks() {
     let first_b = std::fs::read(&files_b[0]).unwrap();
     assert_eq!(first_a, first_b, "same (params, seed) => identical bytes");
 
-    let db = Db2::open_in_memory().unwrap();
+    let db = Db::open_in_memory().unwrap();
     let stats = musefs_core::scan_directory(&db, a.path()).unwrap();
     assert_eq!(stats.scanned, 6);
 }
@@ -529,6 +535,7 @@ use common::corpus::prepare;
 
 #[test]
 fn prepare_generates_when_no_library_set() {
+    let _g = ENV_LOCK.lock().unwrap();
     std::env::remove_var("MUSEFS_BENCH_LIBRARY");
     let scratch = tempfile::tempdir().unwrap();
     std::env::set_var("MUSEFS_BENCH_DIR", scratch.path());
@@ -546,7 +553,7 @@ fn prepare_generates_when_no_library_set() {
     assert!(!t.is_real_library);
     // DB path is separate from the corpus dir.
     assert_ne!(t.db_path, t.corpus_dir);
-    let db = Db2::open(&t.db_path).unwrap();
+    let db = Db::open(&t.db_path).unwrap();
     let stats = musefs_core::scan_directory(&db, &t.corpus_dir).unwrap();
     assert_eq!(stats.scanned, 2);
 }
@@ -600,6 +607,11 @@ pub fn prepare(p: &CorpusParams) -> Target {
     let db_path = std::env::var("MUSEFS_BENCH_DB")
         .map(PathBuf::from)
         .unwrap_or_else(|_| corpus_dir.join("musefs-bench.db"));
+    // Generated mode: start cold so a reused MUSEFS_BENCH_DIR doesn't time the
+    // scan against a DB that already holds the tracks. (WAL sidecars too.)
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
+    }
     Target {
         corpus_dir,
         db_path,
@@ -900,8 +912,12 @@ fn time_refresh(db_path: &std::path::Path, fs: &Musefs, count: usize) -> u128 {
             .unwrap();
     }
     let t0 = Instant::now();
-    fs.poll_refresh();
-    t0.elapsed().as_millis()
+    // poll_refresh returns Ok(true) when a rebuild actually happened. Asserting it
+    // guards against silently timing a no-op (e.g. data_version not observed).
+    let rebuilt = fs.poll_refresh().unwrap();
+    let ms = t0.elapsed().as_millis();
+    assert!(rebuilt, "expected a rebuild after re-tagging {count} track(s)");
+    ms
 }
 
 #[test]
@@ -916,7 +932,12 @@ fn bench_refresh_one_vs_many() {
     let fs = Musefs::open(db, config()).unwrap();
 
     let one_ms = time_refresh(&target.db_path, &fs, 1);
-    let many = (params.track_count() / 2).max(1);
+    // Cap the touch count: today's rebuild is full regardless of how many tracks
+    // changed, so a bounded sample represents "many changed" without a huge
+    // un-batched-write setup on the heavy tiers (the slow path SP1 fixes). SP2
+    // will make rebuild cost scale with the changed set, at which point this cap
+    // is revisited.
+    let many = (params.track_count() / 2).clamp(1, 1000);
     let many_ms = time_refresh(&target.db_path, &fs, many);
 
     println!("\n{}", RunReport::header());
@@ -1156,6 +1177,15 @@ MUSEFS_BENCH_LIBRARY=/srv/music \
 MUSEFS_BENCH_DB=/tmp/musefs-bench.db \
   cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
 ```
+
+Notes:
+- A reused `MUSEFS_BENCH_DIR` is re-scanned cold: `prepare` deletes any prior
+  `musefs-bench.db` (+ `-wal`/`-shm`) so scan timings start from an empty DB.
+- **Regression gate (convention for SP1–SP4):** treat the Criterion `ci`
+  `sequential_read` median as the baseline; a change is a regression if the
+  median rises **>10%** run-over-run on the same machine (Criterion prints the
+  median + its noise estimate). SP1–SP4 record before/after medians in the
+  tracking doc's results log and must not breach this gate.
 ```
 
 - [ ] **Step 2: Commit**

--- a/docs/superpowers/plans/2026-05-30-optimization-sp0b-latency-fuse.md
+++ b/docs/superpowers/plans/2026-05-30-optimization-sp0b-latency-fuse.md
@@ -1,0 +1,1154 @@
+# SP0b — Passthrough latency-injection FUSE — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A bench-only passthrough FUSE filesystem that mirrors a real backing directory but sleeps a configurable amount per operation, so HDD/NFS latency profiles are reproducible on one machine and SQLite's own fsyncs (not just backing reads) are delayed and counted.
+
+**Architecture:** A new dev-only workspace crate `musefs-latencyfs` implements `fuser::Filesystem` as a stateless-path passthrough over a root directory, with a per-op latency table and an fsync counter. A `LatencyMount` RAII helper mounts it (read-write — the DB lives under it) and unmounts on drop, mirroring `musefs-fuse`'s `Session`/`BackgroundSession` pattern. SP0a's scan/read timing benches gain a variant that mounts this FS over the corpus dir when `MUSEFS_BENCH_LATENCY_PROFILE` is set. Needs `/dev/fuse`; every test/bench using it is `#[ignore]`d like the existing e2e suite.
+
+**Tech Stack:** Rust, `fuser` 0.17 (typed API: `INodeNo`, `FileHandle`, `Errno`, `ReplyEntry`/`Attr`/`Data`/`Open`/`Write`/`Create`/`Empty`/`Directory`/`Statfs`), `libc`, `std::os::unix::fs::{FileExt, MetadataExt}`, `rusqlite` (WAL smoke test), `tempfile`.
+
+**Prerequisite:** SP0a is implemented (the corpus generator + `bench_ingest` live in `musefs-core/tests/common/` and `musefs-core/tests/`). Task 6 extends those.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-optimization-pass/SP0-measurement-foundation.md` (Component 3 + the deferred acceptance criteria).
+
+**Verified fuser 0.17 facts (against the vendored source):**
+- `Filesystem` methods take `&self`. Reply objects are `Send`. `Session::new(fs, &Path, &Config) -> io::Result<Session>`; `Session::spawn(self) -> io::Result<BackgroundSession>`; `BackgroundSession::Drop` unmounts. `Config { mount_options: Vec<MountOption>, .. }` (default is read-write).
+- `ReplyEntry::entry(&Duration, &FileAttr, Generation)`, `ReplyAttr::attr(&Duration, &FileAttr)`, `ReplyOpen::opened(FileHandle, FopenFlags)`, `ReplyCreate::created(&Duration, &FileAttr, Generation, FileHandle, FopenFlags)`, `ReplyWrite::written(u32)`, `ReplyData::data(&[u8])`, `ReplyEmpty::ok()`, `ReplyStatfs::statfs(blocks,bfree,bavail,files,ffree,bsize,namelen,frsize)`, `ReplyDirectory::add(INodeNo, offset:u64, FileType, name) -> bool` then `.ok()`. All replies have `.error(Errno)`.
+- `FileAttr { ino: INodeNo, size:u64, blocks:u64, atime/mtime/ctime/crtime: SystemTime, kind: FileType, perm:u16, nlink:u32, uid:u32, gid:u32, rdev:u32, blksize:u32, flags:u32 }`.
+
+---
+
+## File structure
+
+- Create `musefs-latencyfs/Cargo.toml` — dev-only workspace member (`publish = false`).
+- Create `musefs-latencyfs/src/lib.rs` — `Latency`/profiles, `PassthroughFs`, `LatencyMount`, the `metadata → FileAttr` helper.
+- Create `musefs-latencyfs/tests/passthrough.rs` — `#[ignore]`d functional tests (stat / read / write+fsync / rename / unlink).
+- Create `musefs-latencyfs/tests/sqlite_wal.rs` — `#[ignore]`d gating smoke test: a full SQLite WAL cycle through the mount.
+- Create `musefs-latencyfs/tests/latency_effect.rs` — `#[ignore]`d test: a non-zero profile measurably slows I/O and bumps the fsync counter.
+- Modify `Cargo.toml` (workspace `members`) — add `musefs-latencyfs`.
+- Modify `musefs-core/Cargo.toml` — add `musefs-latencyfs` as a dev-dependency.
+- Modify `musefs-core/tests/bench_ingest.rs` — mount the latency FS when `MUSEFS_BENCH_LATENCY_PROFILE` is set; report fsyncs.
+- Modify `docs/superpowers/specs/2026-05-30-optimization-pass/README.md` — status + run instructions.
+
+---
+
+## Task 1: Crate skeleton, latency table, inode/handle tables, and metadata→FileAttr
+
+**Files:**
+- Modify: `Cargo.toml` (root)
+- Create: `musefs-latencyfs/Cargo.toml`
+- Create: `musefs-latencyfs/src/lib.rs`
+
+- [ ] **Step 1: Add the workspace member**
+
+In root `Cargo.toml`, change the members line to:
+
+```toml
+members = ["musefs-db", "musefs-format", "musefs-core", "musefs-fuse", "musefs-cli", "musefs", "musefs-latencyfs"]
+```
+
+- [ ] **Step 2: Create the crate manifest**
+
+Create `musefs-latencyfs/Cargo.toml`:
+
+```toml
+[package]
+name = "musefs-latencyfs"
+description = "Bench-only passthrough FUSE with per-op latency injection for musefs benchmarks."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+fuser = "0.17"
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+rusqlite = { version = "0.40", features = ["bundled"] }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 3: Write the latency table + tables + attr helper (no FS impl yet)**
+
+Create `musefs-latencyfs/src/lib.rs`:
+
+```rust
+//! Bench-only passthrough FUSE that mirrors a backing directory and sleeps a
+//! configurable amount per operation, so HDD/NFS latency profiles are
+//! reproducible on one machine. The corpus AND the SQLite DB live under the
+//! mount, so backing reads and SQLite fsyncs are both delayed (and fsyncs
+//! counted). Not for production; requires /dev/fuse.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::unix::fs::{FileExt, MetadataExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use fuser::{FileAttr, FileType, Generation, INodeNo};
+
+const TTL: Duration = Duration::from_secs(1);
+
+fn ms(n: u64) -> Duration {
+    Duration::from_millis(n)
+}
+fn us(n: u64) -> Duration {
+    Duration::from_micros(n)
+}
+fn nap(d: Duration) {
+    if !d.is_zero() {
+        std::thread::sleep(d);
+    }
+}
+
+/// Per-operation injected latency. `ssd` is all-zero (≈ no injection).
+#[derive(Clone, Copy, Default)]
+pub struct Latency {
+    pub open: Duration,
+    pub stat: Duration,
+    pub read: Duration,
+    pub write: Duration,
+    pub fsync: Duration,
+    pub other: Duration,
+}
+
+impl Latency {
+    /// Named profiles. Unknown / "ssd" => zero.
+    pub fn profile(name: &str) -> Latency {
+        match name {
+            "hdd" => Latency {
+                open: ms(8),
+                stat: ms(8),
+                read: ms(8),
+                write: ms(8),
+                fsync: ms(10),
+                other: ms(2),
+            },
+            "nfs-ssd" => Latency {
+                open: us(600),
+                stat: us(400),
+                read: us(600),
+                write: us(600),
+                fsync: us(800),
+                other: us(300),
+            },
+            "nfs-hdd" => Latency {
+                open: us(8600),
+                stat: us(8400),
+                read: us(8600),
+                write: us(8600),
+                fsync: ms(10) + us(800),
+                other: us(2300),
+            },
+            _ => Latency::default(),
+        }
+    }
+}
+
+/// Bidirectional inode<->path map. Never forgets (bench-scale memory is fine).
+struct Inodes {
+    fwd: HashMap<u64, PathBuf>,
+    rev: HashMap<PathBuf, u64>,
+    next: u64,
+}
+
+impl Inodes {
+    fn new(root: PathBuf) -> Inodes {
+        let mut fwd = HashMap::new();
+        let mut rev = HashMap::new();
+        fwd.insert(1, root.clone());
+        rev.insert(root, 1);
+        Inodes { fwd, rev, next: 2 }
+    }
+    fn path(&self, ino: u64) -> Option<PathBuf> {
+        self.fwd.get(&ino).cloned()
+    }
+    fn intern(&mut self, path: PathBuf) -> u64 {
+        if let Some(&i) = self.rev.get(&path) {
+            return i;
+        }
+        let i = self.next;
+        self.next += 1;
+        self.fwd.insert(i, path.clone());
+        self.rev.insert(path, i);
+        i
+    }
+    fn forget_path(&mut self, path: &Path) {
+        if let Some(i) = self.rev.remove(path) {
+            self.fwd.remove(&i);
+        }
+    }
+    fn rename(&mut self, from: &Path, to: PathBuf) {
+        if let Some(i) = self.rev.remove(from) {
+            self.fwd.insert(i, to.clone());
+            self.rev.insert(to, i);
+        }
+    }
+}
+
+/// `std::fs::Metadata` -> `fuser::FileAttr`, reporting our interned `ino`.
+fn attr_from_meta(ino: u64, m: &std::fs::Metadata) -> FileAttr {
+    let kind = if m.is_dir() {
+        FileType::Directory
+    } else if m.file_type().is_symlink() {
+        FileType::Symlink
+    } else {
+        FileType::RegularFile
+    };
+    let t = |secs: i64, nsec: i64| {
+        if secs >= 0 {
+            SystemTime::UNIX_EPOCH + Duration::new(secs as u64, nsec as u32)
+        } else {
+            SystemTime::UNIX_EPOCH
+        }
+    };
+    FileAttr {
+        ino: INodeNo(ino),
+        size: m.size(),
+        blocks: m.blocks(),
+        atime: t(m.atime(), m.atime_nsec()),
+        mtime: t(m.mtime(), m.mtime_nsec()),
+        ctime: t(m.ctime(), m.ctime_nsec()),
+        crtime: SystemTime::UNIX_EPOCH,
+        kind,
+        perm: (m.mode() & 0o7777) as u16,
+        nlink: m.nlink() as u32,
+        uid: m.uid(),
+        gid: m.gid(),
+        rdev: m.rdev() as u32,
+        blksize: m.blksize() as u32,
+        flags: 0,
+    }
+}
+
+/// The passthrough filesystem. Root inode (1) maps to the backing root.
+pub struct PassthroughFs {
+    inodes: Mutex<Inodes>,
+    handles: Mutex<HashMap<u64, File>>,
+    next_fh: AtomicU64,
+    lat: Latency,
+    fsyncs: Arc<AtomicU64>,
+    uid: u32,
+    gid: u32,
+}
+
+impl PassthroughFs {
+    fn new(root: PathBuf, lat: Latency, fsyncs: Arc<AtomicU64>) -> PassthroughFs {
+        PassthroughFs {
+            inodes: Mutex::new(Inodes::new(root)),
+            handles: Mutex::new(HashMap::new()),
+            next_fh: AtomicU64::new(1),
+            lat,
+            fsyncs,
+            // SAFETY: getuid/getgid never fail.
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+        }
+    }
+    fn ipath(&self, ino: u64) -> Option<PathBuf> {
+        self.inodes.lock().unwrap().path(ino)
+    }
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo build -p musefs-latencyfs`
+Expected: builds clean (unused-field warnings are acceptable at this step; the FS impl in Task 2 uses them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml musefs-latencyfs/Cargo.toml musefs-latencyfs/src/lib.rs
+git commit -m "feat(latencyfs): crate skeleton, latency profiles, inode/handle tables"
+```
+
+---
+
+## Task 2: Metadata + read ops (`lookup`/`getattr`/`opendir`/`readdir`/`releasedir`/`open`/`read`/`flush`/`release`/`statfs`/`access`/`forget`)
+
+This is enough to `ls` and read files through the mount. The mount harness is added here too so the test can exercise it.
+
+**Files:**
+- Modify: `musefs-latencyfs/src/lib.rs`
+- Create: `musefs-latencyfs/tests/passthrough.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `musefs-latencyfs/tests/passthrough.rs`:
+
+```rust
+use std::io::Read;
+
+use musefs_latencyfs::LatencyMount;
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn reads_a_file_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::create_dir(backing.path().join("sub")).unwrap();
+    std::fs::write(backing.path().join("sub/hello.txt"), b"hello world").unwrap();
+
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    // Stat + read through the FUSE mount.
+    let mp = mount.path();
+    let meta = std::fs::metadata(mp.join("sub/hello.txt")).unwrap();
+    assert_eq!(meta.len(), 11);
+    let mut s = String::new();
+    std::fs::File::open(mp.join("sub/hello.txt"))
+        .unwrap()
+        .read_to_string(&mut s)
+        .unwrap();
+    assert_eq!(s, "hello world");
+
+    // readdir sees the entry.
+    let names: Vec<String> = std::fs::read_dir(mp.join("sub"))
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(names.contains(&"hello.txt".to_string()));
+}
+```
+
+- [ ] **Step 2: Run it (fails to compile — no `LatencyMount`)**
+
+Run: `cargo test -p musefs-latencyfs --test passthrough -- --ignored --nocapture`
+Expected: FAIL — `cannot find … LatencyMount`.
+
+- [ ] **Step 3: Implement the read-side ops + mount harness**
+
+Append to `musefs-latencyfs/src/lib.rs`:
+
+```rust
+use fuser::{
+    BackgroundSession, Config, FopenFlags, MountOption, OpenFlags, Request, ReplyAttr, ReplyData,
+    ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, Session,
+};
+use std::ffi::OsStr;
+
+impl fuser::Filesystem for PassthroughFs {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+        nap(self.lat.stat);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::symlink_metadata(&child) {
+            Ok(m) => {
+                let ino = self.inodes.lock().unwrap().intern(child);
+                reply.entry(&TTL, &attr_from_meta(ino, &m), Generation(0));
+            }
+            Err(_) => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<fuser::FileHandle>, reply: ReplyAttr) {
+        nap(self.lat.stat);
+        let Some(p) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        match std::fs::symlink_metadata(&p) {
+            Ok(m) => reply.attr(&TTL, &attr_from_meta(ino.0, &m)),
+            Err(_) => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn opendir(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        nap(self.lat.open);
+        reply.opened(fuser::FileHandle(0), FopenFlags::empty());
+    }
+
+    fn readdir(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: fuser::FileHandle,
+        offset: u64,
+        mut reply: ReplyDirectory,
+    ) {
+        nap(self.lat.stat);
+        let Some(dir) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let parent_ino = dir
+            .parent()
+            .map(|p| self.inodes.lock().unwrap().intern(p.to_path_buf()))
+            .unwrap_or(ino.0);
+        let mut entries: Vec<(u64, FileType, std::ffi::OsString)> = vec![
+            (ino.0, FileType::Directory, ".".into()),
+            (parent_ino, FileType::Directory, "..".into()),
+        ];
+        let rd = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(e) => return reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        };
+        for ent in rd.flatten() {
+            let p = ent.path();
+            let kind = match ent.file_type() {
+                Ok(ft) if ft.is_dir() => FileType::Directory,
+                Ok(ft) if ft.is_symlink() => FileType::Symlink,
+                _ => FileType::RegularFile,
+            };
+            let cino = self.inodes.lock().unwrap().intern(p);
+            entries.push((cino, kind, ent.file_name()));
+        }
+        for (i, (cino, kind, name)) in entries.into_iter().enumerate().skip(offset as usize) {
+            if reply.add(INodeNo(cino), (i + 1) as u64, kind, &name) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+
+    fn releasedir(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: fuser::FileHandle,
+        _flags: OpenFlags,
+        reply: ReplyEmpty,
+    ) {
+        reply.ok();
+    }
+
+    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        nap(self.lat.open);
+        let Some(p) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        // Try read-write (the DB); fall back to read-only (audio files are 0444).
+        let file = match OpenOptions::new().read(true).write(true).open(&p) {
+            Ok(f) => f,
+            Err(_) => match File::open(&p) {
+                Ok(f) => f,
+                Err(e) => {
+                    return reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)))
+                }
+            },
+        };
+        let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
+        self.handles.lock().unwrap().insert(fh, file);
+        reply.opened(fuser::FileHandle(fh), FopenFlags::empty());
+    }
+
+    fn read(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        reply: ReplyData,
+    ) {
+        nap(self.lat.read);
+        let guard = self.handles.lock().unwrap();
+        let Some(file) = guard.get(&fh.0) else {
+            return reply.error(fuser::Errno::EBADF);
+        };
+        let mut buf = vec![0u8; size as usize];
+        match file.read_at(&mut buf, offset) {
+            Ok(n) => reply.data(&buf[..n]),
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn flush(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: fuser::FileHandle,
+        _lock_owner: fuser::LockOwner,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.other);
+        reply.ok();
+    }
+
+    fn release(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: fuser::FileHandle,
+        _flags: OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        _flush: bool,
+        reply: ReplyEmpty,
+    ) {
+        self.handles.lock().unwrap().remove(&fh.0);
+        reply.ok();
+    }
+
+    fn statfs(&self, _req: &Request, ino: INodeNo, reply: ReplyStatfs) {
+        nap(self.lat.stat);
+        // Pass through real statvfs of the inode's path; fall back to benign values.
+        if let Some(p) = self.ipath(ino.0) {
+            if let Ok(cstr) = std::ffi::CString::new(p.as_os_str().to_string_lossy().as_bytes()) {
+                let mut s: libc::statvfs = unsafe { std::mem::zeroed() };
+                // SAFETY: cstr is a valid NUL-terminated path; s is a valid out-param.
+                if unsafe { libc::statvfs(cstr.as_ptr(), &mut s) } == 0 {
+                    return reply.statfs(
+                        s.f_blocks as u64,
+                        s.f_bfree as u64,
+                        s.f_bavail as u64,
+                        s.f_files as u64,
+                        s.f_ffree as u64,
+                        s.f_bsize as u32,
+                        s.f_namemax as u32,
+                        s.f_frsize as u32,
+                    );
+                }
+            }
+        }
+        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
+    }
+
+    fn access(&self, _req: &Request, _ino: INodeNo, _mask: fuser::AccessFlags, reply: ReplyEmpty) {
+        reply.ok();
+    }
+
+    fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
+}
+
+/// A mounted passthrough FS. Unmounts on drop. The corpus + DB live under
+/// `path()`; point scans and `Db::open` there to measure under injected latency.
+pub struct LatencyMount {
+    fsyncs: Arc<AtomicU64>,
+    // Drop order: the session (unmount) must drop before the mountpoint tempdir.
+    _bg: BackgroundSession,
+    _mountdir: tempfile::TempDir,
+}
+
+impl LatencyMount {
+    /// Mount a passthrough over `backing` using the named latency profile
+    /// (`ssd`|`hdd`|`nfs-ssd`|`nfs-hdd`). Returns once the mount is live.
+    pub fn new(backing: &Path, profile: &str) -> io::Result<LatencyMount> {
+        let mountdir = tempfile::tempdir()?;
+        let fsyncs = Arc::new(AtomicU64::new(0));
+        let fs = PassthroughFs::new(
+            backing.to_path_buf(),
+            Latency::profile(profile),
+            Arc::clone(&fsyncs),
+        );
+        let mut cfg = Config::default();
+        cfg.mount_options = vec![MountOption::FSName("musefs-latencyfs".to_string())];
+        let session = Session::new(fs, mountdir.path(), &cfg)?;
+        let bg = session.spawn()?;
+        Ok(LatencyMount {
+            fsyncs,
+            _bg: bg,
+            _mountdir: mountdir,
+        })
+    }
+
+    /// The mountpoint. Use this as the corpus dir / DB parent.
+    pub fn path(&self) -> PathBuf {
+        self._mountdir.path().to_path_buf()
+    }
+
+    /// Total `fsync`/`fsyncdir` operations observed since mount.
+    pub fn fsyncs(&self) -> u64 {
+        self.fsyncs.load(Ordering::Relaxed)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `cargo test -p musefs-latencyfs --test passthrough reads_a_file -- --ignored --nocapture`
+Expected: PASS (stat, read, and readdir succeed through the mount).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-latencyfs/src/lib.rs musefs-latencyfs/tests/passthrough.rs
+git commit -m "feat(latencyfs): metadata + read ops and the LatencyMount harness"
+```
+
+---
+
+## Task 3: Write ops (`create`/`write`/`fsync`/`fsyncdir`/`setattr`/`unlink`/`rename`/`mkdir`/`rmdir`)
+
+These let SQLite create and grow its DB/WAL/SHM files under the mount.
+
+**Files:**
+- Modify: `musefs-latencyfs/src/lib.rs`
+- Modify: `musefs-latencyfs/tests/passthrough.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-latencyfs/tests/passthrough.rs`:
+
+```rust
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn write_fsync_rename_unlink_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let mp = mount.path();
+
+    // create + write + fsync via normal file ops (the kernel issues create/write/fsync).
+    let p = mp.join("data.bin");
+    {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&p)
+            .unwrap();
+        f.write_all(b"abcdef").unwrap();
+        f.sync_all().unwrap();
+    }
+    assert_eq!(std::fs::read(&p).unwrap(), b"abcdef");
+    assert!(mount.fsyncs() >= 1, "fsync should have been counted");
+
+    // rename + unlink.
+    let q = mp.join("renamed.bin");
+    std::fs::rename(&p, &q).unwrap();
+    assert!(q.exists() && !p.exists());
+    std::fs::remove_file(&q).unwrap();
+    assert!(!q.exists());
+
+    // The backing dir reflects the changes (true passthrough).
+    assert!(!backing.path().join("data.bin").exists());
+}
+```
+
+- [ ] **Step 2: Run it (fails — write ops unimplemented, default ENOSYS)**
+
+Run: `cargo test -p musefs-latencyfs --test passthrough write_fsync -- --ignored --nocapture`
+Expected: FAIL — the `OpenOptions::create` returns `ENOSYS`/`EROFS`-style error (write ops not implemented yet).
+
+- [ ] **Step 3: Implement the write ops**
+
+Add these methods inside the existing `impl fuser::Filesystem for PassthroughFs` block (alongside the read ops). Extend the `use fuser::{...}` line to also import `ReplyCreate, ReplyWrite, TimeOrNow, BsdFileFlags, RenameFlags, WriteFlags`:
+
+```rust
+    fn create(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        _mode: u32,
+        _umask: u32,
+        _flags: i32,
+        reply: ReplyCreate,
+    ) {
+        nap(self.lat.open);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        let file = match OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&child)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                return reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)))
+            }
+        };
+        let m = match file.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                return reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)))
+            }
+        };
+        let ino = self.inodes.lock().unwrap().intern(child);
+        let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
+        self.handles.lock().unwrap().insert(fh, file);
+        reply.created(
+            &TTL,
+            &attr_from_meta(ino, &m),
+            Generation(0),
+            fuser::FileHandle(fh),
+            FopenFlags::empty(),
+        );
+    }
+
+    fn write(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: fuser::FileHandle,
+        offset: u64,
+        data: &[u8],
+        _write_flags: WriteFlags,
+        _flags: OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        reply: ReplyWrite,
+    ) {
+        nap(self.lat.write);
+        let guard = self.handles.lock().unwrap();
+        let Some(file) = guard.get(&fh.0) else {
+            return reply.error(fuser::Errno::EBADF);
+        };
+        match file.write_at(data, offset) {
+            Ok(n) => reply.written(n as u32),
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn fsync(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: fuser::FileHandle,
+        datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.fsync);
+        self.fsyncs.fetch_add(1, Ordering::Relaxed);
+        let guard = self.handles.lock().unwrap();
+        let Some(file) = guard.get(&fh.0) else {
+            return reply.error(fuser::Errno::EBADF);
+        };
+        let r = if datasync { file.sync_data() } else { file.sync_all() };
+        match r {
+            Ok(()) => reply.ok(),
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn fsyncdir(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: fuser::FileHandle,
+        _datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.fsync);
+        self.fsyncs.fetch_add(1, Ordering::Relaxed);
+        reply.ok();
+    }
+
+    fn setattr(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        size: Option<u64>,
+        _atime: Option<TimeOrNow>,
+        _mtime: Option<TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<fuser::FileHandle>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<BsdFileFlags>,
+        reply: ReplyAttr,
+    ) {
+        nap(self.lat.other);
+        let Some(p) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        // The only attr SQLite needs: truncate/extend the WAL.
+        if let Some(sz) = size {
+            if let Ok(f) = OpenOptions::new().write(true).open(&p) {
+                let _ = f.set_len(sz);
+            }
+        }
+        match std::fs::symlink_metadata(&p) {
+            Ok(m) => reply.attr(&TTL, &attr_from_meta(ino.0, &m)),
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn unlink(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        nap(self.lat.other);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::remove_file(&child) {
+            Ok(()) => {
+                self.inodes.lock().unwrap().forget_path(&child);
+                reply.ok();
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn rename(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        newparent: INodeNo,
+        newname: &OsStr,
+        _flags: RenameFlags,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.other);
+        let (Some(pp), Some(np)) = (self.ipath(parent.0), self.ipath(newparent.0)) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let from = pp.join(name);
+        let to = np.join(newname);
+        match std::fs::rename(&from, &to) {
+            Ok(()) => {
+                self.inodes.lock().unwrap().rename(&from, to);
+                reply.ok();
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn mkdir(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &OsStr,
+        _mode: u32,
+        _umask: u32,
+        reply: ReplyEntry,
+    ) {
+        nap(self.lat.other);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::create_dir(&child).and_then(|()| std::fs::symlink_metadata(&child)) {
+            Ok(m) => {
+                let ino = self.inodes.lock().unwrap().intern(child);
+                reply.entry(&TTL, &attr_from_meta(ino, &m), Generation(0));
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+
+    fn rmdir(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        nap(self.lat.other);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::remove_dir(&child) {
+            Ok(()) => {
+                self.inodes.lock().unwrap().forget_path(&child);
+                reply.ok();
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))),
+        }
+    }
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `cargo test -p musefs-latencyfs --test passthrough write_fsync -- --ignored --nocapture`
+Expected: PASS (create/write/fsync/rename/unlink all succeed; `fsyncs() >= 1`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-latencyfs/src/lib.rs musefs-latencyfs/tests/passthrough.rs
+git commit -m "feat(latencyfs): write/create/fsync/setattr/unlink/rename ops"
+```
+
+---
+
+## Task 4: Gating smoke test — full SQLite WAL cycle through the mount
+
+This is the spec's gating acceptance criterion: prove the op surface is complete by running a real SQLite WAL workload (create, write, fsync, truncate, checkpoint, read-back) at the `ssd` profile.
+
+**Files:**
+- Create: `musefs-latencyfs/tests/sqlite_wal.rs`
+
+- [ ] **Step 1: Write the smoke test**
+
+Create `musefs-latencyfs/tests/sqlite_wal.rs`:
+
+```rust
+use musefs_latencyfs::LatencyMount;
+use rusqlite::Connection;
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn sqlite_wal_cycle_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let db_path = mount.path().join("test.db");
+
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        // WAL mode exercises -wal/-shm create, write, fsync, and truncate.
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode = WAL", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", [])
+            .unwrap();
+        for i in 0..200 {
+            conn.execute("INSERT INTO t (v) VALUES (?1)", [format!("row-{i}")])
+                .unwrap();
+        }
+        // Force a checkpoint (truncates the WAL).
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);").unwrap();
+        let n: i64 = conn.query_row("SELECT COUNT(*) FROM t", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 200);
+    }
+
+    // Reopen and re-read to confirm durability through the mount.
+    let conn = Connection::open(&db_path).unwrap();
+    let n: i64 = conn.query_row("SELECT COUNT(*) FROM t", [], |r| r.get(0)).unwrap();
+    assert_eq!(n, 200);
+
+    assert!(mount.fsyncs() > 0, "WAL writes must have triggered fsyncs");
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p musefs-latencyfs --test sqlite_wal -- --ignored --nocapture`
+Expected: PASS. If it fails with an `EIO`/`disk I/O error`, an op is missing — the failing operation is the one to implement (the test is the op-completeness guard the spec calls for).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-latencyfs/tests/sqlite_wal.rs
+git commit -m "test(latencyfs): gating SQLite WAL cycle smoke test through the mount"
+```
+
+---
+
+## Task 5: Latency-effect + fsync-direction test
+
+Proves the injected latency is measurable (and ≈0 under `ssd`) and that the fsync count moves with write volume — the relative SP1 signal.
+
+**Files:**
+- Create: `musefs-latencyfs/tests/latency_effect.rs`
+
+- [ ] **Step 1: Write the test**
+
+Create `musefs-latencyfs/tests/latency_effect.rs`:
+
+```rust
+use std::time::Instant;
+
+use musefs_latencyfs::LatencyMount;
+
+fn open_read_close(path: &std::path::Path) {
+    use std::io::Read;
+    let mut s = Vec::new();
+    std::fs::File::open(path).unwrap().read_to_end(&mut s).unwrap();
+}
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn nonzero_profile_is_slower_than_ssd() {
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(backing.path().join("f.bin"), vec![0u8; 64 * 1024]).unwrap();
+
+    // ssd (~0) baseline.
+    let fast = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let t0 = Instant::now();
+    for _ in 0..20 {
+        open_read_close(&fast.path().join("f.bin"));
+    }
+    let fast_ms = t0.elapsed().as_millis();
+    drop(fast);
+
+    // hdd profile: each open+read sleeps multiple ms, so 20 iterations are far slower.
+    let slow = LatencyMount::new(backing.path(), "hdd").unwrap();
+    let t1 = Instant::now();
+    for _ in 0..20 {
+        open_read_close(&slow.path().join("f.bin"));
+    }
+    let slow_ms = t1.elapsed().as_millis();
+
+    println!("ssd={fast_ms}ms hdd={slow_ms}ms");
+    assert!(
+        slow_ms > fast_ms + 50,
+        "hdd profile ({slow_ms}ms) should be clearly slower than ssd ({fast_ms}ms)"
+    );
+}
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn fsync_count_rises_with_more_commits() {
+    use rusqlite::Connection;
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+
+    let conn = Connection::open(mount.path().join("c.db")).unwrap();
+    let _: String = conn
+        .query_row("PRAGMA journal_mode = WAL", [], |r| r.get(0))
+        .unwrap();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", []).unwrap();
+
+    let before = mount.fsyncs();
+    // Each checkpoint forces fsyncs; more checkpoints => strictly more fsyncs.
+    for _ in 0..10 {
+        conn.execute("INSERT INTO t DEFAULT VALUES", []).unwrap();
+        conn.execute_batch("PRAGMA wal_checkpoint(FULL);").unwrap();
+    }
+    let after = mount.fsyncs();
+    assert!(after > before, "fsync count must rise with commits/checkpoints");
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p musefs-latencyfs --test latency_effect -- --ignored --nocapture`
+Expected: PASS; prints e.g. `ssd=2ms hdd=350ms`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-latencyfs/tests/latency_effect.rs
+git commit -m "test(latencyfs): latency-effect and fsync-direction guards"
+```
+
+---
+
+## Task 6: Wire latency injection into the SP0a scan bench
+
+Add an opt-in path to `bench_ingest`: when `MUSEFS_BENCH_LATENCY_PROFILE` is set, mount the latency FS over the corpus dir and run the scan (and DB) through it, reporting real fsync counts.
+
+**Files:**
+- Modify: `musefs-core/Cargo.toml` (dev-dependency)
+- Modify: `musefs-core/tests/bench_ingest.rs`
+
+- [ ] **Step 1: Add the dev-dependency**
+
+In `musefs-core/Cargo.toml`, under `[dev-dependencies]`, add:
+
+```toml
+musefs-latencyfs = { path = "../musefs-latencyfs" }
+```
+
+- [ ] **Step 2: Add a latency-mounted scan variant**
+
+Append to `musefs-core/tests/bench_ingest.rs`:
+
+```rust
+#[test]
+#[ignore = "needs /dev/fuse + MUSEFS_BENCH_LATENCY_PROFILE; run with --ignored --nocapture"]
+fn bench_scan_under_latency() {
+    use musefs_latencyfs::LatencyMount;
+
+    let profile = match std::env::var("MUSEFS_BENCH_LATENCY_PROFILE") {
+        Ok(p) => p,
+        Err(_) => {
+            println!("set MUSEFS_BENCH_LATENCY_PROFILE=ssd|hdd|nfs-ssd|nfs-hdd to run");
+            return;
+        }
+    };
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+
+    // Generate the corpus on a real backing dir, then mount the latency FS over
+    // it so scan + DB I/O go through the injected-latency layer.
+    let backing = tempfile::tempdir().unwrap();
+    common::corpus::generate(backing.path(), &params);
+    let mount = LatencyMount::new(backing.path(), &profile).unwrap();
+
+    let db = Db::open(&mount.path().join("musefs-bench.db")).unwrap();
+    metrics::reset();
+    let t0 = std::time::Instant::now();
+    let stats = scan_directory(&db, &mount.path()).unwrap();
+    let scan_ms = t0.elapsed().as_millis();
+    let s = metrics::snapshot();
+
+    println!("\n{}", RunReport::header());
+    println!(
+        "{}",
+        RunReport {
+            label: "scan".into(),
+            tier,
+            storage: profile,
+            wall_ms: scan_ms,
+            opens: s.opens,
+            preads: s.preads,
+            fsyncs: Some(mount.fsyncs()),
+            peak_rss_kib: None, // FS runs in-process here, but RSS attribution is mixed; omit.
+        }
+        .row()
+    );
+    println!("scanned={} skipped={}\n", stats.scanned, stats.skipped);
+    assert!(stats.scanned > 0);
+}
+```
+
+Note: the corpus is generated on `backing` (no latency), then read through `mount.path()` (read latency) while the DB is created/written through the same mount (write + fsync latency). `mount.fsyncs()` is the real kernel fsync count for the scan's DB writes — the SP1-batching signal. RSS is omitted here because the passthrough FS shares this process, so `VmHWM` no longer isolates the scan's own footprint (use the SP0a tempfs `bench_cold_scan_and_revalidate` for the RSS signal).
+
+- [ ] **Step 3: Run it (ci tier, ssd profile)**
+
+Run: `MUSEFS_BENCH_LATENCY_PROFILE=ssd cargo test -p musefs-core --features metrics --test bench_ingest bench_scan_under_latency -- --ignored --nocapture`
+Expected: PASS; prints a row with a non-`n/a` `fsyncs` value and `scanned=200`.
+
+- [ ] **Step 4: Confirm it no-ops without the env var**
+
+Run: `cargo test -p musefs-core --test bench_ingest bench_scan_under_latency -- --ignored --nocapture`
+Expected: prints the "set MUSEFS_BENCH_LATENCY_PROFILE…" hint and returns (no panic).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/Cargo.toml musefs-core/tests/bench_ingest.rs
+git commit -m "bench(core): scan under injected latency via musefs-latencyfs"
+```
+
+---
+
+## Task 7: Update tracking doc + spec acceptance status
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-30-optimization-pass/README.md`
+
+- [ ] **Step 1: Update status + add run instructions**
+
+In the Status table, change the SP0b row state to `Implemented`. Append to the "Running the SP0a harness" section:
+
+```markdown
+### Latency-injected runs (SP0b — needs /dev/fuse)
+
+```bash
+# Functional + gating tests for the passthrough FS:
+cargo test -p musefs-latencyfs -- --ignored --nocapture
+
+# Scan a generated corpus through an injected-latency mount (real fsync counts):
+MUSEFS_BENCH_LATENCY_PROFILE=nfs-hdd MUSEFS_BENCH_TIER=large-compute \
+  cargo test -p musefs-core --features metrics \
+  --test bench_ingest bench_scan_under_latency -- --ignored --nocapture
+```
+
+Profiles: `ssd` (≈0), `hdd`, `nfs-ssd`, `nfs-hdd`. The corpus is generated on a
+real backing dir; only the scan + DB I/O traverse the latency layer.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+git commit -m "docs: record SP0b latency-injection harness and how to run it"
+```
+
+---
+
+## Self-review notes (for the executor)
+
+- **Spec coverage (the deferred SP0b items):** passthrough-FUSE latency injection (Tasks 1–3), `ssd` gating smoke test incl. WAL (Task 4), latency-effect + fsync-direction (Task 5), fsync counter/column wired into reporting (Task 6). All FUSE tests are `#[ignore]`d, matching the existing e2e convention; the default `cargo test` is unchanged.
+- **Op completeness risk:** Task 4's SQLite WAL cycle is the guard. If it fails, the error names the missing op; implement it following the Task-3 patterns (e.g. `getxattr`/`lseek` are tolerated as ENOSYS by SQLite, but if a build surfaces one, add a `reply.error(Errno::ENOSYS)` override is already the default — no action — whereas a *data* op like `copy_file_range` would need adding).
+- **Drop-order correctness:** `LatencyMount` declares `_bg` before `_mountdir` so the session unmounts before the mountpoint tempdir is removed.
+- **No production code touched:** `musefs-latencyfs` is a new `publish = false` crate; the only edit to a shipping crate is a `[dev-dependencies]` line in `musefs-core`.
+- **Type consistency:** `LatencyMount::{new, path, fsyncs}`, `Latency::profile`, `PassthroughFs` used identically across tasks; reply/trait signatures match the verified fuser 0.17 source.
+- **Known approximation:** profile latencies are representative, not calibrated to specific hardware; they model *relative* HDD/NFS behavior (the spec's stated non-goal is faithful bandwidth, which real-mount runs cover).
+```

--- a/docs/superpowers/plans/2026-05-30-optimization-sp0b-latency-fuse.md
+++ b/docs/superpowers/plans/2026-05-30-optimization-sp0b-latency-fuse.md
@@ -379,10 +379,15 @@ impl fuser::Filesystem for PassthroughFs {
         let Some(dir) = self.ipath(ino.0) else {
             return reply.error(fuser::Errno::ENOENT);
         };
-        let parent_ino = dir
-            .parent()
-            .map(|p| self.inodes.lock().unwrap().intern(p.to_path_buf()))
-            .unwrap_or(ino.0);
+        // Root's `..` is self-referential (conventional FUSE root), so we never
+        // intern a path outside the mounted backing tree.
+        let parent_ino = if ino.0 == 1 {
+            ino.0
+        } else {
+            dir.parent()
+                .map(|p| self.inodes.lock().unwrap().intern(p.to_path_buf()))
+                .unwrap_or(ino.0)
+        };
         let mut entries: Vec<(u64, FileType, std::ffi::OsString)> = vec![
             (ino.0, FileType::Directory, ".".into()),
             (parent_ino, FileType::Directory, "..".into()),
@@ -520,6 +525,16 @@ impl fuser::Filesystem for PassthroughFs {
     fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
 }
 
+/// Serializes the racy fusermount3 mount handshake. `Session::new` forks/execs
+/// `fusermount3` and passes the `/dev/fuse` fd back over a socket; fork and the
+/// fd table are process-global, so two mounts establishing concurrently from one
+/// process race the fd table ("file descriptor N is not a socket, can't send fuse
+/// fd"). `cargo test -- --ignored` runs a binary's tests in parallel and several
+/// test files mount more than once, so guard setup. Mirrors `musefs-fuse`'s
+/// `MOUNT_SETUP`. The lock covers only establishment, never the session lifetime,
+/// so it never serializes filesystem operations.
+static MOUNT_SETUP: Mutex<()> = Mutex::new(());
+
 /// A mounted passthrough FS. Unmounts on drop. The corpus + DB live under
 /// `path()`; point scans and `Db::open` there to measure under injected latency.
 pub struct LatencyMount {
@@ -542,7 +557,14 @@ impl LatencyMount {
         );
         let mut cfg = Config::default();
         cfg.mount_options = vec![MountOption::FSName("musefs-latencyfs".to_string())];
-        let session = Session::new(fs, mountdir.path(), &cfg)?;
+        let session = {
+            // Recover from a poisoned lock: it guards only ordering, so a prior
+            // panic during a mount leaves no inconsistent state to protect.
+            let _guard = MOUNT_SETUP
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Session::new(fs, mountdir.path(), &cfg)?
+        };
         let bg = session.spawn()?;
         Ok(LatencyMount {
             fsyncs,
@@ -628,7 +650,7 @@ fn write_fsync_rename_unlink_through_the_mount() {
 - [ ] **Step 2: Run it (fails — write ops unimplemented, default ENOSYS)**
 
 Run: `cargo test -p musefs-latencyfs --test passthrough write_fsync -- --ignored --nocapture`
-Expected: FAIL — the `OpenOptions::create` returns `ENOSYS`/`EROFS`-style error (write ops not implemented yet).
+Expected: FAIL — `OpenOptions::create` returns `ENOSYS` ("Function not implemented"): with no `create` override the trait default replies `Errno::ENOSYS`.
 
 - [ ] **Step 3: Implement the write ops**
 
@@ -1148,6 +1170,9 @@ git commit -m "docs: record SP0b latency-injection harness and how to run it"
 - **Spec coverage (the deferred SP0b items):** passthrough-FUSE latency injection (Tasks 1–3), `ssd` gating smoke test incl. WAL (Task 4), latency-effect + fsync-direction (Task 5), fsync counter/column wired into reporting (Task 6). All FUSE tests are `#[ignore]`d, matching the existing e2e convention; the default `cargo test` is unchanged.
 - **Op completeness risk:** Task 4's SQLite WAL cycle is the guard. If it fails, the error names the missing op; implement it following the Task-3 patterns (e.g. `getxattr`/`lseek` are tolerated as ENOSYS by SQLite, but if a build surfaces one, add a `reply.error(Errno::ENOSYS)` override is already the default — no action — whereas a *data* op like `copy_file_range` would need adding).
 - **Drop-order correctness:** `LatencyMount` declares `_bg` before `_mountdir` so the session unmounts before the mountpoint tempdir is removed.
+- **Mount-handshake serialization:** `LatencyMount::new` guards `Session::new` with a process-global `MOUNT_SETUP` mutex, mirroring `musefs-fuse/src/lib.rs`. Several `#[ignore]`d test files mount more than once and `cargo test -- --ignored` runs a binary's tests in parallel; the racy fusermount3 fork/fd-passing would otherwise intermittently fail. The lock covers only establishment, never op dispatch.
+- **In-process `on_fsync` hook — declined.** The spec asks for an explicit decision. The passthrough fsync counter (`LatencyMount::fsyncs`) is the single source of truth for SP1; tempfs `ci` runs report it via the same mount path, so no separate in-process `metrics::on_fsync` hook is added. (If a future tempfs-only bench needs fsync counts without a mount, revisit then — YAGNI now.)
+- **Reproducibility / regression gate is SP0a-owned.** That acceptance criterion lives on the tempfs `ci` bench (SP0a's stable-median + threshold check); SP0b deliberately does not re-implement it — its FUSE benches are `#[ignore]`d and latency-injected, not CI-gated.
 - **No production code touched:** `musefs-latencyfs` is a new `publish = false` crate; the only edit to a shipping crate is a `[dev-dependencies]` line in `musefs-core`.
 - **Type consistency:** `LatencyMount::{new, path, fsyncs}`, `Latency::profile`, `PassthroughFs` used identically across tasks; reply/trait signatures match the verified fuser 0.17 source.
 - **Known approximation:** profile latencies are representative, not calibrated to specific hardware; they model *relative* HDD/NFS behavior (the spec's stated non-goal is faithful bandwidth, which real-mount runs cover).

--- a/docs/superpowers/plans/2026-05-31-optimization-sp0a-per-format-coverage.md
+++ b/docs/superpowers/plans/2026-05-31-optimization-sp0a-per-format-coverage.md
@@ -1,0 +1,1049 @@
+# SP0a per-format bench coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sweep the SP0a ingest and read benches over every supported format (FLAC, MP3, M4A moov-first, M4A moov-last, Ogg, WAV) with a per-format report column, and add the missing Ogg (Opus) corpus builder. No production code changes.
+
+**Architecture:** Extend the shared bench-support module (`musefs-core/tests/common/`): add a `write_ogg` builder reusing `musefs-format`'s public `ogg::page_test_support` helpers, a `Format::Ogg` corpus variant, a centralized `ALL_FORMATS` + token mapping, a `format` column on `RunReport`, and a `prepare_format` per-format target helper. The `#[ignore]`d `bench_ingest` and the Criterion `read_throughput` bench then loop the format set; `bench_refresh` stays FLAC-only.
+
+**Tech Stack:** Rust, `criterion` (read bench, `harness = false`), `#[ignore]`d std tests, `tempfile`, `musefs_db::Db`, `musefs_core::{scan_directory, revalidate, Musefs, MountConfig, Mode, VirtualTree, metrics}`, and `musefs_format::ogg::page_test_support` (already a `musefs-core` dev-dependency).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-optimization-pass/SP0a-per-format-coverage.md`
+
+---
+
+## Conventions for every task
+
+- Work in the worktree `/home/cfutro/git/musefs/.claude/worktrees/optimization-pass` on branch `worktree-optimization-pass`.
+- The pre-commit hook runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace`. **Before every commit run `cargo fmt -p musefs-core` then `cargo clippy --all-targets -- -D warnings`** (the `--all-targets` form lints benches and the shared `tests/common` module, which a plain `cargo clippy --tests` misses). A commit fails if any hook fails.
+- The editor's LSP/rust-analyzer diagnostics in this worktree are known to lag (stale "unresolved import"/"unlinked-file" notes). Trust `cargo` output, not diagnostics.
+- End every commit message with a HEREDOC trailer line: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`. Stage only the files named in the task.
+- The `common` module has a crate-level `#![allow(dead_code)]` (top of `tests/common/mod.rs`) that covers `corpus.rs`/`report.rs`, so symbols added before their first use do not trip the dead-code lint.
+
+---
+
+## File structure
+
+- Modify `musefs-core/tests/common/mod.rs` — add `write_ogg`.
+- Modify `musefs-core/tests/common/corpus.rs` — `Format::Ogg`, `format_from_token`/`format_token`, `ALL_FORMATS`, `bench_formats`, `prepare_format`, `bench_base_dir`, `generate_one` Ogg arm.
+- Modify `musefs-core/tests/common/report.rs` — add the `format` column.
+- Modify `musefs-core/tests/common_corpus_smoke.rs` — new unit tests; update the `RunReport` constructor.
+- Rewrite `musefs-core/tests/bench_ingest.rs` — per-format sweep.
+- Modify `musefs-core/benches/read_throughput.rs` — per-format groups + generic inode walk.
+- Modify `musefs-core/tests/bench_refresh.rs` — `format: "flac"` + a clarifying comment (in Task 4).
+- Modify `docs/superpowers/specs/2026-05-30-optimization-pass/README.md` — per-format run notes.
+
+New tests live in `musefs-core/tests/common_corpus_smoke.rs` (which already has a `mod common;`, an `ENV_LOCK` mutex, and uses fully-qualified `common::corpus::…` calls — follow that style; do **not** add new `use common::corpus::{…}` lines, to avoid duplicate-import churn).
+
+---
+
+## Task 1: `write_ogg` corpus builder
+
+**Files:**
+- Modify: `musefs-core/tests/common/mod.rs` (append after `write_m4a_moov_last`, end of file)
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (append two tests + one `use`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add the import near the other `use common::…` lines at the top of `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+use common::write_ogg;
+```
+
+Append to the end of `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+#[test]
+fn write_ogg_scans_as_one_track() {
+    let dir = tempfile::tempdir().unwrap();
+    write_ogg(&dir.path().join("a.ogg"), &[0x22u8; 256]);
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(stats.scanned, 1, "minimal Ogg Opus should probe & ingest");
+    assert_eq!(stats.skipped, 0);
+}
+
+#[test]
+fn write_ogg_is_deterministic() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.ogg");
+    let b = dir.path().join("b.ogg");
+    write_ogg(&a, &[0x33u8; 300]);
+    write_ogg(&b, &[0x33u8; 300]);
+    assert_eq!(
+        std::fs::read(&a).unwrap(),
+        std::fs::read(&b).unwrap(),
+        "same audio bytes => identical Ogg file"
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke write_ogg -- --nocapture`
+Expected: FAIL — `cannot find function write_ogg in module common`.
+
+- [ ] **Step 3: Implement `write_ogg`**
+
+Append to `musefs-core/tests/common/mod.rs`:
+
+```rust
+/// Write a minimal valid Ogg **Opus** file (two header pages + one audio page
+/// whose packet body is `audio`) to `path`, returning (audio_offset,
+/// audio_length) of the audio-page span. Mirrors the recipe in
+/// `musefs-core/src/scan.rs`'s `ogg_probe_tests`: the `OpusTags` body must be a
+/// parseable VorbisComment (here empty) because the scanner runs `read_tags`.
+/// The synthesizer treats the audio packet body as opaque (renumbers pages,
+/// recomputes CRCs, never decodes), so arbitrary `audio` bytes are valid. The
+/// return is informational — `scan_directory` re-probes the file.
+pub fn write_ogg(path: &Path, audio: &[u8]) -> (i64, i64) {
+    use musefs_format::ogg::page_test_support::{
+        build_header_pub, lace_packet_pub, vorbis_body_empty,
+    };
+    let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
+    let mut tags = b"OpusTags".to_vec();
+    tags.extend_from_slice(&vorbis_body_empty());
+    let serial = 0x6d75_7366; // "musf"
+    // build_header returns (bytes, header_page_count); the audio page continues
+    // the sequence at that count.
+    let (mut bytes, header_pages) = build_header_pub(serial, &[&head, &tags]);
+    let header_len = bytes.len();
+    let (page, _) = lace_packet_pub(serial, header_pages, false, 960, audio);
+    bytes.extend_from_slice(&page);
+    std::fs::write(path, &bytes).unwrap();
+    (header_len as i64, (bytes.len() - header_len) as i64)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke write_ogg -- --nocapture`
+Expected: PASS (both `write_ogg_scans_as_one_track` and `write_ogg_is_deterministic`).
+
+- [ ] **Step 5: Verify fmt + clippy**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings`
+Expected: clean (no warnings).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/tests/common/mod.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "$(cat <<'EOF'
+test(core): add write_ogg minimal Opus corpus builder
+
+Reuses musefs-format's public ogg::page_test_support helpers (already a
+musefs-core dev-dep); OpusTags carries an empty VorbisComment body so the
+scanner's read_tags probe succeeds.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `Format::Ogg` + token mapping refactor + `generate_one` arm
+
+**Files:**
+- Modify: `musefs-core/tests/common/corpus.rs`
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (append one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+#[test]
+fn generate_with_ogg_in_mix_scans_all() {
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: 4,
+        bytes_per_track: 256,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac, Format::Mp3, Format::Ogg, Format::Wav],
+        seed: 9,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    common::corpus::generate(dir.path(), &p);
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(stats.scanned, 4, "all four formats (incl. Ogg) ingest");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke generate_with_ogg -- --nocapture`
+Expected: FAIL — `no variant named Ogg found for enum Format` (compile error).
+
+- [ ] **Step 3: Add the `Ogg` variant**
+
+In `musefs-core/tests/common/corpus.rs`, change the `Format` enum (currently ends `M4aMoovLast, Wav,`):
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    Flac,
+    Mp3,
+    M4aMoovFirst,
+    M4aMoovLast,
+    Ogg,
+    Wav,
+}
+```
+
+- [ ] **Step 4: Add the token mapping helpers**
+
+In `musefs-core/tests/common/corpus.rs`, add these two free functions immediately after the `Format` enum (before `pub struct CorpusParams`):
+
+```rust
+/// Map a `MUSEFS_BENCH_FORMAT_MIX` token to a `Format`. Single source of truth
+/// for both `from_env` and `bench_formats`.
+pub fn format_from_token(token: &str) -> Option<Format> {
+    match token.trim() {
+        "flac" => Some(Format::Flac),
+        "mp3" => Some(Format::Mp3),
+        "m4a" => Some(Format::M4aMoovFirst),
+        "m4a-last" => Some(Format::M4aMoovLast),
+        "ogg" => Some(Format::Ogg),
+        "wav" => Some(Format::Wav),
+        _ => None,
+    }
+}
+
+/// The canonical token for a `Format` (inverse of `format_from_token`). Used for
+/// report labels, per-format corpus subdir names, and `.ext` choices.
+pub fn format_token(f: Format) -> &'static str {
+    match f {
+        Format::Flac => "flac",
+        Format::Mp3 => "mp3",
+        Format::M4aMoovFirst => "m4a",
+        Format::M4aMoovLast => "m4a-last",
+        Format::Ogg => "ogg",
+        Format::Wav => "wav",
+    }
+}
+```
+
+- [ ] **Step 5: Route `from_env`'s parser through `format_from_token`**
+
+In `from_env`, replace the inline match block:
+
+```rust
+        if let Ok(mix) = std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
+            let parsed: Vec<Format> = mix
+                .split(',')
+                .filter_map(|s| match s.trim() {
+                    "flac" => Some(Format::Flac),
+                    "mp3" => Some(Format::Mp3),
+                    "m4a" => Some(Format::M4aMoovFirst),
+                    "m4a-last" => Some(Format::M4aMoovLast),
+                    "wav" => Some(Format::Wav),
+                    _ => None,
+                })
+                .collect();
+            // An all-unrecognized value keeps the tier default rather than
+            // erroring or yielding an empty mix.
+            if !parsed.is_empty() {
+                p.format_mix = parsed;
+            }
+        }
+```
+
+with:
+
+```rust
+        if let Ok(mix) = std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
+            let parsed: Vec<Format> = mix.split(',').filter_map(format_from_token).collect();
+            // An all-unrecognized value keeps the tier default rather than
+            // erroring or yielding an empty mix.
+            if !parsed.is_empty() {
+                p.format_mix = parsed;
+            }
+        }
+```
+
+- [ ] **Step 6: Add the `generate_one` Ogg arm**
+
+In `generate_one`, add this arm before the `Format::Wav` arm:
+
+```rust
+        Format::Ogg => {
+            let path = adir.join(format!("track-{idx:06}.ogg"));
+            super::write_ogg(&path, audio);
+            path
+        }
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke generate_with_ogg -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 8: Verify fmt + clippy + full smoke suite**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings && cargo test -p musefs-core --test common_corpus_smoke`
+Expected: clean; all smoke tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add musefs-core/tests/common/corpus.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "$(cat <<'EOF'
+test(core): wire Format::Ogg into the corpus generator
+
+Add the Ogg variant, centralize the token<->Format mapping in
+format_from_token/format_token (now shared by from_env), and emit .ogg tracks
+from generate_one via write_ogg.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `ALL_FORMATS` + `bench_formats`
+
+**Files:**
+- Modify: `musefs-core/tests/common/corpus.rs`
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (append three tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+#[test]
+fn bench_formats_defaults_to_all_when_unset() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
+    assert_eq!(
+        common::corpus::bench_formats(),
+        common::corpus::ALL_FORMATS.to_vec()
+    );
+}
+
+#[test]
+fn bench_formats_filters_and_never_empty() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "ogg,wav");
+    let filtered = common::corpus::bench_formats();
+    std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "garbagetoken");
+    let fallback = common::corpus::bench_formats();
+    std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
+    assert_eq!(filtered, vec![Format::Ogg, Format::Wav]);
+    assert_eq!(
+        fallback,
+        common::corpus::ALL_FORMATS.to_vec(),
+        "all-unrecognized must fall back to full coverage, never empty"
+    );
+}
+
+#[test]
+fn all_formats_round_trip_through_tokens() {
+    for &f in common::corpus::ALL_FORMATS {
+        assert_eq!(
+            common::corpus::format_from_token(common::corpus::format_token(f)),
+            Some(f),
+            "ALL_FORMATS member {f:?} must round-trip through its token"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke bench_formats -- --nocapture`
+Expected: FAIL — `cannot find value ALL_FORMATS` / `cannot find function bench_formats` in `common::corpus`.
+
+- [ ] **Step 3: Implement `ALL_FORMATS` and `bench_formats`**
+
+In `musefs-core/tests/common/corpus.rs`, add after the `format_token` function:
+
+```rust
+/// Every supported format, plus the M4A moov-last layout variant (the SP1
+/// bounded-read hard case). The per-format benches sweep this set.
+pub const ALL_FORMATS: &[Format] = &[
+    Format::Flac,
+    Format::Mp3,
+    Format::M4aMoovFirst,
+    Format::M4aMoovLast,
+    Format::Ogg,
+    Format::Wav,
+];
+
+/// The formats to sweep: `MUSEFS_BENCH_FORMAT_MIX` (comma list) acts as a filter
+/// when set; an unset or all-unrecognized value yields `ALL_FORMATS` (full
+/// coverage). Never returns an empty vec.
+pub fn bench_formats() -> Vec<Format> {
+    match std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
+        Ok(mix) => {
+            let parsed: Vec<Format> = mix.split(',').filter_map(format_from_token).collect();
+            if parsed.is_empty() {
+                ALL_FORMATS.to_vec()
+            } else {
+                parsed
+            }
+        }
+        Err(_) => ALL_FORMATS.to_vec(),
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke bench_formats -- --nocapture && cargo test -p musefs-core --test common_corpus_smoke all_formats_round_trip -- --nocapture`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Verify fmt + clippy**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/tests/common/corpus.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "$(cat <<'EOF'
+test(core): add ALL_FORMATS + bench_formats sweep selector
+
+bench_formats treats MUSEFS_BENCH_FORMAT_MIX as a filter and defaults to full
+coverage; a round-trip test keeps ALL_FORMATS and the token parser in sync.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `format` column on `RunReport` (+ update all constructors)
+
+Adding a required field breaks every `RunReport { … }` literal, so this task adds the column **and** updates all four existing constructors in the same commit to keep the workspace compiling. `read_throughput.rs` does **not** construct `RunReport` (it uses Criterion), so it is untouched here.
+
+**Files:**
+- Modify: `musefs-core/tests/common/report.rs`
+- Modify: `musefs-core/tests/common_corpus_smoke.rs` (the `report_renders_a_row` test)
+- Modify: `musefs-core/tests/bench_ingest.rs` (two literals)
+- Modify: `musefs-core/tests/bench_refresh.rs` (one literal + comment)
+
+- [ ] **Step 1: Update the smoke test (failing first)**
+
+In `musefs-core/tests/common_corpus_smoke.rs`, replace the `report_renders_a_row` test body's `RunReport { … }` construction and add a `format` assertion. Find:
+
+```rust
+    let r = RunReport {
+        label: "scan".into(),
+        tier: "ci".into(),
+        storage: "tempfs".into(),
+        wall_ms: 1234,
+        opens: 200,
+        preads: 200,
+        fsyncs: None,
+        peak_rss_kib: Some(50_000),
+    };
+    let line = r.row();
+    assert!(line.contains("scan"));
+    assert!(line.contains("ci"));
+    assert!(line.contains("n/a"), "fsyncs None renders as n/a");
+```
+
+Replace with:
+
+```rust
+    let r = RunReport {
+        label: "scan".into(),
+        format: "flac".into(),
+        tier: "ci".into(),
+        storage: "tempfs".into(),
+        wall_ms: 1234,
+        opens: 200,
+        preads: 200,
+        fsyncs: None,
+        peak_rss_kib: Some(50_000),
+    };
+    let line = r.row();
+    assert!(line.contains("scan"));
+    assert!(line.contains("flac"), "format column is rendered");
+    assert!(line.contains("ci"));
+    assert!(line.contains("n/a"), "fsyncs None renders as n/a");
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke report_renders -- --nocapture`
+Expected: FAIL — `missing field format in initializer of RunReport` (compile error).
+
+- [ ] **Step 3: Add the `format` column to `RunReport`**
+
+In `musefs-core/tests/common/report.rs`:
+
+Change the macro's format string (add one `{:<10}` column for `format`, after `label`):
+
+```rust
+macro_rules! report_fmt {
+    ($($arg:expr),* $(,)?) => {
+        format!("{:<10} {:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}", $($arg),*)
+    };
+}
+```
+
+Add the field (after `label`):
+
+```rust
+pub struct RunReport {
+    pub label: String,
+    pub format: String,
+    pub tier: String,
+    pub storage: String,
+    pub wall_ms: u128,
+    pub opens: u64,
+    pub preads: u64,
+    pub fsyncs: Option<u64>,
+    pub peak_rss_kib: Option<u64>,
+}
+```
+
+Update `header()` (add `"format"` after `"label"`):
+
+```rust
+    pub fn header() -> String {
+        report_fmt!(
+            "label", "format", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs",
+            "rss_kib"
+        )
+    }
+```
+
+Update `row()` (add `self.format` after `self.label`):
+
+```rust
+    pub fn row(&self) -> String {
+        let opt = |v: Option<u64>| v.map_or_else(|| "n/a".into(), |x| x.to_string());
+        report_fmt!(
+            self.label,
+            self.format,
+            self.tier,
+            self.storage,
+            self.wall_ms,
+            self.opens,
+            self.preads,
+            opt(self.fsyncs),
+            opt(self.peak_rss_kib),
+        )
+    }
+```
+
+- [ ] **Step 4: Update the `bench_ingest` constructors**
+
+In `musefs-core/tests/bench_ingest.rs`, add `format: "flac".into(),` after the `label` line in **both** `RunReport { … }` literals (the `"scan"` row and the `"revalidate"` row). The corpus is FLAC-only here until Task 6 rewrites this file, so `"flac"` is accurate. Example for the scan row:
+
+```rust
+        RunReport {
+            label: "scan".into(),
+            format: "flac".into(),
+            tier: tier.clone(),
+            storage: storage.clone(),
+            wall_ms: scan_ms,
+            opens: s.opens,
+            preads: s.preads,
+            fsyncs: None,
+            peak_rss_kib: peak_rss_kib(),
+        }
+```
+
+Apply the same `format: "flac".into(),` insertion to the `"revalidate"` row.
+
+- [ ] **Step 5: Update the `bench_refresh` constructor + add a clarifying comment**
+
+In `musefs-core/tests/bench_refresh.rs`, the rows are built in a loop. Add `format: "flac".into(),` after the `label` line in that `RunReport { … }` literal. Above the `println!("\n{}", RunReport::header());` line, add:
+
+```rust
+    // bench_refresh stays FLAC-only: poll_refresh times a DB-driven virtual-tree
+    // rebuild, independent of the backing audio format, so per-format rows would
+    // be pure noise. The format column is fixed to "flac" for table consistency.
+```
+
+The constructor becomes:
+
+```rust
+            RunReport {
+                label: label.into(),
+                format: "flac".into(),
+                tier: tier.clone(),
+                storage: "tempfs".into(),
+                wall_ms: ms,
+                opens: 0,
+                preads: 0,
+                fsyncs: None,
+                peak_rss_kib: None,
+            }
+```
+
+- [ ] **Step 6: Run the smoke test + full workspace**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke report_renders -- --nocapture`
+Expected: PASS (row contains "flac").
+Run: `cargo test --workspace`
+Expected: green (the two `#[ignore]`d benches stay ignored; everything compiles).
+
+- [ ] **Step 7: Verify fmt + clippy**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-core/tests/common/report.rs musefs-core/tests/common_corpus_smoke.rs musefs-core/tests/bench_ingest.rs musefs-core/tests/bench_refresh.rs
+git commit -m "$(cat <<'EOF'
+test(core): add a format column to RunReport
+
+New `format` field rendered via the shared report_fmt! macro (so header/row
+can't drift). Existing constructors set "flac"; bench_refresh notes why it
+stays FLAC-only.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `prepare_format` + `bench_base_dir` helpers
+
+**Files:**
+- Modify: `musefs-core/tests/common/corpus.rs`
+- Test: `musefs-core/tests/common_corpus_smoke.rs` (append one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs-core/tests/common_corpus_smoke.rs`:
+
+```rust
+#[test]
+fn prepare_format_generates_scannable_single_format_corpus() {
+    let base = tempfile::tempdir().unwrap();
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: 2,
+        bytes_per_track: 256,
+        // format_mix is overridden by prepare_format; set something different
+        // to prove the override.
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 5,
+    };
+    let t = common::corpus::prepare_format(&p, base.path(), Format::Ogg);
+    assert!(t.corpus_dir.ends_with("ogg"), "per-format subdir named by token");
+    assert_ne!(t.db_path, t.corpus_dir);
+    let db = Db::open(&t.db_path).unwrap();
+    let stats = scan_directory(&db, &t.corpus_dir).unwrap();
+    assert_eq!(stats.scanned, 2, "two Ogg tracks generated and scanned");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke prepare_format -- --nocapture`
+Expected: FAIL — `cannot find function prepare_format in module common::corpus`.
+
+- [ ] **Step 3: Implement the helpers**
+
+In `musefs-core/tests/common/corpus.rs`, add after the `prepare` function:
+
+```rust
+/// Resolve the base directory shared by a per-format sweep: `MUSEFS_BENCH_DIR`
+/// when set (caller-managed, second element `None`), else a fresh tempdir the
+/// caller must hold for the run's duration.
+pub fn bench_base_dir() -> (PathBuf, Option<tempfile::TempDir>) {
+    if let Ok(d) = std::env::var("MUSEFS_BENCH_DIR") {
+        (PathBuf::from(d), None)
+    } else {
+        let s = tempfile::tempdir().unwrap();
+        (s.path().to_path_buf(), Some(s))
+    }
+}
+
+/// Generate a single-format corpus for `fmt` under `<base>/<token>/` with its own
+/// cold DB (`musefs-bench.db` + sidecars deleted first), returning its `Target`.
+/// Per-format generalization of `prepare`'s generated branch. `MUSEFS_BENCH_DB`
+/// is intentionally **ignored** here: each format needs its own DB, so a single
+/// shared path would clobber across formats. `p.format_mix` is overridden to the
+/// single `fmt`. The base tempdir's lifetime is the caller's responsibility, so
+/// `_scratch` is `None`.
+pub fn prepare_format(p: &CorpusParams, base: &Path, fmt: Format) -> Target {
+    let corpus_dir = base.join(format_token(fmt));
+    let mut fp = p.clone();
+    fp.format_mix = vec![fmt];
+    generate(&corpus_dir, &fp);
+    let db_path = corpus_dir.join("musefs-bench.db");
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
+    }
+    Target {
+        corpus_dir,
+        db_path,
+        is_real_library: false,
+        _scratch: None,
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core --test common_corpus_smoke prepare_format -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Verify fmt + clippy**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/tests/common/corpus.rs musefs-core/tests/common_corpus_smoke.rs
+git commit -m "$(cat <<'EOF'
+test(core): add prepare_format + bench_base_dir for the per-format sweep
+
+prepare_format generates a single-format corpus under <base>/<token>/ with its
+own cold DB (MUSEFS_BENCH_DB ignored in sweep mode); bench_base_dir resolves the
+shared base dir once.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `bench_ingest` per-format sweep
+
+Rewrite the harness to loop `bench_formats()` in generated mode and collapse to a single `"mixed"` scan in real-library mode.
+
+**Files:**
+- Rewrite: `musefs-core/tests/bench_ingest.rs`
+
+- [ ] **Step 1: Replace the file**
+
+Replace the entire contents of `musefs-core/tests/bench_ingest.rs` with:
+
+```rust
+mod common;
+
+use std::time::Instant;
+
+use common::corpus::{bench_base_dir, bench_formats, format_token, prepare, prepare_format, CorpusParams, Target};
+use common::report::{peak_rss_kib, RunReport};
+use musefs_core::{metrics, revalidate, scan_directory};
+use musefs_db::Db;
+
+/// Scan + revalidate one resolved target, printing a `scan` and a `revalidate`
+/// row tagged with `format`/`storage`.
+///
+/// The `opens`/`preads` metrics instrument the *serve* path (reader.rs /
+/// open_handle), not the scan path, so both rows print ~0 even under
+/// `--features metrics`. The SP1-relevant signals are `wall_ms` and
+/// `peak_rss_kib`. `peak_rss_kib()` reads VmHWM — a process-lifetime high-water
+/// mark — so every row reflects the same peak; the meaningful figure is the
+/// largest corpus's scan row.
+fn run_one(target: &Target, tier: &str, format: &str, storage: &str) {
+    let db = Db::open(&target.db_path).unwrap();
+
+    metrics::reset();
+    let t0 = Instant::now();
+    let stats = scan_directory(&db, &target.corpus_dir).unwrap();
+    let scan_ms = t0.elapsed().as_millis();
+    let s = metrics::snapshot();
+
+    metrics::reset();
+    let t1 = Instant::now();
+    let _ = revalidate(&db, &target.corpus_dir).unwrap();
+    let reval_ms = t1.elapsed().as_millis();
+    let r = metrics::snapshot();
+
+    for (label, ms, snap) in [("scan", scan_ms, &s), ("revalidate", reval_ms, &r)] {
+        println!(
+            "{}",
+            RunReport {
+                label: label.into(),
+                format: format.into(),
+                tier: tier.into(),
+                storage: storage.into(),
+                wall_ms: ms,
+                opens: snap.opens,
+                preads: snap.preads,
+                fsyncs: None,
+                peak_rss_kib: peak_rss_kib(),
+            }
+            .row()
+        );
+    }
+    assert!(stats.scanned > 0, "format {format}: scanned 0 tracks");
+}
+
+#[test]
+#[ignore = "SP0 timing harness; run with --ignored --nocapture"]
+fn bench_cold_scan_and_revalidate() {
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+
+    println!("\n{}", RunReport::header());
+
+    // Real library: already mixed-format and never written to — a single scan
+    // tagged "mixed" rather than a per-format sweep.
+    if std::env::var("MUSEFS_BENCH_LIBRARY").is_ok() {
+        let target = prepare(&params);
+        run_one(&target, &tier, "mixed", "real-lib");
+        return;
+    }
+
+    // Generated mode: one single-format corpus + cold DB per format under a
+    // shared base dir (held for the loop's duration).
+    let (base, _scratch) = bench_base_dir();
+    let storage = if std::env::var("MUSEFS_BENCH_DIR").is_ok() {
+        "env-dir"
+    } else {
+        "tempfs"
+    };
+    for fmt in bench_formats() {
+        let target = prepare_format(&params, &base, fmt);
+        run_one(&target, &tier, format_token(fmt), storage);
+    }
+}
+```
+
+- [ ] **Step 2: Run the sweep (ci tier, with metrics) to verify it reports per-format rows**
+
+Run: `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture`
+Expected: PASS. Prints a header then a `scan` + `revalidate` row for each of the six formats (`flac`, `mp3`, `m4a`, `m4a-last`, `ogg`, `wav`), each with `scanned > 0` (the assert holds). `wall_ms`/`rss_kib` populated; `opens`/`preads` ~0.
+
+- [ ] **Step 3: Confirm it stays ignored in a normal run**
+
+Run: `cargo test -p musefs-core --test bench_ingest`
+Expected: `0 passed; … 1 ignored`.
+
+- [ ] **Step 4: Confirm the filter works**
+
+Run: `MUSEFS_BENCH_FORMAT_MIX=ogg,wav cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture`
+Expected: only `ogg` and `wav` row-pairs are printed.
+
+- [ ] **Step 5: Verify fmt + clippy + full workspace**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings && cargo test --workspace`
+Expected: clean; green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/tests/bench_ingest.rs
+git commit -m "$(cat <<'EOF'
+test(core): sweep bench_ingest over every format
+
+Generated mode loops bench_formats(), generating a single-format corpus + cold
+DB per format under one base dir and emitting per-format scan/revalidate rows;
+real-library mode collapses to a single "mixed" scan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `read_throughput` per-format groups + generic inode walk
+
+**Files:**
+- Modify: `musefs-core/benches/read_throughput.rs`
+
+- [ ] **Step 1: Update the corpus import**
+
+In `musefs-core/benches/read_throughput.rs`, change:
+
+```rust
+use common::corpus::{generate, CorpusParams, Format};
+```
+
+to:
+
+```rust
+use common::corpus::{bench_formats, format_token, generate, CorpusParams, Format};
+```
+
+- [ ] **Step 2: Add a generic inode walk and make `fixture` format-aware**
+
+Replace the entire current `fixture` function (the one with the doc comment "A small generated corpus … Returns the fs plus all file inodes." and the hardcoded `fs.lookup(VirtualTree::ROOT, "Artist 00000")` walk) with:
+
+```rust
+/// Recursively collect every non-directory inode reachable from `dir`. Used
+/// instead of a name-based lookup because non-FLAC corpus builders embed no tags,
+/// so their tracks render under the `default_fallback` ("Unknown/…") path.
+fn collect_file_inodes(fs: &Musefs, dir: u64, out: &mut Vec<u64>) {
+    for (_, ino, is_dir) in fs.readdir(dir).unwrap() {
+        if is_dir {
+            collect_file_inodes(fs, ino, out);
+        } else {
+            out.push(ino);
+        }
+    }
+}
+
+/// A small single-format generated corpus, scanned into an in-memory DB and
+/// mounted. Returns the fs plus all file inodes (discovered by a format-agnostic
+/// tree walk).
+fn fixture(format: Format, bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: tracks,
+        bytes_per_track,
+        art_bytes_per_track: 0,
+        format_mix: vec![format],
+        seed: 42,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    generate(dir.path(), &p);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Arc::new(Musefs::open(db, config()).unwrap());
+
+    let mut inodes = Vec::new();
+    collect_file_inodes(&fs, VirtualTree::ROOT, &mut inodes);
+    assert!(!inodes.is_empty(), "fixture: no file inodes for {format:?}");
+    // Keep the tempdir alive for the duration of the bench by leaking it.
+    std::mem::forget(dir);
+    (fs, inodes)
+}
+```
+
+- [ ] **Step 3: Make `bench_sequential_read` loop the formats**
+
+Replace the entire current `bench_sequential_read` function with:
+
+```rust
+fn bench_sequential_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sequential_read");
+    let chunk = 128 * 1024u64;
+    for fmt in bench_formats() {
+        let (fs, inodes) = fixture(fmt, 4 * 1024 * 1024, 1);
+        let inode = inodes[0];
+        let size = fs.getattr(inode).unwrap().size;
+        group.throughput(Throughput::Bytes(size));
+        // fh=0 takes the no-handle path: each read resolves the inode via the
+        // HeaderCache rather than reusing a registered fd.
+        group.bench_function(format_token(fmt), |b| {
+            b.iter(|| {
+                let mut off = 0u64;
+                while off < size {
+                    let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
+                    if got.is_empty() {
+                        break;
+                    }
+                    off += got.len() as u64;
+                }
+            });
+        });
+    }
+    group.finish();
+}
+```
+
+- [ ] **Step 4: Point the concurrent bench's fixture at FLAC**
+
+In `bench_concurrent_read_and_walk`, change the fixture call:
+
+```rust
+    let (fs, inodes) = fixture(1024 * 1024, m.max(2));
+```
+
+to:
+
+```rust
+    let (fs, inodes) = fixture(Format::Flac, 1024 * 1024, m.max(2));
+```
+
+- [ ] **Step 5: Smoke-run the bench (both groups, all formats)**
+
+Run: `cargo bench -p musefs-core --bench read_throughput -- --warm-up-time 1 --measurement-time 1`
+Expected: `sequential_read/{flac,mp3,m4a,m4a-last,ogg,wav}` each report a throughput line (no panic; the `!inodes.is_empty()` assert holds for every format including the non-FLAC ones that render under `Unknown/…`), and `concurrent_read_walk/mN_plus_walker` reports a line.
+
+- [ ] **Step 6: Confirm the workspace still builds/tests clean**
+
+Run: `cargo fmt -p musefs-core && cargo clippy --all-targets -- -D warnings && cargo test -p musefs-core`
+Expected: clean; all existing tests pass; benches stay ignored in the default test run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/benches/read_throughput.rs
+git commit -m "$(cat <<'EOF'
+bench(core): sweep sequential read over every format
+
+fixture takes a Format and discovers inodes via a generic tree walk (non-FLAC
+corpora render under Unknown/...); sequential_read emits one Criterion function
+per format. Concurrent read+walk stays FLAC-only (SP3 contention focus).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Document the per-format sweep in the tracking README
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-30-optimization-pass/README.md`
+
+- [ ] **Step 1: Update the "Running the SP0a harness" notes**
+
+In `docs/superpowers/specs/2026-05-30-optimization-pass/README.md`, find the "Notes:" list under the "## Running the SP0a harness" section and insert these two bullets at the top of that list (before the existing "A reused `MUSEFS_BENCH_DIR`…" bullet):
+
+```markdown
+- **Per-format sweep:** `bench_ingest` and the `read_throughput` sequential bench
+  run against every supported format (FLAC, MP3, M4A moov-first, M4A moov-last,
+  Ogg, WAV) by default, one report row / Criterion line per format (see the
+  `format` column). `bench_refresh` stays FLAC-only (it times a format-independent
+  DB-driven tree rebuild).
+- `MUSEFS_BENCH_FORMAT_MIX` (comma list of `flac,mp3,m4a,m4a-last,ogg,wav`)
+  restricts the sweep to those formats; unset = all. In a `bench_ingest` sweep,
+  `MUSEFS_BENCH_DB` is ignored (each format gets its own DB under a per-format
+  subdir); a real `MUSEFS_BENCH_LIBRARY` run does a single `mixed` scan instead of
+  sweeping.
+```
+
+- [ ] **Step 2: Update the SP0a status-row note**
+
+In the Status table, change the SP0a row's Notes cell (currently ending `… See "Running the SP0a harness" below`) to append `; per-format sweep added (SP0a-per-format-coverage.md)`.
+
+- [ ] **Step 3: Verify the commit hook (markdown only, but the hook runs the suite)**
+
+Run: `cargo test --workspace`
+Expected: green (no code changed; sanity check before commit).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+git commit -m "$(cat <<'EOF'
+docs: record the per-format bench sweep
+
+Note the default per-format coverage, the format column, MUSEFS_BENCH_FORMAT_MIX
+as a filter, the per-format DB behavior, and the real-library "mixed" collapse.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes (for the executor)
+
+- **Spec coverage:** `write_ogg` + `Format::Ogg` wiring (Tasks 1–2); `format` column (Task 4); `ALL_FORMATS`/`bench_formats` with filter + never-empty semantics (Task 3); `bench_ingest` per-format sweep with real-library `"mixed"` collapse and per-format DBs (Tasks 5–6); per-format `read_throughput` with a format-agnostic inode walk + `≥1 inode` assert (Task 7); `bench_refresh` stays FLAC-only with a comment (Task 4); determinism + scan + token-consistency tests (Tasks 1–3, 5); docs (Task 8).
+- **Non-goals preserved:** no Ogg art, Opus-only (no OggFLAC), no production-code changes, no new Cargo features, no tag embedding in non-FLAC builders.
+- **Always-green ordering:** Task 4 adds the required `format` field and updates *all* existing `RunReport` literals in the same commit, so `cargo test --workspace` stays green at every step; Task 6 then rewrites `bench_ingest` (its temporary `"flac"` literals from Task 4 are replaced by the looped `format_token(fmt)`).
+- **Type consistency:** `format_from_token(&str) -> Option<Format>`, `format_token(Format) -> &'static str`, `ALL_FORMATS: &[Format]`, `bench_formats() -> Vec<Format>`, `bench_base_dir() -> (PathBuf, Option<TempDir>)`, `prepare_format(&CorpusParams, &Path, Format) -> Target`, and `RunReport.format: String` are used identically across tasks. `Snapshot` fields `opens`/`preads` and `Musefs::{readdir -> Vec<(String,u64,bool)>, getattr().size, read(inode,fh,off,len)}` match the existing code.

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -73,12 +73,48 @@ is built for the full capability regardless.
 
 | SP | State | Spec | Plan | Notes |
 |---|---|---|---|---|
-| SP0a | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now |
+| SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below |
 | SP0b | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS |
 | SP1 | Not started | — | — | |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |
 | SP4 | Not started | — | — | |
+
+## Running the SP0a harness
+
+```bash
+# Read throughput + concurrent read/walk (Criterion):
+cargo bench -p musefs-core --bench read_throughput
+
+# Cold scan + revalidate timing (prints a table):
+cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
+
+# Refresh timing, 1 vs N changed tracks:
+cargo test -p musefs-core --test bench_refresh -- --ignored --nocapture
+
+# Scale / storage knobs (any of the timing/bench commands above):
+MUSEFS_BENCH_TIER=large-compute \
+MUSEFS_BENCH_DIR=/mnt/ssd/musefs-bench \
+  cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
+
+# Run against a real library (never written to; DB goes to MUSEFS_BENCH_DB or a tempfile):
+MUSEFS_BENCH_LIBRARY=/srv/music \
+MUSEFS_BENCH_DB=/tmp/musefs-bench.db \
+  cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture
+```
+
+Notes:
+- A reused `MUSEFS_BENCH_DIR` is re-scanned cold: `prepare` deletes any prior
+  `musefs-bench.db` (+ `-wal`/`-shm`) so scan timings start from an empty DB.
+- The `bench_ingest` `opens`/`preads` columns read ≈0: the metrics counters
+  instrument the serve path, not the scan path (per-file scan I/O counting
+  lands in SP1). `wall_ms` and `peak_rss_kib` are the SP1 signals here.
+- `fsyncs` shows `n/a` for every SP0a run; the SP0b passthrough FS fills it.
+- **Regression gate (convention for SP1–SP4):** treat the Criterion `ci`
+  `sequential_read` median as the baseline; a change is a regression if the
+  median rises **>10%** run-over-run on the same machine (Criterion prints the
+  median + its noise estimate). SP1–SP4 record before/after medians in the
+  results log and must not breach this gate.
 
 ## Results log
 

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -1,0 +1,85 @@
+# Optimization pass (2026-05-30) — tracking document
+
+*Started: 2026-05-30*
+
+This is the umbrella tracking doc for a second optimization pass over musefs.
+Each sub-project (SP) is independently shippable, has its own spec in this
+directory, and records before/after numbers in the results log below.
+
+## Cardinal invariant (non-negotiable, every SP)
+
+**Original audio bytes are never copied or modified, and served audio stays
+byte-identical.** Every SP keeps all existing crate tests and the `#[ignore]`d
+FUSE e2e mount tests green; the byte-identical audio round-trip is the hard gate.
+
+## Relationship to the 2026-05-26 pass
+
+A prior pass (`docs/superpowers/specs/2026-05-26-optimization-pass-design.md`,
+Phases 0–7) already optimized the **serving/read side**. This pass is scoped
+around what that one did *not* deliver. Reconciliation:
+
+| Area | Prior pass | Shipped? | Open here |
+|---|---|---|---|
+| Measurement harness | Phase 0 | `metrics.rs` + one micro-bench (`read_throughput`). No corpus generator, no tiers, no latency injection, no real-mount/concurrent benches. | **SP0** completes it |
+| Ingestion / scan | *not in scope* (serving-side only) | scan still `fs::read`s whole files; no transaction batching; single-threaded | **SP1** — largest untouched win |
+| Refresh | Phase 4 | batched query, debounce, off-thread rebuild, stable inodes — but still a **full** rebuild on any edit | **SP2** — changed-only rebuild |
+| Read/serve | Phases 1–3 | worker pool, per-handle fd, sharded *header* cache | **SP3** residuals: `handles` + `size_cache` are single `Mutex<HashMap>`; `read_segments` double-allocates backing audio |
+| Storage-aware serving | Phase 5 | `max_readahead` / async-read / parallel-dirops in `init` | **SP4** residual: Ogg whole-region index scan on first read |
+
+## Decomposition
+
+- **SP0 — Measurement foundation.** Complete the Phase-0 harness: synthetic
+  library generator (tiered + custom/real-library), scan/refresh/read benches
+  (single + concurrent), a deterministic latency-injection layer (passthrough
+  FUSE), and comparable reporting. *Spec: `SP0-measurement-foundation.md`.*
+- **SP1 — Ingestion scalability.** Bounded probing reads (stop slurping whole
+  files), transaction batching across the scan loop, optional parallel probing,
+  bulk-write pragma tuning. *Spec: TBD after SP0.*
+- **SP2 — Incremental tree refresh.** Rebuild only changed tracks on a
+  `data_version` bump instead of reloading and re-rendering the whole library.
+  *Spec: TBD.*
+- **SP3 — Read/serve residuals.** Remove the `read_segments` double-allocation;
+  reduce `handles` / `size_cache` global-mutex contention. *Spec: TBD.*
+- **SP4 — Storage-aware serving residuals.** Mitigate the Ogg first-read
+  whole-region index scan on HDD/NFS. *Spec: TBD.*
+
+## Ordering & rationale
+
+SP0 → SP1 → SP2 → SP3 → SP4.
+
+- **SP0 first** — the harness gates every later SP (changes are measured, not
+  guessed) and is still mostly unbuilt.
+- **SP1 next** — largest genuinely-open win, and a fast scan is what lets us
+  build large test corpora for SP2–SP4.
+- **SP2 before SP3/SP4** — at 100k tracks a full rebuild storm would swamp the
+  finer read-path gains, so fix refresh cost first.
+- **SP3/SP4 last** — small, well-scoped residual items.
+
+## Conventions
+
+- Each SP records before/after numbers (from SP0's harness) in the results log.
+- Storage-bound claims (SP1, SP4) are validated under both injected latency and
+  a real mount; compute-bound claims (SP2, SP3) on tempfs is sufficient.
+- CI runs only the `ci` tier on tempfs; everything heavier is opt-in / env-gated.
+
+## Active-environment note
+
+The current dev box is storage-constrained: only the `ci` and `large-compute`
+tiers run here. The `bandwidth` tier, real-mount runs, and the `custom`
+real-library tier run later on the VPS that hosts the actual music library. SP0
+is built for the full capability regardless.
+
+## Status
+
+| SP | State | Spec | Plan | Notes |
+|---|---|---|---|---|
+| SP0 | Spec drafted | `SP0-measurement-foundation.md` | — | Awaiting review |
+| SP1 | Not started | — | — | |
+| SP2 | Not started | — | — | |
+| SP3 | Not started | — | — | |
+| SP4 | Not started | — | — | |
+
+## Results log
+
+*(Per-SP before/after numbers land here as each ships. Format: tier · storage
+class · wall time · op counts · fsyncs · peak RSS.)*

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -74,7 +74,7 @@ is built for the full capability regardless.
 | SP | State | Spec | Plan | Notes |
 |---|---|---|---|---|
 | SP0a | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now |
-| SP0b | Not started | `SP0-measurement-foundation.md` | — | Passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS |
+| SP0b | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS |
 | SP1 | Not started | — | — | |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -20,7 +20,7 @@ around what that one did *not* deliver. Reconciliation:
 
 | Area | Prior pass | Shipped? | Open here |
 |---|---|---|---|
-| Measurement harness | Phase 0 | `metrics.rs` + one micro-bench (`read_throughput`). No corpus generator, no tiers, no latency injection, no real-mount/concurrent benches. | **SP0** completes it |
+| Measurement harness | Phase 0 | `metrics.rs` (atomic counters + in-process per-syscall latency injection via `MUSEFS_FAULT_OPEN_US`/`STAT_US`/`PREAD_US` + `snapshot`/`reset`) + one micro-bench (`read_throughput`). No corpus generator, no tiers, **no FUSE-level injection** (so SQLite/write-durability latency is unmodelled and there is no fsync counter), no real-mount/concurrent benches. | **SP0** completes it |
 | Ingestion / scan | *not in scope* (serving-side only) | scan still `fs::read`s whole files; no transaction batching; single-threaded | **SP1** — largest untouched win |
 | Refresh | Phase 4 | batched query, debounce, off-thread rebuild, stable inodes — but still a **full** rebuild on any edit | **SP2** — changed-only rebuild |
 | Read/serve | Phases 1–3 | worker pool, per-handle fd, sharded *header* cache | **SP3** residuals: `handles` + `size_cache` are single `Mutex<HashMap>`; `read_segments` double-allocates backing audio |

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -73,7 +73,8 @@ is built for the full capability regardless.
 
 | SP | State | Spec | Plan | Notes |
 |---|---|---|---|---|
-| SP0 | Spec drafted | `SP0-measurement-foundation.md` | — | Awaiting review |
+| SP0a | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now |
+| SP0b | Not started | `SP0-measurement-foundation.md` | — | Passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS |
 | SP1 | Not started | — | — | |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -73,7 +73,7 @@ is built for the full capability regardless.
 
 | SP | State | Spec | Plan | Notes |
 |---|---|---|---|---|
-| SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below |
+| SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below; per-format sweep added (`SP0a-per-format-coverage.md`) |
 | SP0b | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS |
 | SP1 | Not started | — | — | |
 | SP2 | Not started | — | — | |
@@ -104,6 +104,16 @@ MUSEFS_BENCH_DB=/tmp/musefs-bench.db \
 ```
 
 Notes:
+- **Per-format sweep:** `bench_ingest` and the `read_throughput` sequential bench
+  run against every supported format (FLAC, MP3, M4A moov-first, M4A moov-last,
+  Ogg, WAV) by default, one report row / Criterion line per format (see the
+  `format` column). `bench_refresh` stays FLAC-only (it times a format-independent
+  DB-driven tree rebuild).
+- `MUSEFS_BENCH_FORMAT_MIX` (comma list of `flac,mp3,m4a,m4a-last,ogg,wav`)
+  restricts the sweep to those formats; unset = all. In a `bench_ingest` sweep,
+  `MUSEFS_BENCH_DB` is ignored (each format gets its own DB under a per-format
+  subdir); a real `MUSEFS_BENCH_LIBRARY` run does a single `mixed` scan instead of
+  sweeping.
 - A reused `MUSEFS_BENCH_DIR` is re-scanned cold: `prepare` deletes any prior
   `musefs-bench.db` (+ `-wal`/`-shm`) so scan timings start from an empty DB.
 - The `bench_ingest` `opens`/`preads` columns read ≈0: the metrics counters

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/SP0-measurement-foundation.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/SP0-measurement-foundation.md
@@ -21,7 +21,11 @@ counters (behind the existing `metrics` feature) for paths not already counted.
 ## Reuse (existing foundation)
 
 - `musefs-core/src/metrics.rs` — feature-gated atomic counters
-  (`on_open`/`on_pread`/`on_art_chunk`, etc.). Extend, don't replace.
+  (`on_open`/`on_stat`/`on_pread`/`on_art_chunk`), a `Snapshot` +
+  `snapshot()`/`reset()` API, **and in-process per-syscall latency injection**
+  already wired to `MUSEFS_FAULT_OPEN_US` / `MUSEFS_FAULT_STAT_US` /
+  `MUSEFS_FAULT_PREAD_US`. Extend, don't replace. SP0's reporting reuses
+  `snapshot()`; the only counter gap is fsync (see Component 4).
 - `musefs-core/benches/read_throughput.rs` — the single existing Criterion bench
   (one 4 MiB FLAC, in-memory DB). Generalize it to consume the corpus generator.
 - `musefs-*/tests/common/mod.rs` — `make_flac`, `streaminfo_body`,
@@ -47,25 +51,35 @@ a backing directory of audio files plus, optionally, scans it into a DB.
 Parameters (all env-overridable; see Interfaces):
 
 - `albums`, `tracks_per_album` — tree shape.
-- `bytes_per_track` — audio payload size. Payload is filler bytes (content is
-  irrelevant: `BackingAudio` is served verbatim and probing reads only headers).
-- `art_per_album` — embedded cover count; one shared cover per album so the
-  content-addressed `art` table stays deduped/small. Embeddable into files via a
-  size knob, or omitted for size-sensitive runs.
+- `bytes_per_track` — the **audio payload** size (authoritative definition).
+  Payload is filler bytes (content is irrelevant: `BackingAudio` is served
+  verbatim and probing reads only headers). Total file size = payload +
+  synthesized format front + any embedded art.
+- `art_bytes_per_track` — embedded cover size (0 = no embedded art). One shared
+  cover per album, so the content-addressed `art` table stays deduped/small. Per
+  tier, the table below states whether art is embedded.
 - `format_mix` — default FLAC-only for determinism; optional mix across
-  FLAC/MP3/M4A/Ogg/WAV. The mix **must** be able to include an M4A with `moov`
-  at end-of-file, the interesting case for SP1's bounded reads.
+  FLAC/MP3/M4A/Ogg/WAV. **New work:** the mix must be able to include an M4A with
+  `moov` **at end-of-file** — the interesting case for SP1's bounded reads. The
+  existing `tests/common` builder (`minimal_m4a`) is moov-**first** only, so a
+  moov-at-end builder must be authored. (Verified: the MP4 reader's `locate`
+  finds boxes by scanning top-level atoms regardless of order, so a moov-at-end
+  fixture parses and scans correctly — no reader change needed.)
 - `seed` — deterministic generation; a given (params, seed) reproduces byte-for-
   byte identical files.
 
 Tiers (named presets; each is just a parameter bundle, still overridable):
 
-| Tier | Shape | bytes/track | ~Footprint | Purpose |
-|---|---|---|---|---|
-| `ci` | ~200 tracks | ~4 KB | tens of MB | CI compute regression guard; runs in seconds |
-| `large-compute` | 100k tracks (10k×10) | ~8 KB | ~1 GB | SP2/SP3 scale + injection latency runs |
-| `bandwidth` | ~1k tracks | ~30 MB | ~30 GB | real-mount throughput; extrapolate per-file |
-| `custom` | env-defined | env-defined | — | arbitrary manual composition |
+| Tier | Shape | payload/track | art | ~Footprint | Purpose |
+|---|---|---|---|---|---|
+| `ci` | ~200 tracks | ~4 KB | none | tens of MB | CI compute regression guard; runs in seconds |
+| `large-compute` | 100k tracks (10k×10) | ~8 KB | one ~30 KB cover/album (deduped) | ~1 GB | SP2/SP3 scale + injection latency runs |
+| `bandwidth` | ~1k tracks | ~30 MB | one realistic cover/album | ~30 GB | real-mount throughput; extrapolate per-file |
+| `custom` | env-defined | env-defined | env-defined | — | arbitrary manual composition |
+
+(`ci` omits embedded art to keep files tiny and parsing trivial; art-bearing
+synthesis paths are still exercised because the shared per-album cover lands in
+the DB and on the synthesized read path at the larger tiers.)
 
 Plus a **real-library mode**: instead of generating, point the harness at an
 existing music directory and scan it in place. Scan is read-only with respect to
@@ -80,9 +94,13 @@ separate, explicit knob — **the real library is never modified**.
 - **Refresh** — time `poll_refresh` / tree rebuild after touching 1 track vs N
   tracks. This is the metric SP2 attacks (full vs incremental rebuild).
 - **Read** — generalize `read_throughput`: sequential and random-seek reads,
-  single-threaded and **concurrent** (M streams + a metadata walker). The
-  concurrent variant exercises SP3's `handles` / `size_cache` contention and the
-  worker pool.
+  single-threaded and **concurrent**. The concurrent variant runs `M` reader
+  threads streaming distinct files plus one walker thread that loops
+  `lookup`+`getattr` over the tree, all sharing one `Arc<Musefs>` in-process
+  (`Musefs` methods take `&self`, so no real mount is needed — per the README
+  rule that compute-bound work is fine on tempfs). `M` defaults to `2×ncpu`,
+  env-overridable. This exercises SP3's `handles` / `size_cache` mutex
+  contention and the worker pool.
 
 Each bench reports throughput where meaningful, the metrics op counts, and (for
 scan/refresh) peak RSS.
@@ -97,9 +115,23 @@ delegating to the underlying file via `std::fs`:
 - Delayed ops: `lookup`/`getattr` (stat RTT), `open` (open RTT), `read` (seek +
   RTT, optionally per-op rather than per-byte), `write`/`fsync` (commit
   durability cost).
+- **Full op surface required** (not just the delayed ones): SQLite in WAL mode
+  under the mount needs `create`/`open`/`write`/`read`/`fsync`/`flush`/`release`,
+  `setattr`+`ftruncate` (WAL extend/truncate), `unlink`/`rename` (journal/wal/shm
+  cleanup and checkpoint), plus `opendir`/`readdir`/`lookup`/`getattr`/`statfs`
+  and possibly `getxattr`. A missing op surfaces as an obscure `EIO` mid-scan —
+  the `ssd` smoke test (Acceptance) is the guard, and building this op surface is
+  the **first** plan task, not the last.
 - Because the corpus **and** the SQLite DB live under this mount, both
   backing-file I/O (`fs::read`, `File::open`, `read_exact_at`) **and** SQLite's
   own fsyncs are delayed uniformly — no in-process I/O seam, no SQLite VFS shim.
+- **Relationship to the existing `MUSEFS_FAULT_*_US` knobs:** those stay as the
+  *tempfs-mode* complement — they inject open/stat/pread latency in-process with
+  no mount, useful for read-path microbenchmarks. The passthrough FS is the
+  *whole-system* mechanism that additionally covers `write`/`fsync` and SQLite's
+  durability path (which the in-process counters cannot reach). The two are used
+  in different modes, not simultaneously; SP0 keeps both and documents which to
+  use when.
 - Profiles via env knobs (illustrative defaults, tunable): `ssd` (≈0), `hdd`
   (multi-ms per open/read), `nfs-ssd` (sub-ms RTT per op), `nfs-hdd` (RTT +
   seek). A profile is a bundle of per-op latencies.
@@ -111,9 +143,19 @@ exercises real syscalls end to end.
 
 ### 4. Metrics & reporting
 
-- Extend `metrics.rs` only where a path is uncounted — notably an **fsync
-  counter** for the scan/ingest path (so SP1's batching win is measurable).
-- Peak RSS from `/proc/self/status` `VmHWM` (Linux; no new crate).
+- Reuse `metrics::snapshot()` for opens/stats/preads/pread_bytes/art_chunks.
+- **fsync counts** come from the passthrough FS (it counts kernel `fsync` ops
+  directly); for tempfs in-process runs add a complementary `on_fsync` counter to
+  `metrics.rs` only if a meaningful in-process hook exists. **WAL caveat:** under
+  WAL, SQLite fsyncs the `-wal` file and at checkpoints, not once per row/commit,
+  so the fsync count is a **relative** signal (it must drop when SP1 batches
+  transactions) — *not* an absolute per-transaction number. SP1 must interpret it
+  that way.
+- Peak RSS from `/proc/self/status` `VmHWM` (Linux; no new crate). **Scope:** RSS
+  is the bench process and is meaningful only for the **in-process tempfs**
+  scan/refresh benches (where SP1's whole-file-read spike shows). Under the
+  passthrough mount the FS runs in a separate process, so its memory is out of
+  scope and RSS is not reported for those runs.
 - Emit a compact, comparable table per run: `tier · storage-class · wall ·
   opens · preads · fsyncs · peak-RSS`, so an SSD run and an NFS-HDD run of the
   same tier sit side by side.
@@ -136,32 +178,47 @@ exercises real syscalls end to end.
   mutually exclusive with generation.
 - `MUSEFS_BENCH_DB` — explicit DB path (kept separate from a real library).
 - `MUSEFS_BENCH_LATENCY_PROFILE` = `ssd` | `hdd` | `nfs-ssd` | `nfs-hdd` |
-  per-op overrides — selects the passthrough-FUSE profile.
+  per-op overrides — selects the **passthrough-FUSE** profile (whole-system,
+  incl. write/fsync). Distinct from the pre-existing in-process
+  `MUSEFS_FAULT_OPEN_US` / `MUSEFS_FAULT_STAT_US` / `MUSEFS_FAULT_PREAD_US` knobs,
+  which inject read-path latency with no mount. The two are not combined; the
+  harness documents which mode a run uses.
 
 ## Testing & acceptance criteria
 
 - `cargo bench` runs the `ci`-tier compute benches on tempfs with no extra setup.
 - The generator produces byte-deterministic corpora for a given (params, seed) at
   every tier; real-library mode scans a provided directory without writing to it.
-- An `#[ignore]` test demonstrates the passthrough-FUSE layer measurably raises
+- **Passthrough smoke test (gating, runs before any timed run):** an `#[ignore]`
+  test scans *and* reads a small corpus through the passthrough FS at the `ssd`
+  (≈0) profile — including a SQLite WAL checkpoint — and passes, proving the op
+  surface is complete.
+- An `#[ignore]` test then demonstrates the passthrough layer measurably raises
   scan and read time under a non-zero latency profile (and ~0 under `ssd`).
+- **Reproducibility / regression gate:** the `ci` compute bench reports a stable
+  median across repeated runs on tempfs with documented expected variance, and a
+  regression threshold (e.g. median > X%) is defined so SP1–SP4 have a concrete
+  pass/fail gate — this is what makes the harness *useful*, not merely present.
+- **fsync signal:** a known scan workload through the passthrough FS yields an
+  fsync count that moves in the expected direction (drops) when writes are
+  batched — validating it as the relative SP1 signal described in Component 4.
 - Reporting emits the comparable table described above.
 - All existing crate tests and the `#[ignore]` FUSE e2e tests stay green; with
   the `metrics` feature off, behavior is unchanged.
 
 ## Risks & open questions (resolve during planning)
 
-- **Passthrough FUSE completeness** — needs enough of the `Filesystem` surface
-  (lookup/getattr/open/read/release/opendir/readdir/fsync/flush) for SQLite WAL +
-  scan + reads to work. Risk of a missing op surfacing as an obscure I/O error;
-  mitigate with a smoke test that scans + reads through the passthrough at `ssd`
-  (≈0 latency) before trusting timed runs.
+- **Passthrough FUSE completeness (top risk)** — must implement the full op
+  surface in Component 3 (incl. SQLite WAL's write/create/truncate/rename), not
+  just the delayed ops. A missing op surfaces as an obscure `EIO` mid-scan;
+  guarded by the gating `ssd` smoke test, which is the first plan task.
 - **Criterion vs one-shot** — read benches fit Criterion; scan/refresh at scale
   do not. Plan splits them: Criterion group for read, a separate timed binary or
   `#[ignore]` test for scan/refresh.
-- **fsync counting** — the cleanest hook for fsync counts is the passthrough FS
-  (counts kernel fsync ops); the in-process `metrics` counter is a complement for
-  tempfs runs where there is no FUSE layer. Plan decides whether both are needed.
+- **fsync semantics** — under WAL the count is a relative signal, not a
+  per-transaction absolute (see Component 4). Confirm during planning whether an
+  in-process `on_fsync` hook is worth adding for tempfs runs or whether the
+  passthrough count alone suffices for SP1.
 
 ## New dependencies
 

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/SP0-measurement-foundation.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/SP0-measurement-foundation.md
@@ -1,0 +1,170 @@
+# SP0 — Measurement foundation — design
+
+*Date: 2026-05-30 · Part of the [2026-05-30 optimization pass](./README.md)*
+
+## Goal
+
+Complete the measurement harness the 2026-05-26 Phase 0 only partially built, so
+every later SP is validated against numbers rather than guessed. Deliver:
+
+1. a **synthetic library generator** at controlled scale (tiered + custom +
+   real-library);
+2. a **bench suite** covering scan/ingest, refresh, and read — single-stream and
+   concurrent;
+3. a **deterministic latency-injection layer** (a bench-only passthrough FUSE
+   filesystem) so HDD/NFS profiles are reproducible on one machine;
+4. **comparable reporting** that makes SSD vs HDD vs NFS runs directly readable.
+
+No production code paths change. The only `src/` edits are additive metrics
+counters (behind the existing `metrics` feature) for paths not already counted.
+
+## Reuse (existing foundation)
+
+- `musefs-core/src/metrics.rs` — feature-gated atomic counters
+  (`on_open`/`on_pread`/`on_art_chunk`, etc.). Extend, don't replace.
+- `musefs-core/benches/read_throughput.rs` — the single existing Criterion bench
+  (one 4 MiB FLAC, in-memory DB). Generalize it to consume the corpus generator.
+- `musefs-*/tests/common/mod.rs` — `make_flac`, `streaminfo_body`,
+  `vorbis_comment_body`, and the per-format builders. The generator builds on
+  these rather than inventing new file synthesis.
+- The `#[ignore]` + `/dev/fuse` gating pattern from `musefs-fuse` e2e tests.
+
+## Non-goals
+
+- Any optimization itself (that is SP1–SP4). SP0 only measures.
+- Changing the SQLite schema or any production hot path.
+- A faithful *bandwidth* model from injection — injection models **latency**
+  (per-op RTT/seek); true throughput is measured on a real mount.
+- Cross-platform support beyond Linux (the project is already Linux/FUSE-only).
+
+## Components
+
+### 1. Synthetic library generator
+
+A bench/test-support module (not shipped in the library binary) that materializes
+a backing directory of audio files plus, optionally, scans it into a DB.
+
+Parameters (all env-overridable; see Interfaces):
+
+- `albums`, `tracks_per_album` — tree shape.
+- `bytes_per_track` — audio payload size. Payload is filler bytes (content is
+  irrelevant: `BackingAudio` is served verbatim and probing reads only headers).
+- `art_per_album` — embedded cover count; one shared cover per album so the
+  content-addressed `art` table stays deduped/small. Embeddable into files via a
+  size knob, or omitted for size-sensitive runs.
+- `format_mix` — default FLAC-only for determinism; optional mix across
+  FLAC/MP3/M4A/Ogg/WAV. The mix **must** be able to include an M4A with `moov`
+  at end-of-file, the interesting case for SP1's bounded reads.
+- `seed` — deterministic generation; a given (params, seed) reproduces byte-for-
+  byte identical files.
+
+Tiers (named presets; each is just a parameter bundle, still overridable):
+
+| Tier | Shape | bytes/track | ~Footprint | Purpose |
+|---|---|---|---|---|
+| `ci` | ~200 tracks | ~4 KB | tens of MB | CI compute regression guard; runs in seconds |
+| `large-compute` | 100k tracks (10k×10) | ~8 KB | ~1 GB | SP2/SP3 scale + injection latency runs |
+| `bandwidth` | ~1k tracks | ~30 MB | ~30 GB | real-mount throughput; extrapolate per-file |
+| `custom` | env-defined | env-defined | — | arbitrary manual composition |
+
+Plus a **real-library mode**: instead of generating, point the harness at an
+existing music directory and scan it in place. Scan is read-only with respect to
+the audio files (it writes only to its own SQLite DB), and the DB path is a
+separate, explicit knob — **the real library is never modified**.
+
+### 2. Bench suite
+
+- **Scan / ingest** — one-shot timing (Criterion's resampling does not fit a
+  100k-file scan): wall time, op counts (opens/preads), **fsync count**, and peak
+  RSS for a cold `scan_directory`, and for an incremental `revalidate`.
+- **Refresh** — time `poll_refresh` / tree rebuild after touching 1 track vs N
+  tracks. This is the metric SP2 attacks (full vs incremental rebuild).
+- **Read** — generalize `read_throughput`: sequential and random-seek reads,
+  single-threaded and **concurrent** (M streams + a metadata walker). The
+  concurrent variant exercises SP3's `handles` / `size_cache` contention and the
+  worker pool.
+
+Each bench reports throughput where meaningful, the metrics op counts, and (for
+scan/refresh) peak RSS.
+
+### 3. Latency-injection layer — passthrough FUSE
+
+A bench-only passthrough filesystem (test-support module in `musefs-fuse`, which
+already owns the `fuser` dependency; exposed for benches). It mirrors a real
+backing directory but sleeps a configurable amount per operation before
+delegating to the underlying file via `std::fs`:
+
+- Delayed ops: `lookup`/`getattr` (stat RTT), `open` (open RTT), `read` (seek +
+  RTT, optionally per-op rather than per-byte), `write`/`fsync` (commit
+  durability cost).
+- Because the corpus **and** the SQLite DB live under this mount, both
+  backing-file I/O (`fs::read`, `File::open`, `read_exact_at`) **and** SQLite's
+  own fsyncs are delayed uniformly — no in-process I/O seam, no SQLite VFS shim.
+- Profiles via env knobs (illustrative defaults, tunable): `ssd` (≈0), `hdd`
+  (multi-ms per open/read), `nfs-ssd` (sub-ms RTT per op), `nfs-hdd` (RTT +
+  seek). A profile is a bundle of per-op latencies.
+- Gating: requires `/dev/fuse`; `#[ignore]`d like the existing e2e tests. Never
+  part of the default `cargo test` / `cargo bench`.
+
+This is the heaviest piece to build but keeps the production code untouched and
+exercises real syscalls end to end.
+
+### 4. Metrics & reporting
+
+- Extend `metrics.rs` only where a path is uncounted — notably an **fsync
+  counter** for the scan/ingest path (so SP1's batching win is measurable).
+- Peak RSS from `/proc/self/status` `VmHWM` (Linux; no new crate).
+- Emit a compact, comparable table per run: `tier · storage-class · wall ·
+  opens · preads · fsyncs · peak-RSS`, so an SSD run and an NFS-HDD run of the
+  same tier sit side by side.
+
+### 5. CI gating
+
+- Default CI: only the `ci` tier, on tempfs, as a compute regression guard.
+- `large-compute`, `bandwidth`, real-mount, and all latency-injection runs are
+  `#[ignore]`d / env-gated, opt-in.
+
+## Interfaces (env vars — names indicative, finalized in the plan)
+
+- `MUSEFS_BENCH_TIER` = `ci` | `large-compute` | `bandwidth` | `custom`
+- `MUSEFS_BENCH_ALBUMS`, `MUSEFS_BENCH_TRACKS_PER_ALBUM`,
+  `MUSEFS_BENCH_BYTES_PER_TRACK`, `MUSEFS_BENCH_ART_PER_ALBUM`,
+  `MUSEFS_BENCH_FORMAT_MIX`, `MUSEFS_BENCH_SEED` — override any tier dimension.
+- `MUSEFS_BENCH_DIR` — target directory for corpus + DB (default: tempdir). Point
+  at a real SSD/HDD/NFS mount for ground-truth runs.
+- `MUSEFS_BENCH_LIBRARY` — path to an existing real library (real-library mode);
+  mutually exclusive with generation.
+- `MUSEFS_BENCH_DB` — explicit DB path (kept separate from a real library).
+- `MUSEFS_BENCH_LATENCY_PROFILE` = `ssd` | `hdd` | `nfs-ssd` | `nfs-hdd` |
+  per-op overrides — selects the passthrough-FUSE profile.
+
+## Testing & acceptance criteria
+
+- `cargo bench` runs the `ci`-tier compute benches on tempfs with no extra setup.
+- The generator produces byte-deterministic corpora for a given (params, seed) at
+  every tier; real-library mode scans a provided directory without writing to it.
+- An `#[ignore]` test demonstrates the passthrough-FUSE layer measurably raises
+  scan and read time under a non-zero latency profile (and ~0 under `ssd`).
+- Reporting emits the comparable table described above.
+- All existing crate tests and the `#[ignore]` FUSE e2e tests stay green; with
+  the `metrics` feature off, behavior is unchanged.
+
+## Risks & open questions (resolve during planning)
+
+- **Passthrough FUSE completeness** — needs enough of the `Filesystem` surface
+  (lookup/getattr/open/read/release/opendir/readdir/fsync/flush) for SQLite WAL +
+  scan + reads to work. Risk of a missing op surfacing as an obscure I/O error;
+  mitigate with a smoke test that scans + reads through the passthrough at `ssd`
+  (≈0 latency) before trusting timed runs.
+- **Criterion vs one-shot** — read benches fit Criterion; scan/refresh at scale
+  do not. Plan splits them: Criterion group for read, a separate timed binary or
+  `#[ignore]` test for scan/refresh.
+- **fsync counting** — the cleanest hook for fsync counts is the passthrough FS
+  (counts kernel fsync ops); the in-process `metrics` counter is a complement for
+  tempfs runs where there is no FUSE layer. Plan decides whether both are needed.
+
+## New dependencies
+
+None required at runtime. Bench/test-only: `criterion` and `tempfile` are already
+dev-deps; peak RSS reads `/proc` directly (no crate). The passthrough FUSE reuses
+the existing `fuser` dependency in `musefs-fuse`.

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/SP0a-per-format-coverage.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/SP0a-per-format-coverage.md
@@ -53,24 +53,40 @@ any future format stay in sync.
 pub fn write_ogg(path: &Path, audio: &[u8]) -> (i64, i64)
 ```
 
-Builds a minimal valid **Ogg Opus** file by reusing the already-wired
-`musefs_format::ogg::page_test_support` helpers (`musefs-core`'s
-`[dev-dependencies]` already enable `musefs-format`'s `fuzzing` feature plus the
-`ogg`/`crc` crates; `tests/interop_emit.rs` already uses `fuzz_check::fixtures`):
+Builds a minimal valid **Ogg Opus** file by reusing the public
+`musefs_format::ogg::page_test_support` helpers. (`page_test_support` is an
+ordinary `pub` module — not feature-gated — and `musefs-core`'s
+`[dev-dependencies]` already pull `musefs-format` plus the `ogg`/`crc` crates;
+`tests/interop_emit.rs` already uses `musefs_format::fuzz_check::fixtures`.)
 
-- `build_header_pub(serial, &[OpusHead, OpusTags])` → the two header pages.
-- `lace_packet_pub(serial, 2, false, 960, audio)` → one audio page whose packet
-  body is the corpus's `filler` bytes. The synthesizer treats the packet body as
-  opaque (it renumbers pages / recomputes CRC, never decodes), so arbitrary
-  filler bytes are a valid payload.
+Mirror the **only** working recipe in the codebase — `scan.rs`'s
+`ogg_probe_tests` — exactly. Three helpers are needed: `build_header_pub`,
+`lace_packet_pub`, and `vorbis_body_empty`:
 
-Returns `(audio_offset, audio_length)` from the header length / page span. The
-return is informational only — `generate_one` discards it and `scan_directory`
-re-probes the file (consistent with the other `write_*` helpers).
+- The `OpusHead` packet: `b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00"`.
+- The `OpusTags` packet: `b"OpusTags"` ++ `vorbis_body_empty()`. The empty
+  VorbisComment body is **load-bearing** — `scan.rs`'s probe calls
+  `ogg::read_tags`, which requires a parseable VorbisComment body after the
+  `OpusTags` magic; a hand-rolled body risks a probe failure.
+- `let (mut bytes, _) = build_header_pub(serial, &[&head, &tags]);` → the two
+  header pages. (Both helpers return `(Vec<u8>, u32)`; the second element is a
+  page count — destructure and ignore it.)
+- `let (page, _) = lace_packet_pub(serial, 2, false, 960, audio);` then
+  `bytes.extend_from_slice(&page)` → one audio page whose packet body is the
+  corpus's `filler` bytes. The synthesizer treats the packet body as opaque (it
+  renumbers pages / recomputes CRC, never decodes), so arbitrary filler bytes are
+  a valid payload.
+
+Returns `(audio_offset, audio_length)` = (header-pages byte length, audio-page
+byte length). The return is informational only — `generate_one` discards it and
+`scan_directory` re-probes the file (consistent with the other `write_*`
+helpers), so the lacing/page-framing overhead in `audio_length` is harmless.
 
 Add `Format::Ogg` to the corpus `Format` enum, the `"ogg"` token to
 `from_env`'s `MUSEFS_BENCH_FORMAT_MIX` parser, and the `Format::Ogg => write_ogg`
-arm in `generate_one`. (`scan.rs` already probes `.ogg`.)
+arm in `generate_one`. (`scan.rs` already probes `.ogg`.) Note: the test-corpus
+`Format::Ogg` maps to the production `musefs_db::Format::Opus` at scan time via
+codec detection — there is no 1:1 `Ogg` db variant, which is expected.
 
 ### 2. `format` column in `RunReport` (`musefs-core/tests/common/report.rs`)
 
@@ -90,7 +106,10 @@ pub fn bench_formats() -> Vec<Format>
 
 `bench_formats` reads the env var directly (not via `CorpusParams.format_mix`,
 whose tier default of FLAC is indistinguishable from an explicit `flac`). Reuses
-the same token→`Format` mapping as `from_env`.
+the same token→`Format` mapping as `from_env`. An unset **or** all-unrecognized
+value (e.g. `MUSEFS_BENCH_FORMAT_MIX=garbage`) yields `ALL_FORMATS` (full
+coverage), matching `from_env`'s "never end up with an empty mix" intent — it
+must never return an empty vec (which would silently sweep nothing).
 
 ### 4. `bench_ingest` per-format sweep (`musefs-core/tests/bench_ingest.rs`)
 
@@ -105,7 +124,14 @@ format. Existing metrics/RSS/wall semantics per row.
 
 This is the per-format generalization of SP0a's `prepare`; factor the shared
 base-dir + cold-DB logic into a helper (e.g. `prepare_format(params, fmt)`)
-rather than duplicating it.
+rather than duplicating it. Reuse `prepare`'s exact sidecar-deletion loop (the
+`["", "-wal", "-shm"]` removal) per subdir DB.
+
+Each per-format subdir gets its **own** DB at `<base>/<format>/musefs-bench.db`.
+`MUSEFS_BENCH_DB` (a single explicit path) is **ignored in generated sweep mode**
+— six formats cannot share one DB file without clobbering each other — and the
+helper must document that. (`MUSEFS_BENCH_DB` still applies in real-library mode
+below, which does a single scan.)
 
 **Real-library mode** (`MUSEFS_BENCH_LIBRARY` set): a real library is already
 mixed-format and cannot be regenerated per format, so the sweep collapses to a
@@ -120,6 +146,27 @@ reports a per-format throughput line). The concurrent read+walk variant stays a
 single FLAC-only group — its purpose is mutex-contention scaling (SP3), not
 per-format cost. Throughput annotations as in SP0a.
 
+**Inode discovery must be format-agnostic.** The current SP0a fixture hardcodes
+`fs.lookup(VirtualTree::ROOT, "Artist 00000")`, which only works because the FLAC
+builder embeds `ARTIST/ALBUM/TITLE` vorbis comments. The other builders
+(`write_mp3`/`write_m4a`/`write_m4a_moov_last`/`write_wav`/`write_ogg`) embed **no
+tags**, so `probe` ingests empty artist/album/title and the `$artist/$album/$title`
+template renders every non-FLAC track under `default_fallback` ("Unknown/...").
+A hardcoded `"Artist 00000"` lookup would therefore `unwrap()` on `None` for all
+five non-FLAC formats. The fixture must instead collect file inodes by a generic
+recursive walk from `VirtualTree::ROOT` (descend dirs via `readdir`, collect the
+non-dir entries' inodes), independent of the rendered names. The fixture asserts
+it found ≥1 file inode (so a future tree-shape change fails loudly rather than
+producing a zero-byte bench).
+
+This tagless-non-FLAC reality means the per-format numbers measure container
+probing + synthesis with **minimal/empty** metadata for non-FLAC formats (only
+FLAC carries the 3 comments). That is an acceptable baseline — the dominant
+per-format cost is container parsing, page renumbering (Ogg), `moov` rebuild
+(M4A), and ID3v2 framing (MP3), not tag-string volume. Embedding equal tags
+across all formats for a fairer synthesis comparison is a possible future
+refinement, explicitly out of scope here.
+
 ### 6. `bench_refresh` stays FLAC-only (`musefs-core/tests/bench_refresh.rs`)
 
 `poll_refresh` times a DB-driven virtual-tree rebuild; the backing audio format
@@ -129,11 +176,17 @@ one-line comment stating why it does not sweep formats.
 ### 7. Tests (TDD, `musefs-core/tests/common_corpus_smoke.rs`)
 
 - `write_ogg` output scans as exactly 1 track (`scanned == 1`).
-- `generate` with `format_mix == ALL_FORMATS` scans all tracks and is
-  deterministic (byte-identical first file across two runs, per the existing
-  determinism-test pattern).
+- `write_ogg` is deterministic: two calls with the same `audio` produce
+  byte-identical files (proves the Ogg path specifically, since the existing
+  whole-corpus determinism check only inspects the first file, which is FLAC).
+- `generate` with `format_mix == ALL_FORMATS` scans all tracks (round-robin
+  coverage of every format).
 - `bench_formats()` returns `ALL_FORMATS` when `MUSEFS_BENCH_FORMAT_MIX` is unset
-  and the parsed subset when set (holds `ENV_LOCK`).
+  and the parsed subset when set; an all-unrecognized value returns `ALL_FORMATS`
+  (never empty). Holds `ENV_LOCK`.
+- `ALL_FORMATS` ↔ token-parser consistency: every `ALL_FORMATS` member round-trips
+  through the `MUSEFS_BENCH_FORMAT_MIX` token mapping (and every token maps to an
+  `ALL_FORMATS` member), so the two can't silently drift when a format is added.
 
 The benches remain `#[ignore]`d; their per-format output is verified by running
 them manually (as in SP0a), not asserted in the default suite.
@@ -149,7 +202,9 @@ them manually (as in SP0a), not asserted in the default suite.
   adding an OggFLAC variant is deferred unless a later SP needs codec-specific
   numbers.
 - No new Cargo features and no production-code changes; reuses the existing
-  `fuzzing` dev-dependency wiring.
+  `musefs-format` dev-dependency (and `ogg`/`crc`) already in `musefs-core`.
+- No tag embedding in the non-FLAC corpus builders (see Component 5) — the
+  builders are reused as-is.
 
 ## Acceptance criteria
 
@@ -160,7 +215,10 @@ them manually (as in SP0a), not asserted in the default suite.
    prints a table with a `scan`+`revalidate` row for each of the six formats,
    each with `scanned > 0`.
 3. `cargo bench -p musefs-core --bench read_throughput` reports a sequential
-   throughput line per format without panicking.
+   throughput line for **each** format in `bench_formats()` without panicking
+   (the fixture finds ≥1 inode per format, including the non-FLAC formats that
+   render under `Unknown/...`).
 4. `MUSEFS_BENCH_FORMAT_MIX=ogg,wav` restricts both sweeps to those two formats.
-5. The corpus generator produces a valid, scannable Ogg file, and generation is
-   deterministic for a fixed `(params, seed)`.
+5. The corpus generator produces a valid, scannable Ogg file, and both `write_ogg`
+   and `generate` are deterministic for fixed inputs (`(params, seed)` for the
+   corpus; identical `audio` for `write_ogg`).

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/SP0a-per-format-coverage.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/SP0a-per-format-coverage.md
@@ -1,0 +1,166 @@
+# SP0a extension — per-format bench coverage
+
+*Part of the 2026-05-30 optimization pass. Extends the shipped SP0a harness
+(`SP0-measurement-foundation.md`, plan `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md`).*
+
+## Problem
+
+The SP0a corpus generator and benches are **FLAC-only**: every tier preset uses
+`format_mix: vec![Format::Flac]`, and although the generator already supports
+MP3 / M4A (moov-first & moov-last) / WAV writers, the benches never exercise
+them. Ogg has no corpus builder at all. So scan/ingest and read numbers reflect
+only FLAC — yet probing, tag extraction, audio-offset finding, and metadata
+synthesis differ materially per format (MP3 regenerates ID3v2 wholesale; M4A
+rebuilds `moov` and patches `stco`/`co64`; Ogg renumbers pages and recomputes
+CRCs). SP1–SP4 need per-format baselines to avoid optimizing one format while
+regressing another.
+
+## Goal
+
+Run the ingest and read benches against **every supported format**, reporting
+one row / Criterion line per format, so per-format cost is directly comparable.
+Add the missing Ogg corpus builder. No production code changes.
+
+## Cardinal invariant
+
+Unchanged from the umbrella doc: original audio bytes are never copied or
+modified, served audio stays byte-identical. This is a test/bench-only change
+(everything under `tests/` and `benches/` plus this doc); all existing crate
+tests and the `#[ignore]`d FUSE e2e tests stay green.
+
+## Format set
+
+The sweep covers all supported formats plus the one layout variant that matters
+for SP1:
+
+| Token (`MUSEFS_BENCH_FORMAT_MIX`) | `Format` variant | Builder |
+|---|---|---|
+| `flac` | `Flac` | existing `flac_bytes` (corpus) |
+| `mp3` | `Mp3` | existing `write_mp3` |
+| `m4a` | `M4aMoovFirst` | existing `write_m4a` |
+| `m4a-last` | `M4aMoovLast` | existing `write_m4a_moov_last` (SP1 bounded-read hard case) |
+| `ogg` | `Ogg` | **new** `write_ogg` |
+| `wav` | `Wav` | existing `write_wav` |
+
+Centralized as a single `corpus::ALL_FORMATS: &[Format]` constant so benches and
+any future format stay in sync.
+
+## Components
+
+### 1. `write_ogg` corpus builder (`musefs-core/tests/common/mod.rs`)
+
+```
+pub fn write_ogg(path: &Path, audio: &[u8]) -> (i64, i64)
+```
+
+Builds a minimal valid **Ogg Opus** file by reusing the already-wired
+`musefs_format::ogg::page_test_support` helpers (`musefs-core`'s
+`[dev-dependencies]` already enable `musefs-format`'s `fuzzing` feature plus the
+`ogg`/`crc` crates; `tests/interop_emit.rs` already uses `fuzz_check::fixtures`):
+
+- `build_header_pub(serial, &[OpusHead, OpusTags])` → the two header pages.
+- `lace_packet_pub(serial, 2, false, 960, audio)` → one audio page whose packet
+  body is the corpus's `filler` bytes. The synthesizer treats the packet body as
+  opaque (it renumbers pages / recomputes CRC, never decodes), so arbitrary
+  filler bytes are a valid payload.
+
+Returns `(audio_offset, audio_length)` from the header length / page span. The
+return is informational only — `generate_one` discards it and `scan_directory`
+re-probes the file (consistent with the other `write_*` helpers).
+
+Add `Format::Ogg` to the corpus `Format` enum, the `"ogg"` token to
+`from_env`'s `MUSEFS_BENCH_FORMAT_MIX` parser, and the `Format::Ogg => write_ogg`
+arm in `generate_one`. (`scan.rs` already probes `.ogg`.)
+
+### 2. `format` column in `RunReport` (`musefs-core/tests/common/report.rs`)
+
+Add a `pub format: String` field. Extend the `report_fmt!` macro's column layout
+and the `header()` label row with a `format` column (placed after `label`). Both
+header and row expand the one macro, so they cannot drift.
+
+### 3. Format-set selection (`musefs-core/tests/common/corpus.rs`)
+
+```
+pub const ALL_FORMATS: &[Format] = &[Flac, Mp3, M4aMoovFirst, M4aMoovLast, Ogg, Wav];
+
+pub fn bench_formats() -> Vec<Format>
+//   = parse(MUSEFS_BENCH_FORMAT_MIX) when set   (acts as a sweep filter, e.g. "ogg,wav")
+//   = ALL_FORMATS.to_vec()           when unset (full coverage by default)
+```
+
+`bench_formats` reads the env var directly (not via `CorpusParams.format_mix`,
+whose tier default of FLAC is indistinguishable from an explicit `flac`). Reuses
+the same token→`Format` mapping as `from_env`.
+
+### 4. `bench_ingest` per-format sweep (`musefs-core/tests/bench_ingest.rs`)
+
+**Generated mode** (no `MUSEFS_BENCH_LIBRARY`): resolve a base dir once
+(`MUSEFS_BENCH_DIR` or a tempdir, exactly as `prepare` does today) and loop over
+`bench_formats()`. For each format, clone `params`, set `format_mix = vec![fmt]`,
+generate that single-format corpus into a **per-format subdir** of the base dir
+(e.g. `<base>/<format>/`) with its own cold DB (delete `musefs-bench.db` +
+`-wal`/`-shm` first, mirroring `prepare`), time `scan` then `revalidate`, and emit
+a `scan` + `revalidate` row tagged with the format. `assert!(scanned > 0)` per
+format. Existing metrics/RSS/wall semantics per row.
+
+This is the per-format generalization of SP0a's `prepare`; factor the shared
+base-dir + cold-DB logic into a helper (e.g. `prepare_format(params, fmt)`)
+rather than duplicating it.
+
+**Real-library mode** (`MUSEFS_BENCH_LIBRARY` set): a real library is already
+mixed-format and cannot be regenerated per format, so the sweep collapses to a
+**single** scan + revalidate of the real directory, emitting one row pair tagged
+`format = "mixed"`. No per-format generation occurs.
+
+### 5. `read_throughput` per-format groups (`musefs-core/benches/read_throughput.rs`)
+
+`fixture(format, bytes_per_track, tracks)` takes a `Format`. The sequential read
+bench emits one `bench_function` per format in `bench_formats()` (Criterion
+reports a per-format throughput line). The concurrent read+walk variant stays a
+single FLAC-only group — its purpose is mutex-contention scaling (SP3), not
+per-format cost. Throughput annotations as in SP0a.
+
+### 6. `bench_refresh` stays FLAC-only (`musefs-core/tests/bench_refresh.rs`)
+
+`poll_refresh` times a DB-driven virtual-tree rebuild; the backing audio format
+is irrelevant to it. Per-format rows would be pure noise. Unchanged except a
+one-line comment stating why it does not sweep formats.
+
+### 7. Tests (TDD, `musefs-core/tests/common_corpus_smoke.rs`)
+
+- `write_ogg` output scans as exactly 1 track (`scanned == 1`).
+- `generate` with `format_mix == ALL_FORMATS` scans all tracks and is
+  deterministic (byte-identical first file across two runs, per the existing
+  determinism-test pattern).
+- `bench_formats()` returns `ALL_FORMATS` when `MUSEFS_BENCH_FORMAT_MIX` is unset
+  and the parsed subset when set (holds `ENV_LOCK`).
+
+The benches remain `#[ignore]`d; their per-format output is verified by running
+them manually (as in SP0a), not asserted in the default suite.
+
+## Non-goals (explicit)
+
+- **Ogg cover art.** The `write_ogg` builder embeds no `METADATA_BLOCK_PICTURE`
+  art. The Ogg art path (`OggArtSlice` synthesis) is exercised elsewhere; the
+  per-format scan/read baseline does not need it. Deferred.
+- **FLAC-in-Ogg (OggFLAC).** The builder emits **Opus** only (`OpusHead`/
+  `OpusTags`), not a FLAC codec inside the Ogg container. One Opus stream is
+  enough to measure the Ogg container's page-renumber + CRC synthesis cost;
+  adding an OggFLAC variant is deferred unless a later SP needs codec-specific
+  numbers.
+- No new Cargo features and no production-code changes; reuses the existing
+  `fuzzing` dev-dependency wiring.
+
+## Acceptance criteria
+
+1. `cargo test --workspace` and `cargo clippy --all-targets -- -D warnings` stay
+   green; the default suite is unchanged except the new `common_corpus_smoke`
+   cases.
+2. `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture`
+   prints a table with a `scan`+`revalidate` row for each of the six formats,
+   each with `scanned > 0`.
+3. `cargo bench -p musefs-core --bench read_throughput` reports a sequential
+   throughput line per format without panicking.
+4. `MUSEFS_BENCH_FORMAT_MIX=ogg,wav` restricts both sweeps to those two formats.
+5. The corpus generator produces a valid, scannable Ogg file, and generation is
+   deterministic for a fixed `(params, seed)`.

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -1,56 +1,67 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::thread;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use musefs_core::{scan_directory, MountConfig, Musefs, VirtualTree};
+use musefs_core::{scan_directory, Mode, MountConfig, Musefs, VirtualTree};
 
 #[path = "../tests/common/mod.rs"]
 mod common;
-use common::{make_flac, streaminfo_body, vorbis_comment_body};
+use common::corpus::{generate, CorpusParams, Format};
 
 fn config() -> MountConfig {
     MountConfig {
-        template: "$artist/$title".to_string(),
+        template: "$artist/$album/$title".to_string(),
         fallbacks: BTreeMap::new(),
         default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
+        mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
     }
 }
 
-fn bench_sequential_read(c: &mut Criterion) {
-    let audio_len = 4 * 1024 * 1024usize; // 4 MiB
-                                          // Bind the buffer so the slice passed to make_flac is not an inline `&vec![...]`
-                                          // (avoids clippy::useless_vec while keeping the 4 MiB off the stack).
-    let audio = vec![0x7E_u8; audio_len];
+/// A small generated corpus with a few MB of audio per track, scanned into an
+/// in-memory DB and mounted. Returns the fs plus all file inodes.
+fn fixture(bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: tracks,
+        bytes_per_track,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 42,
+    };
     let dir = tempfile::tempdir().unwrap();
-    let flac = make_flac(
-        &[
-            (0, streaminfo_body()),
-            (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
-        ],
-        &audio,
-    );
-    std::fs::write(dir.path().join("a.flac"), &flac).unwrap();
-
+    generate(dir.path(), &p);
     let db = musefs_db::Db::open_in_memory().unwrap();
     scan_directory(&db, dir.path()).unwrap();
-    let fs = Musefs::open(db, config()).unwrap();
-    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
-    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
-    let size = fs.getattr(file_inode).unwrap().size;
+    let fs = Arc::new(Musefs::open(db, config()).unwrap());
 
+    // Walk the single album dir to collect file inodes.
+    let artist = fs.lookup(VirtualTree::ROOT, "Artist 00000").unwrap();
+    let sub = fs.readdir(artist).unwrap()[0].1; // Album 00000 dir
+    let inodes: Vec<u64> = fs
+        .readdir(sub)
+        .unwrap()
+        .into_iter()
+        .map(|(_, ino, _)| ino)
+        .collect();
+    // Keep the tempdir alive for the duration of the bench by leaking it.
+    std::mem::forget(dir);
+    (fs, inodes)
+}
+
+fn bench_sequential_read(c: &mut Criterion) {
+    let (fs, inodes) = fixture(4 * 1024 * 1024, 1);
+    let inode = inodes[0];
+    let size = fs.getattr(inode).unwrap().size;
     let mut group = c.benchmark_group("sequential_read");
     group.throughput(Throughput::Bytes(size));
     let chunk = 128 * 1024u64;
-    // Steady-state (warm header-cache) sequential throughput: the first iteration
-    // populates the cache; subsequent ones measure the hot read path. The audio
-    // payload is filler bytes — BackingAudio is served verbatim regardless of
-    // content, so this measures the splice/serve mechanism, not audio parsing.
     group.bench_function("flac_128k_chunks", |b| {
         b.iter(|| {
             let mut off = 0u64;
             while off < size {
-                let got = std::hint::black_box(fs.read(file_inode, 0, off, chunk).unwrap());
+                let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
                 if got.is_empty() {
                     break;
                 }
@@ -61,5 +72,70 @@ fn bench_sequential_read(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_sequential_read);
+fn bench_concurrent_read_and_walk(c: &mut Criterion) {
+    // M reader threads streaming distinct files + one metadata walker, sharing
+    // one Arc<Musefs>. Exercises handles/size_cache mutex contention (SP3).
+    let m = std::env::var("MUSEFS_BENCH_READERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(num_streams);
+    let (fs, inodes) = fixture(1024 * 1024, m.max(2));
+
+    let mut group = c.benchmark_group("concurrent_read_walk");
+    group.bench_function(format!("m{m}_plus_walker"), |b| {
+        b.iter(|| {
+            let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            // Walker thread: loop lookups/getattrs over the inodes.
+            let walker = {
+                let fs = Arc::clone(&fs);
+                let inodes = inodes.clone();
+                let stop = Arc::clone(&stop);
+                thread::spawn(move || {
+                    while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                        for &ino in &inodes {
+                            let _ = std::hint::black_box(fs.getattr(ino));
+                        }
+                    }
+                })
+            };
+            let readers: Vec<_> = (0..m)
+                .map(|i| {
+                    let fs = Arc::clone(&fs);
+                    let ino = inodes[i % inodes.len()];
+                    thread::spawn(move || {
+                        // open_handle + per-handle reads exercise the `handles`
+                        // mutex (SP3); the walker's getattr exercises `size_cache`.
+                        let fh = fs.open_handle(ino).unwrap();
+                        let size = fs.getattr(ino).unwrap().size;
+                        let mut off = 0u64;
+                        while off < size {
+                            let got = fs.read(ino, fh, off, 128 * 1024).unwrap();
+                            if got.is_empty() {
+                                break;
+                            }
+                            off += got.len() as u64;
+                        }
+                        fs.release_handle(fh);
+                    })
+                })
+                .collect();
+            for r in readers {
+                r.join().unwrap();
+            }
+            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            walker.join().unwrap();
+        });
+    });
+    group.finish();
+}
+
+fn num_streams() -> usize {
+    std::thread::available_parallelism().map_or(4, |n| n.get() * 2)
+}
+
+criterion_group!(
+    benches,
+    bench_sequential_read,
+    bench_concurrent_read_and_walk
+);
 criterion_main!(benches);

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -53,7 +53,9 @@ fn fixture(format: Format, bytes_per_track: usize, tracks: usize) -> (Arc<Musefs
     let mut inodes = Vec::new();
     collect_file_inodes(&fs, VirtualTree::ROOT, &mut inodes);
     assert!(!inodes.is_empty(), "fixture: no file inodes for {format:?}");
-    // Keep the tempdir alive for the duration of the bench by leaking it.
+    // Keep the tempdir alive for the duration of the bench by leaking it. Each
+    // fixture call leaks one; a full run accumulates at most ALL_FORMATS.len()+1
+    // (sequential per-format + concurrent), all reclaimed when the process exits.
     std::mem::forget(dir);
     (fs, inodes)
 }

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -38,7 +38,12 @@ fn fixture(bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
 
     // Walk the single album dir to collect file inodes.
     let artist = fs.lookup(VirtualTree::ROOT, "Artist 00000").unwrap();
-    let sub = fs.readdir(artist).unwrap()[0].1; // Album 00000 dir
+    let sub = fs
+        .readdir(artist)
+        .unwrap()
+        .first()
+        .expect("fixture: expected at least one album dir under the artist")
+        .1; // Album 00000 dir
     let inodes: Vec<u64> = fs
         .readdir(sub)
         .unwrap()
@@ -57,6 +62,10 @@ fn bench_sequential_read(c: &mut Criterion) {
     let mut group = c.benchmark_group("sequential_read");
     group.throughput(Throughput::Bytes(size));
     let chunk = 128 * 1024u64;
+    // fh=0 takes the no-handle path: each read resolves the inode via the
+    // HeaderCache rather than reusing a registered fd. This measures the
+    // warm-cache resolve+splice cost, not fd-reuse (which the concurrent bench
+    // exercises via open_handle).
     group.bench_function("flac_128k_chunks", |b| {
         b.iter(|| {
             let mut off = 0u64;
@@ -81,8 +90,19 @@ fn bench_concurrent_read_and_walk(c: &mut Criterion) {
         .unwrap_or_else(num_streams);
     let (fs, inodes) = fixture(1024 * 1024, m.max(2));
 
+    // Each iteration streams `m` whole files (reader i reads inodes[i]); the
+    // walker does metadata-only ops and contributes no bytes.
+    let total_bytes: u64 = (0..m)
+        .map(|i| fs.getattr(inodes[i % inodes.len()]).unwrap().size)
+        .sum();
+
     let mut group = c.benchmark_group("concurrent_read_walk");
+    group.throughput(Throughput::Bytes(total_bytes));
     group.bench_function(format!("m{m}_plus_walker"), |b| {
+        // Thread spawn/join overhead is included in each iteration, so this
+        // measures burst concurrency rather than steady-state throughput; the
+        // signal of interest is how that wall time scales with `m` (SP3 lock
+        // contention), not its absolute value.
         b.iter(|| {
             let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
             // Walker thread: loop lookups/getattrs over the inodes.
@@ -119,11 +139,16 @@ fn bench_concurrent_read_and_walk(c: &mut Criterion) {
                     })
                 })
                 .collect();
-            for r in readers {
-                r.join().unwrap();
-            }
+            // Join all readers first, then stop the walker — collecting results
+            // before unwrapping so a reader panic can't leave the walker spinning
+            // (stop is always set before we re-raise the panic).
+            let reader_results: Vec<_> =
+                readers.into_iter().map(thread::JoinHandle::join).collect();
             stop.store(true, std::sync::atomic::Ordering::Relaxed);
             walker.join().unwrap();
+            for r in reader_results {
+                r.unwrap();
+            }
         });
     });
     group.finish();

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -7,7 +7,7 @@ use musefs_core::{scan_directory, Mode, MountConfig, Musefs, VirtualTree};
 
 #[path = "../tests/common/mod.rs"]
 mod common;
-use common::corpus::{generate, CorpusParams, Format};
+use common::corpus::{bench_formats, format_token, generate, CorpusParams, Format};
 
 fn config() -> MountConfig {
     MountConfig {
@@ -19,15 +19,29 @@ fn config() -> MountConfig {
     }
 }
 
-/// A small generated corpus with a few MB of audio per track, scanned into an
-/// in-memory DB and mounted. Returns the fs plus all file inodes.
-fn fixture(bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
+/// Recursively collect every non-directory inode reachable from `dir`. Used
+/// instead of a name-based lookup because non-FLAC corpus builders embed no tags,
+/// so their tracks render under the `default_fallback` ("Unknown/…") path.
+fn collect_file_inodes(fs: &Musefs, dir: u64, out: &mut Vec<u64>) {
+    for (_, ino, is_dir) in fs.readdir(dir).unwrap() {
+        if is_dir {
+            collect_file_inodes(fs, ino, out);
+        } else {
+            out.push(ino);
+        }
+    }
+}
+
+/// A small single-format generated corpus, scanned into an in-memory DB and
+/// mounted. Returns the fs plus all file inodes (discovered by a format-agnostic
+/// tree walk).
+fn fixture(format: Format, bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
     let p = CorpusParams {
         albums: 1,
         tracks_per_album: tracks,
         bytes_per_track,
         art_bytes_per_track: 0,
-        format_mix: vec![Format::Flac],
+        format_mix: vec![format],
         seed: 42,
     };
     let dir = tempfile::tempdir().unwrap();
@@ -36,48 +50,37 @@ fn fixture(bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
     scan_directory(&db, dir.path()).unwrap();
     let fs = Arc::new(Musefs::open(db, config()).unwrap());
 
-    // Walk the single album dir to collect file inodes.
-    let artist = fs.lookup(VirtualTree::ROOT, "Artist 00000").unwrap();
-    let sub = fs
-        .readdir(artist)
-        .unwrap()
-        .first()
-        .expect("fixture: expected at least one album dir under the artist")
-        .1; // Album 00000 dir
-    let inodes: Vec<u64> = fs
-        .readdir(sub)
-        .unwrap()
-        .into_iter()
-        .map(|(_, ino, _)| ino)
-        .collect();
+    let mut inodes = Vec::new();
+    collect_file_inodes(&fs, VirtualTree::ROOT, &mut inodes);
+    assert!(!inodes.is_empty(), "fixture: no file inodes for {format:?}");
     // Keep the tempdir alive for the duration of the bench by leaking it.
     std::mem::forget(dir);
     (fs, inodes)
 }
 
 fn bench_sequential_read(c: &mut Criterion) {
-    let (fs, inodes) = fixture(4 * 1024 * 1024, 1);
-    let inode = inodes[0];
-    let size = fs.getattr(inode).unwrap().size;
     let mut group = c.benchmark_group("sequential_read");
-    group.throughput(Throughput::Bytes(size));
     let chunk = 128 * 1024u64;
-    // fh=0 takes the no-handle path: each read resolves the inode via the
-    // HeaderCache rather than reusing a registered fd. This measures the
-    // warm-cache resolve+splice cost, not fd-reuse (which the concurrent bench
-    // exercises via open_handle).
-    group.bench_function("flac_128k_chunks", |b| {
-        b.iter(|| {
-            let mut off = 0u64;
-            while off < size {
-                let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
-                if got.is_empty() {
-                    break;
+    for fmt in bench_formats() {
+        let (fs, inodes) = fixture(fmt, 4 * 1024 * 1024, 1);
+        let inode = inodes[0];
+        let size = fs.getattr(inode).unwrap().size;
+        group.throughput(Throughput::Bytes(size));
+        // fh=0 takes the no-handle path: each read resolves the inode via the
+        // HeaderCache rather than reusing a registered fd.
+        group.bench_function(format_token(fmt), |b| {
+            b.iter(|| {
+                let mut off = 0u64;
+                while off < size {
+                    let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
+                    if got.is_empty() {
+                        break;
+                    }
+                    off += got.len() as u64;
                 }
-                off += got.len() as u64;
-            }
+            });
         });
-    });
+    }
     group.finish();
 }
 
@@ -88,7 +91,7 @@ fn bench_concurrent_read_and_walk(c: &mut Criterion) {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(num_streams);
-    let (fs, inodes) = fixture(1024 * 1024, m.max(2));
+    let (fs, inodes) = fixture(Format::Flac, 1024 * 1024, m.max(2));
 
     // Each iteration streams `m` whole files (reader i reads inodes[i]); the
     // walker does metadata-only ops and contributes no bytes.

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -16,8 +16,8 @@ use musefs_db::Db;
 /// open_handle), not the scan path, so both rows print ~0 even under
 /// `--features metrics`. The SP1-relevant signals are `wall_ms` and
 /// `peak_rss_kib`. `peak_rss_kib()` reads VmHWM — a process-lifetime high-water
-/// mark — so every row reflects the same peak; the meaningful figure is the
-/// largest corpus's scan row.
+/// mark that only rises — so later rows show the same or a higher value than
+/// earlier ones; read the first format's scan row for the pre-SP1 baseline.
 fn run_one(target: &Target, tier: &str, format: &str, storage: &str) {
     let db = Db::open(&target.db_path).unwrap();
 
@@ -71,7 +71,7 @@ fn bench_cold_scan_and_revalidate() {
 
     // Generated mode: one single-format corpus + cold DB per format under a
     // shared base dir (held for the loop's duration).
-    let (base, _scratch) = bench_base_dir();
+    let (base, _base_tempdir) = bench_base_dir();
     let storage = if std::env::var("MUSEFS_BENCH_DIR").is_ok() {
         "env-dir"
     } else {

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -2,19 +2,55 @@ mod common;
 
 use std::time::Instant;
 
-use common::corpus::{prepare, CorpusParams};
+use common::corpus::{
+    bench_base_dir, bench_formats, format_token, prepare, prepare_format, CorpusParams, Target,
+};
 use common::report::{peak_rss_kib, RunReport};
 use musefs_core::{metrics, revalidate, scan_directory};
 use musefs_db::Db;
 
-fn storage_label(t: &common::corpus::Target) -> String {
-    if t.is_real_library {
-        "real-lib".into()
-    } else if std::env::var("MUSEFS_BENCH_DIR").is_ok() {
-        "env-dir".into()
-    } else {
-        "tempfs".into()
+/// Scan + revalidate one resolved target, printing a `scan` and a `revalidate`
+/// row tagged with `format`/`storage`.
+///
+/// The `opens`/`preads` metrics instrument the *serve* path (reader.rs /
+/// open_handle), not the scan path, so both rows print ~0 even under
+/// `--features metrics`. The SP1-relevant signals are `wall_ms` and
+/// `peak_rss_kib`. `peak_rss_kib()` reads VmHWM — a process-lifetime high-water
+/// mark — so every row reflects the same peak; the meaningful figure is the
+/// largest corpus's scan row.
+fn run_one(target: &Target, tier: &str, format: &str, storage: &str) {
+    let db = Db::open(&target.db_path).unwrap();
+
+    metrics::reset();
+    let t0 = Instant::now();
+    let stats = scan_directory(&db, &target.corpus_dir).unwrap();
+    let scan_ms = t0.elapsed().as_millis();
+    let s = metrics::snapshot();
+
+    metrics::reset();
+    let t1 = Instant::now();
+    let _ = revalidate(&db, &target.corpus_dir).unwrap();
+    let reval_ms = t1.elapsed().as_millis();
+    let r = metrics::snapshot();
+
+    for (label, ms, snap) in [("scan", scan_ms, &s), ("revalidate", reval_ms, &r)] {
+        println!(
+            "{}",
+            RunReport {
+                label: label.into(),
+                format: format.into(),
+                tier: tier.into(),
+                storage: storage.into(),
+                wall_ms: ms,
+                opens: snap.opens,
+                preads: snap.preads,
+                fsyncs: None,
+                peak_rss_kib: peak_rss_kib(),
+            }
+            .row()
+        );
     }
+    assert!(stats.scanned > 0, "format {format}: scanned 0 tracks");
 }
 
 #[test]
@@ -22,65 +58,27 @@ fn storage_label(t: &common::corpus::Target) -> String {
 fn bench_cold_scan_and_revalidate() {
     let params = CorpusParams::from_env();
     let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
-    let target = prepare(&params);
-    let storage = storage_label(&target);
 
-    let db = Db::open(&target.db_path).unwrap();
-
-    // The `opens`/`preads` metrics instrument the *serve* path (reader.rs /
-    // open_handle), not the scan path, so both rows print ≈0 even under
-    // `--features metrics`. The SP1-relevant signals here are `wall_ms` and
-    // `peak_rss_kib` (the latter captures the whole-file `fs::read` memory spike
-    // SP1 eliminates). Per-file scan I/O counting arrives in SP1 with scan.rs.
-    metrics::reset();
-    let t0 = Instant::now();
-    let stats = scan_directory(&db, &target.corpus_dir).unwrap();
-    let scan_ms = t0.elapsed().as_millis();
-    let s = metrics::snapshot();
-
-    // Second pass: revalidate should skip unchanged files (cheap).
-    metrics::reset();
-    let t1 = Instant::now();
-    let _ = revalidate(&db, &target.corpus_dir).unwrap();
-    let reval_ms = t1.elapsed().as_millis();
-    let r = metrics::snapshot();
-
-    // `peak_rss_kib()` reads VmHWM: a process-lifetime high-water mark, not a
-    // per-phase sample. Both rows therefore show the same value (revalidate's
-    // working set never exceeds the scan's) — the meaningful figure is the scan
-    // row's; the revalidate row repeats it for table completeness.
     println!("\n{}", RunReport::header());
-    println!(
-        "{}",
-        RunReport {
-            label: "scan".into(),
-            // Corpus is FLAC-only here; Task 6 replaces this with the swept format.
-            format: "flac".into(),
-            tier: tier.clone(),
-            storage: storage.clone(),
-            wall_ms: scan_ms,
-            opens: s.opens,
-            preads: s.preads,
-            fsyncs: None,
-            peak_rss_kib: peak_rss_kib(),
-        }
-        .row()
-    );
-    println!(
-        "{}",
-        RunReport {
-            label: "revalidate".into(),
-            format: "flac".into(),
-            tier,
-            storage,
-            wall_ms: reval_ms,
-            opens: r.opens,
-            preads: r.preads,
-            fsyncs: None,
-            peak_rss_kib: peak_rss_kib(),
-        }
-        .row()
-    );
-    println!("scanned={} skipped={}\n", stats.scanned, stats.skipped);
-    assert!(stats.scanned > 0);
+
+    // Real library: already mixed-format and never written to — a single scan
+    // tagged "mixed" rather than a per-format sweep.
+    if std::env::var("MUSEFS_BENCH_LIBRARY").is_ok() {
+        let target = prepare(&params);
+        run_one(&target, &tier, "mixed", "real-lib");
+        return;
+    }
+
+    // Generated mode: one single-format corpus + cold DB per format under a
+    // shared base dir (held for the loop's duration).
+    let (base, _scratch) = bench_base_dir();
+    let storage = if std::env::var("MUSEFS_BENCH_DIR").is_ok() {
+        "env-dir"
+    } else {
+        "tempfs"
+    };
+    for fmt in bench_formats() {
+        let target = prepare_format(&params, &base, fmt);
+        run_one(&target, &tier, format_token(fmt), storage);
+    }
 }

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -27,6 +27,11 @@ fn bench_cold_scan_and_revalidate() {
 
     let db = Db::open(&target.db_path).unwrap();
 
+    // The `opens`/`preads` metrics instrument the *serve* path (reader.rs /
+    // open_handle), not the scan path, so both rows print ≈0 even under
+    // `--features metrics`. The SP1-relevant signals here are `wall_ms` and
+    // `peak_rss_kib` (the latter captures the whole-file `fs::read` memory spike
+    // SP1 eliminates). Per-file scan I/O counting arrives in SP1 with scan.rs.
     metrics::reset();
     let t0 = Instant::now();
     let stats = scan_directory(&db, &target.corpus_dir).unwrap();
@@ -38,7 +43,12 @@ fn bench_cold_scan_and_revalidate() {
     let t1 = Instant::now();
     let _ = revalidate(&db, &target.corpus_dir).unwrap();
     let reval_ms = t1.elapsed().as_millis();
+    let r = metrics::snapshot();
 
+    // `peak_rss_kib()` reads VmHWM: a process-lifetime high-water mark, not a
+    // per-phase sample. Both rows therefore show the same value (revalidate's
+    // working set never exceeds the scan's) — the meaningful figure is the scan
+    // row's; the revalidate row repeats it for table completeness.
     println!("\n{}", RunReport::header());
     println!(
         "{}",
@@ -61,8 +71,8 @@ fn bench_cold_scan_and_revalidate() {
             tier,
             storage,
             wall_ms: reval_ms,
-            opens: 0,
-            preads: 0,
+            opens: r.opens,
+            preads: r.preads,
             fsyncs: None,
             peak_rss_kib: peak_rss_kib(),
         }

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -54,6 +54,7 @@ fn bench_cold_scan_and_revalidate() {
         "{}",
         RunReport {
             label: "scan".into(),
+            format: "flac".into(),
             tier: tier.clone(),
             storage: storage.clone(),
             wall_ms: scan_ms,
@@ -68,6 +69,7 @@ fn bench_cold_scan_and_revalidate() {
         "{}",
         RunReport {
             label: "revalidate".into(),
+            format: "flac".into(),
             tier,
             storage,
             wall_ms: reval_ms,

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -54,6 +54,7 @@ fn bench_cold_scan_and_revalidate() {
         "{}",
         RunReport {
             label: "scan".into(),
+            // Corpus is FLAC-only here; Task 6 replaces this with the swept format.
             format: "flac".into(),
             tier: tier.clone(),
             storage: storage.clone(),

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -1,0 +1,73 @@
+mod common;
+
+use std::time::Instant;
+
+use common::corpus::{prepare, CorpusParams};
+use common::report::{peak_rss_kib, RunReport};
+use musefs_core::{metrics, revalidate, scan_directory};
+use musefs_db::Db;
+
+fn storage_label(t: &common::corpus::Target) -> String {
+    if t.is_real_library {
+        "real-lib".into()
+    } else if std::env::var("MUSEFS_BENCH_DIR").is_ok() {
+        "env-dir".into()
+    } else {
+        "tempfs".into()
+    }
+}
+
+#[test]
+#[ignore = "SP0 timing harness; run with --ignored --nocapture"]
+fn bench_cold_scan_and_revalidate() {
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    let target = prepare(&params);
+    let storage = storage_label(&target);
+
+    let db = Db::open(&target.db_path).unwrap();
+
+    metrics::reset();
+    let t0 = Instant::now();
+    let stats = scan_directory(&db, &target.corpus_dir).unwrap();
+    let scan_ms = t0.elapsed().as_millis();
+    let s = metrics::snapshot();
+
+    // Second pass: revalidate should skip unchanged files (cheap).
+    metrics::reset();
+    let t1 = Instant::now();
+    let _ = revalidate(&db, &target.corpus_dir).unwrap();
+    let reval_ms = t1.elapsed().as_millis();
+
+    println!("\n{}", RunReport::header());
+    println!(
+        "{}",
+        RunReport {
+            label: "scan".into(),
+            tier: tier.clone(),
+            storage: storage.clone(),
+            wall_ms: scan_ms,
+            opens: s.opens,
+            preads: s.preads,
+            fsyncs: None,
+            peak_rss_kib: peak_rss_kib(),
+        }
+        .row()
+    );
+    println!(
+        "{}",
+        RunReport {
+            label: "revalidate".into(),
+            tier,
+            storage,
+            wall_ms: reval_ms,
+            opens: 0,
+            preads: 0,
+            fsyncs: None,
+            peak_rss_kib: peak_rss_kib(),
+        }
+        .row()
+    );
+    println!("scanned={} skipped={}\n", stats.scanned, stats.skipped);
+    assert!(stats.scanned > 0);
+}

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use common::corpus::{prepare, CorpusParams};
+use common::report::RunReport;
+use musefs_core::{scan_directory, Mode, MountConfig, Musefs};
+use musefs_db::Db;
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$album/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: Duration::ZERO, // no debounce: each poll actually polls
+    }
+}
+
+/// Replace all tags for `count` tracks via a separate connection, then time
+/// the refresh.  Using `replace_tags` (not an append) is sufficient: it bumps
+/// both `content_version` (per-track trigger) and `data_version` (whole-DB),
+/// which is all `poll_refresh` needs to observe in order to rebuild.
+fn time_refresh(db_path: &std::path::Path, fs: &Musefs, count: usize) -> u128 {
+    let writer = Db::open(db_path).unwrap();
+    let tracks = writer.list_tracks().unwrap();
+    for t in tracks.iter().take(count) {
+        writer
+            .replace_tags(t.id, &[musefs_db::Tag::new("COMMENT", "bench-touch", 0)])
+            .unwrap();
+    }
+    let t0 = Instant::now();
+    // poll_refresh returns Ok(true) when a rebuild actually happened. Asserting it
+    // guards against silently timing a no-op (e.g. data_version not observed).
+    let rebuilt = fs.poll_refresh().unwrap();
+    let ms = t0.elapsed().as_millis();
+    assert!(
+        rebuilt,
+        "expected a rebuild after re-tagging {count} track(s)"
+    );
+    ms
+}
+
+#[test]
+#[ignore = "SP0 timing harness; run with --ignored --nocapture"]
+fn bench_refresh_one_vs_many() {
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    let target = prepare(&params);
+
+    let db = Db::open(&target.db_path).unwrap();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let one_ms = time_refresh(&target.db_path, &fs, 1);
+    // Cap the touch count: today's rebuild is full regardless of how many tracks
+    // changed, so a bounded sample represents "many changed" without a huge
+    // un-batched-write setup on the heavy tiers (the slow path SP1 fixes). SP2
+    // will make rebuild cost scale with the changed set, at which point this cap
+    // is revisited.
+    let many = (params.track_count() / 2).clamp(1, 1000);
+    let many_ms = time_refresh(&target.db_path, &fs, many);
+
+    println!("\n{}", RunReport::header());
+    for (label, ms) in [("refresh-1", one_ms), ("refresh-N", many_ms)] {
+        println!(
+            "{}",
+            RunReport {
+                label: label.into(),
+                tier: tier.clone(),
+                storage: "tempfs".into(),
+                wall_ms: ms,
+                opens: 0,
+                preads: 0,
+                fsyncs: None,
+                peak_rss_kib: None,
+            }
+            .row()
+        );
+    }
+    println!("touched_many={many}\n");
+}

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -70,12 +70,16 @@ fn bench_refresh_one_vs_many() {
 
     // `poll_refresh` is pure CPU + DB work, independent of the corpus storage
     // class, so the storage column is fixed rather than derived from the target.
+    // bench_refresh stays FLAC-only: poll_refresh times a DB-driven virtual-tree
+    // rebuild, independent of the backing audio format, so per-format rows would
+    // be pure noise. The format column is fixed to "flac" for table consistency.
     println!("\n{}", RunReport::header());
     for (label, ms) in [("refresh-1", one_ms), ("refresh-N", many_ms)] {
         println!(
             "{}",
             RunReport {
                 label: label.into(),
+                format: "flac".into(),
                 tier: tier.clone(),
                 storage: "tempfs".into(),
                 wall_ms: ms,

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -53,6 +53,12 @@ fn bench_refresh_one_vs_many() {
     scan_directory(&db, &target.corpus_dir).unwrap();
     let fs = Musefs::open(db, config()).unwrap();
 
+    // Both measurements run on the same `fs`. After the first poll_refresh the
+    // tree is freshly built; the second call starts from that warm state. Because
+    // today's rebuild is unconditionally full (every track, regardless of the
+    // change-set size), the two wall times should be roughly equal — that
+    // equality is the SP2 baseline. When SP2 makes rebuild cost scale with the
+    // changed set, refresh-N should diverge from refresh-1.
     let one_ms = time_refresh(&target.db_path, &fs, 1);
     // Cap the touch count: today's rebuild is full regardless of how many tracks
     // changed, so a bounded sample represents "many changed" without a huge
@@ -62,6 +68,8 @@ fn bench_refresh_one_vs_many() {
     let many = (params.track_count() / 2).clamp(1, 1000);
     let many_ms = time_refresh(&target.db_path, &fs, many);
 
+    // `poll_refresh` is pure CPU + DB work, independent of the corpus storage
+    // class, so the storage column is fixed rather than derived from the target.
     println!("\n{}", RunReport::header());
     for (label, ms) in [("refresh-1", one_ms), ("refresh-N", many_ms)] {
         println!(

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -68,11 +68,9 @@ fn bench_refresh_one_vs_many() {
     let many = (params.track_count() / 2).clamp(1, 1000);
     let many_ms = time_refresh(&target.db_path, &fs, many);
 
-    // `poll_refresh` is pure CPU + DB work, independent of the corpus storage
-    // class, so the storage column is fixed rather than derived from the target.
-    // bench_refresh stays FLAC-only: poll_refresh times a DB-driven virtual-tree
-    // rebuild, independent of the backing audio format, so per-format rows would
-    // be pure noise. The format column is fixed to "flac" for table consistency.
+    // `poll_refresh` is pure CPU + DB work — independent of both the corpus
+    // storage class and the backing audio format — so those columns are fixed
+    // rather than derived from the target. Per-format rows would be pure noise.
     println!("\n{}", RunReport::header());
     for (label, ms) in [("refresh-1", one_ms), ("refresh-N", many_ms)] {
         println!(

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -1,0 +1,122 @@
+//! Deterministic synthetic-library generator for the SP0 bench harness.
+//! Shared by `#[ignore]`d timing tests and the read Criterion bench.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Tier {
+    Ci,
+    LargeCompute,
+    Bandwidth,
+    Custom,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    Flac,
+    Mp3,
+    M4aMoovFirst,
+    M4aMoovLast,
+    Wav,
+}
+
+#[derive(Clone, Debug)]
+pub struct CorpusParams {
+    pub albums: usize,
+    pub tracks_per_album: usize,
+    /// Audio payload bytes per track (file size = payload + format front + art).
+    pub bytes_per_track: usize,
+    /// Embedded cover bytes per track (0 = no embedded art). One shared cover
+    /// per album, so the content-addressed `art` table dedups across the album.
+    pub art_bytes_per_track: usize,
+    /// Round-robin formats. Default `[Flac]`.
+    pub format_mix: Vec<Format>,
+    pub seed: u64,
+}
+
+impl CorpusParams {
+    pub fn track_count(&self) -> usize {
+        self.albums * self.tracks_per_album
+    }
+
+    pub fn for_tier(t: Tier) -> Self {
+        match t {
+            // ~200 tracks, tiny, no art — runs in seconds.
+            Tier::Ci => CorpusParams {
+                albums: 20,
+                tracks_per_album: 10,
+                bytes_per_track: 4 * 1024,
+                art_bytes_per_track: 0,
+                format_mix: vec![Format::Flac],
+                seed: 1,
+            },
+            // 100k tracks, ~8 KB payload + one shared ~30 KB cover/album (deduped).
+            Tier::LargeCompute => CorpusParams {
+                albums: 10_000,
+                tracks_per_album: 10,
+                bytes_per_track: 8 * 1024,
+                art_bytes_per_track: 30 * 1024,
+                format_mix: vec![Format::Flac],
+                seed: 1,
+            },
+            // ~1k tracks, realistic payload — real-mount throughput.
+            Tier::Bandwidth => CorpusParams {
+                albums: 100,
+                tracks_per_album: 10,
+                bytes_per_track: 30 * 1024 * 1024,
+                art_bytes_per_track: 200 * 1024,
+                format_mix: vec![Format::Flac],
+                seed: 1,
+            },
+            // Defaults equal to ci; every dimension is env-overridable.
+            Tier::Custom => CorpusParams::for_tier(Tier::Ci),
+        }
+    }
+
+    /// Read `MUSEFS_BENCH_TIER` (default `ci`) then apply any `MUSEFS_BENCH_*`
+    /// overrides. `MUSEFS_BENCH_FORMAT_MIX` is a comma list of
+    /// flac|mp3|m4a|m4a-last|wav.
+    pub fn from_env() -> Self {
+        let tier = match std::env::var("MUSEFS_BENCH_TIER").as_deref() {
+            Ok("large-compute") => Tier::LargeCompute,
+            Ok("bandwidth") => Tier::Bandwidth,
+            Ok("custom") => Tier::Custom,
+            _ => Tier::Ci,
+        };
+        let mut p = CorpusParams::for_tier(tier);
+        if let Some(v) = env_usize("MUSEFS_BENCH_ALBUMS") {
+            p.albums = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_TRACKS_PER_ALBUM") {
+            p.tracks_per_album = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_BYTES_PER_TRACK") {
+            p.bytes_per_track = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_ART_PER_ALBUM") {
+            p.art_bytes_per_track = v;
+        }
+        if let Some(v) = env_usize("MUSEFS_BENCH_SEED") {
+            p.seed = v as u64;
+        }
+        if let Ok(mix) = std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
+            let parsed: Vec<Format> = mix
+                .split(',')
+                .filter_map(|s| match s.trim() {
+                    "flac" => Some(Format::Flac),
+                    "mp3" => Some(Format::Mp3),
+                    "m4a" => Some(Format::M4aMoovFirst),
+                    "m4a-last" => Some(Format::M4aMoovLast),
+                    "wav" => Some(Format::Wav),
+                    _ => None,
+                })
+                .collect();
+            if !parsed.is_empty() {
+                p.format_mix = parsed;
+            }
+        }
+        p
+    }
+}
+
+fn env_usize(key: &str) -> Option<usize> {
+    std::env::var(key).ok().and_then(|s| s.parse().ok())
+}

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -207,6 +207,54 @@ pub fn generate(dir: &Path, p: &CorpusParams) -> Vec<PathBuf> {
     paths
 }
 
+/// Where the corpus and DB live for a run, and whether it was generated.
+pub struct Target {
+    pub corpus_dir: PathBuf,
+    pub db_path: PathBuf,
+    pub is_real_library: bool,
+    /// Held to keep a tempdir alive for the run when one was created.
+    _scratch: Option<tempfile::TempDir>,
+}
+
+/// Resolve the run target:
+/// - `MUSEFS_BENCH_LIBRARY` set -> scan that real directory in place (never
+///   written to); DB goes to `MUSEFS_BENCH_DB` or a fresh tempfile.
+/// - else generate the corpus under `MUSEFS_BENCH_DIR` (or a tempdir) and put
+///   the DB alongside under a separate `musefs-bench.db` name.
+pub fn prepare(p: &CorpusParams) -> Target {
+    if let Ok(lib) = std::env::var("MUSEFS_BENCH_LIBRARY") {
+        let scratch = tempfile::tempdir().unwrap();
+        let db_path = std::env::var("MUSEFS_BENCH_DB")
+            .map_or_else(|_| scratch.path().join("musefs-bench.db"), PathBuf::from);
+        return Target {
+            corpus_dir: PathBuf::from(lib),
+            db_path,
+            is_real_library: true,
+            _scratch: Some(scratch),
+        };
+    }
+    let (corpus_dir, scratch) = if let Ok(d) = std::env::var("MUSEFS_BENCH_DIR") {
+        (PathBuf::from(d), None)
+    } else {
+        let s = tempfile::tempdir().unwrap();
+        (s.path().to_path_buf(), Some(s))
+    };
+    generate(&corpus_dir, p);
+    let db_path = std::env::var("MUSEFS_BENCH_DB")
+        .map_or_else(|_| corpus_dir.join("musefs-bench.db"), PathBuf::from);
+    // Generated mode: start cold so a reused MUSEFS_BENCH_DIR doesn't time the
+    // scan against a DB that already holds the tracks. (WAL sidecars too.)
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
+    }
+    Target {
+        corpus_dir,
+        db_path,
+        is_real_library: false,
+        _scratch: scratch,
+    }
+}
+
 /// `comments` and `art` are only consumed by [`Format::Flac`]; the other formats
 /// carry tags via the DB at scan time and have no embedded-art builder, so they
 /// ignore both here.

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -22,7 +22,7 @@ pub enum Format {
 }
 
 /// Map a `MUSEFS_BENCH_FORMAT_MIX` token to a `Format`. Single source of truth
-/// for both `from_env` and `bench_formats`.
+/// for `from_env` (and the upcoming `bench_formats`).
 pub fn format_from_token(token: &str) -> Option<Format> {
     match token.trim() {
         "flac" => Some(Format::Flac),
@@ -103,7 +103,7 @@ impl CorpusParams {
 
     /// Read `MUSEFS_BENCH_TIER` (default `ci`) then apply any `MUSEFS_BENCH_*`
     /// overrides. `MUSEFS_BENCH_FORMAT_MIX` is a comma list of
-    /// flac|mp3|m4a|m4a-last|wav.
+    /// flac|mp3|m4a|m4a-last|ogg|wav.
     pub fn from_env() -> Self {
         let tier = match std::env::var("MUSEFS_BENCH_TIER").as_deref() {
             Ok("large-compute") => Tier::LargeCompute,
@@ -301,7 +301,7 @@ fn generate_one(
             // valid MPEG frame sync (0xFF 0xEx) at the start of the audio region.
             // Prepend one so scan_directory can probe corpus MP3 files regardless
             // of what the filler bytes happen to be.
-            let mut scannable = vec![0xFF, 0xFB]; // MPEG-1 Layer3 sync, CBR
+            let mut scannable = vec![0xFF, 0xFB]; // MPEG-1 Layer3, no CRC (satisfies the 11-bit sync check)
             scannable.extend_from_slice(audio);
             super::write_mp3(&path, &scannable);
             path

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -1,6 +1,8 @@
 //! Deterministic synthetic-library generator for the SP0 bench harness.
 //! Shared by `#[ignore]`d timing tests and the read Criterion bench.
 
+use std::path::{Path, PathBuf};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Tier {
     Ci,
@@ -127,11 +129,10 @@ fn env_usize(key: &str) -> Option<usize> {
     std::env::var(key).ok().and_then(|s| s.parse().ok())
 }
 
-use std::path::{Path, PathBuf};
-
 /// Deterministic filler audio: a seedable byte ramp (content is irrelevant —
 /// `BackingAudio` is served verbatim and probing reads only headers).
 fn filler(seed: u64, idx: usize, len: usize) -> Vec<u8> {
+    // Knuth multiplicative hash constant (⌊φ · 2³²⌋) to spread the seed bits.
     let base = seed.wrapping_add(idx as u64).wrapping_mul(2_654_435_761);
     (0..len)
         .map(|i| (base.wrapping_add(i as u64) & 0xFF) as u8)
@@ -206,6 +207,9 @@ pub fn generate(dir: &Path, p: &CorpusParams) -> Vec<PathBuf> {
     paths
 }
 
+/// `comments` and `art` are only consumed by [`Format::Flac`]; the other formats
+/// carry tags via the DB at scan time and have no embedded-art builder, so they
+/// ignore both here.
 fn generate_one(
     adir: &Path,
     idx: usize,

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -48,6 +48,34 @@ pub fn format_token(f: Format) -> &'static str {
     }
 }
 
+/// Every supported format, plus the M4A moov-last layout variant (the SP1
+/// bounded-read hard case). The per-format benches sweep this set.
+pub const ALL_FORMATS: &[Format] = &[
+    Format::Flac,
+    Format::Mp3,
+    Format::M4aMoovFirst,
+    Format::M4aMoovLast,
+    Format::Ogg,
+    Format::Wav,
+];
+
+/// The formats to sweep: `MUSEFS_BENCH_FORMAT_MIX` (comma list) acts as a filter
+/// when set; an unset or all-unrecognized value yields `ALL_FORMATS` (full
+/// coverage). Never returns an empty vec.
+pub fn bench_formats() -> Vec<Format> {
+    match std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
+        Ok(mix) => {
+            let parsed: Vec<Format> = mix.split(',').filter_map(format_from_token).collect();
+            if parsed.is_empty() {
+                ALL_FORMATS.to_vec()
+            } else {
+                parsed
+            }
+        }
+        Err(_) => ALL_FORMATS.to_vec(),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct CorpusParams {
     pub albums: usize,

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -220,17 +220,22 @@ pub struct Target {
 /// - `MUSEFS_BENCH_LIBRARY` set -> scan that real directory in place (never
 ///   written to); DB goes to `MUSEFS_BENCH_DB` or a fresh tempfile.
 /// - else generate the corpus under `MUSEFS_BENCH_DIR` (or a tempdir) and put
-///   the DB alongside under a separate `musefs-bench.db` name.
+///   the DB at `MUSEFS_BENCH_DB`, or alongside the corpus as `musefs-bench.db`.
 pub fn prepare(p: &CorpusParams) -> Target {
     if let Ok(lib) = std::env::var("MUSEFS_BENCH_LIBRARY") {
-        let scratch = tempfile::tempdir().unwrap();
-        let db_path = std::env::var("MUSEFS_BENCH_DB")
-            .map_or_else(|_| scratch.path().join("musefs-bench.db"), PathBuf::from);
+        // Only allocate a scratch tempdir when no explicit DB path is given.
+        let (db_path, scratch) = if let Ok(p) = std::env::var("MUSEFS_BENCH_DB") {
+            (PathBuf::from(p), None)
+        } else {
+            let s = tempfile::tempdir().unwrap();
+            let p = s.path().join("musefs-bench.db");
+            (p, Some(s))
+        };
         return Target {
             corpus_dir: PathBuf::from(lib),
             db_path,
             is_real_library: true,
-            _scratch: Some(scratch),
+            _scratch: scratch,
         };
     }
     let (corpus_dir, scratch) = if let Ok(d) = std::env::var("MUSEFS_BENCH_DIR") {

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -17,7 +17,35 @@ pub enum Format {
     Mp3,
     M4aMoovFirst,
     M4aMoovLast,
+    Ogg,
     Wav,
+}
+
+/// Map a `MUSEFS_BENCH_FORMAT_MIX` token to a `Format`. Single source of truth
+/// for both `from_env` and `bench_formats`.
+pub fn format_from_token(token: &str) -> Option<Format> {
+    match token.trim() {
+        "flac" => Some(Format::Flac),
+        "mp3" => Some(Format::Mp3),
+        "m4a" => Some(Format::M4aMoovFirst),
+        "m4a-last" => Some(Format::M4aMoovLast),
+        "ogg" => Some(Format::Ogg),
+        "wav" => Some(Format::Wav),
+        _ => None,
+    }
+}
+
+/// The canonical token for a `Format` (inverse of `format_from_token`). Used for
+/// report labels, per-format corpus subdir names, and `.ext` choices.
+pub fn format_token(f: Format) -> &'static str {
+    match f {
+        Format::Flac => "flac",
+        Format::Mp3 => "mp3",
+        Format::M4aMoovFirst => "m4a",
+        Format::M4aMoovLast => "m4a-last",
+        Format::Ogg => "ogg",
+        Format::Wav => "wav",
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -104,17 +132,7 @@ impl CorpusParams {
             p.seed = v as u64;
         }
         if let Ok(mix) = std::env::var("MUSEFS_BENCH_FORMAT_MIX") {
-            let parsed: Vec<Format> = mix
-                .split(',')
-                .filter_map(|s| match s.trim() {
-                    "flac" => Some(Format::Flac),
-                    "mp3" => Some(Format::Mp3),
-                    "m4a" => Some(Format::M4aMoovFirst),
-                    "m4a-last" => Some(Format::M4aMoovLast),
-                    "wav" => Some(Format::Wav),
-                    _ => None,
-                })
-                .collect();
+            let parsed: Vec<Format> = mix.split(',').filter_map(format_from_token).collect();
             // An all-unrecognized value keeps the tier default rather than
             // erroring or yielding an empty mix.
             if !parsed.is_empty() {
@@ -279,7 +297,13 @@ fn generate_one(
         }
         Format::Mp3 => {
             let path = adir.join(format!("track-{idx:06}.mp3"));
-            super::write_mp3(&path, audio);
+            // write_mp3 emits [ID3 header][audio]; mp3::locate_audio requires a
+            // valid MPEG frame sync (0xFF 0xEx) at the start of the audio region.
+            // Prepend one so scan_directory can probe corpus MP3 files regardless
+            // of what the filler bytes happen to be.
+            let mut scannable = vec![0xFF, 0xFB]; // MPEG-1 Layer3 sync, CBR
+            scannable.extend_from_slice(audio);
+            super::write_mp3(&path, &scannable);
             path
         }
         Format::M4aMoovFirst => {
@@ -290,6 +314,11 @@ fn generate_one(
         Format::M4aMoovLast => {
             let path = adir.join(format!("track-{idx:06}.m4a"));
             super::write_m4a_moov_last(&path, audio);
+            path
+        }
+        Format::Ogg => {
+            let path = adir.join(format!("track-{idx:06}.ogg"));
+            super::write_ogg(&path, audio);
             path
         }
         Format::Wav => {

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -126,3 +126,119 @@ impl CorpusParams {
 fn env_usize(key: &str) -> Option<usize> {
     std::env::var(key).ok().and_then(|s| s.parse().ok())
 }
+
+use std::path::{Path, PathBuf};
+
+/// Deterministic filler audio: a seedable byte ramp (content is irrelevant —
+/// `BackingAudio` is served verbatim and probing reads only headers).
+fn filler(seed: u64, idx: usize, len: usize) -> Vec<u8> {
+    let base = seed.wrapping_add(idx as u64).wrapping_mul(2_654_435_761);
+    (0..len)
+        .map(|i| (base.wrapping_add(i as u64) & 0xFF) as u8)
+        .collect()
+}
+
+/// One shared cover per album so the content-addressed `art` table dedups.
+fn cover(seed: u64, album: usize, len: usize) -> Vec<u8> {
+    filler(
+        seed ^ 0x00C0_FFEE,
+        album.wrapping_mul(101).wrapping_add(1),
+        len,
+    )
+}
+
+/// A FLAC with STREAMINFO + comments + (optionally) a PICTURE block + audio.
+/// Mirrors `tests/common/scan.rs`'s `flac_with_picture` layout.
+fn flac_bytes(comments: &[String], art: Option<&[u8]>, audio: &[u8]) -> Vec<u8> {
+    use super::{flac_block, streaminfo_body, vorbis_comment_body};
+    let refs: Vec<&str> = comments.iter().map(String::as_str).collect();
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    let last_meta = art.is_none();
+    out.extend_from_slice(&flac_block(
+        4,
+        &vorbis_comment_body("musefs-bench", &refs),
+        last_meta,
+    ));
+    if let Some(img) = art {
+        let mut body = Vec::new();
+        body.extend_from_slice(&3u32.to_be_bytes()); // picture type: front cover
+        body.extend_from_slice(&(b"image/png".len() as u32).to_be_bytes());
+        body.extend_from_slice(b"image/png");
+        body.extend_from_slice(&0u32.to_be_bytes()); // description len
+        body.extend_from_slice(&0u32.to_be_bytes()); // width
+        body.extend_from_slice(&0u32.to_be_bytes()); // height
+        body.extend_from_slice(&0u32.to_be_bytes()); // depth
+        body.extend_from_slice(&0u32.to_be_bytes()); // colors
+        body.extend_from_slice(&(img.len() as u32).to_be_bytes());
+        body.extend_from_slice(img);
+        out.extend_from_slice(&flac_block(6, &body, true));
+    }
+    out.extend_from_slice(audio);
+    out
+}
+
+/// Generate the corpus into `dir` (created if missing). Layout is
+/// `dir/album-{a}/track-{t}.{ext}`. Returns created file paths in stable order.
+pub fn generate(dir: &Path, p: &CorpusParams) -> Vec<PathBuf> {
+    std::fs::create_dir_all(dir).unwrap();
+    let mut paths = Vec::with_capacity(p.track_count());
+    let mut idx = 0usize;
+    for album in 0..p.albums {
+        let adir = dir.join(format!("album-{album:05}"));
+        std::fs::create_dir_all(&adir).unwrap();
+        let art_blob =
+            (p.art_bytes_per_track > 0).then(|| cover(p.seed, album, p.art_bytes_per_track));
+        for track in 0..p.tracks_per_album {
+            let fmt = p.format_mix[idx % p.format_mix.len()];
+            let audio = filler(p.seed, idx, p.bytes_per_track);
+            let comments = vec![
+                format!("ARTIST=Artist {album:05}"),
+                format!("ALBUM=Album {album:05}"),
+                format!("TITLE=Track {track:03}"),
+            ];
+            let path = generate_one(&adir, idx, fmt, &comments, art_blob.as_deref(), &audio);
+            paths.push(path);
+            idx += 1;
+        }
+    }
+    paths
+}
+
+fn generate_one(
+    adir: &Path,
+    idx: usize,
+    fmt: Format,
+    comments: &[String],
+    art: Option<&[u8]>,
+    audio: &[u8],
+) -> PathBuf {
+    match fmt {
+        Format::Flac => {
+            let path = adir.join(format!("track-{idx:06}.flac"));
+            std::fs::write(&path, flac_bytes(comments, art, audio)).unwrap();
+            path
+        }
+        Format::Mp3 => {
+            let path = adir.join(format!("track-{idx:06}.mp3"));
+            super::write_mp3(&path, audio);
+            path
+        }
+        Format::M4aMoovFirst => {
+            let path = adir.join(format!("track-{idx:06}.m4a"));
+            super::write_m4a(&path, audio);
+            path
+        }
+        Format::M4aMoovLast => {
+            let path = adir.join(format!("track-{idx:06}.m4a"));
+            super::write_m4a_moov_last(&path, audio);
+            path
+        }
+        Format::Wav => {
+            let path = adir.join(format!("track-{idx:06}.wav"));
+            super::write_wav(&path, audio);
+            path
+        }
+    }
+}

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -91,6 +91,10 @@ impl CorpusParams {
         if let Some(v) = env_usize("MUSEFS_BENCH_BYTES_PER_TRACK") {
             p.bytes_per_track = v;
         }
+        // One cover of this size is generated per album and embedded in each of
+        // its tracks (the var names the per-album cover; the field holds its
+        // byte size, embedded per track and deduped by the content-addressed
+        // `art` table).
         if let Some(v) = env_usize("MUSEFS_BENCH_ART_PER_ALBUM") {
             p.art_bytes_per_track = v;
         }
@@ -109,6 +113,8 @@ impl CorpusParams {
                     _ => None,
                 })
                 .collect();
+            // An all-unrecognized value keeps the tier default rather than
+            // erroring or yielding an empty mix.
             if !parsed.is_empty() {
                 p.format_mix = parsed;
             }

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -256,6 +256,14 @@ pub fn generate(dir: &Path, p: &CorpusParams) -> Vec<PathBuf> {
     paths
 }
 
+/// Delete a DB file and its WAL/SHM sidecars so a reused dir is scanned cold
+/// (timings start from an empty DB rather than one that already holds tracks).
+fn delete_cold_db(db_path: &Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
+    }
+}
+
 /// Where the corpus and DB live for a run, and whether it was generated.
 pub struct Target {
     pub corpus_dir: PathBuf,
@@ -296,11 +304,7 @@ pub fn prepare(p: &CorpusParams) -> Target {
     generate(&corpus_dir, p);
     let db_path = std::env::var("MUSEFS_BENCH_DB")
         .map_or_else(|_| corpus_dir.join("musefs-bench.db"), PathBuf::from);
-    // Generated mode: start cold so a reused MUSEFS_BENCH_DIR doesn't time the
-    // scan against a DB that already holds the tracks. (WAL sidecars too.)
-    for suffix in ["", "-wal", "-shm"] {
-        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
-    }
+    delete_cold_db(&db_path);
     Target {
         corpus_dir,
         db_path,
@@ -334,9 +338,7 @@ pub fn prepare_format(p: &CorpusParams, base: &Path, fmt: Format) -> Target {
     fp.format_mix = vec![fmt];
     generate(&corpus_dir, &fp);
     let db_path = corpus_dir.join("musefs-bench.db");
-    for suffix in ["", "-wal", "-shm"] {
-        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
-    }
+    delete_cold_db(&db_path);
     Target {
         corpus_dir,
         db_path,

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -50,6 +50,9 @@ pub fn format_token(f: Format) -> &'static str {
 
 /// Every supported format, plus the M4A moov-last layout variant (the SP1
 /// bounded-read hard case). The per-format benches sweep this set.
+///
+/// Not enforced by a compile check: if you add a `Format` variant, add it here
+/// too. The round-trip test guards token drift, not omission from this list.
 pub const ALL_FORMATS: &[Format] = &[
     Format::Flac,
     Format::Mp3,

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -309,6 +309,42 @@ pub fn prepare(p: &CorpusParams) -> Target {
     }
 }
 
+/// Resolve the base directory shared by a per-format sweep: `MUSEFS_BENCH_DIR`
+/// when set (caller-managed, second element `None`), else a fresh tempdir the
+/// caller must hold for the run's duration.
+pub fn bench_base_dir() -> (PathBuf, Option<tempfile::TempDir>) {
+    if let Ok(d) = std::env::var("MUSEFS_BENCH_DIR") {
+        (PathBuf::from(d), None)
+    } else {
+        let s = tempfile::tempdir().unwrap();
+        (s.path().to_path_buf(), Some(s))
+    }
+}
+
+/// Generate a single-format corpus for `fmt` under `<base>/<token>/` with its own
+/// cold DB (`musefs-bench.db` + sidecars deleted first), returning its `Target`.
+/// Per-format generalization of `prepare`'s generated branch. `MUSEFS_BENCH_DB`
+/// is intentionally **ignored** here: each format needs its own DB, so a single
+/// shared path would clobber across formats. `p.format_mix` is overridden to the
+/// single `fmt`. The base tempdir's lifetime is the caller's responsibility, so
+/// `_scratch` is `None`.
+pub fn prepare_format(p: &CorpusParams, base: &Path, fmt: Format) -> Target {
+    let corpus_dir = base.join(format_token(fmt));
+    let mut fp = p.clone();
+    fp.format_mix = vec![fmt];
+    generate(&corpus_dir, &fp);
+    let db_path = corpus_dir.join("musefs-bench.db");
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", db_path.display()));
+    }
+    Target {
+        corpus_dir,
+        db_path,
+        is_real_library: false,
+        _scratch: None,
+    }
+}
+
 /// `comments` and `art` are only consumed by [`Format::Flac`]; the other formats
 /// carry tags via the DB at scan time and have no embedded-art builder, so they
 /// ignore both here.

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 pub mod corpus;
+pub mod report;
 
 pub fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -178,9 +178,11 @@ pub fn minimal_m4a(mdat_payload: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Build a minimal valid M4A with `moov` AFTER `mdat` (the SP1 bounded-read hard
-/// case). Same box contents as `minimal_m4a`; only top-level order differs. The
-/// MP4 reader locates boxes by scanning, so order does not affect parsing.
+/// Build a minimal valid M4A with `moov` AFTER `mdat`. Same box contents as
+/// `minimal_m4a`; only top-level order differs — `moov` trails `mdat`, so a
+/// bounded-read implementation must seek backward over the payload to reach the
+/// metadata (the SP1 hard case). The MP4 reader locates boxes by scanning, so
+/// order does not affect parsing.
 pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
     let ilst_atoms = [
         bx(b"\xa9nam", &m4a_data_atom(1, b"Orig M4A")),
@@ -216,12 +218,16 @@ pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
     // Order: ftyp, mdat, moov. The mdat payload starts right after ftyp + mdat header.
     // ftyp box: 8-byte header + 8-byte payload "M4A isom" = 16 bytes total.
     // mdat header: 8 bytes. So payload offset = 16 + 8 = 24.
+    // Search for `stco` only within `moov`: the mdat payload precedes it here
+    // and could otherwise contain a false `stco` byte match.
+    let moov_start = ftyp.len() + mdat.len();
     let mut out = [ftyp, mdat, moov].concat();
     let mdat_payload_offset = (8 + b"M4A isom".len() + 8) as u32;
-    let stco_pos = out
-        .windows(4)
-        .position(|w| w == b"stco")
-        .expect("stco present");
+    let stco_pos = moov_start
+        + out[moov_start..]
+            .windows(4)
+            .position(|w| w == b"stco")
+            .expect("stco present");
     let entry = stco_pos + 4 + 4 + 4; // past "stco" type + version/flags + entry count
     out[entry..entry + 4].copy_from_slice(&mdat_payload_offset.to_be_bytes());
     out
@@ -229,7 +235,7 @@ pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
 
 /// Write a moov-at-end M4A to `path`, returning (audio_offset, audio_length) of
 /// the verbatim `mdat` payload.
-pub fn write_m4a_moov_last(path: &std::path::Path, audio: &[u8]) -> (i64, i64) {
+pub fn write_m4a_moov_last(path: &Path, audio: &[u8]) -> (i64, i64) {
     let bytes = minimal_m4a_moov_last(audio);
     // ftyp: 8 header + 8 payload = 16; mdat header: 8 → payload at offset 24.
     let audio_offset = (8 + b"M4A isom".len() + 8) as i64;

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -177,3 +177,62 @@ pub fn minimal_m4a(mdat_payload: &[u8]) -> Vec<u8> {
     out[entry..entry + 4].copy_from_slice(&mdat_payload_offset.to_be_bytes());
     out
 }
+
+/// Build a minimal valid M4A with `moov` AFTER `mdat` (the SP1 bounded-read hard
+/// case). Same box contents as `minimal_m4a`; only top-level order differs. The
+/// MP4 reader locates boxes by scanning, so order does not affect parsing.
+pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
+    let ilst_atoms = [
+        bx(b"\xa9nam", &m4a_data_atom(1, b"Orig M4A")),
+        bx(b"\xa9ART", &m4a_data_atom(1, b"Orig Artist")),
+    ]
+    .concat();
+    let ilst = bx(b"ilst", &ilst_atoms);
+
+    let mut meta_hdlr = vec![0u8; 8];
+    meta_hdlr.extend_from_slice(b"mdir");
+    meta_hdlr.extend_from_slice(b"appl");
+    meta_hdlr.extend_from_slice(&[0u8; 9]);
+    let mut meta = vec![0u8; 4]; // FullBox version/flags
+    meta.extend(bx(b"hdlr", &meta_hdlr));
+    meta.extend(ilst);
+    let udta = bx(b"udta", &bx(b"meta", &meta));
+
+    let mut soun_hdlr = vec![0u8; 8];
+    soun_hdlr.extend_from_slice(b"soun");
+    soun_hdlr.extend_from_slice(&[0u8; 12]);
+    let mut stco = vec![0u8; 4];
+    stco.extend_from_slice(&1u32.to_be_bytes());
+    stco.extend_from_slice(&0u32.to_be_bytes());
+    let minf = bx(b"minf", &bx(b"stbl", &bx(b"stco", &stco)));
+    let trak = bx(
+        b"trak",
+        &bx(b"mdia", &[bx(b"hdlr", &soun_hdlr), minf].concat()),
+    );
+    let moov = bx(b"moov", &[bx(b"mvhd", &[0u8; 8]), trak, udta].concat());
+    let ftyp = bx(b"ftyp", b"M4A isom");
+    let mdat = bx(b"mdat", mdat_payload);
+
+    // Order: ftyp, mdat, moov. The mdat payload starts right after ftyp + mdat header.
+    // ftyp box: 8-byte header + 8-byte payload "M4A isom" = 16 bytes total.
+    // mdat header: 8 bytes. So payload offset = 16 + 8 = 24.
+    let mut out = [ftyp, mdat, moov].concat();
+    let mdat_payload_offset = (8 + b"M4A isom".len() + 8) as u32;
+    let stco_pos = out
+        .windows(4)
+        .position(|w| w == b"stco")
+        .expect("stco present");
+    let entry = stco_pos + 4 + 4 + 4; // past "stco" type + version/flags + entry count
+    out[entry..entry + 4].copy_from_slice(&mdat_payload_offset.to_be_bytes());
+    out
+}
+
+/// Write a moov-at-end M4A to `path`, returning (audio_offset, audio_length) of
+/// the verbatim `mdat` payload.
+pub fn write_m4a_moov_last(path: &std::path::Path, audio: &[u8]) -> (i64, i64) {
+    let bytes = minimal_m4a_moov_last(audio);
+    // ftyp: 8 header + 8 payload = 16; mdat header: 8 → payload at offset 24.
+    let audio_offset = (8 + b"M4A isom".len() + 8) as i64;
+    std::fs::write(path, &bytes).unwrap();
+    (audio_offset, audio.len() as i64)
+}

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -245,3 +245,29 @@ pub fn write_m4a_moov_last(path: &Path, audio: &[u8]) -> (i64, i64) {
     std::fs::write(path, &bytes).unwrap();
     (audio_offset, audio.len() as i64)
 }
+
+/// Write a minimal valid Ogg **Opus** file (two header pages + one audio page
+/// whose packet body is `audio`) to `path`, returning (audio_offset,
+/// audio_length) of the audio-page span. Mirrors the recipe in
+/// `musefs-core/src/scan.rs`'s `ogg_probe_tests`: the `OpusTags` body must be a
+/// parseable VorbisComment (here empty) because the scanner runs `read_tags`.
+/// The synthesizer treats the audio packet body as opaque (renumbers pages,
+/// recomputes CRCs, never decodes), so arbitrary `audio` bytes are valid. The
+/// return is informational — `scan_directory` re-probes the file.
+pub fn write_ogg(path: &Path, audio: &[u8]) -> (i64, i64) {
+    use musefs_format::ogg::page_test_support::{
+        build_header_pub, lace_packet_pub, vorbis_body_empty,
+    };
+    let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
+    let mut tags = b"OpusTags".to_vec();
+    tags.extend_from_slice(&vorbis_body_empty());
+    let serial = 0x6d75_7366; // "musf"
+                              // build_header returns (bytes, header_page_count); the audio page continues
+                              // the sequence at that count.
+    let (mut bytes, header_pages) = build_header_pub(serial, &[&head, &tags]);
+    let header_len = bytes.len();
+    let (page, _) = lace_packet_pub(serial, header_pages, false, 960, audio);
+    bytes.extend_from_slice(&page);
+    std::fs::write(path, &bytes).unwrap();
+    (header_len as i64, (bytes.len() - header_len) as i64)
+}

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+pub mod corpus;
+
 pub fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();
     out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -248,7 +248,8 @@ pub fn write_m4a_moov_last(path: &Path, audio: &[u8]) -> (i64, i64) {
 
 /// Write a minimal valid Ogg **Opus** file (two header pages + one audio page
 /// whose packet body is `audio`) to `path`, returning (audio_offset,
-/// audio_length) of the audio-page span. Mirrors the recipe in
+/// audio_length) where audio_length is the Ogg page span (raw audio bytes plus
+/// page-framing overhead, not `audio.len()`). Mirrors the recipe in
 /// `musefs-core/src/scan.rs`'s `ogg_probe_tests`: the `OpusTags` body must be a
 /// parseable VorbisComment (here empty) because the scanner runs `read_tags`.
 /// The synthesizer treats the audio packet body as opaque (renumbers pages,

--- a/musefs-core/tests/common/report.rs
+++ b/musefs-core/tests/common/report.rs
@@ -5,7 +5,7 @@
 /// literal, so this is a macro rather than a `const`.)
 macro_rules! report_fmt {
     ($($arg:expr),* $(,)?) => {
-        format!("{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}", $($arg),*)
+        format!("{:<10} {:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}", $($arg),*)
     };
 }
 
@@ -14,6 +14,7 @@ macro_rules! report_fmt {
 #[derive(Debug)]
 pub struct RunReport {
     pub label: String,
+    pub format: String,
     pub tier: String,
     pub storage: String,
     pub wall_ms: u128,
@@ -25,13 +26,16 @@ pub struct RunReport {
 
 impl RunReport {
     pub fn header() -> String {
-        report_fmt!("label", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib")
+        report_fmt!(
+            "label", "format", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib"
+        )
     }
 
     pub fn row(&self) -> String {
         let opt = |v: Option<u64>| v.map_or_else(|| "n/a".into(), |x| x.to_string());
         report_fmt!(
             self.label,
+            self.format,
             self.tier,
             self.storage,
             self.wall_ms,

--- a/musefs-core/tests/common/report.rs
+++ b/musefs-core/tests/common/report.rs
@@ -1,7 +1,17 @@
 //! Comparable run reporting for the SP0 bench harness.
 
+/// The shared column layout for both the header and data rows. Kept in one
+/// place so the two can never drift out of alignment. (`format!` needs a string
+/// literal, so this is a macro rather than a `const`.)
+macro_rules! report_fmt {
+    ($($arg:expr),* $(,)?) => {
+        format!("{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}", $($arg),*)
+    };
+}
+
 /// One measured run. `fsyncs`/`peak_rss_kib` are `None` when not applicable
 /// (e.g. fsyncs need the SP0b passthrough FS; RSS is meaningful only in-process).
+#[derive(Debug)]
 pub struct RunReport {
     pub label: String,
     pub tier: String,
@@ -15,16 +25,12 @@ pub struct RunReport {
 
 impl RunReport {
     pub fn header() -> String {
-        format!(
-            "{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}",
-            "label", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib"
-        )
+        report_fmt!("label", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib")
     }
 
     pub fn row(&self) -> String {
         let opt = |v: Option<u64>| v.map_or_else(|| "n/a".into(), |x| x.to_string());
-        format!(
-            "{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+        report_fmt!(
             self.label,
             self.tier,
             self.storage,

--- a/musefs-core/tests/common/report.rs
+++ b/musefs-core/tests/common/report.rs
@@ -1,0 +1,50 @@
+//! Comparable run reporting for the SP0 bench harness.
+
+/// One measured run. `fsyncs`/`peak_rss_kib` are `None` when not applicable
+/// (e.g. fsyncs need the SP0b passthrough FS; RSS is meaningful only in-process).
+pub struct RunReport {
+    pub label: String,
+    pub tier: String,
+    pub storage: String,
+    pub wall_ms: u128,
+    pub opens: u64,
+    pub preads: u64,
+    pub fsyncs: Option<u64>,
+    pub peak_rss_kib: Option<u64>,
+}
+
+impl RunReport {
+    pub fn header() -> String {
+        format!(
+            "{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+            "label", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib"
+        )
+    }
+
+    pub fn row(&self) -> String {
+        let opt = |v: Option<u64>| v.map_or_else(|| "n/a".into(), |x| x.to_string());
+        format!(
+            "{:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}",
+            self.label,
+            self.tier,
+            self.storage,
+            self.wall_ms,
+            self.opens,
+            self.preads,
+            opt(self.fsyncs),
+            opt(self.peak_rss_kib),
+        )
+    }
+}
+
+/// Peak resident set size (high-water mark) in KiB, from `/proc/self/status`
+/// `VmHWM`. Linux only; `None` elsewhere or if unreadable.
+pub fn peak_rss_kib() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
+            return rest.trim().trim_end_matches(" kB").trim().parse().ok();
+        }
+    }
+    None
+}

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -1,0 +1,15 @@
+mod common;
+
+use common::write_m4a_moov_last;
+use musefs_core::scan_directory;
+use musefs_db::Db;
+
+#[test]
+fn moov_last_m4a_scans_as_one_track() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_off, _len) = write_m4a_moov_last(&dir.path().join("a.m4a"), &[0x11u8; 256]);
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(stats.scanned, 1, "moov-at-end M4A should probe & ingest");
+    assert_eq!(stats.skipped, 0);
+}

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -204,3 +204,27 @@ fn all_formats_round_trip_through_tokens() {
         );
     }
 }
+
+#[test]
+fn prepare_format_generates_scannable_single_format_corpus() {
+    let base = tempfile::tempdir().unwrap();
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: 2,
+        bytes_per_track: 256,
+        // format_mix is overridden by prepare_format; set something different
+        // to prove the override.
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 5,
+    };
+    let t = common::corpus::prepare_format(&p, base.path(), Format::Ogg);
+    assert!(
+        t.corpus_dir.ends_with("ogg"),
+        "per-format subdir named by token"
+    );
+    assert_ne!(t.db_path, t.corpus_dir);
+    let db = Db::open(&t.db_path).unwrap();
+    let stats = scan_directory(&db, &t.corpus_dir).unwrap();
+    assert_eq!(stats.scanned, 2, "two Ogg tracks generated and scanned");
+}

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -109,6 +109,7 @@ fn prepare_generates_when_no_library_set() {
 fn report_renders_a_row() {
     let r = RunReport {
         label: "scan".into(),
+        format: "flac".into(),
         tier: "ci".into(),
         storage: "tempfs".into(),
         wall_ms: 1234,
@@ -119,6 +120,7 @@ fn report_renders_a_row() {
     };
     let line = r.row();
     assert!(line.contains("scan"));
+    assert!(line.contains("flac"), "format column is rendered");
     assert!(line.contains("ci"));
     assert!(line.contains("n/a"), "fsyncs None renders as n/a");
     // RSS is readable and positive on Linux.

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -148,3 +148,20 @@ fn write_ogg_is_deterministic() {
         "same audio bytes => identical Ogg file"
     );
 }
+
+#[test]
+fn generate_with_ogg_in_mix_scans_all() {
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: 4,
+        bytes_per_track: 256,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac, Format::Mp3, Format::Ogg, Format::Wav],
+        seed: 9,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    common::corpus::generate(dir.path(), &p);
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(stats.scanned, 4, "all four formats (incl. Ogg) ingest");
+}

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -1,8 +1,46 @@
 mod common;
 
+use common::corpus::{CorpusParams, Tier};
 use common::write_m4a_moov_last;
 use musefs_core::scan_directory;
 use musefs_db::Db;
+
+/// Serializes tests that mutate process-global `MUSEFS_BENCH_*` env vars —
+/// cargo runs all tests in one binary across threads, so concurrent
+/// set_var/remove_var would race. Every env-touching test locks this first.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn tier_presets_have_expected_shape() {
+    let ci = CorpusParams::for_tier(Tier::Ci);
+    assert_eq!(ci.track_count(), 200);
+    assert_eq!(ci.art_bytes_per_track, 0, "ci omits embedded art");
+
+    let lc = CorpusParams::for_tier(Tier::LargeCompute);
+    assert_eq!(lc.track_count(), 100_000);
+    assert!(lc.art_bytes_per_track > 0, "large-compute embeds a cover");
+
+    let bw = CorpusParams::for_tier(Tier::Bandwidth);
+    assert!(
+        bw.bytes_per_track >= 1_000_000,
+        "bandwidth uses realistic payloads"
+    );
+}
+
+#[test]
+fn env_overrides_apply_over_tier() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("MUSEFS_BENCH_TIER", "ci");
+    std::env::set_var("MUSEFS_BENCH_ALBUMS", "3");
+    std::env::set_var("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
+    let p = CorpusParams::from_env();
+    std::env::remove_var("MUSEFS_BENCH_ALBUMS");
+    std::env::remove_var("MUSEFS_BENCH_TRACKS_PER_ALBUM");
+    std::env::remove_var("MUSEFS_BENCH_TIER");
+    assert_eq!(p.albums, 3);
+    assert_eq!(p.tracks_per_album, 4);
+    assert_eq!(p.track_count(), 12);
+}
 
 #[test]
 fn moov_last_m4a_scans_as_one_track() {

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::corpus::{CorpusParams, Format, Tier};
+use common::corpus::{prepare, CorpusParams, Format, Tier};
 use common::write_m4a_moov_last;
 use musefs_core::scan_directory;
 use musefs_db::Db;
@@ -75,4 +75,30 @@ fn moov_last_m4a_scans_as_one_track() {
     let stats = scan_directory(&db, dir.path()).unwrap();
     assert_eq!(stats.scanned, 1, "moov-at-end M4A should probe & ingest");
     assert_eq!(stats.skipped, 0);
+}
+
+#[test]
+fn prepare_generates_when_no_library_set() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("MUSEFS_BENCH_LIBRARY");
+    std::env::remove_var("MUSEFS_BENCH_DB");
+    let scratch = tempfile::tempdir().unwrap();
+    std::env::set_var("MUSEFS_BENCH_DIR", scratch.path());
+    let p = CorpusParams {
+        albums: 1,
+        tracks_per_album: 2,
+        bytes_per_track: 128,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 3,
+    };
+    let t = prepare(&p);
+    std::env::remove_var("MUSEFS_BENCH_DIR");
+    assert!(t.corpus_dir.exists());
+    assert!(!t.is_real_library);
+    // DB path is separate from the corpus dir.
+    assert_ne!(t.db_path, t.corpus_dir);
+    let db = Db::open(&t.db_path).unwrap();
+    let stats = musefs_core::scan_directory(&db, &t.corpus_dir).unwrap();
+    assert_eq!(stats.scanned, 2);
 }

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::corpus::{prepare, CorpusParams, Format, Tier};
+use common::report::{peak_rss_kib, RunReport};
 use common::write_m4a_moov_last;
 use musefs_core::scan_directory;
 use musefs_db::Db;
@@ -101,4 +102,24 @@ fn prepare_generates_when_no_library_set() {
     let db = Db::open(&t.db_path).unwrap();
     let stats = musefs_core::scan_directory(&db, &t.corpus_dir).unwrap();
     assert_eq!(stats.scanned, 2);
+}
+
+#[test]
+fn report_renders_a_row() {
+    let r = RunReport {
+        label: "scan".into(),
+        tier: "ci".into(),
+        storage: "tempfs".into(),
+        wall_ms: 1234,
+        opens: 200,
+        preads: 200,
+        fsyncs: None,
+        peak_rss_kib: Some(50_000),
+    };
+    let line = r.row();
+    assert!(line.contains("scan"));
+    assert!(line.contains("ci"));
+    assert!(line.contains("n/a"), "fsyncs None renders as n/a");
+    // RSS is readable and positive on Linux.
+    assert!(peak_rss_kib().unwrap_or(1) > 0);
 }

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -9,7 +9,9 @@ use musefs_db::Db;
 
 /// Serializes tests that mutate process-global `MUSEFS_BENCH_*` env vars —
 /// cargo runs all tests in one binary across threads, so concurrent
-/// set_var/remove_var would race. Every env-touching test locks this first.
+/// set_var/remove_var would race. Every env-touching test locks this first, and
+/// recovers from poisoning (`PoisonError::into_inner`) so that a panic in one
+/// locked test doesn't cascade into spurious `.lock()` failures in the others.
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
@@ -31,7 +33,9 @@ fn tier_presets_have_expected_shape() {
 
 #[test]
 fn env_overrides_apply_over_tier() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::set_var("MUSEFS_BENCH_TIER", "ci");
     std::env::set_var("MUSEFS_BENCH_ALBUMS", "3");
     std::env::set_var("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
@@ -81,7 +85,9 @@ fn moov_last_m4a_scans_as_one_track() {
 
 #[test]
 fn prepare_generates_when_no_library_set() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::remove_var("MUSEFS_BENCH_LIBRARY");
     std::env::remove_var("MUSEFS_BENCH_DB");
     let scratch = tempfile::tempdir().unwrap();
@@ -175,7 +181,9 @@ fn generate_with_all_formats_scans_all() {
 
 #[test]
 fn bench_formats_defaults_to_all_when_unset() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
     assert_eq!(
         common::corpus::bench_formats(),
@@ -185,7 +193,9 @@ fn bench_formats_defaults_to_all_when_unset() {
 
 #[test]
 fn bench_formats_filters_and_never_empty() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "ogg,wav");
     let filtered = common::corpus::bench_formats();
     std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "garbagetoken");
@@ -236,7 +246,9 @@ fn prepare_format_generates_scannable_single_format_corpus() {
 
 #[test]
 fn bench_base_dir_defaults_to_held_tempdir() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     std::env::remove_var("MUSEFS_BENCH_DIR");
     let (base, scratch) = common::corpus::bench_base_dir();
     assert!(base.exists(), "base dir exists");

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -152,20 +152,25 @@ fn write_ogg_is_deterministic() {
 }
 
 #[test]
-fn generate_with_ogg_in_mix_scans_all() {
+fn generate_with_all_formats_scans_all() {
+    // One track per supported format (round-robin over ALL_FORMATS), so every
+    // `generate_one` arm — including both M4A layouts and Ogg — is exercised
+    // through `generate()` + `scan_directory` in the default suite.
+    let mix = common::corpus::ALL_FORMATS.to_vec();
+    let n = mix.len();
     let p = CorpusParams {
         albums: 1,
-        tracks_per_album: 4,
+        tracks_per_album: n,
         bytes_per_track: 256,
         art_bytes_per_track: 0,
-        format_mix: vec![Format::Flac, Format::Mp3, Format::Ogg, Format::Wav],
+        format_mix: mix,
         seed: 9,
     };
     let dir = tempfile::tempdir().unwrap();
     common::corpus::generate(dir.path(), &p);
     let db = Db::open_in_memory().unwrap();
     let stats = scan_directory(&db, dir.path()).unwrap();
-    assert_eq!(stats.scanned, 4, "all four formats (incl. Ogg) ingest");
+    assert_eq!(stats.scanned, n as u64, "every supported format ingests");
 }
 
 #[test]

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -228,3 +228,15 @@ fn prepare_format_generates_scannable_single_format_corpus() {
     let stats = scan_directory(&db, &t.corpus_dir).unwrap();
     assert_eq!(stats.scanned, 2, "two Ogg tracks generated and scanned");
 }
+
+#[test]
+fn bench_base_dir_defaults_to_held_tempdir() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("MUSEFS_BENCH_DIR");
+    let (base, scratch) = common::corpus::bench_base_dir();
+    assert!(base.exists(), "base dir exists");
+    assert!(
+        scratch.is_some(),
+        "unset MUSEFS_BENCH_DIR yields a caller-held tempdir"
+    );
+}

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -165,3 +165,40 @@ fn generate_with_ogg_in_mix_scans_all() {
     let stats = scan_directory(&db, dir.path()).unwrap();
     assert_eq!(stats.scanned, 4, "all four formats (incl. Ogg) ingest");
 }
+
+#[test]
+fn bench_formats_defaults_to_all_when_unset() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
+    assert_eq!(
+        common::corpus::bench_formats(),
+        common::corpus::ALL_FORMATS.to_vec()
+    );
+}
+
+#[test]
+fn bench_formats_filters_and_never_empty() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "ogg,wav");
+    let filtered = common::corpus::bench_formats();
+    std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "garbagetoken");
+    let fallback = common::corpus::bench_formats();
+    std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
+    assert_eq!(filtered, vec![Format::Ogg, Format::Wav]);
+    assert_eq!(
+        fallback,
+        common::corpus::ALL_FORMATS.to_vec(),
+        "all-unrecognized must fall back to full coverage, never empty"
+    );
+}
+
+#[test]
+fn all_formats_round_trip_through_tokens() {
+    for &f in common::corpus::ALL_FORMATS {
+        assert_eq!(
+            common::corpus::format_from_token(common::corpus::format_token(f)),
+            Some(f),
+            "ALL_FORMATS member {f:?} must round-trip through its token"
+        );
+    }
+}

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::corpus::{CorpusParams, Tier};
+use common::corpus::{CorpusParams, Format, Tier};
 use common::write_m4a_moov_last;
 use musefs_core::scan_directory;
 use musefs_db::Db;
@@ -40,6 +40,31 @@ fn env_overrides_apply_over_tier() {
     assert_eq!(p.albums, 3);
     assert_eq!(p.tracks_per_album, 4);
     assert_eq!(p.track_count(), 12);
+}
+
+#[test]
+fn generate_is_deterministic_and_scans_all_tracks() {
+    let p = CorpusParams {
+        albums: 2,
+        tracks_per_album: 3,
+        bytes_per_track: 512,
+        art_bytes_per_track: 64,
+        format_mix: vec![Format::Flac],
+        seed: 7,
+    };
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    let files_a = common::corpus::generate(a.path(), &p);
+    let files_b = common::corpus::generate(b.path(), &p);
+    assert_eq!(files_a.len(), 6);
+    // Determinism: same relative names and identical bytes for the first file.
+    let first_a = std::fs::read(&files_a[0]).unwrap();
+    let first_b = std::fs::read(&files_b[0]).unwrap();
+    assert_eq!(first_a, first_b, "same (params, seed) => identical bytes");
+
+    let db = Db::open_in_memory().unwrap();
+    let stats = musefs_core::scan_directory(&db, a.path()).unwrap();
+    assert_eq!(stats.scanned, 6);
 }
 
 #[test]

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -3,6 +3,7 @@ mod common;
 use common::corpus::{prepare, CorpusParams, Format, Tier};
 use common::report::{peak_rss_kib, RunReport};
 use common::write_m4a_moov_last;
+use common::write_ogg;
 use musefs_core::scan_directory;
 use musefs_db::Db;
 
@@ -122,4 +123,28 @@ fn report_renders_a_row() {
     assert!(line.contains("n/a"), "fsyncs None renders as n/a");
     // RSS is readable and positive on Linux.
     assert!(peak_rss_kib().unwrap_or(1) > 0);
+}
+
+#[test]
+fn write_ogg_scans_as_one_track() {
+    let dir = tempfile::tempdir().unwrap();
+    write_ogg(&dir.path().join("a.ogg"), &[0x22u8; 256]);
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(stats.scanned, 1, "minimal Ogg Opus should probe & ingest");
+    assert_eq!(stats.skipped, 0);
+}
+
+#[test]
+fn write_ogg_is_deterministic() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.ogg");
+    let b = dir.path().join("b.ogg");
+    write_ogg(&a, &[0x33u8; 300]);
+    write_ogg(&b, &[0x33u8; 300]);
+    assert_eq!(
+        std::fs::read(&a).unwrap(),
+        std::fs::read(&b).unwrap(),
+        "same audio bytes => identical Ogg file"
+    );
 }


### PR DESCRIPTION
## Summary

Builds the **SP0 measurement foundation** for the optimization pass — a benchmarking/measurement harness that gives later sub-projects (SP1–SP4) comparable before/after numbers — plus the **per-format coverage** extension. Entirely test/bench-only and docs: **no production code paths change.**

- **Corpus generator** (`musefs-core/tests/common/corpus.rs`): deterministic synthetic-library generator with tier presets (`ci` / `large-compute` / `bandwidth` / `custom`), full `MUSEFS_BENCH_*` env overrides, seeded generation with optional FLAC art, and `prepare`/`prepare_format` target resolution for generated-vs-real-library runs (a real `MUSEFS_BENCH_LIBRARY` is never written to).
- **Benches**: `#[ignore]`d `bench_ingest` (cold scan + revalidate timing) and `bench_refresh` (1-vs-N changed-track rebuild, the SP2 baseline), plus a corpus-driven Criterion `read_throughput` (sequential + concurrent read/walk exercising the SP3 handles/size_cache mutexes).
- **Reporting** (`report.rs`): `RunReport` with a shared `report_fmt!` macro (header/row can't drift) and `/proc/self/status` peak-RSS.
- **Per-format coverage**: `bench_ingest` and the `read_throughput` sequential bench now sweep every supported format (FLAC, MP3, M4A moov-first, M4A moov-last, Ogg, WAV) with a per-format `format` column; adds the missing Ogg (Opus) corpus builder (`write_ogg`). `MUSEFS_BENCH_FORMAT_MIX` filters the sweep; a real library collapses to a single `mixed` scan. `bench_refresh` stays FLAC-only (format-independent).
- **Docs**: SP0 spec, the optimization-pass tracking README, and the SP0a / SP0a-per-format / SP0b implementation plans.

**Not implemented here:** SP0b (the `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter) is **planned only** — it needs `/dev/fuse` and lands in a later PR. `fsyncs` shows `n/a` in all SP0a runs until then. Non-goals for the Ogg builder (cover-art, FLAC-in-Ogg) are explicitly deferred.

## Test plan

- [ ] `cargo test --workspace` — green; the timing benches stay `#[ignore]`d, default suite unchanged apart from new `common_corpus_smoke` cases
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture` — prints a `scan`+`revalidate` row for all six formats, each `scanned > 0`
- [ ] `cargo bench -p musefs-core --bench read_throughput` — one `sequential_read/<format>` throughput line per format + a `concurrent_read_walk` line, no panics
- [ ] `cargo test -p musefs-core --test bench_refresh -- --ignored --nocapture` — `refresh-1` / `refresh-N` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added benchmark suites measuring scan, refresh, sequential and concurrent read performance across multiple audio formats; added corpus-generation and smoke tests validating determinism and format coverage.

* **Documentation**
  * Added planning and specification docs for the 2026-05-30 optimization pass, SP0 measurement foundation, per-format coverage, and latency-injection FUSE plan with run instructions.

* **Chores**
  * Established benchmark harness framework and reporting utilities for consistent timing and resource reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->