### PR TITLE
SP0b: passthrough latency-injection FUSE (musefs-latencyfs) + scan fsync counts

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,16 +1,18 @@
 # cargo-mutants workspace config.
 #
-# Crates intentionally out of scope for mutation testing. The scheduled full
-# campaign (`scripts/mutants.sh`) only mutates the logic files in musefs-db,
-# musefs-core, and musefs-format; thin FUSE/CLI glue and bench-only tooling are
-# excluded because their behavior is exercised solely by `#[ignore]`d e2e tests
-# (the FUSE crates need /dev/fuse). A mountless `cargo mutants` run can never
-# execute those tests, so every mutant there would falsely "survive". This
-# `exclude_globs` makes the per-PR `--in-diff` gate honor the same scope the
-# campaign already uses, so changing one of these crates no longer trips the gate
-# with un-killable mutants. See docs/audits/2026-05-29-test-audit.md.
+# Crates permanently out of scope for mutation testing: thin glue with no real
+# logic. musefs-fuse is a thin fuser adapter, musefs-cli is thin CLI dispatch,
+# and the `musefs` binary is a one-line entrypoint — their behavior is covered by
+# e2e/integration tests, and mutating them yields only equivalent or trivially
+# untestable mutants. See docs/audits/2026-05-29-test-audit.md.
+#
+# musefs-latencyfs is NOT excluded here: it carries real logic (the inode map,
+# latency table, attr mapping, passthrough op behavior), so it gets its own
+# mutation leg in scripts/mutants.sh / mutants.yml that installs libfuse and runs
+# the #[ignore]d mounted tests (`-- -- --include-ignored`). The fast per-PR
+# `--in-diff` gate excludes it separately (it is mountless and can't kill its
+# mutants); see .github/workflows/mutants.yml.
 exclude_globs = [
-    "musefs-latencyfs/**",
     "musefs-fuse/**",
     "musefs-cli/**",
     "musefs/**",

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,17 @@
+# cargo-mutants workspace config.
+#
+# Crates intentionally out of scope for mutation testing. The scheduled full
+# campaign (`scripts/mutants.sh`) only mutates the logic files in musefs-db,
+# musefs-core, and musefs-format; thin FUSE/CLI glue and bench-only tooling are
+# excluded because their behavior is exercised solely by `#[ignore]`d e2e tests
+# (the FUSE crates need /dev/fuse). A mountless `cargo mutants` run can never
+# execute those tests, so every mutant there would falsely "survive". This
+# `exclude_globs` makes the per-PR `--in-diff` gate honor the same scope the
+# campaign already uses, so changing one of these crates no longer trips the gate
+# with un-killable mutants. See docs/audits/2026-05-29-test-audit.md.
+exclude_globs = [
+    "musefs-latencyfs/**",
+    "musefs-fuse/**",
+    "musefs-cli/**",
+    "musefs/**",
+]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,12 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Collect coverage
-        run: cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+        # musefs-fuse and musefs-latencyfs are the FUSE crates: their behavior is
+        # exercised only by #[ignore]d /dev/fuse e2e tests, which this job does not
+        # run, so instrumenting them would report misleading near-zero coverage.
+        # They follow the FUSE coverage strategy (scored by e2e evidence, not
+        # llvm-cov); see docs/audits/2026-05-29-test-audit.md.
+        run: cargo llvm-cov --workspace --exclude musefs-fuse --exclude musefs-latencyfs --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -53,7 +53,12 @@ jobs:
           if [ ! -s mutants.diff ]; then
             echo "No in-scope Rust changes; nothing to mutate."; exit 0
           fi
-          cargo mutants --in-diff mutants.diff -j1
+          # This fast gate runs the default `cargo test` (no libfuse, no
+          # `--ignored`), so it can't exercise musefs-latencyfs — every mutant
+          # there would falsely survive. That crate is mutation-tested in the
+          # scheduled `full` job below, which installs libfuse and runs its
+          # mounted #[ignore]d tests. Exclude it here so the gate stays honest.
+          cargo mutants --in-diff mutants.diff -j1 --exclude 'musefs-latencyfs/**'
 
   canary:
     # Per-PR: exercise the REAL scripts/mutants.sh pipeline (out-of-repo scratch,
@@ -95,6 +100,10 @@ jobs:
           - { crate: musefs-format, label: musefs-format-1, shard: 1/4 }
           - { crate: musefs-format, label: musefs-format-2, shard: 2/4 }
           - { crate: musefs-format, label: musefs-format-3, shard: 3/4 }
+          # musefs-latencyfs carries real logic (inode map, latency table, attr
+          # mapping, passthrough ops); scripts/mutants.sh runs its mounted
+          # #[ignore]d tests, so this leg needs libfuse + /dev/fuse.
+          - { crate: musefs-latencyfs, label: musefs-latencyfs }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -103,6 +112,10 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - name: Install FUSE
+        # Only the musefs-latencyfs leg mounts a passthrough FS in its tests.
+        if: matrix.crate == 'musefs-latencyfs'
+        run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev pkg-config
       - name: Install cargo-mutants
         # Unpinned (like fuzz.yml installs cargo-fuzz) for toolchain-compat;
         # known-good version is 27.0.0 (documented in scripts/mutants.sh).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "metaflac",
  "musefs-db",
  "musefs-format",
+ "musefs-latencyfs",
  "ogg",
  "once_cell",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "musefs-latencyfs"
+version = "0.2.0"
+dependencies = [
+ "fuser",
+ "libc",
+ "rusqlite",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["musefs-db", "musefs-format", "musefs-core", "musefs-fuse", "musefs-cli", "musefs"]
+members = ["musefs-db", "musefs-format", "musefs-core", "musefs-fuse", "musefs-cli", "musefs", "musefs-latencyfs"]
 exclude = ["fuzz"]
 
 [workspace.package]

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -74,7 +74,7 @@ is built for the full capability regardless.
 | SP | State | Spec | Plan | Notes |
 |---|---|---|---|---|
 | SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below; per-format sweep added (`SP0a-per-format-coverage.md`) |
-| SP0b | Plan drafted | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS |
+| SP0b | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS. See "Latency-injected runs" below. |
 | SP1 | Not started | — | — | |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |
@@ -125,6 +125,26 @@ Notes:
   median rises **>10%** run-over-run on the same machine (Criterion prints the
   median + its noise estimate). SP1–SP4 record before/after medians in the
   results log and must not breach this gate.
+
+### Latency-injected runs (SP0b — needs /dev/fuse)
+
+```bash
+# Functional + gating tests for the passthrough FS (5 tests across 3 files):
+cargo test -p musefs-latencyfs -- --ignored --nocapture
+
+# Scan a generated corpus through an injected-latency mount (real fsync counts):
+MUSEFS_BENCH_LATENCY_PROFILE=nfs-hdd MUSEFS_BENCH_TIER=large-compute \
+  cargo test -p musefs-core --features metrics \
+  --test bench_ingest bench_scan_under_latency -- --ignored --nocapture
+```
+
+Profiles: `ssd` (≈0), `hdd`, `nfs-ssd`, `nfs-hdd`. The corpus is generated on a
+real backing dir; only the scan + DB I/O traverse the latency layer, so the row's
+`fsyncs` column is the real kernel fsync count for the scan's DB writes (the
+SP1-batching signal). `peak_rss_kib` reads `n/a` here (the FS shares this process,
+so VmHWM no longer isolates the scan's footprint — use the SP0a tempfs
+`bench_cold_scan_and_revalidate` for the RSS signal). Without
+`MUSEFS_BENCH_LATENCY_PROFILE` the test no-ops with a hint.
 
 ## Results log
 

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -17,6 +17,7 @@ once_cell = "1"
 thiserror = "1"
 
 [dev-dependencies]
+musefs-latencyfs = { path = "../musefs-latencyfs" }
 tempfile = "3"
 metaflac = "0.2"
 id3 = "1"

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -82,3 +82,61 @@ fn bench_cold_scan_and_revalidate() {
         run_one(&target, &tier, format_token(fmt), storage);
     }
 }
