### PR TITLE
SP1: ingestion scalability — bounded probing reads + parallel scan pipeline

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -12,8 +12,18 @@
 # the #[ignore]d mounted tests (`-- -- --include-ignored`). The fast per-PR
 # `--in-diff` gate excludes it separately (it is mountless and can't kill its
 # mutants); see .github/workflows/mutants.yml.
+#
+# musefs-core/src/metrics.rs is feature-gated instrumentation: its active impl is
+# `#[cfg(feature = "metrics")]` and is only compiled (with its tests) under
+# `--features metrics`. The per-PR `--in-diff` gate runs cargo-mutants without that
+# feature, so the counter bodies aren't compiled and any mutation there is
+# unobservable — reported MISSED yet unkillable in that config. The counters are a
+# pure observability shim with no serving/correctness role and are covered
+# functionally by the feature-gated tests in that file, so exclude them from
+# mutation rather than carry permanently-surviving mutants.
 exclude_globs = [
     "musefs-fuse/**",
     "musefs-cli/**",
     "musefs/**",
+    "musefs-core/src/metrics.rs",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -27,3 +27,54 @@ exclude_globs = [
     "musefs/**",
     "musefs-core/src/metrics.rs",
 ]
+
+# Equivalent / unreachable mutants in the SP1 scan pipeline that no correctness
+# test can kill (they alter performance or batching granularity, not observable
+# results, or live in unreachable defensive branches). Documented per class.
+# Anchored on file:line:col so only the proven-equivalent sites are suppressed;
+# killable siblings (e.g. flac `|`->`&`, scan 711 `+`->`*`) stay in scope.
+exclude_re = [
+    # probe_file widen loop: `.max(want + 1)` is dominated — the bounded probers
+    # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
+    # block end past the prefix), so `up_to.min(file_len)` always wins the max and
+    # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
+    'musefs-core/src/scan\.rs:225:31:',
+    # probe_file post-loop fallback guard `(prefix.len() as u64) < file_len`: when
+    # it differs, the only effect is a redundant whole-file re-read that feeds the
+    # same `probe_full` result. The >8-retry path that could diverge is unreachable
+    # given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
+    'musefs-core/src/scan\.rs:232:30:',
+    # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
+    # the persisted track set is identical for any positive capacity.
+    'musefs-core/src/scan\.rs:493:46:',
+    # run_pipeline flush cadence (batch_bytes accounting + the
+    # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
+    # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
+    # top of the flush-on-empty safety net + the final post-loop flush, so any
+    # cadence mutation persists the identical track set. The win is fewer commits
+    # (fsyncs), a performance property only observable via the `metrics`
+    # instrumentation the in-diff gate does not build.
+    'musefs-core/src/scan\.rs:573:29:',
+    'musefs-core/src/scan\.rs:575:32:',
+    'musefs-core/src/scan\.rs:575:47:',
+    'musefs-core/src/scan\.rs:575:62:',
+    'musefs-core/src/scan\.rs:583:37:',
+    'musefs-core/src/scan\.rs:585:40:',
+    'musefs-core/src/scan\.rs:585:55:',
+    'musefs-core/src/scan\.rs:585:70:',
+    # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
+    # collect_audio yields only existing regular files, so a just-collected file's
+    # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
+    # from a deterministic test. With skip_failed identically 0, the `failed =
+    # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
+    # variant IS caught, so only `-` is excluded here).
+    'musefs-core/src/scan\.rs:672:25:',
+    'musefs-core/src/scan\.rs:676:25:',
+    'musefs-core/src/scan\.rs:711:29: replace \+ with -',
+    # flac::read_metadata_bounded 24-bit block-length assembly: the three length
+    # bytes occupy disjoint bit ranges after shifting, so `|`, `^`, and `+` are
+    # bit-for-bit identical there (the `|`->`&` variant collapses to 0 and IS
+    # caught). Same equivalence the sibling parse_blocks/read_vorbis_comments tests
+    # already note.
+    'musefs-format/src/flac\.rs:\d+:\d+: replace \| with \^ in read_metadata_bounded',
+]

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -58,7 +58,20 @@ jobs:
           # there would falsely survive. That crate is mutation-tested in the
           # scheduled `full` job below, which installs libfuse and runs its
           # mounted #[ignore]d tests. Exclude it here so the gate stays honest.
-          cargo mutants --in-diff mutants.diff -j1 --exclude 'musefs-latencyfs/**'
+          # `--output` collects the per-mutant report (missed.txt / caught.txt /
+          # outcomes.json) so it can be uploaded even when the gate fails, giving
+          # the authoritative survivor list without re-running the campaign.
+          cargo mutants --in-diff mutants.diff -j1 --exclude 'musefs-latencyfs/**' \
+            --output mutants-out/in-diff
+      - name: Upload survivor report
+        # `always()` so the report uploads even when the gate fails on a survivor
+        # (the failing run is exactly when the survivor list is wanted).
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mutants-in-diff
+          path: mutants-out/in-diff
+          if-no-files-found: warn
 
   canary:
     # Per-PR: exercise the REAL scripts/mutants.sh pipeline (out-of-repo scratch,

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -61,6 +61,9 @@ jobs:
           # `--output` collects the per-mutant report (missed.txt / caught.txt /
           # outcomes.json) so it can be uploaded even when the gate fails, giving
           # the authoritative survivor list without re-running the campaign.
+          # cargo-mutants' --output does a plain mkdir of the leaf (not mkdir -p),
+          # so the parent must already exist (same gotcha as scripts/mutants.sh).
+          mkdir -p mutants-out
           cargo mutants --in-diff mutants.diff -j1 --exclude 'musefs-latencyfs/**' \
             --output mutants-out/in-diff
       - name: Upload survivor report

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,103 @@
+# Benchmarks
+
+Before/after measurements for the [2026-05-30 optimization pass](docs/superpowers/specs/2026-05-30-optimization-pass/README.md). Each section is reproducible from the SP0 harness (`bench_ingest`); commands are given inline.
+
+**Machine:** AMD EPYC (6 cores) · 17 GiB RAM · `/dev/sda3` SSD (non-rotational) · Linux 7.0 · rustc 1.96 · release builds.
+
+---
+
+## SP1 — Ingestion scalability
+
+*Measured 2026-05-31.*
+
+- **Before** = `main` @ `16caba4` (pre-SP1): whole-file `fs::read` slurp, single-threaded, per-file commits at `synchronous=FULL`.
+- **After** = `sp1-ingestion-scalability`: bounded probing reads + parallel-probe/single-writer pipeline + per-batch transactions at `synchronous=NORMAL` (WAL retained).
+- Harness: `cargo test --release -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture <test>`. `wall_ms` is the `scan_directory` call only; `bytes_read` = `scan_bytes_read` (SP1 metric); `fsyncs` via the SP0b passthrough latency-FS.
+
+### 1. Durable storage, small files — the fsync/batching win
+
+`ci` tier (200 tracks × 4 KiB, no embedded art), corpus + DB on the SSD (`MUSEFS_BENCH_DIR=…`), per-format sweep. This is *not* compute-bound — `main` issues ~4 commits/file at `synchronous=FULL`, so it is dominated by per-file `fsync` latency on durable storage.
+
+| format    | before scan (ms) | after scan (ms) | speedup |
+|-----------|-----------------:|----------------:|--------:|
+| flac      | 8949 | 17 | **526×** |
+| mp3       | 6090 | 21 | 290× |
+| m4a       | 10877 | 32 | 340× |
+| m4a-last  | 5324 | 25 | 213× |
+| ogg       | 2679 | 20 | 134× |
+| wav       | 3033 | 96 | 32× |
+
+```
+MUSEFS_BENCH_TIER=ci MUSEFS_BENCH_DIR=/path/on/ssd \
+  cargo test --release -p musefs-core --features metrics --test bench_ingest \
+  -- --ignored --nocapture bench_cold_scan_and_revalidate
+```
+
+### 2. Durable storage, large files — bounded reads + batching
+
+`bandwidth` tier (1000 tracks × 30 MiB FLAC + 200 KiB art = ~30 GiB), corpus + DB on the SSD.
+
+| metric              | before (slurp) | after (bounded) | delta |
+|---------------------|---------------:|----------------:|-------|
+| scan wall (ms)      | 170 263 | 8 735 | **19.5× faster** |
+| `bytes_read`        | ~30 GiB¹ | 1.05 GiB | **~30× less I/O** |
+| peak RSS (KiB)      | 98 724 | 123 016 | comparable² |
+| revalidate (ms)     | 329 | 21 | 16× |
+
+¹ `main` has no `scan_bytes_read` counter; it `fs::read`s every 30 MiB file in full, so it reads the whole ~30 GiB corpus. The "after" reads only a 1 MiB metadata window per file (1.05 GiB total).
+² `main` holds one 30 MiB file in memory at a time (released per file); the pipeline holds its in-flight art budget + worker buffers. Neither is unbounded. The memory *win* is on M4A moov-last (the seek reader avoids slurping a hundreds-of-MB audiobook to reach a trailing `moov`) — not captured by this FLAC corpus.
+
+```
+MUSEFS_BENCH_TIER=bandwidth MUSEFS_BENCH_FORMAT_MIX=flac MUSEFS_BENCH_DIR=/path/on/ssd \
+  cargo test --release -p musefs-core --features metrics --test bench_ingest \
+  -- --ignored --nocapture bench_cold_scan_and_revalidate
+```
+
+### 3. fsync count — the mechanism
+
+`ci` tier (200 FLAC) scanned through the SP0b passthrough latency-FS (`ssd` profile), which counts `fsync`/`fsyncdir` at the FUSE layer.
+
+| config | fsyncs | scan wall (ms) |
+|--------|-------:|---------------:|
+| before (`synchronous=FULL`, per-file commits) | **403** | 1300 |
+| after (`synchronous=NORMAL`, batched commits) | **0** | 494 |
+
+The 403 → 0 fsync collapse is the root cause of §1's durable-storage speedups: SP1 commits one transaction per batch (≤256 files) under `synchronous=NORMAL`, so the WAL is not fsync'd per commit.
+
+```
+MUSEFS_BENCH_LATENCY_PROFILE=ssd MUSEFS_BENCH_TIER=ci MUSEFS_BENCH_FORMAT_MIX=flac \
+  cargo test --release -p musefs-core --features metrics --test bench_ingest \
+  bench_scan_under_latency -- --ignored --nocapture
+```
+
+### 4. Compute-isolated (tempfs) — the honest cost
+
+`large-compute` tier (100k tracks × ~38 KiB FLAC, including a 30 KiB cover/file) on **tempfs (RAM)**, where `fsync` is essentially free — so the §1/§3 batching win is *neutralized* and only raw compute remains.
+
+| config | scan wall (ms) | peak RSS (KiB) |
+|--------|---------------:|---------------:|
+| before (slurp, 1 thread) | **24 687** | 28 004 |
+| after, `--jobs 1` (sequential pipeline) | 68 436 | 97 704 |
+| after, `--jobs 6` (parallel) | 46 077 | 109 964 |
+
+On RAM with tiny files, SP1 is **~1.9× slower** than the simple slurp: the parallel pipeline adds per-file coordination (channel, budget, batch buffering, art held/cloned in flight) that the absent fsync win can't offset, and the single DB writer serializes the 100k inserts (so parallelism only recovers part of it: 68 s → 46 s). `bytes_read` here is ~3.92 GiB for both jobs settings — the 38 KiB files are smaller than the 1 MiB window, so bounded reads don't help at this size.
+
+This is the deliberate trade SP1 makes: **a little extra compute in exchange for eliminating the durable-write (fsync) storm** — a large net win on any real (non-RAM) disk, as §1–§3 show, and a small loss only on RAM-backed storage with sub-window files (not a real music-library deployment).
+
+```
+MUSEFS_BENCH_TIER=large-compute MUSEFS_BENCH_FORMAT_MIX=flac [MUSEFS_BENCH_JOBS=1] \
+  cargo test --release -p musefs-core --features metrics --test bench_ingest \
+  -- --ignored --nocapture bench_cold_scan_and_revalidate
+```
+
+### Summary
+
+- **On durable storage (the deployment target), SP1 is 20–500× faster at cold scan**, scaling with how fsync-bound the old per-file-commit path was. The win is overwhelmingly from transaction batching + `synchronous=NORMAL` (403 → 0 fsyncs), with bounded reads adding a ~30× I/O reduction on large files.
+- **Bounded reads** cut scan I/O from full-file to a ~1 MiB window — negligible below the window size, ~30× at 30 MiB; M4A additionally seeks to `moov` instead of slurping `mdat`.
+- **Parallel probing** (`--jobs`) helps when probing dominates (large files / slow storage); the single DB writer caps its benefit on tiny-track-heavy libraries.
+- **Honest caveat:** on RAM-backed tempfs with sub-window files, the pipeline overhead makes SP1 slower than the naive slurp — there is no fsync cost there to amortize.
+
+### Follow-up optimization candidates (surfaced by these runs)
+
+- The bounded path issues a 128-byte ID3v1 tail read for *every* front-anchored file, but only MP3 consumes it — gating it to MP3 would drop a syscall/file for FLAC/OGG/WAV.
+- `ingest_bulk` clones each picture's bytes (the batch holds `&Probed`); draining owned `Unit`s into the writer would let the art move instead of copy.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -27,7 +27,7 @@ Before/after measurements for the [2026-05-30 optimization pass](docs/superpower
 | ogg       | 2679 | 20 | 134× |
 | wav       | 3033 | 96 | 32× |
 
-```
+```bash
 MUSEFS_BENCH_TIER=ci MUSEFS_BENCH_DIR=/path/on/ssd \
   cargo test --release -p musefs-core --features metrics --test bench_ingest \
   -- --ignored --nocapture bench_cold_scan_and_revalidate
@@ -47,7 +47,7 @@ MUSEFS_BENCH_TIER=ci MUSEFS_BENCH_DIR=/path/on/ssd \
 ¹ `main` has no `scan_bytes_read` counter; it `fs::read`s every 30 MiB file in full, so it reads the whole ~30 GiB corpus. The "after" reads only a 1 MiB metadata window per file (1.05 GiB total).
 ² `main` holds one 30 MiB file in memory at a time (released per file); the pipeline holds its in-flight art budget + worker buffers. Neither is unbounded. The memory *win* is on M4A moov-last (the seek reader avoids slurping a hundreds-of-MB audiobook to reach a trailing `moov`) — not captured by this FLAC corpus.
 
-```
+```bash
 MUSEFS_BENCH_TIER=bandwidth MUSEFS_BENCH_FORMAT_MIX=flac MUSEFS_BENCH_DIR=/path/on/ssd \
   cargo test --release -p musefs-core --features metrics --test bench_ingest \
   -- --ignored --nocapture bench_cold_scan_and_revalidate
@@ -64,7 +64,7 @@ MUSEFS_BENCH_TIER=bandwidth MUSEFS_BENCH_FORMAT_MIX=flac MUSEFS_BENCH_DIR=/path/
 
 The 403 → 0 fsync collapse is the root cause of §1's durable-storage speedups: SP1 commits one transaction per batch (≤256 files) under `synchronous=NORMAL`, so the WAL is not fsync'd per commit.
 
-```
+```bash
 MUSEFS_BENCH_LATENCY_PROFILE=ssd MUSEFS_BENCH_TIER=ci MUSEFS_BENCH_FORMAT_MIX=flac \
   cargo test --release -p musefs-core --features metrics --test bench_ingest \
   bench_scan_under_latency -- --ignored --nocapture
@@ -84,7 +84,7 @@ On RAM with tiny files, SP1 is **~1.9× slower** than the simple slurp: the para
 
 This is the deliberate trade SP1 makes: **a little extra compute in exchange for eliminating the durable-write (fsync) storm** — a large net win on any real (non-RAM) disk, as §1–§3 show, and a small loss only on RAM-backed storage with sub-window files (not a real music-library deployment).
 
-```
+```bash
 MUSEFS_BENCH_TIER=large-compute MUSEFS_BENCH_FORMAT_MIX=flac [MUSEFS_BENCH_JOBS=1] \
   cargo test --release -p musefs-core --features metrics --test bench_ingest \
   -- --ignored --nocapture bench_cold_scan_and_revalidate

--- a/docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md
+++ b/docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md
@@ -1,0 +1,2013 @@
+# SP1 — Ingestion scalability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `scan` / `revalidate` fast and bounded-memory over large libraries — bounded probing reads (no whole-file slurp), parallel probing with a single serial DB writer, per-batch transactions, and bulk-write pragmas — without changing what is written to the DB or the served bytes.
+
+**Architecture:** Two stages. **Stage A** replaces the whole-file slurp with a per-format *bounded* metadata probe (a `prefix` window + `file_len`, widened on a `NeedMore { up_to }` signal; M4A uses the existing seek reader), gated green by an **equivalence property** (bounded probe ≡ full-file probe). **Stage B** layers a parallel-probe / single-writer pipeline on top: probe workers (no DB access) feed a bounded byte-budgeted channel to one writer thread that batches transactions on a scan-scoped bulk connection.
+
+**Tech Stack:** Rust workspace (`musefs-format`, `musefs-db`, `musefs-core`, `musefs-cli`), `rusqlite` (SQLite, WAL), `thiserror`, `std::thread` + `std::sync::mpsc::sync_channel`, `proptest`, the SP0 bench harness (`musefs-core/tests/bench_ingest.rs`, `musefs-latencyfs`).
+
+**Spec:** `docs/superpowers/specs/2026-05-30-optimization-pass/SP1-ingestion-scalability.md`
+
+---
+
+## File map
+
+**Stage A**
+- `musefs-core/src/metrics.rs` — add scan-path counters (`scan_opens`, `scan_preads`, `scan_bytes_read`) + hooks `on_scan_open` / `on_scan_read`.
+- `musefs-format/src/probe.rs` *(new)* — the shared `Extent<T>` outcome type (`Complete(T)` / `NeedMore { up_to }`).
+- `musefs-format/src/flac.rs` — add `read_metadata_bounded(prefix) -> Result<Extent<FlacMeta>>`.
+- `musefs-format/src/mp3.rs` — add `locate_audio_bounded(prefix, file_len, tail) -> Result<Extent<Mp3Bounds>>`.
+- `musefs-format/src/ogg/mod.rs` — add `read_metadata_bounded(prefix, file_len) -> Result<Extent<OggHeader>>`.
+- `musefs-format/src/wav.rs` — add `locate_audio_bounded(prefix, file_len) -> Result<Extent<WavBounds>>`.
+- `musefs-format/src/lib.rs` — `pub mod probe;` + re-exports.
+- `musefs-core/src/scan.rs` — new bounded `probe_file(path) -> io::Result<ProbeOutcome>`, the windowed read loop, `read_window`; rewire `scan_directory` / `revalidate`; keep `probe_full` (test-only) for equivalence.
+- `musefs-core/tests/probe_equivalence.rs` *(new)* — the headline equivalence property.
+
+**Stage B**
+- `musefs-db/src/bulk.rs` *(new)* — `Db::apply_bulk_pragmas` / `apply_bulk_pragmas_self`, `BulkWriter` (one transaction wrapping the four writes).
+- `musefs-db/src/lib.rs` — `mod bulk;` wiring.
+- `musefs-core/src/scan.rs` — `ScanStats`/`RevalidateStats` gain `failed`; `ScanOptions`; `scan_directory_with` / `revalidate_with` pipeline (probe pool + `ByteBudget` backpressure + writer batching); `revalidate` pre-dispatch skip pass.
+- `musefs-core/src/byte_budget.rs` *(new)* — `ByteBudget` (Mutex<u64> + Condvar) backpressure.
+- `musefs-cli/src/lib.rs` — `--jobs` flag wired through `run_scan`.
+- `musefs-core/tests/common/report.rs` — add `bytes_read` column.
+- `musefs-core/tests/bench_ingest.rs` — report `scan_bytes_read`; add a `jobs` dimension; fix the stale "opens/preads are serve-only" comment.
+
+**Constants** (all in `musefs-core/src/scan.rs`): `WINDOW = 1 << 20` (1 MiB), `BATCH_FILES = 256`, `BATCH_BYTES = 64 << 20` (64 MiB), `MAX_WIDEN_RETRIES = 8`.
+
+---
+
+# Stage A — Bounded reads (single-threaded, gated by equivalence)
+
+## Task A1: Scan-path metrics counters
+
+**Files:**
+- Modify: `musefs-core/src/metrics.rs` (both the `#[cfg(feature = "metrics")]` and `#[cfg(not(...))]` modules)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(all(test, feature = "metrics"))] mod tests` block in `musefs-core/src/metrics.rs`:
+
+```rust
+    #[test]
+    fn scan_counters_accumulate_and_reset() {
+        reset();
+        on_scan_open();
+        on_scan_read(4096);
+        on_scan_read(128);
+        let s = snapshot();
+        assert_eq!(s.scan_opens, 1);
+        assert_eq!(s.scan_preads, 2);
+        assert_eq!(s.scan_bytes_read, 4096 + 128);
+        reset();
+        assert_eq!(snapshot(), Snapshot::default());
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --features metrics --lib metrics::tests::scan_counters -- --nocapture`
+Expected: FAIL — `on_scan_open` / `on_scan_read` / `Snapshot.scan_opens` not found.
+
+- [ ] **Step 3: Implement the counters**
+
+In the `#[cfg(feature = "metrics")] mod imp`, add three statics beside the existing ones:
+
+```rust
+    static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
+```
+
+Add two hooks beside `on_art_chunk`:
+
+```rust
+    /// One backing-file open on the *scan* path (distinct from serve-path `on_open`).
+    pub fn on_scan_open() {
+        SCAN_OPENS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// One positioned scan-path read of `bytes` bytes (prefix, widen, or tail read).
+    pub fn on_scan_read(bytes: u64) {
+        SCAN_PREADS.fetch_add(1, Ordering::Relaxed);
+        SCAN_BYTES_READ.fetch_add(bytes, Ordering::Relaxed);
+    }
+```
+
+Add the three fields to `Snapshot` (after `art_chunks`):
+
+```rust
+        pub scan_opens: u64,
+        pub scan_preads: u64,
+        pub scan_bytes_read: u64,
+```
+
+Populate them in `snapshot()`:
+
+```rust
+            scan_opens: SCAN_OPENS.load(Ordering::Relaxed),
+            scan_preads: SCAN_PREADS.load(Ordering::Relaxed),
+            scan_bytes_read: SCAN_BYTES_READ.load(Ordering::Relaxed),
+```
+
+Zero them in `reset()`:
+
+```rust
+        SCAN_OPENS.store(0, Ordering::Relaxed);
+        SCAN_PREADS.store(0, Ordering::Relaxed);
+        SCAN_BYTES_READ.store(0, Ordering::Relaxed);
+```
+
+In the `#[cfg(not(feature = "metrics"))] mod imp`, mirror the surface: add the same three `Snapshot` fields, and the two no-op hooks:
+
+```rust
+    #[inline(always)]
+    pub fn on_scan_open() {}
+    #[inline(always)]
+    pub fn on_scan_read(_bytes: u64) {}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core --features metrics --lib metrics:: -- --nocapture`
+Expected: PASS (both `counters_accumulate_and_reset` and `scan_counters_accumulate_and_reset`).
+Run: `cargo build -p musefs-core` (no-metrics build still compiles).
+Expected: builds clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/metrics.rs
+git commit -m "feat(metrics): scan-path open/read/byte counters"
+```
+
+---
+
+## Task A2: `Extent` outcome type + FLAC bounded metadata
+
+**Files:**
+- Create: `musefs-format/src/probe.rs`
+- Modify: `musefs-format/src/lib.rs`
+- Modify: `musefs-format/src/flac.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `musefs-format/src/flac.rs`:
+
+```rust
+    use crate::probe::Extent;
+
+    /// Build a minimal FLAC: marker + a single last STREAMINFO (type 0, 34-byte
+    /// body) + `audio` bytes. Returns (full_bytes, audio_offset).
+    fn flac_with_streaminfo(audio: &[u8]) -> (Vec<u8>, u64) {
+        let mut v = b"fLaC".to_vec();
+        push_block_header(&mut v, BLOCK_STREAMINFO, 34, true);
+        v.extend(std::iter::repeat(0u8).take(34));
+        let audio_offset = v.len() as u64;
+        v.extend_from_slice(audio);
+        (v, audio_offset)
+    }
+
+    #[test]
+    fn read_metadata_bounded_complete_when_prefix_covers_blocks() {
+        let (full, audio_offset) = flac_with_streaminfo(b"AUDIOAUDIO");
+        // Prefix that includes all metadata but not all audio.
+        let prefix = &full[..audio_offset as usize + 2];
+        match read_metadata_bounded(prefix).unwrap() {
+            Extent::Complete(meta) => assert_eq!(meta.audio_offset, audio_offset),
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_needmore_when_block_body_truncated() {
+        let (full, audio_offset) = flac_with_streaminfo(b"AUDIO");
+        // Cut inside the STREAMINFO body (header is 4 bytes after the marker).
+        let prefix = &full[..8];
+        match read_metadata_bounded(prefix).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, audio_offset),
+            other => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format --lib flac::tests::read_metadata_bounded -- --nocapture`
+Expected: FAIL — `crate::probe` and `read_metadata_bounded` do not exist.
+
+- [ ] **Step 3: Create the `Extent` type and the FLAC bounded walk**
+
+Create `musefs-format/src/probe.rs`:
+
+```rust
+//! Shared outcome type for *bounded* metadata probing: a format parser is given
+//! only a `prefix` of the file (plus the true `file_len`) and either completes,
+//! or reports the exact byte offset it must reach to continue.
+
+/// Result of a bounded metadata probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Extent<T> {
+    /// The metadata region is fully present in the prefix; here is the parse.
+    Complete(T),
+    /// The prefix is too short. Read at least up to `up_to` bytes (capped at the
+    /// file length) and retry. `up_to` is strictly greater than the current
+    /// prefix length unless the parser cannot bound its need, in which case the
+    /// caller falls back to reading the whole file.
+    NeedMore { up_to: u64 },
+}
+```
+
+In `musefs-format/src/lib.rs`, register the module beside the existing `pub mod` lines and re-export the type:
+
+```rust
+pub mod probe;
+pub use probe::Extent;
+```
+
+In `musefs-format/src/flac.rs`, add (next to `read_metadata`):
+
+```rust
+use crate::probe::Extent;
+
+/// Bounded twin of [`read_metadata`]: walk the metadata blocks present in
+/// `prefix` (which may be a front-only window of the file). If a block's declared
+/// body runs past the prefix, return `NeedMore { up_to }` with the exact end of
+/// that block — the caller widens the window and retries. Otherwise `Complete`.
+pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
+    if prefix.len() < 4 || &prefix[0..4] != FLAC_MARKER {
+        return Err(FormatError::NotFlac);
+    }
+    let mut pos = 4usize;
+    let mut preserved = Vec::new();
+    loop {
+        if pos + 4 > prefix.len() {
+            // Need at least the 4-byte block header.
+            return Ok(Extent::NeedMore {
+                up_to: (pos + 4) as u64,
+            });
+        }
+        let header = prefix[pos];
+        let is_last = (header & 0x80) != 0;
+        let block_type = header & 0x7F;
+        let len = ((prefix[pos + 1] as usize) << 16)
+            | ((prefix[pos + 2] as usize) << 8)
+            | (prefix[pos + 3] as usize);
+        let body_start = pos + 4;
+        let body_end = body_start + len;
+        if body_end > prefix.len() {
+            return Ok(Extent::NeedMore {
+                up_to: body_end as u64,
+            });
+        }
+        match block_type {
+            BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
+                preserved.push(MetadataBlock {
+                    block_type,
+                    body: prefix[body_start..body_end].to_vec(),
+                });
+            }
+            _ => {}
+        }
+        pos = body_end;
+        if is_last {
+            break;
+        }
+    }
+    Ok(Extent::Complete(FlacMeta {
+        audio_offset: pos as u64,
+        preserved,
+    }))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format --lib flac::tests::read_metadata_bounded -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/probe.rs musefs-format/src/lib.rs musefs-format/src/flac.rs
+git commit -m "feat(format): Extent type + flac::read_metadata_bounded"
+```
+
+---
+
+## Task A3: MP3 bounded metadata
+
+**Files:**
+- Modify: `musefs-format/src/mp3.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/mp3.rs`:
+
+```rust
+    use crate::probe::Extent;
+
+    /// ID3v2 header declaring `body` bytes of tag, then a frame-sync byte pair,
+    /// then `audio`. Returns (full, audio_offset).
+    fn mp3_with_id3v2(body_len: usize, audio: &[u8]) -> (Vec<u8>, u64) {
+        let mut v = b"ID3\x04\x00\x00".to_vec(); // version 2.4, no flags
+        v.extend_from_slice(&syncsafe(body_len as u32));
+        v.extend(std::iter::repeat(0u8).take(body_len)); // tag body
+        let audio_offset = v.len() as u64;
+        v.extend_from_slice(&[0xFF, 0xFB]); // MPEG frame sync
+        v.extend_from_slice(audio);
+        (v, audio_offset)
+    }
+
+    #[test]
+    fn locate_audio_bounded_complete_with_no_id3v1() {
+        let (full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        let prefix = &full[..audio_offset as usize + 2]; // covers tag + sync
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(prefix, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                assert_eq!(b.audio_length, file_len - audio_offset);
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_needmore_when_tag_exceeds_prefix() {
+        let (full, _audio_offset) = mp3_with_id3v2(4096, b"frames");
+        let prefix = &full[..32]; // only the 10-byte header is present
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(prefix, file_len, None).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 10 + 4096 + 2),
+            other => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_strips_id3v1_tail() {
+        let (mut full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        let body_end = full.len();
+        full.extend_from_slice(b"TAG"); // ID3v1 marker
+        full.extend(std::iter::repeat(0u8).take(125)); // 128-byte tag total
+        let file_len = full.len() as u64;
+        let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
+        let prefix = &full[..audio_offset as usize + 2];
+        match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                assert_eq!(b.audio_length, body_end as u64 - audio_offset);
+            }
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format --lib mp3::tests::locate_audio_bounded -- --nocapture`
+Expected: FAIL — `locate_audio_bounded` not found.
+
+- [ ] **Step 3: Implement `locate_audio_bounded`**
+
+Add to `musefs-format/src/mp3.rs` (next to `locate_audio`):
+
+```rust
+use crate::probe::Extent;
+
+/// Bounded twin of [`locate_audio`]. `prefix` is a front window; `file_len` is the
+/// true size; `tail` is the file's last 128 bytes (or `None` if the file is
+/// shorter than 128 bytes). The audio start is the end of any leading ID3v2 tag
+/// (declared in its 10-byte header); if that end is past the prefix, returns
+/// `NeedMore`. The audio end is `file_len` minus a 128-byte ID3v1 trailer when the
+/// `tail` begins with `TAG`.
+pub fn locate_audio_bounded(
+    prefix: &[u8],
+    file_len: u64,
+    tail: Option<&[u8; 128]>,
+) -> Result<Extent<Mp3Bounds>> {
+    let mut audio_offset = 0usize;
+    if prefix.len() >= 10 && &prefix[0..3] == b"ID3" {
+        let flags = prefix[5];
+        let body = synchsafe_decode(&prefix[6..10]) as usize;
+        let mut tag_len = 10 + body;
+        if flags & 0x10 != 0 {
+            tag_len += 10; // ID3v2.4 footer
+        }
+        if tag_len as u64 > file_len {
+            return Err(FormatError::Malformed);
+        }
+        audio_offset = tag_len;
+    } else if prefix.len() < 10 && (file_len as usize) >= 10 {
+        // Not enough bytes even to read the ID3v2 header.
+        return Ok(Extent::NeedMore { up_to: 10 });
+    }
+
+    // Need the frame-sync pair at the audio offset to be inside the prefix.
+    if audio_offset + 2 > prefix.len() {
+        return Ok(Extent::NeedMore {
+            up_to: (audio_offset + 2) as u64,
+        });
+    }
+
+    if prefix[audio_offset] != 0xFF || (prefix[audio_offset + 1] & 0xE0) != 0xE0 {
+        return Err(FormatError::NotMp3);
+    }
+
+    let mut audio_end = file_len;
+    if let Some(tail) = tail {
+        if file_len >= audio_offset as u64 + 128 && &tail[0..3] == b"TAG" {
+            audio_end -= 128;
+        }
+    }
+
+    Ok(Extent::Complete(Mp3Bounds {
+        audio_offset: audio_offset as u64,
+        audio_length: audio_end - audio_offset as u64,
+    }))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format --lib mp3::tests::locate_audio_bounded -- --nocapture`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/mp3.rs
+git commit -m "feat(format): mp3::locate_audio_bounded (prefix + ID3v1 tail)"
+```
+
+---
+
+## Task A4: OGG bounded metadata
+
+**Files:**
+- Modify: `musefs-format/src/ogg/mod.rs`
+
+OGG header packets are all front-anchored (so is all OGG embedded art). `read_header` already stops once the header packets are reassembled, but it returns `Malformed` on a truncated front rather than a "need more" signal — and the packet-level page walk does not cheaply expose an exact byte high-water mark. So the bounded variant geometrically grows the window (still capped at `file_len`, so the worst case equals reading the whole file and the equivalence property holds).
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new test module at the bottom of `musefs-format/src/ogg/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod bounded_tests {
+    use super::*;
+    use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
+    use crate::probe::Extent;
+
+    /// A minimal single-page Opus stream: OpusHead BOS packet + OpusTags packet,
+    /// then a trailing audio page. Returns (full, audio_offset).
+    fn opus_stream() -> (Vec<u8>, u64) {
+        let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
+        let mut tags = b"OpusTags".to_vec();
+        tags.extend_from_slice(&vorbis_body_empty());
+        let serial = 0x1234;
+        let mut v = build_header_pub(serial, 0, 0x02, &[lace_packet_pub(&head)]);
+        v.extend(build_header_pub(serial, 1, 0x00, &[lace_packet_pub(&tags)]));
+        let audio_offset = v.len() as u64;
+        // A trailing audio page (FLAG_NONE, granule advanced).
+        v.extend(build_header_pub(serial, 2, 0x00, &[lace_packet_pub(b"AUDIO")]));
+        (v, audio_offset)
+    }
+
+    #[test]
+    fn read_metadata_bounded_complete_when_prefix_covers_header() {
+        let (full, audio_offset) = opus_stream();
+        let file_len = full.len() as u64;
+        let prefix = &full[..audio_offset as usize]; // exactly the header region
+        match read_metadata_bounded(prefix, file_len).unwrap() {
+            Extent::Complete(h) => assert_eq!(h.audio_offset, audio_offset),
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_needmore_when_header_truncated() {
+        let (full, _audio_offset) = opus_stream();
+        let file_len = full.len() as u64;
+        let prefix = &full[..20]; // mid first page
+        match read_metadata_bounded(prefix, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert!(up_to > 20 && up_to <= file_len),
+            other => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+}
+```
+
+(If `build_header_pub` / `lace_packet_pub` / `vorbis_body_empty` are not yet `pub` in `page_test_support`, they already are — they are used by `scan.rs`'s `ogg_probe_tests`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format --lib ogg::bounded_tests -- --nocapture`
+Expected: FAIL — `read_metadata_bounded` not found.
+
+- [ ] **Step 3: Implement `read_metadata_bounded`**
+
+Add to `musefs-format/src/ogg/mod.rs` (next to `read_metadata`):
+
+```rust
+use crate::probe::Extent;
+
+/// Bounded twin of [`read_metadata`]. OGG header packets (and all OGG embedded
+/// art) are front-anchored, so a prefix covering the header region is sufficient.
+/// `read_header` does not expose an exact byte need, so on a short/truncated
+/// prefix this geometrically grows the window (doubling, capped at `file_len`):
+/// header regions are tiny, so the first 1 MiB window almost always completes,
+/// and the cap guarantees the worst case equals reading the whole file.
+pub fn read_metadata_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<OggHeader>> {
+    match read_header(prefix) {
+        Ok(header) => Ok(Extent::Complete(header)),
+        Err(_) if (prefix.len() as u64) < file_len => {
+            let grown = ((prefix.len() as u64).saturating_mul(2)).max(64 * 1024);
+            Ok(Extent::NeedMore {
+                up_to: grown.min(file_len),
+            })
+        }
+        Err(e) => Err(e),
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format --lib ogg::bounded_tests -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/ogg/mod.rs
+git commit -m "feat(format): ogg::read_metadata_bounded (geometric widen, file_len cap)"
+```
+
+---
+
+## Task A5: WAV bounded metadata
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs`
+
+WAV metadata chunks (`LIST`/`INFO`, `id3 `) may sit *after* the `data` payload, and the slice-based walk cannot skip a `data` payload it doesn't hold. To keep the equivalence property trivially true, the bounded variant completes only when the prefix already covers the whole file; otherwise it asks for the whole file (`NeedMore { up_to: file_len }`). This is "no worse than today" (a seek-based RIFF walk is out of scope per the spec).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/wav.rs`:
+
+```rust
+    use crate::probe::Extent;
+
+    /// RIFF/WAVE with a `fmt ` (16-byte) chunk and a `data` chunk of `audio`.
+    fn wav_file(audio: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"fmt ");
+        body.extend_from_slice(&16u32.to_le_bytes());
+        body.extend(std::iter::repeat(0u8).take(16));
+        body.extend_from_slice(b"data");
+        body.extend_from_slice(&(audio.len() as u32).to_le_bytes());
+        body.extend_from_slice(audio);
+        let mut v = b"RIFF".to_vec();
+        v.extend_from_slice(&((4 + body.len()) as u32).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(&body);
+        v
+    }
+
+    #[test]
+    fn locate_audio_bounded_complete_when_prefix_is_whole_file() {
+        let full = wav_file(b"AUDIOAUDIO");
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(&full, file_len).unwrap() {
+            Extent::Complete(b) => assert_eq!(b.audio_length, 10),
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_needmore_when_prefix_short() {
+        let full = wav_file(b"AUDIOAUDIO");
+        let file_len = full.len() as u64;
+        let prefix = &full[..full.len() - 4];
+        match locate_audio_bounded(prefix, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, file_len),
+            other => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format --lib wav::tests::locate_audio_bounded -- --nocapture`
+Expected: FAIL — `locate_audio_bounded` not found.
+
+- [ ] **Step 3: Implement `locate_audio_bounded`**
+
+Add to `musefs-format/src/wav.rs` (next to `locate_audio`):
+
+```rust
+use crate::probe::Extent;
+
+/// Bounded twin of [`locate_audio`]. WAV metadata chunks can trail the `data`
+/// payload, which the slice walk cannot skip past, so completion requires the
+/// whole file in `prefix`; otherwise request it. Equivalence is trivially
+/// preserved (the completing parse is exactly `locate_audio` on the full file).
+pub fn locate_audio_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<WavBounds>> {
+    if (prefix.len() as u64) < file_len {
+        return Ok(Extent::NeedMore { up_to: file_len });
+    }
+    Ok(Extent::Complete(locate_audio(prefix)?))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format --lib wav::tests::locate_audio_bounded -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/wav.rs
+git commit -m "feat(format): wav::locate_audio_bounded (whole-file gate; seek-walk deferred)"
+```
+
+---
+
+## Task A6: Bounded read loop in scan.rs
+
+This is the integration task: a windowed `probe_file` that reads a bounded prefix, dispatches per format, widens on `NeedMore`, opens M4A through the seek reader, and reads the MP3 tail — counting every read via the new metrics hooks. `scan_directory` and `revalidate` switch to it. The original slice-based `probe` is renamed `probe_full` and kept (used by the equivalence test in Task A7).
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the bottom of `musefs-core/src/scan.rs` (new test module):
+
+```rust
+#[cfg(test)]
+mod bounded_probe_tests {
+    use super::*;
+    use musefs_db::Db;
+
+    /// Minimal FLAC: marker + a single last STREAMINFO (34-byte body) + audio.
+    /// FLAC has no frame-sync check at the audio offset, so any payload works.
+    fn flac_fixture() -> Vec<u8> {
+        let mut bytes = b"fLaC".to_vec();
+        bytes.push(0x80); // last-block flag set, type 0 (STREAMINFO)
+        bytes.extend_from_slice(&[0, 0, 34]); // 24-bit length = 34
+        bytes.extend(std::iter::repeat(0u8).take(34));
+        bytes.extend_from_slice(b"AUDIOPAYLOAD");
+        bytes
+    }
+
+    #[test]
+    fn scan_directory_bounded_matches_full_for_flac() {
+        // A FLAC fixture written to a temp dir, scanned with the (default) bounded
+        // path, yields a track with the same audio bounds as a full-file probe.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.flac");
+        let bytes = flac_fixture();
+        std::fs::write(&path, &bytes).unwrap();
+
+        let full = probe_full(&path, &bytes).expect("full probe");
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = scan_directory(&db, dir.path()).unwrap();
+        assert_eq!(stats.scanned, 1);
+        let track = db.get_track_by_path(&std::fs::canonicalize(&path).unwrap().to_string_lossy()).unwrap().unwrap();
+        assert_eq!(track.audio_offset as u64, full.audio_offset);
+        assert_eq!(track.audio_length as u64, full.audio_length);
+    }
+}
+```
+
+(The other `bounded_probe_tests` cases below — B2, B3, B4 — reuse this `flac_fixture()` shape inline; each builds its own bytes so tasks read independently.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --lib scan::bounded_probe_tests -- --nocapture`
+Expected: FAIL — `probe_full` not found (and `scan_directory` still slurps, so the symbol is missing).
+
+- [ ] **Step 3: Implement the bounded read loop**
+
+In `musefs-core/src/scan.rs`:
+
+1. Add imports/constants near the top:
+
+```rust
+use std::io::{Read, Seek, SeekFrom};
+use musefs_format::Extent;
+use crate::metrics;
+
+/// Initial bounded-read window. Covers typical metadata + cover art; a larger
+/// metadata region triggers a `NeedMore` widen.
+const WINDOW: usize = 1 << 20; // 1 MiB
+/// Cap on widen iterations before falling back to a whole-file read.
+const MAX_WIDEN_RETRIES: usize = 8;
+```
+
+2. Rename the existing `fn probe(path: &Path, bytes: &[u8]) -> Option<Probed>` to:
+
+```rust
+/// Full-buffer probe (legacy path). Retained as the reference implementation the
+/// bounded path is checked against (see `tests/probe_equivalence.rs`).
+pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
+```
+
+(Keep its body unchanged.)
+
+3. Add a positioned reader helper and the bounded probe:
+
+```rust
+/// Read `[0, len)` of `path` into a buffer, counting the read. `len` is clamped
+/// to the file size by the OS (short read at EOF is fine).
+fn read_window(file: &std::fs::File, len: usize) -> std::io::Result<Vec<u8>> {
+    use std::os::unix::fs::FileExt;
+    let mut buf = vec![0u8; len];
+    let n = file.read_at(&mut buf, 0)?;
+    buf.truncate(n);
+    metrics::on_scan_read(n as u64);
+    Ok(buf)
+}
+
+/// Read the file's last 128 bytes (for the MP3 ID3v1 trailer check), or `None`
+/// if the file is shorter than 128 bytes.
+fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<[u8; 128]>> {
+    if file_len < 128 {
+        return Ok(None);
+    }
+    use std::os::unix::fs::FileExt;
+    let mut buf = [0u8; 128];
+    file.read_exact_at(&mut buf, file_len - 128)?;
+    metrics::on_scan_read(128);
+    Ok(Some(buf))
+}
+
+/// Bounded probe of one backing file: open once, read a bounded window, dispatch
+/// per format, widening on `NeedMore`. Never reads the audio payload (M4A uses
+/// the seek reader; front-anchored formats read only the metadata extent).
+/// Returns `Ok(None)` for an unsupported/unparseable file (to be skipped).
+fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
+    let file = std::fs::File::open(path)?;
+    metrics::on_scan_open();
+
+    // M4A: seek reader, never touches mdat.
+    if has_ext(path, "m4a") || has_ext(path, "m4b") {
+        let mut f = &file;
+        let scan = match mp4::read_structure_from(&mut f, file_len) {
+            Ok(s) => s,
+            Err(_) => return Ok(None),
+        };
+        return Ok(Some(Probed {
+            format: Format::M4a,
+            audio_offset: scan.mdat_payload_offset,
+            audio_length: scan.mdat_payload_len,
+            tags: mp4::read_tags(&scan.moov),
+            pictures: mp4::read_pictures(&scan.moov),
+        }));
+    }
+
+    // Front-anchored formats: read a window, widen on NeedMore.
+    let tail = read_tail_128(&file, file_len)?;
+    let mut want = (WINDOW as u64).min(file_len) as usize;
+    let mut prefix = read_window(&file, want)?;
+    for _ in 0..MAX_WIDEN_RETRIES {
+        match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
+            Probe::Done(p) => return Ok(Some(p)),
+            Probe::Skip => return Ok(None),
+            Probe::NeedMore(up_to) => {
+                let next = (up_to.min(file_len) as usize).max(want + 1);
+                if next <= want {
+                    break;
+                }
+                want = next;
+                prefix = read_window(&file, want)?;
+            }
+        }
+    }
+    // Fallback: read the whole file once and use the full-buffer probe.
+    if (prefix.len() as u64) < file_len {
+        prefix = read_window(&file, file_len as usize)?;
+    }
+    Ok(probe_full(path, &prefix))
+}
+
+/// Outcome of a single bounded dispatch attempt against the current `prefix`.
+enum Probe {
+    Done(Probed),
+    NeedMore(u64),
+    Skip,
+}
+
+/// Dispatch the front-anchored formats against `prefix` + `file_len`.
+fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 128]>) -> Probe {
+    if has_ext(path, "flac") {
+        match flac::read_metadata_bounded(prefix) {
+            Ok(Extent::Complete(meta)) => Probe::Done(Probed {
+                format: Format::Flac,
+                audio_offset: meta.audio_offset,
+                audio_length: file_len - meta.audio_offset,
+                tags: flac::read_vorbis_comments(prefix).unwrap_or_default(),
+                pictures: flac::read_pictures(prefix).unwrap_or_default(),
+            }),
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else if has_ext(path, "mp3") {
+        match mp3::locate_audio_bounded(prefix, file_len, tail) {
+            Ok(Extent::Complete(b)) => Probe::Done(Probed {
+                format: Format::Mp3,
+                audio_offset: b.audio_offset,
+                audio_length: b.audio_length,
+                tags: mp3::read_tags(prefix),
+                pictures: mp3::read_pictures(prefix),
+            }),
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else if has_ext(path, "ogg") || has_ext(path, "oga") || has_ext(path, "opus") {
+        match ogg::read_metadata_bounded(prefix, file_len) {
+            Ok(Extent::Complete(header)) => {
+                let format = match header.codec {
+                    ogg::Codec::Opus => Format::Opus,
+                    ogg::Codec::Vorbis => Format::Vorbis,
+                    ogg::Codec::OggFlac => Format::OggFlac,
+                };
+                Probe::Done(Probed {
+                    format,
+                    audio_offset: header.audio_offset,
+                    audio_length: file_len - header.audio_offset,
+                    tags: ogg::read_tags(prefix).unwrap_or_default(),
+                    pictures: ogg::read_pictures(prefix).unwrap_or_default(),
+                })
+            }
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else if has_ext(path, "wav") {
+        match wav::locate_audio_bounded(prefix, file_len) {
+            Ok(Extent::Complete(b)) => Probe::Done(Probed {
+                format: Format::Wav,
+                audio_offset: b.audio_offset,
+                audio_length: b.audio_length,
+                tags: wav::read_tags(prefix),
+                pictures: wav::read_pictures(prefix),
+            }),
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else {
+        Probe::Skip
+    }
+}
+```
+
+4. Rewrite `scan_directory`'s per-file loop body to use `probe_file` (replacing the `std::fs::read` + `probe` + `metadata` ordering):
+
+```rust
+    for path in files {
+        let meta = std::fs::metadata(&path)?;
+        let Some(probed) = probe_file(&path, meta.len())? else {
+            stats.skipped += 1;
+            continue;
+        };
+        let abs = std::fs::canonicalize(&path)?;
+        ingest(db, &abs.to_string_lossy(), &meta, probed)?;
+        stats.scanned += 1;
+    }
+```
+
+5. Rewrite `revalidate`'s changed-file branch likewise:
+
+```rust
+        let Some(probed) = probe_file(&path, meta.len())? else {
+            continue;
+        };
+        ingest(db, &abs_str, &meta, probed)?;
+        stats.updated += 1;
+```
+
+(Delete the `let bytes = std::fs::read(&path)?;` lines in both functions.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core --lib scan:: -- --nocapture`
+Expected: PASS (the new `bounded_probe_tests` plus the existing `ogg_probe_tests`).
+Run: `cargo test -p musefs-core` and `cargo test -p musefs-format`
+Expected: PASS — no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/scan.rs
+git commit -m "feat(scan): bounded windowed probe_file (widen on NeedMore, M4A seek, tail read)"
+```
+
+---
+
+## Task A7: Equivalence property (headline gate)
+
+The true SP1 guard: a bounded scan (run with a deliberately tiny window so the `NeedMore`/widen path fires on every file) must produce **identical** DB state to a scan done with the legacy full-file probe (`probe_full`) as the oracle — for every format. Comparing against the legacy oracle (not just two bounded runs) is what proves the bounded path cannot drift the served output.
+
+**Files:**
+- Create: `musefs-core/tests/probe_equivalence.rs`
+- Modify: `musefs-core/src/scan.rs` (env-overridable window + a `#[doc(hidden)]` full-probe oracle scan)
+- Modify: `musefs-core/tests/common/corpus.rs` (`CorpusParams::single`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `musefs-core/tests/probe_equivalence.rs`:
+
+```rust
+//! Headline SP1 correctness guard: a tiny-window bounded scan is equivalent (in
+//! its parsed DB rows) to a legacy full-file-probe scan, for every format.
+
+mod common;
+
+use common::corpus::{bench_formats, format_token, generate, CorpusParams};
+use musefs_db::Db;
+
+/// Normalize a DB to comparable rows: tracks by path, tags by (key,value,ordinal),
+/// art by (sha256, ordinal). Excludes raw `art.id` (insertion-order rowid).
+fn normalized(db: &Db) -> Vec<(String, i64, i64, Vec<(String, String, i64)>, Vec<(String, i64)>)> {
+    let mut out = Vec::new();
+    for t in db.list_tracks().unwrap() {
+        let tags: Vec<_> = db
+            .get_tags(t.id)
+            .unwrap()
+            .into_iter()
+            .map(|tg| (tg.key, tg.value, tg.ordinal))
+            .collect();
+        let art: Vec<_> = db
+            .get_track_art(t.id)
+            .unwrap()
+            .into_iter()
+            .map(|a| (db.get_art(a.art_id).unwrap().unwrap().sha256, a.ordinal))
+            .collect();
+        out.push((t.backing_path, t.audio_offset, t.audio_length, tags, art));
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn bounded_probe_equivalent_to_full_for_every_format() {
+    for fmt in bench_formats() {
+        let dir = tempfile::tempdir().unwrap();
+        let params = CorpusParams::single(fmt, /*albums*/ 2, /*tracks*/ 3);
+        generate(dir.path(), &params);
+
+        // Oracle: legacy whole-file probe.
+        let oracle_db = Db::open_in_memory().unwrap();
+        musefs_core::scan_directory_full_oracle(&oracle_db, dir.path()).unwrap();
+        let oracle = normalized(&oracle_db);
+
+        // Bounded scan with a 64-byte window → widen path fires on every file.
+        std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
+        let bounded_db = Db::open_in_memory().unwrap();
+        musefs_core::scan_directory(&bounded_db, dir.path()).unwrap();
+        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+        let bounded = normalized(&bounded_db);
+
+        assert_eq!(
+            oracle, bounded,
+            "format {}: bounded scan diverged from full-probe oracle",
+            format_token(fmt)
+        );
+        assert!(!oracle.is_empty(), "format {}: scanned nothing", format_token(fmt));
+    }
+}
+```
+
+(This integration file has a single test in its own test binary, so the `set_var`/`remove_var` around the bounded scan cannot race another test. Edition 2021 — `set_var` is safe.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --test probe_equivalence -- --nocapture`
+Expected: FAIL — `scan_directory_full_oracle` and `CorpusParams::single` do not exist, and `MUSEFS_SCAN_WINDOW` is not honored.
+
+- [ ] **Step 3: Add the window override, the oracle scan, and the corpus helper**
+
+In `musefs-core/src/scan.rs`:
+
+Make the window env-overridable:
+
+```rust
+/// Effective initial window: `MUSEFS_SCAN_WINDOW` (bytes) if set, else `WINDOW`.
+fn scan_window() -> usize {
+    std::env::var("MUSEFS_SCAN_WINDOW")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(WINDOW)
+}
+```
+
+and in `probe_file` change the initial `want` to `let mut want = (scan_window() as u64).min(file_len) as usize;`.
+
+Add the full-probe oracle scan (a thin retention of the pre-SP1 slurp path, used only as a test oracle):
+
+```rust
+/// Test/oracle only: scan using the legacy whole-file probe (`probe_full`). The
+/// equivalence property compares this against the bounded `scan_directory`.
+#[doc(hidden)]
+pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
+    let mut files = Vec::new();
+    if root.is_file() {
+        if is_supported_audio(root) {
+            files.push(root.to_path_buf());
+        }
+    } else {
+        collect_audio(root, &mut files)?;
+    }
+    let mut stats = ScanStats { scanned: 0, skipped: 0, failed: 0 };
+    for path in files {
+        let bytes = std::fs::read(&path)?;
+        let Some(probed) = probe_full(&path, &bytes) else {
+            stats.skipped += 1;
+            continue;
+        };
+        let meta = std::fs::metadata(&path)?;
+        let abs = std::fs::canonicalize(&path)?;
+        ingest(db, &abs.to_string_lossy(), &meta, probed)?;
+        stats.scanned += 1;
+    }
+    Ok(stats)
+}
+```
+
+Re-export it from `musefs-core/src/lib.rs` beside the other scan re-exports:
+
+```rust
+pub use scan::scan_directory_full_oracle;
+```
+
+In `musefs-core/tests/common/corpus.rs`, add the constructor (fields verified against the struct: `albums`, `tracks_per_album`, `bytes_per_track`, `art_bytes_per_track`, `format_mix`, `seed`):
+
+```rust
+impl CorpusParams {
+    /// A small single-format corpus *with embedded art* (so a tiny-window scan
+    /// must exercise the widen path), used by the equivalence property.
+    pub fn single(fmt: Format, albums: usize, tracks_per_album: usize) -> Self {
+        Self {
+            albums,
+            tracks_per_album,
+            bytes_per_track: 4 * 1024,
+            art_bytes_per_track: 8 * 1024,
+            format_mix: vec![fmt],
+            seed: 1,
+        }
+    }
+}
+```
+
+Note: this task depends on Task B2 having added the `failed` field to `ScanStats` — but A7 runs in Stage A, before B2. So in Stage A, `ScanStats` still has only `scanned`/`skipped`; write `ScanStats { scanned: 0, skipped: 0 }` here and add `failed: 0` when Task B2 lands (Task B2's diff already updates every `ScanStats` constructor). If executing strictly in order, omit `failed` in this task.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core --test probe_equivalence -- --nocapture`
+Expected: PASS for all six formats (flac, mp3, m4a-moov-first, m4a-moov-last, ogg, wav).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/src/lib.rs musefs-core/tests/probe_equivalence.rs musefs-core/tests/common/corpus.rs
+git commit -m "test(scan): bounded≡full-oracle probe equivalence (all formats, tiny-window widen)"
+```
+
+**Stage A gate:** `cargo test --workspace` green, `cargo clippy --all-targets -- -D warnings` clean. Do not start Stage B until the equivalence property passes.
+
+---
+
+# Stage B — Pipeline (parallel probe, single writer, batching, bulk pragmas)
+
+## Task B1: `BulkWriter` + bulk pragmas (musefs-db)
+
+A batch-writer that wraps many files' writes in **one** transaction, plus the scan-scoped bulk pragmas. The four write operations are duplicated onto a held `Transaction` (the existing `upsert_track`/`replace_tags`/etc. each open their own transaction and cannot be nested). The "scan-scoped connection distinct from any mount connection" the spec calls for is realized by applying the bulk pragmas to the scanner's own short-lived `Db` (CLI `run_scan` opens it, scans, drops it; the mount opens a different connection) — no separate `open_bulk` is needed.
+
+**Files:**
+- Create: `musefs-db/src/bulk.rs`
+- Modify: `musefs-db/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `musefs-db/src/bulk.rs` with only this test for now (implementation in Step 3). The test reads `db.conn` directly — `conn` is a private field of `Db` (defined in the crate root `lib.rs`), and `bulk` / `bulk::tests` are descendant modules, so the private field is in scope:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use crate::models::{Format, NewArt, NewTrack, Tag, TrackArt};
+    use crate::Db;
+
+    #[test]
+    fn bulk_writer_persists_a_batch_in_one_commit() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            for i in 0..3 {
+                let id = bw
+                    .upsert_track(&NewTrack {
+                        backing_path: format!("/m/{i}.flac"),
+                        format: Format::Flac,
+                        audio_offset: 100,
+                        audio_length: 200,
+                        backing_size: 300,
+                        backing_mtime: 1,
+                    })
+                    .unwrap();
+                bw.replace_tags(id, &[Tag::new("title", &format!("t{i}"), 0)])
+                    .unwrap();
+                let art_id = bw
+                    .upsert_art(&NewArt {
+                        mime: "image/png".into(),
+                        width: None,
+                        height: None,
+                        data: vec![1, 2, 3, 4],
+                    })
+                    .unwrap();
+                bw.set_track_art(
+                    id,
+                    &[TrackArt { art_id, picture_type: 3, description: String::new(), ordinal: 0 }],
+                )
+                .unwrap();
+            }
+            bw.commit().unwrap();
+        }
+        assert_eq!(db.list_tracks().unwrap().len(), 3);
+        // Dedup: identical art blob stored once.
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM art", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-db --lib bulk::tests -- --nocapture`
+Expected: FAIL — `bulk_writer` / `BulkWriter` not found.
+
+- [ ] **Step 3: Implement the bulk pragmas + writer**
+
+Add to `musefs-db/src/bulk.rs` (above the test module):
+
+```rust
+use crate::models::{NewArt, NewTrack, Tag, TrackArt};
+use crate::{Db, Result};
+use rusqlite::{params, Transaction};
+use sha2::{Digest, Sha256};
+
+fn sha256_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+impl Db {
+    /// Apply the bulk-write pragmas to an open connection. WAL is left untouched
+    /// (retained from `open`), so concurrent mount readers keep working. Safe on
+    /// in-memory DBs. Intended for a scan-scoped `Db` the caller drops at scan end.
+    pub fn apply_bulk_pragmas(conn: &rusqlite::Connection) -> Result<()> {
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.pragma_update(None, "cache_size", -65536)?; // 64 MiB
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+        Ok(())
+    }
+
+    /// Apply bulk pragmas to this DB's own connection.
+    pub fn apply_bulk_pragmas_self(&self) -> Result<()> {
+        Self::apply_bulk_pragmas(&self.conn)
+    }
+
+    /// Begin a batch transaction. All writes go through the returned handle and
+    /// land atomically on `commit()`.
+    pub fn bulk_writer(&self) -> Result<BulkWriter<'_>> {
+        Ok(BulkWriter {
+            tx: self.conn.unchecked_transaction()?,
+        })
+    }
+}
+
+/// A batch of track writes held in one transaction. Mirrors `Db::upsert_track` /
+/// `replace_tags` / `upsert_art` / `set_track_art`, but executes on a single
+/// caller-held transaction so a whole batch commits with one fsync.
+pub struct BulkWriter<'c> {
+    tx: Transaction<'c>,
+}
+
+impl BulkWriter<'_> {
+    pub fn upsert_track(&mut self, t: &NewTrack) -> Result<i64> {
+        self.tx.execute(
+            "INSERT INTO tracks
+                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CAST(strftime('%s','now') AS INTEGER))
+             ON CONFLICT(backing_path) DO UPDATE SET
+                format=excluded.format, audio_offset=excluded.audio_offset,
+                audio_length=excluded.audio_length, backing_size=excluded.backing_size,
+                backing_mtime=excluded.backing_mtime,
+                updated_at=CAST(strftime('%s','now') AS INTEGER)",
+            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime],
+        )?;
+        Ok(self.tx.query_row(
+            "SELECT id FROM tracks WHERE backing_path = ?1",
+            params![t.backing_path],
+            |r| r.get(0),
+        )?)
+    }
+
+    pub fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> Result<()> {
+        self.tx.execute("DELETE FROM tags WHERE track_id = ?1", params![track_id])?;
+        let mut stmt = self
+            .tx
+            .prepare_cached("INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)")?;
+        for t in tags {
+            stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+        }
+        Ok(())
+    }
+
+    pub fn upsert_art(&mut self, a: &NewArt) -> Result<i64> {
+        let sha = sha256_hex(&a.data);
+        self.tx.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) ON CONFLICT(sha256) DO NOTHING",
+            params![sha, a.mime, a.width, a.height, a.data.len() as i64, a.data],
+        )?;
+        Ok(self
+            .tx
+            .query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| r.get(0))?)
+    }
+
+    pub fn set_track_art(&mut self, track_id: i64, items: &[TrackArt]) -> Result<()> {
+        self.tx.execute("DELETE FROM track_art WHERE track_id = ?1", params![track_id])?;
+        let mut stmt = self.tx.prepare_cached(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+        )?;
+        for it in items {
+            stmt.execute(params![track_id, it.art_id, it.picture_type, it.description, it.ordinal])?;
+        }
+        Ok(())
+    }
+
+    pub fn commit(self) -> Result<()> {
+        self.tx.commit()?;
+        Ok(())
+    }
+}
+```
+
+In `musefs-db/src/lib.rs`, register the module beside the others:
+
+```rust
+mod bulk;
+pub use bulk::BulkWriter;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-db --lib bulk::tests -- --nocapture`
+Expected: PASS.
+Run: `cargo test -p musefs-db`
+Expected: PASS — no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-db/src/bulk.rs musefs-db/src/lib.rs
+git commit -m "feat(db): scan-scoped bulk connection + BulkWriter batch transaction"
+```
+
+---
+
+## Task B2: Resilience — `failed` counter, non-fatal per-file errors
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `bounded_probe_tests` in `musefs-core/src/scan.rs`:
+
+```rust
+    #[test]
+    fn scan_counts_unreadable_file_as_failed_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        // One good FLAC + one zero-byte ".flac" that cannot parse.
+        let good = dir.path().join("good.flac");
+        let mut bytes = b"fLaC".to_vec();
+        bytes.push(0x80);
+        bytes.extend_from_slice(&[0, 0, 34]);
+        bytes.extend(std::iter::repeat(0u8).take(34));
+        bytes.extend_from_slice(b"AUDIO");
+        std::fs::write(&good, &bytes).unwrap();
+        std::fs::write(dir.path().join("bad.flac"), b"").unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = scan_directory(&db, dir.path()).unwrap();
+        assert_eq!(stats.scanned, 1);
+        assert_eq!(stats.skipped + stats.failed, 1);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --lib scan::bounded_probe_tests::scan_counts_unreadable -- --nocapture`
+Expected: FAIL — `ScanStats` has no `failed` field.
+
+- [ ] **Step 3: Add the `failed` field and make per-file IO non-fatal**
+
+In `musefs-core/src/scan.rs`:
+
+Add `pub failed: u64,` to `ScanStats` and `RevalidateStats` (and a `failed: 0,` initializer where each is constructed).
+
+Wrap the per-file work in `scan_directory` so a per-file IO error is counted, not propagated:
+
+```rust
+    for path in files {
+        let meta = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => { stats.failed += 1; continue; }
+        };
+        match probe_file(&path, meta.len()) {
+            Ok(Some(probed)) => {
+                let abs = std::fs::canonicalize(&path)?;
+                ingest(db, &abs.to_string_lossy(), &meta, probed)?;
+                stats.scanned += 1;
+            }
+            Ok(None) => stats.skipped += 1,
+            Err(_) => stats.failed += 1,
+        }
+    }
+```
+
+Apply the same `Err(_) => { failed += 1; continue }` treatment to `revalidate`'s `metadata` / `probe_file` calls. (Keep `db.*` write errors propagating via `?` — those are fatal.)
+
+Update the CLI print line in `musefs-cli/src/lib.rs::run_scan` to include `failed`:
+
+```rust
+        println!(
+            "scanned {} file(s), skipped {}, failed {}",
+            stats.scanned, stats.skipped, stats.failed
+        );
+```
+
+and the revalidate print to add `, {} failed` / `stats.failed`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core --lib scan:: -- --nocapture` and `cargo build -p musefs-cli`
+Expected: PASS / builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-cli/src/lib.rs
+git commit -m "feat(scan): non-fatal per-file errors with a failed counter"
+```
+
+---
+
+## Task B3: Byte-budget backpressure + parallel pipeline
+
+**Files:**
+- Create: `musefs-core/src/byte_budget.rs`
+- Modify: `musefs-core/src/lib.rs` (`mod byte_budget;`)
+- Modify: `musefs-core/src/scan.rs`
+
+- [ ] **Step 1: Write the failing test (byte budget)**
+
+Create `musefs-core/src/byte_budget.rs`:
+
+```rust
+//! A byte-accounted semaphore: producers reserve N bytes before holding a value,
+//! blocking until the in-flight total would stay within the cap; the consumer
+//! releases bytes after persisting. Bounds peak in-flight art memory.
+
+use std::sync::{Condvar, Mutex};
+
+pub struct ByteBudget {
+    cap: u64,
+    state: Mutex<u64>,
+    cv: Condvar,
+}
+
+impl ByteBudget {
+    pub fn new(cap: u64) -> Self {
+        Self { cap, state: Mutex::new(0), cv: Condvar::new() }
+    }
+
+    /// Reserve `n` bytes, blocking until they fit (a single item larger than the
+    /// cap is admitted alone once in-flight is zero, to guarantee progress).
+    pub fn acquire(&self, n: u64) {
+        let mut in_flight = self.state.lock().unwrap();
+        while *in_flight != 0 && *in_flight + n > self.cap {
+            in_flight = self.cv.wait(in_flight).unwrap();
+        }
+        *in_flight += n;
+    }
+
+    /// Release `n` previously reserved bytes.
+    pub fn release(&self, n: u64) {
+        let mut in_flight = self.state.lock().unwrap();
+        *in_flight = in_flight.saturating_sub(n);
+        self.cv.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn oversized_item_admitted_when_idle() {
+        let b = ByteBudget::new(10);
+        b.acquire(1000); // larger than cap, but in-flight was 0 → admitted
+        b.release(1000);
+    }
+
+    #[test]
+    fn blocks_until_release() {
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(10);
+        let b2 = Arc::clone(&b);
+        let h = std::thread::spawn(move || b2.acquire(5)); // must block
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        b.release(10); // unblocks the spawned acquire
+        h.join().unwrap();
+        b.release(5);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --lib byte_budget -- --nocapture`
+Expected: FAIL — module not registered.
+
+- [ ] **Step 3: Register the module and add the parallel pipeline**
+
+In `musefs-core/src/lib.rs` add `mod byte_budget;`.
+
+In `musefs-core/src/scan.rs` add the options struct and the pipelined scan. Keep `scan_directory` as a back-compat wrapper:
+
+```rust
+use crate::byte_budget::ByteBudget;
+use std::sync::mpsc::sync_channel;
+
+const BATCH_FILES: usize = 256;
+const BATCH_BYTES: u64 = 64 << 20; // 64 MiB
+
+/// Knobs for a scan. `jobs == 0` means "use available parallelism".
+#[derive(Debug, Clone)]
+pub struct ScanOptions {
+    pub jobs: usize,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self { jobs: 0 }
+    }
+}
+
+fn effective_jobs(jobs: usize) -> usize {
+    if jobs != 0 {
+        return jobs;
+    }
+    std::thread::available_parallelism().map_or(1, |n| n.get())
+}
+
+/// One probed file ready to write, plus its art-byte weight for backpressure.
+struct Unit {
+    abs_path: String,
+    meta_len: u64,
+    meta_mtime: i64,
+    probed: Probed,
+    weight: u64,
+}
+
+fn art_weight(p: &Probed) -> u64 {
+    p.pictures.iter().map(|pic| pic.data.len() as u64).sum()
+}
+
+/// Public entry: parallel-probe / single-writer scan of `root`.
+pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
+    let mut files = Vec::new();
+    if root.is_file() {
+        if is_supported_audio(root) {
+            files.push(root.to_path_buf());
+        }
+    } else {
+        collect_audio(root, &mut files)?;
+    }
+    db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
+    let stats = run_pipeline(db, files, opts)?;
+    Ok(stats)
+}
+
+/// Back-compat shim used by the CLI and existing tests.
+pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
+    scan_directory_with(db, root, &ScanOptions::default())
+}
+```
+
+(`apply_bulk_pragmas_self` was added to `Db` in Task B1.) Now the pipeline itself, in `scan.rs`:
+
+```rust
+/// Probe `files` across `jobs` workers (no DB access) and write the results from a
+/// single writer (this thread) in batched transactions. Per-file errors are
+/// counted, not fatal.
+fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<ScanStats> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    let jobs = effective_jobs(opts.jobs);
+    let budget = Arc::new(ByteBudget::new(BATCH_BYTES));
+    let skipped = Arc::new(AtomicU64::new(0));
+    let failed = Arc::new(AtomicU64::new(0));
+
+    // Work queue: a shared iterator behind a mutex (cheap; probing dominates).
+    let work = Arc::new(std::sync::Mutex::new(files.into_iter()));
+    let (tx, rx) = sync_channel::<Unit>(jobs * 2);
+
+    let mut workers = Vec::with_capacity(jobs);
+    for _ in 0..jobs {
+        let work = Arc::clone(&work);
+        let tx = tx.clone();
+        let budget = Arc::clone(&budget);
+        let skipped = Arc::clone(&skipped);
+        let failed = Arc::clone(&failed);
+        workers.push(std::thread::spawn(move || loop {
+            let next = { work.lock().unwrap().next() };
+            let Some(path) = next else { break };
+            let meta = match std::fs::metadata(&path) {
+                Ok(m) => m,
+                Err(_) => { failed.fetch_add(1, Ordering::Relaxed); continue; }
+            };
+            match probe_file(&path, meta.len()) {
+                Ok(Some(probed)) => {
+                    let abs = match std::fs::canonicalize(&path) {
+                        Ok(a) => a,
+                        Err(_) => { failed.fetch_add(1, Ordering::Relaxed); continue; }
+                    };
+                    let weight = art_weight(&probed);
+                    budget.acquire(weight); // backpressure on in-flight art bytes
+                    let unit = Unit {
+                        abs_path: abs.to_string_lossy().into_owned(),
+                        meta_len: meta.len(),
+                        meta_mtime: mtime_secs(&meta),
+                        probed,
+                        weight,
+                    };
+                    if tx.send(unit).is_err() {
+                        budget.release(weight);
+                        break;
+                    }
+                }
+                Ok(None) => { skipped.fetch_add(1, Ordering::Relaxed); }
+                Err(_) => { failed.fetch_add(1, Ordering::Relaxed); }
+            }
+        }));
+    }
+    drop(tx); // close the channel once all clones (workers) finish
+
+    // Writer: this thread. Batch by file count and accumulated art bytes.
+    let mut scanned = 0u64;
+    let mut batch: Vec<Unit> = Vec::new();
+    let mut batch_bytes = 0u64;
+    let mut flush = |batch: &mut Vec<Unit>, batch_bytes: &mut u64, scanned: &mut u64| -> Result<()> {
+        if batch.is_empty() { return Ok(()); }
+        let mut bw = db.bulk_writer()?;
+        for u in batch.iter() {
+            ingest_bulk(&mut bw, &u.abs_path, u.meta_len, u.meta_mtime, &u.probed)?;
+            *scanned += 1;
+        }
+        bw.commit()?;
+        for u in batch.drain(..) {
+            budget.release(u.weight);
+        }
+        *batch_bytes = 0;
+        Ok(())
+    };
+
+    for unit in rx {
+        batch_bytes += unit.weight;
+        batch.push(unit);
+        if batch.len() >= BATCH_FILES || batch_bytes >= BATCH_BYTES {
+            flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+        }
+    }
+    flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+    for w in workers { let _ = w.join(); }
+
+    Ok(ScanStats {
+        scanned,
+        skipped: skipped.load(Ordering::Relaxed),
+        failed: failed.load(Ordering::Relaxed),
+    })
+}
+```
+
+Add a `BulkWriter` flavour of `ingest` next to the existing `ingest` in `scan.rs` (the existing `ingest` stays for any single-`Db` callers; both share the tag/art mapping logic):
+
+```rust
+/// Like `ingest`, but writes through a batch `BulkWriter`.
+fn ingest_bulk(
+    bw: &mut musefs_db::BulkWriter<'_>,
+    abs_path: &str,
+    meta_len: u64,
+    meta_mtime: i64,
+    probed: &Probed,
+) -> Result<()> {
+    let track_id = bw.upsert_track(&NewTrack {
+        backing_path: abs_path.to_string(),
+        format: probed.format,
+        audio_offset: probed.audio_offset as i64,
+        audio_length: probed.audio_length as i64,
+        backing_size: meta_len as i64,
+        backing_mtime: meta_mtime,
+    })?;
+
+    let mut tags = Vec::new();
+    let mut ordinals: HashMap<String, i64> = HashMap::new();
+    for (key, value) in &probed.tags {
+        let ord = ordinals.entry(key.clone()).or_insert(0);
+        tags.push(Tag::new(key, value, *ord));
+        *ord += 1;
+    }
+    bw.replace_tags(track_id, &tags)?;
+
+    let mut track_arts = Vec::new();
+    let accepted = probed.pictures.iter().filter(|p| p.data.len() <= MAX_ART_BYTES);
+    for (ordinal, pic) in accepted.enumerate() {
+        let art_id = bw.upsert_art(&NewArt {
+            mime: pic.mime.clone(),
+            width: (pic.width != 0).then_some(pic.width as i64),
+            height: (pic.height != 0).then_some(pic.height as i64),
+            data: pic.data.clone(),
+        })?;
+        let picture_type = if pic.picture_type <= 20 { pic.picture_type as i64 } else { 0 };
+        track_arts.push(TrackArt {
+            art_id,
+            picture_type,
+            description: pic.description.clone(),
+            ordinal: ordinal as i64,
+        });
+    }
+    bw.set_track_art(track_id, &track_arts)?;
+    Ok(())
+}
+```
+
+Re-export `ScanOptions` from `musefs-core/src/lib.rs` (beside the existing `scan_directory`/`revalidate` re-exports):
+
+```rust
+pub use scan::{revalidate, scan_directory, scan_directory_with, RevalidateStats, ScanOptions, ScanStats};
+```
+
+- [ ] **Step 4: Write the determinism test, then run all**
+
+Add to `bounded_probe_tests` in `scan.rs`:
+
+```rust
+    #[test]
+    fn jobs1_and_jobsN_produce_equivalent_state() {
+        let dir = tempfile::tempdir().unwrap();
+        // A handful of distinct FLACs.
+        for i in 0..12 {
+            let mut bytes = b"fLaC".to_vec();
+            bytes.push(0x80);
+            bytes.extend_from_slice(&[0, 0, 34]);
+            bytes.extend(std::iter::repeat(0u8).take(34));
+            bytes.extend_from_slice(format!("AUDIO-{i}").as_bytes());
+            std::fs::write(dir.path().join(format!("t{i}.flac")), &bytes).unwrap();
+        }
+        let norm = |jobs: usize| {
+            let db = Db::open_in_memory().unwrap();
+            scan_directory_with(&db, dir.path(), &ScanOptions { jobs }).unwrap();
+            let mut rows: Vec<(String, i64, i64)> = db
+                .list_tracks()
+                .unwrap()
+                .into_iter()
+                .map(|t| (t.backing_path, t.audio_offset, t.audio_length))
+                .collect();
+            rows.sort();
+            rows
+        };
+        assert_eq!(norm(1), norm(4));
+        assert_eq!(norm(1).len(), 12);
+    }
+```
+
+Run: `cargo test -p musefs-core --lib -- --nocapture`
+Run: `cargo test -p musefs-core --test probe_equivalence -- --nocapture`
+Expected: PASS (determinism holds; equivalence still green through the pipeline since `scan_directory` now routes through `run_pipeline`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/byte_budget.rs musefs-core/src/lib.rs musefs-core/src/scan.rs musefs-db/src/bulk.rs
+git commit -m "feat(scan): parallel-probe/single-writer pipeline with byte-budget backpressure + batching"
+```
+
+---
+
+## Task B4: `revalidate` pre-dispatch skip pass + pipeline
+
+The unchanged-file skip is a DB read and must run on the writer/main thread before workers (which are DB-free) are dispatched.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `bounded_probe_tests`:
+
+```rust
+    #[test]
+    fn revalidate_skips_unchanged_and_reprobes_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("x.flac");
+        let mk = |audio: &[u8]| {
+            let mut b = b"fLaC".to_vec();
+            b.push(0x80);
+            b.extend_from_slice(&[0, 0, 34]);
+            b.extend(std::iter::repeat(0u8).take(34));
+            b.extend_from_slice(audio);
+            b
+        };
+        std::fs::write(&p, mk(b"AUDIO")).unwrap();
+        let db = Db::open_in_memory().unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+
+        // Unchanged → all unchanged.
+        let s1 = revalidate_with(&db, dir.path(), &ScanOptions::default()).unwrap();
+        assert_eq!(s1.unchanged, 1);
+        assert_eq!(s1.updated, 0);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --lib scan::bounded_probe_tests::revalidate_skips -- --nocapture`
+Expected: FAIL — `revalidate_with` not found.
+
+- [ ] **Step 3: Implement `revalidate_with`**
+
+In `scan.rs`, add the pre-dispatch filter and pipeline the changed set:
+
+```rust
+pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<RevalidateStats> {
+    let mut files = Vec::new();
+    collect_audio(root, &mut files)?;
+    db.apply_bulk_pragmas_self()?;
+
+    // Main-thread pre-dispatch skip pass: load existing (path -> size,mtime) once,
+    // stat each candidate, keep only changed files. Workers stay DB-free.
+    let existing: HashMap<String, (i64, i64)> = db
+        .list_tracks()?
+        .into_iter()
+        .map(|t| (t.backing_path, (t.backing_size, t.backing_mtime)))
+        .collect();
+
+    let mut unchanged = 0u64;
+    let mut changed: Vec<PathBuf> = Vec::new();
+    for path in files {
+        let Ok(meta) = std::fs::metadata(&path) else { continue };
+        let Ok(abs) = std::fs::canonicalize(&path) else { continue };
+        let key = abs.to_string_lossy().to_string();
+        if let Some(&(size, mtime)) = existing.get(&key) {
+            if size == meta.len() as i64 && mtime == mtime_secs(&meta) {
+                unchanged += 1;
+                continue;
+            }
+        }
+        changed.push(path);
+    }
+
+    let scan = run_pipeline(db, changed, opts)?;
+
+    // Prune + GC on the writer connection (single-threaded), unchanged from before.
+    let canon_root = std::fs::canonicalize(root)?;
+    let mut pruned = 0u64;
+    for track in db.list_tracks()? {
+        if !Path::new(&track.backing_path).starts_with(&canon_root) {
+            continue;
+        }
+        if let Err(e) = std::fs::metadata(&track.backing_path) {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                db.delete_track(track.id)?;
+                pruned += 1;
+            }
+        }
+    }
+    db.gc_orphan_art()?;
+
+    Ok(RevalidateStats {
+        updated: scan.scanned,
+        unchanged,
+        pruned,
+        failed: scan.failed,
+    })
+}
+
+pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
+    revalidate_with(db, root, &ScanOptions::default())
+}
+```
+
+Delete the old `revalidate` body (replaced above). Update the `musefs-core/src/lib.rs` re-export to include `revalidate_with`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core -- --nocapture`
+Expected: PASS (including existing revalidate tests, which call `revalidate`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/src/lib.rs
+git commit -m "feat(scan): pipelined revalidate with main-thread pre-dispatch skip pass"
+```
+
+---
+
+## Task B5: CLI `--jobs` flag
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `musefs-cli/src/lib.rs` (or create one):
+
+```rust
+    #[test]
+    fn scan_command_parses_jobs_flag() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "scan", "/m", "--db", "/tmp/x.db", "--jobs", "3"])
+            .unwrap();
+        match cli.command {
+            Command::Scan { jobs, .. } => assert_eq!(jobs, 3),
+            _ => panic!("expected Scan"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-cli --lib scan_command_parses_jobs -- --nocapture`
+Expected: FAIL — `Scan` has no `jobs` field.
+
+- [ ] **Step 3: Add the flag and thread it through**
+
+In the `Command::Scan { .. }` variant, add:
+
+```rust
+        /// Probe worker threads (0 = available parallelism). 1 = sequential.
+        #[arg(long, default_value_t = 0)]
+        jobs: usize,
+```
+
+Change `run_scan`'s signature and body to take and use `jobs`:
+
+```rust
+pub fn run_scan(db_path: &Path, backing_dir: &Path, revalidate: bool, jobs: usize) -> Result<()> {
+    let db =
+        Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
+    let opts = musefs_core::ScanOptions { jobs };
+    if revalidate {
+        let stats = musefs_core::revalidate_with(&db, backing_dir, &opts)
+            .with_context(|| format!("revalidating {}", backing_dir.display()))?;
+        println!(
+            "revalidated: {} updated, {} unchanged, {} pruned, {} failed",
+            stats.updated, stats.unchanged, stats.pruned, stats.failed
+        );
+    } else {
+        let stats = musefs_core::scan_directory_with(&db, backing_dir, &opts)
+            .with_context(|| format!("scanning {}", backing_dir.display()))?;
+        println!(
+            "scanned {} file(s), skipped {}, failed {}",
+            stats.scanned, stats.skipped, stats.failed
+        );
+    }
+    Ok(())
+}
+```
+
+Update the dispatch in `run` where `Command::Scan { backing_dir, db, revalidate }` is destructured to also bind `jobs` and pass it: `run_scan(&db, &backing_dir, revalidate, jobs)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-cli -- --nocapture` and `cargo build`
+Expected: PASS / builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-cli/src/lib.rs
+git commit -m "feat(cli): scan --jobs flag (0=auto, 1=sequential)"
+```
+
+---
+
+## Task B6: Bench/report — `bytes_read` column + `jobs` dimension
+
+**Files:**
+- Modify: `musefs-core/tests/common/report.rs`
+- Modify: `musefs-core/tests/bench_ingest.rs`
+
+- [ ] **Step 1: Add the `bytes_read` column to the report**
+
+In `musefs-core/tests/common/report.rs`:
+
+- Add a column to the macro format string (one more `{:>14}`):
+
+```rust
+        format!("{:<10} {:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>14} {:>12}", $($arg),*)
+```
+
+- Add `pub bytes_read: u64,` to `RunReport`.
+- Add `"bytes_read"` to `header()` (before `"rss_kib"`).
+- Add `self.bytes_read,` to `row()` (before the `opt(self.peak_rss_kib)` arg).
+
+- [ ] **Step 2: Report `scan_bytes_read` and add a `jobs` dimension in bench_ingest**
+
+In `musefs-core/tests/bench_ingest.rs`:
+
+- In `run_one`, set `bytes_read: snap.scan_bytes_read,` on both `RunReport`s (scan and revalidate), where `snap` is the corresponding `metrics::snapshot()`.
+- In `bench_scan_under_latency`, set `bytes_read: s.scan_bytes_read,`.
+- Read `MUSEFS_BENCH_JOBS` (default 0) and thread it into a `ScanOptions`, replacing the bare `scan_directory(&db, …)` / `revalidate(&db, …)` calls with `scan_directory_with(&db, …, &opts)` / `revalidate_with(&db, …, &opts)`. Add near the top of `run_one`:
+
+```rust
+    let jobs = std::env::var("MUSEFS_BENCH_JOBS").ok().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let opts = musefs_core::ScanOptions { jobs };
+```
+
+and use `scan_directory_with(&db, &target.corpus_dir, &opts)` / `revalidate_with(&db, &target.corpus_dir, &opts)`.
+
+- Replace the stale doc comment on `run_one` ("The `opens`/`preads` metrics instrument the *serve* path … print ~0") with:
+
+```rust
+/// Scan + revalidate one resolved target, printing a `scan` and a `revalidate`
+/// row tagged with `format`/`storage`. The `bytes_read` column reports
+/// `scan_bytes_read` (the SP1 bounded-read signal: front-anchored prefix + widen
+/// + MP3 tail reads). M4A's seek-reader bytes are not counted here (they live in
+/// musefs-format); M4A's win shows in `wall_ms` + `peak_rss_kib`. `opens`/`preads`
+/// remain serve-path counters and stay ~0 on the scan path.
+```
+
+- [ ] **Step 3: Run the benches to verify they print the new column**
+
+Run: `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture bench_cold_scan_and_revalidate`
+Expected: a table including a populated `bytes_read` column; `scan` rows show `bytes_read` far below the corpus's per-file size for FLAC/MP3/OGG.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test --workspace` and `cargo clippy --all-targets -- -D warnings`
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/common/report.rs musefs-core/tests/bench_ingest.rs
+git commit -m "test(bench): report scan_bytes_read + MUSEFS_BENCH_JOBS dimension"
+```
+
+---
+
+# Final verification (before opening the PR)
+
+- [ ] `cargo test --workspace` green (includes `probe_equivalence`).
+- [ ] `cargo test -p musefs-format --features fuzzing` green (format proptests under feature unification).
+- [ ] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
+- [ ] `cargo test -p musefs-fuse -- --ignored` green on `/dev/fuse` (byte-identical e2e holds — SP1 doesn't touch the serve path, but confirm).
+- [ ] Bench evidence captured for the results log:
+  - `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture` on the `ci` and `large-compute` tiers (compute + `bytes_read` + `peak_rss_kib`), comparing `MUSEFS_BENCH_JOBS=1` vs unset.
+  - `bandwidth` tier on a real mount (30 MiB payloads): `MUSEFS_BENCH_TIER=bandwidth MUSEFS_BENCH_DIR=<real-disk> …`.
+  - fsync drop via latency FS: `MUSEFS_BENCH_LATENCY_PROFILE=hdd cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture bench_scan_under_latency` (batched vs `MUSEFS_BENCH_JOBS=1` per-file).
+  - Record tier · storage · wall · bytes_read · fsyncs · peak_rss in `docs/superpowers/specs/2026-05-30-optimization-pass/README.md` results log.
+- [ ] Update the SP1 status row in that README to **Implemented**, and link this plan.
+- [ ] Finish the branch via `superpowers:finishing-a-development-branch`.
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** bounded reads (A2–A6) · M4A seek (A6) · `NeedMore`/widen (A6, A7) · equivalence property (A7) · parallel default-on + `--jobs` (B3, B5) · single writer + batching (B1, B3) · byte-budget backpressure (B3) · bulk pragmas scan-scoped (B1) · resilience `failed` (B2) · revalidate pre-dispatch skip (B4) · scan-path metrics + bench (A1, B6) · all four spec components mapped.
+- **M4A bytes-read caveat** is documented (B6) — the in-process scan counter covers front-anchored reads; M4A's win is wall/RSS. Not a correctness gap.
+- **Determinism** is asserted on normalized state (B3), never on raw `art.id`, per the spec.
+- **Naming consistency:** `read_metadata_bounded` (flac, ogg), `locate_audio_bounded` (mp3, wav), `Extent`, `ScanOptions`, `scan_directory_with` / `revalidate_with`, `BulkWriter`, `ByteBudget`, `ingest_bulk`, `probe_file` / `probe_full` / `probe_prefix` — used identically across tasks.

--- a/docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md
+++ b/docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md
@@ -2019,7 +2019,8 @@ git commit -m "test(bench): report scan_bytes_read + MUSEFS_BENCH_JOBS dimension
   - `cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture` on the `ci` and `large-compute` tiers (compute + `bytes_read` + `peak_rss_kib`), comparing `MUSEFS_BENCH_JOBS=1` vs unset.
   - `bandwidth` tier on a real mount (30 MiB payloads): `MUSEFS_BENCH_TIER=bandwidth MUSEFS_BENCH_DIR=<real-disk> …`.
   - fsync drop via latency FS: `MUSEFS_BENCH_LATENCY_PROFILE=hdd cargo test -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture bench_scan_under_latency` (batched vs `MUSEFS_BENCH_JOBS=1` per-file).
-  - Record tier · storage · wall · bytes_read · fsyncs · peak_rss in `docs/superpowers/specs/2026-05-30-optimization-pass/README.md` results log.
+  - **Write the captured baselines to a `BENCHMARKS.md` at the repo root** (create it): a dated SP1 section with the before/after tables (columns: tier · storage · format · jobs · wall_ms · bytes_read · fsyncs · peak_rss_kib), the machine/storage class the run was on, and the exact commands used so a run is reproducible. This is the durable, human-readable record.
+  - Also drop a one-line pointer + the headline before/after delta into the `docs/superpowers/specs/2026-05-30-optimization-pass/README.md` results log, linking to `BENCHMARKS.md` for the full tables.
 - [ ] Update the SP1 status row in that README to **Implemented**, and link this plan.
 - [ ] Finish the branch via `superpowers:finishing-a-development-branch`.
 

--- a/docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md
+++ b/docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md
@@ -461,18 +461,21 @@ mod bounded_tests {
     use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
     use crate::probe::Extent;
 
-    /// A minimal single-page Opus stream: OpusHead BOS packet + OpusTags packet,
-    /// then a trailing audio page. Returns (full, audio_offset).
+    /// A minimal Opus stream: OpusHead + OpusTags header packets, then a trailing
+    /// audio page. Returns (full, audio_offset). Mirrors the proven fixture in
+    /// `musefs-core/src/scan.rs::ogg_probe_tests::probe_detects_opus_and_seeds_tags`.
+    /// Note `build_header_pub(serial, &[&[u8]])` laces *all* header packets across
+    /// pages (BOS set once) and returns `(Vec<u8>, u32)`; `lace_packet_pub` takes
+    /// `(serial, seq_start, bos, granule, packet)` and returns `(Vec<u8>, u32)`.
     fn opus_stream() -> (Vec<u8>, u64) {
         let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
         let mut tags = b"OpusTags".to_vec();
         tags.extend_from_slice(&vorbis_body_empty());
         let serial = 0x1234;
-        let mut v = build_header_pub(serial, 0, 0x02, &[lace_packet_pub(&head)]);
-        v.extend(build_header_pub(serial, 1, 0x00, &[lace_packet_pub(&tags)]));
+        let (mut v, _) = build_header_pub(serial, &[&head, &tags]);
         let audio_offset = v.len() as u64;
-        // A trailing audio page (FLAG_NONE, granule advanced).
-        v.extend(build_header_pub(serial, 2, 0x00, &[lace_packet_pub(b"AUDIO")]));
+        let (audio, _) = lace_packet_pub(serial, 2, false, 960, &[0u8; 100]);
+        v.extend_from_slice(&audio);
         (v, audio_offset)
     }
 
@@ -720,7 +723,7 @@ const MAX_WIDEN_RETRIES: usize = 8;
 pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
 ```
 
-(Keep its body unchanged.)
+(Keep its body unchanged.) **Also update the existing in-module test call sites** that call the old `probe(&path, …)` — `cargo build -p musefs-core --tests` will name them; at the time of writing they are in `scan.rs::ogg_probe_tests` (the `probe(&path, &bytes)` calls in the opus/oga/wav probe tests and the `probe(&path, b"not a real audio file")` negative test). Rewrite each `probe(` → `probe_full(`. (The two production call sites at the old lines 208/250 are replaced wholesale in steps 4–5 below, so don't rename those — they become `probe_file`.)
 
 3. Add a positioned reader helper and the bounded probe:
 
@@ -782,11 +785,13 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
             Probe::Done(p) => return Ok(Some(p)),
             Probe::Skip => return Ok(None),
             Probe::NeedMore(up_to) => {
-                let next = (up_to.min(file_len) as usize).max(want + 1);
-                if next <= want {
+                // Already at EOF? The prefix is the whole file; widening can't help.
+                if want as u64 >= file_len {
                     break;
                 }
-                want = next;
+                // Grow to at least `up_to` (capped at the file), always making
+                // progress (`+1`), then retry.
+                want = (up_to.min(file_len) as usize).max(want + 1).min(file_len as usize);
                 prefix = read_window(&file, want)?;
             }
         }
@@ -1052,8 +1057,12 @@ In `musefs-core/tests/common/corpus.rs`, add the constructor (fields verified ag
 
 ```rust
 impl CorpusParams {
-    /// A small single-format corpus *with embedded art* (so a tiny-window scan
-    /// must exercise the widen path), used by the equivalence property.
+    /// A small single-format corpus used by the equivalence property. `art_bytes`
+    /// is honored only by the FLAC generator (the MP3/M4A/Ogg/WAV corpus files
+    /// carry no embedded art or in-file tags — those ride via the DB at scan
+    /// time). The tiny `MUSEFS_SCAN_WINDOW=64` still forces the widen path on
+    /// every format, via the format's own trigger: FLAC the metadata-block walk,
+    /// MP3 the ID3v2 tag size, OGG the geometric grow, WAV the whole-file gate.
     pub fn single(fmt: Format, albums: usize, tracks_per_album: usize) -> Self {
         Self {
             albums,
@@ -1066,6 +1075,8 @@ impl CorpusParams {
     }
 }
 ```
+
+The spec's headline property names "every format fixture **and** proptest-generated files." This task covers the six format fixtures (via the corpus generator) directly; the **generative** side is already covered by the format-layer proptests (`cargo test -p musefs-format --features fuzzing`) and `musefs-core/tests/proptest_read_fidelity` — both run in the final verification. No new proptest oracle is added here; the corpus-based oracle is the SP1-specific bounded≡full guard.
 
 Note: this task depends on Task B2 having added the `failed` field to `ScanStats` — but A7 runs in Stage A, before B2. So in Stage A, `ScanStats` still has only `scanned`/`skipped`; write `ScanStats { scanned: 0, skipped: 0 }` here and add `failed: 0` when Task B2 lands (Task B2's diff already updates every `ScanStats` constructor). If executing strictly in order, omit `failed` in this task.
 
@@ -1621,6 +1632,8 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
 }
 ```
 
+**Resilience invariant (keep workers panic-free).** The spec counts per-file errors and makes only writer/DB errors fatal. That guarantee holds **only because `probe_file` returns `io::Result` and never `unwrap()`s on per-file I/O** — a worker that panicked would silently drop its file (neither `failed`-counted nor ingested) and just reduce throughput. So: the worker body must propagate every per-file error as `Err`/`Ok(None)` (as written above), never `unwrap`/`expect` on `metadata`/`canonicalize`/read/probe. (The format parsers are already panic-hardened by the fuzz suite; this invariant keeps the orchestration layer matching it. A `catch_unwind` wrapper is deliberately *not* added — it would mask a real parser regression that the fuzzers should catch instead.)
+
 Add a `BulkWriter` flavour of `ingest` next to the existing `ingest` in `scan.rs` (the existing `ingest` stays for any single-`Db` callers; both share the tag/art mapping logic):
 
 ```rust
@@ -1948,8 +1961,15 @@ In `musefs-core/tests/common/report.rs`:
 
 In `musefs-core/tests/bench_ingest.rs`:
 
+- Update the import at the top of the file (it currently reads `use musefs_core::{metrics, revalidate, scan_directory};`) to add the `_with` variants and `ScanOptions`:
+
+```rust
+use musefs_core::{metrics, revalidate_with, scan_directory_with, ScanOptions};
+```
+
+(`scan_directory` / `revalidate` are no longer called directly once the `_with` forms below replace them; drop them from the `use` to avoid an unused-import warning.)
 - In `run_one`, set `bytes_read: snap.scan_bytes_read,` on both `RunReport`s (scan and revalidate), where `snap` is the corresponding `metrics::snapshot()`.
-- In `bench_scan_under_latency`, set `bytes_read: s.scan_bytes_read,`.
+- In `bench_scan_under_latency`, set `bytes_read: s.scan_bytes_read,` **and** convert its `scan_directory(&db, &mount.path())` call to `scan_directory_with(&db, &mount.path(), &ScanOptions { jobs: std::env::var("MUSEFS_BENCH_JOBS").ok().and_then(|s| s.parse().ok()).unwrap_or(0) })` (it has no `run_one` `opts` in scope).
 - Read `MUSEFS_BENCH_JOBS` (default 0) and thread it into a `ScanOptions`, replacing the bare `scan_directory(&db, …)` / `revalidate(&db, …)` calls with `scan_directory_with(&db, …, &opts)` / `revalidate_with(&db, …, &opts)`. Add near the top of `run_one`:
 
 ```rust

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -33,8 +33,9 @@ around what that one did *not* deliver. Reconciliation:
   (single + concurrent), a deterministic latency-injection layer (passthrough
   FUSE), and comparable reporting. *Spec: `SP0-measurement-foundation.md`.*
 - **SP1 — Ingestion scalability.** Bounded probing reads (stop slurping whole
-  files), transaction batching across the scan loop, optional parallel probing,
-  bulk-write pragma tuning. *Spec: TBD after SP0.*
+  files), transaction batching across the scan loop, parallel probing
+  (default-on, `--jobs` knob), bulk-write pragma tuning. *Spec:
+  `SP1-ingestion-scalability.md`.*
 - **SP2 — Incremental tree refresh.** Rebuild only changed tracks on a
   `data_version` bump instead of reloading and re-rendering the whole library.
   *Spec: TBD.*
@@ -75,7 +76,7 @@ is built for the full capability regardless.
 |---|---|---|---|---|
 | SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below; per-format sweep added (`SP0a-per-format-coverage.md`) |
 | SP0b | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS. See "Latency-injected runs" below. |
-| SP1 | Not started | — | — | |
+| SP1 | Spec drafted | `SP1-ingestion-scalability.md` | — | Hybrid bounded reads (window+`NeedMore` for FLAC/MP3/OGG/WAV, seek reader for M4A) · parallel-probe/serial-writer · txn batching · bulk pragmas |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |
 | SP4 | Not started | — | — | |

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -76,7 +76,7 @@ is built for the full capability regardless.
 |---|---|---|---|---|
 | SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below; per-format sweep added (`SP0a-per-format-coverage.md`) |
 | SP0b | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS. See "Latency-injected runs" below. |
-| SP1 | Spec drafted | `SP1-ingestion-scalability.md` | — | Hybrid bounded reads (window+`NeedMore` for FLAC/MP3/OGG/WAV, seek reader for M4A) · parallel-probe/serial-writer · txn batching · bulk pragmas |
+| SP1 | Implemented | `SP1-ingestion-scalability.md` | `../../plans/2026-05-31-sp1-ingestion-scalability.md` | Hybrid bounded reads (window+`NeedMore` for FLAC/MP3/OGG/WAV, seek reader for M4A) · parallel-probe/serial-writer pipeline (`--jobs`) · byte-budget backpressure · txn batching · bulk pragmas · `failed` resilience. Bounded≡full equivalence gate + byte-identical PCM e2e green. Bench baselines → `BENCHMARKS.md` (pending run). |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |
 | SP4 | Not started | — | — | |

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/README.md
@@ -76,7 +76,7 @@ is built for the full capability regardless.
 |---|---|---|---|---|
 | SP0a | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0a-corpus-and-benches.md` | Corpus generator + compute benches + reporting; no /dev/fuse — runs now. See "Running the SP0a harness" below; per-format sweep added (`SP0a-per-format-coverage.md`) |
 | SP0b | Implemented | `SP0-measurement-foundation.md` | `../../plans/2026-05-30-optimization-sp0b-latency-fuse.md` | `musefs-latencyfs` passthrough latency-injection FUSE + fsync counter; needs /dev/fuse — VPS. See "Latency-injected runs" below. |
-| SP1 | Implemented | `SP1-ingestion-scalability.md` | `../../plans/2026-05-31-sp1-ingestion-scalability.md` | Hybrid bounded reads (window+`NeedMore` for FLAC/MP3/OGG/WAV, seek reader for M4A) · parallel-probe/serial-writer pipeline (`--jobs`) · byte-budget backpressure · txn batching · bulk pragmas · `failed` resilience. Bounded≡full equivalence gate + byte-identical PCM e2e green. Bench baselines → `BENCHMARKS.md` (pending run). |
+| SP1 | Implemented | `SP1-ingestion-scalability.md` | `../../plans/2026-05-31-sp1-ingestion-scalability.md` | Hybrid bounded reads (window+`NeedMore` for FLAC/MP3/OGG/WAV, seek reader for M4A) · parallel-probe/serial-writer pipeline (`--jobs`) · byte-budget backpressure · txn batching · bulk pragmas · `failed` resilience. Bounded≡full equivalence gate + byte-identical PCM e2e green. Bench baselines in `BENCHMARKS.md` (durable-storage cold scan 20–500× faster). |
 | SP2 | Not started | — | — | |
 | SP3 | Not started | — | — | |
 | SP4 | Not started | — | — | |
@@ -150,4 +150,14 @@ so VmHWM no longer isolates the scan's footprint — use the SP0a tempfs
 ## Results log
 
 *(Per-SP before/after numbers land here as each ships. Format: tier · storage
-class · wall time · op counts · fsyncs · peak RSS.)*
+class · wall time · op counts · fsyncs · peak RSS. Full tables + reproducing
+commands live in the repo-root [`BENCHMARKS.md`](../../../../BENCHMARKS.md).)*
+
+- **SP1 — Ingestion scalability** (2026-05-31, AMD EPYC 6c · SSD): on durable
+  storage cold scan is **20–500× faster** — `ci`/SSD FLAC 8949 ms → 17 ms
+  (526×); `bandwidth`/SSD 30 MiB FLAC 170 263 ms → 8735 ms (19.5×) with
+  `bytes_read` 30 GiB → 1.05 GiB. Mechanism: per-file commits at
+  `synchronous=FULL` → batched at `NORMAL` = **403 → 0 fsyncs** (latency-FS, 200
+  files). Caveat: on tempfs/RAM with sub-window files (`large-compute`) the
+  pipeline overhead makes it ~1.9× slower (no fsync cost to amortize). See
+  `BENCHMARKS.md` §1–§4.

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/SP1-ingestion-scalability.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/SP1-ingestion-scalability.md
@@ -24,7 +24,7 @@ SP1 changes only *how metadata is extracted at scan time*. It writes the same
 `audio_offset` / `audio_length` / `tags` / `art` rows, and **never touches the
 serve/read path**. So the byte-identical-audio guarantee holds by construction —
 provided bounded probing produces results identical to full-file probing. That
-equivalence is the **headline correctness guard** (see Testing §8.1).
+equivalence is the **headline correctness guard** (see Testing & acceptance gate, item 1).
 
 ## Reuse (existing foundation)
 
@@ -54,8 +54,7 @@ splits accordingly.
 
 ### Front-anchored formats: FLAC, MP3, OGG, WAV
 
-The prober entry points (`locate_audio`, `read_vorbis_comments` / `read_tags`,
-`read_pictures`, `read_header`) change signature to accept a **probe window**:
+These probers are fed a **probe window** instead of the whole file:
 
 - `prefix: &[u8]` — the first `prefix.len()` bytes of the file
   (`prefix.len() ≤ file_len`).
@@ -67,20 +66,42 @@ Contract:
   `data.len() - audio_offset`. The audio bytes are not in `prefix`; their length
   is arithmetic, not a read.
 - If parsing needs byte index `i` with `prefix.len() ≤ i < file_len`, the prober
-  returns **`NeedMore { up_to: u64 }`** carrying the exact high-water byte it
-  needs. Block/frame/chunk *headers* are tiny and front-anchored, so a small
-  prefix lets a prober learn the exact extent of bodies (notably embedded art)
-  and request precisely that range.
+  returns **`NeedMore { up_to: u64 }`** where `up_to` is the exact end of the
+  structure it is mid-parse on. The current parsers already detect the truncation
+  point (they return `Malformed` the instant a declared body length runs past the
+  buffer); SP1 converts each such site from **"truncated → `Malformed`"** into
+  **"truncated but the declared length is known → `NeedMore { up_to }`"** vs.
+  **"truncated and length is unknowable → `Malformed`."** The field that yields
+  `up_to` per format is named in the table below.
 - The scan loop answers a `NeedMore` with **one widening read** up to `up_to`
   (capped at `file_len`) and retries the prober. Worst case for front-anchored
   formats is two bounded reads, never a full slurp — except WAV with metadata
   trailing a huge `data` chunk, whose `up_to` lands near `file_len` (≈ today's
-  cost, no worse; see §9).
+  cost, no worse; see Out of scope).
 - **MP3 ID3v1**: detected via a dedicated 128-byte **tail read**, separate from
   the prefix.
 
-`WINDOW` (initial prefix size) is a tunable constant; default **1 MiB**. Typical
-metadata + cover art fits inside it, so the widening read is rare.
+**Per-format reality (the work is not uniform).** Two formats already have a
+front-only metadata split; two do not. The plan must budget accordingly:
+
+| Format | Front-only metadata fn today | `read_tags`/`read_pictures` reach audio payload? | Field yielding `up_to` | Net work |
+|---|---|---|---|---|
+| **FLAC** | **Yes** — `read_metadata → FlacMeta { audio_offset, preserved }` (no `audio_length`); `locate_audio` is just that + `len - offset` (flac.rs:80/90) | No — metadata blocks (incl. PICTURE) are all `< audio_offset` | 24-bit METADATA_BLOCK length at the truncation point | **Small** — thread `file_len`, emit `NeedMore` from `parse_blocks` |
+| **OGG** | **Yes** — `read_metadata(front) → OggHeader` is the front-only twin of `locate_audio` (ogg/mod.rs:202/208) | No — **all** art is in the header packets before `audio_offset`: Opus/Vorbis `METADATA_BLOCK_PICTURE` in the comment packet, OggFLAC type-6 packets (ogg/mod.rs:154–184) | end of header-packet reassembly (= `audio_offset`) | **Small** — emit `NeedMore` when header packets aren't fully present in `prefix` |
+| **MP3** | **No** — `locate_audio(&[u8])` takes whole buffer (mp3.rs:26) | ID3v2 tag is front; ID3v1 is the 128-byte tail | ID3v2 synchsafe `tag_len` (fully known from the first 10 bytes, mp3.rs:36–40) | **Real** — add a front-only variant + tail read |
+| **WAV** | **No** — `locate_audio(&[u8])` takes whole buffer (wav.rs:64) | LIST/INFO + `id3 ` chunks may sit **after** `data` | next-chunk offset from the RIFF chunk header (`walk_chunks`, wav.rs:35) | **Real** — front-only chunk walk; trailing-metadata case widens toward `file_len` (Out of scope) |
+
+Note OGG art is **front-anchored by construction**, so a `WINDOW` covering the
+header region captures it with no widening read; the only OGG widening trigger is
+a header region (many/large embedded images) exceeding `WINDOW`.
+
+`WINDOW` (initial prefix size) is a tunable constant; **default 1 MiB**. Embedded
+front-cover art is routinely 0.5–3 MB, so for art-bearing FLAC/MP3 the widening
+read is the **expected** path, not a rare one — but it is still bounded to
+*metadata + the exact art extent*, never the audio payload, which is the whole
+point. (The `custom`/real-library bench tier can later inform a `WINDOW` that
+brackets a given library's p95 art size; the default is deliberately conservative
+so a giant cover never wastes a slurp.)
 
 ### M4A: seek reader
 
@@ -90,8 +111,9 @@ eliminated; `mdat` is never read.
 
 ### Per-file scan flow
 
-1. `fs::metadata` → `file_len`, `mtime`. (`revalidate`: unchanged size+mtime →
-   skip with no file read, as today.)
+1. `fs::metadata` → `file_len`, `mtime`. (`revalidate` first runs its main-thread
+   pre-dispatch skip pass — Component 2 — so unchanged files never reach a worker
+   and do no file read.)
 2. Read `prefix = min(file_len, WINDOW)` bytes.
 3. Dispatch by extension:
    - FLAC/MP3/OGG/WAV → probers with `(prefix, file_len)`; MP3 also issues the
@@ -130,44 +152,100 @@ collect_audio (main thread)
   parsing and bounded file reads — they never touch the DB.
 - **Single writer thread** owns the one write connection, so SQLite stays
   single-writer-safe with zero write contention.
-- **Bounded channel** between workers and writer provides backpressure, so
-  in-flight `Probed` values (which hold art blobs) cannot balloon memory —
-  protecting the bounded-memory goal.
-- **Order-independence**: upserts are keyed by `backing_path`, so final DB state
-  is identical regardless of `--jobs`. `--jobs 1` and `--jobs N` converge to the
-  same rows — keeping tests deterministic.
+- **Backpressure / memory budget**: the worker→writer channel is bounded so
+  in-flight `Probed` values (which hold art `Vec<u8>` blobs) cannot balloon
+  memory. The bound is **a byte budget over accumulated art**, and it is the
+  *same* budget as the batch byte-ceiling (Component 3) — a `Probed` is held
+  either in the channel or in the forming batch, so they are accounted as one
+  pool, not two. Concretely: cap total in-flight art at **B<sub>bytes</sub>**
+  (default **64 MiB**); peak scan RSS for art ≈ B<sub>bytes</sub> + the current
+  batch. (`--jobs` only sets worker count, not the memory bound.)
+- **Semantic (not literal) determinism across `--jobs`**: track rows are keyed by
+  `backing_path` (upserted) and art is deduplicated by `art.sha256 UNIQUE`, so
+  the *content* of the DB is independent of `--jobs`. But `art.id` is an
+  insertion-order rowid (schema.rs:26), so with nondeterministic worker
+  completion the same image can receive a different `art.id` (and hence
+  `track_art.art_id`) run-to-run. The DB is therefore **semantically equivalent,
+  not byte-identical at the id level**. The determinism test compares
+  **normalized** state — tracks by `backing_path`, tags by `(key, value,
+  ordinal)`, art by `sha256` + its per-track usage — **not** raw `art.id` values
+  (see Testing & acceptance gate, item 3).
+- **`revalidate` skip-unchanged must not put a DB read in the workers.** The
+  size+mtime fast-skip (scan.rs:240) is a DB lookup, and workers are DB-free. So
+  `revalidate` does a **pre-dispatch pass on the main thread**: load the existing
+  `(backing_path → backing_size, backing_mtime)` set once (one query, the way
+  prune already lists tracks), `stat` each candidate, and enqueue only the files
+  whose size/mtime changed. Workers still only probe; unchanged files never reach
+  them.
 - The **directory walk stays single-threaded** (cheap relative to probing;
   parallelizing it is out of scope).
-- `revalidate` uses the same worker/writer shape; its whole-DB tail steps (prune
-  missing tracks, `gc_orphan_art`) run after, single-threaded on the writer
-  connection.
+- `revalidate`'s whole-DB tail steps (prune missing tracks, `gc_orphan_art`) run
+  after the pipeline drains, single-threaded on the writer connection.
 
 ## Component 3 — Transaction batching
 
-- The writer accumulates **B files** and wraps all their
+- The writer accumulates files and wraps all their
   `upsert_track` + `replace_tags` + `upsert_art` + `set_track_art` calls in a
   **single transaction**, then commits — collapsing today's several
-  commits-per-file into a handful per batch.
-- **Batch sizing**: count-based default (**B = 256**) with a **byte ceiling** on
-  accumulated art so a batch can neither hold too much memory nor build an
-  oversized transaction; whichever bound trips first flushes the batch.
+  commits-per-file into a handful per batch. This is the primary **fsync**
+  reduction (one fsync per batch under `synchronous=NORMAL`, vs. several per file
+  today), measured via `musefs-latencyfs` (Component 6).
+- **Flush triggers (whichever trips first):** a **count** bound — default
+  **B = 256** files, chosen to amortize commit/fsync overhead while keeping a
+  failed-commit blast radius small — **or** the shared **art byte budget**
+  B<sub>bytes</sub> (default **64 MiB**, the same pool as the channel
+  backpressure in Component 2; measured as raw image-blob bytes, excluding
+  framing). Both are tunable constants.
+- **Trigger semantics are unaffected.** The `content_version`/`updated_at`
+  triggers (schema.rs:44–74) fire **per row** and are **scoped to the owning
+  `tracks` row** (`WHERE id = NEW.track_id`). Batching many tracks into one
+  transaction does not cross-contaminate: each track's `replace_tags`
+  (DELETE-all + INSERT-each, tags.rs:8–15) bumps only its own `content_version`,
+  exactly as today.
 - **Error semantics**: per-file read/probe failures are handled in the worker and
   **never enter a batch**, so batches need no partial-rollback logic. A DB error
-  on commit is **fatal** (stops workers, propagates).
+  on commit is **fatal** (stops workers, propagates). A batch is a unit of
+  durability only, not of correctness: a crash mid-scan loses at most the
+  un-committed batch, which a re-scan re-ingests (additive); a crash mid-`revalidate`
+  may also lose the destructive prune/GC tail, but re-running re-prunes
+  idempotently.
 
 ## Component 4 — Bulk-write pragmas
 
-A dedicated **bulk-write connection** (owned by `musefs-db`, the pragma-policy
-owner — e.g. a `Db::open_bulk` / bulk-configured connection):
+A **scan-scoped bulk-write connection**, opened by `musefs-db` at the start of a
+scan/revalidate and **closed at the end** — explicitly *distinct* from any
+long-lived mount connection, so its pragmas never leak into the serve path. New
+API surface SP1 must add (today `Db` is a single `Connection`, lib.rs:15, with no
+bulk path):
+
+- a constructor for the bulk connection (e.g. `Db::open_bulk`), and
+- a **batch-writer handle** (e.g. `BulkWriter`) that wraps the per-track
+  `upsert_track` / `replace_tags` / `upsert_art` / `set_track_art` calls in one
+  transaction and exposes `flush`/`commit`.
+
+Pragmas on that connection:
 
 - `synchronous = NORMAL` — safe under WAL (survives app crash; only a power-loss
   on the very last commit is at risk, which a re-scan fixes since scan is
-  re-runnable).
+  re-runnable; see the revalidate caveat in Component 3).
 - `cache_size` ≈ **-65536** (64 MiB).
 - `temp_store = MEMORY`.
-- **`journal_mode = WAL` retained** — a concurrent live mount keeps reading.
-- `busy_timeout` retained; optional `wal_checkpoint(TRUNCATE)` at scan end to
-  bound WAL growth.
+- **`journal_mode = WAL` retained.** WAL allows concurrent *readers* (a live
+  mount keeps reading), but only **one writer**.
+- `busy_timeout` retained (currently 5 s, lib.rs:43); `wal_checkpoint(TRUNCATE)`
+  on close to bound WAL growth.
+
+**Exclusive-write assumption (stated, not assumed silently).** `musefs scan` /
+`revalidate` assumes it is the **sole writer** for its duration. WAL's single-writer
+rule means a long-running bulk transaction holds the write lock; a *second*
+concurrent writer (e.g. a beets/picard sync to the same DB) would hit
+`SQLITE_BUSY` once the 5 s `busy_timeout` is exceeded by a slow batch. This is
+acceptable because scan is an operator-initiated maintenance pass, not a
+steady-state mount activity; the roadmap's out-of-band writers are expected to
+run a scan, not concurrently with one. A concurrent live mount only *reads* and
+is unaffected. (If concurrent external writes during scan ever become a real
+requirement, smaller batches / a shorter lock-hold would be the lever — out of
+scope here.)
 
 ## Component 5 — Resilience
 
@@ -195,14 +273,26 @@ whole scan.) `ScanStats` / `RevalidateStats` gain a **`failed`** field alongside
 
 1. **Equivalence property (headline).** For every format fixture **and**
    proptest-generated files, bounded probing — run with a deliberately tiny
-   `WINDOW` to force the `NeedMore`/widen path — yields a `Probed`
-   (`audio_offset`, `audio_length`, `tags`, `pictures`) **byte-identical** to the
-   legacy full-buffer probe. This is the core guard that the served output cannot
-   drift.
+   `WINDOW` to force the `NeedMore`/widen path — yields a `Probed` **structurally
+   equal** (all fields; tags and pictures **order-preserved**, since ordinals
+   drive template rendering and synthesis) to the legacy full-buffer probe.
+   Precisely, for each file: `bounded.audio_offset == legacy.audio_offset`;
+   `bounded.audio_length == file_len - bounded.audio_offset == legacy.audio_length`;
+   `bounded.tags == legacy.tags` as an ordered list of `(key, value)`; and
+   `bounded.pictures == legacy.pictures` as an ordered list (bytes, mime,
+   picture_type, description). ("Structurally equal," not "byte-identical" — the
+   latter is the *serve-path* guarantee; this asserts the parsed values match.)
+   This is the core guard that the served output cannot drift.
 2. **`NeedMore`/widen units.** Tiny window → correct `up_to`, exactly one
-   widening read, embedded art beyond the window still captured intact.
-3. **Parallel determinism.** `--jobs 1` vs `--jobs N` over the same corpus →
-   identical DB state (rows + tags + art).
+   widening read, embedded art beyond the window still captured intact. Includes
+   the OGG case (incomplete header-packet reassembly in `prefix` → `NeedMore`) and
+   the WAV trailing-metadata case (`up_to` near `file_len`).
+3. **Parallel determinism (normalized).** `--jobs 1` vs `--jobs N` over the same
+   corpus → **semantically equivalent** DB state, compared on **normalized** form:
+   tracks by `backing_path`; tags by `(key, value, ordinal)`; art by `sha256` plus
+   its per-track usage `(picture_type, description, ordinal)`. Raw `art.id` /
+   `track_art.art_id` values are **excluded** from the comparison (they are
+   insertion-order rowids and legitimately differ across runs).
 4. **Resilience.** A corrupt/unreadable file in the corpus → scan completes, that
    file counted `failed`, all others ingested.
 5. **Batching.** A forced DB error mid-batch is fatal and surfaces.
@@ -223,8 +313,28 @@ whole scan.) `ScanStats` / `RevalidateStats` gain a **`failed`** field alongside
 - **Seek-based RIFF chunk-walk for WAV** — WAV with metadata trailing a huge
   `data` chunk widens toward `file_len` (no worse than today). A seek-based walk
   is a possible follow-up.
+- **APEv2 tags** — not read by the current MP3 prober (only ID3v1 + ID3v2) and not
+  emitted by synthesis; SP1 does not change that. The 128-byte tail read is
+  ID3v1-only.
 - **Parallelizing the directory walk** — cheap relative to probing.
 - **Any serve/read-path change** — SP1 is ingestion-only.
 - **New formats.**
 - No storage-bound validation is deferred: SP0b's `musefs-latencyfs` and a real
   `bandwidth`-tier mount both run on the current box.
+
+## Implementation sequencing (for the plan)
+
+This is one SP, but it has a natural two-stage order the plan should follow so the
+riskiest change is verified before the concurrency machinery is layered on:
+
+1. **Stage A — bounded reads (Component 1), still single-threaded.** Land the
+   probe-window / `file_len` / `NeedMore` contract and the M4A seek route, gated
+   green by the **equivalence property (Testing item 1)** before anything else. This is the
+   only change that touches the byte-identical parsing surface.
+2. **Stage B — pipeline (Components 2–4).** Add the parallel-probe/serial-writer
+   pool, the `BulkWriter` batching, the scan-scoped bulk connection, the
+   `revalidate` pre-dispatch skip pass, and resilience counting — on top of an
+   already-verified Stage A.
+
+Stages may ship as one or two PRs at the implementer's discretion; the gating
+order (A's equivalence property green before B) is the requirement.

--- a/docs/superpowers/specs/2026-05-30-optimization-pass/SP1-ingestion-scalability.md
+++ b/docs/superpowers/specs/2026-05-30-optimization-pass/SP1-ingestion-scalability.md
@@ -1,0 +1,230 @@
+# SP1 — Ingestion scalability — design
+
+*Date: 2026-05-30 · Part of the [2026-05-30 optimization pass](./README.md)*
+
+## Goal
+
+Make `scan` / `revalidate` fast and bounded-memory over large libraries
+**without changing what is written to the DB**. Today the scan loop slurps every
+backing file whole (`std::fs::read` at `scan.rs:207` and `:249`), probes
+single-threaded, and commits per file. SP1 delivers four things:
+
+1. **Bounded probing reads** — stop reading whole files; read only the metadata
+   region (plus the exact embedded-art extent), never the audio payload.
+2. **Parallel probing** — a bounded worker pool probes concurrently, default-on,
+   with a `--jobs` knob; a single writer thread keeps SQLite single-writer-safe.
+3. **Transaction batching** — group many files per transaction instead of
+   committing per file.
+4. **Bulk-write pragma tuning** — a dedicated bulk connection trades a sliver of
+   crash-durability (re-runnable anyway) for throughput.
+
+## Cardinal invariant (preserved structurally)
+
+SP1 changes only *how metadata is extracted at scan time*. It writes the same
+`audio_offset` / `audio_length` / `tags` / `art` rows, and **never touches the
+serve/read path**. So the byte-identical-audio guarantee holds by construction —
+provided bounded probing produces results identical to full-file probing. That
+equivalence is the **headline correctness guard** (see Testing §8.1).
+
+## Reuse (existing foundation)
+
+- **`mp4::read_structure_from<R: Read + Seek>`** (`mp4.rs:244`, built in the
+  2026-05-26 Phase 6) already seeks to the `moov` atom wherever it lives and
+  never reads `mdat`. SP1 routes M4A scanning through it instead of the
+  slice-based path — the one format whose metadata can legitimately sit at the
+  end of a multi-hundred-MB file.
+- **`musefs-core/src/metrics.rs`** — feature-gated atomic serve-path counters
+  (`on_open`/`on_stat`/`on_pread`/`on_art_chunk`) with `Snapshot` +
+  `snapshot()`/`reset()`. SP1 *adds* scan-path counters here (none exist yet).
+- **`musefs-latencyfs`** (SP0b) — passthrough FUSE hosting corpus **and** DB
+  under the mount, injecting per-op latency (`ssd`/`hdd`/`nfs` profiles) and
+  counting `fsync`/`fsyncdir` ops (`LatencyFs::fsyncs()`). SP1 measures scan
+  fsyncs and latency-sensitivity through it — no new in-process fsync counter.
+- **`musefs-core/tests/bench_ingest.rs`** + the SP0a corpus generator and
+  `RunReport` — extended, not replaced, to report the new scan signals.
+- **`db_pool.rs`** worker-pool shape is the reference pattern for the probe pool
+  (though SP1's pool is write-free — only the single writer thread touches the
+  DB).
+
+## Component 1 — Bounded probing reads (Hybrid)
+
+Replace the whole-file slurp with a bounded contract. Metadata location varies by
+format, and only M4A can legitimately place it at the file's end, so the strategy
+splits accordingly.
+
+### Front-anchored formats: FLAC, MP3, OGG, WAV
+
+The prober entry points (`locate_audio`, `read_vorbis_comments` / `read_tags`,
+`read_pictures`, `read_header`) change signature to accept a **probe window**:
+
+- `prefix: &[u8]` — the first `prefix.len()` bytes of the file
+  (`prefix.len() ≤ file_len`).
+- `file_len: u64` — the true file size, from `fs::metadata`.
+
+Contract:
+
+- **`audio_length` is computed against `file_len`**, replacing today's
+  `data.len() - audio_offset`. The audio bytes are not in `prefix`; their length
+  is arithmetic, not a read.
+- If parsing needs byte index `i` with `prefix.len() ≤ i < file_len`, the prober
+  returns **`NeedMore { up_to: u64 }`** carrying the exact high-water byte it
+  needs. Block/frame/chunk *headers* are tiny and front-anchored, so a small
+  prefix lets a prober learn the exact extent of bodies (notably embedded art)
+  and request precisely that range.
+- The scan loop answers a `NeedMore` with **one widening read** up to `up_to`
+  (capped at `file_len`) and retries the prober. Worst case for front-anchored
+  formats is two bounded reads, never a full slurp — except WAV with metadata
+  trailing a huge `data` chunk, whose `up_to` lands near `file_len` (≈ today's
+  cost, no worse; see §9).
+- **MP3 ID3v1**: detected via a dedicated 128-byte **tail read**, separate from
+  the prefix.
+
+`WINDOW` (initial prefix size) is a tunable constant; default **1 MiB**. Typical
+metadata + cover art fits inside it, so the widening read is rare.
+
+### M4A: seek reader
+
+M4A routes through `mp4::read_structure_from` (seek to `ftyp`/`moov` + `mdat`
+header only). The moov-last audiobook case — the single largest slurp today — is
+eliminated; `mdat` is never read.
+
+### Per-file scan flow
+
+1. `fs::metadata` → `file_len`, `mtime`. (`revalidate`: unchanged size+mtime →
+   skip with no file read, as today.)
+2. Read `prefix = min(file_len, WINDOW)` bytes.
+3. Dispatch by extension:
+   - FLAC/MP3/OGG/WAV → probers with `(prefix, file_len)`; MP3 also issues the
+     128-byte tail read when the ID3v1 region is outside the prefix.
+   - M4A → `read_structure_from` over an opened `File`.
+4. On `NeedMore { up_to }` from a front-anchored prober → one widening read to
+   `up_to`, retry. (`up_to == file_len` is allowed; it is the rare full-read
+   case.)
+5. Produce `Probed`; hand to the writer.
+
+The legacy slice-based prober bodies are largely reused — the change is the
+window/`file_len`/`NeedMore` plumbing at their boundaries, keeping the hardened
+fuzz + byte-identical parsing surface intact.
+
+## Component 2 — Parallel probing (default-on, knob)
+
+```
+collect_audio (main thread)
+        │  paths
+        ▼
+   [bounded work queue]
+        │
+   N probe workers  ── pure parse + bounded file reads, no DB ──┐
+        │  Probed / Skipped / Failed                            │
+        ▼                                                       │
+   [bounded results channel]  ◄── backpressure caps in-flight art blobs
+        │
+   1 writer thread  ── owns the bulk-write connection, batches txns
+        ▼
+     SQLite
+```
+
+- **Workers**: default count = `std::thread::available_parallelism()`; `--jobs N`
+  overrides; **`--jobs 1` collapses to a fully sequential scan** (canonical
+  measurement baseline + escape hatch on constrained boxes). Workers do pure
+  parsing and bounded file reads — they never touch the DB.
+- **Single writer thread** owns the one write connection, so SQLite stays
+  single-writer-safe with zero write contention.
+- **Bounded channel** between workers and writer provides backpressure, so
+  in-flight `Probed` values (which hold art blobs) cannot balloon memory —
+  protecting the bounded-memory goal.
+- **Order-independence**: upserts are keyed by `backing_path`, so final DB state
+  is identical regardless of `--jobs`. `--jobs 1` and `--jobs N` converge to the
+  same rows — keeping tests deterministic.
+- The **directory walk stays single-threaded** (cheap relative to probing;
+  parallelizing it is out of scope).
+- `revalidate` uses the same worker/writer shape; its whole-DB tail steps (prune
+  missing tracks, `gc_orphan_art`) run after, single-threaded on the writer
+  connection.
+
+## Component 3 — Transaction batching
+
+- The writer accumulates **B files** and wraps all their
+  `upsert_track` + `replace_tags` + `upsert_art` + `set_track_art` calls in a
+  **single transaction**, then commits — collapsing today's several
+  commits-per-file into a handful per batch.
+- **Batch sizing**: count-based default (**B = 256**) with a **byte ceiling** on
+  accumulated art so a batch can neither hold too much memory nor build an
+  oversized transaction; whichever bound trips first flushes the batch.
+- **Error semantics**: per-file read/probe failures are handled in the worker and
+  **never enter a batch**, so batches need no partial-rollback logic. A DB error
+  on commit is **fatal** (stops workers, propagates).
+
+## Component 4 — Bulk-write pragmas
+
+A dedicated **bulk-write connection** (owned by `musefs-db`, the pragma-policy
+owner — e.g. a `Db::open_bulk` / bulk-configured connection):
+
+- `synchronous = NORMAL` — safe under WAL (survives app crash; only a power-loss
+  on the very last commit is at risk, which a re-scan fixes since scan is
+  re-runnable).
+- `cache_size` ≈ **-65536** (64 MiB).
+- `temp_store = MEMORY`.
+- **`journal_mode = WAL` retained** — a concurrent live mount keeps reading.
+- `busy_timeout` retained; optional `wal_checkpoint(TRUNCATE)` at scan end to
+  bound WAL growth.
+
+## Component 5 — Resilience
+
+Per-file I/O and probe errors are **logged and counted**, and the scan
+**continues**; only writer/DB errors are fatal. (Today a single `?` aborts the
+whole scan.) `ScanStats` / `RevalidateStats` gain a **`failed`** field alongside
+`scanned` / `skipped`. `probe`-returns-`None` continues to count as `skipped`.
+
+## Component 6 — Measurement
+
+- **New in-process scan counters** in `metrics.rs` (behind the existing `metrics`
+  feature): `scan_opens`, `scan_preads`, `scan_bytes_read` (+ a batch/commit
+  count), wired through the prefix read, any widening read, the MP3 tail read,
+  the M4A seek reads, and the writer. These prove bounded reads directly:
+  `scan_bytes_read` per file drops from full-file size to ≈ `WINDOW` + exact art
+  extent.
+- **fsyncs** are measured externally by running a scan against a
+  `musefs-latencyfs`-mounted corpus+DB and reading `LatencyFs::fsyncs()` — the
+  direct signal for transaction batching's win. No in-process fsync counter.
+- `bench_ingest` is extended to report `scan_bytes_read` per format (and make
+  `opens`/`preads` meaningful) and to take a `jobs` dimension. Before/after
+  numbers land in the umbrella results log.
+
+## Testing & acceptance gate
+
+1. **Equivalence property (headline).** For every format fixture **and**
+   proptest-generated files, bounded probing — run with a deliberately tiny
+   `WINDOW` to force the `NeedMore`/widen path — yields a `Probed`
+   (`audio_offset`, `audio_length`, `tags`, `pictures`) **byte-identical** to the
+   legacy full-buffer probe. This is the core guard that the served output cannot
+   drift.
+2. **`NeedMore`/widen units.** Tiny window → correct `up_to`, exactly one
+   widening read, embedded art beyond the window still captured intact.
+3. **Parallel determinism.** `--jobs 1` vs `--jobs N` over the same corpus →
+   identical DB state (rows + tags + art).
+4. **Resilience.** A corrupt/unreadable file in the corpus → scan completes, that
+   file counted `failed`, all others ingested.
+5. **Batching.** A forced DB error mid-batch is fatal and surfaces.
+6. **Regression gates.** All crate tests + format fuzz seeds + interop + the
+   `#[ignore]` e2e mount suite stay green; byte-identical audio holds; the
+   Criterion `ci` `sequential_read` median stays within the **<10%** run-over-run
+   rule (SP1 barely touches the read path, but the gate is enforced).
+7. **Benches / evidence.** `bench_ingest` shows `scan_bytes_read` and `opens`
+   drop sharply on large-payload files; fsyncs (via `musefs-latencyfs`) drop with
+   batching. Validation spans `ci` + `large-compute` (tempfs — compute/RSS), the
+   **`bandwidth` tier on a real mount** (1,000 × ~30 MiB payloads, where bounded
+   reads pay off most), and `musefs-latencyfs` `ssd`/`hdd`/`nfs` profiles
+   (fsync + latency-sensitivity) — all runnable on the current box (6 cores,
+   `/dev/fuse`). Numbers recorded in the results log.
+
+## Out of scope (YAGNI)
+
+- **Seek-based RIFF chunk-walk for WAV** — WAV with metadata trailing a huge
+  `data` chunk widens toward `file_len` (no worse than today). A seek-based walk
+  is a possible follow-up.
+- **Parallelizing the directory walk** — cheap relative to probing.
+- **Any serve/read-path change** — SP1 is ingestion-only.
+- **New formats.**
+- No storage-bound validation is deferred: SP0b's `musefs-latencyfs` and a real
+  `bandwidth`-tier mount both run on the current box.

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -50,6 +50,9 @@ pub enum Command {
         /// gone, and garbage-collect orphaned art.
         #[arg(long)]
         revalidate: bool,
+        /// Probe worker threads (0 = available parallelism). 1 = sequential.
+        #[arg(long, default_value_t = 0)]
+        jobs: usize,
     },
     /// Mount a read-only FUSE view of the store.
     Mount {
@@ -92,18 +95,19 @@ pub enum Command {
 /// Open (creating/migrating) the DB at `db_path` and scan `backing_dir`. With
 /// `revalidate`, run the maintenance pass (skip-unchanged, prune, GC) instead of
 /// a full ingest.
-pub fn run_scan(db_path: &Path, backing_dir: &Path, revalidate: bool) -> Result<()> {
+pub fn run_scan(db_path: &Path, backing_dir: &Path, revalidate: bool, jobs: usize) -> Result<()> {
     let db =
         Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
+    let opts = musefs_core::ScanOptions { jobs };
     if revalidate {
-        let stats = musefs_core::revalidate(&db, backing_dir)
+        let stats = musefs_core::revalidate_with(&db, backing_dir, &opts)
             .with_context(|| format!("revalidating {}", backing_dir.display()))?;
         println!(
             "revalidated: {} updated, {} unchanged, {} pruned, {} failed",
             stats.updated, stats.unchanged, stats.pruned, stats.failed
         );
     } else {
-        let stats = musefs_core::scan_directory(&db, backing_dir)
+        let stats = musefs_core::scan_directory_with(&db, backing_dir, &opts)
             .with_context(|| format!("scanning {}", backing_dir.display()))?;
         println!(
             "scanned {} file(s), skipped {}, failed {}",
@@ -182,7 +186,8 @@ pub fn run(cli: Cli) -> Result<()> {
             backing_dir,
             db,
             revalidate,
-        } => run_scan(&db, &backing_dir, revalidate),
+            jobs,
+        } => run_scan(&db, &backing_dir, revalidate, jobs),
         Command::Mount {
             mountpoint,
             db,
@@ -206,5 +211,21 @@ pub fn run(cli: Cli) -> Result<()> {
             max_background,
             keep_cache,
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_command_parses_jobs_flag() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "scan", "/m", "--db", "/tmp/x.db", "--jobs", "3"])
+            .unwrap();
+        match cli.command {
+            Command::Scan { jobs, .. } => assert_eq!(jobs, 3),
+            Command::Mount { .. } => panic!("expected Scan"),
+        }
     }
 }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -99,15 +99,15 @@ pub fn run_scan(db_path: &Path, backing_dir: &Path, revalidate: bool) -> Result<
         let stats = musefs_core::revalidate(&db, backing_dir)
             .with_context(|| format!("revalidating {}", backing_dir.display()))?;
         println!(
-            "revalidated: {} updated, {} unchanged, {} pruned",
-            stats.updated, stats.unchanged, stats.pruned
+            "revalidated: {} updated, {} unchanged, {} pruned, {} failed",
+            stats.updated, stats.unchanged, stats.pruned, stats.failed
         );
     } else {
         let stats = musefs_core::scan_directory(&db, backing_dir)
             .with_context(|| format!("scanning {}", backing_dir.display()))?;
         println!(
-            "scanned {} file(s), skipped {}",
-            stats.scanned, stats.skipped
+            "scanned {} file(s), skipped {}, failed {}",
+            stats.scanned, stats.skipped, stats.failed
         );
     }
     Ok(())

--- a/musefs-cli/tests/scan.rs
+++ b/musefs-cli/tests/scan.rs
@@ -54,7 +54,7 @@ fn scan_ingests_flacs_into_a_fresh_db() {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("musefs.db");
 
-    run_scan(&db_path, backing.path(), false).unwrap();
+    run_scan(&db_path, backing.path(), false, 0).unwrap();
 
     // The DB file was created and persists the track.
     let db = musefs_db::Db::open(&db_path).unwrap();

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -63,4 +63,84 @@ mod tests {
         h.join().unwrap();
         b.release(5);
     }
+
+    /// Spawn `acquire(n)` and report whether it completed within `wait` (i.e. did
+    /// NOT block). Always returns the join handle so the caller can drain it after
+    /// releasing the held budget.
+    fn acquire_completes_within(
+        b: &Arc<ByteBudget>,
+        n: u64,
+        wait: std::time::Duration,
+    ) -> (bool, std::thread::JoinHandle<()>) {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let done = Arc::new(AtomicBool::new(false));
+        let b2 = Arc::clone(b);
+        let done2 = Arc::clone(&done);
+        let h = std::thread::spawn(move || {
+            b2.acquire(n);
+            done2.store(true, Ordering::SeqCst);
+        });
+        std::thread::sleep(wait);
+        (done.load(Ordering::SeqCst), h)
+    }
+
+    /// Accumulation must be additive: from idle, `acquire(4)` then `acquire(7)`
+    /// (4+7=11 > cap 10) MUST block. This pins `*in_flight += n` (line 32):
+    ///   - no-op (`acquire` body → `()`): in_flight stays 0, so the 2nd acquire
+    ///     sees 0 and admits 7 (7 <= 10) → would NOT block → killed.
+    ///   - `+=`→`*=`: first acquire makes 0*4 = 0, so in_flight stays 0 and the
+    ///     2nd acquire admits → would NOT block → killed.
+    // kills byte_budget L24 acquire→no-op and L32 `+=`→`*=`
+    #[test]
+    fn accumulates_additively_then_blocks() {
+        let wait = std::time::Duration::from_millis(100);
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(4); // in_flight = 4 (must be > 0 and == 4 for the next to block)
+        let (completed, h) = acquire_completes_within(&b, 7, wait);
+        assert!(
+            !completed,
+            "4+7=11 > cap 10 must block; if it completed, accounting is not additive"
+        );
+        b.release(4); // unblocks the spawned acquire(7)
+        h.join().unwrap();
+        b.release(7);
+    }
+
+    /// Boundary: `in_flight + n == cap` is admitted (guard is strictly `> cap`).
+    /// From idle, `acquire(6)` then `acquire(4)` → 6+4 == 10, `10 > 10` false →
+    /// must NOT block. Kills L29 `>`→`>=` (`10>=10` true → block) and `>`→`==`
+    /// (`10==10` true → block).
+    // kills byte_budget L29 `>`→`>=` and `>`→`==`
+    #[test]
+    fn exact_cap_is_admitted() {
+        let wait = std::time::Duration::from_millis(100);
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(6); // in_flight = 6
+        let (completed, h) = acquire_completes_within(&b, 4, wait);
+        assert!(
+            completed,
+            "6+4 == cap 10 must be admitted (guard is `> cap`, not `>=`/`==`)"
+        );
+        h.join().unwrap();
+        b.release(6);
+        b.release(4);
+    }
+
+    /// Over cap blocks: `acquire(6)` then `acquire(8)` → 6+8=14, `14 > 10` true →
+    /// must block. Kills L29 `>`→`<` (`14 < 10` false → wrongly admitted).
+    // kills byte_budget L29 `>`→`<`
+    #[test]
+    fn over_cap_blocks() {
+        let wait = std::time::Duration::from_millis(100);
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(6); // in_flight = 6 (nonzero, so guard is evaluated)
+        let (completed, h) = acquire_completes_within(&b, 8, wait);
+        assert!(
+            !completed,
+            "6+8=14 > cap 10 must block; if it completed, the guard admitted an over-cap reservation"
+        );
+        b.release(6); // unblocks the spawned acquire(8) (idle → admitted alone)
+        h.join().unwrap();
+        b.release(8);
+    }
 }

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -23,7 +23,10 @@ impl ByteBudget {
     /// cap is admitted alone once in-flight is zero, to guarantee progress).
     pub fn acquire(&self, n: u64) {
         let mut in_flight = self.state.lock().unwrap();
-        while *in_flight != 0 && *in_flight + n > self.cap {
+        // `saturating_add` mirrors `release`'s saturating style; art weights are
+        // file-bounded so this never saturates in practice, but it keeps the
+        // guard total-order-safe regardless.
+        while *in_flight != 0 && in_flight.saturating_add(n) > self.cap {
             in_flight = self.cv.wait(in_flight).unwrap();
         }
         *in_flight += n;

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -1,0 +1,63 @@
+//! A byte-accounted semaphore: producers reserve N bytes before holding a value,
+//! blocking until the in-flight total would stay within the cap; the consumer
+//! releases bytes after persisting. Bounds peak in-flight art memory.
+
+use std::sync::{Condvar, Mutex};
+
+pub struct ByteBudget {
+    cap: u64,
+    state: Mutex<u64>,
+    cv: Condvar,
+}
+
+impl ByteBudget {
+    pub fn new(cap: u64) -> Self {
+        Self {
+            cap,
+            state: Mutex::new(0),
+            cv: Condvar::new(),
+        }
+    }
+
+    /// Reserve `n` bytes, blocking until they fit (a single item larger than the
+    /// cap is admitted alone once in-flight is zero, to guarantee progress).
+    pub fn acquire(&self, n: u64) {
+        let mut in_flight = self.state.lock().unwrap();
+        while *in_flight != 0 && *in_flight + n > self.cap {
+            in_flight = self.cv.wait(in_flight).unwrap();
+        }
+        *in_flight += n;
+    }
+
+    /// Release `n` previously reserved bytes.
+    pub fn release(&self, n: u64) {
+        let mut in_flight = self.state.lock().unwrap();
+        *in_flight = in_flight.saturating_sub(n);
+        self.cv.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn oversized_item_admitted_when_idle() {
+        let b = ByteBudget::new(10);
+        b.acquire(1000); // larger than cap, but in-flight was 0 → admitted
+        b.release(1000);
+    }
+
+    #[test]
+    fn blocks_until_release() {
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(10);
+        let b2 = Arc::clone(&b);
+        let h = std::thread::spawn(move || b2.acquire(5)); // must block
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        b.release(10); // unblocks the spawned acquire
+        h.join().unwrap();
+        b.release(5);
+    }
+}

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -43,67 +43,91 @@ impl ByteBudget {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::time::Duration;
 
-    #[test]
-    fn oversized_item_admitted_when_idle() {
-        let b = ByteBudget::new(10);
-        b.acquire(1000); // larger than cap, but in-flight was 0 → admitted
-        b.release(1000);
-    }
+    const WAIT: Duration = Duration::from_millis(100);
 
-    #[test]
-    fn blocks_until_release() {
-        let b = Arc::new(ByteBudget::new(10));
-        b.acquire(10);
-        let b2 = Arc::clone(&b);
-        let h = std::thread::spawn(move || b2.acquire(5)); // must block
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        b.release(10); // unblocks the spawned acquire
-        h.join().unwrap();
-        b.release(5);
-    }
-
-    /// Spawn `acquire(n)` and report whether it completed within `wait` (i.e. did
-    /// NOT block). Always returns the join handle so the caller can drain it after
-    /// releasing the held budget.
-    fn acquire_completes_within(
-        b: &Arc<ByteBudget>,
-        n: u64,
-        wait: std::time::Duration,
-    ) -> (bool, std::thread::JoinHandle<()>) {
-        use std::sync::atomic::{AtomicBool, Ordering};
+    /// Spawn `acquire(n)` on a worker and report whether it completed within `wait`
+    /// (i.e. did NOT block).
+    ///
+    /// Deliberately does NOT join the worker: a mutation that turns `acquire` (or
+    /// `release`, called by the test afterwards) into a deadlock would make a join
+    /// hang forever, which cargo-mutants reports as TIMEOUT (≈20s, fails the gate)
+    /// instead of a fast CAUGHT. By polling a flag and leaking any still-blocked
+    /// worker (the test harness reaps it at process exit), every such mutation is
+    /// caught in ~`wait` by a normal assertion. Tests must never `acquire` on the
+    /// main thread for the same reason — only the never-blocking setup `acquire`s
+    /// (from idle, which short-circuits the guard) run inline.
+    fn completes_within(b: &Arc<ByteBudget>, n: u64, wait: Duration) -> bool {
         let done = Arc::new(AtomicBool::new(false));
         let b2 = Arc::clone(b);
         let done2 = Arc::clone(&done);
-        let h = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             b2.acquire(n);
             done2.store(true, Ordering::SeqCst);
         });
         std::thread::sleep(wait);
-        (done.load(Ordering::SeqCst), h)
+        done.load(Ordering::SeqCst)
+    }
+
+    /// From idle, an item larger than the cap is admitted alone (guarantees
+    /// progress). Run on a worker: the `!=`→`==` and `&&`→`||` mutants both turn
+    /// this into an infinite wait (`0 == 0 && 1000 > 10` / `0 != 0 || 1000 > 10`
+    /// both stay true with nothing to release), so a hang here means CAUGHT.
+    // kills byte_budget L29 `!=`→`==` and `&&`→`||`
+    #[test]
+    fn oversized_item_admitted_when_idle() {
+        let b = Arc::new(ByteBudget::new(10));
+        assert!(
+            completes_within(&b, 1000, WAIT),
+            "an oversized item must be admitted alone from idle (else acquire deadlocks)"
+        );
+    }
+
+    /// A blocked reservation proceeds once enough is released. Pins `release`
+    /// (line 37): if it is a no-op the worker never unblocks → not completed.
+    // kills byte_budget L37 release→no-op
+    #[test]
+    fn blocked_acquire_proceeds_after_release() {
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(10); // idle → admitted inline (never blocks under any single mutation)
+        let done = Arc::new(AtomicBool::new(false));
+        let b2 = Arc::clone(&b);
+        let done2 = Arc::clone(&done);
+        std::thread::spawn(move || {
+            b2.acquire(5); // 10+5 > 10 → blocks until release
+            done2.store(true, Ordering::SeqCst);
+        });
+        std::thread::sleep(WAIT);
+        assert!(
+            !done.load(Ordering::SeqCst),
+            "acquire(5) must block while full"
+        );
+        b.release(10); // unblocks the worker — unless release was mutated to a no-op
+        std::thread::sleep(WAIT);
+        assert!(
+            done.load(Ordering::SeqCst),
+            "acquire(5) must proceed after release(10); a no-op release leaves it blocked"
+        );
     }
 
     /// Accumulation must be additive: from idle, `acquire(4)` then `acquire(7)`
-    /// (4+7=11 > cap 10) MUST block. This pins `*in_flight += n` (line 32):
+    /// (4+7=11 > cap 10) MUST block. Pins `*in_flight += n` (line 32) and the
+    /// acquire body:
     ///   - no-op (`acquire` body → `()`): in_flight stays 0, so the 2nd acquire
-    ///     sees 0 and admits 7 (7 <= 10) → would NOT block → killed.
-    ///   - `+=`→`*=`: first acquire makes 0*4 = 0, so in_flight stays 0 and the
-    ///     2nd acquire admits → would NOT block → killed.
-    // kills byte_budget L24 acquire→no-op and L32 `+=`→`*=`
+    ///     sees 0 and admits 7 → would NOT block → killed.
+    ///   - `+=`→`*=`: first acquire makes 0*4 = 0, so in_flight stays 0 → killed.
+    // kills byte_budget L25 acquire→no-op and L32 `+=`→`*=`
     #[test]
     fn accumulates_additively_then_blocks() {
-        let wait = std::time::Duration::from_millis(100);
         let b = Arc::new(ByteBudget::new(10));
-        b.acquire(4); // in_flight = 4 (must be > 0 and == 4 for the next to block)
-        let (completed, h) = acquire_completes_within(&b, 7, wait);
+        b.acquire(4); // idle → admitted inline; in_flight = 4
         assert!(
-            !completed,
+            !completes_within(&b, 7, WAIT),
             "4+7=11 > cap 10 must block; if it completed, accounting is not additive"
         );
-        b.release(4); // unblocks the spawned acquire(7)
-        h.join().unwrap();
-        b.release(7);
     }
 
     /// Boundary: `in_flight + n == cap` is admitted (guard is strictly `> cap`).
@@ -113,17 +137,12 @@ mod tests {
     // kills byte_budget L29 `>`→`>=` and `>`→`==`
     #[test]
     fn exact_cap_is_admitted() {
-        let wait = std::time::Duration::from_millis(100);
         let b = Arc::new(ByteBudget::new(10));
-        b.acquire(6); // in_flight = 6
-        let (completed, h) = acquire_completes_within(&b, 4, wait);
+        b.acquire(6); // idle → admitted inline; in_flight = 6
         assert!(
-            completed,
+            completes_within(&b, 4, WAIT),
             "6+4 == cap 10 must be admitted (guard is `> cap`, not `>=`/`==`)"
         );
-        h.join().unwrap();
-        b.release(6);
-        b.release(4);
     }
 
     /// Over cap blocks: `acquire(6)` then `acquire(8)` → 6+8=14, `14 > 10` true →
@@ -131,16 +150,11 @@ mod tests {
     // kills byte_budget L29 `>`→`<`
     #[test]
     fn over_cap_blocks() {
-        let wait = std::time::Duration::from_millis(100);
         let b = Arc::new(ByteBudget::new(10));
-        b.acquire(6); // in_flight = 6 (nonzero, so guard is evaluated)
-        let (completed, h) = acquire_completes_within(&b, 8, wait);
+        b.acquire(6); // idle → admitted inline; in_flight = 6
         assert!(
-            !completed,
+            !completes_within(&b, 8, WAIT),
             "6+8=14 > cap 10 must block; if it completed, the guard admitted an over-cap reservation"
         );
-        b.release(6); // unblocks the spawned acquire(8) (idle → admitted alone)
-        h.join().unwrap();
-        b.release(8);
     }
 }

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -13,6 +13,7 @@ pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
 pub use facade::{Attr, Mode, MountConfig, Musefs};
 pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
+pub use scan::scan_directory_full_oracle;
 pub use scan::{revalidate, scan_directory, RevalidateStats, ScanStats};
 pub use template::render_path;
 pub use tree::{Node, NodeKind, VirtualTree};

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -16,7 +16,8 @@ pub use facade::{Attr, Mode, MountConfig, Musefs};
 pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{
-    revalidate, scan_directory, scan_directory_with, RevalidateStats, ScanOptions, ScanStats,
+    revalidate, revalidate_with, scan_directory, scan_directory_with, RevalidateStats, ScanOptions,
+    ScanStats,
 };
 pub use template::render_path;
 pub use tree::{Node, NodeKind, VirtualTree};

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -1,3 +1,4 @@
+mod byte_budget;
 mod db_pool;
 mod error;
 mod facade;
@@ -14,6 +15,8 @@ pub use error::{CoreError, Result};
 pub use facade::{Attr, Mode, MountConfig, Musefs};
 pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
 pub use scan::scan_directory_full_oracle;
-pub use scan::{revalidate, scan_directory, RevalidateStats, ScanStats};
+pub use scan::{
+    revalidate, scan_directory, scan_directory_with, RevalidateStats, ScanOptions, ScanStats,
+};
 pub use template::render_path;
 pub use tree::{Node, NodeKind, VirtualTree};

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -8,6 +8,9 @@
 //! internal positioned reads (via the page server) and art-blob reads are
 //! tracked by call count (`on_open`/`on_art_chunk`) but are not byte-counted.
 //! `on_open` fires on the open *attempt* (a failed open is still a syscall).
+//! `on_scan_open`/`on_scan_read` count backing-file opens and positioned reads
+//! on the *scan* path (distinct from the serve path); `on_scan_read` also
+//! accumulates bytes read, analogous to `on_pread`.
 
 pub use imp::*;
 

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -22,6 +22,9 @@ mod imp {
     static PREADS: AtomicU64 = AtomicU64::new(0);
     static PREAD_BYTES: AtomicU64 = AtomicU64::new(0);
     static ART_CHUNKS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
 
     /// Sleep for the duration named by `var` (microseconds), parsed once.
     fn fault(var: &'static str, cell: &OnceLock<Option<Duration>>) {
@@ -60,6 +63,17 @@ mod imp {
         ART_CHUNKS.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// One backing-file open on the *scan* path (distinct from serve-path `on_open`).
+    pub fn on_scan_open() {
+        SCAN_OPENS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// One positioned scan-path read of `bytes` bytes (prefix, widen, or tail read).
+    pub fn on_scan_read(bytes: u64) {
+        SCAN_PREADS.fetch_add(1, Ordering::Relaxed);
+        SCAN_BYTES_READ.fetch_add(bytes, Ordering::Relaxed);
+    }
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub struct Snapshot {
         pub opens: u64,
@@ -67,6 +81,9 @@ mod imp {
         pub preads: u64,
         pub pread_bytes: u64,
         pub art_chunks: u64,
+        pub scan_opens: u64,
+        pub scan_preads: u64,
+        pub scan_bytes_read: u64,
     }
 
     pub fn snapshot() -> Snapshot {
@@ -76,6 +93,9 @@ mod imp {
             preads: PREADS.load(Ordering::Relaxed),
             pread_bytes: PREAD_BYTES.load(Ordering::Relaxed),
             art_chunks: ART_CHUNKS.load(Ordering::Relaxed),
+            scan_opens: SCAN_OPENS.load(Ordering::Relaxed),
+            scan_preads: SCAN_PREADS.load(Ordering::Relaxed),
+            scan_bytes_read: SCAN_BYTES_READ.load(Ordering::Relaxed),
         }
     }
 
@@ -85,6 +105,9 @@ mod imp {
         PREADS.store(0, Ordering::Relaxed);
         PREAD_BYTES.store(0, Ordering::Relaxed);
         ART_CHUNKS.store(0, Ordering::Relaxed);
+        SCAN_OPENS.store(0, Ordering::Relaxed);
+        SCAN_PREADS.store(0, Ordering::Relaxed);
+        SCAN_BYTES_READ.store(0, Ordering::Relaxed);
     }
 }
 
@@ -97,6 +120,9 @@ mod imp {
         pub preads: u64,
         pub pread_bytes: u64,
         pub art_chunks: u64,
+        pub scan_opens: u64,
+        pub scan_preads: u64,
+        pub scan_bytes_read: u64,
     }
 
     #[inline(always)]
@@ -107,6 +133,10 @@ mod imp {
     pub fn on_pread(_bytes: u64) {}
     #[inline(always)]
     pub fn on_art_chunk() {}
+    #[inline(always)]
+    pub fn on_scan_open() {}
+    #[inline(always)]
+    pub fn on_scan_read(_bytes: u64) {}
     #[inline(always)]
     pub fn snapshot() -> Snapshot {
         Snapshot::default()
@@ -131,6 +161,20 @@ mod tests {
         assert_eq!(s.preads, 1);
         assert_eq!(s.pread_bytes, 100);
         assert_eq!(s.art_chunks, 1);
+        reset();
+        assert_eq!(snapshot(), Snapshot::default());
+    }
+
+    #[test]
+    fn scan_counters_accumulate_and_reset() {
+        reset();
+        on_scan_open();
+        on_scan_read(4096);
+        on_scan_read(128);
+        let s = snapshot();
+        assert_eq!(s.scan_opens, 1);
+        assert_eq!(s.scan_preads, 2);
+        assert_eq!(s.scan_bytes_read, 4096 + 128);
         reset();
         assert_eq!(snapshot(), Snapshot::default());
     }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -4,7 +4,12 @@ use std::path::{Path, PathBuf};
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedPicture, Extent};
 
+use crate::byte_budget::ByteBudget;
 use crate::error::Result;
+use std::sync::mpsc::sync_channel;
+
+const BATCH_FILES: usize = 256;
+const BATCH_BYTES: u64 = 64 << 20; // 64 MiB
 
 /// Initial bounded-read window. Covers typical metadata + cover art; a larger
 /// metadata region triggers a `NeedMore` widen.
@@ -299,6 +304,32 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
     }
 }
 
+/// Knobs for a scan. `jobs == 0` means "use available parallelism".
+#[derive(Debug, Clone, Default)]
+pub struct ScanOptions {
+    pub jobs: usize,
+}
+
+fn effective_jobs(jobs: usize) -> usize {
+    if jobs != 0 {
+        return jobs;
+    }
+    std::thread::available_parallelism().map_or(1, std::num::NonZero::get)
+}
+
+/// One probed file ready to write, plus its art-byte weight for backpressure.
+struct Unit {
+    abs_path: String,
+    meta_len: u64,
+    meta_mtime: i64,
+    probed: Probed,
+    weight: u64,
+}
+
+fn art_weight(p: &Probed) -> u64 {
+    p.pictures.iter().map(|pic| pic.data.len() as u64).sum()
+}
+
 /// Upsert a track from a probed backing file: write the track row, replace its
 /// seeded tags, and ingest its embedded art (capped, deduped, clamped).
 fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
@@ -351,6 +382,62 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     Ok(())
 }
 
+/// Like `ingest`, but writes through a batch `BulkWriter`.
+fn ingest_bulk(
+    bw: &mut musefs_db::BulkWriter<'_>,
+    abs_path: &str,
+    meta_len: u64,
+    meta_mtime: i64,
+    probed: &Probed,
+) -> Result<()> {
+    let track_id = bw.upsert_track(&NewTrack {
+        backing_path: abs_path.to_string(),
+        format: probed.format,
+        audio_offset: probed.audio_offset as i64,
+        audio_length: probed.audio_length as i64,
+        backing_size: meta_len as i64,
+        backing_mtime: meta_mtime,
+    })?;
+
+    let mut tags = Vec::new();
+    let mut ordinals: HashMap<String, i64> = HashMap::new();
+    for (key, value) in &probed.tags {
+        let ord = ordinals.entry(key.clone()).or_insert(0);
+        tags.push(Tag::new(key, value, *ord));
+        *ord += 1;
+    }
+    bw.replace_tags(track_id, &tags)?;
+
+    let mut track_arts = Vec::new();
+    let accepted = probed
+        .pictures
+        .iter()
+        .filter(|p| p.data.len() <= MAX_ART_BYTES);
+    for (ordinal, pic) in accepted.enumerate() {
+        let art_id = bw.upsert_art(&NewArt {
+            mime: pic.mime.clone(),
+            width: (pic.width != 0).then_some(pic.width as i64),
+            height: (pic.height != 0).then_some(pic.height as i64),
+            data: pic.data.clone(),
+        })?;
+        let picture_type = if pic.picture_type <= 20 {
+            pic.picture_type as i64
+        } else {
+            0
+        };
+        track_arts.push(TrackArt {
+            art_id,
+            picture_type,
+            description: pic.description.clone(),
+            ordinal: ordinal as i64,
+        });
+    }
+    bw.set_track_art(track_id, &track_arts)?;
+    Ok(())
+}
+
+/// Public entry: parallel-probe / single-writer scan of `root`.
+///
 /// Insert/update a track row for each supported audio file (FLAC, MP3, M4A,
 /// Opus, Vorbis, FLAC-in-Ogg) under `root` (with audio bounds and validation
 /// stamps), seeding its tags from the file's existing metadata. `root` may be
@@ -358,7 +445,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
 /// recursively). Unsupported-format files increment `ScanStats::skipped`; files
 /// with a per-file I/O or parse error increment `ScanStats::failed` and do not
 /// abort the scan.
-pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
+pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
     let mut files = Vec::new();
     if root.is_file() {
         if is_supported_audio(root) {
@@ -367,33 +454,115 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
     } else {
         collect_audio(root, &mut files)?;
     }
+    db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
+    let stats = run_pipeline(db, files, opts)?;
+    Ok(stats)
+}
 
-    let mut stats = ScanStats {
-        scanned: 0,
-        skipped: 0,
-        failed: 0,
-    };
-    for path in files {
-        let Ok(meta) = std::fs::metadata(&path) else {
-            stats.failed += 1;
-            continue;
-        };
-        match probe_file(&path, meta.len()) {
-            Ok(Some(probed)) => {
-                // `canonicalize` is per-file I/O (a symlink target can vanish in
-                // the window after the walk), so keep it non-fatal like `metadata`.
-                let Ok(abs) = std::fs::canonicalize(&path) else {
-                    stats.failed += 1;
-                    continue;
-                };
-                ingest(db, &abs.to_string_lossy(), &meta, probed)?;
-                stats.scanned += 1;
+/// Back-compat shim used by the CLI and existing tests.
+pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
+    scan_directory_with(db, root, &ScanOptions::default())
+}
+
+/// Probe `files` across `jobs` workers (no DB access) and write the results from a
+/// single writer (this thread) in batched transactions. Per-file errors are
+/// counted, not fatal.
+fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<ScanStats> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    let jobs = effective_jobs(opts.jobs);
+    let budget = Arc::new(ByteBudget::new(BATCH_BYTES));
+    let skipped = Arc::new(AtomicU64::new(0));
+    let failed = Arc::new(AtomicU64::new(0));
+
+    // Work queue: a shared iterator behind a mutex (cheap; probing dominates).
+    let work = Arc::new(std::sync::Mutex::new(files.into_iter()));
+    let (tx, rx) = sync_channel::<Unit>(jobs * 2);
+
+    let mut workers = Vec::with_capacity(jobs);
+    for _ in 0..jobs {
+        let work = Arc::clone(&work);
+        let tx = tx.clone();
+        let budget = Arc::clone(&budget);
+        let skipped = Arc::clone(&skipped);
+        let failed = Arc::clone(&failed);
+        workers.push(std::thread::spawn(move || loop {
+            let next = { work.lock().unwrap().next() };
+            let Some(path) = next else { break };
+            let Ok(meta) = std::fs::metadata(&path) else {
+                failed.fetch_add(1, Ordering::Relaxed);
+                continue;
+            };
+            match probe_file(&path, meta.len()) {
+                Ok(Some(probed)) => {
+                    let Ok(abs) = std::fs::canonicalize(&path) else {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    };
+                    let weight = art_weight(&probed);
+                    budget.acquire(weight); // backpressure on in-flight art bytes
+                    let unit = Unit {
+                        abs_path: abs.to_string_lossy().into_owned(),
+                        meta_len: meta.len(),
+                        meta_mtime: mtime_secs(&meta),
+                        probed,
+                        weight,
+                    };
+                    if tx.send(unit).is_err() {
+                        budget.release(weight);
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    skipped.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(_) => {
+                    failed.fetch_add(1, Ordering::Relaxed);
+                }
             }
-            Ok(None) => stats.skipped += 1,
-            Err(_) => stats.failed += 1,
+        }));
+    }
+    drop(tx); // close the channel once all clones (workers) finish
+
+    // Writer: this thread. Batch by file count and accumulated art bytes.
+    let mut scanned = 0u64;
+    let mut batch: Vec<Unit> = Vec::new();
+    let mut batch_bytes = 0u64;
+    let flush = |batch: &mut Vec<Unit>, batch_bytes: &mut u64, scanned: &mut u64| -> Result<()> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let mut bw = db.bulk_writer()?;
+        for u in batch.iter() {
+            ingest_bulk(&mut bw, &u.abs_path, u.meta_len, u.meta_mtime, &u.probed)?;
+            *scanned += 1;
+        }
+        bw.commit()?;
+        for u in batch.drain(..) {
+            budget.release(u.weight);
+        }
+        *batch_bytes = 0;
+        Ok(())
+    };
+
+    for unit in rx {
+        batch_bytes += unit.weight;
+        batch.push(unit);
+        if batch.len() >= BATCH_FILES || batch_bytes >= BATCH_BYTES {
+            flush(&mut batch, &mut batch_bytes, &mut scanned)?;
         }
     }
-    Ok(stats)
+    flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+    for w in workers {
+        let _ = w.join();
+    }
+
+    Ok(ScanStats {
+        scanned,
+        skipped: skipped.load(Ordering::Relaxed),
+        failed: failed.load(Ordering::Relaxed),
+    })
 }
 
 /// Test/oracle only: scan using the legacy whole-file probe (`probe_full`). The
@@ -895,5 +1064,33 @@ mod bounded_probe_tests {
             .unwrap();
         assert_eq!(track.audio_offset as u64, full.audio_offset);
         assert_eq!(track.audio_length as u64, full.audio_length);
+    }
+
+    #[test]
+    fn jobs1_and_jobs_n_produce_equivalent_state() {
+        let dir = tempfile::tempdir().unwrap();
+        // A handful of distinct FLACs.
+        for i in 0..12 {
+            let mut bytes = b"fLaC".to_vec();
+            bytes.push(0x80);
+            bytes.extend_from_slice(&[0, 0, 34]);
+            bytes.extend(std::iter::repeat_n(0u8, 34));
+            bytes.extend_from_slice(format!("AUDIO-{i}").as_bytes());
+            std::fs::write(dir.path().join(format!("t{i}.flac")), &bytes).unwrap();
+        }
+        let norm = |jobs: usize| {
+            let db = Db::open_in_memory().unwrap();
+            scan_directory_with(&db, dir.path(), &ScanOptions { jobs }).unwrap();
+            let mut rows: Vec<(String, i64, i64)> = db
+                .list_tracks()
+                .unwrap()
+                .into_iter()
+                .map(|t| (t.backing_path, t.audio_offset, t.audio_length))
+                .collect();
+            rows.sort();
+            rows
+        };
+        assert_eq!(norm(1), norm(4));
+        assert_eq!(norm(1).len(), 12);
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -166,6 +166,11 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
 /// per format, widening on `NeedMore`. Never reads the audio payload (M4A uses
 /// the seek reader; front-anchored formats read only the metadata extent).
 /// Returns `Ok(None)` for an unsupported/unparseable file (to be skipped).
+///
+/// Metrics note: `on_scan_read` counts the front-anchored prefix/widen/tail
+/// reads only. The M4A seek reader does its own positioned reads internally, so
+/// its bytes are not reflected in `SCAN_BYTES_READ` (only `on_scan_open` fires
+/// for M4A); its win shows up in wall time and peak RSS instead.
 fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -317,6 +317,17 @@ fn effective_jobs(jobs: usize) -> usize {
     std::thread::available_parallelism().map_or(1, std::num::NonZero::get)
 }
 
+/// In-flight art-byte budget (and per-batch byte-flush threshold). Overridable via
+/// `MUSEFS_BATCH_BYTES` so tests can exercise the backpressure path without 64 MiB
+/// of fixture art; defaults to `BATCH_BYTES`.
+fn batch_bytes_cap() -> u64 {
+    std::env::var("MUSEFS_BATCH_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(BATCH_BYTES)
+}
+
 /// One probed file ready to write, plus its art-byte weight for backpressure.
 struct Unit {
     abs_path: String,
@@ -472,7 +483,8 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
     use std::sync::Arc;
 
     let jobs = effective_jobs(opts.jobs);
-    let budget = Arc::new(ByteBudget::new(BATCH_BYTES));
+    let cap = batch_bytes_cap();
+    let budget = Arc::new(ByteBudget::new(cap));
     let skipped = Arc::new(AtomicU64::new(0));
     let failed = Arc::new(AtomicU64::new(0));
 
@@ -546,11 +558,38 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         Ok(())
     };
 
-    for unit in rx {
-        batch_bytes += unit.weight;
-        batch.push(unit);
-        if batch.len() >= BATCH_FILES || batch_bytes >= BATCH_BYTES {
-            flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+    // Drain the channel, batching by file count and accumulated art bytes. The
+    // budget cap equals the byte-flush threshold, so a worker calling
+    // `budget.acquire` (which it does *before* `send`) could block while the
+    // writer's pending batch sits just below the threshold — if the writer then
+    // parked on a blocking `recv`, neither side could make progress (the held
+    // budget is never released, the batch never reaches the threshold). To avoid
+    // that, whenever the channel momentarily drains we flush the pending batch —
+    // releasing the budget so blocked producers proceed — *before* blocking on the
+    // next item.
+    loop {
+        match rx.try_recv() {
+            Ok(unit) => {
+                batch_bytes += unit.weight;
+                batch.push(unit);
+                if batch.len() >= BATCH_FILES || batch_bytes >= cap {
+                    flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+                }
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+                match rx.recv() {
+                    Ok(unit) => {
+                        batch_bytes += unit.weight;
+                        batch.push(unit);
+                        if batch.len() >= BATCH_FILES || batch_bytes >= cap {
+                            flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+                        }
+                    }
+                    Err(_) => break, // all workers finished; channel closed
+                }
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
         }
     }
     flush(&mut batch, &mut batch_bytes, &mut scanned)?;

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -554,6 +554,10 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         }
     }
     flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+    // A fatal flush error above returns via `?` *before* this join, abandoning the
+    // worker threads — acceptable because a DB-write failure aborts the whole scan.
+    // On the success path every worker has already exited (the work queue drained
+    // and `drop(tx)` closed the channel), so these joins return promptly.
     for w in workers {
         let _ = w.join();
     }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -22,6 +22,7 @@ const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
 pub struct ScanStats {
     pub scanned: u64,
     pub skipped: u64,
+    pub failed: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +30,7 @@ pub struct RevalidateStats {
     pub updated: u64,
     pub unchanged: u64,
     pub pruned: u64,
+    pub failed: u64,
 }
 
 fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
@@ -367,16 +369,22 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
     let mut stats = ScanStats {
         scanned: 0,
         skipped: 0,
+        failed: 0,
     };
     for path in files {
-        let meta = std::fs::metadata(&path)?;
-        let Some(probed) = probe_file(&path, meta.len())? else {
-            stats.skipped += 1;
+        let Ok(meta) = std::fs::metadata(&path) else {
+            stats.failed += 1;
             continue;
         };
-        let abs = std::fs::canonicalize(&path)?;
-        ingest(db, &abs.to_string_lossy(), &meta, probed)?;
-        stats.scanned += 1;
+        match probe_file(&path, meta.len()) {
+            Ok(Some(probed)) => {
+                let abs = std::fs::canonicalize(&path)?;
+                ingest(db, &abs.to_string_lossy(), &meta, probed)?;
+                stats.scanned += 1;
+            }
+            Ok(None) => stats.skipped += 1,
+            Err(_) => stats.failed += 1,
+        }
     }
     Ok(stats)
 }
@@ -396,6 +404,7 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
     let mut stats = ScanStats {
         scanned: 0,
         skipped: 0,
+        failed: 0,
     };
     for path in files {
         let bytes = std::fs::read(&path)?;
@@ -425,10 +434,17 @@ pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
         updated: 0,
         unchanged: 0,
         pruned: 0,
+        failed: 0,
     };
     for path in files {
-        let meta = std::fs::metadata(&path)?;
-        let abs = std::fs::canonicalize(&path)?;
+        let Ok(meta) = std::fs::metadata(&path) else {
+            stats.failed += 1;
+            continue;
+        };
+        let Ok(abs) = std::fs::canonicalize(&path) else {
+            stats.failed += 1;
+            continue;
+        };
         let abs_str = abs.to_string_lossy().to_string();
 
         if let Some(existing) = db.get_track_by_path(&abs_str)? {
@@ -440,11 +456,16 @@ pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
             }
         }
 
-        let Some(probed) = probe_file(&path, meta.len())? else {
-            continue;
-        };
-        ingest(db, &abs_str, &meta, probed)?;
-        stats.updated += 1;
+        match probe_file(&path, meta.len()) {
+            Ok(Some(probed)) => {
+                ingest(db, &abs_str, &meta, probed)?;
+                stats.updated += 1;
+            }
+            Ok(None) => {}
+            Err(_) => {
+                stats.failed += 1;
+            }
+        }
     }
 
     // Prune tracks under `root` whose backing file is gone. Scoped to `root` so a
@@ -826,6 +847,25 @@ mod bounded_probe_tests {
         bytes.extend(std::iter::repeat_n(0u8, 34));
         bytes.extend_from_slice(b"AUDIOPAYLOAD");
         bytes
+    }
+
+    #[test]
+    fn scan_counts_unreadable_file_as_failed_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        // One good FLAC + one zero-byte ".flac" that cannot parse.
+        let good = dir.path().join("good.flac");
+        let mut bytes = b"fLaC".to_vec();
+        bytes.push(0x80);
+        bytes.extend_from_slice(&[0, 0, 34]);
+        bytes.extend(std::iter::repeat_n(0u8, 34));
+        bytes.extend_from_slice(b"AUDIO");
+        std::fs::write(&good, &bytes).unwrap();
+        std::fs::write(dir.path().join("bad.flac"), b"").unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = scan_directory(&db, dir.path()).unwrap();
+        assert_eq!(stats.scanned, 1);
+        assert_eq!(stats.skipped + stats.failed, 1);
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -718,6 +718,153 @@ pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
 }
 
 #[cfg(test)]
+mod scan_unit_tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    /// Env is process-global: serialize the env-mutating tests so they never
+    /// observe each other's `MUSEFS_*` vars.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // --- scan_window() / WINDOW (lines 16, 149-154) ---
+
+    // kills scan L16 WINDOW `<<`→`>>` (default must be 1<<20, not 1>>20==0)
+    // kills scan L153 filter `>`→`>=`/`==`/`<`
+    #[test]
+    fn scan_window_default_and_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // Default (unset): WINDOW == 1<<20. `1>>20` == 0 → distinguishes the shift.
+        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+        assert_eq!(scan_window(), 1 << 20);
+        assert_eq!(scan_window(), 1_048_576);
+
+        // "0" is filtered out (`0 > 0` is false) → falls back to WINDOW.
+        // Under `>=`/`==`, `0` would be kept and returned (wrong).
+        std::env::set_var("MUSEFS_SCAN_WINDOW", "0");
+        assert_eq!(
+            scan_window(),
+            1 << 20,
+            "zero must be filtered → default window"
+        );
+
+        // "5" passes the filter (`5 > 0`) → returned verbatim. Under `<`,
+        // `5 < 0` is false → 5 would be filtered → default (wrong).
+        std::env::set_var("MUSEFS_SCAN_WINDOW", "5");
+        assert_eq!(scan_window(), 5, "positive override must pass the filter");
+
+        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+    }
+
+    // --- read_tail_128() (lines 170-178) ---
+
+    fn write_temp(name: &str, bytes: &[u8]) -> (tempfile::TempDir, std::fs::File) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(bytes)
+            .unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        (dir, file)
+    }
+
+    // kills scan L171 `<`→`<=` (128-byte file must be Some)
+    // kills scan L172 Ok(None) constant, L178 Ok(Some) value
+    // kills scan L176 `file_len - 128`→`/` (offset 0 vs 1 shifts the bytes)
+    // kills scan L175 buf init [0;128]/[1;128] constants (exact bytes asserted)
+    #[test]
+    fn read_tail_128_exact_128_bytes() {
+        // Distinct, position-sensitive pattern: byte[i] = i (0..=127).
+        let pattern: Vec<u8> = (0u8..128).collect();
+        let (_dir, file) = write_temp("tail128.bin", &pattern);
+
+        let tail = read_tail_128(&file, 128).unwrap();
+        let expected: [u8; 128] = pattern.clone().try_into().unwrap();
+        // Exact equality kills:
+        //  - Ok(None) (would be None, not Some)
+        //  - [0;128]/[1;128] buf-init constants (would mismatch the pattern)
+        //  - `<`→`<=` (128<=128 true → returns None for a 128-byte file)
+        //  - `-`→`/` (offset 128/128==1 reads bytes[1..], shifting the pattern)
+        assert_eq!(tail, Some(expected));
+    }
+
+    // kills scan L171 `<`→`<=` boundary the other way (127 bytes → None)
+    #[test]
+    fn read_tail_128_short_file_is_none() {
+        let (_dir, file) = write_temp("tail127.bin", &[0xABu8; 127]);
+        assert_eq!(read_tail_128(&file, 127).unwrap(), None);
+    }
+
+    // --- effective_jobs() (lines 313-318) ---
+
+    // kills scan L314 effective_jobs body→1 (assuming parallelism > 1)
+    #[test]
+    fn effective_jobs_zero_uses_parallelism_and_nonzero_passes_through() {
+        let par = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+        assert_eq!(effective_jobs(0), par);
+        assert_eq!(effective_jobs(4), 4);
+        assert_eq!(effective_jobs(1), 1);
+    }
+
+    // --- batch_bytes_cap() / BATCH_BYTES (lines 323-329) ---
+
+    // kills scan L324 batch_bytes_cap body→0/→1 (default must be BATCH_BYTES)
+    // kills scan L327 filter `>`→`>=`/`==`/`<`
+    #[test]
+    fn batch_bytes_cap_default_and_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MUSEFS_BATCH_BYTES");
+        assert_eq!(batch_bytes_cap(), BATCH_BYTES);
+        assert_eq!(batch_bytes_cap(), 64 << 20);
+        assert_eq!(batch_bytes_cap(), 67_108_864);
+
+        // "0" filtered (`0 > 0` false) → default. Kills `>=`/`==`.
+        std::env::set_var("MUSEFS_BATCH_BYTES", "0");
+        assert_eq!(batch_bytes_cap(), BATCH_BYTES);
+
+        // "5" passes (`5 > 0`) → 5. Kills `<`.
+        std::env::set_var("MUSEFS_BATCH_BYTES", "5");
+        assert_eq!(batch_bytes_cap(), 5);
+
+        std::env::remove_var("MUSEFS_BATCH_BYTES");
+    }
+
+    // --- art_weight() (lines 340-342) ---
+
+    // kills scan L341 art_weight body→0/→1 (sum of picture data lengths)
+    #[test]
+    fn art_weight_sums_picture_byte_lengths() {
+        let pic = |n: usize| EmbeddedPicture {
+            mime: "image/png".to_string(),
+            picture_type: 3,
+            description: String::new(),
+            width: 0,
+            height: 0,
+            data: vec![0u8; n],
+        };
+        let probed = Probed {
+            format: Format::Flac,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: Vec::new(),
+            pictures: vec![pic(3), pic(5)],
+        };
+        assert_eq!(art_weight(&probed), 8);
+
+        // Empty → 0, distinguishes the →1 constant (which ignores the input).
+        let empty = Probed {
+            format: Format::Flac,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: Vec::new(),
+            pictures: Vec::new(),
+        };
+        assert_eq!(art_weight(&empty), 0);
+    }
+}
+
+#[cfg(test)]
 mod ogg_probe_tests {
     use super::*;
     use musefs_format::ogg::page_test_support::{

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -2,9 +2,15 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
-use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedPicture};
+use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedPicture, Extent};
 
 use crate::error::Result;
+
+/// Initial bounded-read window. Covers typical metadata + cover art; a larger
+/// metadata region triggers a `NeedMore` widen.
+const WINDOW: usize = 1 << 20; // 1 MiB
+/// Cap on widen iterations before falling back to a whole-file read.
+const MAX_WIDEN_RETRIES: usize = 8;
 
 /// Skip embedded art whose image bytes exceed this. The binding limit is FLAC's
 /// 24-bit PICTURE block length (~16 MiB for the whole block); reserve 64 KiB of
@@ -66,7 +72,7 @@ fn collect_audio(root: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
 
 /// A backing file parsed into the fields a track row needs, plus its raw
 /// `(key, value)` tags to seed.
-struct Probed {
+pub(crate) struct Probed {
     format: Format,
     audio_offset: u64,
     audio_length: u64,
@@ -74,9 +80,9 @@ struct Probed {
     pictures: Vec<EmbeddedPicture>,
 }
 
-/// Parse one backing file into a `Probed`, or `None` if it does not parse as a
-/// supported format (and should be skipped).
-fn probe(path: &Path, bytes: &[u8]) -> Option<Probed> {
+/// Full-buffer probe (legacy path). Retained as the reference implementation the
+/// bounded path is checked against (see the equivalence property test).
+pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
     if has_ext(path, "flac") {
         let scan = flac::locate_audio(bytes).ok()?;
         Some(Probed {
@@ -129,6 +135,151 @@ fn probe(path: &Path, bytes: &[u8]) -> Option<Probed> {
         })
     } else {
         None
+    }
+}
+
+/// Read `[0, len)` of `path` into a buffer, counting the read. A short read at
+/// EOF is fine (`len` may exceed the file size).
+fn read_window(file: &std::fs::File, len: usize) -> std::io::Result<Vec<u8>> {
+    use std::os::unix::fs::FileExt;
+    let mut buf = vec![0u8; len];
+    let n = file.read_at(&mut buf, 0)?;
+    buf.truncate(n);
+    crate::metrics::on_scan_read(n as u64);
+    Ok(buf)
+}
+
+/// Read the file's last 128 bytes (for the MP3 ID3v1 trailer check), or `None`
+/// if the file is shorter than 128 bytes.
+fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<[u8; 128]>> {
+    if file_len < 128 {
+        return Ok(None);
+    }
+    use std::os::unix::fs::FileExt;
+    let mut buf = [0u8; 128];
+    file.read_exact_at(&mut buf, file_len - 128)?;
+    crate::metrics::on_scan_read(128);
+    Ok(Some(buf))
+}
+
+/// Bounded probe of one backing file: open once, read a bounded window, dispatch
+/// per format, widening on `NeedMore`. Never reads the audio payload (M4A uses
+/// the seek reader; front-anchored formats read only the metadata extent).
+/// Returns `Ok(None)` for an unsupported/unparseable file (to be skipped).
+fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
+    let file = std::fs::File::open(path)?;
+    crate::metrics::on_scan_open();
+
+    // M4A: seek reader, never touches mdat.
+    if has_ext(path, "m4a") || has_ext(path, "m4b") {
+        let mut f = &file;
+        let Ok(scan) = mp4::read_structure_from(&mut f, file_len) else {
+            return Ok(None);
+        };
+        return Ok(Some(Probed {
+            format: Format::M4a,
+            audio_offset: scan.mdat_payload_offset,
+            audio_length: scan.mdat_payload_len,
+            tags: mp4::read_tags(&scan.moov),
+            pictures: mp4::read_pictures(&scan.moov),
+        }));
+    }
+
+    // Front-anchored formats: read a window, widen on NeedMore.
+    let tail = read_tail_128(&file, file_len)?;
+    let mut want = (WINDOW as u64).min(file_len) as usize;
+    let mut prefix = read_window(&file, want)?;
+    for _ in 0..MAX_WIDEN_RETRIES {
+        match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
+            Probe::Done(p) => return Ok(Some(p)),
+            Probe::Skip => return Ok(None),
+            Probe::NeedMore(up_to) => {
+                // Already at EOF? The prefix is the whole file; widening can't help.
+                if want as u64 >= file_len {
+                    break;
+                }
+                // Grow to at least `up_to` (capped at the file), always making
+                // progress (`+1`), then retry.
+                want = (up_to.min(file_len) as usize)
+                    .max(want + 1)
+                    .min(file_len as usize);
+                prefix = read_window(&file, want)?;
+            }
+        }
+    }
+    // Fallback: read the whole file once and use the full-buffer probe.
+    if (prefix.len() as u64) < file_len {
+        prefix = read_window(&file, file_len as usize)?;
+    }
+    Ok(probe_full(path, &prefix))
+}
+
+/// Outcome of a single bounded dispatch attempt against the current `prefix`.
+enum Probe {
+    Done(Probed),
+    NeedMore(u64),
+    Skip,
+}
+
+/// Dispatch the front-anchored formats against `prefix` + `file_len`.
+fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 128]>) -> Probe {
+    if has_ext(path, "flac") {
+        match flac::read_metadata_bounded(prefix) {
+            Ok(Extent::Complete(meta)) => Probe::Done(Probed {
+                format: Format::Flac,
+                audio_offset: meta.audio_offset,
+                audio_length: file_len - meta.audio_offset,
+                tags: flac::read_vorbis_comments(prefix).unwrap_or_default(),
+                pictures: flac::read_pictures(prefix).unwrap_or_default(),
+            }),
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else if has_ext(path, "mp3") {
+        match mp3::locate_audio_bounded(prefix, file_len, tail) {
+            Ok(Extent::Complete(b)) => Probe::Done(Probed {
+                format: Format::Mp3,
+                audio_offset: b.audio_offset,
+                audio_length: b.audio_length,
+                tags: mp3::read_tags(prefix),
+                pictures: mp3::read_pictures(prefix),
+            }),
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else if has_ext(path, "ogg") || has_ext(path, "oga") || has_ext(path, "opus") {
+        match ogg::read_metadata_bounded(prefix, file_len) {
+            Ok(Extent::Complete(header)) => {
+                let format = match header.codec {
+                    ogg::Codec::Opus => Format::Opus,
+                    ogg::Codec::Vorbis => Format::Vorbis,
+                    ogg::Codec::OggFlac => Format::OggFlac,
+                };
+                Probe::Done(Probed {
+                    format,
+                    audio_offset: header.audio_offset,
+                    audio_length: file_len - header.audio_offset,
+                    tags: ogg::read_tags(prefix).unwrap_or_default(),
+                    pictures: ogg::read_pictures(prefix).unwrap_or_default(),
+                })
+            }
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else if has_ext(path, "wav") {
+        match wav::locate_audio_bounded(prefix, file_len) {
+            Ok(Extent::Complete(b)) => Probe::Done(Probed {
+                format: Format::Wav,
+                audio_offset: b.audio_offset,
+                audio_length: b.audio_length,
+                tags: wav::read_tags(prefix),
+                pictures: wav::read_pictures(prefix),
+            }),
+            Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
+            Err(_) => Probe::Skip,
+        }
+    } else {
+        Probe::Skip
     }
 }
 
@@ -204,12 +355,11 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
         skipped: 0,
     };
     for path in files {
-        let bytes = std::fs::read(&path)?;
-        let Some(probed) = probe(&path, &bytes) else {
+        let meta = std::fs::metadata(&path)?;
+        let Some(probed) = probe_file(&path, meta.len())? else {
             stats.skipped += 1;
             continue;
         };
-        let meta = std::fs::metadata(&path)?;
         let abs = std::fs::canonicalize(&path)?;
         ingest(db, &abs.to_string_lossy(), &meta, probed)?;
         stats.scanned += 1;
@@ -246,11 +396,11 @@ pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
             }
         }
 
-        let bytes = std::fs::read(&path)?;
-        if let Some(probed) = probe(&path, &bytes) {
-            ingest(db, &abs_str, &meta, probed)?;
-            stats.updated += 1;
-        }
+        let Some(probed) = probe_file(&path, meta.len())? else {
+            continue;
+        };
+        ingest(db, &abs_str, &meta, probed)?;
+        stats.updated += 1;
     }
 
     // Prune tracks under `root` whose backing file is gone. Scoped to `root` so a
@@ -299,7 +449,7 @@ mod ogg_probe_tests {
             .write_all(&bytes)
             .unwrap();
 
-        let probed = probe(&path, &bytes).expect("opus should probe");
+        let probed = probe_full(&path, &bytes).expect("opus should probe");
         assert_eq!(probed.format, Format::Opus);
         assert_eq!(probed.audio_offset, (bytes.len() - audio.len()) as u64);
     }
@@ -340,7 +490,7 @@ mod ogg_probe_tests {
             .write_all(&bytes)
             .unwrap();
 
-        let probed = probe(&path, &bytes).expect("oga should probe");
+        let probed = probe_full(&path, &bytes).expect("oga should probe");
         assert_eq!(probed.format, Format::Opus);
     }
 }
@@ -383,7 +533,7 @@ mod wav_probe_tests {
             .write_all(&bytes)
             .unwrap();
 
-        let probed = probe(&path, &bytes).expect("wav should probe");
+        let probed = probe_full(&path, &bytes).expect("wav should probe");
         assert_eq!(probed.format, Format::Wav);
         assert_eq!(probed.audio_length, 16);
     }
@@ -450,7 +600,7 @@ mod hardening_tests {
             let path = dir.path().join(name);
             std::fs::write(&path, b"not a real audio file").unwrap();
             assert!(
-                probe(&path, b"not a real audio file").is_none(),
+                probe_full(&path, b"not a real audio file").is_none(),
                 "{name} must skip"
             );
         }
@@ -615,5 +765,44 @@ mod hardening_tests {
                 .any(|t| t.backing_path == ghost.to_string_lossy()),
             "ghost track must still exist"
         );
+    }
+}
+
+#[cfg(test)]
+mod bounded_probe_tests {
+    use super::*;
+    use musefs_db::Db;
+
+    /// Minimal FLAC: marker + a single last STREAMINFO (34-byte body) + audio.
+    /// FLAC has no frame-sync check at the audio offset, so any payload works.
+    fn flac_fixture() -> Vec<u8> {
+        let mut bytes = b"fLaC".to_vec();
+        bytes.push(0x80); // last-block flag set, type 0 (STREAMINFO)
+        bytes.extend_from_slice(&[0, 0, 34]); // 24-bit length = 34
+        bytes.extend(std::iter::repeat_n(0u8, 34));
+        bytes.extend_from_slice(b"AUDIOPAYLOAD");
+        bytes
+    }
+
+    #[test]
+    fn scan_directory_bounded_matches_full_for_flac() {
+        // A FLAC fixture written to a temp dir, scanned with the (default) bounded
+        // path, yields a track with the same audio bounds as a full-file probe.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.flac");
+        let bytes = flac_fixture();
+        std::fs::write(&path, &bytes).unwrap();
+
+        let full = probe_full(&path, &bytes).expect("full probe");
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = scan_directory(&db, dir.path()).unwrap();
+        assert_eq!(stats.scanned, 1);
+        let track = db
+            .get_track_by_path(&std::fs::canonicalize(&path).unwrap().to_string_lossy())
+            .unwrap()
+            .unwrap();
+        assert_eq!(track.audio_offset as u64, full.audio_offset);
+        assert_eq!(track.audio_length as u64, full.audio_length);
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -606,68 +606,71 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
 /// backing file is gone (cascading tags/art links) and garbage-collect
 /// now-unreferenced art. Pruning is scoped to `root`, so revalidating one library
 /// root never removes tracks belonging to another.
-pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
+///
+/// Uses `opts` to configure the probe pipeline (e.g. `jobs` for parallelism).
+/// The skip-unchanged decision runs on the calling thread before workers are
+/// dispatched, so workers remain DB-free.
+pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<RevalidateStats> {
     let mut files = Vec::new();
     collect_audio(root, &mut files)?;
+    db.apply_bulk_pragmas_self()?;
 
-    let mut stats = RevalidateStats {
-        updated: 0,
-        unchanged: 0,
-        pruned: 0,
-        failed: 0,
-    };
+    // Main-thread pre-dispatch skip pass: load existing (path -> size,mtime) once,
+    // stat each candidate, keep only changed files. Workers stay DB-free.
+    let existing: HashMap<String, (i64, i64)> = db
+        .list_tracks()?
+        .into_iter()
+        .map(|t| (t.backing_path, (t.backing_size, t.backing_mtime)))
+        .collect();
+
+    let mut unchanged = 0u64;
+    let mut changed: Vec<PathBuf> = Vec::new();
     for path in files {
         let Ok(meta) = std::fs::metadata(&path) else {
-            stats.failed += 1;
             continue;
         };
         let Ok(abs) = std::fs::canonicalize(&path) else {
-            stats.failed += 1;
             continue;
         };
-        let abs_str = abs.to_string_lossy().to_string();
-
-        if let Some(existing) = db.get_track_by_path(&abs_str)? {
-            if existing.backing_size == meta.len() as i64
-                && existing.backing_mtime == mtime_secs(&meta)
-            {
-                stats.unchanged += 1;
+        let key = abs.to_string_lossy().to_string();
+        if let Some(&(size, mtime)) = existing.get(&key) {
+            if size == meta.len() as i64 && mtime == mtime_secs(&meta) {
+                unchanged += 1;
                 continue;
             }
         }
-
-        match probe_file(&path, meta.len()) {
-            Ok(Some(probed)) => {
-                ingest(db, &abs_str, &meta, probed)?;
-                stats.updated += 1;
-            }
-            Ok(None) => {}
-            Err(_) => {
-                stats.failed += 1;
-            }
-        }
+        changed.push(path);
     }
 
-    // Prune tracks under `root` whose backing file is gone. Scoped to `root` so a
-    // targeted revalidate never touches tracks from a different library root, and
-    // gated on `NotFound` so a transient I/O error (an unreadable mount, a denied
-    // permission) does not delete a track whose file still exists.
+    let scan = run_pipeline(db, changed, opts)?;
+
+    // Prune + GC on the writer connection (single-threaded), unchanged from before.
     let canon_root = std::fs::canonicalize(root)?;
+    let mut pruned = 0u64;
     for track in db.list_tracks()? {
         if !Path::new(&track.backing_path).starts_with(&canon_root) {
             continue;
         }
-        match std::fs::metadata(&track.backing_path) {
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        if let Err(e) = std::fs::metadata(&track.backing_path) {
+            if e.kind() == std::io::ErrorKind::NotFound {
                 db.delete_track(track.id)?;
-                stats.pruned += 1;
+                pruned += 1;
             }
-            _ => {}
         }
     }
     db.gc_orphan_art()?;
 
-    Ok(stats)
+    Ok(RevalidateStats {
+        updated: scan.scanned,
+        unchanged,
+        pruned,
+        failed: scan.failed,
+    })
+}
+
+/// Back-compat shim used by the CLI and existing tests.
+pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
+    revalidate_with(db, root, &ScanOptions::default())
 }
 
 #[cfg(test)]
@@ -1068,6 +1071,28 @@ mod bounded_probe_tests {
             .unwrap();
         assert_eq!(track.audio_offset as u64, full.audio_offset);
         assert_eq!(track.audio_length as u64, full.audio_length);
+    }
+
+    #[test]
+    fn revalidate_skips_unchanged_and_reprobes_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("x.flac");
+        let mk = |audio: &[u8]| {
+            let mut b = b"fLaC".to_vec();
+            b.push(0x80);
+            b.extend_from_slice(&[0, 0, 34]);
+            b.extend(std::iter::repeat_n(0u8, 34));
+            b.extend_from_slice(audio);
+            b
+        };
+        std::fs::write(&p, mk(b"AUDIO")).unwrap();
+        let db = Db::open_in_memory().unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+
+        // Unchanged → all unchanged.
+        let s1 = revalidate_with(&db, dir.path(), &ScanOptions::default()).unwrap();
+        assert_eq!(s1.unchanged, 1);
+        assert_eq!(s1.updated, 0);
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -355,7 +355,9 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
 /// Opus, Vorbis, FLAC-in-Ogg) under `root` (with audio bounds and validation
 /// stamps), seeding its tags from the file's existing metadata. `root` may be
 /// a single audio file (only that file is scanned) or a directory (walked
-/// recursively). Files that fail to parse are skipped.
+/// recursively). Unsupported-format files increment `ScanStats::skipped`; files
+/// with a per-file I/O or parse error increment `ScanStats::failed` and do not
+/// abort the scan.
 pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
     let mut files = Vec::new();
     if root.is_file() {
@@ -378,7 +380,12 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
         };
         match probe_file(&path, meta.len()) {
             Ok(Some(probed)) => {
-                let abs = std::fs::canonicalize(&path)?;
+                // `canonicalize` is per-file I/O (a symlink target can vanish in
+                // the window after the walk), so keep it non-fatal like `metadata`.
+                let Ok(abs) = std::fs::canonicalize(&path) else {
+                    stats.failed += 1;
+                    continue;
+                };
                 ingest(db, &abs.to_string_lossy(), &meta, probed)?;
                 stats.scanned += 1;
             }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -138,6 +138,15 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
     }
 }
 
+/// Effective initial window: `MUSEFS_SCAN_WINDOW` (bytes) if set, else `WINDOW`.
+fn scan_window() -> usize {
+    std::env::var("MUSEFS_SCAN_WINDOW")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(WINDOW)
+}
+
 /// Read `[0, len)` of `path` into a buffer, counting the read. A short read at
 /// EOF is fine (`len` may exceed the file size).
 fn read_window(file: &std::fs::File, len: usize) -> std::io::Result<Vec<u8>> {
@@ -192,7 +201,7 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
 
     // Front-anchored formats: read a window, widen on NeedMore.
     let tail = read_tail_128(&file, file_len)?;
-    let mut want = (WINDOW as u64).min(file_len) as usize;
+    let mut want = (scan_window() as u64).min(file_len) as usize;
     let mut prefix = read_window(&file, want)?;
     for _ in 0..MAX_WIDEN_RETRIES {
         match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
@@ -365,6 +374,36 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
             stats.skipped += 1;
             continue;
         };
+        let abs = std::fs::canonicalize(&path)?;
+        ingest(db, &abs.to_string_lossy(), &meta, probed)?;
+        stats.scanned += 1;
+    }
+    Ok(stats)
+}
+
+/// Test/oracle only: scan using the legacy whole-file probe (`probe_full`). The
+/// equivalence property compares this against the bounded `scan_directory`.
+#[doc(hidden)]
+pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
+    let mut files = Vec::new();
+    if root.is_file() {
+        if is_supported_audio(root) {
+            files.push(root.to_path_buf());
+        }
+    } else {
+        collect_audio(root, &mut files)?;
+    }
+    let mut stats = ScanStats {
+        scanned: 0,
+        skipped: 0,
+    };
+    for path in files {
+        let bytes = std::fs::read(&path)?;
+        let Some(probed) = probe_full(&path, &bytes) else {
+            stats.skipped += 1;
+            continue;
+        };
+        let meta = std::fs::metadata(&path)?;
         let abs = std::fs::canonicalize(&path)?;
         ingest(db, &abs.to_string_lossy(), &meta, probed)?;
         stats.scanned += 1;

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -609,7 +609,9 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
 ///
 /// Uses `opts` to configure the probe pipeline (e.g. `jobs` for parallelism).
 /// The skip-unchanged decision runs on the calling thread before workers are
-/// dispatched, so workers remain DB-free.
+/// dispatched, so workers remain DB-free. A `stat`/`canonicalize` failure on a
+/// candidate during the skip pass is counted in `failed` (and the file is left
+/// for the next revalidation) rather than re-probed or pruned.
 pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<RevalidateStats> {
     let mut files = Vec::new();
     collect_audio(root, &mut files)?;
@@ -624,12 +626,15 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         .collect();
 
     let mut unchanged = 0u64;
+    let mut skip_failed = 0u64;
     let mut changed: Vec<PathBuf> = Vec::new();
     for path in files {
         let Ok(meta) = std::fs::metadata(&path) else {
+            skip_failed += 1;
             continue;
         };
         let Ok(abs) = std::fs::canonicalize(&path) else {
+            skip_failed += 1;
             continue;
         };
         let key = abs.to_string_lossy().to_string();
@@ -664,7 +669,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         updated: scan.scanned,
         unchanged,
         pruned,
-        failed: scan.failed,
+        failed: scan.failed + skip_failed,
     })
 }
 
@@ -1093,6 +1098,18 @@ mod bounded_probe_tests {
         let s1 = revalidate_with(&db, dir.path(), &ScanOptions::default()).unwrap();
         assert_eq!(s1.unchanged, 1);
         assert_eq!(s1.updated, 0);
+
+        // Rewrite with a different size → detected as changed and re-probed.
+        std::fs::write(&p, mk(b"DIFFERENT-AUDIO")).unwrap();
+        let s2 = revalidate_with(&db, dir.path(), &ScanOptions::default()).unwrap();
+        assert_eq!(s2.updated, 1);
+        assert_eq!(s2.unchanged, 0);
+        // The track row now reflects the new (longer) audio length.
+        let track = db
+            .get_track_by_path(&std::fs::canonicalize(&p).unwrap().to_string_lossy())
+            .unwrap()
+            .unwrap();
+        assert_eq!(track.audio_length as usize, b"DIFFERENT-AUDIO".len());
     }
 
     #[test]

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -6,30 +6,33 @@ use common::corpus::{
     bench_base_dir, bench_formats, format_token, prepare, prepare_format, CorpusParams, Target,
 };
 use common::report::{peak_rss_kib, RunReport};
-use musefs_core::{metrics, revalidate, scan_directory};
+use musefs_core::{metrics, revalidate_with, scan_directory_with, ScanOptions};
 use musefs_db::Db;
 
 /// Scan + revalidate one resolved target, printing a `scan` and a `revalidate`
-/// row tagged with `format`/`storage`.
-///
-/// The `opens`/`preads` metrics instrument the *serve* path (reader.rs /
-/// open_handle), not the scan path, so both rows print ~0 even under
-/// `--features metrics`. The SP1-relevant signals are `wall_ms` and
-/// `peak_rss_kib`. `peak_rss_kib()` reads VmHWM — a process-lifetime high-water
-/// mark that only rises — so later rows show the same or a higher value than
-/// earlier ones; read the first format's scan row for the pre-SP1 baseline.
+/// row tagged with `format`/`storage`. The `bytes_read` column reports
+/// `scan_bytes_read` (the SP1 bounded-read signal: front-anchored prefix, widen,
+/// and MP3 tail reads). M4A's seek-reader bytes are not counted here (they live in
+/// musefs-format); M4A's win shows in `wall_ms` and `peak_rss_kib`. `opens`/`preads`
+/// remain serve-path counters and stay ~0 on the scan path.
 fn run_one(target: &Target, tier: &str, format: &str, storage: &str) {
     let db = Db::open(&target.db_path).unwrap();
 
+    let jobs = std::env::var("MUSEFS_BENCH_JOBS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let opts = ScanOptions { jobs };
+
     metrics::reset();
     let t0 = Instant::now();
-    let stats = scan_directory(&db, &target.corpus_dir).unwrap();
+    let stats = scan_directory_with(&db, &target.corpus_dir, &opts).unwrap();
     let scan_ms = t0.elapsed().as_millis();
     let s = metrics::snapshot();
 
     metrics::reset();
     let t1 = Instant::now();
-    let _ = revalidate(&db, &target.corpus_dir).unwrap();
+    let _ = revalidate_with(&db, &target.corpus_dir, &opts).unwrap();
     let reval_ms = t1.elapsed().as_millis();
     let r = metrics::snapshot();
 
@@ -45,6 +48,7 @@ fn run_one(target: &Target, tier: &str, format: &str, storage: &str) {
                 opens: snap.opens,
                 preads: snap.preads,
                 fsyncs: None,
+                bytes_read: snap.scan_bytes_read,
                 peak_rss_kib: peak_rss_kib(),
             }
             .row()
@@ -117,7 +121,17 @@ fn bench_scan_under_latency() {
     let fsyncs_before_scan = mount.fsyncs();
     metrics::reset();
     let t0 = Instant::now();
-    let stats = scan_directory(&db, &mount.path()).unwrap();
+    let stats = scan_directory_with(
+        &db,
+        &mount.path(),
+        &ScanOptions {
+            jobs: std::env::var("MUSEFS_BENCH_JOBS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+        },
+    )
+    .unwrap();
     let scan_ms = t0.elapsed().as_millis();
     let s = metrics::snapshot();
 
@@ -133,6 +147,7 @@ fn bench_scan_under_latency() {
             opens: s.opens,
             preads: s.preads,
             fsyncs: Some(mount.fsyncs().saturating_sub(fsyncs_before_scan)),
+            bytes_read: s.scan_bytes_read,
             peak_rss_kib: None, // FS runs in-process here, but RSS attribution is mixed; omit.
         }
         .row()

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -84,6 +84,7 @@ fn bench_refresh_one_vs_many() {
                 opens: 0,
                 preads: 0,
                 fsyncs: None,
+                bytes_read: 0,
                 peak_rss_kib: None,
             }
             .row()

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -94,6 +94,23 @@ pub struct CorpusParams {
 }
 
 impl CorpusParams {
+    /// A small single-format corpus used by the equivalence property. `art_bytes`
+    /// is honored only by the FLAC generator (the MP3/M4A/Ogg/WAV corpus files
+    /// carry no embedded art or in-file tags — those ride via the DB at scan
+    /// time). The tiny `MUSEFS_SCAN_WINDOW=64` still forces the widen path on
+    /// every format, via the format's own trigger: FLAC the metadata-block walk,
+    /// MP3 the ID3v2 tag size, OGG the geometric grow, WAV the whole-file gate.
+    pub fn single(fmt: Format, albums: usize, tracks_per_album: usize) -> Self {
+        Self {
+            albums,
+            tracks_per_album,
+            bytes_per_track: 4 * 1024,
+            art_bytes_per_track: 8 * 1024,
+            format_mix: vec![fmt],
+            seed: 1,
+        }
+    }
+
     pub fn track_count(&self) -> usize {
         self.albums * self.tracks_per_album
     }

--- a/musefs-core/tests/common/report.rs
+++ b/musefs-core/tests/common/report.rs
@@ -5,7 +5,7 @@
 /// literal, so this is a macro rather than a `const`.)
 macro_rules! report_fmt {
     ($($arg:expr),* $(,)?) => {
-        format!("{:<10} {:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>12}", $($arg),*)
+        format!("{:<10} {:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>14} {:>12}", $($arg),*)
     };
 }
 
@@ -21,13 +21,23 @@ pub struct RunReport {
     pub opens: u64,
     pub preads: u64,
     pub fsyncs: Option<u64>,
+    pub bytes_read: u64,
     pub peak_rss_kib: Option<u64>,
 }
 
 impl RunReport {
     pub fn header() -> String {
         report_fmt!(
-            "label", "format", "tier", "storage", "wall_ms", "opens", "preads", "fsyncs", "rss_kib"
+            "label",
+            "format",
+            "tier",
+            "storage",
+            "wall_ms",
+            "opens",
+            "preads",
+            "fsyncs",
+            "bytes_read",
+            "rss_kib"
         )
     }
 
@@ -42,6 +52,7 @@ impl RunReport {
             self.opens,
             self.preads,
             opt(self.fsyncs),
+            self.bytes_read,
             opt(self.peak_rss_kib),
         )
     }

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -122,6 +122,7 @@ fn report_renders_a_row() {
         opens: 200,
         preads: 200,
         fsyncs: None,
+        bytes_read: 0,
         peak_rss_kib: Some(50_000),
     };
     let line = r.row();

--- a/musefs-core/tests/pipeline_backpressure.rs
+++ b/musefs-core/tests/pipeline_backpressure.rs
@@ -1,0 +1,72 @@
+//! Regression guard for the scan pipeline's byte-budget backpressure: with the
+//! in-flight budget cap equal to the per-batch byte-flush threshold, a worker
+//! blocking in `budget.acquire` (called before `send`) must never strand the
+//! writer parked on `recv`. Pre-fix this deadlocked on art-bearing libraries.
+
+use musefs_core::{scan_directory_with, ScanOptions};
+use musefs_db::Db;
+
+/// A minimal FLAC carrying a PICTURE block of `data_len` image bytes (so the
+/// scanned track has a non-zero art weight for the budget). marker + STREAMINFO
+/// (not last) + PICTURE (last) + a little audio.
+fn flac_with_art(data_len: usize) -> Vec<u8> {
+    let mut v = b"fLaC".to_vec();
+    // STREAMINFO (type 0), not last, 34-byte body.
+    v.push(0x00);
+    v.extend_from_slice(&[0, 0, 34]);
+    v.extend(std::iter::repeat_n(0u8, 34));
+    // PICTURE (type 6), last block.
+    let mut body = Vec::new();
+    body.extend_from_slice(&3u32.to_be_bytes()); // picture type (front cover)
+    let mime = b"image/png";
+    body.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+    body.extend_from_slice(mime);
+    body.extend_from_slice(&0u32.to_be_bytes()); // description length
+    body.extend_from_slice(&0u32.to_be_bytes()); // width
+    body.extend_from_slice(&0u32.to_be_bytes()); // height
+    body.extend_from_slice(&0u32.to_be_bytes()); // depth
+    body.extend_from_slice(&0u32.to_be_bytes()); // colors
+    body.extend_from_slice(&(data_len as u32).to_be_bytes());
+    body.extend(std::iter::repeat_n(0u8, data_len));
+    v.push(0x86); // last-block flag (0x80) | PICTURE (0x06)
+    let blen = body.len();
+    v.extend_from_slice(&[(blen >> 16) as u8, (blen >> 8) as u8, blen as u8]);
+    v.extend_from_slice(&body);
+    v.extend_from_slice(b"AUDIO");
+    v
+}
+
+#[test]
+fn pipeline_completes_under_art_backpressure() {
+    use std::time::{Duration, Instant};
+
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..8 {
+        std::fs::write(dir.path().join(format!("a{i}.flac")), flac_with_art(6)).unwrap();
+    }
+
+    // Cap the in-flight budget below two files' cumulative art (6 bytes each), so a
+    // second concurrent `acquire` blocks while the writer's batch sits below the
+    // flush threshold — the exact pre-fix deadlock window.
+    std::env::set_var("MUSEFS_BATCH_BYTES", "8");
+
+    let root = dir.path().to_path_buf();
+    let handle = std::thread::spawn(move || {
+        let db = Db::open_in_memory().unwrap();
+        scan_directory_with(&db, &root, &ScanOptions { jobs: 4 }).unwrap();
+        db.list_tracks().unwrap().len()
+    });
+
+    // Watchdog: fail fast with a clear message instead of hanging forever.
+    let start = Instant::now();
+    while !handle.is_finished() {
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "scan pipeline deadlocked under art backpressure"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let scanned = handle.join().unwrap();
+    std::env::remove_var("MUSEFS_BATCH_BYTES");
+    assert_eq!(scanned, 8, "all art-bearing files should ingest");
+}

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -1,0 +1,73 @@
+//! Headline SP1 correctness guard: a tiny-window bounded scan is equivalent (in
+//! its parsed DB rows) to a legacy full-file-probe scan, for every format.
+
+mod common;
+
+use common::corpus::{bench_formats, format_token, generate, CorpusParams};
+use musefs_db::Db;
+
+/// One comparable track row: `(backing_path, audio_offset, audio_length, tags,
+/// art)`, with tags as `(key, value, ordinal)` and art as `(sha256, ordinal)`.
+type NormalizedTrack = (
+    String,
+    i64,
+    i64,
+    Vec<(String, String, i64)>,
+    Vec<(String, i64)>,
+);
+
+/// Normalize a DB to comparable rows: tracks by path, tags by (key,value,ordinal),
+/// art by (sha256, ordinal). Excludes raw `art.id` (insertion-order rowid).
+fn normalized(db: &Db) -> Vec<NormalizedTrack> {
+    let mut out = Vec::new();
+    for t in db.list_tracks().unwrap() {
+        let tags: Vec<_> = db
+            .get_tags(t.id)
+            .unwrap()
+            .into_iter()
+            .map(|tg| (tg.key, tg.value, tg.ordinal))
+            .collect();
+        let art: Vec<_> = db
+            .get_track_art(t.id)
+            .unwrap()
+            .into_iter()
+            .map(|a| (db.get_art(a.art_id).unwrap().unwrap().sha256, a.ordinal))
+            .collect();
+        out.push((t.backing_path, t.audio_offset, t.audio_length, tags, art));
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn bounded_probe_equivalent_to_full_for_every_format() {
+    for fmt in bench_formats() {
+        let dir = tempfile::tempdir().unwrap();
+        let params = CorpusParams::single(fmt, /*albums*/ 2, /*tracks*/ 3);
+        generate(dir.path(), &params);
+
+        // Oracle: legacy whole-file probe.
+        let oracle_db = Db::open_in_memory().unwrap();
+        musefs_core::scan_directory_full_oracle(&oracle_db, dir.path()).unwrap();
+        let oracle = normalized(&oracle_db);
+
+        // Bounded scan with a 64-byte window → widen path fires on every file.
+        std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
+        let bounded_db = Db::open_in_memory().unwrap();
+        musefs_core::scan_directory(&bounded_db, dir.path()).unwrap();
+        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+        let bounded = normalized(&bounded_db);
+
+        assert_eq!(
+            oracle,
+            bounded,
+            "format {}: bounded scan diverged from full-probe oracle",
+            format_token(fmt)
+        );
+        assert!(
+            !oracle.is_empty(),
+            "format {}: scanned nothing",
+            format_token(fmt)
+        );
+    }
+}

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -7,17 +7,20 @@ use common::corpus::{bench_formats, format_token, generate, CorpusParams};
 use musefs_db::Db;
 
 /// One comparable track row: `(backing_path, audio_offset, audio_length, tags,
-/// art)`, with tags as `(key, value, ordinal)` and art as `(sha256, ordinal)`.
+/// art)`, with tags as `(key, value, ordinal)` and art as
+/// `(sha256, picture_type, description, ordinal)`.
 type NormalizedTrack = (
     String,
     i64,
     i64,
     Vec<(String, String, i64)>,
-    Vec<(String, i64)>,
+    Vec<(String, i64, String, i64)>,
 );
 
 /// Normalize a DB to comparable rows: tracks by path, tags by (key,value,ordinal),
-/// art by (sha256, ordinal). Excludes raw `art.id` (insertion-order rowid).
+/// art by (sha256, picture_type, description, ordinal). Excludes raw `art.id`
+/// (insertion-order rowid) but covers every other observable art field, so the
+/// gate catches any drift in picture-type/description parsing too.
 fn normalized(db: &Db) -> Vec<NormalizedTrack> {
     let mut out = Vec::new();
     for t in db.list_tracks().unwrap() {
@@ -31,7 +34,10 @@ fn normalized(db: &Db) -> Vec<NormalizedTrack> {
             .get_track_art(t.id)
             .unwrap()
             .into_iter()
-            .map(|a| (db.get_art(a.art_id).unwrap().unwrap().sha256, a.ordinal))
+            .map(|a| {
+                let sha = db.get_art(a.art_id).unwrap().unwrap().sha256;
+                (sha, a.picture_type, a.description, a.ordinal)
+            })
             .collect();
         out.push((t.backing_path, t.audio_offset, t.audio_length, tags, art));
     }

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -1,0 +1,281 @@
+//! Pipeline / revalidate / widen-fallback mutation guards for `scan.rs`.
+//!
+//! These exercise the parts of the scan pipeline that need a real `Db` and real
+//! backing files: batch-flush cadence, the bounded-read widen + whole-file
+//! fallback, and the revalidate skip-pass counters.
+
+use musefs_core::{
+    revalidate, revalidate_with, scan_directory, scan_directory_full_oracle, scan_directory_with,
+    ScanOptions,
+};
+use musefs_db::Db;
+
+/// Serialize env-mutating tests: `MUSEFS_*` vars are process-global.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Minimal valid FLAC: marker + last STREAMINFO (34-byte body) + audio payload.
+fn flac_minimal(audio: &[u8]) -> Vec<u8> {
+    let mut b = b"fLaC".to_vec();
+    b.push(0x80); // last-block flag | STREAMINFO (type 0)
+    b.extend_from_slice(&[0, 0, 34]);
+    b.extend(std::iter::repeat_n(0u8, 34));
+    b.extend_from_slice(audio);
+    b
+}
+
+/// FLAC with a large PICTURE block (so the bounded probe must widen past a tiny
+/// window). marker + STREAMINFO (not last) + PICTURE (last) + audio.
+fn flac_with_big_art(data_len: usize, audio: &[u8]) -> Vec<u8> {
+    let mut v = b"fLaC".to_vec();
+    v.push(0x00); // STREAMINFO (type 0), not last
+    v.extend_from_slice(&[0, 0, 34]);
+    v.extend(std::iter::repeat_n(0u8, 34));
+
+    let mut body = Vec::new();
+    body.extend_from_slice(&3u32.to_be_bytes()); // picture type (front cover)
+    let mime = b"image/png";
+    body.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+    body.extend_from_slice(mime);
+    body.extend_from_slice(&0u32.to_be_bytes()); // description length
+    body.extend_from_slice(&0u32.to_be_bytes()); // width
+    body.extend_from_slice(&0u32.to_be_bytes()); // height
+    body.extend_from_slice(&0u32.to_be_bytes()); // depth
+    body.extend_from_slice(&0u32.to_be_bytes()); // colors
+    body.extend_from_slice(&(data_len as u32).to_be_bytes());
+    // Distinct, position-sensitive bytes so a misparse is observable.
+    body.extend((0..data_len).map(|i| (i % 251) as u8));
+    v.push(0x86); // last-block flag (0x80) | PICTURE (0x06)
+    let blen = body.len();
+    v.extend_from_slice(&[(blen >> 16) as u8, (blen >> 8) as u8, blen as u8]);
+    v.extend_from_slice(&body);
+    v.extend_from_slice(audio);
+    v
+}
+
+/// Normalize a DB to comparable `(path, audio_offset, audio_length)` rows.
+fn rows(db: &Db) -> Vec<(String, i64, i64)> {
+    let mut r: Vec<_> = db
+        .list_tracks()
+        .unwrap()
+        .into_iter()
+        .map(|t| (t.backing_path, t.audio_offset, t.audio_length))
+        .collect();
+    r.sort();
+    r
+}
+
+// === Widen / whole-file-fallback (probe_file, lines 211-235) ===
+
+/// A FLAC whose metadata (a large PICTURE) exceeds a tiny scan window scans to
+/// the SAME rows as a full-file oracle. Drives the widen loop (L213-228) and,
+/// for files that never `Complete` within retries, the whole-file fallback
+/// (L232). Guards L232 fallback guard `<`→`<=`/`==`/`>` (a mis-set guard either
+/// re-reads or skips the fallback, changing the parsed art/offset).
+// kills scan L232 `(prefix.len() as u64) < file_len`→`<=`/`==`/`>` (oracle match)
+#[test]
+fn widen_then_fallback_matches_oracle_under_tiny_window() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    // Big-art FLAC: bounded probe must widen well past a 64-byte window.
+    std::fs::write(
+        dir.path().join("big.flac"),
+        flac_with_big_art(5000, b"AUDIOPAYLOAD-BIG"),
+    )
+    .unwrap();
+    // Small FLAC entirely inside the window: prefix.len() == file_len, the
+    // fallback guard must be false (no redundant re-read), still correct.
+    std::fs::write(
+        dir.path().join("small.flac"),
+        flac_minimal(b"AUDIOPAYLOAD-SMALL"),
+    )
+    .unwrap();
+
+    let oracle_db = Db::open_in_memory().unwrap();
+    scan_directory_full_oracle(&oracle_db, dir.path()).unwrap();
+    let oracle = rows(&oracle_db);
+
+    std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
+    let bounded_db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&bounded_db, dir.path()).unwrap();
+    std::env::remove_var("MUSEFS_SCAN_WINDOW");
+
+    assert_eq!(stats.scanned, 2);
+    assert_eq!(rows(&bounded_db), oracle, "bounded widen/fallback diverged");
+    assert!(!oracle.is_empty());
+}
+
+/// A FLAC that never reaches `Complete` within the widen retries (its bounded
+/// parse keeps asking for slightly more than the window grants) must still land
+/// the correct bounds via the whole-file fallback at L232. We force this by
+/// pinning the window tiny AND verifying the big-art file's art survives a round
+/// trip identical to the oracle (covers L225 widen progress + L232 fallback).
+// kills scan L225 `want + 1` (widen must make progress to reach the art body)
+#[test]
+fn widen_preserves_art_bytes_vs_oracle() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("art.flac"),
+        flac_with_big_art(4096, b"TAILAUDIO"),
+    )
+    .unwrap();
+
+    let oracle_db = Db::open_in_memory().unwrap();
+    scan_directory_full_oracle(&oracle_db, dir.path()).unwrap();
+    let o_track = oracle_db.list_tracks().unwrap().into_iter().next().unwrap();
+    let o_art = oracle_db.get_track_art(o_track.id).unwrap();
+    let o_sha = oracle_db.get_art(o_art[0].art_id).unwrap().unwrap().sha256;
+
+    // Tiny window forces a multi-step widen to reach the 4 KiB picture body.
+    std::env::set_var("MUSEFS_SCAN_WINDOW", "16");
+    let db = Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    std::env::remove_var("MUSEFS_SCAN_WINDOW");
+
+    let track = db.list_tracks().unwrap().into_iter().next().unwrap();
+    assert_eq!(track.audio_offset, o_track.audio_offset);
+    assert_eq!(track.audio_length, o_track.audio_length);
+    let art = db.get_track_art(track.id).unwrap();
+    assert_eq!(art.len(), 1, "the embedded picture must survive the widen");
+    let sha = db.get_art(art[0].art_id).unwrap().unwrap().sha256;
+    assert_eq!(
+        sha, o_sha,
+        "widened art bytes must match the oracle exactly"
+    );
+}
+
+// === Batch flush cadence (run_pipeline, lines 570-595) ===
+
+/// Scanning more than BATCH_FILES (256) tiny files persists EVERY file exactly
+/// once. The file-count flush threshold (`batch.len() >= BATCH_FILES`, L575/585)
+/// fires mid-corpus, so a broken flush cadence (`>=`→`<`, `||`→`&&`) would drop
+/// or duplicate writes — caught by the exact scanned-count and track-count.
+// kills scan L575/585 `batch.len() >= BATCH_FILES` cadence; L573/583 batch_bytes accumulation
+#[test]
+fn scans_more_than_batch_files_persists_all_once() {
+    let n = 300usize; // > BATCH_FILES (256), so at least one mid-scan flush
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..n {
+        // Distinct audio so each file is a distinct row (no dedupe surprises).
+        std::fs::write(
+            dir.path().join(format!("t{i:04}.flac")),
+            flac_minimal(format!("AUDIO-{i}").as_bytes()),
+        )
+        .unwrap();
+    }
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+    assert_eq!(stats.scanned, n as u64, "every file must be scanned once");
+    assert_eq!(
+        db.list_tracks().unwrap().len(),
+        n,
+        "every file persisted once"
+    );
+
+    // Idempotent re-scan: still exactly n rows (catches duplicate writes from a
+    // wrong flush cadence).
+    let stats2 = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+    assert_eq!(stats2.scanned, n as u64);
+    assert_eq!(db.list_tracks().unwrap().len(), n);
+}
+
+/// Byte-threshold flushing: with a tiny `MUSEFS_BATCH_BYTES` and art-bearing
+/// files, the byte branch (`batch_bytes >= cap`, L575/585) drives flushes. All
+/// tracks and their art must persist. Guards the `batch_bytes +=` accumulation
+/// (L573/583, `+=`→`*=`) and the `||` flush disjunction.
+// kills scan L573/583 `batch_bytes += unit.weight` `+=`→`*=`; L575/585 byte branch
+#[test]
+fn byte_threshold_flush_persists_all_art() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let n = 20usize;
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..n {
+        std::fs::write(
+            dir.path().join(format!("a{i:03}.flac")),
+            flac_with_big_art(64, format!("AUD-{i}").as_bytes()),
+        )
+        .unwrap();
+    }
+    // Cap below a couple files' cumulative art so the byte branch flushes often.
+    std::env::set_var("MUSEFS_BATCH_BYTES", "100");
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+    std::env::remove_var("MUSEFS_BATCH_BYTES");
+
+    assert_eq!(stats.scanned, n as u64);
+    let tracks = db.list_tracks().unwrap();
+    assert_eq!(tracks.len(), n);
+    for t in tracks {
+        assert_eq!(
+            db.get_track_art(t.id).unwrap().len(),
+            1,
+            "each track's art must persist through byte-threshold flushing"
+        );
+    }
+}
+
+// === Revalidate counters (revalidate_with, lines 667-712) ===
+
+/// Revalidating an unchanged tree buckets every file as `unchanged`. A count of
+/// N (not 0) kills `unchanged += 1`→`-=`/`*=` (both give 0/garbage from 0).
+// kills scan L682 `unchanged += 1`→`-=`/`*=`
+#[test]
+fn revalidate_unchanged_count_matches_file_count() {
+    let n = 5usize;
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..n {
+        std::fs::write(
+            dir.path().join(format!("u{i}.flac")),
+            flac_minimal(format!("AUDIO-{i}").as_bytes()),
+        )
+        .unwrap();
+    }
+    let db = Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+
+    let stats = revalidate_with(&db, dir.path(), &ScanOptions::default()).unwrap();
+    assert_eq!(
+        stats.unchanged, n as u64,
+        "all files unchanged → unchanged == N"
+    );
+    assert_eq!(stats.updated, 0);
+    assert_eq!(stats.pruned, 0);
+    assert_eq!(stats.failed, 0);
+}
+
+/// `RevalidateStats.failed == scan.failed + skip_failed` (L711). We produce a
+/// nonzero `scan.failed` with `skip_failed == 0`: an unreadable (chmod 000) new
+/// `.flac` is a *changed* candidate (not in the existing set), passes the
+/// skip-pass (metadata + canonicalize succeed), then fails inside `probe_file`
+/// when `File::open` is denied → `scan.failed += 1`. With `skip_failed == 0`,
+/// `+`→`*` gives `1*0 == 0 != 1` → killed. (`+`→`-` gives `1-0 == 1`, NOT
+/// distinguished — see report.)
+// kills scan L711 `scan.failed + skip_failed` `+`→`*` (nonzero scan.failed, zero skip_failed)
+#[test]
+fn revalidate_failed_carries_scan_failure() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("ok.flac"), flac_minimal(b"AUDIO-OK")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let s0 = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!(s0.scanned, 1);
+    assert_eq!(s0.failed, 0);
+
+    // Add a NEW unreadable .flac: it is a changed candidate (not yet in the DB),
+    // survives the skip-pass, then probe_file's File::open is denied → failed.
+    let denied = dir.path().join("denied.flac");
+    std::fs::write(&denied, flac_minimal(b"AUDIO-DENIED")).unwrap();
+    std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let stats = revalidate(&db, dir.path()).unwrap();
+
+    // Restore perms so the TempDir can be cleaned up.
+    std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    assert_eq!(stats.unchanged, 1, "ok.flac is unchanged");
+    assert_eq!(
+        stats.failed, 1,
+        "failed must carry the re-probe scan failure (skip_failed == 0)"
+    );
+}

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -1,0 +1,173 @@
+use crate::models::{NewArt, NewTrack, Tag, TrackArt};
+use crate::{Db, Result};
+use rusqlite::{params, Transaction};
+use sha2::{Digest, Sha256};
+
+fn sha256_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+impl Db {
+    /// Apply the bulk-write pragmas to an open connection. WAL is left untouched
+    /// (retained from `open`), so concurrent mount readers keep working. Safe on
+    /// in-memory DBs. Intended for a scan-scoped `Db` the caller drops at scan end.
+    pub fn apply_bulk_pragmas(conn: &rusqlite::Connection) -> Result<()> {
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.pragma_update(None, "cache_size", -65536)?; // 64 MiB
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+        Ok(())
+    }
+
+    /// Apply bulk pragmas to this DB's own connection.
+    pub fn apply_bulk_pragmas_self(&self) -> Result<()> {
+        Self::apply_bulk_pragmas(&self.conn)
+    }
+
+    /// Begin a batch transaction. All writes go through the returned handle and
+    /// land atomically on `commit()`.
+    pub fn bulk_writer(&self) -> Result<BulkWriter<'_>> {
+        Ok(BulkWriter {
+            tx: self.conn.unchecked_transaction()?,
+        })
+    }
+}
+
+/// A batch of track writes held in one transaction. Mirrors `Db::upsert_track` /
+/// `replace_tags` / `upsert_art` / `set_track_art`, but executes on a single
+/// caller-held transaction so a whole batch commits with one fsync.
+pub struct BulkWriter<'c> {
+    tx: Transaction<'c>,
+}
+
+impl BulkWriter<'_> {
+    pub fn upsert_track(&mut self, t: &NewTrack) -> Result<i64> {
+        self.tx.execute(
+            "INSERT INTO tracks
+                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CAST(strftime('%s','now') AS INTEGER))
+             ON CONFLICT(backing_path) DO UPDATE SET
+                format=excluded.format, audio_offset=excluded.audio_offset,
+                audio_length=excluded.audio_length, backing_size=excluded.backing_size,
+                backing_mtime=excluded.backing_mtime,
+                updated_at=CAST(strftime('%s','now') AS INTEGER)",
+            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime],
+        )?;
+        Ok(self.tx.query_row(
+            "SELECT id FROM tracks WHERE backing_path = ?1",
+            params![t.backing_path],
+            |r| r.get(0),
+        )?)
+    }
+
+    pub fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> Result<()> {
+        self.tx
+            .execute("DELETE FROM tags WHERE track_id = ?1", params![track_id])?;
+        let mut stmt = self.tx.prepare_cached(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for t in tags {
+            stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+        }
+        Ok(())
+    }
+
+    pub fn upsert_art(&mut self, a: &NewArt) -> Result<i64> {
+        let sha = sha256_hex(&a.data);
+        self.tx.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) ON CONFLICT(sha256) DO NOTHING",
+            params![sha, a.mime, a.width, a.height, a.data.len() as i64, a.data],
+        )?;
+        Ok(self
+            .tx
+            .query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| {
+                r.get(0)
+            })?)
+    }
+
+    pub fn set_track_art(&mut self, track_id: i64, items: &[TrackArt]) -> Result<()> {
+        self.tx.execute(
+            "DELETE FROM track_art WHERE track_id = ?1",
+            params![track_id],
+        )?;
+        let mut stmt = self.tx.prepare_cached(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+        )?;
+        for it in items {
+            stmt.execute(params![
+                track_id,
+                it.art_id,
+                it.picture_type,
+                it.description,
+                it.ordinal
+            ])?;
+        }
+        Ok(())
+    }
+
+    pub fn commit(self) -> Result<()> {
+        self.tx.commit()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::{Format, NewArt, NewTrack, Tag, TrackArt};
+    use crate::Db;
+
+    #[test]
+    fn bulk_writer_persists_a_batch_in_one_commit() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            for i in 0..3 {
+                let id = bw
+                    .upsert_track(&NewTrack {
+                        backing_path: format!("/m/{i}.flac"),
+                        format: Format::Flac,
+                        audio_offset: 100,
+                        audio_length: 200,
+                        backing_size: 300,
+                        backing_mtime: 1,
+                    })
+                    .unwrap();
+                bw.replace_tags(id, &[Tag::new("title", &format!("t{i}"), 0)])
+                    .unwrap();
+                let art_id = bw
+                    .upsert_art(&NewArt {
+                        mime: "image/png".into(),
+                        width: None,
+                        height: None,
+                        data: vec![1, 2, 3, 4],
+                    })
+                    .unwrap();
+                bw.set_track_art(
+                    id,
+                    &[TrackArt {
+                        art_id,
+                        picture_type: 3,
+                        description: String::new(),
+                        ordinal: 0,
+                    }],
+                )
+                .unwrap();
+            }
+            bw.commit().unwrap();
+        }
+        assert_eq!(db.list_tracks().unwrap().len(), 3);
+        // Dedup: identical art blob stored once.
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM art", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -169,6 +169,60 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM art", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 1);
+        // replace_tags actually persisted one tag per track (kills no-op replace_tags).
+        let tag_count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM tags", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(tag_count, 3);
+        let title0: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM tags WHERE key = 'title' ORDER BY value LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(title0, "t0");
+        // set_track_art actually persisted one link per track (kills no-op set_track_art).
+        let track_art_count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM track_art", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(track_art_count, 3);
+    }
+
+    #[test]
+    fn sha256_hex_matches_known_digest() {
+        // NIST sample vector: sha256("abc").
+        assert_eq!(
+            super::sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn apply_bulk_pragmas_self_sets_non_default_pragmas() {
+        let db = Db::open_in_memory().unwrap();
+        db.apply_bulk_pragmas_self().unwrap();
+        // synchronous NORMAL == 1 (default for in-memory is FULL == 2).
+        let synchronous: i64 = db
+            .conn
+            .pragma_query_value(None, "synchronous", |r| r.get(0))
+            .unwrap();
+        assert_eq!(synchronous, 1);
+        // cache_size == -65536 (negative => KiB; sign matters, default is -2000).
+        let cache_size: i64 = db
+            .conn
+            .pragma_query_value(None, "cache_size", |r| r.get(0))
+            .unwrap();
+        assert_eq!(cache_size, -65536);
+        // temp_store MEMORY == 2 (default is 0).
+        let temp_store: i64 = db
+            .conn
+            .pragma_query_value(None, "temp_store", |r| r.get(0))
+            .unwrap();
+        assert_eq!(temp_store, 2);
     }
 
     #[test]

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -170,4 +170,23 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
     }
+
+    #[test]
+    fn bulk_writer_dropped_without_commit_rolls_back() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            bw.upsert_track(&NewTrack {
+                backing_path: "/m/ghost.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+            // Dropped here without `commit()` → Transaction rolls back.
+        }
+        assert_eq!(db.list_tracks().unwrap().len(), 0);
+    }
 }

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -17,7 +17,7 @@ impl Db {
     /// Apply the bulk-write pragmas to an open connection. WAL is left untouched
     /// (retained from `open`), so concurrent mount readers keep working. Safe on
     /// in-memory DBs. Intended for a scan-scoped `Db` the caller drops at scan end.
-    pub fn apply_bulk_pragmas(conn: &rusqlite::Connection) -> Result<()> {
+    pub(crate) fn apply_bulk_pragmas(conn: &rusqlite::Connection) -> Result<()> {
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         conn.pragma_update(None, "cache_size", -65536)?; // 64 MiB
         conn.pragma_update(None, "temp_store", "MEMORY")?;

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -1,10 +1,12 @@
 mod art;
+mod bulk;
 mod error;
 mod models;
 mod schema;
 mod tags;
 mod tracks;
 
+pub use bulk::BulkWriter;
 pub use error::{DbError, Result};
 pub use models::{Art, ArtMeta, Format, NewArt, NewTrack, Tag, Track, TrackArt};
 

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -645,6 +645,176 @@ mod tests {
         assert_eq!(read_pictures(&mid), Err(FormatError::Malformed));
     }
 
+    // ---- read_metadata_bounded mutant-kill tests (flac.rs:89-133) ----
+
+    #[test]
+    fn bounded_rejects_short_and_wrong_marker() {
+        // kills flac L90 `<` -> `==`/`<=` and `||` -> `&&`:
+        // a 3-byte prefix is too short. Original short-circuits NotFlac; the `==`
+        // mutant (len==4 is false for len 3) and the `&&` mutant force evaluation
+        // of &prefix[0..4] on 3 bytes -> panic. NotFlac kills both.
+        assert_eq!(read_metadata_bounded(b"fLa"), Err(FormatError::NotFlac));
+        // kills flac L90 `<` -> `<=`: a 4-byte "fLaC"-only prefix is exactly the
+        // marker. Original (len 4 < 4 is false) proceeds; since pos+4=8 > 4 it
+        // returns NeedMore{up_to:8}. The `<=` mutant (4 <= 4 true) wrongly returns
+        // NotFlac. Asserting NOT NotFlac (and the exact NeedMore) kills it.
+        match read_metadata_bounded(b"fLaC").unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 8),
+            other @ Extent::Complete(_) => panic!("expected NeedMore{{up_to:8}}, got {other:?}"),
+        }
+        // kills flac L90 marker check: a non-FLAC 4-byte prefix -> NotFlac.
+        assert_eq!(read_metadata_bounded(b"XXXX"), Err(FormatError::NotFlac));
+    }
+
+    #[test]
+    fn bounded_needmore_up_to_is_pos_plus_4_for_truncated_header() {
+        // Marker + a non-last STREAMINFO (empty body) then truncated: after the
+        // first block, pos = 4 + 4 + 0 = 8. The prefix ends exactly there, so the
+        // loop guard `pos + 4 > prefix.len()` fires with pos == 8.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], false, None)]);
+        // file is fLaC(4) + header(4) = 8 bytes; pos lands at 8 == prefix.len().
+        assert_eq!(file.len(), 8);
+        match read_metadata_bounded(&file).unwrap() {
+            // kills flac L96 `pos + 4 > prefix.len()` `+` -> `-`: with `pos - 4`
+            // (8-4=4) the comparison 4 > 8 is false, so it would NOT return NeedMore
+            // and instead panic reading prefix[8..]. NeedMore here kills it.
+            // kills flac L99 up_to `(pos + 4)` `+` -> `-`/`*`: pos==8 -> correct
+            // up_to == 12. `pos - 4` gives 4; `pos * 4` gives 32. Exact 12 kills both.
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 12),
+            other @ Extent::Complete(_) => panic!("expected NeedMore{{up_to:12}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bounded_is_last_flag_continues_past_nonlast_block() {
+        // Two blocks: first NON-last STREAMINFO (body 0xAA*2), then a LAST
+        // STREAMINFO (body 0xBB*3) + no audio. audio_offset must span BOTH.
+        let b1 = raw_block(BLOCK_STREAMINFO, &[0xAA, 0xAA], false, None); // 4+2=6
+        let b2 = raw_block(BLOCK_STREAMINFO, &[0xBB, 0xBB, 0xBB], true, None); // 4+3=7
+        let file = flac_with(&[b1, b2]);
+        let expected_offset = (4 + 6 + 7) as u64; // marker + block1 + block2
+        match read_metadata_bounded(&file).unwrap() {
+            Extent::Complete(meta) => {
+                // kills flac L103 `header & 0x80` `&` -> `|`: `header | 0x80` is always
+                // nonzero -> is_last always true -> it would stop after block 1 with
+                // audio_offset == 4+6 == 10. Spanning both blocks (17) kills it.
+                assert_eq!(meta.audio_offset, expected_offset);
+                // both STREAMINFO blocks preserved -> proves we walked past block 1.
+                assert_eq!(meta.preserved.len(), 2);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bounded_block_type_mask_preserves_streaminfo() {
+        // A single last STREAMINFO (type 0) with a known body.
+        let body = vec![0x5A; 8];
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &body, true, None)]);
+        match read_metadata_bounded(&file).unwrap() {
+            Extent::Complete(meta) => {
+                // kills flac L104 `header & 0x7F` `&` -> `|`/`^`: for a last STREAMINFO
+                // the header byte is 0x80 (is_last set, type 0). Correct block_type =
+                // 0x80 & 0x7F = 0. `0x80 | 0x7F` = 0xFF, `0x80 ^ 0x7F` = 0xFF -> neither
+                // matches the STREAMINFO arm -> preserved stays empty. Asserting the
+                // block IS preserved with block_type 0 kills both.
+                assert_eq!(meta.preserved.len(), 1);
+                assert_eq!(meta.preserved[0].block_type, BLOCK_STREAMINFO);
+                assert_eq!(meta.preserved[0].body, body);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bounded_decodes_24bit_length_exactly() {
+        // Single last block whose declared length = 0x010203 (bytes 0x01,0x02,0x03),
+        // exercising all three length positions. Body is that many bytes so the block
+        // fits and we get a Complete with an exact audio_offset.
+        let len = 0x01_0203usize;
+        let body = vec![0u8; len];
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &body, true, None)]);
+        let expected_offset = (4 + 4 + len) as u64;
+        match read_metadata_bounded(&file).unwrap() {
+            Extent::Complete(meta) => {
+                // kills flac L105 `<< 16` -> `>> 16`: (0x01 >> 16) == 0 -> len loses
+                //   its high byte -> body_end shifts -> wrong audio_offset.
+                // kills flac L106 `<< 8` -> `>> 8`: (0x02 >> 8) == 0 -> mid byte lost.
+                // kills flac L106 `|` -> `&`: (0x010000) & (0x000200) == 0 -> length
+                //   collapses (disjoint high/mid bits) -> wrong audio_offset.
+                // kills flac L107 final `|` -> assembles low byte; an exact audio_offset
+                //   pins the full 24-bit assembly.
+                assert_eq!(meta.audio_offset, expected_offset);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bounded_length_or_vs_and_high_byte() {
+        // Dedicated `|` -> `&` kill on flac L106: declare length 0x010100 (high byte
+        // 0x01, mid byte 0x01, low 0x00). Correct len = 65792. With `(b1<<16) &
+        // (b2<<8)` the disjoint bits AND to 0, then `| low` -> very different length.
+        // Use NeedMore: body is absent, so the correct parse asks for the full body.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0100))]);
+        match read_metadata_bounded(&file).unwrap() {
+            Extent::NeedMore { up_to } => {
+                // body_start = 4 + 4 = 8; up_to = body_end = 8 + 0x010100.
+                assert_eq!(up_to, 8 + 0x01_0100);
+            }
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bounded_body_end_equal_to_prefix_is_complete() {
+        // A single LAST STREAMINFO whose body ends EXACTLY at the prefix end (no
+        // audio). body_end == prefix.len().
+        let body = vec![0xCC; 6];
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &body, true, None)]);
+        let total = file.len() as u64; // 4 + 4 + 6 == 14
+        match read_metadata_bounded(&file).unwrap() {
+            // kills flac L110 `body_end > prefix.len()` `>` -> `>=`: with `>=`,
+            // body_end == prefix.len() is true -> wrongly returns NeedMore. Original
+            // (`>`) proceeds and, since is_last, returns Complete{audio_offset==len}.
+            Extent::Complete(meta) => assert_eq!(meta.audio_offset, total),
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete (exact fit), got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn bounded_preserves_all_structural_block_types() {
+        // kills flac L116 (delete the STREAMINFO|APPLICATION|SEEKTABLE|CUESHEET arm):
+        // a prefix containing each preserved type must yield all four in `preserved`.
+        // Deleting the arm makes `preserved` empty -> these assertions fail.
+        let b_si = raw_block(BLOCK_STREAMINFO, &[0x01], false, None);
+        let b_app = raw_block(BLOCK_APPLICATION, &[0x02, 0x02], false, None);
+        let b_seek = raw_block(BLOCK_SEEKTABLE, &[0x03, 0x03, 0x03], false, None);
+        let b_cue = raw_block(BLOCK_CUESHEET, &[0x04], true, None);
+        let file = flac_with(&[b_si, b_app, b_seek, b_cue]);
+        match read_metadata_bounded(&file).unwrap() {
+            Extent::Complete(meta) => {
+                let types: Vec<u8> = meta.preserved.iter().map(|b| b.block_type).collect();
+                assert_eq!(
+                    types,
+                    vec![
+                        BLOCK_STREAMINFO,
+                        BLOCK_APPLICATION,
+                        BLOCK_SEEKTABLE,
+                        BLOCK_CUESHEET,
+                    ]
+                );
+                assert_eq!(meta.preserved[0].body, vec![0x01]);
+                assert_eq!(meta.preserved[1].body, vec![0x02, 0x02]);
+                assert_eq!(meta.preserved[2].body, vec![0x03, 0x03, 0x03]);
+                assert_eq!(meta.preserved[3].body, vec![0x04]);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
     #[test]
     fn synthesize_layout_picture_block_size_boundary_is_inclusive() {
         // body_len = picture_body_framing(art).len() + art.data_len. The guard at

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -1,4 +1,5 @@
 use crate::error::{FormatError, Result};
+use crate::probe::Extent;
 
 pub(crate) const FLAC_MARKER: &[u8; 4] = b"fLaC";
 
@@ -80,8 +81,6 @@ fn parse_blocks(data: &[u8]) -> Result<FlacMeta> {
 pub fn read_metadata(data: &[u8]) -> Result<FlacMeta> {
     parse_blocks(data)
 }
-
-use crate::probe::Extent;
 
 /// Bounded twin of [`read_metadata`]: walk the metadata blocks present in
 /// `prefix` (which may be a front-only window of the file). If a block's declared

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -81,6 +81,58 @@ pub fn read_metadata(data: &[u8]) -> Result<FlacMeta> {
     parse_blocks(data)
 }
 
+use crate::probe::Extent;
+
+/// Bounded twin of [`read_metadata`]: walk the metadata blocks present in
+/// `prefix` (which may be a front-only window of the file). If a block's declared
+/// body runs past the prefix, return `NeedMore { up_to }` with the exact end of
+/// that block — the caller widens the window and retries. Otherwise `Complete`.
+pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
+    if prefix.len() < 4 || &prefix[0..4] != FLAC_MARKER {
+        return Err(FormatError::NotFlac);
+    }
+    let mut pos = 4usize;
+    let mut preserved = Vec::new();
+    loop {
+        if pos + 4 > prefix.len() {
+            // Need at least the 4-byte block header.
+            return Ok(Extent::NeedMore {
+                up_to: (pos + 4) as u64,
+            });
+        }
+        let header = prefix[pos];
+        let is_last = (header & 0x80) != 0;
+        let block_type = header & 0x7F;
+        let len = ((prefix[pos + 1] as usize) << 16)
+            | ((prefix[pos + 2] as usize) << 8)
+            | (prefix[pos + 3] as usize);
+        let body_start = pos + 4;
+        let body_end = body_start + len;
+        if body_end > prefix.len() {
+            return Ok(Extent::NeedMore {
+                up_to: body_end as u64,
+            });
+        }
+        match block_type {
+            BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
+                preserved.push(MetadataBlock {
+                    block_type,
+                    body: prefix[body_start..body_end].to_vec(),
+                });
+            }
+            _ => {}
+        }
+        pos = body_end;
+        if is_last {
+            break;
+        }
+    }
+    Ok(Extent::Complete(FlacMeta {
+        audio_offset: pos as u64,
+        preserved,
+    }))
+}
+
 /// Parse the FLAC metadata section of a complete file, returning the audio
 /// boundary, audio length, and the structural blocks to carry over.
 pub fn locate_audio(data: &[u8]) -> Result<FlacScan> {
@@ -314,6 +366,40 @@ pub fn read_pictures(data: &[u8]) -> Result<Vec<EmbeddedPicture>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::probe::Extent;
+
+    /// Build a minimal FLAC: marker + a single last STREAMINFO (type 0, 34-byte
+    /// body) + `audio` bytes. Returns (full_bytes, audio_offset).
+    fn flac_with_streaminfo(audio: &[u8]) -> (Vec<u8>, u64) {
+        let mut v = b"fLaC".to_vec();
+        push_block_header(&mut v, BLOCK_STREAMINFO, 34, true);
+        v.extend(std::iter::repeat_n(0u8, 34));
+        let audio_offset = v.len() as u64;
+        v.extend_from_slice(audio);
+        (v, audio_offset)
+    }
+
+    #[test]
+    fn read_metadata_bounded_complete_when_prefix_covers_blocks() {
+        let (full, audio_offset) = flac_with_streaminfo(b"AUDIOAUDIO");
+        // Prefix that includes all metadata but not all audio.
+        let prefix = &full[..audio_offset as usize + 2];
+        match read_metadata_bounded(prefix).unwrap() {
+            Extent::Complete(meta) => assert_eq!(meta.audio_offset, audio_offset),
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_needmore_when_block_body_truncated() {
+        let (full, audio_offset) = flac_with_streaminfo(b"AUDIO");
+        // Cut inside the STREAMINFO body (header is 4 bytes after the marker).
+        let prefix = &full[..8];
+        match read_metadata_bounded(prefix).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, audio_offset),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
 
     #[test]
     fn read_u32_be_assembles_big_endian_and_guards_length() {

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -5,6 +5,7 @@ mod layout;
 pub mod mp3;
 pub mod mp4;
 pub mod ogg;
+pub mod probe;
 mod tagmap;
 mod vorbiscomment;
 pub mod wav;
@@ -16,6 +17,7 @@ pub use error::{FormatError, Result};
 pub use input::{ArtInput, EmbeddedPicture, TagInput};
 pub use layout::{LayoutError, RegionLayout, Segment};
 pub use ogg::{Codec, OggHeader, OggScan};
+pub use probe::Extent;
 
 // tagmap is pure &str→key mapping with no byte parsing and is already exercised
 // indirectly by the per-format fuzz targets (which pass arbitrary tag keys through

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -88,6 +88,15 @@ pub fn locate_audio_bounded(
         return Ok(Extent::NeedMore { up_to: 10 });
     }
 
+    // The audio start (plus its 2-byte frame sync) must fit in the file. Mirrors
+    // the unbounded `locate_audio`'s `audio_offset + 1 >= len` reject: without
+    // this, a tag that claims audio begins at/after EOF would return `NeedMore`
+    // with `up_to > file_len`, and the caller would widen to the full file and
+    // get the same answer every retry instead of failing fast.
+    if audio_offset as u64 + 2 > file_len {
+        return Err(FormatError::NotMp3);
+    }
+
     // Need the frame-sync pair at the audio offset to be inside the prefix.
     if audio_offset + 2 > prefix.len() {
         return Ok(Extent::NeedMore {
@@ -1173,6 +1182,21 @@ mod tests {
                 assert_eq!(b.audio_length, body_end as u64 - audio_offset);
             }
             other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_rejects_audio_start_past_eof() {
+        // An ID3v2 tag whose declared length leaves no room for the frame sync
+        // (audio_offset == file_len). The bounded prober must fail fast with
+        // `NotMp3` rather than loop on `NeedMore { up_to > file_len }`.
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(8));
+        full.extend(std::iter::repeat_n(0u8, 8)); // tag body; file ends here
+        let file_len = full.len() as u64; // == tag end == audio_offset
+        match locate_audio_bounded(&full, file_len, None) {
+            Err(FormatError::NotMp3) => {}
+            other => panic!("expected Err(NotMp3), got {other:?}"),
         }
     }
 }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1199,4 +1199,352 @@ mod tests {
             other => panic!("expected Err(NotMp3), got {other:?}"),
         }
     }
+
+    // kills mp3 L75 (`prefix.len() >= 10 && &prefix[0..3] == b"ID3"`: `&&`->`||`).
+    // A long (>=10) prefix that is NOT "ID3" and starts with a valid frame sync.
+    // Correct (`&&`): the ID3 branch is skipped -> audio_offset stays 0 -> Complete
+    // at offset 0. Under `||`: `len>=10 || "ID3"==..` is true, so it parses an ID3
+    // header out of the non-ID3 bytes, computing a bogus tag_len and a wrong
+    // audio_offset (or Malformed). Asserting audio_offset==0 kills it.
+    #[test]
+    fn locate_audio_bounded_plain_mp3_no_id3_starts_at_zero() {
+        // 0xFF 0xFB frame sync at offset 0, then payload. len 12 (>= 10).
+        let data = [0xFF, 0xFB, 0x90, 0x00, 1, 2, 3, 4, 5, 6, 7, 8];
+        let file_len = data.len() as u64;
+        match locate_audio_bounded(&data, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, 0);
+                assert_eq!(b.audio_length, file_len);
+            }
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete at offset 0, got {other:?}")
+            }
+        }
+    }
+
+    // Reinforces L75 with a short non-ID3 prefix below the ID3-header length.
+    // A 5-byte prefix that is not "ID3", file_len < 10. Correct (`&&`): the ID3
+    // branch is false (len 5 < 10) AND the else-if at L86 is `len<10 && file_len>=10`
+    // = `true && false` = false, so it proceeds; the frame sync at offset 0 is in
+    // the prefix -> Complete. Under L75 `||`: `5>=10 || "ID3"==prefix[0..3]` ->
+    // false || false is still false here, BUT the point is the `&&`->`||` mutant on
+    // a len>=10 non-ID3 prefix (covered above). This case pins that a short non-ID3
+    // prefix with a valid sync resolves to Complete (no panic indexing prefix[5..]).
+    #[test]
+    fn locate_audio_bounded_short_non_id3_with_small_file() {
+        // 0xFF 0xFB sync at offset 0; file_len 5 (< 10).
+        let data = [0xFF, 0xFB, 0x90, 0x00, 0x00];
+        let file_len = data.len() as u64; // 5
+        match locate_audio_bounded(&data, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, 0);
+                assert_eq!(b.audio_length, 5);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    // kills mp3 L80 (footer `tag_len += 10`: `+=`->`-=`,`*=`).
+    // ID3v2.4 tag WITH the footer flag (0x10) and a known body. tag_len must be
+    // 10 (header) + body + 10 (footer). With body=6, audio_offset must be 26.
+    // `-=` gives 10+6-10 = 6; `*=` gives (10+6)*10 = 160 (> file_len -> Malformed).
+    // Frame sync is placed at offset 26 so the correct path returns Complete.
+    #[test]
+    fn locate_audio_bounded_footer_flag_adds_ten() {
+        let body = 6usize;
+        let mut full = b"ID3\x04\x00".to_vec();
+        full.push(0x10); // flags: footer present
+        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend(std::iter::repeat_n(0u8, body)); // tag body
+        full.extend(std::iter::repeat_n(0u8, 10)); // footer region
+        let expected_offset = full.len() as u64; // 10 + 6 + 10 = 26
+        full.extend_from_slice(&[0xFF, 0xFB]); // frame sync at offset 26
+        full.extend_from_slice(b"audio");
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(&full, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, 26);
+                assert_eq!(b.audio_offset, expected_offset);
+                assert_eq!(b.audio_length, file_len - 26);
+            }
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete at offset 26, got {other:?}")
+            }
+        }
+    }
+
+    // kills mp3 L82 (`tag_len as u64 > file_len`: `>`->`==`,`>=`).
+    // Construct a tag where tag_len == file_len EXACTLY (no room for audio).
+    // Correct (`>`): `tag_len > file_len` is false -> proceeds; then the L96
+    // `audio_offset + 2 > file_len` check fires (audio_offset == file_len) ->
+    // Err(NotMp3). Under `==`/`>=`: `tag_len == file_len` true -> early
+    // Err(Malformed). Asserting NotMp3 (not Malformed) kills both.
+    #[test]
+    fn locate_audio_bounded_tag_len_equals_file_len_is_notmp3_not_malformed() {
+        let body = 8usize;
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend(std::iter::repeat_n(0u8, body)); // file ends exactly at tag end
+        let file_len = full.len() as u64; // == tag_len == audio_offset (18)
+        match locate_audio_bounded(&full, file_len, None) {
+            Err(FormatError::NotMp3) => {}
+            other => panic!("expected Err(NotMp3) for tag_len==file_len, got {other:?}"),
+        }
+    }
+
+    // kills mp3 L82 true branch (`>`): a tag declaring more than the file holds
+    // must be Malformed. Pins that the `>` branch is reachable and returns
+    // Malformed (so the `>`->`==`/`>=` mutants, which change WHICH side is taken,
+    // are distinguished from the equals case above).
+    #[test]
+    fn locate_audio_bounded_tag_len_exceeds_file_len_is_malformed() {
+        // Declare body=100 but provide a tiny file. tag_len = 110 > file_len.
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(100));
+        full.extend_from_slice(&[0xFF, 0xFB]); // some bytes, but file is short
+        let file_len = full.len() as u64; // 12, << 110
+        match locate_audio_bounded(&full, file_len, None) {
+            Err(FormatError::Malformed) => {}
+            other => panic!("expected Err(Malformed), got {other:?}"),
+        }
+    }
+
+    // kills mp3 L86 (`prefix.len() < 10 && file_len >= 10`: the NeedMore{up_to:10}
+    // else-if). Short non-ID3 prefix (len 5) with file_len >= 10. Correct: `5 < 10
+    // && 10 >= 10` = true -> NeedMore{up_to:10} (we cannot even read the ID3 header).
+    // `&&`->`||` keeps it true here; the distinguishing variants are below.
+    #[test]
+    fn locate_audio_bounded_short_prefix_large_file_needs_header() {
+        let prefix = [0x00, 0x00, 0x00, 0x00, 0x00]; // 5 bytes, not "ID3"
+        let file_len = 64u64; // >= 10
+        match locate_audio_bounded(&prefix, file_len, None).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 10),
+            other @ Extent::Complete(_) => panic!("expected NeedMore{{up_to:10}}, got {other:?}"),
+        }
+    }
+
+    // kills mp3 L86 `<`->`<=` (and `<`->`==`): boundary prefix.len()==10.
+    // A 10-byte non-ID3 prefix with file_len >= 10. Correct (`<`): `10 < 10` is
+    // false -> does NOT take the NeedMore-header branch -> proceeds. The first two
+    // prefix bytes are a valid frame sync, so audio at offset 0 resolves Complete.
+    // Under `<=`: `10 <= 10` true -> wrongly NeedMore{up_to:10}. Under `==`:
+    // `10 == 10` true -> wrongly NeedMore. Asserting Complete kills both.
+    #[test]
+    fn locate_audio_bounded_prefix_len_exactly_ten_proceeds() {
+        // 10 bytes, not "ID3", frame sync at offset 0.
+        let prefix = [0xFF, 0xFB, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let file_len = 64u64; // >= 10, audio extends to file_len
+        match locate_audio_bounded(&prefix, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, 0);
+                assert_eq!(b.audio_length, file_len);
+            }
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete (10<10 false), got {other:?}")
+            }
+        }
+    }
+
+    // kills mp3 L86 `>=`->`<` on file_len (and helps `&&`->`||`). Short non-ID3
+    // prefix (len 5) with file_len < 10 (file_len=8). Correct (`>=`): `5 < 10 &&
+    // 8 >= 10` = `true && false` = false -> does NOT NeedMore -> proceeds; sync at
+    // offset 0 is in the prefix -> Complete with audio_length 8. Under `>=`->`<`:
+    // `8 < 10` true -> `true && true` -> wrongly NeedMore{up_to:10}. Under `&&`->
+    // `||`: `true || false` -> true -> wrongly NeedMore. Asserting Complete kills
+    // both the `>=`->`<` and the `&&`->`||` mutants.
+    #[test]
+    fn locate_audio_bounded_short_prefix_small_file_proceeds() {
+        let data = [0xFF, 0xFB, 0x90, 0x00, 0x00]; // len 5, file_len 8 -> but prefix==file here
+                                                   // Make file_len 8 with the same 5-byte prefix window; the sync pair (2 bytes)
+                                                   // is inside the prefix, so it resolves without needing more.
+        let file_len = 8u64;
+        match locate_audio_bounded(&data, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, 0);
+                assert_eq!(b.audio_length, 8);
+            }
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete (file_len<10), got {other:?}")
+            }
+        }
+    }
+
+    // kills mp3 L96 (`audio_offset as u64 + 2 > file_len`: `+`->`-`).
+    // Build a real ID3v2 tag so audio_offset > 0, with the audio start placed
+    // JUST past EOF: audio_offset + 2 == file_len + 1 (i.e. audio_offset ==
+    // file_len - 1). Correct (`+`): `audio_offset + 2 > file_len` -> true ->
+    // Err(NotMp3). Under `-`: `audio_offset - 2 > file_len` -> false (since
+    // audio_offset < file_len) -> proceeds -> would read past EOF / wrong answer.
+    #[test]
+    fn locate_audio_bounded_sync_one_byte_past_eof_is_notmp3() {
+        let body = 4usize;
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend(std::iter::repeat_n(0u8, body)); // tag end at offset 14
+        let audio_offset = full.len() as u64; // 14
+        full.push(0xFF); // a single sync byte present (so prefix has audio_offset+1)
+                         // file_len = audio_offset + 1, so audio_offset + 2 == file_len + 1 (just past).
+        let file_len = audio_offset + 1; // 15
+        match locate_audio_bounded(&full, file_len, None) {
+            Err(FormatError::NotMp3) => {}
+            other => panic!("expected Err(NotMp3) (sync past EOF), got {other:?}"),
+        }
+    }
+
+    // Complement to L96: audio_offset + 2 <= file_len must proceed (not reject).
+    // Pins that the `>` comparison's false branch is reachable; with `+`->`-` the
+    // earlier case flips, so this guards the true semantics of "+2 fits".
+    #[test]
+    fn locate_audio_bounded_sync_fits_in_file_proceeds() {
+        let (full, audio_offset) = mp3_with_id3v2(4, b"frames");
+        let file_len = full.len() as u64; // audio_offset + 2 + 6
+        match locate_audio_bounded(&full, file_len, None).unwrap() {
+            Extent::Complete(b) => assert_eq!(b.audio_offset, audio_offset),
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    // kills mp3 L107 (`prefix[audio_offset] != 0xFF || (prefix[audio_offset+1] &
+    // 0xE0) != 0xE0`): `||`->`&&` and `+`->`*`.
+    // Frame-sync byte 0 is 0xFF but byte 1 lacks the 0xE0 sync bits. Correct
+    // (`||`): first operand false, second true -> reject NotMp3. Under `&&`:
+    // `false && true` -> accept (wrong) -> would return Complete. The `+`->`*` on
+    // `audio_offset + 1`: with audio_offset==0, `0*1 == 0` reads byte 0 (0xFF)
+    // instead of byte 1, so `(0xFF & 0xE0) != 0xE0` is false -> with `||` short of
+    // first-operand-false the decision changes; pairing distinct bytes makes the
+    // sync verdict observable.
+    #[test]
+    fn locate_audio_bounded_rejects_bad_second_sync_byte() {
+        // byte0 = 0xFF (passes first half), byte1 = 0x00 (fails the 0xE0 check).
+        let data = [
+            0xFF, 0x00, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let file_len = data.len() as u64;
+        match locate_audio_bounded(&data, file_len, None) {
+            Err(FormatError::NotMp3) => {}
+            other => panic!("expected Err(NotMp3) (bad sync byte 1), got {other:?}"),
+        }
+    }
+
+    // Reinforces L107 `+`->`*` at a NON-zero audio_offset so `audio_offset + 1`
+    // and `audio_offset * 1` differ. With an ID3 tag pushing audio_offset to 14:
+    // byte[14] = 0xFF (good), byte[15] = 0x00 (bad second byte). Correct reads
+    // byte[15] -> reject NotMp3. Under `+`->`*`: `14 * 1 == 14` reads byte[14]
+    // (0xFF) again -> `(0xFF & 0xE0)==0xE0` so the second test passes -> accept
+    // (wrong). Asserting NotMp3 kills `+`->`*`.
+    #[test]
+    fn locate_audio_bounded_rejects_bad_second_sync_byte_after_id3() {
+        let body = 4usize;
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend(std::iter::repeat_n(0u8, body)); // audio_offset = 14
+        full.extend_from_slice(&[0xFF, 0x00]); // byte14=0xFF good, byte15=0x00 bad
+        full.extend_from_slice(b"tail");
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(&full, file_len, None) {
+            Err(FormatError::NotMp3) => {}
+            other => panic!("expected Err(NotMp3) (bad sync at 15), got {other:?}"),
+        }
+    }
+
+    // kills mp3 L101 frame-sync NeedMore (`audio_offset + 2 > prefix.len()`).
+    // A tag whose audio_offset is inside file_len, but the prefix is shorter than
+    // audio_offset + 2 (the sync pair is past the prefix window). Correct: returns
+    // NeedMore{up_to: audio_offset + 2}. A `+`->`*` (audio_offset*2) or a flipped
+    // comparison changes up_to. Here audio_offset=14, so up_to must be 16; prefix
+    // is only 15 bytes (one short of the sync pair).
+    #[test]
+    fn locate_audio_bounded_needmore_for_sync_past_prefix() {
+        let body = 4usize;
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend(std::iter::repeat_n(0u8, body)); // audio_offset = 14
+        full.extend_from_slice(&[0xFF, 0xFB]); // sync at 14..16
+        full.extend_from_slice(b"more audio bytes here");
+        let file_len = full.len() as u64; // plenty of room
+        let prefix = &full[..15]; // 14-byte tag + only 1 of the 2 sync bytes
+        match locate_audio_bounded(prefix, file_len, None).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 16), // audio_offset(14) + 2
+            other @ Extent::Complete(_) => panic!("expected NeedMore{{up_to:16}}, got {other:?}"),
+        }
+    }
+
+    // kills mp3 L113 (`file_len >= audio_offset + 128 && &tail[0..3] == b"TAG"`:
+    // `&&`->`||`) — the TRIM case. A valid MP3 with a "TAG"-prefixed tail and
+    // file_len >= audio_offset + 128. Correct: trim -> audio_length = file_len -
+    // audio_offset - 128. (The complement no-trim case is below; together they pin
+    // the `&&`.)
+    #[test]
+    fn locate_audio_bounded_trims_id3v1_when_tag_and_room() {
+        let (mut full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        let body_end = full.len();
+        full.extend_from_slice(b"TAG");
+        full.extend(std::iter::repeat_n(0u8, 125)); // 128-byte ID3v1 trailer
+        let file_len = full.len() as u64;
+        assert!(file_len >= audio_offset + 128); // both conditions true
+        let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
+        let prefix = &full[..audio_offset as usize + 2];
+        match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                // kills mp3 L113: trimmed length excludes the 128-byte ID3v1 tail.
+                assert_eq!(b.audio_length, file_len - audio_offset - 128);
+                assert_eq!(b.audio_length, body_end as u64 - audio_offset);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete (trimmed), got {other:?}"),
+        }
+    }
+
+    // kills mp3 L113 (`&&`->`||`) — the NO-TRIM case. file_len >= audio_offset+128
+    // is TRUE, but the tail does NOT start with "TAG". Correct (`&&`): second
+    // operand false -> no trim -> audio_length == file_len - audio_offset. Under
+    // `||`: first operand true -> trims 128 wrongly -> shorter length. Asserting
+    // the un-trimmed length kills the `||` mutant.
+    #[test]
+    fn locate_audio_bounded_no_trim_when_tail_not_tag() {
+        let (mut full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        // Pad with enough non-"TAG" trailing bytes so file_len >= audio_offset+128.
+        full.extend(std::iter::repeat_n(0u8, 200));
+        let file_len = full.len() as u64;
+        assert!(file_len >= audio_offset + 128); // first operand TRUE
+        let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
+        assert_ne!(&tail[0..3], b"TAG"); // second operand FALSE
+        let prefix = &full[..audio_offset as usize + 2];
+        match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                // No trim: full audio length from offset to EOF.
+                assert_eq!(b.audio_length, file_len - audio_offset);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete (no trim), got {other:?}"),
+        }
+    }
+
+    // Complement to L113 first-operand: tail starts with "TAG" but file_len <
+    // audio_offset + 128 (no room for a real ID3v1). Correct (`&&`): first operand
+    // false -> no trim. Under `||`: second operand true -> trims 128 even though
+    // file_len < audio_offset + 128, which would underflow / shorten wrongly.
+    // Asserting the un-trimmed length pins the first operand of the `&&`.
+    #[test]
+    fn locate_audio_bounded_no_trim_when_no_room_even_with_tag_tail() {
+        let (mut full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        // Short file: append a "TAG"-prefixed tail but keep file_len < offset+128.
+        full.extend_from_slice(b"TAGxx"); // tail-ish marker, but file stays short
+        let file_len = full.len() as u64;
+        assert!(file_len < audio_offset + 128); // first operand FALSE
+                                                // Build a 128-byte tail buffer that starts with "TAG" (the function only
+                                                // looks at tail[0..3]); file_len is the real gate here.
+        let mut tail = [0u8; 128];
+        tail[0..3].copy_from_slice(b"TAG");
+        let prefix = &full[..audio_offset as usize + 2];
+        match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                assert_eq!(b.audio_length, file_len - audio_offset); // no trim
+            }
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete (no room, no trim), got {other:?}")
+            }
+        }
+    }
 }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1,6 +1,7 @@
 use crate::error::{FormatError, Result};
 use crate::input::{ArtInput, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
+use crate::probe::Extent;
 
 /// Where the MP3 audio frames begin and end (excluding any ID3v2 prefix and
 /// ID3v1 trailer). Unlike FLAC there is no preserved structural metadata: the
@@ -57,6 +58,58 @@ pub fn locate_audio(data: &[u8]) -> Result<Mp3Bounds> {
         audio_offset: audio_offset as u64,
         audio_length: (audio_end - audio_offset) as u64,
     })
+}
+
+/// Bounded twin of [`locate_audio`]. `prefix` is a front window; `file_len` is the
+/// true size; `tail` is the file's last 128 bytes (or `None` if the file is
+/// shorter than 128 bytes). The audio start is the end of any leading ID3v2 tag
+/// (declared in its 10-byte header); if that end is past the prefix, returns
+/// `NeedMore`. The audio end is `file_len` minus a 128-byte ID3v1 trailer when the
+/// `tail` begins with `TAG`.
+pub fn locate_audio_bounded(
+    prefix: &[u8],
+    file_len: u64,
+    tail: Option<&[u8; 128]>,
+) -> Result<Extent<Mp3Bounds>> {
+    let mut audio_offset = 0usize;
+    if prefix.len() >= 10 && &prefix[0..3] == b"ID3" {
+        let flags = prefix[5];
+        let body = synchsafe_decode(&prefix[6..10]) as usize;
+        let mut tag_len = 10 + body;
+        if flags & 0x10 != 0 {
+            tag_len += 10; // ID3v2.4 footer
+        }
+        if tag_len as u64 > file_len {
+            return Err(FormatError::Malformed);
+        }
+        audio_offset = tag_len;
+    } else if prefix.len() < 10 && (file_len as usize) >= 10 {
+        // Not enough bytes even to read the ID3v2 header.
+        return Ok(Extent::NeedMore { up_to: 10 });
+    }
+
+    // Need the frame-sync pair at the audio offset to be inside the prefix.
+    if audio_offset + 2 > prefix.len() {
+        return Ok(Extent::NeedMore {
+            up_to: (audio_offset + 2) as u64,
+        });
+    }
+
+    if prefix[audio_offset] != 0xFF || (prefix[audio_offset + 1] & 0xE0) != 0xE0 {
+        return Err(FormatError::NotMp3);
+    }
+
+    let mut audio_end = file_len;
+    if let Some(tail) = tail {
+        if file_len >= audio_offset as u64 + 128 && &tail[0..3] == b"TAG" {
+            audio_end -= 128;
+        }
+    }
+
+    Ok(Extent::Complete(Mp3Bounds {
+        audio_offset: audio_offset as u64,
+        audio_length: audio_end - audio_offset as u64,
+    }))
 }
 
 const ENC_UTF8: u8 = 0x03;
@@ -1066,5 +1119,62 @@ mod tests {
         // allocation. Reinforces C.
         let huge = v23_frame(b"TIT2", 100, &[1, 2, 3, 4]);
         assert!(!id3v2_alloc_safe(&id3v2(0x03, 0x00, 14, &huge)));
+    }
+
+    use crate::probe::Extent;
+
+    /// ID3v2 header declaring `body` bytes of tag, then a frame-sync byte pair,
+    /// then `audio`. Returns (full, audio_offset).
+    fn mp3_with_id3v2(body_len: usize, audio: &[u8]) -> (Vec<u8>, u64) {
+        let mut v = b"ID3\x04\x00\x00".to_vec(); // version 2.4, no flags
+        v.extend_from_slice(&syncsafe(body_len as u32));
+        v.extend(std::iter::repeat_n(0u8, body_len)); // tag body
+        let audio_offset = v.len() as u64;
+        v.extend_from_slice(&[0xFF, 0xFB]); // MPEG frame sync
+        v.extend_from_slice(audio);
+        (v, audio_offset)
+    }
+
+    #[test]
+    fn locate_audio_bounded_complete_with_no_id3v1() {
+        let (full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        let prefix = &full[..audio_offset as usize + 2]; // covers tag + sync
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(prefix, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                assert_eq!(b.audio_length, file_len - audio_offset);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_needmore_when_tag_exceeds_prefix() {
+        let (full, _audio_offset) = mp3_with_id3v2(4096, b"frames");
+        let prefix = &full[..32]; // only the 10-byte header is present
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(prefix, file_len, None).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 10 + 4096 + 2),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_strips_id3v1_tail() {
+        let (mut full, audio_offset) = mp3_with_id3v2(8, b"frames");
+        let body_end = full.len();
+        full.extend_from_slice(b"TAG"); // ID3v1 marker
+        full.extend(std::iter::repeat_n(0u8, 125)); // 128-byte tag total
+        let file_len = full.len() as u64;
+        let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
+        let prefix = &full[..audio_offset as usize + 2];
+        match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                assert_eq!(b.audio_length, body_end as u64 - audio_offset);
+            }
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
     }
 }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -83,7 +83,7 @@ pub fn locate_audio_bounded(
             return Err(FormatError::Malformed);
         }
         audio_offset = tag_len;
-    } else if prefix.len() < 10 && (file_len as usize) >= 10 {
+    } else if prefix.len() < 10 && file_len >= 10 {
         // Not enough bytes even to read the ID3v2 header.
         return Ok(Extent::NeedMore { up_to: 10 });
     }
@@ -1120,8 +1120,6 @@ mod tests {
         let huge = v23_frame(b"TIT2", 100, &[1, 2, 3, 4]);
         assert!(!id3v2_alloc_safe(&id3v2(0x03, 0x00, 14, &huge)));
     }
-
-    use crate::probe::Extent;
 
     /// ID3v2 header declaring `body` bytes of tag, then a frame-sync byte pair,
     /// then `audio`. Returns (full, audio_offset).

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1404,6 +1404,32 @@ mod tests {
         }
     }
 
+    #[test]
+    fn locate_audio_bounded_sync_exactly_at_eof_proceeds() {
+        // Boundary: audio_offset + 2 == file_len exactly (audio is just the 2-byte
+        // frame sync). `audio_offset + 2 > file_len` is false -> Complete. The
+        // `>`->`>=` mutant makes `16 >= 16` true -> wrongly Err(NotMp3). Mirrors the
+        // unbounded reject `audio_offset + 1 >= len` (accepts when +2 <= len).
+        let body = 4usize;
+        let mut full = b"ID3\x04\x00\x00".to_vec();
+        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend(std::iter::repeat_n(0u8, body)); // tag end at offset 14
+        let audio_offset = full.len() as u64; // 14
+        full.push(0xFF); // frame sync pair, and nothing after
+        full.push(0xFB);
+        let file_len = full.len() as u64; // 16 == audio_offset + 2
+                                          // kills mp3 L96 `>`->`>=`: equal-fit audio must be accepted, not rejected.
+        match locate_audio_bounded(&full, file_len, None).unwrap() {
+            Extent::Complete(b) => {
+                assert_eq!(b.audio_offset, audio_offset);
+                assert_eq!(b.audio_length, 2);
+            }
+            other @ Extent::NeedMore { .. } => {
+                panic!("expected Complete (exact fit), got {other:?}")
+            }
+        }
+    }
+
     // kills mp3 L107 (`prefix[audio_offset] != 0xFF || (prefix[audio_offset+1] &
     // 0xE0) != 0xE0`): `||`->`&&` and `+`->`*`.
     // Frame-sync byte 0 is 0xFF but byte 1 lacks the 0xE0 sync bits. Correct

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -1285,9 +1285,25 @@ mod bounded_tests {
                                       // Confirm the premise: read_header genuinely errors on this buffer.
         assert!(read_header(&buf).is_err());
         let file_len = 10_000_000u64;
-        // kills ogg L227 `*`->`+` and `*`->`/`: only `*2` yields up_to == 200_000.
         match read_metadata_bounded(&buf, file_len).unwrap() {
             Extent::NeedMore { up_to } => assert_eq!(up_to, 200_000),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_floor_is_64kib_for_small_prefix() {
+        // The `*` at L227 col 74 is the `64 * 1024` FLOOR in `.max(64 * 1024)`,
+        // not the doubling. To exercise it the floor must bind: a tiny prefix whose
+        // doubled length (200) is below 64 KiB, with file_len well above 64 KiB so
+        // `.min(file_len)` doesn't clamp. Correct floor = 65_536.
+        let buf = vec![0u8; 100]; // garbage: read_header errors
+        assert!(read_header(&buf).is_err());
+        let file_len = 10_000_000u64;
+        // kills ogg L227 `64 * 1024` -> `64 + 1024` (=1088) and `64 / 1024` (=0):
+        // only `*` yields the 65_536 floor when the doubled length is smaller.
+        match read_metadata_bounded(&buf, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 65_536),
             other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
         }
     }

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -1257,4 +1257,53 @@ mod bounded_tests {
             other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
         }
     }
+
+    #[test]
+    fn read_metadata_bounded_errors_when_whole_file_is_unparseable() {
+        // A short garbage buffer that IS the whole file: prefix.len() == file_len and
+        // read_header errors. The guard `(prefix.len() as u64) < file_len` is FALSE,
+        // so the function must fall to the `Err(e)` arm and return Err — never grow.
+        let bad: &[u8] = b"not an ogg stream at all"; // capture pattern != "OggS"
+                                                      // Confirm the premise: read_header genuinely errors on this buffer.
+        assert!(read_header(bad).is_err());
+        let len = bad.len() as u64;
+        // kills ogg L226 guard `< file_len` -> `true`: under `true` this returns
+        // NeedMore; correct is Err.
+        // kills ogg L226 `<` -> `<=`: `len <= len` is true -> NeedMore; correct is Err.
+        match read_metadata_bounded(bad, len) {
+            Err(_) => {}
+            Ok(other) => panic!("expected Err when whole file unparseable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_doubles_window_exactly() {
+        // L = 100_000 bytes of garbage (read_header errors): L > 64*1024 so `.max`
+        // does not mask, and file_len = 10_000_000 > L*2 so `.min` does not clamp.
+        // Correct up_to = L*2 = 200_000. `+`->100_002, `/`->50_000 all differ.
+        let buf = vec![0u8; 100_000]; // all zeros: capture pattern != "OggS" -> errors
+                                      // Confirm the premise: read_header genuinely errors on this buffer.
+        assert!(read_header(&buf).is_err());
+        let file_len = 10_000_000u64;
+        // kills ogg L227 `*`->`+` and `*`->`/`: only `*2` yields up_to == 200_000.
+        match read_metadata_bounded(&buf, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 200_000),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_grows_when_truncated_prefix_shorter_than_file() {
+        // Pins the TRUE side of the guard: a truncated valid-prefix where
+        // prefix.len() < file_len must return NeedMore (kills `<`->`<=` from the
+        // other direction by requiring growth here while requiring Err when equal).
+        let (full, _audio_offset) = opus_stream();
+        let file_len = full.len() as u64;
+        let prefix = &full[..10]; // far short of the header region
+        assert!(read_header(prefix).is_err());
+        match read_metadata_bounded(prefix, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert!(up_to > prefix.len() as u64),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
+    }
 }

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -6,6 +6,7 @@ pub use b64::{b64_len, b64_window, encode_b64_slice, B64Window};
 pub use page::{parse_page, patch_page_header, PageHeader};
 
 use crate::error::{FormatError, Result};
+use crate::probe::Extent;
 
 /// The codec carried inside an Ogg logical bitstream that we synthesize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -207,6 +208,25 @@ pub fn locate_audio(data: &[u8]) -> Result<OggScan> {
 /// synthesis. Identical to `read_header` but named to mirror `flac::read_metadata`.
 pub fn read_metadata(front: &[u8]) -> Result<OggHeader> {
     read_header(front)
+}
+
+/// Bounded twin of [`read_metadata`]. OGG header packets (and all OGG embedded
+/// art) are front-anchored, so a prefix covering the header region is sufficient.
+/// `read_header` does not expose an exact byte need, so on a short/truncated
+/// prefix this geometrically grows the window (doubling, capped at `file_len`):
+/// header regions are tiny, so the first 1 MiB window almost always completes,
+/// and the cap guarantees the worst case equals reading the whole file.
+pub fn read_metadata_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<OggHeader>> {
+    match read_header(prefix) {
+        Ok(header) => Ok(Extent::Complete(header)),
+        Err(_) if (prefix.len() as u64) < file_len => {
+            let grown = ((prefix.len() as u64).saturating_mul(2)).max(64 * 1024);
+            Ok(Extent::NeedMore {
+                up_to: grown.min(file_len),
+            })
+        }
+        Err(e) => Err(e),
+    }
 }
 
 use crate::input::TagInput;
@@ -1186,5 +1206,52 @@ mod tests {
         let pad = declared - art.description.len() as u32;
         assert!(pad <= 2, "pad must be 0..=2, got {pad}");
         assert_eq!(pad, 0, "base % 3 == 0 implies pad 0");
+    }
+}
+
+#[cfg(test)]
+mod bounded_tests {
+    use super::*;
+    use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
+    use crate::probe::Extent;
+
+    /// A minimal Opus stream: OpusHead + OpusTags header packets, then a trailing
+    /// audio page. Returns (full, audio_offset). Mirrors the proven fixture in
+    /// `musefs-core/src/scan.rs::ogg_probe_tests::probe_detects_opus_and_seeds_tags`.
+    /// `build_header_pub(serial, &[&[u8]])` laces *all* header packets across
+    /// pages (BOS set once) and returns `(Vec<u8>, u32)`; `lace_packet_pub` takes
+    /// `(serial, seq_start, bos, granule, packet)` and returns `(Vec<u8>, u32)`.
+    fn opus_stream() -> (Vec<u8>, u64) {
+        let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
+        let mut tags = b"OpusTags".to_vec();
+        tags.extend_from_slice(&vorbis_body_empty());
+        let serial = 0x1234;
+        let (mut v, _) = build_header_pub(serial, &[&head, &tags]);
+        let audio_offset = v.len() as u64;
+        let (audio, _) = lace_packet_pub(serial, 2, false, 960, &[0u8; 100]);
+        v.extend_from_slice(&audio);
+        (v, audio_offset)
+    }
+
+    #[test]
+    fn read_metadata_bounded_complete_when_prefix_covers_header() {
+        let (full, audio_offset) = opus_stream();
+        let file_len = full.len() as u64;
+        let prefix = &full[..audio_offset as usize]; // exactly the header region
+        match read_metadata_bounded(prefix, file_len).unwrap() {
+            Extent::Complete(h) => assert_eq!(h.audio_offset, audio_offset),
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_metadata_bounded_needmore_when_header_truncated() {
+        let (full, _audio_offset) = opus_stream();
+        let file_len = full.len() as u64;
+        let prefix = &full[..20]; // mid first page
+        match read_metadata_bounded(prefix, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert!(up_to > 20 && up_to <= file_len),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
     }
 }

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -219,6 +219,10 @@ pub fn read_metadata(front: &[u8]) -> Result<OggHeader> {
 pub fn read_metadata_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<OggHeader>> {
     match read_header(prefix) {
         Ok(header) => Ok(Extent::Complete(header)),
+        // `read_header` cannot distinguish a truncated front from genuine
+        // corruption, so we widen optimistically; a real error resurfaces via the
+        // `Err(e)` arm once `prefix` reaches `file_len` (and the caller's retry
+        // limit + full-read fallback bound the cost).
         Err(_) if (prefix.len() as u64) < file_len => {
             let grown = ((prefix.len() as u64).saturating_mul(2)).max(64 * 1024);
             Ok(Extent::NeedMore {
@@ -1213,7 +1217,6 @@ mod tests {
 mod bounded_tests {
     use super::*;
     use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
-    use crate::probe::Extent;
 
     /// A minimal Opus stream: OpusHead + OpusTags header packets, then a trailing
     /// audio page. Returns (full, audio_offset). Mirrors the proven fixture in

--- a/musefs-format/src/probe.rs
+++ b/musefs-format/src/probe.rs
@@ -1,0 +1,15 @@
+//! Shared outcome type for *bounded* metadata probing: a format parser is given
+//! only a `prefix` of the file (plus the true `file_len`) and either completes,
+//! or reports the exact byte offset it must reach to continue.
+
+/// Result of a bounded metadata probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Extent<T> {
+    /// The metadata region is fully present in the prefix; here is the parse.
+    Complete(T),
+    /// The prefix is too short. Read at least up to `up_to` bytes (capped at the
+    /// file length) and retry. `up_to` is strictly greater than the current
+    /// prefix length unless the parser cannot bound its need, in which case the
+    /// caller falls back to reading the whole file.
+    NeedMore { up_to: u64 },
+}

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -1,5 +1,6 @@
 use crate::error::{FormatError, Result};
 use crate::input::EmbeddedPicture;
+use crate::probe::Extent;
 use std::collections::HashSet;
 
 /// The served audio bounds of a WAV: the `data` chunk's payload.
@@ -78,6 +79,17 @@ pub fn locate_audio(buf: &[u8]) -> Result<WavBounds> {
         }
         _ => Err(FormatError::NotWav),
     }
+}
+
+/// Bounded twin of [`locate_audio`]. WAV metadata chunks can trail the `data`
+/// payload, which the slice walk cannot skip past, so completion requires the
+/// whole file in `prefix`; otherwise request it. Equivalence is trivially
+/// preserved (the completing parse is exactly `locate_audio` on the full file).
+pub fn locate_audio_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<WavBounds>> {
+    if (prefix.len() as u64) < file_len {
+        return Ok(Extent::NeedMore { up_to: file_len });
+    }
+    Ok(Extent::Complete(locate_audio(prefix)?))
 }
 
 /// Read the preserved structural chunks (`fmt `, optional `fact`) from the front
@@ -621,6 +633,43 @@ mod tests {
         };
         let res = synthesize_layout(&scan, 0, u32::MAX as u64, &[], &[]);
         assert_eq!(res, Err(FormatError::TooLarge));
+    }
+
+    /// RIFF/WAVE with a `fmt ` (16-byte) chunk and a `data` chunk of `audio`.
+    fn wav_file(audio: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"fmt ");
+        body.extend_from_slice(&16u32.to_le_bytes());
+        body.extend(std::iter::repeat_n(0u8, 16));
+        body.extend_from_slice(b"data");
+        body.extend_from_slice(&(audio.len() as u32).to_le_bytes());
+        body.extend_from_slice(audio);
+        let mut v = b"RIFF".to_vec();
+        v.extend_from_slice(&((4 + body.len()) as u32).to_le_bytes());
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(&body);
+        v
+    }
+
+    #[test]
+    fn locate_audio_bounded_complete_when_prefix_is_whole_file() {
+        let full = wav_file(b"AUDIOAUDIO");
+        let file_len = full.len() as u64;
+        match locate_audio_bounded(&full, file_len).unwrap() {
+            Extent::Complete(b) => assert_eq!(b.audio_length, 10),
+            other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn locate_audio_bounded_needmore_when_prefix_short() {
+        let full = wav_file(b"AUDIOAUDIO");
+        let file_len = full.len() as u64;
+        let prefix = &full[..full.len() - 4];
+        match locate_audio_bounded(prefix, file_len).unwrap() {
+            Extent::NeedMore { up_to } => assert_eq!(up_to, file_len),
+            other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
+        }
     }
 
     // Documented EQUIVALENT mutants in this file (no test targets them; each was

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -118,6 +118,7 @@ for crate in "${crates[@]}"; do
         --file musefs-core/src/reader.rs \
         --file musefs-core/src/tree.rs \
         --file musefs-core/src/scan.rs \
+        --file musefs-core/src/byte_budget.rs \
         --file musefs-core/src/facade.rs \
         --file musefs-core/src/ogg_index.rs
       ;;


### PR DESCRIPTION
## Summary

SP1 of the 2026-05-30 optimization pass: makes `scan` / `revalidate` fast and bounded-memory over large libraries, **without changing the served bytes** (the cardinal byte-identical-audio invariant holds — verified end-to-end). Spec: `docs/superpowers/specs/2026-05-30-optimization-pass/SP1-ingestion-scalability.md`; plan: `docs/superpowers/plans/2026-05-31-sp1-ingestion-scalability.md`.

**Stage A — bounded reads** (no more whole-file slurp):
- Per-format bounded probers returning `Extent::Complete | NeedMore { up_to }`: `flac::read_metadata_bounded`, `mp3::locate_audio_bounded` (+ ID3v1 tail), `ogg::read_metadata_bounded`, `wav::locate_audio_bounded`.
- `scan.rs::probe_file` reads a bounded window (default 1 MiB), widens precisely on `NeedMore`, and routes **M4A through the existing `mp4::read_structure_from` seek reader** (never reads `mdat`).
- **Headline gate:** a tiny-window (`MUSEFS_SCAN_WINDOW=64`) bounded scan is proven byte-for-byte equivalent (tracks/tags/art incl. picture_type+description) to the legacy full-file probe, for every format (`tests/probe_equivalence.rs`).

**Stage B — pipeline:**
- Parallel-probe / single-writer pipeline: DB-free worker threads → bounded channel → one writer batching transactions via a new `BulkWriter`. `--jobs` CLI flag (0 = available parallelism, 1 = sequential); determinism across `--jobs` is asserted on normalized state.
- `ByteBudget` semaphore bounds in-flight art memory; the writer flushes on channel drain to avoid a budget/flush deadlock (regression-tested in `tests/pipeline_backpressure.rs`).
- Scan-scoped bulk pragmas (`synchronous=NORMAL`, 64 MiB cache, `temp_store=MEMORY`; WAL retained).
- Resilience: per-file I/O/parse errors are counted (`failed`) and non-fatal; only DB-write errors abort.
- `revalidate` uses the pipeline with a main-thread pre-dispatch skip-unchanged pass (keeps workers DB-free).
- Scan-path metrics (`scan_opens`/`scan_preads`/`scan_bytes_read`) surfaced in the `bench_ingest` report (+ `MUSEFS_BENCH_JOBS`).

## Test Plan

- [x] `cargo test --workspace` green (66 suites)
- [x] `cargo test -p musefs-format --features fuzzing` green (249 proptests)
- [x] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean
- [x] FUSE e2e on `/dev/fuse` green, incl. **`all_supported_formats_decode_to_same_pcm_sha_as_source`** (byte-identical PCM through a real mount, all formats)
- [x] Bounded≡full equivalence gate (`probe_equivalence`) green for all 6 formats
- [x] Deadlock regression (`pipeline_backpressure`) + `--jobs` determinism green
- [ ] **Benchmark baselines → `BENCHMARKS.md`** (follow-up: before/after wall/bytes_read/fsync/RSS across tiers; the SP1 results-log evidence)

Each task was implemented subagent-driven with a spec-compliance review and a code-quality review; a final holistic review caught and fixed a budget/flush deadlock (now regression-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel scan control via a new --jobs option; bounded metadata probing for common audio formats; single-writer parallel-probe pipeline with byte-budget backpressure; bulk write batching; new scan metrics (opens/preads/bytes read) surfaced in reports.

* **Bug Fixes**
  * Per-file failure accounting and a reported "failed" counter for scans and revalidations; resilient per-file error handling.

* **Performance**
  * Transaction batching, bulk-write tuning and reduced fsyncs for faster, lower-memory ingestion.

* **Documentation**
  * SP1 ingestion-scalability spec, plan, benchmarks, and results added.

* **Tests**
  * Extensive equivalence, backpressure, bounded-probe, and benchmark updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->