+
+#[test]
+#[ignore = "needs /dev/fuse + MUSEFS_BENCH_LATENCY_PROFILE; run with --ignored --nocapture"]
+fn bench_scan_under_latency() {
+    use musefs_latencyfs::LatencyMount;
+
+    let Ok(profile) = std::env::var("MUSEFS_BENCH_LATENCY_PROFILE") else {
+        println!("set MUSEFS_BENCH_LATENCY_PROFILE=ssd|hdd|nfs-ssd|nfs-hdd to run");
+        return;
+    };
+    let params = CorpusParams::from_env();
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+
+    // Label the row with the corpus's actual format (matching the file's
+    // per-format / "mixed" convention) rather than assuming FLAC.
+    let format = if params.format_mix.len() == 1 {
+        format_token(params.format_mix[0]).to_string()
+    } else {
+        "mixed".to_string()
+    };
+
+    // Generate the corpus on a real backing dir, then mount the latency FS over
+    // it so the scan and its SQLite writes traverse the injected-latency layer.
+    let backing = tempfile::tempdir().unwrap();
+    common::corpus::generate(backing.path(), &params);
+    let mount = LatencyMount::new(backing.path(), &profile).unwrap();
+
+    let db = Db::open(mount.path().join("musefs-bench.db")).unwrap();
+    // Reset after Db::open so its migration/WAL-setup fsyncs are excluded; the
+    // reported fsync count then covers scan_directory's DB writes only.
+    metrics::reset();
+    let t0 = Instant::now();
+    let stats = scan_directory(&db, &mount.path()).unwrap();
+    let scan_ms = t0.elapsed().as_millis();
+    let s = metrics::snapshot();
+
+    println!("\n{}", RunReport::header());
+    println!(
+        "{}",
+        RunReport {
+            label: "scan".into(),
+            format,
+            tier,
+            storage: profile.clone(),
+            wall_ms: scan_ms,
+            opens: s.opens,
+            preads: s.preads,
+            fsyncs: Some(mount.fsyncs()),
+            peak_rss_kib: None, // FS runs in-process here, but RSS attribution is mixed; omit.
+        }
+        .row()
+    );
+    println!("scanned={} skipped={}\n", stats.scanned, stats.skipped);
+    assert!(
+        stats.scanned > 0,
+        "scanned 0 tracks under {profile} latency"
+    );
+}

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -110,8 +110,11 @@ fn bench_scan_under_latency() {
     let mount = LatencyMount::new(backing.path(), &profile).unwrap();
 
     let db = Db::open(mount.path().join("musefs-bench.db")).unwrap();
-    // Reset after Db::open so its migration/WAL-setup fsyncs are excluded; the
-    // reported fsync count then covers scan_directory's DB writes only.
+    // `metrics::reset()` clears the in-process counters but NOT the mount's
+    // fsync counter, so snapshot the mount's count here to subtract Db::open's
+    // migration/WAL-setup fsyncs; the reported value then covers scan_directory
+    // only.
+    let fsyncs_before_scan = mount.fsyncs();
     metrics::reset();
     let t0 = Instant::now();
     let stats = scan_directory(&db, &mount.path()).unwrap();
@@ -129,7 +132,7 @@ fn bench_scan_under_latency() {
             wall_ms: scan_ms,
             opens: s.opens,
             preads: s.preads,
-            fsyncs: Some(mount.fsyncs()),
+            fsyncs: Some(mount.fsyncs().saturating_sub(fsyncs_before_scan)),
             peak_rss_kib: None, // FS runs in-process here, but RSS attribution is mixed; omit.
         }
         .row()

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -23,14 +23,16 @@ fn config() -> MountConfig {
 
 #[test]
 fn baseline_one_open_per_read_call() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().unwrap();
     let flac = make_flac(
         &[
             (0, streaminfo_body()),
             (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
         ],
-        &[0xCD; 64 * 1024],
+        &vec![0xCD_u8; 64 * 1024],
     );
     std::fs::write(dir.path().join("a.flac"), &flac).unwrap();
 
@@ -69,14 +71,16 @@ fn baseline_one_open_per_read_call() {
 
 #[test]
 fn handle_reuses_one_open_and_no_per_read_stat() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().unwrap();
     let flac = make_flac(
         &[
             (0, streaminfo_body()),
             (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
         ],
-        &[0xCD; 64 * 1024],
+        &vec![0xCD_u8; 64 * 1024],
     );
     std::fs::write(dir.path().join("a.flac"), &flac).unwrap();
 
@@ -113,7 +117,9 @@ fn handle_reuses_one_open_and_no_per_read_stat() {
 
 #[test]
 fn getattr_size_cache_hit_skips_stat() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().unwrap();
     let flac = make_flac(
         &[
@@ -141,7 +147,9 @@ fn getattr_size_cache_hit_skips_stat() {
 #[test]
 fn layout_cache_survives_unrelated_refresh() {
     use musefs_db::{Format, NewTrack, Tag};
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let dir = tempfile::tempdir().unwrap();
     let bytes = make_flac(

--- a/musefs-latencyfs/Cargo.toml
+++ b/musefs-latencyfs/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "musefs-latencyfs"
+description = "Bench-only passthrough FUSE with per-op latency injection for musefs benchmarks."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+fuser = "0.17"
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+rusqlite = { version = "0.40", features = ["bundled"] }
+
+[lints]
+workspace = true

--- a/musefs-latencyfs/Cargo.toml
+++ b/musefs-latencyfs/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 [dependencies]
 fuser = "0.17"
 libc = "0.2"
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 rusqlite = { version = "0.40", features = ["bundled"] }
 
 [lints]

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -4,10 +4,6 @@
 //! mount, so backing reads and SQLite fsyncs are both delayed (and fsyncs
 //! counted). Not for production; requires /dev/fuse.
 
-// Task 3 will add write ops (create/write/fsync/fsyncdir/setattr/unlink/rename/mkdir/rmdir)
-// that consume forget_path, rename, lat.write, lat.fsync, uid, and gid.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -18,9 +14,10 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use fuser::{
-    AccessFlags, BackgroundSession, Config, FileAttr, FileHandle, FileType, FopenFlags, Generation,
-    INodeNo, MountOption, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry,
-    ReplyOpen, ReplyStatfs, Request, Session,
+    AccessFlags, BackgroundSession, BsdFileFlags, Config, FileAttr, FileHandle, FileType,
+    FopenFlags, Generation, INodeNo, MountOption, OpenFlags, RenameFlags, ReplyAttr, ReplyCreate,
+    ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyWrite, Request,
+    Session, TimeOrNow, WriteFlags,
 };
 
 const TTL: Duration = Duration::from_secs(1);
@@ -174,7 +171,11 @@ pub struct PassthroughFs {
     next_fh: AtomicU64,
     lat: Latency,
     fsyncs: Arc<AtomicU64>,
+    // Stored for future use (e.g. chown passthrough); attrs are read from disk
+    // metadata via attr_from_meta, so these are not read by any current op.
+    #[allow(dead_code)]
     uid: u32,
+    #[allow(dead_code)]
     gid: u32,
 }
 
@@ -403,6 +404,254 @@ impl fuser::Filesystem for PassthroughFs {
     }
 
     fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
+
+    fn create(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &std::ffi::OsStr,
+        _mode: u32,
+        _umask: u32,
+        _flags: i32,
+        reply: ReplyCreate,
+    ) {
+        nap(self.lat.open);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        let file = match OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(&child)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                return reply.error(fuser::Errno::from_i32(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                ))
+            }
+        };
+        let m = match file.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                return reply.error(fuser::Errno::from_i32(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                ))
+            }
+        };
+        let ino = self.inodes.lock().unwrap().intern(child);
+        let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
+        self.handles.lock().unwrap().insert(fh, file);
+        reply.created(
+            &TTL,
+            &attr_from_meta(ino, &m),
+            Generation(0),
+            FileHandle(fh),
+            FopenFlags::empty(),
+        );
+    }
+
+    fn write(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
+        data: &[u8],
+        _write_flags: WriteFlags,
+        _flags: OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        reply: ReplyWrite,
+    ) {
+        nap(self.lat.write);
+        // The `handles` lock is held across `write_at` — safe under single-threaded
+        // dispatch (see `PassthroughFs` invariant and the `read` op comment above).
+        let guard = self.handles.lock().unwrap();
+        let Some(file) = guard.get(&fh.0) else {
+            return reply.error(fuser::Errno::EBADF);
+        };
+        match file.write_at(data, offset) {
+            Ok(n) => reply.written(n as u32),
+            Err(e) => {
+                reply.error(fuser::Errno::from_i32(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                ));
+            }
+        }
+    }
+
+    fn fsync(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: FileHandle,
+        datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.fsync);
+        self.fsyncs.fetch_add(1, Ordering::Relaxed);
+        let guard = self.handles.lock().unwrap();
+        let Some(file) = guard.get(&fh.0) else {
+            return reply.error(fuser::Errno::EBADF);
+        };
+        let r = if datasync {
+            file.sync_data()
+        } else {
+            file.sync_all()
+        };
+        match r {
+            Ok(()) => reply.ok(),
+            Err(e) => reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            )),
+        }
+    }
+
+    fn fsyncdir(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.fsync);
+        self.fsyncs.fetch_add(1, Ordering::Relaxed);
+        reply.ok();
+    }
+
+    fn setattr(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        size: Option<u64>,
+        _atime: Option<TimeOrNow>,
+        _mtime: Option<TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<FileHandle>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<BsdFileFlags>,
+        reply: ReplyAttr,
+    ) {
+        nap(self.lat.other);
+        let Some(p) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        // The only attr SQLite needs: truncate/extend the WAL. Propagate any
+        // failure rather than replying ok with the stale (un-truncated) size,
+        // which would lie to the kernel and desync the WAL on disk.
+        if let Some(sz) = size {
+            if let Err(e) = OpenOptions::new()
+                .write(true)
+                .open(&p)
+                .and_then(|f| f.set_len(sz))
+            {
+                return reply.error(fuser::Errno::from_i32(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                ));
+            }
+        }
+        match std::fs::symlink_metadata(&p) {
+            Ok(m) => reply.attr(&TTL, &attr_from_meta(ino.0, &m)),
+            Err(e) => reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            )),
+        }
+    }
+
+    fn unlink(&self, _req: &Request, parent: INodeNo, name: &std::ffi::OsStr, reply: ReplyEmpty) {
+        nap(self.lat.other);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::remove_file(&child) {
+            Ok(()) => {
+                self.inodes.lock().unwrap().forget_path(&child);
+                reply.ok();
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            )),
+        }
+    }
+
+    fn rename(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &std::ffi::OsStr,
+        newparent: INodeNo,
+        newname: &std::ffi::OsStr,
+        _flags: RenameFlags,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.other);
+        let (Some(pp), Some(np)) = (self.ipath(parent.0), self.ipath(newparent.0)) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let from = pp.join(name);
+        let to = np.join(newname);
+        match std::fs::rename(&from, &to) {
+            Ok(()) => {
+                self.inodes.lock().unwrap().rename(&from, to);
+                reply.ok();
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            )),
+        }
+    }
+
+    fn mkdir(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        name: &std::ffi::OsStr,
+        _mode: u32,
+        _umask: u32,
+        reply: ReplyEntry,
+    ) {
+        nap(self.lat.other);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::create_dir(&child).and_then(|()| std::fs::symlink_metadata(&child)) {
+            Ok(m) => {
+                let ino = self.inodes.lock().unwrap().intern(child);
+                reply.entry(&TTL, &attr_from_meta(ino, &m), Generation(0));
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            )),
+        }
+    }
+
+    fn rmdir(&self, _req: &Request, parent: INodeNo, name: &std::ffi::OsStr, reply: ReplyEmpty) {
+        nap(self.lat.other);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::remove_dir(&child) {
+            Ok(()) => {
+                self.inodes.lock().unwrap().forget_path(&child);
+                reply.ok();
+            }
+            Err(e) => reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            )),
+        }
+    }
 }
 
 /// Serializes the racy fusermount3 mount handshake. `Session::new` forks/execs

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -756,44 +756,61 @@ mod tests {
         }
     }
 
+    // Assert against literal `Duration`s rather than ms()/us(), so a mutation
+    // of those helpers can't hide by also corrupting the expected value.
+    fn millis(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+    fn micros(n: u64) -> Duration {
+        Duration::from_micros(n)
+    }
+
     #[test]
     fn profile_hdd_values() {
         let l = Latency::profile("hdd");
-        assert_eq!(l.open, ms(8));
-        assert_eq!(l.stat, ms(8));
-        assert_eq!(l.read, ms(8));
-        assert_eq!(l.write, ms(8));
-        assert_eq!(l.fsync, ms(10));
-        assert_eq!(l.other, ms(2));
+        assert_eq!(l.open, millis(8));
+        assert_eq!(l.stat, millis(8));
+        assert_eq!(l.read, millis(8));
+        assert_eq!(l.write, millis(8));
+        assert_eq!(l.fsync, millis(10));
+        assert_eq!(l.other, millis(2));
     }
 
     #[test]
     fn profile_nfs_ssd_values() {
         let l = Latency::profile("nfs-ssd");
-        assert_eq!(l.open, us(600));
-        assert_eq!(l.stat, us(400));
-        assert_eq!(l.read, us(600));
-        assert_eq!(l.write, us(600));
-        assert_eq!(l.fsync, us(800));
-        assert_eq!(l.other, us(300));
+        assert_eq!(l.open, micros(600));
+        assert_eq!(l.stat, micros(400));
+        assert_eq!(l.read, micros(600));
+        assert_eq!(l.write, micros(600));
+        assert_eq!(l.fsync, micros(800));
+        assert_eq!(l.other, micros(300));
     }
 
     #[test]
     fn profile_nfs_hdd_values() {
         let l = Latency::profile("nfs-hdd");
-        assert_eq!(l.open, us(8600));
-        assert_eq!(l.stat, us(8400));
-        assert_eq!(l.read, us(8600));
-        assert_eq!(l.write, us(8600));
-        assert_eq!(l.fsync, ms(10) + us(800));
-        assert_eq!(l.other, us(2300));
+        assert_eq!(l.open, micros(8600));
+        assert_eq!(l.stat, micros(8400));
+        assert_eq!(l.read, micros(8600));
+        assert_eq!(l.write, micros(8600));
+        // 10ms + 800us; also pins the `+` in the profile table.
+        assert_eq!(l.fsync, micros(10_800));
+        assert_eq!(l.other, micros(2300));
     }
 
     #[test]
-    fn nap_zero_is_noop_nonzero_sleeps() {
-        // Zero duration must not sleep (the guard); a tiny non-zero one returns.
+    fn nap_sleeps_for_nonzero_and_skips_zero() {
+        use std::time::Instant;
+        // A non-zero nap sleeps at least its duration (sleep never under-sleeps),
+        // so this pins both the no-op mutation and the `!is_zero` guard direction.
+        let t = Instant::now();
+        nap(millis(30));
+        assert!(t.elapsed() >= millis(25), "nonzero nap should sleep");
+        // A zero nap returns promptly (no sleep).
+        let t = Instant::now();
         nap(Duration::ZERO);
-        nap(us(1));
+        assert!(t.elapsed() < millis(20), "zero nap should not sleep");
     }
 
     #[test]
@@ -878,6 +895,9 @@ mod tests {
         assert_eq!(fa.kind, FileType::RegularFile);
         // perm carries only the 12 permission bits, never the file-type bits.
         assert_eq!(fa.perm & !0o7777, 0);
+        // mtime is reconstructed from the raw secs/nsecs as UNIX_EPOCH + delta;
+        // it must equal what std read from the same inode (pins the epoch math).
+        assert_eq!(fa.mtime, fmeta.modified().unwrap());
 
         let dmeta = std::fs::symlink_metadata(dir.path()).unwrap();
         let da = attr_from_meta(1, &dmeta);

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -112,14 +112,35 @@ impl Inodes {
         }
     }
     fn rename(&mut self, from: &Path, to: PathBuf) {
-        if let Some(i) = self.rev.remove(from) {
-            self.fwd.insert(i, to.clone());
-            // An overwrite-rename onto an already-interned path must drop the
-            // displaced inode's stale `fwd` entry, or the bidirectional map
-            // would report two inodes for one path.
-            if let Some(displaced) = self.rev.insert(to, i) {
+        let Some(i) = self.rev.remove(from) else {
+            return;
+        };
+        // Renaming a directory must re-point its already-interned descendants
+        // (`from/<suffix>` -> `to/<suffix>`); otherwise their inodes would be
+        // stranded on stale paths and later inode->path lookups would fail.
+        // `from` is already removed above, so no descendant matches it exactly.
+        let descendants: Vec<(u64, PathBuf, PathBuf)> = self
+            .rev
+            .iter()
+            .filter_map(|(path, &ino)| {
+                path.strip_prefix(from)
+                    .ok()
+                    .map(|suffix| (ino, path.clone(), to.join(suffix)))
+            })
+            .collect();
+        for (ino, old, new) in descendants {
+            self.rev.remove(&old);
+            if let Some(displaced) = self.rev.insert(new.clone(), ino) {
                 self.fwd.remove(&displaced);
             }
+            self.fwd.insert(ino, new);
+        }
+        self.fwd.insert(i, to.clone());
+        // An overwrite-rename onto an already-interned path must drop the
+        // displaced inode's stale `fwd` entry, or the bidirectional map
+        // would report two inodes for one path.
+        if let Some(displaced) = self.rev.insert(to, i) {
+            self.fwd.remove(&displaced);
         }
     }
 }
@@ -710,5 +731,157 @@ impl LatencyMount {
     /// Total `fsync`/`fsyncdir` operations observed since mount.
     pub fn fsyncs(&self) -> u64 {
         self.fsyncs.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn profile_ssd_and_unknown_are_zero() {
+        for name in ["ssd", "", "garbage"] {
+            let l = Latency::profile(name);
+            assert_eq!(l.open, Duration::ZERO);
+            assert_eq!(l.stat, Duration::ZERO);
+            assert_eq!(l.read, Duration::ZERO);
+            assert_eq!(l.write, Duration::ZERO);
+            assert_eq!(l.fsync, Duration::ZERO);
+            assert_eq!(l.other, Duration::ZERO);
+        }
+    }
+
+    #[test]
+    fn profile_hdd_values() {
+        let l = Latency::profile("hdd");
+        assert_eq!(l.open, ms(8));
+        assert_eq!(l.stat, ms(8));
+        assert_eq!(l.read, ms(8));
+        assert_eq!(l.write, ms(8));
+        assert_eq!(l.fsync, ms(10));
+        assert_eq!(l.other, ms(2));
+    }
+
+    #[test]
+    fn profile_nfs_ssd_values() {
+        let l = Latency::profile("nfs-ssd");
+        assert_eq!(l.open, us(600));
+        assert_eq!(l.stat, us(400));
+        assert_eq!(l.read, us(600));
+        assert_eq!(l.write, us(600));
+        assert_eq!(l.fsync, us(800));
+        assert_eq!(l.other, us(300));
+    }
+
+    #[test]
+    fn profile_nfs_hdd_values() {
+        let l = Latency::profile("nfs-hdd");
+        assert_eq!(l.open, us(8600));
+        assert_eq!(l.stat, us(8400));
+        assert_eq!(l.read, us(8600));
+        assert_eq!(l.write, us(8600));
+        assert_eq!(l.fsync, ms(10) + us(800));
+        assert_eq!(l.other, us(2300));
+    }
+
+    #[test]
+    fn nap_zero_is_noop_nonzero_sleeps() {
+        // Zero duration must not sleep (the guard); a tiny non-zero one returns.
+        nap(Duration::ZERO);
+        nap(us(1));
+    }
+
+    #[test]
+    fn inodes_root_is_one_and_next_starts_at_two() {
+        let m = Inodes::new(p("/root"));
+        assert_eq!(m.path(1), Some(p("/root")));
+        assert_eq!(m.next, 2);
+        assert_eq!(m.path(2), None);
+    }
+
+    #[test]
+    fn intern_is_idempotent_and_increments() {
+        let mut m = Inodes::new(p("/root"));
+        let a = m.intern(p("/root/a"));
+        let b = m.intern(p("/root/b"));
+        assert_eq!(a, 2);
+        assert_eq!(b, 3);
+        // Re-interning the same path returns the same inode, no increment.
+        assert_eq!(m.intern(p("/root/a")), a);
+        assert_eq!(m.next, 4);
+        assert_eq!(m.path(a), Some(p("/root/a")));
+    }
+
+    #[test]
+    fn forget_path_clears_both_directions() {
+        let mut m = Inodes::new(p("/root"));
+        let a = m.intern(p("/root/a"));
+        m.forget_path(&p("/root/a"));
+        assert_eq!(m.path(a), None);
+        // A fresh intern of the same path gets a new inode (never recycled).
+        let a2 = m.intern(p("/root/a"));
+        assert_ne!(a2, a);
+    }
+
+    #[test]
+    fn rename_moves_inode_and_keeps_map_consistent() {
+        let mut m = Inodes::new(p("/root"));
+        let a = m.intern(p("/root/a"));
+        m.rename(&p("/root/a"), p("/root/b"));
+        assert_eq!(m.path(a), Some(p("/root/b")));
+        assert_eq!(m.intern(p("/root/b")), a);
+        // The old path no longer resolves to the moved inode.
+        assert_ne!(m.intern(p("/root/a")), a);
+    }
+
+    #[test]
+    fn rename_onto_existing_path_drops_displaced_inode() {
+        let mut m = Inodes::new(p("/root"));
+        let a = m.intern(p("/root/a"));
+        let b = m.intern(p("/root/b"));
+        // Overwrite-rename a -> b: b's path is now owned by inode `a`, and the
+        // displaced inode `b` must have no stale forward entry.
+        m.rename(&p("/root/a"), p("/root/b"));
+        assert_eq!(m.intern(p("/root/b")), a);
+        assert_eq!(m.path(b), None);
+    }
+
+    #[test]
+    fn rename_directory_repoints_interned_descendants() {
+        let mut m = Inodes::new(p("/root"));
+        let dir = m.intern(p("/root/d"));
+        let child = m.intern(p("/root/d/c"));
+        let grandchild = m.intern(p("/root/d/sub/g"));
+        m.rename(&p("/root/d"), p("/root/e"));
+        // The directory and every interned descendant follow the new prefix,
+        // keeping their inodes (a held descriptor stays valid).
+        assert_eq!(m.path(dir), Some(p("/root/e")));
+        assert_eq!(m.path(child), Some(p("/root/e/c")));
+        assert_eq!(m.path(grandchild), Some(p("/root/e/sub/g")));
+        // The stale paths no longer resolve to the moved inodes.
+        assert_ne!(m.intern(p("/root/d/c")), child);
+    }
+
+    #[test]
+    fn attr_from_meta_maps_file_and_dir_kinds() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f"), b"hello").unwrap();
+        let fmeta = std::fs::symlink_metadata(dir.path().join("f")).unwrap();
+        let fa = attr_from_meta(42, &fmeta);
+        assert_eq!(fa.ino, INodeNo(42));
+        assert_eq!(fa.size, 5);
+        assert_eq!(fa.kind, FileType::RegularFile);
+        // perm carries only the 12 permission bits, never the file-type bits.
+        assert_eq!(fa.perm & !0o7777, 0);
+
+        let dmeta = std::fs::symlink_metadata(dir.path()).unwrap();
+        let da = attr_from_meta(1, &dmeta);
+        assert_eq!(da.kind, FileType::Directory);
+        assert_eq!(da.ino, INodeNo(1));
     }
 }

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -1,0 +1,188 @@
+//! Bench-only passthrough FUSE that mirrors a backing directory and sleeps a
+//! configurable amount per operation, so HDD/NFS latency profiles are
+//! reproducible on one machine. The corpus AND the SQLite DB live under the
+//! mount, so backing reads and SQLite fsyncs are both delayed (and fsyncs
+//! counted). Not for production; requires /dev/fuse.
+
+// Task 1 skeleton: all items below are consumed by the Filesystem impl in Task 2.
+// Remove this attribute once Task 2 lands.
+#![allow(dead_code, unused_imports)]
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::unix::fs::{FileExt, MetadataExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use fuser::{FileAttr, FileType, Generation, INodeNo};
+
+const TTL: Duration = Duration::from_secs(1);
+
+fn ms(n: u64) -> Duration {
+    Duration::from_millis(n)
+}
+fn us(n: u64) -> Duration {
+    Duration::from_micros(n)
+}
+fn nap(d: Duration) {
+    if !d.is_zero() {
+        std::thread::sleep(d);
+    }
+}
+
+/// Per-operation injected latency. `ssd` is all-zero (≈ no injection).
+#[derive(Clone, Copy, Default)]
+pub struct Latency {
+    pub open: Duration,
+    pub stat: Duration,
+    pub read: Duration,
+    pub write: Duration,
+    pub fsync: Duration,
+    pub other: Duration,
+}
+
+impl Latency {
+    /// Named profiles. Unknown / "ssd" => zero.
+    pub fn profile(name: &str) -> Latency {
+        match name {
+            "hdd" => Latency {
+                open: ms(8),
+                stat: ms(8),
+                read: ms(8),
+                write: ms(8),
+                fsync: ms(10),
+                other: ms(2),
+            },
+            "nfs-ssd" => Latency {
+                open: us(600),
+                stat: us(400),
+                read: us(600),
+                write: us(600),
+                fsync: us(800),
+                other: us(300),
+            },
+            "nfs-hdd" => Latency {
+                open: us(8600),
+                stat: us(8400),
+                read: us(8600),
+                write: us(8600),
+                fsync: ms(10) + us(800),
+                other: us(2300),
+            },
+            _ => Latency::default(),
+        }
+    }
+}
+
+/// Bidirectional inode<->path map. Never forgets (bench-scale memory is fine).
+struct Inodes {
+    fwd: HashMap<u64, PathBuf>,
+    rev: HashMap<PathBuf, u64>,
+    next: u64,
+}
+
+impl Inodes {
+    fn new(root: PathBuf) -> Inodes {
+        let mut fwd = HashMap::new();
+        let mut rev = HashMap::new();
+        fwd.insert(1, root.clone());
+        rev.insert(root, 1);
+        Inodes { fwd, rev, next: 2 }
+    }
+    fn path(&self, ino: u64) -> Option<PathBuf> {
+        self.fwd.get(&ino).cloned()
+    }
+    fn intern(&mut self, path: PathBuf) -> u64 {
+        if let Some(&i) = self.rev.get(&path) {
+            return i;
+        }
+        let i = self.next;
+        self.next += 1;
+        self.fwd.insert(i, path.clone());
+        self.rev.insert(path, i);
+        i
+    }
+    fn forget_path(&mut self, path: &Path) {
+        if let Some(i) = self.rev.remove(path) {
+            self.fwd.remove(&i);
+        }
+    }
+    fn rename(&mut self, from: &Path, to: PathBuf) {
+        if let Some(i) = self.rev.remove(from) {
+            self.fwd.insert(i, to.clone());
+            // An overwrite-rename onto an already-interned path must drop the
+            // displaced inode's stale `fwd` entry, or the bidirectional map
+            // would report two inodes for one path.
+            if let Some(displaced) = self.rev.insert(to, i) {
+                self.fwd.remove(&displaced);
+            }
+        }
+    }
+}
+
+/// `std::fs::Metadata` -> `fuser::FileAttr`, reporting our interned `ino`.
+fn attr_from_meta(ino: u64, m: &std::fs::Metadata) -> FileAttr {
+    let kind = if m.is_dir() {
+        FileType::Directory
+    } else if m.file_type().is_symlink() {
+        FileType::Symlink
+    } else {
+        FileType::RegularFile
+    };
+    let t = |secs: i64, nsec: i64| {
+        if secs >= 0 {
+            SystemTime::UNIX_EPOCH + Duration::new(secs as u64, nsec as u32)
+        } else {
+            SystemTime::UNIX_EPOCH
+        }
+    };
+    FileAttr {
+        ino: INodeNo(ino),
+        size: m.size(),
+        blocks: m.blocks(),
+        atime: t(m.atime(), m.atime_nsec()),
+        mtime: t(m.mtime(), m.mtime_nsec()),
+        ctime: t(m.ctime(), m.ctime_nsec()),
+        crtime: SystemTime::UNIX_EPOCH,
+        kind,
+        perm: (m.mode() & 0o7777) as u16,
+        nlink: m.nlink() as u32,
+        uid: m.uid(),
+        gid: m.gid(),
+        rdev: m.rdev() as u32,
+        blksize: m.blksize() as u32,
+        flags: 0,
+    }
+}
+
+/// The passthrough filesystem. Root inode (1) maps to the backing root.
+pub struct PassthroughFs {
+    inodes: Mutex<Inodes>,
+    handles: Mutex<HashMap<u64, File>>,
+    next_fh: AtomicU64,
+    lat: Latency,
+    fsyncs: Arc<AtomicU64>,
+    uid: u32,
+    gid: u32,
+}
+
+impl PassthroughFs {
+    fn new(root: PathBuf, lat: Latency, fsyncs: Arc<AtomicU64>) -> PassthroughFs {
+        PassthroughFs {
+            inodes: Mutex::new(Inodes::new(root)),
+            handles: Mutex::new(HashMap::new()),
+            next_fh: AtomicU64::new(1),
+            lat,
+            fsyncs,
+            // SAFETY: getuid/getgid never fail.
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+        }
+    }
+    fn ipath(&self, ino: u64) -> Option<PathBuf> {
+        self.inodes.lock().unwrap().path(ino)
+    }
+}

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -4,9 +4,9 @@
 //! mount, so backing reads and SQLite fsyncs are both delayed (and fsyncs
 //! counted). Not for production; requires /dev/fuse.
 
-// Task 1 skeleton: all items below are consumed by the Filesystem impl in Task 2.
-// Remove this attribute once Task 2 lands.
-#![allow(dead_code, unused_imports)]
+// Task 3 will add write ops (create/write/fsync/fsyncdir/setattr/unlink/rename/mkdir/rmdir)
+// that consume forget_path, rename, lat.write, lat.fsync, uid, and gid.
+#![allow(dead_code)]
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -17,7 +17,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
-use fuser::{FileAttr, FileType, Generation, INodeNo};
+use fuser::{
+    AccessFlags, BackgroundSession, Config, FileAttr, FileHandle, FileType, FopenFlags, Generation,
+    INodeNo, MountOption, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry,
+    ReplyOpen, ReplyStatfs, Request, Session,
+};
 
 const TTL: Duration = Duration::from_secs(1);
 
@@ -159,6 +163,11 @@ fn attr_from_meta(ino: u64, m: &std::fs::Metadata) -> FileAttr {
 }
 
 /// The passthrough filesystem. Root inode (1) maps to the backing root.
+///
+/// Invariant: mounted with single-threaded FUSE dispatch (`Config::default()`,
+/// no `n_threads`), so filesystem ops never run concurrently. The `handles` and
+/// `inodes` locks therefore never contend, and ops may hold a lock across a
+/// blocking syscall. A multi-threaded bench would need `Arc<File>` handles.
 pub struct PassthroughFs {
     inodes: Mutex<Inodes>,
     handles: Mutex<HashMap<u64, File>>,
@@ -184,5 +193,273 @@ impl PassthroughFs {
     }
     fn ipath(&self, ino: u64) -> Option<PathBuf> {
         self.inodes.lock().unwrap().path(ino)
+    }
+}
+
+impl fuser::Filesystem for PassthroughFs {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &std::ffi::OsStr, reply: ReplyEntry) {
+        nap(self.lat.stat);
+        let Some(pp) = self.ipath(parent.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        let child = pp.join(name);
+        match std::fs::symlink_metadata(&child) {
+            Ok(m) => {
+                let ino = self.inodes.lock().unwrap().intern(child);
+                reply.entry(&TTL, &attr_from_meta(ino, &m), Generation(0));
+            }
+            Err(_) => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+        nap(self.lat.stat);
+        let Some(p) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        match std::fs::symlink_metadata(&p) {
+            Ok(m) => reply.attr(&TTL, &attr_from_meta(ino.0, &m)),
+            Err(_) => reply.error(fuser::Errno::ENOENT),
+        }
+    }
+
+    fn opendir(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        nap(self.lat.open);
+        reply.opened(FileHandle(0), FopenFlags::empty());
+    }
+
+    fn readdir(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: FileHandle,
+        offset: u64,
+        mut reply: ReplyDirectory,
+    ) {
+        nap(self.lat.stat);
+        let Some(dir) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        // Root's `..` is self-referential (conventional FUSE root), so we never
+        // intern a path outside the mounted backing tree.
+        let parent_ino = if ino.0 == 1 {
+            ino.0
+        } else {
+            dir.parent().map_or(ino.0, |p| {
+                self.inodes.lock().unwrap().intern(p.to_path_buf())
+            })
+        };
+        let mut entries: Vec<(u64, FileType, std::ffi::OsString)> = vec![
+            (ino.0, FileType::Directory, ".".into()),
+            (parent_ino, FileType::Directory, "..".into()),
+        ];
+        let rd = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(e) => {
+                return reply.error(fuser::Errno::from_i32(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                ))
+            }
+        };
+        for ent in rd.flatten() {
+            let p = ent.path();
+            let kind = match ent.file_type() {
+                Ok(ft) if ft.is_dir() => FileType::Directory,
+                Ok(ft) if ft.is_symlink() => FileType::Symlink,
+                _ => FileType::RegularFile,
+            };
+            let cino = self.inodes.lock().unwrap().intern(p);
+            entries.push((cino, kind, ent.file_name()));
+        }
+        for (i, (cino, kind, name)) in entries.into_iter().enumerate().skip(offset as usize) {
+            if reply.add(INodeNo(cino), (i + 1) as u64, kind, &name) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+
+    fn releasedir(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _flags: OpenFlags,
+        reply: ReplyEmpty,
+    ) {
+        reply.ok();
+    }
+
+    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        nap(self.lat.open);
+        let Some(p) = self.ipath(ino.0) else {
+            return reply.error(fuser::Errno::ENOENT);
+        };
+        // Try read-write (the DB); fall back to read-only (audio files are 0444).
+        let file = match OpenOptions::new().read(true).write(true).open(&p) {
+            Ok(f) => f,
+            Err(_) => match File::open(&p) {
+                Ok(f) => f,
+                Err(e) => {
+                    return reply.error(fuser::Errno::from_i32(
+                        e.raw_os_error().unwrap_or(libc::EIO),
+                    ))
+                }
+            },
+        };
+        let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
+        self.handles.lock().unwrap().insert(fh, file);
+        reply.opened(FileHandle(fh), FopenFlags::empty());
+    }
+
+    fn read(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        reply: ReplyData,
+    ) {
+        nap(self.lat.read);
+        // The `handles` lock is held across `read_at` (and `write_at` in the
+        // write ops). This is fine because the mount uses `Config::default()`,
+        // i.e. single-threaded FUSE dispatch (see `PassthroughFs` invariant), so
+        // ops never run concurrently. If a future bench sets `n_threads`, switch
+        // the handle values to `Arc<File>` and drop the guard before the syscall.
+        let guard = self.handles.lock().unwrap();
+        let Some(file) = guard.get(&fh.0) else {
+            return reply.error(fuser::Errno::EBADF);
+        };
+        let mut buf = vec![0u8; size as usize];
+        match file.read_at(&mut buf, offset) {
+            Ok(n) => reply.data(&buf[..n]),
+            Err(e) => {
+                reply.error(fuser::Errno::from_i32(
+                    e.raw_os_error().unwrap_or(libc::EIO),
+                ));
+            }
+        }
+    }
+
+    fn flush(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _lock_owner: fuser::LockOwner,
+        reply: ReplyEmpty,
+    ) {
+        nap(self.lat.other);
+        reply.ok();
+    }
+
+    fn release(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: FileHandle,
+        _flags: OpenFlags,
+        _lock_owner: Option<fuser::LockOwner>,
+        _flush: bool,
+        reply: ReplyEmpty,
+    ) {
+        self.handles.lock().unwrap().remove(&fh.0);
+        reply.ok();
+    }
+
+    fn statfs(&self, _req: &Request, ino: INodeNo, reply: ReplyStatfs) {
+        nap(self.lat.stat);
+        // Pass through real statvfs of the inode's path; fall back to benign values.
+        if let Some(p) = self.ipath(ino.0) {
+            // Use the raw OS path bytes (not `to_string_lossy`, which would
+            // mangle non-UTF-8 names into U+FFFD and statvfs a different path).
+            if let Ok(cstr) =
+                std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(p.as_os_str()))
+            {
+                let mut s: libc::statvfs = unsafe { std::mem::zeroed() };
+                // SAFETY: cstr is a valid NUL-terminated path; s is a valid out-param.
+                if unsafe { libc::statvfs(cstr.as_ptr(), &raw mut s) } == 0 {
+                    return reply.statfs(
+                        s.f_blocks as u64,
+                        s.f_bfree as u64,
+                        s.f_bavail as u64,
+                        s.f_files as u64,
+                        s.f_ffree as u64,
+                        s.f_bsize as u32,
+                        s.f_namemax as u32,
+                        s.f_frsize as u32,
+                    );
+                }
+            }
+        }
+        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
+    }
+
+    fn access(&self, _req: &Request, _ino: INodeNo, _mask: AccessFlags, reply: ReplyEmpty) {
+        reply.ok();
+    }
+
+    fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
+}
+
+/// Serializes the racy fusermount3 mount handshake. `Session::new` forks/execs
+/// `fusermount3` and passes the `/dev/fuse` fd back over a socket; fork and the
+/// fd table are process-global, so two mounts establishing concurrently from one
+/// process race the fd table ("file descriptor N is not a socket, can't send fuse
+/// fd"). `cargo test -- --ignored` runs a binary's tests in parallel and several
+/// test files mount more than once, so guard setup. Mirrors `musefs-fuse`'s
+/// `MOUNT_SETUP`. The lock covers only establishment, never the session lifetime,
+/// so it never serializes filesystem operations.
+static MOUNT_SETUP: Mutex<()> = Mutex::new(());
+
+/// A mounted passthrough FS. Unmounts on drop. The corpus + DB live under
+/// `path()`; point scans and `Db::open` there to measure under injected latency.
+pub struct LatencyMount {
+    fsyncs: Arc<AtomicU64>,
+    // Drop order: the session (unmount) must drop before the mountpoint tempdir.
+    _bg: BackgroundSession,
+    mountdir: tempfile::TempDir,
+}
+
+impl LatencyMount {
+    /// Mount a passthrough over `backing` using the named latency profile
+    /// (`ssd`|`hdd`|`nfs-ssd`|`nfs-hdd`). Returns once the mount is live.
+    pub fn new(backing: &Path, profile: &str) -> io::Result<LatencyMount> {
+        let mountdir = tempfile::tempdir()?;
+        let fsyncs = Arc::new(AtomicU64::new(0));
+        let fs = PassthroughFs::new(
+            backing.to_path_buf(),
+            Latency::profile(profile),
+            Arc::clone(&fsyncs),
+        );
+        let mut cfg = Config::default();
+        cfg.mount_options = vec![MountOption::FSName("musefs-latencyfs".to_string())];
+        let session = {
+            // Recover from a poisoned lock: it guards only ordering, so a prior
+            // panic during a mount leaves no inconsistent state to protect.
+            let _guard = MOUNT_SETUP
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Session::new(fs, mountdir.path(), &cfg)?
+        };
+        let bg = session.spawn()?;
+        Ok(LatencyMount {
+            fsyncs,
+            _bg: bg,
+            mountdir,
+        })
+    }
+
+    /// The mountpoint. Use this as the corpus dir / DB parent.
+    pub fn path(&self) -> PathBuf {
+        self.mountdir.path().to_path_buf()
+    }
+
+    /// Total `fsync`/`fsyncdir` operations observed since mount.
+    pub fn fsyncs(&self) -> u64 {
+        self.fsyncs.load(Ordering::Relaxed)
     }
 }

--- a/musefs-latencyfs/tests/latency_effect.rs
+++ b/musefs-latencyfs/tests/latency_effect.rs
@@ -1,0 +1,69 @@
+use std::time::Instant;
+
+use musefs_latencyfs::LatencyMount;
+
+fn open_read_close(path: &std::path::Path) {
+    use std::io::Read;
+    let mut s = Vec::new();
+    std::fs::File::open(path)
+        .unwrap()
+        .read_to_end(&mut s)
+        .unwrap();
+}
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn nonzero_profile_is_slower_than_ssd() {
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(backing.path().join("f.bin"), vec![0u8; 64 * 1024]).unwrap();
+
+    // ssd (~0) baseline.
+    let fast = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let t0 = Instant::now();
+    for _ in 0..20 {
+        open_read_close(&fast.path().join("f.bin"));
+    }
+    let fast_ms = t0.elapsed().as_millis();
+    drop(fast);
+
+    // hdd profile: each open+read sleeps multiple ms, so 20 iterations are far slower.
+    let slow = LatencyMount::new(backing.path(), "hdd").unwrap();
+    let t1 = Instant::now();
+    for _ in 0..20 {
+        open_read_close(&slow.path().join("f.bin"));
+    }
+    let slow_ms = t1.elapsed().as_millis();
+
+    println!("ssd={fast_ms}ms hdd={slow_ms}ms");
+    assert!(
+        slow_ms > fast_ms + 50,
+        "hdd profile ({slow_ms}ms) should be clearly slower than ssd ({fast_ms}ms)"
+    );
+}
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn fsync_count_rises_with_more_commits() {
+    use rusqlite::Connection;
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+
+    let conn = Connection::open(mount.path().join("c.db")).unwrap();
+    let _: String = conn
+        .query_row("PRAGMA journal_mode = WAL", [], |r| r.get(0))
+        .unwrap();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", [])
+        .unwrap();
+
+    let before = mount.fsyncs();
+    // Each checkpoint forces fsyncs; more checkpoints => strictly more fsyncs.
+    for _ in 0..10 {
+        conn.execute("INSERT INTO t DEFAULT VALUES", []).unwrap();
+        conn.execute_batch("PRAGMA wal_checkpoint(FULL);").unwrap();
+    }
+    let after = mount.fsyncs();
+    assert!(
+        after > before,
+        "fsync count must rise with commits/checkpoints"
+    );
+}

--- a/musefs-latencyfs/tests/passthrough.rs
+++ b/musefs-latencyfs/tests/passthrough.rs
@@ -8,6 +8,8 @@ fn reads_a_file_through_the_mount() {
     let backing = tempfile::tempdir().unwrap();
     std::fs::create_dir(backing.path().join("sub")).unwrap();
     std::fs::write(backing.path().join("sub/hello.txt"), b"hello world").unwrap();
+    std::fs::create_dir(backing.path().join("sub/nested")).unwrap();
+    std::os::unix::fs::symlink("hello.txt", backing.path().join("sub/link")).unwrap();
 
     let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
     // Stat + read through the FUSE mount.
@@ -21,12 +23,32 @@ fn reads_a_file_through_the_mount() {
         .unwrap();
     assert_eq!(s, "hello world");
 
-    // readdir sees the entry.
-    let names: Vec<String> = std::fs::read_dir(mp.join("sub"))
+    // readdir reports each entry with the correct file type, so the dirent
+    // kind classification (file vs dir vs symlink) is actually exercised.
+    let mut kinds: Vec<(String, bool, bool, bool)> = std::fs::read_dir(mp.join("sub"))
         .unwrap()
-        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .map(|e| {
+            let e = e.unwrap();
+            // `file_type()` here comes from the dirent the FS returned, without
+            // a follow-up stat, so it reflects the kind reported by `readdir`.
+            let ft = e.file_type().unwrap();
+            (
+                e.file_name().to_string_lossy().into_owned(),
+                ft.is_file(),
+                ft.is_dir(),
+                ft.is_symlink(),
+            )
+        })
         .collect();
-    assert!(names.contains(&"hello.txt".to_string()));
+    kinds.sort();
+    assert_eq!(
+        kinds,
+        vec![
+            ("hello.txt".to_string(), true, false, false),
+            ("link".to_string(), false, false, true),
+            ("nested".to_string(), false, true, false),
+        ]
+    );
 }
 
 #[test]
@@ -66,4 +88,26 @@ fn write_fsync_rename_unlink_through_the_mount() {
 
     // The backing dir reflects the changes (true passthrough).
     assert!(!backing.path().join("data.bin").exists());
+}
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn mkdir_rmdir_and_statfs_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let mp = mount.path();
+
+    // mkdir then rmdir, each reflected in the backing dir (true passthrough).
+    std::fs::create_dir(mp.join("d")).unwrap();
+    assert!(backing.path().join("d").is_dir());
+    std::fs::remove_dir(mp.join("d")).unwrap();
+    assert!(!backing.path().join("d").exists());
+
+    // statfs returns real, non-empty filesystem stats for the mount (not the
+    // benign all-zero fallback), exercising the passthrough statvfs path.
+    let cpath = std::ffi::CString::new(mp.to_str().unwrap()).unwrap();
+    let mut s: libc::statvfs = unsafe { std::mem::zeroed() };
+    // SAFETY: cpath is a valid NUL-terminated path; s is a valid out-param.
+    assert_eq!(unsafe { libc::statvfs(cpath.as_ptr(), &raw mut s) }, 0);
+    assert!(s.f_blocks > 0, "statfs should report real block counts");
 }

--- a/musefs-latencyfs/tests/passthrough.rs
+++ b/musefs-latencyfs/tests/passthrough.rs
@@ -28,3 +28,42 @@ fn reads_a_file_through_the_mount() {
         .collect();
     assert!(names.contains(&"hello.txt".to_string()));
 }
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn write_fsync_rename_unlink_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let mp = mount.path();
+
+    // create + write + fsync via normal file ops (the kernel issues create/write/fsync).
+    let p = mp.join("data.bin");
+    {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&p)
+            .unwrap();
+        f.write_all(b"abcdef").unwrap();
+        f.sync_all().unwrap();
+    }
+    assert_eq!(std::fs::read(&p).unwrap(), b"abcdef");
+    assert!(mount.fsyncs() >= 1, "fsync should have been counted");
+    // The bytes landed in the backing dir, not a tmpfs overlay (true passthrough).
+    assert_eq!(
+        std::fs::read(backing.path().join("data.bin")).unwrap(),
+        b"abcdef"
+    );
+
+    // rename + unlink.
+    let q = mp.join("renamed.bin");
+    std::fs::rename(&p, &q).unwrap();
+    assert!(q.exists() && !p.exists());
+    std::fs::remove_file(&q).unwrap();
+    assert!(!q.exists());
+
+    // The backing dir reflects the changes (true passthrough).
+    assert!(!backing.path().join("data.bin").exists());
+}

--- a/musefs-latencyfs/tests/passthrough.rs
+++ b/musefs-latencyfs/tests/passthrough.rs
@@ -1,0 +1,30 @@
+use std::io::Read;
+
+use musefs_latencyfs::LatencyMount;
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn reads_a_file_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::create_dir(backing.path().join("sub")).unwrap();
+    std::fs::write(backing.path().join("sub/hello.txt"), b"hello world").unwrap();
+
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    // Stat + read through the FUSE mount.
+    let mp = mount.path();
+    let meta = std::fs::metadata(mp.join("sub/hello.txt")).unwrap();
+    assert_eq!(meta.len(), 11);
+    let mut s = String::new();
+    std::fs::File::open(mp.join("sub/hello.txt"))
+        .unwrap()
+        .read_to_string(&mut s)
+        .unwrap();
+    assert_eq!(s, "hello world");
+
+    // readdir sees the entry.
+    let names: Vec<String> = std::fs::read_dir(mp.join("sub"))
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(names.contains(&"hello.txt".to_string()));
+}

--- a/musefs-latencyfs/tests/sqlite_wal.rs
+++ b/musefs-latencyfs/tests/sqlite_wal.rs
@@ -1,0 +1,41 @@
+use musefs_latencyfs::LatencyMount;
+use rusqlite::Connection;
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn sqlite_wal_cycle_through_the_mount() {
+    let backing = tempfile::tempdir().unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let db_path = mount.path().join("test.db");
+
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        // WAL mode exercises -wal/-shm create, write, fsync, and truncate.
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode = WAL", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", [])
+            .unwrap();
+        for i in 0..200 {
+            conn.execute("INSERT INTO t (v) VALUES (?1)", [format!("row-{i}")])
+                .unwrap();
+        }
+        // Force a checkpoint (truncates the WAL).
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+            .unwrap();
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM t", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 200);
+    }
+
+    // Reopen and re-read to confirm durability through the mount.
+    let conn = Connection::open(&db_path).unwrap();
+    let n: i64 = conn
+        .query_row("SELECT COUNT(*) FROM t", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(n, 200);
+
+    assert!(mount.fsyncs() > 0, "WAL writes must have triggered fsyncs");
+}

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# Run cargo-mutants over the three logic-bearing crates with a disk budget that
-# fits a small VPS. Known-good cargo-mutants version: 27.0.0.
+# Run cargo-mutants over the logic-bearing crates with a disk budget that fits a
+# small VPS. Known-good cargo-mutants version: 27.0.0.
 #
-# musefs-cli, musefs-fuse, and musefs-latencyfs are intentionally out of scope
-# (thin glue / e2e-only — the FUSE crates need /dev/fuse; see the remediation
-# tracking doc). The per-PR `--in-diff` gate excludes them via .cargo/mutants.toml.
+# musefs-cli, musefs-fuse, and the `musefs` binary are thin glue with no real
+# logic and are excluded from mutation entirely via .cargo/mutants.toml.
+# musefs-latencyfs is NOT thin (inode map, latency table, attr mapping, passthrough
+# ops): it has its own leg below, which runs the crate's #[ignore]d mounted tests
+# (`-- -- --include-ignored`) and so needs /dev/fuse + libfuse. The fast per-PR
+# `--in-diff` gate excludes it separately (that job is mountless); see mutants.yml.
 #
-# Usage: scripts/mutants.sh [crate ...]   (default: all three in-scope crates)
+# Usage: scripts/mutants.sh [crate ...]   (default: the three in-scope logic crates)
 # Env:   MUTANTS_TMP  scratch PARENT dir, MUST be OUTSIDE this repo (default: the
 #                     system temp dir). cargo-mutants copies the source tree into
 #                     a build dir under TMPDIR, so a scratch dir inside the repo

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -2,8 +2,9 @@
 # Run cargo-mutants over the three logic-bearing crates with a disk budget that
 # fits a small VPS. Known-good cargo-mutants version: 27.0.0.
 #
-# musefs-cli and musefs-fuse are intentionally out of scope (thin glue / e2e-only;
-# see the remediation tracking doc).
+# musefs-cli, musefs-fuse, and musefs-latencyfs are intentionally out of scope
+# (thin glue / e2e-only — the FUSE crates need /dev/fuse; see the remediation
+# tracking doc). The per-PR `--in-diff` gate excludes them via .cargo/mutants.toml.
 #
 # Usage: scripts/mutants.sh [crate ...]   (default: all three in-scope crates)
 # Env:   MUTANTS_TMP  scratch PARENT dir, MUST be OUTSIDE this repo (default: the

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -129,6 +129,15 @@ for crate in "${crates[@]}"; do
         --file musefs-format/src/ogg/crc.rs \
         --file musefs-format/src/ogg/b64.rs
       ;;
+    musefs-latencyfs)
+      # Every test in this crate is #[ignore]d (it mounts a real passthrough
+      # FUSE), so the trailing `-- -- --include-ignored` forwards through
+      # cargo-mutants -> cargo test -> the test harness to run them. Needs
+      # /dev/fuse + libfuse on the runner (the CI leg installs fuse3).
+      run_crate musefs-latencyfs --test-workspace=false \
+        --file musefs-latencyfs/src/lib.rs \
+        -- -- --include-ignored
+      ;;
     *)
       echo "unknown crate: $crate" >&2; status=1; continue
       ;;


### PR DESCRIPTION
## Summary

Implements **SP0b** of the 2026-05-30 optimization pass (`docs/superpowers/specs/2026-05-30-optimization-pass/`): completes the measurement foundation's deferred latency layer.

- New **dev-only** crate `musefs-latencyfs` (`publish = false`): a passthrough FUSE that mirrors a backing dir but sleeps a configurable amount per op (profiles `ssd`/`hdd`/`nfs-ssd`/`nfs-hdd`) and counts fsyncs. The corpus **and** the SQLite DB live under the mount, so backing reads and SQLite's durability fsyncs are both delayed and measured — no in-process I/O seam, no VFS shim.
- Full `fuser::Filesystem` op surface (read + write + WAL ops: create/write/fsync/fsyncdir/setattr-ftruncate/unlink/rename/mkdir/rmdir), plus a `LatencyMount` RAII mount harness mirroring `musefs-fuse`'s `Session`/`BackgroundSession` pattern.
- Wires the latency mount into the SP0a `bench_ingest` scan bench via `MUSEFS_BENCH_LATENCY_PROFILE`, reporting **real kernel fsync counts** (the SP1-batching signal) in the existing report table.

### Cardinal invariant
No production serving/read code changed. The only shipping-crate edit is a single `[dev-dependencies]` line in `musefs-core/Cargo.toml`; everything else is the new dev crate, tests, and docs. Served audio bytes are untouched.

### Spec acceptance (all met)
- Full op surface; gating `ssd` SQLite WAL-checkpoint smoke test proving op completeness.
- Non-zero profile measurably slower than `ssd`; fsync count rises with write volume.
- fsync wired into the reporting table.
- All FUSE tests `#[ignore]`d + `/dev/fuse`-gated; default `cargo test` unchanged (metrics-off path green).
- In-process `on_fsync` hook deliberately declined (passthrough counter is the single SP1 source).

## Test Plan
- [x] `cargo test` (default, metrics off): 426 passed, 18 ignored
- [x] `cargo test -p musefs-latencyfs -- --ignored`: 5 passed (passthrough ×2, sqlite_wal ×1, latency_effect ×2) — needs `/dev/fuse`
- [x] `MUSEFS_BENCH_LATENCY_PROFILE=ssd cargo test -p musefs-core --features metrics --test bench_ingest bench_scan_under_latency -- --ignored --nocapture`: row `fsyncs=410 scanned=200`
- [x] `cargo clippy --all-targets` and `--features metrics`: clean
- [x] latency-effect sample: `ssd≈11ms vs hdd≈817ms` over 20 open+read iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bench-only latency-injection filesystem for benchmarking that simulates latency profiles and exposes fsync counts.

* **Documentation**
  * Updated optimization tracking docs with instructions for running latency-injected benchmark runs and interpreting measurements.

* **Tests**
  * Added ignored integration and benchmark tests validating latency effects, fsync counting, passthrough behavior, and SQLite WAL interactions.

* **Chores**
  * Added the new crate to the workspace, added its manifest, and excluded musefs crates from mutation-testing runs; CI workflow and scripts updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->