### PR TITLE
feat: binary tags Phase 2 — ID3 (MP3 + WAV)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -77,6 +77,12 @@ exclude_re = [
     # caught). Same equivalence the sibling parse_blocks/read_vorbis_comments tests
     # already note.
     'musefs-format/src/flac\.rs:\d+:\d+: replace \| with \^ in read_metadata_bounded',
+    # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
+    # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
+    # each combine, so its low byte is always zero where `b` lands; `|` and `^` are
+    # bit-for-bit identical for every input (same equivalence as the flac assembly
+    # above). The `<<`->`>>` and `> 0` siblings in this fn ARE caught and stay in scope.
+    'musefs-format/src/mp3\.rs:\d+:\d+: replace \| with \^ in classify_binary_frame',
 
     # SP2 incremental tree refresh — equivalent mutants in apply_changes & friends.
     # The whole design contract is "the incrementally-mutated tree is byte-identical

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "id3",
  "metaflac",
  "mp4",
+ "musefs-db",
  "proptest",
  "thiserror 1.0.69",
 ]

--- a/docs/superpowers/plans/2026-06-02-binary-tags-phase2-id3.md
+++ b/docs/superpowers/plans/2026-06-02-binary-tags-phase2-id3.md
@@ -1,0 +1,1412 @@
+# Binary Tags Phase 2 — ID3 (MP3 + WAV) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ID3v2 binary frames (`PRIV`/`GEOB`/`SYLT`/unpromoted `POPM`/`UFID`/…) survive scan → DB → re-synthesis as opaque passthrough, and promote the two frames with universal text equivalents (`POPM`→`rating`/`playcount`, MusicBrainz `UFID`→`musicbrainz_trackid`) to editable text tags — for both MP3 and WAV (WAV carries ID3 in its `id3 ` chunk).
+
+**Architecture:** Opaque binary frames are extracted by a self-contained raw ID3 frame-body walker (byte-exact — no `id3`-crate re-encode), and synthesis stays hand-rolled (`push_frame_header` + body builders, emitting `Segment::BinaryTag` for streamed opaque payloads, exactly as `APIC` emits `ArtImage`). Binary payloads stream from `tags.value_blob` via the Phase-1 DB layer; nothing is materialized in memory. Phase 2 closes the open-handle `payload_id`-reuse gap (spec's "Open-handle gap (Phase-2 obligation)") with two cooperating mechanisms in `facade.rs`, landed before any task emits a `BinaryTag`: a lazy generation-gated handle re-resolve (freshness + size correctness), and a transactional `content_version` guard around reads of `BinaryTag`-bearing layouts (a single WAL read snapshot wraps the version check and the chunk reads, so a reused rowid can never be served).
+
+**Tech Stack:** Rust workspace (`musefs-db`, `musefs-format` byte-surgery, `musefs-core` orchestration, `musefs-fuse`), the `id3` crate v1.17.0, `arc-swap`, `sharded_slab`, proptest.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-binary-tags-design.md` (§5 ID3, §6 query-split, the open-handle gap note). Phase 1 (merged): schema V2 + `Segment::BinaryTag` + DB binary-tag layer + `BinaryTagInput`.
+
+---
+
+## Key decisions locked before coding
+
+These were resolved during planning (codebase + `id3`-crate research); do not re-litigate mid-implementation:
+
+- **Opaque extraction uses a raw frame walker, NOT the `id3` crate.** `Content::to_unknown()` re-encodes typed frames with `Version::default()` + forced `Encoding::UTF8` (verified in `id3-1.17.0/src/frame/content.rs:289`), and the decoder dispatches `GEOB`/`SYLT`/`POPM`/`UFID`/`PRIV` to typed variants (`stream/frame/content.rs:420-447`). So `to_unknown` is **not byte-exact** for `GEOB`/`SYLT` (they carry a text-encoding byte) — it would silently mangle Serato `GEOB` analysis blobs, the spec's flagship case. Instead, `read_binary_tags` is a self-contained raw walker that slices each frame's post-header body verbatim. This is sound because `id3v2_alloc_safe` (`mp3.rs:335`) — already the gate on all ID3 parsing here — **rejects unsynchronised tags, extended headers, and non-zero frame flags**, so the on-disk body equals the logical body (no de-unsync needed). `read_tags`/`read_pictures` keep using the `id3` crate (text/art are unaffected by the re-encode issue). The walker handles v2.3/v2.4; v2.2 binary frames (3-char ids) are skipped (rare; text/art still parse via the crate).
+- **POPM/UFID are parsed from the raw body** (not typed accessors), trivially: POPM body `<owner>\0<rating:u8>[<counter:be>]`, UFID body `<owner>\0<identifier>`.
+- **Synthesis is hand-rolled** (matching `mp3.rs`'s existing `push_frame_header` + `*_frame_data` pattern). There is no public single-frame encoder in `id3` 1.17, and synthesis emits `Segment`s, not an `id3::Tag`. Opaque frames become `push_frame_header(id, len)` + `Segment::BinaryTag`; promoted frames are rebuilt by new `popm_frame_data`/`ufid_frame_data` from the `rating`/`playcount`/`musicbrainz_trackid` text tags.
+- **Promotion is lossy by design** (spec §5): `POPM` owner-email dropped (rebuilt with empty owner); `POPM` counter capped at `u32` on rebuild; only `UFID` with owner `http://musicbrainz.org` promotes — any other owner is opaque. Round-trip proptests assert *semantic* survival (values), **not** byte-identical promoted frames.
+- **Promoted keys must not double-emit.** `rating`/`playcount`/`musicbrainz_trackid` are excluded from the generic text/`TXXX` emission loop in `build_id3v2_segments` (otherwise they'd leak out as `TXXX:rating`, etc.).
+- **Open-handle fix = gen-gated re-resolve + transactional `content_version` guard** (not content-addressing; the gap is fully closed). `sharded_slab::Slab` can't be iterated with `&self`, so a global `AtomicU64 refresh_gen` (bumped on a non-empty refresh) gates a per-handle re-resolve on the next read (`HeaderCache::resolve` is `content_version`-keyed, so unchanged tracks are a cheap cache hit). This alone shrinks but does not close the window — a refresh can land *between* the gen-check and the chunk read. So for `BinaryTag`-bearing layouts the read additionally runs inside one WAL read snapshot that first checks `live content_version == resolved.content_version` and bails (→ bounded re-resolve-and-retry) on mismatch; within a single SQLite read snapshot the `content_version` row and the `value_blob` rows are mutually consistent, so a reused rowid is impossible to serve. Plain `Inline`/`BackingAudio` layouts skip the guard (no per-read cost). The gen re-resolve also fixes a pre-existing size/content skew for handles held across a re-tag.
+
+## Cross-layer types (consistency reference)
+
+| Type | Where | Shape | Role |
+| --- | --- | --- | --- |
+| `EmbeddedBinaryTag` | `musefs-format/src/input.rs` (new) | `{ key: String, payload: Vec<u8> }` | parser → scan; opaque frame id + raw body |
+| `BinaryTag` | `musefs-db` (Phase 1) | `{ key, payload, ordinal }` | scan → DB write |
+| `BinaryTagRow` | `musefs-db` (Phase 1) | `{ rowid, key, byte_len }` | DB read → mapping |
+| `BinaryTagInput` | `musefs-format` (Phase 1) | `{ key, payload_id, len }` | mapping → synthesis; `payload_id` == `tags` rowid |
+| `Segment::BinaryTag` | `musefs-format` (Phase 1) | `{ payload_id, len }` | streamed at read time |
+
+`read_binary_tags` returns `(Vec<EmbeddedBinaryTag>, Vec<(String, String)>)` — `(opaque, promoted)`. `promoted` pairs merge into the text-tag vector (written by `replace_tags`); `opaque` is written by `set_binary_tags`.
+
+---
+
+## File structure
+
+| File | Change | Responsibility |
+| --- | --- | --- |
+| `musefs-core/src/facade.rs` | Modify | `refresh_gen`; `Handle { track_id, resolved: ArcSwap, gen }`; gen-gated re-resolve + transactional `content_version` guard in `read`; bump on non-empty refresh. |
+| `musefs-db/src/tracks.rs` | Modify | `track_content_version`; `begin_read`/`end_read` read-snapshot delimiters. |
+| `musefs-db/src/bulk.rs` | Modify | Scope `BulkWriter::replace_tags` DELETE to text rows (`value_blob IS NULL`); add `BulkWriter::set_binary_tags` batch mirror. |
+| `musefs-format/src/input.rs` | Modify | Add `EmbeddedBinaryTag`; re-export. |
+| `musefs-format/src/layout.rs` | Modify | `RegionLayout::has_binary_tag()` (gates the read-time guard). |
+| `musefs-format/src/mp3.rs` | Modify | `read_binary_tags` (raw frame walker, byte-exact) + `classify_binary_frame`; `popm_frame_data`/`ufid_frame_data`; `build_id3v2_segments(tags, binary_tags, arts)`; thread `synthesize_layout`. |
+| `musefs-format/src/wav.rs` | Modify | `read_binary_tags` over the `id3 ` chunk; thread `binary_tags` through `synthesize_layout`. |
+| `musefs-core/src/mapping.rs` | Modify | `binary_tags_to_inputs(db, track_id)`. |
+| `musefs-core/src/scan.rs` | Modify | `Probed.binary_tags`; `MAX_BINARY_TAG_BYTES`; populate in MP3/WAV probe arms; write via `set_binary_tags` after text replace; merge `promoted`. |
+| `musefs-core/src/reader.rs` | Modify | `ResolvedFile.has_binary_tag` (set in `build`); MP3 + WAV resolve arms load `get_binary_tags` → `BinaryTagInput`, pass to `synthesize_layout`; `BinaryTag` serve arm emits the chunk metric. |
+| `musefs-core/src/metrics.rs` | Modify | `binary_tag_chunks` counter + `on_binary_tag_chunk()` (parity with `art_chunks`). |
+
+---
+
+## Tasks
+
+### Task 2.1: Close the open-handle `payload_id`-reuse gap (handle re-resolve)
+
+Lands first so the gate is in place before any task emits a `BinaryTag`. Behavior-neutral on its own.
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (`Handle` struct ~53, `Musefs` fields ~108, `read` ~608, `open_handle` ~638, `poll_refresh_notify` ~372)
+- Modify: `musefs-db/src/tags.rs` or `tracks.rs` (`track_content_version`, `begin_read`/`end_read` snapshot helpers)
+- Modify: `musefs-format/src/layout.rs` (`RegionLayout::has_binary_tag`)
+- Test: `musefs-core/src/facade.rs` (inline)
+
+This task lands two cooperating mechanisms: (A) the gen-gated re-resolve (freshness + size), and (B) the transactional `content_version` guard for `BinaryTag`-bearing reads (full close of the reuse window). Both are behavior-neutral in Phase 1 terms (no layout yet contains a `BinaryTag`), so they land safely first.
+
+- [ ] **Step 1: Write the failing test (re-resolve / size correctness)**
+
+Add to `facade.rs` a `#[cfg(test)]` test (mirror existing facade tests for `Musefs::open`/mount setup; they construct a `Db`, scan a temp file, and `Musefs::open`). The assertion: a handle held across a content_version bump re-resolves and serves the *new* layout length.
+
+```rust
+#[test]
+fn open_handle_reresolves_after_content_version_bump() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let mp3 = dir.path().join("a.mp3");
+    // Minimal MP3: tiny ID3v2 + 1 frame of silence is unnecessary here — scan only
+    // needs a probe-able file. Reuse the crate's mp3 test fixture helper if present;
+    // otherwise write known-good bytes from an existing facade/scan test.
+    std::fs::write(&mp3, super::test_support::minimal_mp3()).unwrap();
+
+    let db_path = dir.path().join("db.sqlite");
+    let db = Db::open(&db_path).unwrap();
+    crate::scan::scan_directory(&db, dir.path(), false).unwrap();
+    let fs = Musefs::open(Db::open(&db_path).unwrap(), MountConfig::default()).unwrap();
+
+    let ino = /* resolve the inode for a.mp3 via fs.lookup/readdir as other tests do */
+        super::test_support::inode_of(&fs, "a.mp3");
+    let fh = fs.open_handle(ino).unwrap();
+    let len_before = fs.read(ino, fh, 0, 1 << 20).unwrap().len();
+
+    // Out-of-band re-tag: add a long text tag so the synthesized region grows.
+    let track_id = super::test_support::track_id_of(&db, "a.mp3");
+    db.replace_tags(track_id, &[musefs_db::Tag::new("comment", &"x".repeat(4096), 0)])
+        .unwrap();
+    assert!(fs.poll_refresh().unwrap());
+
+    // Same handle now serves the larger layout (re-resolved), not the stale snapshot.
+    let len_after = fs.read(ino, fh, 0, 1 << 20).unwrap().len();
+    assert!(len_after > len_before, "handle did not re-resolve: {len_before} -> {len_after}");
+    fs.release_handle(fh);
+}
+```
+
+> Implementer note: copy the exact mount/lookup/track-id helpers from the nearest existing `facade.rs` test (e.g. the `poll_refresh` tests). If no `test_support` helpers exist, inline the inode lookup (`fs.lookup(ROOT_INODE, "a.mp3")`) and `db.tracks()`-style track-id lookup the way those tests do. The behavioral assertion (`len_after > len_before`) is the point.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core open_handle_reresolves_after_content_version_bump`
+Expected: FAIL — `len_after == len_before` (handle keeps serving the stale snapshot).
+
+- [ ] **Step 3: Add `refresh_gen` and extend `Handle`**
+
+In `musefs-core/src/facade.rs`, change the `Handle` struct (currently `{ resolved: Arc<ResolvedFile>, file }`) and update its doc comment:
+
+```rust
+/// An open file handle: the resolved layout, the track it belongs to, the
+/// generation at which `resolved` was last validated, and a backing fd opened
+/// once at `open`.
+///
+/// A handle survives `poll_refresh`, but is **not** a frozen snapshot: when the
+/// global `refresh_gen` advances (a refresh applied changes), the next `read`
+/// re-resolves the track (a cheap `content_version`-keyed cache hit when the
+/// track is unchanged) and swaps in the fresh layout. This keeps a re-tagged
+/// file's handle consistent with the size the kernel sees via getattr, and
+/// prevents a stale `Segment::BinaryTag { payload_id }` from serving reused-rowid
+/// bytes after a re-tag.
+struct Handle {
+    track_id: i64,
+    resolved: arc_swap::ArcSwap<ResolvedFile>,
+    gen: std::sync::atomic::AtomicU64,
+    file: std::fs::File,
+}
+```
+
+Add a field to `Musefs` (near `handles`):
+
+```rust
+    refresh_gen: std::sync::atomic::AtomicU64,
+```
+
+Initialize it in `Musefs::open`/constructor alongside `handles: sharded_slab::Slab::new()`:
+
+```rust
+            refresh_gen: std::sync::atomic::AtomicU64::new(0),
+```
+
+- [ ] **Step 4: Build the handle with the new fields in `open_handle`**
+
+Change the final line of `open_handle` (currently `fh_from_key(self.handles.insert(Arc::new(Handle { resolved, file })))`):
+
+```rust
+        let gen = self.refresh_gen.load(std::sync::atomic::Ordering::Acquire);
+        fh_from_key(self.handles.insert(Arc::new(Handle {
+            track_id,
+            resolved: arc_swap::ArcSwap::from(resolved),
+            gen: std::sync::atomic::AtomicU64::new(gen),
+            file,
+        })))
+```
+
+- [ ] **Step 5: Add the supporting helpers (`has_binary_tag`, DB snapshot + version read)**
+
+In `musefs-format/src/layout.rs`, add to `impl RegionLayout`:
+
+```rust
+/// True if any segment streams an opaque binary tag payload from the DB. Used by
+/// the reader to decide whether a read needs the transactional content_version
+/// guard (plain Inline/BackingAudio layouts don't).
+pub fn has_binary_tag(&self) -> bool {
+    self.segments.iter().any(|s| matches!(s, Segment::BinaryTag { .. }))
+}
+```
+
+In `musefs-db` (e.g. `tracks.rs`), add to `impl Db` a lightweight version read and a pair of read-snapshot delimiters (the facade can't touch `self.conn` from `musefs-core`, so these wrap it). The snapshot is connection-level, so reads issued on the same `Db` between `begin_read` and `end_read` share one consistent WAL snapshot:
+
+```rust
+/// The track's current `content_version` (cheap; no full-row fetch).
+pub fn track_content_version(&self, track_id: i64) -> Result<i64> {
+    Ok(self.conn.query_row(
+        "SELECT content_version FROM tracks WHERE id = ?1",
+        rusqlite::params![track_id],
+        |r| r.get(0),
+    )?)
+}
+
+/// Begin a deferred (read) transaction: subsequent reads on this connection see a
+/// single consistent snapshot until `end_read`. Used to make a binary-tag read's
+/// content_version check and its blob reads mutually consistent.
+pub fn begin_read(&self) -> Result<()> {
+    self.conn.execute_batch("BEGIN DEFERRED")?;
+    Ok(())
+}
+
+/// End the read transaction opened by `begin_read` (rollback — it is read-only).
+pub fn end_read(&self) -> Result<()> {
+    self.conn.execute_batch("ROLLBACK")?;
+    Ok(())
+}
+```
+
+Add a one-line `musefs-db` test that `track_content_version` returns the value the triggers maintain (insert a tag, assert it incremented).
+
+- [ ] **Step 6: Gen-gated re-resolve + transactional guard in the `read` fast path**
+
+Replace the `fh != 0` fast-path body in `Musefs::read` (currently clones the handle and calls `read_at_with_file(&h.resolved, …)`). The loop re-resolves on a stale generation, then reads — guarding `BinaryTag` layouts inside a snapshot and retrying (bounded) if a refresh raced the read:
+
+```rust
+        if fh != 0 {
+            let handle = self.handles.get((fh - 1) as usize).map(|g| Arc::clone(&g));
+            if let Some(h) = handle {
+                // Bounded retry absorbs a refresh landing mid-read; out-of-band
+                // re-tags are human/batch-paced, so >1 attempt is already rare.
+                for _attempt in 0..4 {
+                    let cur = self.refresh_gen.load(std::sync::atomic::Ordering::Acquire);
+                    if h.gen.load(std::sync::atomic::Ordering::Acquire) != cur {
+                        // A refresh changed something; re-resolve (cheap content_version
+                        // cache hit when this track is unchanged) and re-stamp.
+                        let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
+                        h.resolved.store(fresh);
+                        h.gen.store(cur, std::sync::atomic::Ordering::Release);
+                    }
+                    let resolved = h.resolved.load();
+                    let r: &ResolvedFile = &resolved;
+                    let served = self.pool.with(|db| -> Result<Option<Vec<u8>>> {
+                        if r.has_binary_tag {
+                            // Snapshot-consistent: version check + blob reads see one
+                            // WAL snapshot, so a reused rowid can't be served.
+                            db.begin_read()?;
+                            let res = (|| {
+                                if db.track_content_version(h.track_id)? != r.content_version {
+                                    return Ok(None); // stale layout — retry after re-resolve
+                                }
+                                Ok(Some(read_at_with_file(r, db, &h.file, offset, size)?))
+                            })();
+                            let _ = db.end_read(); // always release the snapshot
+                            res
+                        } else {
+                            Ok(Some(read_at_with_file(r, db, &h.file, offset, size)?))
+                        }
+                    })?;
+                    match served {
+                        Some(bytes) => return Ok(bytes),
+                        None => {
+                            // Force a re-resolve next iteration against the live version.
+                            let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
+                            h.resolved.store(fresh);
+                            h.gen.store(
+                                self.refresh_gen.load(std::sync::atomic::Ordering::Acquire),
+                                std::sync::atomic::Ordering::Release,
+                            );
+                        }
+                    }
+                }
+                // Pathological constant re-tagging raced every attempt; surface a
+                // retryable error rather than risk wrong bytes.
+                return Err(CoreError::BackingChanged(
+                    h.resolved.load().backing_path.to_string_lossy().to_string(),
+                ));
+            }
+        }
+```
+
+Add a `has_binary_tag: bool` field to `ResolvedFile` (`reader.rs`), set once in `HeaderCache::build` from `layout.has_binary_tag()` — so the read path checks a precomputed bool, not the segment vector each call.
+
+> Notes: `cache.resolve` re-stats/re-validates the backing file, so a moved/deleted backing surfaces as `BackingChanged` on the read. `let r: &ResolvedFile = &resolved;` pins the deref from the `ArcSwap` guard explicitly (the guard derefs `Guard → Arc → ResolvedFile`). `end_read` runs on every path via the inner closure so the snapshot is always released. If your `Result`/`CoreError` lacks a clean "retry" variant, `BackingChanged` is the closest existing retryable signal; consider a dedicated variant if one reads better.
+
+- [ ] **Step 7: Bump `refresh_gen` on a non-empty refresh**
+
+In `poll_refresh_notify`, the rebuild returns `(new_snapshot, change)` (currently `let (new_snapshot, _change) = …`). Capture `change` and, after the snapshot is committed (end of a successful refresh that applied changes), bump the generation. Locate the block that updates the stored snapshot (around line 442) and add, guarded by the change set being non-empty:
+
+```rust
+        if !change.is_empty() {
+            self.refresh_gen.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        }
+```
+
+Rename `_change` to `change` at the `rebuild_incremental` call site. `ChangeSet::is_empty()` already exists (`refresh_diff.rs:31`).
+
+- [ ] **Step 8: Run the size-correctness test to verify it passes**
+
+Run: `cargo test -p musefs-core open_handle_reresolves_after_content_version_bump`
+Expected: PASS.
+
+- [ ] **Step 9: Write the rowid-reuse safety test (the property the guard actually protects)**
+
+The Step-1 test only proves the layout re-resolves (size grows). Add a test that proves the real safety property: a handle holding a `BinaryTag` never serves a *different* row's bytes after the original payload's rowid is reused. Because the guard makes the read snapshot-consistent, the held handle must serve either the original bytes or a clean `BackingChanged` error — never another payload.
+
+```rust
+#[test]
+fn binary_tag_handle_never_serves_reused_rowid_bytes() {
+    // Scan an MP3 carrying a PRIV frame; open a handle; read the original payload.
+    // Then churn the tags rowids by re-tagging binary rows (delete the PRIV, insert
+    // a different same-length payload that reuses the freed rowid), poll_refresh,
+    // and read again on the SAME handle. Assert the result is either the original
+    // payload bytes or an Err — but never the new (reused-rowid) payload's bytes.
+    // (Construct the fixture + handle exactly as in Step 1; force rowid reuse by
+    // set_binary_tags([]) then set_binary_tags([<same-length different payload>]).)
+}
+```
+
+> Implementer: the deterministic way to force reuse is to make the PRIV row the highest rowid, delete it (`set_binary_tags(tid, &[])`), then insert one new binary row — SQLite reclaims the freed max rowid. Assert the handle read ≠ the new payload bytes.
+
+- [ ] **Step 10: Confirm `arc-swap` is a direct dependency of `musefs-core`**
+
+Run: `cargo tree -p musefs-core -i arc-swap --depth 0`
+Expected: shows `arc-swap` (the tree already uses `ArcSwap<VirtualTree>`). If it is only transitive, add `arc-swap = "1"` to `musefs-core/Cargo.toml` `[dependencies]` and re-run.
+
+- [ ] **Step 11: Full crate test + commit**
+
+Run: `cargo test -p musefs-core -p musefs-db -p musefs-format`
+Expected: PASS (existing handle/poll tests still green; new `track_content_version` + `has_binary_tag` tests pass; both handle tests pass).
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/src/reader.rs musefs-core/Cargo.toml \
+        musefs-db/src/tracks.rs musefs-format/src/layout.rs
+git commit -m "fix(core): close open-handle payload_id reuse gap (re-resolve + snapshot guard)"
+```
+
+---
+
+### Task 2.2: Bulk-writer binary-tag support (`replace_tags` scoping + `set_binary_tags`)
+
+Two `bulk.rs` changes the scan fast path needs: (a) scope `BulkWriter::replace_tags` to text rows so it stops wiping binary rows, and (b) add a `BulkWriter::set_binary_tags` batch mirror of `Db::set_binary_tags` (Phase 1 added only the `Db` method). `ingest_bulk` (Task 2.8) calls both.
+
+**Files:**
+- Modify: `musefs-db/src/bulk.rs` (`replace_tags` ~68; new `set_binary_tags`)
+- Test: `musefs-db/src/bulk.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `bulk.rs` tests (mirror the existing bulk test setup that opens an in-memory `Db` and a `BulkWriter`):
+
+```rust
+#[test]
+fn bulk_replace_tags_preserves_binary_rows() {
+    let db = Db::open_in_memory().unwrap();
+    let tid = db.upsert_track(&crate::NewTrack {
+        backing_path: "/a.mp3".into(),
+        format: crate::Format::Mp3,
+        audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime: 0,
+    }).unwrap();
+    db.set_binary_tags(tid, &[crate::BinaryTag { key: "PRIV".into(), payload: vec![1,2,3], ordinal: 0 }]).unwrap();
+
+    {
+        let mut bw = db.bulk_writer().unwrap();
+        bw.replace_tags(tid, &[crate::Tag::new("artist", "A", 0)]).unwrap();
+        bw.commit().unwrap();
+    }
+
+    assert_eq!(db.get_binary_tags(tid).unwrap().len(), 1, "bulk replace_tags wiped binary rows");
+    assert_eq!(db.get_tags(tid).unwrap(), vec![crate::Tag::new("artist", "A", 0)]);
+}
+```
+
+> Use the actual `BulkWriter` construction + commit API from the nearest existing `bulk.rs` test (the exact constructor name may be `db.bulk_writer()` / `BulkWriter::new`). The assertion is the point.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-db bulk_replace_tags_preserves_binary_rows`
+Expected: FAIL — `get_binary_tags` returns 0 (the unscoped DELETE removed the `PRIV` row).
+
+- [ ] **Step 3: Scope the DELETE**
+
+In `musefs-db/src/bulk.rs`, change the `replace_tags` DELETE (currently `DELETE FROM tags WHERE track_id = ?1`):
+
+```rust
+        self.tx.execute(
+            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
+            params![track_id],
+        )?;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-db bulk_replace_tags_preserves_binary_rows`
+Expected: PASS.
+
+- [ ] **Step 5: Full crate test + commit the scoping fix**
+
+Run: `cargo test -p musefs-db`
+
+```bash
+git add musefs-db/src/bulk.rs
+git commit -m "fix(db): scope BulkWriter::replace_tags to text rows"
+```
+
+- [ ] **Step 6: Write the failing test for `BulkWriter::set_binary_tags`**
+
+Add to `bulk.rs` tests:
+
+```rust
+#[test]
+fn bulk_set_binary_tags_round_trips_and_scopes_to_binary_rows() {
+    let db = Db::open_in_memory().unwrap();
+    let tid = db.upsert_track(&crate::NewTrack {
+        backing_path: "/a.mp3".into(), format: crate::Format::Mp3,
+        audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime: 0,
+    }).unwrap();
+    {
+        let mut bw = db.bulk_writer().unwrap();
+        bw.replace_tags(tid, &[crate::Tag::new("artist", "A", 0)]).unwrap();
+        bw.set_binary_tags(tid, &[crate::BinaryTag { key: "PRIV".into(), payload: vec![7, 7, 7], ordinal: 0 }]).unwrap();
+        bw.commit().unwrap();
+    }
+    let rows = db.get_binary_tags(tid).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, "PRIV");
+    assert_eq!(rows[0].byte_len, 3);
+    // Text row untouched by the binary write.
+    assert_eq!(db.get_tags(tid).unwrap(), vec![crate::Tag::new("artist", "A", 0)]);
+}
+```
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `cargo test -p musefs-db bulk_set_binary_tags_round_trips`
+Expected: FAIL — `BulkWriter::set_binary_tags` not found.
+
+- [ ] **Step 8: Implement `BulkWriter::set_binary_tags`**
+
+In `musefs-db/src/bulk.rs`, add to `impl BulkWriter` (mirror `Db::set_binary_tags`, but using the batch transaction `self.tx`). Ensure `BinaryTag` is imported (`use crate::models::BinaryTag;` or `crate::BinaryTag`):
+
+```rust
+/// Replace the track's binary tag rows (`value_blob IS NOT NULL`) through the
+/// batch transaction; text rows (managed by `replace_tags`) are untouched. Binary
+/// rows store '' in `value`. The batch mirror of `Db::set_binary_tags`.
+pub fn set_binary_tags(&mut self, track_id: i64, tags: &[BinaryTag]) -> Result<()> {
+    self.tx.execute(
+        "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
+        params![track_id],
+    )?;
+    let mut stmt = self.tx.prepare(
+        "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
+         VALUES (?1, ?2, '', ?3, ?4)",
+    )?;
+    for t in tags {
+        stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
+    }
+    Ok(())
+}
+```
+
+> Match the exact borrow shape of the existing `replace_tags` in this file — if it scopes the prepared `stmt` in a `{ … }` block to drop the `self.tx` borrow before `commit`, do the same here.
+
+- [ ] **Step 9: Run test + commit**
+
+Run: `cargo test -p musefs-db bulk_set_binary_tags_round_trips && cargo test -p musefs-db`
+
+```bash
+git add musefs-db/src/bulk.rs
+git commit -m "feat(db): BulkWriter::set_binary_tags batch mirror"
+```
+
+---
+
+### Task 2.3: `EmbeddedBinaryTag` parser return type
+
+**Files:**
+- Modify: `musefs-format/src/input.rs`
+- Modify: `musefs-format/src/lib.rs` (re-export)
+- Test: `musefs-format/src/input.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `input.rs` tests:
+
+```rust
+#[test]
+fn embedded_binary_tag_constructs() {
+    let e = super::EmbeddedBinaryTag { key: "PRIV".into(), payload: vec![1, 2, 3] };
+    assert_eq!(e.key, "PRIV");
+    assert_eq!(e.payload.len(), 3);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format embedded_binary_tag_constructs`
+Expected: FAIL — `EmbeddedBinaryTag` not found.
+
+- [ ] **Step 3: Add the struct**
+
+Append to `musefs-format/src/input.rs`:
+
+```rust
+/// A binary tag frame extracted at scan time: the format-private identifier
+/// (`key` — an ID3 4-char frame id, a FLAC `APPLICATION`/`CUESHEET`, or an MP4
+/// `----:<mean>:<name>`) and the raw post-header body (`payload`). Unlike
+/// `BinaryTagInput`, this owns the bytes (scan ingests them into the DB).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedBinaryTag {
+    pub key: String,
+    pub payload: Vec<u8>,
+}
+```
+
+- [ ] **Step 4: Re-export**
+
+In `musefs-format/src/lib.rs`, extend the input re-export (currently `pub use input::{ArtInput, BinaryTagInput, EmbeddedPicture, TagInput};`):
+
+```rust
+pub use input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format embedded_binary_tag_constructs`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-format/src/input.rs musefs-format/src/lib.rs
+git commit -m "feat(format): EmbeddedBinaryTag parser return type"
+```
+
+---
+
+### Task 2.4: `read_binary_tags` — classify + promote (mp3.rs)
+
+**Files:**
+- Modify: `musefs-format/src/mp3.rs`
+- Test: `musefs-format/src/mp3.rs` (inline)
+
+- [ ] **Step 1: Write the failing tests (classification + byte-exact GEOB)**
+
+Add to `mp3.rs` tests. The first uses the `id3` crate's `Encoder` to build a v2.4 fixture (default encoder emits no unsync / no extended header / zero frame flags, so it passes `id3v2_alloc_safe`). The second builds a `GEOB` frame **by hand** with a Latin1 (encoding byte `0x00`) description and asserts the opaque payload is byte-identical — this is the fidelity property `to_unknown` would have broken.
+
+```rust
+#[test]
+fn read_binary_tags_promotes_popm_and_mbid_and_passes_through_priv() {
+    use id3::frame::{Content, Popularimeter, UniqueFileIdentifier, Unknown};
+    use id3::{Frame, Tag, TagLike, Version};
+
+    let mut tag = Tag::new();
+    tag.add_frame(Popularimeter { user: "a@b.c".into(), rating: 200, counter: 7 });
+    tag.add_frame(UniqueFileIdentifier {
+        owner_identifier: "http://musicbrainz.org".into(),
+        identifier: b"mbid-123".to_vec(),
+    });
+    tag.add_frame(UniqueFileIdentifier {
+        owner_identifier: "http://other.example".into(),
+        identifier: b"other".to_vec(),
+    });
+    tag.add_frame(Frame::with_content(
+        "PRIV",
+        Content::Unknown(Unknown { data: vec![9, 8, 7], version: Version::Id3v24 }),
+    ));
+    let mut buf = Vec::new();
+    id3::Encoder::new().version(Version::Id3v24).encode(&tag, &mut buf).unwrap();
+
+    let (opaque, promoted) = super::read_binary_tags(&buf);
+    assert!(promoted.contains(&("rating".to_string(), "200".to_string())));
+    assert!(promoted.contains(&("playcount".to_string(), "7".to_string())));
+    assert!(promoted.contains(&("musicbrainz_trackid".to_string(), "mbid-123".to_string())));
+    let keys: Vec<&str> = opaque.iter().map(|e| e.key.as_str()).collect();
+    assert!(keys.contains(&"PRIV"));
+    assert_eq!(keys.iter().filter(|k| **k == "UFID").count(), 1); // non-MB UFID opaque
+    assert_eq!(opaque.iter().find(|e| e.key == "PRIV").unwrap().payload, vec![9, 8, 7]);
+}
+
+#[test]
+fn read_binary_tags_preserves_geob_body_byte_exact() {
+    // A GEOB body with a Latin1 (encoding 0x00) description — the exact case the
+    // crate's to_unknown() would re-encode to UTF-8. Build a minimal v2.4 tag by
+    // hand: header + one GEOB frame header + body.
+    let geob_body: Vec<u8> = {
+        let mut b = vec![0x00];                 // text encoding: ISO-8859-1
+        b.extend_from_slice(b"application/octet-stream\0"); // mime
+        b.extend_from_slice(b"Serato Overview\0");          // filename (latin1)
+        b.extend_from_slice(b"\0");                          // description
+        b.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);      // object data
+        b
+    };
+    let tag = build_v24_tag(&[(b"GEOB", &geob_body)]); // small test helper (Step 3 note)
+
+    let (opaque, _promoted) = super::read_binary_tags(&tag);
+    let geob = opaque.iter().find(|e| e.key == "GEOB").expect("GEOB preserved");
+    assert_eq!(geob.payload, geob_body, "GEOB body must survive byte-identical");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-format read_binary_tags`
+Expected: FAIL — `read_binary_tags` not found.
+
+- [ ] **Step 3: Implement `read_binary_tags` as a raw frame walker**
+
+Add to `musefs-format/src/mp3.rs` (after `read_tags`). This does **not** use the `id3` crate: it walks frames with the same size-decode logic as `id3v2_alloc_safe` (which has already guaranteed no unsync / no extended header / zero frame flags, so on-disk bodies are byte-exact). The MusicBrainz owner constant is reused by synthesis (Task 2.5), so make it `pub(crate)`.
+
+```rust
+pub(crate) const MUSICBRAINZ_UFID_OWNER: &str = "http://musicbrainz.org";
+
+/// Extract an ID3v2.3/2.4 tag's binary frames. Returns `(opaque, promoted)`:
+/// - `opaque`: frames preserved **byte-exact** — `(frame-id, raw post-header body)`.
+///   `PRIV`/`GEOB`/`SYLT`/`MCDI`/unknown frames and any non-MusicBrainz `UFID`.
+/// - `promoted`: `(key, value)` text pairs — `POPM` → `rating` (raw 0–255) `+ playcount`
+///   (counter, omitted when 0); MusicBrainz `UFID` → `musicbrainz_trackid`. Promoted
+///   frames are NOT in `opaque`.
+///
+/// Text (`T***`), `COMM`, `USLT`, `APIC` are handled by `read_tags`/`read_pictures`
+/// and skipped. Gated by `id3v2_alloc_safe`, so the tag is well-formed, has no
+/// unsynchronisation/extended header/frame flags, and bodies are sliced verbatim.
+/// v2.2 (3-char ids) is not processed (rare; text/art still parse via the crate).
+pub fn read_binary_tags(data: &[u8]) -> (Vec<EmbeddedBinaryTag>, Vec<(String, String)>) {
+    let mut opaque = Vec::new();
+    let mut promoted = Vec::new();
+    if !id3v2_alloc_safe(data) || data[3] < 3 {
+        return (opaque, promoted);
+    }
+    let tag_end = 10 + synchsafe_decode(&data[6..10]) as usize; // bounds validated upstream
+    let mut pos = 10usize;
+    while pos + 10 <= tag_end {
+        if data[pos] == 0 {
+            break; // padding
+        }
+        let id = &data[pos..pos + 4];
+        let size = if data[3] == 3 {
+            u32::from_be_bytes([data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7]]) as usize
+        } else {
+            synchsafe_decode(&data[pos + 4..pos + 8]) as usize
+        };
+        let body_start = pos + 10;
+        if body_start + size > tag_end {
+            break; // defensive; id3v2_alloc_safe already validated bounds
+        }
+        classify_binary_frame(id, &data[body_start..body_start + size], &mut opaque, &mut promoted);
+        pos = body_start + size;
+    }
+    (opaque, promoted)
+}
+
+/// Classify one ID3v2 frame body into opaque-passthrough or promoted-text.
+fn classify_binary_frame(
+    id: &[u8],
+    body: &[u8],
+    opaque: &mut Vec<EmbeddedBinaryTag>,
+    promoted: &mut Vec<(String, String)>,
+) {
+    // Handled by read_tags/read_pictures: text frames (T***), COMM, USLT, APIC.
+    if id[0] == b'T' || id == b"COMM" || id == b"USLT" || id == b"APIC" {
+        return;
+    }
+    match id {
+        b"POPM" => {
+            // <owner>\0<rating:u8>[<counter: big-endian>]
+            if let Some(nul) = body.iter().position(|&b| b == 0) {
+                if let Some((&rating, counter)) = body[nul + 1..].split_first() {
+                    promoted.push(("rating".to_string(), rating.to_string()));
+                    let c = counter.iter().take(8).fold(0u64, |a, &b| (a << 8) | b as u64);
+                    if c > 0 {
+                        promoted.push(("playcount".to_string(), c.to_string()));
+                    }
+                }
+            }
+        }
+        b"UFID" => {
+            // <owner>\0<identifier>. MusicBrainz owner promotes; others opaque.
+            match body.iter().position(|&b| b == 0) {
+                Some(nul) if &body[..nul] == MUSICBRAINZ_UFID_OWNER.as_bytes() => {
+                    promoted.push((
+                        "musicbrainz_trackid".to_string(),
+                        String::from_utf8_lossy(&body[nul + 1..]).into_owned(),
+                    ));
+                }
+                _ => opaque.push(EmbeddedBinaryTag { key: "UFID".to_string(), payload: body.to_vec() }),
+            }
+        }
+        _ => {
+            // Opaque verbatim: PRIV, GEOB, SYLT, MCDI, W***, unknown, … (4-byte ids).
+            if id.iter().all(|b| b.is_ascii_graphic()) {
+                opaque.push(EmbeddedBinaryTag {
+                    key: String::from_utf8_lossy(id).into_owned(),
+                    payload: body.to_vec(),
+                });
+            }
+        }
+    }
+}
+```
+
+Add `use crate::input::EmbeddedBinaryTag;` to `mp3.rs` if not in scope. Note `synchsafe_decode` already exists in this file (used by `id3v2_alloc_safe`). For the byte-exact test, add a small `#[cfg(test)] fn build_v24_tag(frames: &[(&[u8;4], &[u8])]) -> Vec<u8>` helper that writes `b"ID3\x04\x00\x00"` + a synchsafe total size + each frame's 10-byte header (id + synchsafe size + `\0\0`) + body. (Use the file's `syncsafe` helper for the size fields.)
+
+> One definition of `MUSICBRAINZ_UFID_OWNER` (a `&str`): the parser compares against `.as_bytes()`, synthesis (Task 2.5) passes it straight to `ufid_frame_data(owner: &str, …)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-format read_binary_tags`
+Expected: PASS (both classification and byte-exact GEOB).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/mp3.rs
+git commit -m "feat(format): read_binary_tags — ID3 opaque passthrough + POPM/UFID promotion"
+```
+
+---
+
+### Task 2.5: Synthesis — rebuild POPM/UFID + emit opaque binary frames
+
+Changes `build_id3v2_segments`'s signature to `(tags, binary_tags, arts)`; updates its two callers (`mp3::synthesize_layout`, `wav::synthesize_layout`) to pass `binary_tags` through (the reader passes `&[]` until Task 2.9, keeping the workspace compiling). Adds the two body builders and the promoted-key exclusion.
+
+**Files:**
+- Modify: `musefs-format/src/mp3.rs` (`build_id3v2_segments`, `synthesize_layout`, new builders)
+- Modify: `musefs-format/src/wav.rs` (`synthesize_layout` call site)
+- Modify: `musefs-core/src/reader.rs` (MP3 + WAV arms: pass `&[]` for now)
+- Test: `musefs-format/src/mp3.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mp3.rs` tests. Asserts: promoted text tags rebuild a `POPM`/`UFID` frame (and don't leak as `TXXX`), and an opaque `BinaryTagInput` becomes a header + `Segment::BinaryTag`.
+
+```rust
+#[test]
+fn build_id3v2_segments_rebuilds_popm_ufid_and_streams_opaque() {
+    use crate::{BinaryTagInput, TagInput};
+    let tags = vec![
+        TagInput::new("artist", "A"),
+        TagInput::new("rating", "200"),
+        TagInput::new("playcount", "7"),
+        TagInput::new("musicbrainz_trackid", "mbid-123"),
+    ];
+    let bin = vec![BinaryTagInput { key: "PRIV".into(), payload_id: 42, len: 3 }];
+    let (segments, _len) = super::build_id3v2_segments(&tags, &bin, &[]).unwrap();
+
+    // The opaque PRIV streams as a BinaryTag carrying its payload_id.
+    assert!(segments.iter().any(|s| matches!(s, Segment::BinaryTag { payload_id: 42, len: 3 })));
+
+    // Materialize the inline bytes and confirm POPM + UFID frame ids are present
+    // and rating/playcount/musicbrainz_trackid did NOT leak as TXXX descriptors.
+    let inline: Vec<u8> = segments.iter().flat_map(|s| match s {
+        Segment::Inline(b) => b.clone(),
+        _ => Vec::new(),
+    }).collect();
+    assert!(find_sub(&inline, b"POPM"), "POPM not rebuilt");
+    assert!(find_sub(&inline, b"UFID"), "UFID not rebuilt");
+    assert!(find_sub(&inline, b"http://musicbrainz.org"), "UFID owner missing");
+    assert!(!find_sub(&inline, b"rating"), "promoted key leaked as TXXX");
+    assert!(!find_sub(&inline, b"musicbrainz_trackid"), "promoted key leaked as TXXX");
+}
+
+// Tiny substring search helper for the test module (add once if absent).
+fn find_sub(hay: &[u8], needle: &[u8]) -> bool {
+    hay.windows(needle.len()).any(|w| w == needle)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format build_id3v2_segments_rebuilds_popm_ufid`
+Expected: FAIL — `build_id3v2_segments` takes 2 args (arity mismatch / won't compile).
+
+- [ ] **Step 3: Add the body builders**
+
+In `musefs-format/src/mp3.rs`, near the other `*_frame_data` helpers (after `apic_framing`):
+
+```rust
+/// POPM body: `<owner>\0<rating:u8>[<counter: 4-byte big-endian>]`. Owner is empty
+/// by design (spec §5 — the original tagger identity is dropped). The counter is
+/// emitted as 4 bytes when `playcount > 0` and omitted when 0; values above
+/// `u32::MAX` are clamped (the typed read path caps at u64, the common case fits
+/// u32).
+fn popm_frame_data(rating: u8, playcount: u64) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.push(0x00); // empty owner, NUL-terminated
+    d.push(rating);
+    if playcount > 0 {
+        let c = u32::try_from(playcount).unwrap_or(u32::MAX);
+        d.extend_from_slice(&c.to_be_bytes());
+    }
+    d
+}
+
+/// UFID body: `<owner>\0<identifier bytes>`.
+fn ufid_frame_data(owner: &str, identifier: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(owner.as_bytes());
+    d.push(0x00);
+    d.extend_from_slice(identifier);
+    d
+}
+
+/// True for the canonical text keys that are rebuilt as POPM/UFID frames and must
+/// therefore be excluded from the generic text/TXXX emission (no double-store).
+fn is_promoted_key(key: &str) -> bool {
+    matches!(key, "rating" | "playcount" | "musicbrainz_trackid")
+}
+```
+
+- [ ] **Step 4: Change `build_id3v2_segments`**
+
+Replace the signature and weave in promotion + opaque emission. The new signature:
+
+```rust
+pub(crate) fn build_id3v2_segments(
+    tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
+    arts: &[ArtInput],
+) -> Result<(Vec<Segment>, u64)> {
+```
+
+Add `use crate::input::BinaryTagInput;` at the top of `mp3.rs` if not already in scope.
+
+Inside, **before** the `groups` build, pull the promoted scalar values out of `tags` (first value wins per key):
+
+```rust
+    let mut popm_rating: Option<u8> = None;
+    let mut popm_playcount: u64 = 0;
+    let mut mbid: Option<String> = None;
+    for t in tags {
+        match t.key.as_str() {
+            "rating" if popm_rating.is_none() => popm_rating = t.value.parse().ok(),
+            "playcount" => popm_playcount = t.value.parse().unwrap_or(popm_playcount),
+            "musicbrainz_trackid" if mbid.is_none() => mbid = Some(t.value.clone()),
+            _ => {}
+        }
+    }
+```
+
+In the `for t in tags` grouping loop, skip promoted keys so they don't enter the text/`TXXX` path:
+
+```rust
+    for t in tags {
+        if is_promoted_key(&t.key) {
+            continue;
+        }
+        match groups.last_mut() {
+            Some(g) if g.0 == t.key => g.1.push(t.value.clone()),
+            _ => groups.push((t.key.clone(), vec![t.value.clone()])),
+        }
+    }
+```
+
+**After** the existing text-frame `for (key, values) in &groups { … }` loop and **before** the `for art in arts` loop, emit the rebuilt promoted frames and the opaque binary frames:
+
+```rust
+    // Rebuilt promoted frames (POPM from rating/playcount, UFID from MBID).
+    if let Some(rating) = popm_rating {
+        let data = popm_frame_data(rating, popm_playcount);
+        push_frame_header(&mut buf, b"POPM", data.len())?;
+        buf.extend_from_slice(&data);
+        frames_len += 10 + data.len() as u64;
+    }
+    if let Some(id) = &mbid {
+        let data = ufid_frame_data(MUSICBRAINZ_UFID_OWNER, id.as_bytes());
+        push_frame_header(&mut buf, b"UFID", data.len())?;
+        buf.extend_from_slice(&data);
+        frames_len += 10 + data.len() as u64;
+    }
+
+    // Opaque binary frames: header (inline) + streamed body (BinaryTag segment).
+    for bt in binary_tags {
+        if bt.len == 0 {
+            continue; // an empty BinaryTag fails RegionLayout::validate.
+        }
+        let Ok(id): std::result::Result<[u8; 4], _> = bt.key.as_bytes().try_into() else {
+            continue; // defensive: ID3 opaque keys are 4-byte frame ids.
+        };
+        push_frame_header(&mut buf, &id, bt.len as usize)?;
+        segments.push(Segment::Inline(std::mem::take(&mut buf)));
+        segments.push(Segment::BinaryTag { payload_id: bt.payload_id, len: bt.len });
+        frames_len += 10 + bt.len;
+    }
+```
+
+> The existing 28-bit syncsafe guards in `push_frame_header` and the final `frames_len` check now bound binary frame lengths too — no new guard needed.
+
+- [ ] **Step 5: Thread the new parameter through callers (keep compiling)**
+
+`mp3::synthesize_layout` — add `binary_tags` and forward it:
+
+```rust
+pub fn synthesize_layout(
+    audio_offset: u64,
+    audio_length: u64,
+    tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
+    arts: &[ArtInput],
+) -> Result<RegionLayout> {
+    let (mut segments, _tag_len) = build_id3v2_segments(tags, binary_tags, arts)?;
+    segments.push(Segment::BackingAudio { offset: audio_offset, len: audio_length });
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+}
+```
+
+`wav::synthesize_layout` — add `binary_tags` and pass through (it calls `mp3::build_id3v2_segments`):
+
+```rust
+pub fn synthesize_layout(
+    scan: &WavScan,
+    audio_offset: u64,
+    audio_length: u64,
+    tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
+    arts: &[ArtInput],
+) -> Result<RegionLayout> {
+    // ... existing body, but change the build call:
+    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, binary_tags, arts)?;
+    // ... rest unchanged.
+}
+```
+
+In `musefs-core/src/reader.rs`, update the MP3 and WAV arms to pass an empty slice for now (Task 2.9 replaces it):
+
+```rust
+        Format::Mp3 => mp3::synthesize_layout(
+            track.audio_offset as u64,
+            track.audio_length as u64,
+            &inputs,
+            &[], // binary_tags — wired in Task 2.9
+            &art_inputs,
+        )?,
+```
+
+```rust
+        Format::Wav => {
+            let front = read_front(Path::new(&track.backing_path), track.audio_offset as u64)?;
+            let scan = wav::read_structure(&front)?;
+            wav::synthesize_layout(
+                &scan,
+                track.audio_offset as u64,
+                track.audio_length as u64,
+                &inputs,
+                &[], // binary_tags — wired in Task 2.9
+                &art_inputs,
+            )?
+        }
+```
+
+- [ ] **Step 6: Run test + workspace build**
+
+Run: `cargo test -p musefs-format build_id3v2_segments_rebuilds_popm_ufid && cargo build --workspace`
+Expected: PASS / builds (all callers updated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-format/src/mp3.rs musefs-format/src/wav.rs musefs-core/src/reader.rs
+git commit -m "feat(format): synthesize ID3 POPM/UFID + stream opaque binary frames"
+```
+
+---
+
+### Task 2.6: WAV `id3 ` chunk → `read_binary_tags`
+
+Expose a WAV-side `read_binary_tags` that extracts the embedded `id3 ` chunk and runs the MP3 classifier over it (the scan path uses it in Task 2.8).
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs`
+- Test: `musefs-format/src/wav.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `wav.rs` tests (reuse the existing WAV fixture builder that wraps an ID3v2 tag in an `id3 ` chunk; the file already has `find_id3_chunk` + `read_tags` tests to copy structure from):
+
+```rust
+#[test]
+fn wav_read_binary_tags_extracts_id3_chunk_frames() {
+    // Build an ID3v2.4 tag with a PRIV frame, wrap it in an `id3 ` chunk inside a
+    // minimal RIFF/WAVE container (mirror the existing wav read_tags test fixture).
+    let id3 = build_id3_with_priv(&[5, 6, 7]); // helper used by existing wav tests
+    let wav = wrap_in_wav_with_id3_chunk(&id3);  // helper used by existing wav tests
+
+    let (opaque, _promoted) = super::read_binary_tags(&wav);
+    let priv_tag = opaque.iter().find(|e| e.key == "PRIV").expect("PRIV preserved");
+    assert_eq!(priv_tag.payload, vec![5, 6, 7]);
+}
+```
+
+> If the WAV test module lacks `build_id3_with_priv`/`wrap_in_wav_with_id3_chunk`, construct the bytes inline the way the existing `wav.rs` `read_tags` test builds its `id3 ` chunk fixture (ID3 tag via the `id3` crate `Encoder`, then an 8-byte `id3 ` + LE-size chunk header inside `RIFF....WAVE`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format wav_read_binary_tags_extracts_id3_chunk`
+Expected: FAIL — `wav::read_binary_tags` not found.
+
+- [ ] **Step 3: Implement `wav::read_binary_tags`**
+
+Add to `musefs-format/src/wav.rs` (near `read_tags`, reusing the existing chunk-walk + `find_id3_chunk`):
+
+```rust
+/// Extract binary ID3 frames from a WAV's embedded `id3 ` chunk. Classification is
+/// identical to MP3 (`mp3::read_binary_tags`); only the chunk extraction differs.
+/// Returns `(opaque, promoted)`; empty when there is no `id3 ` chunk.
+pub fn read_binary_tags(data: &[u8]) -> (Vec<EmbeddedBinaryTag>, Vec<(String, String)>) {
+    let Some(chunks) = list_chunks(data) else {
+        return (Vec::new(), Vec::new());
+    };
+    match find_id3_chunk(data, &chunks) {
+        Some(id3_bytes) => crate::mp3::read_binary_tags(id3_bytes),
+        None => (Vec::new(), Vec::new()),
+    }
+}
+```
+
+> Use whatever chunk-enumeration the existing `read_tags` uses to feed `find_id3_chunk` (the agent map shows `read_tags` walks chunks then calls `find_id3_chunk(buf, &chunks)`). Match that exact call shape — if the helper is named differently than `list_chunks`, use the real one. Add `use crate::input::EmbeddedBinaryTag;` if not in scope.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format wav_read_binary_tags_extracts_id3_chunk`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/wav.rs
+git commit -m "feat(format): wav::read_binary_tags over the id3 chunk"
+```
+
+---
+
+### Task 2.7: `binary_tags_to_inputs` (mapping.rs)
+
+**Files:**
+- Modify: `musefs-core/src/mapping.rs`
+- Test: `musefs-core/src/mapping.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mapping.rs` tests (mirror the `track_art_to_inputs` test):
+
+```rust
+#[test]
+fn binary_tags_to_inputs_maps_rows() {
+    let db = Db::open_in_memory().unwrap();
+    let tid = db.upsert_track(&NewTrack {
+        backing_path: "/a.mp3".into(), format: Format::Mp3,
+        audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime: 0,
+    }).unwrap();
+    db.set_binary_tags(tid, &[musefs_db::BinaryTag { key: "PRIV".into(), payload: vec![1,2,3,4], ordinal: 0 }]).unwrap();
+
+    let inputs = super::binary_tags_to_inputs(&db, tid).unwrap();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0].key, "PRIV");
+    assert_eq!(inputs[0].len, 4);
+    // payload_id is the streaming handle (the tags rowid).
+    let rowid = db.get_binary_tags(tid).unwrap()[0].rowid;
+    assert_eq!(inputs[0].payload_id, rowid);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core binary_tags_to_inputs_maps_rows`
+Expected: FAIL — `binary_tags_to_inputs` not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `musefs-core/src/mapping.rs` (next to `track_art_to_inputs`). Ensure `BinaryTagInput` is imported (`use musefs_format::BinaryTagInput;`):
+
+```rust
+/// Map a track's binary tag rows to `BinaryTagInput`s for synthesis. Never reads
+/// the payload bytes — only `(rowid, key, byte_len)`; the bytes stream at read
+/// time. Ordered by (key, ordinal), matching `get_binary_tags`.
+pub(crate) fn binary_tags_to_inputs(db: &Db, track_id: i64) -> Result<Vec<BinaryTagInput>> {
+    Ok(db
+        .get_binary_tags(track_id)?
+        .into_iter()
+        .map(|row| BinaryTagInput {
+            key: row.key,
+            payload_id: row.rowid,
+            len: row.byte_len as u64,
+        })
+        .collect())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core binary_tags_to_inputs_maps_rows`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/mapping.rs
+git commit -m "feat(core): binary_tags_to_inputs row->input mapping"
+```
+
+---
+
+### Task 2.8: Scan ingestion (scan.rs)
+
+Add `Probed.binary_tags`, the size cap, populate the MP3 + WAV probe arms, and write binary rows via `set_binary_tags` **after** the text replace (so the scoped deletes don't race) in both the single-track and bulk paths. Merge `promoted` text pairs into the text tags.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (`Probed` ~82, probe arms ~108/140/265/296, `ingest` ~346, `ingest_bulk` ~397, `MAX_ART_BYTES` ~24)
+- Test: `musefs-core/src/scan.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `scan.rs` tests (mirror the existing scan tests that write a fixture file and assert DB state):
+
+```rust
+#[test]
+fn scan_ingests_binary_tags_and_promotes() {
+    use id3::frame::{Content, Popularimeter, Unknown};
+    use id3::{Frame, Tag, TagLike, Version};
+    let dir = tempfile::tempdir().unwrap();
+
+    // Build an MP3 with a PRIV (opaque) + POPM (promoted) tag.
+    let mut tag = Tag::new();
+    tag.add_frame(Popularimeter { user: "u".into(), rating: 128, counter: 3 });
+    tag.add_frame(Frame::with_content("PRIV",
+        Content::Unknown(Unknown { data: vec![1, 1, 2, 3, 5], version: Version::Id3v24 })));
+    let mut bytes = Vec::new();
+    id3::Encoder::new().version(Version::Id3v24).encode(&tag, &mut bytes).unwrap();
+    bytes.extend_from_slice(&crate::scan::tests::silent_mpeg_frame()); // existing audio helper
+    std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path(), false).unwrap();
+    let tid = /* track id for a.mp3 */ db_first_track_id(&db);
+
+    // Opaque PRIV survives as a binary row.
+    let bin = db.get_binary_tags(tid).unwrap();
+    assert!(bin.iter().any(|r| r.key == "PRIV" && r.byte_len == 5));
+
+    // POPM promoted into editable text tags.
+    let texts = db.get_tags(tid).unwrap();
+    assert!(texts.iter().any(|t| t.key == "rating" && t.value == "128"));
+    assert!(texts.iter().any(|t| t.key == "playcount" && t.value == "3"));
+}
+```
+
+> Use the existing scan-test helpers for the audio frame and track-id lookup (copy from the nearest scan test). The assertions are the point.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core scan_ingests_binary_tags_and_promotes`
+Expected: FAIL — binary rows empty / no `rating` text tag (scan doesn't parse binary frames yet).
+
+- [ ] **Step 3: Add the cap and the `Probed` field**
+
+In `musefs-core/src/scan.rs`, after `MAX_ART_BYTES` (~24):
+
+```rust
+/// Per-frame cap for opaque binary tags, mirroring `MAX_ART_BYTES`. Oversize
+/// payloads (e.g. a GEOB embedding a multi-MB file) are logged-and-skipped.
+const MAX_BINARY_TAG_BYTES: usize = MAX_ART_BYTES;
+```
+
+Add a field to `Probed` (~82):
+
+```rust
+    binary_tags: Vec<EmbeddedBinaryTag>,
+```
+
+Import it: `use musefs_format::EmbeddedBinaryTag;` (alongside `EmbeddedPicture`).
+
+- [ ] **Step 4: Populate the MP3 + WAV probe arms**
+
+Every `Probed { … }` literal must now set `binary_tags`. For the **MP3** and **WAV** arms (probe_full ~104–110 & ~136–142; probe_prefix ~261–266 & ~292–297), compute the binaries and merge promoted text into `tags`. Because the current arms use struct-literal `tags:` initializers, restructure each MP3/WAV arm into a block. MP3 example (`probe_full`):
+
+```rust
+        } else if /* mp3 detection */ {
+            let (binary_tags, promoted) = mp3::read_binary_tags(bytes);
+            let mut tags = mp3::read_tags(bytes);
+            tags.extend(promoted);
+            Some(Probed {
+                format: Format::Mp3,
+                audio_offset, // (existing values)
+                audio_length,
+                tags,
+                pictures: mp3::read_pictures(bytes),
+                binary_tags,
+            })
+        }
+```
+
+WAV arm (analogous), using `wav::read_binary_tags(bytes)` and `wav::read_tags(bytes)`.
+
+For **all other** `Probed { … }` literals (FLAC, MP4, Ogg, and the `probe_file` MP4 arm, plus the test fixtures around ~846/856), add `binary_tags: Vec::new(),` — Phase 2 does not parse their binary frames (FLAC is Phase 4, MP4 is Phase 3). The compiler will flag every missing field; add the empty default to each.
+
+- [ ] **Step 5: Write binary tags in `ingest` (single-track path)**
+
+In `ingest` (~346), after `db.replace_tags(track_id, &tags)?;` (line 363) and before/after art — order relative to art is irrelevant, but it MUST be after the text replace. Add:
+
+```rust
+    let binary_tags: Vec<musefs_db::BinaryTag> = probed
+        .binary_tags
+        .into_iter()
+        .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
+        .enumerate()
+        .map(|(ordinal, b)| musefs_db::BinaryTag { key: b.key, payload: b.payload, ordinal: ordinal as i64 })
+        .collect();
+    db.set_binary_tags(track_id, &binary_tags)?;
+```
+
+> `ordinal` is a gap-free index over accepted (non-empty, non-oversize) frames, mirroring the art ordinal scheme. Note `probed.binary_tags` is moved here; ensure this runs after any other use of `probed` fields (in `ingest`, `probed.tags`/`probed.pictures` are consumed earlier, so the move is fine — confirm by compiling).
+
+- [ ] **Step 6: Write binary tags in `ingest_bulk` (bulk path)**
+
+In `ingest_bulk` (~397), after `bw.replace_tags(track_id, &tags)?;` (line 420). `ingest_bulk` takes `probed: &Probed` (borrowed), so clone:
+
+```rust
+    let binary_tags: Vec<musefs_db::BinaryTag> = probed
+        .binary_tags
+        .iter()
+        .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
+        .enumerate()
+        .map(|(ordinal, b)| musefs_db::BinaryTag {
+            key: b.key.clone(), payload: b.payload.clone(), ordinal: ordinal as i64,
+        })
+        .collect();
+    bw.set_binary_tags(track_id, &binary_tags)?;
+```
+
+> `bw.set_binary_tags` was added in Task 2.2 (Steps 6–9), so it is available here.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core scan_ingests_binary_tags_and_promotes`
+Expected: PASS.
+
+- [ ] **Step 8: Full crate test + commit**
+
+Run: `cargo test -p musefs-core -p musefs-db`
+
+```bash
+git add musefs-core/src/scan.rs musefs-db/src/bulk.rs
+git commit -m "feat(core): ingest ID3 binary tags (opaque + promoted) during scan"
+```
+
+---
+
+### Task 2.9: Wire binary tags into the reader resolve arms
+
+Replace the `&[]` placeholders (Task 2.5) with real `BinaryTagInput`s loaded from the DB, so synthesized MP3/WAV files emit their binary frames.
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs` (MP3 + WAV arms in `HeaderCache::build`)
+- Test: `musefs-core/src/reader.rs` (inline) — end-to-end resolve→read
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `reader.rs` tests: scan an MP3 with a PRIV frame into a DB, resolve it, read the full synthesized file, and assert the PRIV body bytes appear in the output (proving the reader threaded the binary tag through synthesis + served it from the DB).
+
+```rust
+#[test]
+fn resolve_mp3_emits_binary_tag_in_synthesized_region() {
+    use id3::frame::{Content, Unknown};
+    use id3::{Frame, Tag, Version};
+    let dir = tempfile::tempdir().unwrap();
+    let mut tag = Tag::new();
+    let needle = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02];
+    tag.add_frame(Frame::with_content("PRIV",
+        Content::Unknown(Unknown { data: needle.to_vec(), version: Version::Id3v24 })));
+    let mut bytes = Vec::new();
+    id3::Encoder::new().version(Version::Id3v24).encode(&tag, &mut bytes).unwrap();
+    bytes.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]); // tiny audio tail
+    let path = dir.path().join("a.mp3");
+    std::fs::write(&path, &bytes).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    crate::scan::scan_directory(&db, dir.path(), false).unwrap();
+    let tid = /* track id for a.mp3 */;
+    let cache = HeaderCache::new(/* args as other reader tests */);
+    let resolved = cache.resolve(&db, tid).unwrap();
+    let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+    assert!(whole.windows(needle.len()).any(|w| w == needle), "PRIV body not in synthesized file");
+}
+```
+
+> Copy `HeaderCache::new` construction + track-id lookup from the nearest existing reader test. The assertion (needle present) is the point.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core resolve_mp3_emits_binary_tag`
+Expected: FAIL — the synthesized region has no PRIV (reader passes `&[]`).
+
+- [ ] **Step 3: Load and pass binary tags**
+
+In `musefs-core/src/reader.rs`, in `HeaderCache::build` (where `art_inputs` is computed ~251), add:
+
+```rust
+        let binary_tag_inputs = crate::mapping::binary_tags_to_inputs(db, track.id)?;
+```
+
+Then in the MP3 arm, replace `&[]` with `&binary_tag_inputs`:
+
+```rust
+        Format::Mp3 => mp3::synthesize_layout(
+            track.audio_offset as u64,
+            track.audio_length as u64,
+            &inputs,
+            &binary_tag_inputs,
+            &art_inputs,
+        )?,
+```
+
+And the WAV arm likewise (`&binary_tag_inputs` in place of `&[]`).
+
+> Only MP3 + WAV consume `binary_tag_inputs` in Phase 2. FLAC/MP4/Ogg arms ignore it (their binary handling is Phase 3/4); computing it for every track is a single cheap query (rows only, no blobs), and is empty for tracks with no binary frames.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core resolve_mp3_emits_binary_tag`
+Expected: PASS.
+
+- [ ] **Step 5: Add the binary-tag-chunk serve metric (parity with art)**
+
+The Phase-1 `Segment::BinaryTag` serve arm streams from the DB but emits no metric, unlike `ArtImage` (`metrics::on_art_chunk`). Now that binary tags are actually served, add a counter for observability parity.
+
+In `musefs-core/src/metrics.rs`, mirror the `art_chunks`/`on_art_chunk` plumbing for `binary_tag_chunks` in **both** the enabled-feature block and the no-op block:
+- add `static BINARY_TAG_CHUNKS: AtomicU64 = AtomicU64::new(0);` beside `ART_CHUNKS`;
+- add `pub fn on_binary_tag_chunk() { BINARY_TAG_CHUNKS.fetch_add(1, Ordering::Relaxed); }` beside `on_art_chunk` (and a no-op `pub fn on_binary_tag_chunk() {}` in the disabled block);
+- add `pub binary_tag_chunks: u64,` to the stats struct (both blocks), populate it in the snapshot constructor (`binary_tag_chunks: BINARY_TAG_CHUNKS.load(Ordering::Relaxed),`), and reset it (`BINARY_TAG_CHUNKS.store(0, Ordering::Relaxed);`) wherever `ART_CHUNKS` is reset.
+
+Then in `musefs-core/src/reader.rs`, in `read_segments`'s `Segment::BinaryTag` arm (Phase-1 code), add the metric call after the chunk read:
+
+```rust
+                Segment::BinaryTag { payload_id, .. } => {
+                    let chunk = db.read_binary_tag_chunk(*payload_id, within, n)?;
+                    crate::metrics::on_binary_tag_chunk();
+                    out.extend_from_slice(&chunk);
+                }
+```
+
+If `metrics.rs` has a test asserting a snapshot's fields (e.g. `art_chunks == 1`), extend it to cover `on_binary_tag_chunk()` → `binary_tag_chunks == 1`.
+
+- [ ] **Step 6: Full workspace test + commit**
+
+Run: `cargo test --workspace`
+
+```bash
+git add musefs-core/src/reader.rs musefs-core/src/metrics.rs
+git commit -m "feat(core): emit ID3 binary tags from MP3/WAV resolve arms + serve metric"
+```
+
+---
+
+### Task 2.10: Round-trip proptest + Phase-2 gate
+
+**Files:**
+- Modify: `musefs-format/tests/proptest_mp3.rs` (or create if absent)
+- Validation only otherwise
+
+- [ ] **Step 1: Write the round-trip property test**
+
+Add to `musefs-format/tests/proptest_mp3.rs` a property over arbitrary opaque frames + POPM/UFID, asserting: opaque payloads (incl. `GEOB`/`SYLT` bodies with **non-UTF-8 encoding bytes** — the case that motivated the raw walker) survive **byte-identical** through `read_binary_tags` → DB-shaped round-trip → `build_id3v2_segments` (materialized) → `read_binary_tags`; and `POPM`/`UFID` promote to the right `rating`/`playcount`/`musicbrainz_trackid`. Assert opaque-payload **byte-identity**, but for the (regenerated) promoted frames assert only **value** survival, not byte-identical framing/ordering. Cover these boundaries explicitly: a `POPM` with `counter == 0` (promotes `rating` only, rebuilds with no counter); the **dual-UFID** case — a MusicBrainz UFID (promoted) + a non-MusicBrainz UFID (opaque) re-synthesize to two distinct `UFID` frames with distinct owners (ID3v2.4 distinct-owner rule). Model the round-trip with an in-memory `Db` (`set_binary_tags`/`get_binary_tags`) so `payload_id`s are real, then materialize the inline segments and resolve `Segment::BinaryTag` lengths against the DB.
+
+> Constrain the proptest generators to what `id3v2_alloc_safe` accepts (no unsync/extended header/frame flags) and to v2.3/v2.4 — that's the domain `read_binary_tags` operates on.
+
+> Use the Phase-1 `resolve_layout(layout, backing, art, binary_tags)` test helper (`musefs-format/tests/common/mod.rs`) to splice a layout into concrete bytes, feeding a `payload_id -> bytes` map.
+
+- [ ] **Step 2: Run the property test**
+
+Run: `cargo test -p musefs-format --features fuzzing proptest_mp3`
+Expected: PASS.
+
+- [ ] **Step 3: Query-split correctness regression**
+
+Add a test asserting a `PRIV`-bearing track renders the same template path as the same track without the `PRIV` frame (the binary row must not pollute `tags_to_fields`). Place it in `musefs-core` (it needs the DB + mapping). This guards the Phase-1 `value_blob IS NULL` filter against Phase-2 writes.
+
+Run: `cargo test -p musefs-core`
+
+- [ ] **Step 4: Format + clippy**
+
+Run: `cargo fmt --all --check` (expect clean) and `cargo clippy --all-targets` (expect no warnings).
+
+> Generate any in-diff artifacts via `rtk proxy` if the rtk hook is active — see memory `sp-validation-expectations` (plain `git diff` is token-compacted and breaks tooling).
+
+- [ ] **Step 5: Full workspace test**
+
+Run: `cargo test --workspace`
+Expected: PASS.
+
+- [ ] **Step 6: In-diff mutation gate**
+
+Per memory `sp-validation-expectations`, mirror `.github/workflows/mutants.yml` — and generate the diff with `rtk proxy git diff` (plain `git diff` is rtk-compacted into an invalid unified diff → silent false pass):
+
+```bash
+rtk proxy git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+rtk proxy grep -c '^+++ b/.*\.rs' mutants.diff   # sanity: matches changed .rs count
+rtk proxy cargo mutants --in-diff mutants.diff -j"$(nproc)" --exclude 'musefs-latencyfs/**'
+```
+
+Expected: 0 missed (add tests if any survive).
+
+- [ ] **Step 7: Open the Phase-2 PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --base main --title "feat: binary tags Phase 2 — ID3 (MP3 + WAV)" --body-file <body>
+```
+
+---
+
+## Deferred to later phases (do NOT do here)
+
+- **Phase 3 (MP4 `----`):** the `build_udta` (prefix,len) → `Vec<Segment>` refactor and multi-`----` streaming. Phase 2 leaves the MP4 probe arm's `binary_tags: Vec::new()`.
+- **Phase 4 (FLAC):** `APPLICATION`/`CUESHEET` → DB, `STREAMINFO`/`SEEKTABLE` → `structural_blocks`, resolve re-read elimination. Phase 2 leaves the FLAC probe arm's `binary_tags: Vec::new()`.
+- **Phase 5 (test surface):** mutagen interop fixtures + fuzz seeds for binary frames.
+
+## Phase 2 Self-Review
+
+**Spec coverage (§5 ID3 + §6 query-split + open-handle obligation):** opaque passthrough — **byte-exact** via the raw frame walker, incl. GEOB/SYLT/Serato (2.4/2.5/2.8/2.9 ✓), POPM/UFID promotion incl. owner-drop + non-MB-UFID-opaque (2.4/2.5 ✓), WAV `id3 ` chunk parity (2.6/2.8 ✓), `MAX_BINARY_TAG_BYTES` + skip-zero-length (2.8 ✓), bulk delete scoping + `BulkWriter::set_binary_tags` (2.2 ✓), serve-metric parity `on_binary_tag_chunk` (2.9 ✓), query-split regression (2.10 ✓), dual-UFID distinct-owner + POPM counter==0 boundary (2.10 ✓), open-handle gap **fully closed** via gen re-resolve + transactional `content_version` snapshot guard, with a rowid-reuse safety test (2.1 ✓). Production query-split is already complete (Phase 1 filtered all three text read methods; no other production `FROM tags` read exists). MP4/FLAC are out of scope by design.
+
+**Review fixes folded in (spec-plan-reviewer, 2026-06-02):** the `Content::to_unknown()` fidelity blocker → replaced with a byte-exact raw walker (2.4); the open-handle residual-race → closed with the transactional snapshot guard + bounded retry, and the overstated "closes the gap" claim corrected (2.1). Minors: `ArcSwap` guard deref pinned (2.1 Step 6), POPM `counter==0` + dual-UFID boundaries added to the proptest (2.10).
+
+**Type consistency:** `read_binary_tags -> (Vec<EmbeddedBinaryTag>, Vec<(String,String)>)` (opaque, promoted) consumed by scan (2.8); `EmbeddedBinaryTag {key,payload}` → `BinaryTag {key,payload,ordinal}` (DB write) → `BinaryTagRow {rowid,key,byte_len}` (read) → `BinaryTagInput {key,payload_id,len}` (synthesis) → `Segment::BinaryTag {payload_id,len}`. `build_id3v2_segments(tags, binary_tags, arts)` and `{mp3,wav}::synthesize_layout(..., binary_tags, arts)` arg order is consistent across 2.5/2.6/2.9. Promoted keys (`rating`/`playcount`/`musicbrainz_trackid`) are excluded in synthesis (2.5) exactly where they're produced in parse (2.4).
+
+**Placeholder scan:** the only "fill from the nearest existing test" notes are for test *scaffolding* (mount/lookup/track-id/fixture helpers that already exist in each module's test file) — the assertions and production code are fully specified. No production-code placeholders.

--- a/docs/superpowers/specs/2026-06-01-binary-tags-design.md
+++ b/docs/superpowers/specs/2026-06-01-binary-tags-design.md
@@ -199,11 +199,24 @@ same-length reuse would then be served silently as the snapshot's bytes
 (`read_binary_tag_chunk` only errors on a *short* read). This is the one binary-tag
 path the cache-invalidation invariant does not reach. Phase 1 is behavior-neutral
 (no synthesis path emits `BinaryTag`, so no handle can hold one) and is unaffected,
-but **Phase 2 must close this before emitting binary tags.** The preferred fix is to
-make the binary payload handle *stable and non-reused* — content-address binary
-payloads the way `art` is (so the id is never deleted out from under an open
-handle) — rather than a read-time staleness check, which would defeat the
-open-fd snapshot semantics that `Inline`/`BackingAudio` rely on.
+but **Phase 2 must close this before emitting binary tags.**
+
+**Resolution (Phase 2, chosen over content-addressing).** Rather than content-address
+binary payloads (a larger rework of the `value_blob`-in-`tags` model), Phase 2 closes
+the gap with two cooperating mechanisms in `facade.rs`: (1) a generation-gated handle
+re-resolve — a global `refresh_gen` bumped on any non-empty `poll_refresh` makes the
+next `read` re-resolve a stale handle (cheap `content_version`-keyed cache hit when
+the track is unchanged), restoring freshness and fixing a pre-existing size/content
+skew for handles held across a re-tag; and (2) for `BinaryTag`-bearing layouts only, a
+**transactional `content_version` guard** — the read runs inside one WAL read snapshot
+that first checks `live content_version == resolved.content_version` and bails to a
+bounded re-resolve-and-retry on mismatch. Within a single SQLite read snapshot the
+`content_version` row and the `value_blob` rows are mutually consistent, so a reused
+rowid can never be served — the gap is fully closed, not merely narrowed. Plain
+`Inline`/`BackingAudio` layouts skip the guard, preserving their open-fd snapshot
+semantics at no per-read cost. (The earlier "preferred: content-addressing" note is
+superseded by this resolution; content-addressing remains a viable future option if
+binary-payload dedup ever becomes worthwhile.)
 
 ### 4. Format-layer input (`musefs-format/src/input.rs`)
 

--- a/fuzz/fuzz_targets/mp3.rs
+++ b/fuzz/fuzz_targets/mp3.rs
@@ -18,7 +18,7 @@ fuzz_target!(|data: &[u8]| {
     let tags = arb_tags(&mut u).unwrap_or_default();
     let arts = arb_arts(&mut u).unwrap_or_default();
     if let Ok(layout) =
-        mp3::synthesize_layout(bounds.audio_offset, bounds.audio_length, &tags, &arts)
+        mp3::synthesize_layout(bounds.audio_offset, bounds.audio_length, &tags, &[], &arts)
     {
         assert_backing_covers_audio(bounds.audio_offset, bounds.audio_length, &layout);
     }

--- a/fuzz/fuzz_targets/wav.rs
+++ b/fuzz/fuzz_targets/wav.rs
@@ -26,6 +26,7 @@ fuzz_target!(|data: &[u8]| {
         bounds.audio_offset,
         bounds.audio_length,
         &tags,
+        &[],
         &arts,
     ) {
         assert_backing_covers_audio(bounds.audio_offset, bounds.audio_length, &layout);

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -829,4 +829,128 @@ mod tests {
         );
         fs.release_handle(fh);
     }
+
+    /// The safety property the transactional `content_version` guard exists to
+    /// protect: a handle holding a `Segment::BinaryTag { payload_id }` must never
+    /// serve the bytes of a *different* row that later reused that rowid under the
+    /// stale layout's framing.
+    ///
+    /// We free the original PRIV row's rowid and reuse it with a different-length
+    /// payload **without** calling `poll_refresh`, so `refresh_gen` does not move
+    /// and the gen-gated re-resolve cannot mask the bug — the content_version
+    /// guard is the only thing standing between the read and torn bytes. With the
+    /// guard, a successful read is byte-identical to a fresh resolve of the new DB
+    /// state (the guard forces a re-resolve on the version mismatch); a clean
+    /// `Err` is the only other acceptable outcome. Without the guard the stale
+    /// handle would serve `len_a` bytes off the reused rowid, framed by the old
+    /// header — neither the original nor a valid new file.
+    #[test]
+    fn binary_tag_handle_never_serves_reused_rowid_bytes() {
+        use crate::scan::scan_directory;
+        use id3::frame::{Content, Unknown};
+        use id3::{Encoder, Frame, TagLike, Version};
+        use std::collections::BTreeMap;
+
+        let needle_a = [0xDEu8, 0xAD, 0xBE, 0xEF, 0x01, 0x02];
+        let needle_b = [0x11u8, 0x22, 0x33]; // different bytes AND different length
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            // PRIV-only tag: text frames are omitted because the `id3` crate's
+            // reader errors on a `Content::Unknown` frame it round-tripped, which
+            // would drop the text tags (the raw binary walker is unaffected). The
+            // track therefore renders under the `$artist/$title` fallback path.
+            let mut tag = id3::Tag::new();
+            tag.add_frame(Frame::with_content(
+                "PRIV",
+                Content::Unknown(Unknown {
+                    data: needle_a.to_vec(),
+                    version: Version::Id3v24,
+                }),
+            ));
+            let mut bytes = Vec::new();
+            Encoder::new()
+                .version(Version::Id3v24)
+                .encode(&tag, &mut bytes)
+                .unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00, 0, 0, 0, 0]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+        let artist = fs
+            .lookup(VirtualTree::ROOT, "Unknown")
+            .expect("fallback artist dir");
+        let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+
+        // Open the handle and read the original synthesized file (carries needle_a).
+        let fh = fs.open_handle(file_inode).unwrap();
+        let whole_a = fs.read(file_inode, fh, 0, 1 << 20).unwrap();
+        assert!(
+            whole_a.windows(needle_a.len()).any(|w| w == needle_a),
+            "baseline must carry the original PRIV body"
+        );
+
+        // Out-of-band: free the PRIV row's rowid, then reuse it with a different
+        // payload. With no other tag rows present, deleting the PRIV row empties
+        // `tags` and the next insert reclaims the freed rowid (plain INTEGER
+        // PRIMARY KEY, no AUTOINCREMENT). Both writes bump content_version. No
+        // poll_refresh, so refresh_gen stays put — only the guard can catch this.
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            let track_id = db.list_tracks().unwrap().into_iter().next().unwrap().id;
+            db.set_binary_tags(track_id, &[]).unwrap();
+            db.set_binary_tags(
+                track_id,
+                &[musefs_db::BinaryTag {
+                    key: "PRIV".into(),
+                    payload: needle_b.to_vec(),
+                    ordinal: 0,
+                }],
+            )
+            .unwrap();
+        }
+
+        // What a freshly resolved handle serves for the *current* DB state.
+        let fh2 = fs.open_handle(file_inode).unwrap();
+        let whole_b = fs.read(file_inode, fh2, 0, 1 << 20).unwrap();
+        fs.release_handle(fh2);
+        assert!(
+            whole_b.windows(needle_b.len()).any(|w| w == needle_b),
+            "fresh resolve must carry the new PRIV body"
+        );
+        assert!(
+            !whole_b.windows(needle_a.len()).any(|w| w == needle_a),
+            "fresh resolve must not carry the freed payload"
+        );
+        assert_ne!(
+            whole_a.len(),
+            whole_b.len(),
+            "test setup: payloads must differ in length to expose stale framing"
+        );
+
+        // The stale handle: either a clean error, or — via the guard's forced
+        // re-resolve — byte-identical to the fresh resolve. Never torn bytes.
+        match fs.read(file_inode, fh, 0, 1 << 20) {
+            Ok(bytes) => assert_eq!(
+                bytes, whole_b,
+                "stale handle served torn/reused-rowid bytes instead of re-resolving"
+            ),
+            Err(_) => {} // acceptable: guard surfaced a retryable error
+        }
+        fs.release_handle(fh);
+    }
 }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
@@ -43,15 +43,21 @@ pub struct Attr {
     pub mtime_secs: i64,
 }
 
-/// An open file handle: the resolved layout and a backing fd opened (and
-/// validated) once at `open`, reused for every `read` on this handle.
+/// An open file handle: the resolved layout, the track it belongs to, the
+/// generation at which `resolved` was last validated, and a backing fd opened
+/// once at `open`.
 ///
-/// A handle intentionally outlives `poll_refresh`: it keeps serving the layout
-/// (and backing path) it was opened with, even if a rescan changes the track,
-/// until `release`. This is consistent POSIX-like open-fd snapshot behavior and
-/// is bounded by the FUSE descriptor's lifetime.
+/// A handle survives `poll_refresh`, but is **not** a frozen snapshot: when the
+/// global `refresh_gen` advances (a refresh applied changes), the next `read`
+/// re-resolves the track (a cheap `content_version`-keyed cache hit when the
+/// track is unchanged) and swaps in the fresh layout. This keeps a re-tagged
+/// file's handle consistent with the size the kernel sees via getattr, and
+/// prevents a stale `Segment::BinaryTag { payload_id }` from serving reused-rowid
+/// bytes after a re-tag.
 struct Handle {
-    resolved: Arc<ResolvedFile>,
+    track_id: i64,
+    resolved: arc_swap::ArcSwap<ResolvedFile>,
+    gen: AtomicU64,
     file: std::fs::File,
 }
 
@@ -111,6 +117,11 @@ pub struct Musefs {
     tree: ArcSwap<VirtualTree>,
     cache: HeaderCache,
     last_data_version: AtomicI64,
+    /// Bumped on every non-empty refresh (see `poll_refresh_notify`). Open handles
+    /// stamp their `gen` with the current value at `open_handle` and re-resolve
+    /// when the global value moves ahead of theirs, so a held handle cannot serve
+    /// a layout that was invalidated by a refresh the kernel did not yet see.
+    refresh_gen: AtomicU64,
     handles: sharded_slab::Slab<Arc<Handle>>,
     /// `SizeEntry` keyed by track id. Tiny entries, effectively unbounded; serves
     /// getattr/lookup without a backing stat or full synthesis. Self-invalidates on
@@ -153,6 +164,7 @@ impl Musefs {
         Ok(Musefs {
             cache: HeaderCache::new(config.mode),
             last_data_version: AtomicI64::new(last_data_version),
+            refresh_gen: AtomicU64::new(0),
             tree: ArcSwap::from_pointee(tree),
             pool: DbPool::new(db)?,
             config,
@@ -413,7 +425,7 @@ impl Musefs {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
-        let (new_snapshot, _change) = match self.rebuild_incremental(&old_snapshot) {
+        let (new_snapshot, change) = match self.rebuild_incremental(&old_snapshot) {
             Ok(v) => v,
             Err(err) => {
                 *self
@@ -445,6 +457,12 @@ impl Musefs {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = new_snapshot;
 
         self.last_data_version.store(version, Ordering::Release);
+        if !change.is_empty() {
+            // A non-empty refresh invalidates every open handle's stamp; the
+            // next read will re-resolve (cheap content_version cache hit for
+            // unchanged tracks).
+            self.refresh_gen.fetch_add(1, Ordering::AcqRel);
+        }
         self.stamp_successful_poll();
 
         Ok(true)
@@ -610,9 +628,50 @@ impl Musefs {
         if fh != 0 {
             let handle = self.handles.get((fh - 1) as usize).map(|g| Arc::clone(&g));
             if let Some(h) = handle {
-                return self
-                    .pool
-                    .with(|db| read_at_with_file(&h.resolved, db, &h.file, offset, size));
+                // Bounded retry absorbs a refresh landing mid-read; out-of-band
+                // re-tags are human/batch-paced, so >1 attempt is already rare.
+                for _attempt in 0..4 {
+                    let cur = self.refresh_gen.load(Ordering::Acquire);
+                    if h.gen.load(Ordering::Acquire) != cur {
+                        // A refresh changed something; re-resolve (cheap content_version
+                        // cache hit when this track is unchanged) and re-stamp.
+                        let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
+                        h.resolved.store(fresh);
+                        h.gen.store(cur, Ordering::Release);
+                    }
+                    let resolved = h.resolved.load();
+                    let r: &ResolvedFile = &resolved;
+                    let served = self.pool.with(|db| -> Result<Option<Vec<u8>>> {
+                        if r.has_binary_tag {
+                            // Snapshot-consistent: version check + blob reads see one
+                            // WAL snapshot, so a reused rowid can't be served.
+                            db.begin_read()?;
+                            let res = (|| {
+                                if db.track_content_version(h.track_id)? != r.content_version {
+                                    return Ok(None); // stale layout — retry after re-resolve
+                                }
+                                Ok(Some(read_at_with_file(r, db, &h.file, offset, size)?))
+                            })();
+                            let _ = db.end_read(); // always release the snapshot
+                            res
+                        } else {
+                            Ok(Some(read_at_with_file(r, db, &h.file, offset, size)?))
+                        }
+                    })?;
+                    if let Some(bytes) = served {
+                        return Ok(bytes);
+                    }
+                    // Stale layout: force a re-resolve next iteration against the live version.
+                    let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
+                    h.resolved.store(fresh);
+                    h.gen
+                        .store(self.refresh_gen.load(Ordering::Acquire), Ordering::Release);
+                }
+                // Pathological constant re-tagging raced every attempt; surface a
+                // retryable error rather than risk wrong bytes.
+                return Err(CoreError::BackingChanged(
+                    h.resolved.load().backing_path.to_string_lossy().to_string(),
+                ));
             }
         }
         // Fallback (no prior open, or unknown handle): resolve by inode and open.
@@ -650,7 +709,13 @@ impl Musefs {
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
         validate_opened_backing(&file, &resolved)?;
-        fh_from_key(self.handles.insert(Arc::new(Handle { resolved, file })))
+        let gen = self.refresh_gen.load(Ordering::Acquire);
+        fh_from_key(self.handles.insert(Arc::new(Handle {
+            track_id,
+            resolved: arc_swap::ArcSwap::from(resolved),
+            gen: AtomicU64::new(gen),
+            file,
+        })))
     }
 
     /// Drop an open handle (closes its backing fd when the last reference goes).
@@ -695,11 +760,73 @@ mod tests {
             mtime_secs: mtime_secs(&expected_meta),
             last_page: std::sync::Mutex::new(None),
             cache_bytes: 0,
+            has_binary_tag: false,
         };
 
         assert!(matches!(
             validate_opened_backing(&replacement, &resolved),
             Err(CoreError::BackingChanged(_))
         ));
+    }
+
+    #[test]
+    fn open_handle_reresolves_after_content_version_bump() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+        let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+        let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+        let fh = fs.open_handle(file_inode).unwrap();
+        let len_before = fs.read(file_inode, fh, 0, 1 << 20).unwrap().len();
+        assert!(len_before > 0, "baseline read must be non-empty");
+
+        // Out-of-band re-tag: a long comment grows the synthesized ID3v2 region.
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            let track_id = db.list_tracks().unwrap().into_iter().next().unwrap().id;
+            db.replace_tags(
+                track_id,
+                &[musefs_db::Tag::new("comment", &"x".repeat(4096), 0)],
+            )
+            .unwrap();
+        }
+        assert!(
+            fs.poll_refresh().unwrap(),
+            "poll_refresh must detect the change"
+        );
+
+        // Same handle: must re-resolve and serve the larger layout.
+        let len_after = fs.read(file_inode, fh, 0, 1 << 20).unwrap().len();
+        assert!(
+            len_after > len_before,
+            "handle did not re-resolve: {len_before} -> {len_after}"
+        );
+        fs.release_handle(fh);
     }
 }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -636,6 +636,11 @@ impl Musefs {
                         // A refresh changed something; re-resolve (cheap content_version
                         // cache hit when this track is unchanged) and re-stamp.
                         let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
+                        // If a refresh raced the resolve, `fresh` may already be stale;
+                        // don't publish it under `cur` — retry against the newer gen.
+                        if self.refresh_gen.load(Ordering::Acquire) != cur {
+                            continue;
+                        }
                         h.resolved.store(fresh);
                         h.gen.store(cur, Ordering::Release);
                     }
@@ -705,11 +710,16 @@ impl Musefs {
                 },
             }
         };
+        // Snapshot the generation BEFORE resolving: if a refresh lands during the
+        // resolve, stamping the post-refresh gen onto this (pre-refresh) layout
+        // would make the first read skip re-resolution and serve stale bytes. With
+        // the pre-resolve gen, a racing refresh leaves gen behind refresh_gen, so
+        // the next read re-resolves.
+        let gen = self.refresh_gen.load(Ordering::Acquire);
         let resolved = self.pool.with(|db| self.cache.resolve(db, track_id))?;
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
         validate_opened_backing(&file, &resolved)?;
-        let gen = self.refresh_gen.load(Ordering::Acquire);
         fh_from_key(self.handles.insert(Arc::new(Handle {
             track_id,
             resolved: arc_swap::ArcSwap::from(resolved),
@@ -944,12 +954,12 @@ mod tests {
 
         // The stale handle: either a clean error, or — via the guard's forced
         // re-resolve — byte-identical to the fresh resolve. Never torn bytes.
-        match fs.read(file_inode, fh, 0, 1 << 20) {
-            Ok(bytes) => assert_eq!(
+        // Err is acceptable too (the guard can surface a retryable error).
+        if let Ok(bytes) = fs.read(file_inode, fh, 0, 1 << 20) {
+            assert_eq!(
                 bytes, whole_b,
                 "stale handle served torn/reused-rowid bytes instead of re-resolving"
-            ),
-            Err(_) => {} // acceptable: guard surfaced a retryable error
+            );
         }
         fs.release_handle(fh);
     }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use musefs_db::{Db, Tag};
-use musefs_format::{ArtInput, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, TagInput};
 
 use crate::error::Result;
 
@@ -49,6 +49,22 @@ pub(crate) fn track_art_to_inputs(db: &Db, track_id: i64) -> Result<Vec<ArtInput
     Ok(inputs)
 }
 
+/// Map a track's binary tag rows to `BinaryTagInput`s for synthesis. Never reads
+/// the payload bytes — only `(rowid, key, byte_len)`; the bytes stream at read
+/// time. Ordered by (key, ordinal), matching `get_binary_tags`.
+#[allow(dead_code)] // wired into the reader resolve arms in Task 2.9
+pub(crate) fn binary_tags_to_inputs(db: &Db, track_id: i64) -> Result<Vec<BinaryTagInput>> {
+    Ok(db
+        .get_binary_tags(track_id)?
+        .into_iter()
+        .map(|row| BinaryTagInput {
+            key: row.key,
+            payload_id: row.rowid,
+            len: row.byte_len as u64,
+        })
+        .collect())
+}
+
 /// Read each embedded image's raw bytes for synthesis (Ogg needs the bytes to
 /// compute page CRCs at resolve). Parallel to `track_art_to_inputs`; returns the
 /// same order. Only the Ogg synthesis path calls this — FLAC/MP3/MP4 stream art
@@ -64,6 +80,7 @@ pub(crate) fn track_art_images(db: &Db, inputs: &[ArtInput]) -> Result<Vec<Vec<u
 #[cfg(test)]
 mod tests {
     use super::*;
+    use musefs_db::{BinaryTag, Db, Format, NewTrack};
 
     fn tag(key: &str, value: &str, ordinal: i64) -> Tag {
         Tag::new(key, value, ordinal)
@@ -108,5 +125,37 @@ mod tests {
         let fields = tags_to_fields(&tags);
         assert_eq!(fields.get("myrating").map(String::as_str), Some("5"));
         assert_eq!(fields.get("albumartist").map(String::as_str), Some("VA"));
+    }
+
+    #[test]
+    fn binary_tags_to_inputs_maps_rows() {
+        let db = Db::open_in_memory().unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.mp3".into(),
+                format: Format::Mp3,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        db.set_binary_tags(
+            tid,
+            &[BinaryTag {
+                key: "PRIV".into(),
+                payload: vec![1, 2, 3, 4],
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+
+        let inputs = super::binary_tags_to_inputs(&db, tid).unwrap();
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].key, "PRIV");
+        assert_eq!(inputs[0].len, 4);
+        // payload_id is the streaming handle (the tags rowid).
+        let rowid = db.get_binary_tags(tid).unwrap()[0].rowid;
+        assert_eq!(inputs[0].payload_id, rowid);
     }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -158,4 +158,37 @@ mod tests {
         let rowid = db.get_binary_tags(tid).unwrap()[0].rowid;
         assert_eq!(inputs[0].payload_id, rowid);
     }
+
+    #[test]
+    fn binary_rows_do_not_pollute_tags_to_fields() {
+        let db = Db::open_in_memory().unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.mp3".into(),
+                format: Format::Mp3,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        db.replace_tags(tid, &[Tag::new("artist", "A", 0)]).unwrap();
+        db.set_binary_tags(
+            tid,
+            &[BinaryTag {
+                key: "PRIV".into(),
+                payload: vec![1, 2, 3],
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+
+        let tags = db.get_tags(tid).unwrap();
+        let fields = super::tags_to_fields(&tags);
+        assert_eq!(fields.get("artist").map(String::as_str), Some("A"));
+        assert!(
+            !fields.contains_key("priv"),
+            "binary PRIV leaked into fields: {fields:?}"
+        );
+    }
 }

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -25,6 +25,7 @@ mod imp {
     static PREADS: AtomicU64 = AtomicU64::new(0);
     static PREAD_BYTES: AtomicU64 = AtomicU64::new(0);
     static ART_CHUNKS: AtomicU64 = AtomicU64::new(0);
+    static BINARY_TAG_CHUNKS: AtomicU64 = AtomicU64::new(0);
     static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
     static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
     static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
@@ -66,6 +67,10 @@ mod imp {
         ART_CHUNKS.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn on_binary_tag_chunk() {
+        BINARY_TAG_CHUNKS.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// One backing-file open on the *scan* path (distinct from serve-path `on_open`).
     pub fn on_scan_open() {
         SCAN_OPENS.fetch_add(1, Ordering::Relaxed);
@@ -84,6 +89,7 @@ mod imp {
         pub preads: u64,
         pub pread_bytes: u64,
         pub art_chunks: u64,
+        pub binary_tag_chunks: u64,
         pub scan_opens: u64,
         pub scan_preads: u64,
         pub scan_bytes_read: u64,
@@ -96,6 +102,7 @@ mod imp {
             preads: PREADS.load(Ordering::Relaxed),
             pread_bytes: PREAD_BYTES.load(Ordering::Relaxed),
             art_chunks: ART_CHUNKS.load(Ordering::Relaxed),
+            binary_tag_chunks: BINARY_TAG_CHUNKS.load(Ordering::Relaxed),
             scan_opens: SCAN_OPENS.load(Ordering::Relaxed),
             scan_preads: SCAN_PREADS.load(Ordering::Relaxed),
             scan_bytes_read: SCAN_BYTES_READ.load(Ordering::Relaxed),
@@ -108,6 +115,7 @@ mod imp {
         PREADS.store(0, Ordering::Relaxed);
         PREAD_BYTES.store(0, Ordering::Relaxed);
         ART_CHUNKS.store(0, Ordering::Relaxed);
+        BINARY_TAG_CHUNKS.store(0, Ordering::Relaxed);
         SCAN_OPENS.store(0, Ordering::Relaxed);
         SCAN_PREADS.store(0, Ordering::Relaxed);
         SCAN_BYTES_READ.store(0, Ordering::Relaxed);
@@ -123,6 +131,7 @@ mod imp {
         pub preads: u64,
         pub pread_bytes: u64,
         pub art_chunks: u64,
+        pub binary_tag_chunks: u64,
         pub scan_opens: u64,
         pub scan_preads: u64,
         pub scan_bytes_read: u64,
@@ -136,6 +145,8 @@ mod imp {
     pub fn on_pread(_bytes: u64) {}
     #[inline(always)]
     pub fn on_art_chunk() {}
+    #[inline(always)]
+    pub fn on_binary_tag_chunk() {}
     #[inline(always)]
     pub fn on_scan_open() {}
     #[inline(always)]
@@ -159,11 +170,13 @@ mod tests {
         on_open();
         on_pread(100);
         on_art_chunk();
+        on_binary_tag_chunk();
         let s = snapshot();
         assert_eq!(s.opens, 2);
         assert_eq!(s.preads, 1);
         assert_eq!(s.pread_bytes, 100);
         assert_eq!(s.art_chunks, 1);
+        assert_eq!(s.binary_tag_chunks, 1);
         reset();
         assert_eq!(snapshot(), Snapshot::default());
     }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -31,6 +31,10 @@ pub struct ResolvedFile {
     /// Approximate resident bytes this entry costs the cache (sum of `Inline`
     /// segment bytes; backing/art/ogg-audio bytes are not resident).
     pub cache_bytes: u64,
+    /// Precomputed from the layout: true if any segment streams an opaque binary
+    /// tag payload from the DB. Gates the transactional `content_version` guard in
+    /// the read fast path so plain Inline/BackingAudio layouts pay no per-read cost.
+    pub has_binary_tag: bool,
 }
 
 const CACHE_SHARDS: usize = 16;
@@ -338,6 +342,7 @@ impl HeaderCache {
                 _ => 0,
             })
             .sum::<u64>();
+        let has_binary_tag = layout.has_binary_tag();
         Ok(Arc::new(ResolvedFile {
             layout,
             total_len,
@@ -348,6 +353,7 @@ impl HeaderCache {
             mtime_secs: mtime_secs_val,
             last_page: Mutex::new(None),
             cache_bytes,
+            has_binary_tag,
         }))
     }
 }
@@ -531,6 +537,7 @@ mod ogg_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 8,
+            has_binary_tag: false,
         };
 
         // Read the whole virtual file; needs a Db only for ArtImage (unused here).
@@ -803,6 +810,7 @@ mod ogg_art_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
+            has_binary_tag: false,
         };
 
         // Full read.
@@ -847,6 +855,7 @@ mod ogg_art_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
+            has_binary_tag: false,
         };
         let got = read_at(&resolved, &db, 10, 50).unwrap();
         assert_eq!(got, image[10..60]);
@@ -869,6 +878,7 @@ mod cache_bound_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: inline_len as u64,
+            has_binary_tag: false,
         })
     }
 
@@ -1172,6 +1182,7 @@ mod binary_tag_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
+            has_binary_tag: true,
         };
         // No BackingAudio segment, so read_at opens no file.
         let got = read_at(&resolved, &db, 1, 2).unwrap();

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -273,6 +273,7 @@ impl HeaderCache {
                         track.audio_offset as u64,
                         track.audio_length as u64,
                         &inputs,
+                        &[], // binary_tags — wired in Task 2.9
                         &art_inputs,
                     )?,
                     Format::M4a => {
@@ -304,6 +305,7 @@ impl HeaderCache {
                             track.audio_offset as u64,
                             track.audio_length as u64,
                             &inputs,
+                            &[], // binary_tags — wired in Task 2.9
                             &art_inputs,
                         )?
                     }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -253,6 +253,7 @@ impl HeaderCache {
                 let tags = db.get_tags(track.id)?;
                 let inputs = tags_to_inputs(&tags);
                 let art_inputs = track_art_to_inputs(db, track.id)?;
+                let binary_tag_inputs = crate::mapping::binary_tags_to_inputs(db, track.id)?;
 
                 // FLAC re-reads the front for its preserved structural blocks; MP3 needs no
                 // front read — its ID3v2 tag is regenerated entirely from the DB and the
@@ -273,7 +274,7 @@ impl HeaderCache {
                         track.audio_offset as u64,
                         track.audio_length as u64,
                         &inputs,
-                        &[], // binary_tags — wired in Task 2.9
+                        &binary_tag_inputs,
                         &art_inputs,
                     )?,
                     Format::M4a => {
@@ -305,7 +306,7 @@ impl HeaderCache {
                             track.audio_offset as u64,
                             track.audio_length as u64,
                             &inputs,
-                            &[], // binary_tags — wired in Task 2.9
+                            &binary_tag_inputs,
                             &art_inputs,
                         )?
                     }
@@ -1146,6 +1147,67 @@ mod cache_bound_tests {
 mod binary_tag_serve_tests {
     use super::*;
     use musefs_db::{BinaryTag, NewTrack};
+
+    #[test]
+    fn resolve_mp3_emits_binary_tag_in_synthesized_region() {
+        use id3::frame::{Content, Unknown};
+        use id3::{Encoder, Frame, Tag, TagLike, Version};
+        let dir = tempfile::tempdir().unwrap();
+        let mut tag = Tag::new();
+        let needle = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x77, 0x88];
+        tag.add_frame(Frame::with_content(
+            "PRIV",
+            Content::Unknown(Unknown {
+                data: needle.to_vec(),
+                version: Version::Id3v24,
+            }),
+        ));
+        let mut bytes = Vec::new();
+        Encoder::new()
+            .version(Version::Id3v24)
+            .encode(&tag, &mut bytes)
+            .unwrap();
+        bytes.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+        let path = dir.path().join("a.mp3");
+        std::fs::write(&path, &bytes).unwrap();
+
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let bounds = musefs_format::mp3::locate_audio(&bytes).unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let tid = db
+            .upsert_track(&musefs_db::NewTrack {
+                backing_path: path.to_string_lossy().to_string(),
+                format: musefs_db::Format::Mp3,
+                audio_offset: bounds.audio_offset as i64,
+                audio_length: bounds.audio_length as i64,
+                backing_size: meta.len() as i64,
+                backing_mtime: meta
+                    .modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as i64,
+            })
+            .unwrap();
+        db.set_binary_tags(
+            tid,
+            &[musefs_db::BinaryTag {
+                key: "PRIV".into(),
+                payload: needle.to_vec(),
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+
+        let cache = crate::reader::HeaderCache::new(crate::Mode::Synthesis);
+        let resolved = cache.resolve(&db, tid).unwrap();
+        let whole =
+            crate::reader::read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+        assert!(
+            whole.windows(needle.len()).any(|w| w == needle),
+            "PRIV body not in synthesized file"
+        );
+    }
 
     #[test]
     fn read_at_serves_binary_tag_segment() {

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -433,6 +433,7 @@ fn read_segments(
                 }
                 Segment::BinaryTag { payload_id, .. } => {
                     let chunk = db.read_binary_tag_chunk(*payload_id, within, n)?;
+                    crate::metrics::on_binary_tag_chunk();
                     out.extend_from_slice(&chunk);
                 }
                 Segment::OggAudio {

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -1201,8 +1201,7 @@ mod binary_tag_serve_tests {
 
         let cache = crate::reader::HeaderCache::new(crate::Mode::Synthesis);
         let resolved = cache.resolve(&db, tid).unwrap();
-        let whole =
-            crate::reader::read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+        let whole = crate::reader::read_at(&resolved, &db, 0, resolved.total_len).unwrap();
         assert!(
             whole.windows(needle.len()).any(|w| w == needle),
             "PRIV body not in synthesized file"

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
-use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedPicture, Extent};
+use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedBinaryTag, EmbeddedPicture, Extent};
 
 use crate::byte_budget::ByteBudget;
 use crate::error::Result;
@@ -22,6 +22,10 @@ const MAX_WIDEN_RETRIES: usize = 8;
 /// headroom so the block framing + mime + description can never push a near-cap
 /// image past the limit at synthesis time. Real cover art is far smaller.
 const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
+
+/// Per-frame cap for opaque binary tags, mirroring `MAX_ART_BYTES`. Oversize
+/// payloads (e.g. a GEOB embedding a multi-MB file) are logged-and-skipped.
+const MAX_BINARY_TAG_BYTES: usize = MAX_ART_BYTES;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanStats {
@@ -85,6 +89,7 @@ pub(crate) struct Probed {
     audio_length: u64,
     tags: Vec<(String, String)>,
     pictures: Vec<EmbeddedPicture>,
+    binary_tags: Vec<EmbeddedBinaryTag>,
 }
 
 /// Full-buffer probe (legacy path). Retained as the reference implementation the
@@ -98,15 +103,20 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             audio_length: scan.audio_length,
             tags: flac::read_vorbis_comments(bytes).unwrap_or_default(),
             pictures: flac::read_pictures(bytes).unwrap_or_default(),
+            binary_tags: Vec::new(),
         })
     } else if has_ext(path, "mp3") {
         let bounds = mp3::locate_audio(bytes).ok()?;
+        let (binary_tags, promoted) = mp3::read_binary_tags(bytes);
+        let mut tags = mp3::read_tags(bytes);
+        tags.extend(promoted);
         Some(Probed {
             format: Format::Mp3,
             audio_offset: bounds.audio_offset,
             audio_length: bounds.audio_length,
-            tags: mp3::read_tags(bytes),
+            tags,
             pictures: mp3::read_pictures(bytes),
+            binary_tags,
         })
     } else if has_ext(path, "m4a") || has_ext(path, "m4b") {
         let bounds = mp4::locate_audio(bytes).ok()?;
@@ -116,6 +126,7 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             audio_length: bounds.audio_length,
             tags: mp4::read_tags(bytes),
             pictures: mp4::read_pictures(bytes),
+            binary_tags: Vec::new(),
         })
     } else if has_ext(path, "ogg") || has_ext(path, "oga") || has_ext(path, "opus") {
         let scan = ogg::locate_audio(bytes).ok()?;
@@ -130,15 +141,20 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             audio_length: scan.audio_length,
             tags: ogg::read_tags(bytes).unwrap_or_default(),
             pictures: ogg::read_pictures(bytes).unwrap_or_default(),
+            binary_tags: Vec::new(),
         })
     } else if has_ext(path, "wav") {
         let bounds = wav::locate_audio(bytes).ok()?;
+        let (binary_tags, promoted) = wav::read_binary_tags(bytes);
+        let mut tags = wav::read_tags(bytes);
+        tags.extend(promoted);
         Some(Probed {
             format: Format::Wav,
             audio_offset: bounds.audio_offset,
             audio_length: bounds.audio_length,
-            tags: wav::read_tags(bytes),
+            tags,
             pictures: wav::read_pictures(bytes),
+            binary_tags,
         })
     } else {
         None
@@ -203,6 +219,7 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
             audio_length: scan.mdat_payload_len,
             tags: mp4::read_tags(&scan.moov),
             pictures: mp4::read_pictures(&scan.moov),
+            binary_tags: Vec::new(),
         }));
     }
 
@@ -252,19 +269,26 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
                 audio_length: file_len - meta.audio_offset,
                 tags: flac::read_vorbis_comments(prefix).unwrap_or_default(),
                 pictures: flac::read_pictures(prefix).unwrap_or_default(),
+                binary_tags: Vec::new(),
             }),
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
             Err(_) => Probe::Skip,
         }
     } else if has_ext(path, "mp3") {
         match mp3::locate_audio_bounded(prefix, file_len, tail) {
-            Ok(Extent::Complete(b)) => Probe::Done(Probed {
-                format: Format::Mp3,
-                audio_offset: b.audio_offset,
-                audio_length: b.audio_length,
-                tags: mp3::read_tags(prefix),
-                pictures: mp3::read_pictures(prefix),
-            }),
+            Ok(Extent::Complete(b)) => {
+                let (binary_tags, promoted) = mp3::read_binary_tags(prefix);
+                let mut tags = mp3::read_tags(prefix);
+                tags.extend(promoted);
+                Probe::Done(Probed {
+                    format: Format::Mp3,
+                    audio_offset: b.audio_offset,
+                    audio_length: b.audio_length,
+                    tags,
+                    pictures: mp3::read_pictures(prefix),
+                    binary_tags,
+                })
+            }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
             Err(_) => Probe::Skip,
         }
@@ -282,6 +306,7 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
                     audio_length: file_len - header.audio_offset,
                     tags: ogg::read_tags(prefix).unwrap_or_default(),
                     pictures: ogg::read_pictures(prefix).unwrap_or_default(),
+                    binary_tags: Vec::new(),
                 })
             }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
@@ -289,13 +314,19 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
         }
     } else if has_ext(path, "wav") {
         match wav::locate_audio_bounded(prefix, file_len) {
-            Ok(Extent::Complete(b)) => Probe::Done(Probed {
-                format: Format::Wav,
-                audio_offset: b.audio_offset,
-                audio_length: b.audio_length,
-                tags: wav::read_tags(prefix),
-                pictures: wav::read_pictures(prefix),
-            }),
+            Ok(Extent::Complete(b)) => {
+                let (binary_tags, promoted) = wav::read_binary_tags(prefix);
+                let mut tags = wav::read_tags(prefix);
+                tags.extend(promoted);
+                Probe::Done(Probed {
+                    format: Format::Wav,
+                    audio_offset: b.audio_offset,
+                    audio_length: b.audio_length,
+                    tags,
+                    pictures: wav::read_pictures(prefix),
+                    binary_tags,
+                })
+            }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
             Err(_) => Probe::Skip,
         }
@@ -362,6 +393,19 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     }
     db.replace_tags(track_id, &tags)?;
 
+    let binary_tags: Vec<musefs_db::BinaryTag> = probed
+        .binary_tags
+        .into_iter()
+        .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
+        .enumerate()
+        .map(|(ordinal, b)| musefs_db::BinaryTag {
+            key: b.key,
+            payload: b.payload,
+            ordinal: ordinal as i64,
+        })
+        .collect();
+    db.set_binary_tags(track_id, &binary_tags)?;
+
     let mut track_arts = Vec::new();
     // Filter before enumerating so skipped (oversized) art doesn't leave gaps
     // in the stored ordinals.
@@ -418,6 +462,19 @@ fn ingest_bulk(
         *ord += 1;
     }
     bw.replace_tags(track_id, &tags)?;
+
+    let binary_tags: Vec<musefs_db::BinaryTag> = probed
+        .binary_tags
+        .iter()
+        .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
+        .enumerate()
+        .map(|(ordinal, b)| musefs_db::BinaryTag {
+            key: b.key.clone(),
+            payload: b.payload.clone(),
+            ordinal: ordinal as i64,
+        })
+        .collect();
+    bw.set_binary_tags(track_id, &binary_tags)?;
 
     let mut track_arts = Vec::new();
     let accepted = probed
@@ -849,6 +906,7 @@ mod scan_unit_tests {
             audio_length: 0,
             tags: Vec::new(),
             pictures: vec![pic(3), pic(5)],
+            binary_tags: Vec::new(),
         };
         assert_eq!(art_weight(&probed), 8);
 
@@ -859,6 +917,7 @@ mod scan_unit_tests {
             audio_length: 0,
             tags: Vec::new(),
             pictures: Vec::new(),
+            binary_tags: Vec::new(),
         };
         assert_eq!(art_weight(&empty), 0);
     }
@@ -1203,6 +1262,60 @@ mod hardening_tests {
                 .iter()
                 .any(|t| t.backing_path == ghost.to_string_lossy()),
             "ghost track must still exist"
+        );
+    }
+
+    #[test]
+    fn scan_ingests_binary_tags_and_promotes() {
+        use id3::frame::{Content, Popularimeter, Unknown};
+        use id3::{Encoder, Frame, Tag, TagLike, Version};
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // Build an MP3 with a PRIV (opaque) + POPM (promoted) tag.
+        let mut tag = Tag::new();
+        tag.add_frame(Popularimeter {
+            user: "u".into(),
+            rating: 128,
+            counter: 3,
+        });
+        tag.add_frame(Frame::with_content(
+            "PRIV",
+            Content::Unknown(Unknown {
+                data: vec![1, 1, 2, 3, 5],
+                version: Version::Id3v24,
+            }),
+        ));
+        let mut bytes = Vec::new();
+        Encoder::new()
+            .version(Version::Id3v24)
+            .encode(&tag, &mut bytes)
+            .unwrap();
+        // A real MP3 frame header is enough for locate_audio_bounded to find audio.
+        bytes.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        crate::scan::scan_directory(&db, dir.path()).unwrap();
+        let track = db.list_tracks().unwrap().into_iter().next().unwrap();
+        let tid = track.id;
+
+        // Opaque PRIV survives as a binary row.
+        let bin = db.get_binary_tags(tid).unwrap();
+        assert!(
+            bin.iter().any(|r| r.key == "PRIV" && r.byte_len == 5),
+            "PRIV not ingested as binary row; got: {bin:?}"
+        );
+
+        // POPM promoted into editable text tags.
+        let texts = db.get_tags(tid).unwrap();
+        assert!(
+            texts.iter().any(|t| t.key == "rating" && t.value == "128"),
+            "rating not promoted; got: {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.key == "playcount" && t.value == "3"),
+            "playcount not promoted; got: {texts:?}"
         );
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1318,6 +1318,80 @@ mod hardening_tests {
             "playcount not promoted; got: {texts:?}"
         );
     }
+
+    /// Probed carrying a valid, an empty, and an oversize binary tag. Only the
+    /// valid one is stored: the filter drops empty (`EmptySegment` would fail
+    /// layout validation) and oversize (`> MAX_BINARY_TAG_BYTES`) payloads, with
+    /// gap-free ordinals.
+    fn probed_with_mixed_binary_tags() -> Probed {
+        Probed {
+            format: musefs_db::Format::Mp3,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: Vec::new(),
+            pictures: Vec::new(),
+            binary_tags: vec![
+                EmbeddedBinaryTag {
+                    key: "PRIV".into(),
+                    payload: vec![1, 2, 3],
+                },
+                EmbeddedBinaryTag {
+                    key: "GEOB".into(),
+                    payload: Vec::new(),
+                },
+                EmbeddedBinaryTag {
+                    key: "SYLT".into(),
+                    payload: vec![0u8; MAX_BINARY_TAG_BYTES + 1],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn ingest_filters_empty_and_oversize_binary_tags() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.mp3");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let db = Db::open_in_memory().unwrap();
+
+        ingest(
+            &db,
+            &path.to_string_lossy(),
+            &meta,
+            probed_with_mixed_binary_tags(),
+        )
+        .unwrap();
+
+        let tid = db.list_tracks().unwrap()[0].id;
+        let rows = db.get_binary_tags(tid).unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "only the valid binary tag survives: {rows:?}"
+        );
+        assert_eq!(rows[0].key, "PRIV");
+        assert_eq!(rows[0].byte_len, 3);
+    }
+
+    #[test]
+    fn ingest_bulk_filters_empty_and_oversize_binary_tags() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            ingest_bulk(&mut bw, "/a.mp3", 1, 0, &probed_with_mixed_binary_tags()).unwrap();
+            bw.commit().unwrap();
+        }
+        let tid = db.list_tracks().unwrap()[0].id;
+        let rows = db.get_binary_tags(tid).unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "only the valid binary tag survives: {rows:?}"
+        );
+        assert_eq!(rows[0].key, "PRIV");
+        assert_eq!(rows[0].byte_len, 3);
+    }
 }
 
 #[cfg(test)]

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -119,6 +119,7 @@ fn read_at_streams_art_image_segments() {
         mtime_secs: 0,
         last_page: std::sync::Mutex::new(None),
         cache_bytes: 0,
+        has_binary_tag: false,
     };
 
     // Whole read: inline framing then the streamed art bytes.

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -1,4 +1,4 @@
-use crate::models::{NewArt, NewTrack, Tag, TrackArt};
+use crate::models::{BinaryTag, NewArt, NewTrack, Tag, TrackArt};
 use crate::{Db, Result};
 use rusqlite::{params, Transaction};
 use sha2::{Digest, Sha256};
@@ -75,6 +75,21 @@ impl BulkWriter<'_> {
         )?;
         for t in tags {
             stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+        }
+        Ok(())
+    }
+
+    pub fn set_binary_tags(&mut self, track_id: i64, tags: &[BinaryTag]) -> Result<()> {
+        self.tx.execute(
+            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
+            params![track_id],
+        )?;
+        let mut stmt = self.tx.prepare(
+            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
+             VALUES (?1, ?2, '', ?3, ?4)",
+        )?;
+        for t in tags {
+            stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
         }
         Ok(())
     }
@@ -262,6 +277,44 @@ mod tests {
             1,
             "bulk replace_tags wiped binary rows"
         );
+        assert_eq!(
+            db.get_tags(tid).unwrap(),
+            vec![crate::Tag::new("artist", "A", 0)]
+        );
+    }
+
+    #[test]
+    fn bulk_set_binary_tags_round_trips_and_scopes_to_binary_rows() {
+        let db = Db::open_in_memory().unwrap();
+        let tid = db
+            .upsert_track(&crate::NewTrack {
+                backing_path: "/a.mp3".into(),
+                format: crate::Format::Mp3,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            bw.replace_tags(tid, &[crate::Tag::new("artist", "A", 0)])
+                .unwrap();
+            bw.set_binary_tags(
+                tid,
+                &[crate::BinaryTag {
+                    key: "PRIV".into(),
+                    payload: vec![7, 7, 7],
+                    ordinal: 0,
+                }],
+            )
+            .unwrap();
+            bw.commit().unwrap();
+        }
+        let rows = db.get_binary_tags(tid).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key, "PRIV");
+        assert_eq!(rows[0].byte_len, 3);
         assert_eq!(
             db.get_tags(tid).unwrap(),
             vec![crate::Tag::new("artist", "A", 0)]

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -66,8 +66,10 @@ impl BulkWriter<'_> {
     }
 
     pub fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> Result<()> {
-        self.tx
-            .execute("DELETE FROM tags WHERE track_id = ?1", params![track_id])?;
+        self.tx.execute(
+            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
+            params![track_id],
+        )?;
         let mut stmt = self.tx.prepare_cached(
             "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
         )?;
@@ -223,6 +225,47 @@ mod tests {
             .pragma_query_value(None, "temp_store", |r| r.get(0))
             .unwrap();
         assert_eq!(temp_store, 2);
+    }
+
+    #[test]
+    fn bulk_replace_tags_preserves_binary_rows() {
+        let db = Db::open_in_memory().unwrap();
+        let tid = db
+            .upsert_track(&crate::NewTrack {
+                backing_path: "/a.mp3".into(),
+                format: crate::Format::Mp3,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        db.set_binary_tags(
+            tid,
+            &[crate::BinaryTag {
+                key: "PRIV".into(),
+                payload: vec![1, 2, 3],
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            bw.replace_tags(tid, &[crate::Tag::new("artist", "A", 0)])
+                .unwrap();
+            bw.commit().unwrap();
+        }
+
+        assert_eq!(
+            db.get_binary_tags(tid).unwrap().len(),
+            1,
+            "bulk replace_tags wiped binary rows"
+        );
+        assert_eq!(
+            db.get_tags(tid).unwrap(),
+            vec![crate::Tag::new("artist", "A", 0)]
+        );
     }
 
     #[test]

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -82,6 +82,20 @@ impl Db {
         )?)
     }
 
+    /// Begin a deferred (read) transaction: subsequent reads on this connection see
+    /// a single consistent snapshot until `end_read`. Used to make a binary-tag
+    /// read's content_version check and its blob reads mutually consistent.
+    pub fn begin_read(&self) -> Result<()> {
+        self.conn.execute_batch("BEGIN DEFERRED")?;
+        Ok(())
+    }
+
+    /// End the read transaction opened by `begin_read` (rollback — it is read-only).
+    pub fn end_read(&self) -> Result<()> {
+        self.conn.execute_batch("ROLLBACK")?;
+        Ok(())
+    }
+
     fn query_optional_track(&self, sql: &str, p: impl rusqlite::Params) -> Result<Option<Track>> {
         let mut stmt = self.conn.prepare(sql)?;
         let mut rows = stmt.query(p)?;
@@ -188,5 +202,45 @@ mod render_key_tests {
             Format::Mp3,
             "set_format_for_test must actually UPDATE the format column"
         );
+    }
+
+    /// `begin_read`/`end_read` bracket a single WAL read snapshot on a connection,
+    /// so a write by another connection that bumps `content_version` (or reuses a
+    /// freed binary-tag rowid) is invisible until the snapshot ends. The
+    /// `read` fast path's BinaryTag guard depends on this consistency: it pins the
+    /// version + the blob reads to one snapshot so a reused rowid can't be served.
+    #[test]
+    fn begin_read_pins_a_single_wal_snapshot_against_external_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("m.db");
+        let writer = Db::open(&path).unwrap();
+        let id = writer
+            .upsert_track(&new_track("/a.mp3", Format::Mp3))
+            .unwrap();
+        assert_eq!(writer.track_content_version(id).unwrap(), 0);
+
+        // The reader opens a second connection; the two share the WAL.
+        let reader = Db::open(&path).unwrap();
+        assert_eq!(reader.track_content_version(id).unwrap(), 0);
+
+        reader.begin_read().unwrap();
+        // Within the snapshot: the version is 0.
+        assert_eq!(reader.track_content_version(id).unwrap(), 0);
+
+        // An external write bumps the version. The reader's snapshot must NOT see it.
+        writer
+            .replace_tags(id, &[Tag::new("artist", "Alice", 0)])
+            .unwrap();
+        assert_eq!(
+            reader.track_content_version(id).unwrap(),
+            0,
+            "snapshot must pin to the pre-write content_version"
+        );
+        // Latest version (visible without the snapshot) is bumped.
+        assert_eq!(writer.track_content_version(id).unwrap(), 1);
+
+        reader.end_read().unwrap();
+        // After the snapshot ends, the reader sees the new version.
+        assert_eq!(reader.track_content_version(id).unwrap(), 1);
     }
 }

--- a/musefs-format/Cargo.toml
+++ b/musefs-format/Cargo.toml
@@ -21,6 +21,7 @@ metaflac = "0.2"
 mp4 = "0.14"
 crc = "3"
 hound = "3"
+musefs-db = { path = "../musefs-db", version = "0.2.0" }
 proptest = "1"
 
 [lints]

--- a/musefs-format/src/input.rs
+++ b/musefs-format/src/input.rs
@@ -54,6 +54,16 @@ pub struct BinaryTagInput {
     pub len: u64,
 }
 
+/// A binary tag frame extracted at scan time: the format-private identifier
+/// (`key` — an ID3 4-char frame id, a FLAC `APPLICATION`/`CUESHEET`, or an MP4
+/// `----:<mean>:<name>`) and the raw post-header body (`payload`). Unlike
+/// `BinaryTagInput`, this owns the bytes (scan ingests them into the DB).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedBinaryTag {
+    pub key: String,
+    pub payload: Vec<u8>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::BinaryTagInput;
@@ -67,5 +77,12 @@ mod tests {
         };
         assert_eq!(b.payload_id, 7);
         assert_eq!(b.len, 3);
+    }
+
+    #[test]
+    fn embedded_binary_tag_constructs() {
+        let e = super::EmbeddedBinaryTag { key: "PRIV".into(), payload: vec![1, 2, 3] };
+        assert_eq!(e.key, "PRIV");
+        assert_eq!(e.payload.len(), 3);
     }
 }

--- a/musefs-format/src/input.rs
+++ b/musefs-format/src/input.rs
@@ -81,7 +81,10 @@ mod tests {
 
     #[test]
     fn embedded_binary_tag_constructs() {
-        let e = super::EmbeddedBinaryTag { key: "PRIV".into(), payload: vec![1, 2, 3] };
+        let e = super::EmbeddedBinaryTag {
+            key: "PRIV".into(),
+            payload: vec![1, 2, 3],
+        };
         assert_eq!(e.key, "PRIV");
         assert_eq!(e.payload.len(), 3);
     }

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -142,4 +142,28 @@ mod tests {
         }]);
         assert!(matches!(err, Err(LayoutError::EmptySegment)));
     }
+
+    #[test]
+    fn has_binary_tag_detects_binary_segment() {
+        let with = RegionLayout::new(vec![
+            Segment::BinaryTag {
+                payload_id: 1,
+                len: 3,
+            },
+            Segment::BackingAudio { offset: 0, len: 8 },
+        ]);
+        assert!(
+            with.has_binary_tag(),
+            "layout with a BinaryTag must report true"
+        );
+
+        let without = RegionLayout::new(vec![
+            Segment::Inline(vec![1, 2, 3]),
+            Segment::BackingAudio { offset: 0, len: 8 },
+        ]);
+        assert!(
+            !without.has_binary_tag(),
+            "layout with no BinaryTag must report false"
+        );
+    }
 }

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -82,6 +82,15 @@ impl RegionLayout {
         &self.segments
     }
 
+    /// True if any segment streams an opaque binary tag payload from the DB. Used by
+    /// the reader to decide whether a read needs the transactional content_version
+    /// guard (plain Inline/BackingAudio layouts don't).
+    pub fn has_binary_tag(&self) -> bool {
+        self.segments
+            .iter()
+            .any(|s| matches!(s, Segment::BinaryTag { .. }))
+    }
+
     /// Total size of the synthesized virtual file in bytes.
     pub fn total_len(&self) -> u64 {
         self.segments.iter().map(Segment::len).sum()

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -23,4 +23,6 @@ pub use probe::Extent;
 // indirectly by the per-format fuzz targets (which pass arbitrary tag keys through
 // synthesize_layout), so no dedicated tagmap fuzz target is needed.
 #[cfg(feature = "fuzzing")]
+pub use mp3::build_id3v2_segments;
+#[cfg(feature = "fuzzing")]
 pub use vorbiscomment::parse as parse_vorbis_comment;

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -14,7 +14,7 @@ pub mod wav;
 pub mod fuzz_check;
 
 pub use error::{FormatError, Result};
-pub use input::{ArtInput, BinaryTagInput, EmbeddedPicture, TagInput};
+pub use input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 pub use layout::{LayoutError, RegionLayout, Segment};
 pub use ogg::{Codec, OggHeader, OggScan};
 pub use probe::Extent;

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1,5 +1,5 @@
 use crate::error::{FormatError, Result};
-use crate::input::{ArtInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
 use crate::probe::Extent;
 
@@ -192,6 +192,37 @@ fn apic_framing(art: &ArtInput) -> Vec<u8> {
     d
 }
 
+/// POPM body: `<owner>\0<rating:u8>[<counter: 4-byte big-endian>]`. Owner is empty
+/// by design (spec §5 — the original tagger identity is dropped). The counter is
+/// emitted as 4 bytes when `playcount > 0` and omitted when 0; values above
+/// `u32::MAX` are clamped (the typed read path caps at u64, the common case fits
+/// u32).
+fn popm_frame_data(rating: u8, playcount: u64) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.push(0x00); // empty owner, NUL-terminated
+    d.push(rating);
+    if playcount > 0 {
+        let c = u32::try_from(playcount).unwrap_or(u32::MAX);
+        d.extend_from_slice(&c.to_be_bytes());
+    }
+    d
+}
+
+/// UFID body: `<owner>\0<identifier bytes>`.
+fn ufid_frame_data(owner: &str, identifier: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(owner.as_bytes());
+    d.push(0x00);
+    d.extend_from_slice(identifier);
+    d
+}
+
+/// True for the canonical text keys that are rebuilt as POPM/UFID frames and must
+/// therefore be excluded from the generic text/TXXX emission (no double-store).
+fn is_promoted_key(key: &str) -> bool {
+    matches!(key, "rating" | "playcount" | "musicbrainz_trackid")
+}
+
 /// Build the ID3v2.4 tag region for `tags`/`arts`: an inline 10-byte header
 /// followed by text/`TXXX` frames and `APIC` frames whose image bytes are
 /// streamed as `ArtImage` segments. Returns the segments (no backing audio) and
@@ -199,11 +230,32 @@ fn apic_framing(art: &ArtInput) -> Vec<u8> {
 /// `id3 ` chunk.
 pub(crate) fn build_id3v2_segments(
     tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<(Vec<Segment>, u64)> {
-    // Group consecutive same-key values (the DB returns tags ordered by key).
+    // Pull the promoted scalar values out of `tags` (first value wins per key,
+    // except playcount which accumulates — multiple playcount rows in the DB
+    // sum, matching the scan-time read path's behaviour).
+    let mut popm_rating: Option<u8> = None;
+    let mut popm_playcount: u64 = 0;
+    let mut mbid: Option<String> = None;
+    for t in tags {
+        match t.key.as_str() {
+            "rating" if popm_rating.is_none() => popm_rating = t.value.parse().ok(),
+            "playcount" => popm_playcount = t.value.parse().unwrap_or(popm_playcount),
+            "musicbrainz_trackid" if mbid.is_none() => mbid = Some(t.value.clone()),
+            _ => {}
+        }
+    }
+
+    // Group consecutive same-key values (the DB returns tags ordered by key),
+    // skipping promoted keys so they never enter the generic text/TXXX path
+    // (no double-store).
     let mut groups: Vec<(String, Vec<String>)> = Vec::new();
     for t in tags {
+        if is_promoted_key(&t.key) {
+            continue;
+        }
         match groups.last_mut() {
             Some(g) if g.0 == t.key => g.1.push(t.value.clone()),
             _ => groups.push((t.key.clone(), vec![t.value.clone()])),
@@ -265,6 +317,39 @@ pub(crate) fn build_id3v2_segments(
         }
     }
 
+    // Rebuilt promoted frames (POPM from rating/playcount, UFID from MBID).
+    if let Some(rating) = popm_rating {
+        let data = popm_frame_data(rating, popm_playcount);
+        push_frame_header(&mut buf, b"POPM", data.len())?;
+        buf.extend_from_slice(&data);
+        frames_len += 10 + data.len() as u64;
+    }
+    if let Some(id) = &mbid {
+        let data = ufid_frame_data(MUSICBRAINZ_UFID_OWNER, id.as_bytes());
+        push_frame_header(&mut buf, b"UFID", data.len())?;
+        buf.extend_from_slice(&data);
+        frames_len += 10 + data.len() as u64;
+    }
+
+    // Opaque binary frames: header (inline) + streamed body (BinaryTag segment).
+    for bt in binary_tags {
+        if bt.len == 0 {
+            // An empty BinaryTag fails `RegionLayout::validate` (`EmptySegment`).
+            continue;
+        }
+        // Defensive: ID3 opaque keys are 4-byte frame ids.
+        let Ok(id): std::result::Result<[u8; 4], _> = bt.key.as_bytes().try_into() else {
+            continue;
+        };
+        push_frame_header(&mut buf, &id, bt.len as usize)?;
+        segments.push(Segment::Inline(std::mem::take(&mut buf)));
+        segments.push(Segment::BinaryTag {
+            payload_id: bt.payload_id,
+            len: bt.len,
+        });
+        frames_len += 10 + bt.len;
+    }
+
     for art in arts {
         if art.data_len == 0 {
             // Skip degenerate empty art: an `ArtImage { len: 0 }` segment fails
@@ -313,9 +398,10 @@ pub fn synthesize_layout(
     audio_offset: u64,
     audio_length: u64,
     tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<RegionLayout> {
-    let (mut segments, _tag_len) = build_id3v2_segments(tags, arts)?;
+    let (mut segments, _tag_len) = build_id3v2_segments(tags, binary_tags, arts)?;
     segments.push(Segment::BackingAudio {
         offset: audio_offset,
         len: audio_length,
@@ -780,7 +866,7 @@ mod tests {
             TagInput::new("lyrics", "la la"), // -> USLT
             TagInput::new("replaygain_track_gain", "-3.21 dB"), // -> TXXX (fixed desc)
         ];
-        let (segments, _len) = build_id3v2_segments(&tags, &[]).unwrap();
+        let (segments, _len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
         let mut buf = Vec::new();
         for seg in &segments {
             if let Segment::Inline(bytes) = seg {
@@ -908,7 +994,7 @@ mod tests {
         // The `is_id3_text_frame_id` match-guard `-> false` mutant would route it to
         // the TXXX branch, so read_tags would surface it under a different key.
         let tags = vec![TagInput::new("TPE1", "Band")];
-        let (segments, _len) = build_id3v2_segments(&tags, &[]).unwrap();
+        let (segments, _len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
         let mut buf = Vec::new();
         for seg in &segments {
             if let Segment::Inline(b) = seg {
@@ -943,23 +1029,23 @@ mod tests {
             data_len,
         };
         assert_eq!(
-            build_id3v2_segments(&[], &[mk(0x1000_0000)]).err(),
+            build_id3v2_segments(&[], &[], &[mk(0x1000_0000)]).err(),
             Some(FormatError::TooLarge)
         );
-        assert!(build_id3v2_segments(&[], &[mk(16)]).is_ok());
+        assert!(build_id3v2_segments(&[], &[], &[mk(16)]).is_ok());
         // Exact boundary: compute the APIC framing overhead, then place
         // frames_len exactly on 0x0FFF_FFFF (one byte under must succeed) and
         // 0x1_0000_0000 (must error). This pins the `> -> >=` mutation. The
         // baseline art uses data_len=1 (not 0) because zero-byte art is skipped.
-        let (_, total_at_one) = build_id3v2_segments(&[], &[mk(1)]).unwrap();
+        let (_, total_at_one) = build_id3v2_segments(&[], &[], &[mk(1)]).unwrap();
         let overhead = total_at_one - 10 - 1; // frames_len = overhead + data_len
         let boundary_data_len = 0x0FFF_FFFF - overhead;
         assert!(
-            build_id3v2_segments(&[], &[mk(boundary_data_len)]).is_ok(),
+            build_id3v2_segments(&[], &[], &[mk(boundary_data_len)]).is_ok(),
             "exact boundary (frames_len == 0x0FFF_FFFF) should be accepted"
         );
         assert_eq!(
-            build_id3v2_segments(&[], &[mk(boundary_data_len + 1)]).err(),
+            build_id3v2_segments(&[], &[], &[mk(boundary_data_len + 1)]).err(),
             Some(FormatError::TooLarge),
             "one byte past boundary must be rejected"
         );
@@ -980,7 +1066,7 @@ mod tests {
             height: 0,
             data_len: 0,
         };
-        let (segments, _len) = build_id3v2_segments(&[], &[empty]).unwrap();
+        let (segments, _len) = build_id3v2_segments(&[], &[], &[empty]).unwrap();
         assert!(
             !segments
                 .iter()
@@ -1011,7 +1097,7 @@ mod tests {
             height: 0,
             data_len,
         };
-        let (segments, _len) = build_id3v2_segments(&[], &[mk(1, 0), mk(2, 16)]).unwrap();
+        let (segments, _len) = build_id3v2_segments(&[], &[], &[mk(1, 0), mk(2, 16)]).unwrap();
         let art_segs: Vec<_> = segments
             .iter()
             .filter_map(|s| match s {
@@ -1766,5 +1852,56 @@ mod tests {
             geob.payload, geob_body,
             "GEOB body must survive byte-identical"
         );
+    }
+
+    #[test]
+    fn build_id3v2_segments_rebuilds_popm_ufid_and_streams_opaque() {
+        use crate::BinaryTagInput;
+        let tags = vec![
+            TagInput::new("artist", "A"),
+            TagInput::new("rating", "200"),
+            TagInput::new("playcount", "7"),
+            TagInput::new("musicbrainz_trackid", "mbid-123"),
+        ];
+        let bin = vec![BinaryTagInput {
+            key: "PRIV".into(),
+            payload_id: 42,
+            len: 3,
+        }];
+        let (segments, _len) = super::build_id3v2_segments(&tags, &bin, &[]).unwrap();
+
+        assert!(
+            segments.iter().any(|s| matches!(
+                s,
+                Segment::BinaryTag {
+                    payload_id: 42,
+                    len: 3
+                }
+            )),
+            "opaque PRIV must stream as Segment::BinaryTag"
+        );
+
+        let inline: Vec<u8> = segments
+            .iter()
+            .flat_map(|s| match s {
+                Segment::Inline(b) => b.clone(),
+                _ => Vec::new(),
+            })
+            .collect();
+        assert!(find_sub(&inline, b"POPM"), "POPM not rebuilt");
+        assert!(find_sub(&inline, b"UFID"), "UFID not rebuilt");
+        assert!(
+            find_sub(&inline, b"http://musicbrainz.org"),
+            "UFID owner missing"
+        );
+        assert!(!find_sub(&inline, b"rating"), "promoted key leaked as TXXX");
+        assert!(
+            !find_sub(&inline, b"musicbrainz_trackid"),
+            "promoted key leaked as TXXX"
+        );
+    }
+
+    fn find_sub(hay: &[u8], needle: &[u8]) -> bool {
+        hay.windows(needle.len()).any(|w| w == needle)
     }
 }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1902,6 +1902,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_id3v2_segments_first_promoted_scalar_wins() {
+        // Duplicate `rating`/`musicbrainz_trackid` rows (e.g. an over-tagged DB):
+        // the first value is rebuilt into the POPM/UFID frame, later ones dropped.
+        // Pins the `popm_rating.is_none()` / `mbid.is_none()` guards.
+        let tags = vec![
+            TagInput::new("rating", "10"),
+            TagInput::new("rating", "20"),
+            TagInput::new("musicbrainz_trackid", "mbid-first"),
+            TagInput::new("musicbrainz_trackid", "mbid-second"),
+        ];
+        let (segments, _len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
+        let inline: Vec<u8> = segments
+            .iter()
+            .flat_map(|s| match s {
+                Segment::Inline(b) => b.clone(),
+                _ => Vec::new(),
+            })
+            .collect();
+
+        // First MusicBrainz id wins, later one dropped.
+        assert!(find_sub(&inline, b"mbid-first"), "first mbid must win");
+        assert!(
+            !find_sub(&inline, b"mbid-second"),
+            "later mbid must be dropped"
+        );
+
+        // First rating wins: re-parse the synthesized tag and read the promoted value.
+        let (_opaque, promoted) = super::read_binary_tags(&inline);
+        assert!(
+            promoted.contains(&("rating".to_string(), "10".to_string())),
+            "first rating must win: {promoted:?}"
+        );
+        assert!(
+            !promoted.iter().any(|(k, v)| k == "rating" && v == "20"),
+            "later rating must be dropped: {promoted:?}"
+        );
+    }
+
     fn find_sub(hay: &[u8], needle: &[u8]) -> bool {
         hay.windows(needle.len()).any(|w| w == needle)
     }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -228,7 +228,7 @@ fn is_promoted_key(key: &str) -> bool {
 /// streamed as `ArtImage` segments. Returns the segments (no backing audio) and
 /// the total tag length (`10 + frames_len`). Shared by MP3 synthesis and the WAV
 /// `id3 ` chunk.
-pub(crate) fn build_id3v2_segments(
+pub fn build_id3v2_segments(
     tags: &[TagInput],
     binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -233,9 +233,10 @@ pub fn build_id3v2_segments(
     binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<(Vec<Segment>, u64)> {
-    // Pull the promoted scalar values out of `tags` (first value wins per key,
-    // except playcount which accumulates — multiple playcount rows in the DB
-    // sum, matching the scan-time read path's behaviour).
+    // Pull the promoted scalar values out of `tags`: first `rating` /
+    // `musicbrainz_trackid` wins, `playcount` takes the last parseable value. A
+    // single POPM/UFID is the norm, so this only diverges from "first wins" for
+    // the rare multi-frame tag.
     let mut popm_rating: Option<u8> = None;
     let mut popm_playcount: u64 = 0;
     let mut mbid: Option<String> = None;

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1,5 +1,5 @@
 use crate::error::{FormatError, Result};
-use crate::input::{ArtInput, EmbeddedPicture, TagInput};
+use crate::input::{ArtInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
 use crate::probe::Extent;
 
@@ -490,6 +490,107 @@ pub fn read_tags(data: &[u8]) -> Vec<(String, String)> {
         }
     }
     out
+}
+
+pub(crate) const MUSICBRAINZ_UFID_OWNER: &str = "http://musicbrainz.org";
+
+/// Extract an ID3v2.3/2.4 tag's binary frames. Returns `(opaque, promoted)`:
+/// - `opaque`: frames preserved **byte-exact** — `(frame-id, raw post-header body)`.
+///   `PRIV`/`GEOB`/`SYLT`/`MCDI`/unknown frames and any non-MusicBrainz `UFID`.
+/// - `promoted`: `(key, value)` text pairs — `POPM` → `rating` (raw 0–255) + `playcount`
+///   (counter, omitted when 0); MusicBrainz `UFID` → `musicbrainz_trackid`. Promoted
+///   frames are NOT in `opaque`.
+///
+/// Text (`T***`), `COMM`, `USLT`, `APIC` are handled by `read_tags`/`read_pictures`
+/// and skipped. Gated by `id3v2_alloc_safe`, so the tag is well-formed, has no
+/// unsynchronisation/extended header/frame flags, and bodies are sliced verbatim.
+/// v2.2 (3-char ids) is not processed (rare; text/art still parse via the crate).
+pub fn read_binary_tags(data: &[u8]) -> (Vec<EmbeddedBinaryTag>, Vec<(String, String)>) {
+    let mut opaque = Vec::new();
+    let mut promoted = Vec::new();
+    if !id3v2_alloc_safe(data) || data[3] < 3 {
+        return (opaque, promoted);
+    }
+    let tag_end = 10 + synchsafe_decode(&data[6..10]) as usize;
+    let mut pos = 10usize;
+    while pos + 10 <= tag_end {
+        if data[pos] == 0 {
+            break;
+        }
+        let id = &data[pos..pos + 4];
+        let size = if data[3] == 3 {
+            u32::from_be_bytes([data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7]])
+                as usize
+        } else {
+            synchsafe_decode(&data[pos + 4..pos + 8]) as usize
+        };
+        let body_start = pos + 10;
+        if body_start + size > tag_end {
+            break;
+        }
+        classify_binary_frame(
+            id,
+            &data[body_start..body_start + size],
+            &mut opaque,
+            &mut promoted,
+        );
+        pos = body_start + size;
+    }
+    (opaque, promoted)
+}
+
+/// Classify one ID3v2 frame body into opaque-passthrough or promoted-text.
+fn classify_binary_frame(
+    id: &[u8],
+    body: &[u8],
+    opaque: &mut Vec<EmbeddedBinaryTag>,
+    promoted: &mut Vec<(String, String)>,
+) {
+    // Handled by read_tags/read_pictures: text frames (T***), COMM, USLT, APIC.
+    if id[0] == b'T' || id == b"COMM" || id == b"USLT" || id == b"APIC" {
+        return;
+    }
+    match id {
+        b"POPM" => {
+            // <owner>\0<rating:u8>[<counter: big-endian>]
+            if let Some(nul) = body.iter().position(|&b| b == 0) {
+                if let Some((&rating, counter)) = body[nul + 1..].split_first() {
+                    promoted.push(("rating".to_string(), rating.to_string()));
+                    let c = counter
+                        .iter()
+                        .take(8)
+                        .fold(0u64, |a, &b| (a << 8) | b as u64);
+                    if c > 0 {
+                        promoted.push(("playcount".to_string(), c.to_string()));
+                    }
+                }
+            }
+        }
+        b"UFID" => {
+            // <owner>\0<identifier>. MusicBrainz owner promotes; others opaque.
+            match body.iter().position(|&b| b == 0) {
+                Some(nul) if &body[..nul] == MUSICBRAINZ_UFID_OWNER.as_bytes() => {
+                    promoted.push((
+                        "musicbrainz_trackid".to_string(),
+                        String::from_utf8_lossy(&body[nul + 1..]).into_owned(),
+                    ));
+                }
+                _ => opaque.push(EmbeddedBinaryTag {
+                    key: "UFID".to_string(),
+                    payload: body.to_vec(),
+                }),
+            }
+        }
+        _ => {
+            // Opaque verbatim: PRIV, GEOB, SYLT, MCDI, W***, unknown, … (4-byte ids).
+            if id.iter().all(u8::is_ascii_graphic) {
+                opaque.push(EmbeddedBinaryTag {
+                    key: String::from_utf8_lossy(id).into_owned(),
+                    payload: body.to_vec(),
+                });
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1572,5 +1673,98 @@ mod tests {
                 panic!("expected Complete (no room, no trim), got {other:?}")
             }
         }
+    }
+
+    /// Build a minimal ID3v2.4 tag containing the given frames, with header
+    /// flags=0 (no unsync, no extended header) and per-frame flags=0 so
+    /// `id3v2_alloc_safe` accepts it. Used by `read_binary_tags` tests that
+    /// need a tag without going through the `id3` crate's encoder (which would
+    /// re-encode `Unknown` bodies and defeat the byte-exact property).
+    fn build_v24_tag(frames: &[(&[u8; 4], &[u8])]) -> Vec<u8> {
+        let total_body: usize = frames.iter().map(|(_, b)| 10 + b.len()).sum();
+        let mut out = Vec::new();
+        out.extend_from_slice(b"ID3");
+        out.extend_from_slice(&[0x04, 0x00, 0x00]); // v2.4.0, no flags
+        out.extend_from_slice(&ss(total_body as u32));
+        for (id, body) in frames {
+            out.extend_from_slice(*id);
+            out.extend_from_slice(&ss(body.len() as u32));
+            out.extend_from_slice(&[0x00, 0x00]); // frame flags
+            out.extend_from_slice(body);
+        }
+        out
+    }
+
+    #[test]
+    fn read_binary_tags_promotes_popm_and_mbid_and_passes_through_priv() {
+        use id3::frame::{Content, Popularimeter, UniqueFileIdentifier, Unknown};
+        use id3::{Encoder, Frame, Tag, TagLike, Version};
+
+        let mut tag = Tag::new();
+        tag.add_frame(Popularimeter {
+            user: "a@b.c".into(),
+            rating: 200,
+            counter: 7,
+        });
+        tag.add_frame(UniqueFileIdentifier {
+            owner_identifier: "http://musicbrainz.org".into(),
+            identifier: b"mbid-123".to_vec(),
+        });
+        tag.add_frame(UniqueFileIdentifier {
+            owner_identifier: "http://other.example".into(),
+            identifier: b"other".to_vec(),
+        });
+        tag.add_frame(Frame::with_content(
+            "PRIV",
+            Content::Unknown(Unknown {
+                data: vec![9, 8, 7],
+                version: Version::Id3v24,
+            }),
+        ));
+        let mut buf = Vec::new();
+        Encoder::new()
+            .version(Version::Id3v24)
+            .encode(&tag, &mut buf)
+            .unwrap();
+
+        let (opaque, promoted) = super::read_binary_tags(&buf);
+        assert!(promoted.contains(&("rating".to_string(), "200".to_string())));
+        assert!(promoted.contains(&("playcount".to_string(), "7".to_string())));
+        assert!(promoted.contains(&("musicbrainz_trackid".to_string(), "mbid-123".to_string())));
+        let keys: Vec<&str> = opaque.iter().map(|e| e.key.as_str()).collect();
+        assert!(keys.contains(&"PRIV"));
+        // Non-MusicBrainz UFID is opaque (raw body, owner + identifier); exactly one UFID.
+        assert_eq!(keys.iter().filter(|k| **k == "UFID").count(), 1);
+        assert_eq!(
+            opaque.iter().find(|e| e.key == "PRIV").unwrap().payload,
+            vec![9, 8, 7]
+        );
+    }
+
+    #[test]
+    fn read_binary_tags_preserves_geob_body_byte_exact() {
+        // A GEOB body with a Latin1 (encoding 0x00) description — the exact case
+        // the crate's to_unknown() would re-encode to UTF-8. Build a minimal v2.4
+        // tag by hand so the bytes on the wire are guaranteed to match the
+        // asserted body.
+        let geob_body: Vec<u8> = {
+            let mut b = vec![0x00]; // text encoding: ISO-8859-1
+            b.extend_from_slice(b"application/octet-stream\0"); // mime
+            b.extend_from_slice(b"Serato Overview\0"); // filename (latin1)
+            b.extend_from_slice(b"\0"); // description (empty, terminator only)
+            b.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // object data
+            b
+        };
+        let tag = build_v24_tag(&[(b"GEOB", &geob_body)]);
+
+        let (opaque, _promoted) = super::read_binary_tags(&tag);
+        let geob = opaque
+            .iter()
+            .find(|e| e.key == "GEOB")
+            .expect("GEOB preserved");
+        assert_eq!(
+            geob.payload, geob_body,
+            "GEOB body must survive byte-identical"
+        );
     }
 }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1808,18 +1808,31 @@ mod tests {
 
     #[test]
     fn read_binary_tags_v23_plain_u32_frame_size() {
-        // A v2.3 PRIV frame whose body is >= 128 bytes so the plain-u32 size
-        // decode (data[3] == 3 branch) differs from a synchsafe decode of the same
-        // bytes. Non-zero, distinct bytes so a wrong size-byte offset misaligns.
+        // Two v2.3 frames: a non-zero filler followed by a >=128-byte PRIV. The
+        // filler's trailing bytes sit just before the PRIV header, so every byte of
+        // the plain-u32 size field (data[pos+4..pos+8], the `data[3] == 3` branch)
+        // reads a distinct non-zero value — a wrong size-byte offset (e.g. `pos + 4`
+        // -> `pos - 4`) then decodes a bogus size and drops/corrupts the PRIV, and a
+        // synchsafe misdecode (the `== 3` branch flipped) truncates it. Both frames
+        // must survive byte-exact.
+        let filler = vec![0xAAu8; 8];
         let body: Vec<u8> = (0..200u32).map(|i| (i % 250 + 1) as u8).collect();
-        let tag = build_v23_tag(&[(b"PRIV", &body)]);
+        let tag = build_v23_tag(&[(b"GEOB", &filler), (b"PRIV", &body)]);
         let (opaque, _promoted) = super::read_binary_tags(&tag);
-        let p = opaque
+        let geob = opaque
+            .iter()
+            .find(|e| e.key == "GEOB")
+            .expect("v2.3 GEOB preserved");
+        assert_eq!(
+            geob.payload, filler,
+            "v2.3 first frame must survive byte-exact"
+        );
+        let priv_frame = opaque
             .iter()
             .find(|e| e.key == "PRIV")
             .expect("v2.3 PRIV preserved");
         assert_eq!(
-            p.payload, body,
+            priv_frame.payload, body,
             "v2.3 plain-u32 frame body must survive byte-exact"
         );
     }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1782,6 +1782,162 @@ mod tests {
         out
     }
 
+    /// Like `build_v24_tag` but emits an ID3v2.3 tag: frame sizes are plain
+    /// 32-bit big-endian (not synchsafe). Exercises the `data[3] == 3` size-decode
+    /// branch of `read_binary_tags`, which no v2.4 fixture can reach.
+    fn build_v23_tag(frames: &[(&[u8; 4], &[u8])]) -> Vec<u8> {
+        let total_body: usize = frames.iter().map(|(_, b)| 10 + b.len()).sum();
+        let mut out = Vec::new();
+        out.extend_from_slice(b"ID3");
+        out.extend_from_slice(&[0x03, 0x00, 0x00]); // v2.3.0, no flags
+        out.extend_from_slice(&ss(total_body as u32)); // tag size is synchsafe in every version
+        for (id, body) in frames {
+            out.extend_from_slice(*id);
+            out.extend_from_slice(&(body.len() as u32).to_be_bytes()); // v2.3: plain u32 frame size
+            out.extend_from_slice(&[0x00, 0x00]); // frame flags
+            out.extend_from_slice(body);
+        }
+        out
+    }
+
+    // Documented EQUIVALENT mutant (no test can kill it):
+    //  * classify_binary_frame counter fold `(a << 8) | b` -> `(a << 8) ^ b`.
+    //    The accumulator is left-shifted by 8 before each combine, so its low
+    //    byte is always zero where `b` lands; OR and XOR are bit-for-bit identical
+    //    for every input. Confirmed by hand; left as-is.
+
+    #[test]
+    fn read_binary_tags_v23_plain_u32_frame_size() {
+        // A v2.3 PRIV frame whose body is >= 128 bytes so the plain-u32 size
+        // decode (data[3] == 3 branch) differs from a synchsafe decode of the same
+        // bytes. Non-zero, distinct bytes so a wrong size-byte offset misaligns.
+        let body: Vec<u8> = (0..200u32).map(|i| (i % 250 + 1) as u8).collect();
+        let tag = build_v23_tag(&[(b"PRIV", &body)]);
+        let (opaque, _promoted) = super::read_binary_tags(&tag);
+        let p = opaque
+            .iter()
+            .find(|e| e.key == "PRIV")
+            .expect("v2.3 PRIV preserved");
+        assert_eq!(
+            p.payload, body,
+            "v2.3 plain-u32 frame body must survive byte-exact"
+        );
+    }
+
+    #[test]
+    fn read_binary_tags_skips_unsafe_tag() {
+        // A well-formed v2.4 PRIV tag with the unsynchronisation flag forced on:
+        // id3v2_alloc_safe rejects it, so read_binary_tags must yield nothing. The
+        // major version stays >= 3, so the `!alloc_safe || major<3` guard hinges on
+        // the `||` (an `&&` mutant would parse the rejected tag).
+        let mut tag = build_v24_tag(&[(b"PRIV", &[1, 2, 3])]);
+        tag[5] = 0x80; // unsynchronisation flag
+        let (opaque, promoted) = super::read_binary_tags(&tag);
+        assert!(
+            opaque.is_empty() && promoted.is_empty(),
+            "an alloc-unsafe tag must yield no binary frames"
+        );
+    }
+
+    #[test]
+    fn read_binary_tags_skips_text_comm_uslt_apic() {
+        // T***/COMM/USLT/APIC are handled by read_tags/read_pictures and must NOT
+        // be captured as opaque binary frames; only PRIV is.
+        let tag = build_v24_tag(&[
+            (b"TIT2", &[0x00, b'x']),
+            (b"COMM", &[0x00]),
+            (b"USLT", &[0x00]),
+            (b"APIC", &[0x00]),
+            (b"PRIV", &[9, 9, 9]),
+        ]);
+        let (opaque, _promoted) = super::read_binary_tags(&tag);
+        let keys: Vec<&str> = opaque.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec!["PRIV"],
+            "only PRIV is opaque; T***/COMM/USLT/APIC are handled elsewhere: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn read_binary_tags_decodes_popm_counter_big_endian_and_zero() {
+        // Multi-byte counter must decode big-endian (0x0102 == 258), pinning the
+        // `<< 8` shift in the fold.
+        let tag = build_v24_tag(&[(b"POPM", &[0x00, 200, 0x01, 0x02])]);
+        let (_opaque, promoted) = super::read_binary_tags(&tag);
+        assert!(
+            promoted.contains(&("rating".to_string(), "200".to_string())),
+            "rating: {promoted:?}"
+        );
+        assert!(
+            promoted.contains(&("playcount".to_string(), "258".to_string())),
+            "counter must decode big-endian: {promoted:?}"
+        );
+
+        // A zero counter must NOT promote a playcount (pins `c > 0`).
+        let tag0 = build_v24_tag(&[(b"POPM", &[0x00, 128, 0x00])]);
+        let (_o0, promoted0) = super::read_binary_tags(&tag0);
+        assert!(
+            promoted0.contains(&("rating".to_string(), "128".to_string())),
+            "rating: {promoted0:?}"
+        );
+        assert!(
+            !promoted0.iter().any(|(k, _)| k == "playcount"),
+            "a zero POPM counter must not promote playcount: {promoted0:?}"
+        );
+    }
+
+    #[test]
+    fn popm_frame_data_emits_counter_only_when_positive() {
+        // playcount == 0: owner-nul + rating, no counter.
+        assert_eq!(
+            super::popm_frame_data(200, 0),
+            vec![0x00, 200],
+            "playcount 0 must omit the counter"
+        );
+        // playcount > 0: 4-byte big-endian counter appended.
+        assert_eq!(
+            super::popm_frame_data(200, 5),
+            vec![0x00, 200, 0x00, 0x00, 0x00, 0x05],
+            "playcount > 0 must append a 4-byte counter"
+        );
+    }
+
+    #[test]
+    fn build_id3v2_segments_accounts_playcount_and_opaque_len() {
+        use crate::{BinaryTagInput, TagInput};
+
+        // playcount text tag must rebuild into the POPM counter (pins the
+        // `"playcount"` match arm).
+        let tags = vec![
+            TagInput::new("rating", "100"),
+            TagInput::new("playcount", "42"),
+        ];
+        let (segments, _len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
+        let inline: Vec<u8> = segments
+            .iter()
+            .flat_map(|s| match s {
+                Segment::Inline(b) => b.clone(),
+                _ => Vec::new(),
+            })
+            .collect();
+        let (_opaque, promoted) = super::read_binary_tags(&inline);
+        assert!(
+            promoted.contains(&("playcount".to_string(), "42".to_string())),
+            "playcount must rebuild into the POPM counter: {promoted:?}"
+        );
+
+        // Opaque-frame length accounting: total == ID3 header (10) + frame header
+        // (10) + body. Pins `frames_len += 10 + bt.len`.
+        let bin = vec![BinaryTagInput {
+            key: "PRIV".into(),
+            payload_id: 1,
+            len: 7,
+        }];
+        let (_segs, total) = build_id3v2_segments(&[], &bin, &[]).unwrap();
+        assert_eq!(total, 10 + 10 + 7, "opaque binary frame length accounting");
+    }
+
     #[test]
     fn read_binary_tags_promotes_popm_and_mbid_and_passes_through_priv() {
         use id3::frame::{Content, Popularimeter, UniqueFileIdentifier, Unknown};

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -1,5 +1,5 @@
 use crate::error::{FormatError, Result};
-use crate::input::EmbeddedPicture;
+use crate::input::{EmbeddedBinaryTag, EmbeddedPicture};
 use crate::probe::Extent;
 use std::collections::HashSet;
 
@@ -324,6 +324,17 @@ pub fn read_tags(buf: &[u8]) -> Vec<(String, String)> {
         }
     }
     out
+}
+
+/// Extract binary ID3 frames from a WAV's embedded `id3 ` chunk. Classification is
+/// identical to MP3 (`mp3::read_binary_tags`); only the chunk extraction differs.
+/// Returns `(opaque, promoted)`; empty when there is no `id3 ` chunk.
+pub fn read_binary_tags(data: &[u8]) -> (Vec<EmbeddedBinaryTag>, Vec<(String, String)>) {
+    let chunks = walk_chunks(data);
+    match find_id3_chunk(data, &chunks) {
+        Some(id3_bytes) => crate::mp3::read_binary_tags(id3_bytes),
+        None => (Vec::new(), Vec::new()),
+    }
 }
 
 /// Read embedded pictures for scan-time art ingestion. Pictures live only in the
@@ -670,6 +681,33 @@ mod tests {
             Extent::NeedMore { up_to } => assert_eq!(up_to, file_len),
             other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn wav_read_binary_tags_extracts_id3_chunk_frames() {
+        use id3::frame::{Content, Unknown};
+        use id3::{Frame, Tag, TagLike, Version};
+        let mut tag = Tag::new();
+        tag.add_frame(Frame::with_content(
+            "PRIV",
+            Content::Unknown(Unknown {
+                data: vec![5, 6, 7],
+                version: Version::Id3v24,
+            }),
+        ));
+        let mut id3 = Vec::new();
+        id3::Encoder::new()
+            .version(Version::Id3v24)
+            .encode(&tag, &mut id3)
+            .unwrap();
+        let wav = wav(&[(b"id3 ", id3)]);
+
+        let (opaque, _promoted) = super::read_binary_tags(&wav);
+        let priv_tag = opaque
+            .iter()
+            .find(|e| e.key == "PRIV")
+            .expect("PRIV preserved");
+        assert_eq!(priv_tag.payload, vec![5, 6, 7]);
     }
 
     // Documented EQUIVALENT mutants in this file (no test targets them; each was

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -1,5 +1,5 @@
 use crate::error::{FormatError, Result};
-use crate::input::{EmbeddedBinaryTag, EmbeddedPicture};
+use crate::input::{BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture};
 use crate::probe::Extent;
 use std::collections::HashSet;
 
@@ -193,6 +193,7 @@ pub fn synthesize_layout(
     audio_offset: u64,
     audio_length: u64,
     tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<RegionLayout> {
     if audio_length > u32::MAX as u64 {
@@ -213,7 +214,7 @@ pub fn synthesize_layout(
     // `build_id3v2_segments` already skips degenerate zero-byte art (finding #16) —
     // an empty `ArtImage { len: 0 }` would fail `RegionLayout::validate` and brick
     // the track — so WAV inherits that handling by delegating to it.
-    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, arts)?;
+    let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, binary_tags, arts)?;
     let mut id3_head = Vec::with_capacity(8);
     id3_head.extend_from_slice(b"id3 ");
     id3_head.extend_from_slice(&(tag_len as u32).to_le_bytes());
@@ -606,7 +607,7 @@ mod tests {
         let mut tag_len = 0u64;
         for n in 1..64 {
             let cand = vec![TagInput::new("albumartist", &"x".repeat(n))];
-            let (_, tl) = crate::mp3::build_id3v2_segments(&cand, &[]).unwrap();
+            let (_, tl) = crate::mp3::build_id3v2_segments(&cand, &[], &[]).unwrap();
             if tl % 2 == 1 {
                 tags = cand;
                 tag_len = tl;
@@ -619,7 +620,7 @@ mod tests {
             fmt: fmt_pcm(),
             fact: None,
         };
-        let layout = synthesize_layout(&scan, 0, 8, &tags, &[]).unwrap();
+        let layout = synthesize_layout(&scan, 0, 8, &tags, &[], &[]).unwrap();
         assert_eq!(
             inline_offset_of(&layout, b"data") % 2,
             0,
@@ -642,7 +643,7 @@ mod tests {
             fmt: fmt_pcm(),
             fact: None,
         };
-        let res = synthesize_layout(&scan, 0, u32::MAX as u64, &[], &[]);
+        let res = synthesize_layout(&scan, 0, u32::MAX as u64, &[], &[], &[]);
         assert_eq!(res, Err(FormatError::TooLarge));
     }
 

--- a/musefs-format/tests/mp3_synthesize.rs
+++ b/musefs-format/tests/mp3_synthesize.rs
@@ -40,7 +40,7 @@ fn synthesizes_id3v24_text_frames_and_preserves_audio() {
         TagInput::new("title", "Song"),
         TagInput::new("album", "Record"),
     ];
-    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[]).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &[]).unwrap();
 
     // total_len must equal the bytes actually produced (generate-and-measure).
     let bytes = assemble(&layout, &audio, &[]);
@@ -70,7 +70,7 @@ fn synthesizes_apic_with_streamed_image_bytes() {
         height: 0,
         data_len: art_bytes.len() as u64,
     }];
-    let layout = synthesize_layout(0, audio.len() as u64, &tags, &arts).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &arts).unwrap();
 
     // The image is a streamed segment, not materialized inline.
     assert!(layout
@@ -105,7 +105,7 @@ fn embedded_size_field_matches_the_frame_region() {
         height: 0,
         data_len: art_bytes.len() as u64,
     }];
-    let layout = synthesize_layout(0, audio.len() as u64, &tags, &arts).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &arts).unwrap();
     let bytes = assemble(&layout, &audio, &[(1, &art_bytes)]);
 
     // Verify the 10-byte ID3v2.4 header magic and version/flags.
@@ -127,7 +127,7 @@ fn embedded_size_field_matches_the_frame_region() {
 #[test]
 fn empty_tag_when_no_tags_or_art() {
     let audio = [0xFFu8, 0xFB, 0, 0];
-    let layout = synthesize_layout(0, audio.len() as u64, &[], &[]).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &[], &[], &[]).unwrap();
 
     // Exactly two segments: the 10-byte inline header and the backing audio.
     assert_eq!(layout.segments.len(), 2);
@@ -153,7 +153,7 @@ fn empty_tag_when_no_tags_or_art() {
 fn unknown_key_becomes_txxx() {
     let audio = [0xFFu8, 0xFB, 0, 0];
     let tags = vec![TagInput::new("mood", "calm")];
-    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[]).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &[]).unwrap();
     let bytes = assemble(&layout, &audio, &[]);
 
     let tag = id3::Tag::read_from2(Cursor::new(&bytes)).unwrap();
@@ -171,7 +171,7 @@ fn multi_value_text_frame_round_trips() {
         TagInput::new("artist", "Alice"),
         TagInput::new("artist", "Bob"),
     ];
-    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[]).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &[]).unwrap();
     let bytes = assemble(&layout, &audio, &[]);
 
     let tag = id3::Tag::read_from2(Cursor::new(&bytes)).unwrap();
@@ -214,7 +214,7 @@ fn multiple_art_frames_keep_order() {
             data_len: art2.len() as u64,
         },
     ];
-    let layout = synthesize_layout(0, audio.len() as u64, &[], &arts).unwrap();
+    let layout = synthesize_layout(0, audio.len() as u64, &[], &[], &arts).unwrap();
 
     // The layout must contain ArtImage segments for art_id 1 then 2.
     let art_segs: Vec<i64> = layout
@@ -250,7 +250,7 @@ fn synthesize_errors_on_oversized_frame() {
         data_len: 0x1000_0000, // 256 MiB, over the per-frame limit
     }];
     assert_eq!(
-        synthesize_layout(0, 0, &[], &arts),
+        synthesize_layout(0, 0, &[], &[], &arts),
         Err(FormatError::TooLarge)
     );
 }
@@ -271,7 +271,7 @@ fn synthesize_errors_when_frames_sum_past_the_tag_limit() {
     };
     let arts = vec![art(1), art(2)];
     assert_eq!(
-        synthesize_layout(0, 0, &[], &arts),
+        synthesize_layout(0, 0, &[], &[], &arts),
         Err(FormatError::TooLarge)
     );
 }

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -14,9 +14,13 @@ proptest! {
         let bounds = mp3::locate_audio(&file).unwrap();
         let taginputs: Vec<TagInput> = tags.iter().map(|(k, v)| TagInput::new(k, v)).collect();
         let arts: Vec<ArtInput> = Vec::new();
-        if let Ok(layout) =
-            mp3::synthesize_layout(bounds.audio_offset, bounds.audio_length, &taginputs, &arts)
-        {
+        if let Ok(layout) = mp3::synthesize_layout(
+            bounds.audio_offset,
+            bounds.audio_length,
+            &taginputs,
+            &[],
+            &arts,
+        ) {
             assert_backing_covers_audio(bounds.audio_offset, bounds.audio_length, &layout);
         }
     }

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -28,6 +28,8 @@ proptest! {
     #[test]
     fn binary_tags_round_trip_survives_byte_identically(
         priv_payload in proptest::collection::vec(any::<u8>(), 1..100),
+        geob_payload in proptest::collection::vec(any::<u8>(), 1..100),
+        sylt_payload in proptest::collection::vec(any::<u8>(), 1..100),
         popm_rating in proptest::option::of(0u8..=255),
         playcount in 0u64..10_000,
         has_mb_ufid in proptest::bool::ANY,
@@ -42,6 +44,21 @@ proptest! {
         tag.add_frame(Frame::with_content(
             "PRIV",
             Content::Unknown(Unknown { data: priv_payload.clone(), version: Version::Id3v24 }),
+        ));
+
+        // GEOB/SYLT opaque frames whose bodies open with a 0x00 (ISO-8859-1)
+        // text-encoding byte followed by arbitrary, likely non-UTF-8 bytes — the
+        // exact case the crate's `to_unknown()` re-encode would mangle. The raw
+        // walker must preserve them byte-identical.
+        let geob_body: Vec<u8> = std::iter::once(0x00).chain(geob_payload.iter().copied()).collect();
+        tag.add_frame(Frame::with_content(
+            "GEOB",
+            Content::Unknown(Unknown { data: geob_body.clone(), version: Version::Id3v24 }),
+        ));
+        let sylt_body: Vec<u8> = std::iter::once(0x00).chain(sylt_payload.iter().copied()).collect();
+        tag.add_frame(Frame::with_content(
+            "SYLT",
+            Content::Unknown(Unknown { data: sylt_body.clone(), version: Version::Id3v24 }),
         ));
 
         // POPM — promoted.
@@ -74,6 +91,8 @@ proptest! {
         // Step 1: Parse binary tags.
         let (opaque, promoted) = mp3::read_binary_tags(&tag_bytes);
         prop_assert!(opaque.iter().any(|e| e.key == "PRIV"), "PRIV must be opaque");
+        prop_assert!(opaque.iter().any(|e| e.key == "GEOB"), "GEOB must be opaque");
+        prop_assert!(opaque.iter().any(|e| e.key == "SYLT"), "SYLT must be opaque");
         prop_assert!(opaque.iter().any(|e| e.key == "UFID"), "non-MB UFID must be opaque");
 
         // Step 2: DB round-trip.

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{mp3, ArtInput, TagInput};
+use musefs_format::{mp3, ArtInput, BinaryTagInput, Segment, TagInput};
 use proptest::prelude::*;
 
 proptest! {
@@ -23,5 +23,149 @@ proptest! {
         ) {
             assert_backing_covers_audio(bounds.audio_offset, bounds.audio_length, &layout);
         }
+    }
+
+    #[test]
+    fn binary_tags_round_trip_survives_byte_identically(
+        priv_payload in proptest::collection::vec(any::<u8>(), 1..100),
+        popm_rating in proptest::option::of(0u8..=255),
+        playcount in 0u64..10_000,
+        has_mb_ufid in proptest::bool::ANY,
+    ) {
+        use id3::frame::{Content, Popularimeter, UniqueFileIdentifier, Unknown};
+        use id3::{Encoder, Frame, Tag, TagLike, Version};
+        use musefs_format::build_id3v2_segments;
+
+        let mut tag = Tag::new();
+
+        // PRIV opaque frame with arbitrary payload.
+        tag.add_frame(Frame::with_content(
+            "PRIV",
+            Content::Unknown(Unknown { data: priv_payload.clone(), version: Version::Id3v24 }),
+        ));
+
+        // POPM — promoted.
+        if let Some(rating) = popm_rating {
+            tag.add_frame(Popularimeter {
+                user: "user@example".into(),
+                rating,
+                counter: playcount,
+            });
+        }
+
+        // UFID — MusicBrainz (promoted).
+        if has_mb_ufid {
+            tag.add_frame(UniqueFileIdentifier {
+                owner_identifier: "http://musicbrainz.org".into(),
+                identifier: b"test-mbid-value".to_vec(),
+            });
+        }
+
+        // UFID — non-MusicBrainz (opaque).
+        tag.add_frame(UniqueFileIdentifier {
+            owner_identifier: "http://other.example".into(),
+            identifier: b"other-id-data".to_vec(),
+        });
+
+        // Encode.
+        let mut tag_bytes = Vec::new();
+        Encoder::new().version(Version::Id3v24).encode(&tag, &mut tag_bytes).unwrap();
+
+        // Step 1: Parse binary tags.
+        let (opaque, promoted) = mp3::read_binary_tags(&tag_bytes);
+        prop_assert!(opaque.iter().any(|e| e.key == "PRIV"), "PRIV must be opaque");
+        prop_assert!(opaque.iter().any(|e| e.key == "UFID"), "non-MB UFID must be opaque");
+
+        // Step 2: DB round-trip.
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let tid = db.upsert_track(&musefs_db::NewTrack {
+            backing_path: "/a.mp3".into(),
+            format: musefs_db::Format::Mp3,
+            audio_offset: 0,
+            audio_length: 0,
+            backing_size: 0,
+            backing_mtime: 0,
+        }).unwrap();
+        let db_tags: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
+            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as i64 }
+        }).collect();
+        db.set_binary_tags(tid, &db_tags).unwrap();
+        let rows = db.get_binary_tags(tid).unwrap();
+        let binary_tag_inputs: Vec<BinaryTagInput> = rows.iter().map(|r| {
+            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len as u64 }
+        }).collect();
+
+        // Step 3: Build promoted text tags.
+        let mut text_tags: Vec<TagInput> = Vec::new();
+        for (k, v) in &promoted {
+            text_tags.push(TagInput::new(k, v));
+        }
+
+        // Step 4: Synthesize ID3v2 segments.
+        let (segments, _len) = build_id3v2_segments(&text_tags, &binary_tag_inputs, &[]).unwrap();
+
+        // Step 5: Materialize — inline bytes + substituted BinaryTag payloads.
+        let mut materialized = Vec::new();
+        let payload_map: std::collections::HashMap<i64, Vec<u8>> = rows.iter().map(|r| {
+            let blob = db.read_binary_tag_chunk(r.rowid, 0, r.byte_len as usize).unwrap();
+            (r.rowid, blob)
+        }).collect();
+        for seg in &segments {
+            match seg {
+                Segment::Inline(b) => materialized.extend_from_slice(b),
+                Segment::BinaryTag { payload_id, .. } => {
+                    materialized.extend_from_slice(payload_map.get(payload_id).unwrap());
+                }
+                _ => prop_assert!(false, "unexpected segment type in tag-only build"),
+            }
+        }
+
+        // Step 6: Re-parse materialized tag.
+        let (opaque2, promoted2) = mp3::read_binary_tags(&materialized);
+
+        // Step 7: Opaque frames must be byte-identical.
+        prop_assert_eq!(opaque.len(), opaque2.len(), "opaque count mismatch");
+        for orig in &opaque {
+            let found = opaque2.iter().find(|o| o.key == orig.key && o.payload == orig.payload);
+            prop_assert!(found.is_some(), "opaque frame {:?} not found in round-trip", orig.key);
+        }
+
+        // Step 8: Promoted values survive (semantic, not byte-identical).
+        if let Some(rating) = popm_rating {
+            prop_assert!(
+                promoted.iter().any(|(k, v)| k == "rating" && v == &rating.to_string()),
+                "rating not promoted on first parse"
+            );
+            prop_assert!(
+                promoted2.iter().any(|(k, v)| k == "rating" && v == &rating.to_string()),
+                "rating lost on round-trip"
+            );
+            if playcount > 0 {
+                prop_assert!(
+                    promoted.iter().any(|(k, _)| k == "playcount"),
+                    "playcount not promoted on first parse"
+                );
+            }
+        }
+        if has_mb_ufid {
+            prop_assert!(
+                promoted.iter().any(|(k, _)| k == "musicbrainz_trackid"),
+                "mbid not promoted on first parse"
+            );
+            prop_assert!(
+                promoted2.iter().any(|(k, _)| k == "musicbrainz_trackid"),
+                "mbid lost on round-trip"
+            );
+        }
+
+        // Dual-UFID: the synthesized tag must contain two distinct UFID frames
+        // only when the MB UFID was included (promoted MB + opaque non-MB).
+        let inline_bytes: Vec<u8> = segments.iter().flat_map(|s| match s {
+            Segment::Inline(b) => b.clone(),
+            _ => Vec::new(),
+        }).collect();
+        let ufid_count = inline_bytes.windows(4).filter(|w| w == b"UFID").count();
+        let expected_ufid_count = if has_mb_ufid { 2 } else { 1 };
+        prop_assert_eq!(ufid_count, expected_ufid_count, "UFID frame count mismatch (MB promoted + non-MB opaque)");
     }
 }

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -17,7 +17,12 @@ proptest! {
         let taginputs: Vec<TagInput> = tags.iter().map(|(k, v)| TagInput::new(k, v)).collect();
         let arts: Vec<ArtInput> = Vec::new();
         if let Ok(layout) = wav::synthesize_layout(
-            &scan, bounds.audio_offset, bounds.audio_length, &taginputs, &arts,
+            &scan,
+            bounds.audio_offset,
+            bounds.audio_length,
+            &taginputs,
+            &[],
+            &arts,
         ) {
             assert_backing_covers_audio(bounds.audio_offset, bounds.audio_length, &layout);
         }

--- a/musefs-format/tests/wav_synthesize.rs
+++ b/musefs-format/tests/wav_synthesize.rs
@@ -46,7 +46,7 @@ fn synthesizes_valid_riff_and_preserves_audio() {
         TagInput::new("artist", "Alice"),
     ];
 
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[]).unwrap();
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &[]).unwrap();
     let bytes = assemble(&layout, &audio, &[]);
 
     // total_len equals the bytes actually produced (generate-and-measure).
@@ -89,7 +89,7 @@ fn embeds_full_fidelity_id3_tag_with_art() {
         data_len: art_bytes.len() as u64,
     }];
 
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
     // Art is a streamed segment, never materialized inline.
     assert!(layout
         .segments
@@ -121,7 +121,7 @@ fn emits_native_info_chunk_for_mapped_tags() {
         TagInput::new("title", "Hello"),
         TagInput::new("artist", "Bob"),
     ];
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[]).unwrap();
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &[]).unwrap();
     let bytes = assemble(&layout, &audio, &[]);
 
     let (off, len) = find_chunk(&bytes, b"LIST").expect("a LIST chunk");
@@ -141,7 +141,7 @@ fn pads_odd_data_payload_to_word_boundary() {
         fmt: fmt_pcm_16bit_mono(),
         fact: None,
     };
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &[], &[]).unwrap();
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &[], &[], &[]).unwrap();
     let bytes = assemble(&layout, &audio, &[]);
     // File length is even and total_len accounts for the pad byte.
     assert_eq!(bytes.len() % 2, 0);
@@ -163,7 +163,7 @@ fn rejects_audio_over_32bit() {
         fmt: fmt_pcm_16bit_mono(),
         fact: None,
     };
-    let res = synthesize_layout(&scan, 0, (u32::MAX as u64) + 1, &[], &[]);
+    let res = synthesize_layout(&scan, 0, (u32::MAX as u64) + 1, &[], &[], &[]);
     assert_eq!(res, Err(musefs_format::FormatError::TooLarge));
 }
 
@@ -207,7 +207,7 @@ fn skips_zero_byte_art() {
         data_len: 0,
     }];
 
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
     assert!(
         !layout
             .segments
@@ -254,7 +254,7 @@ fn keeps_real_art_when_mixed_with_empty() {
         },
     ];
 
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &arts).unwrap();
+    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
     let art_segs: Vec<&Segment> = layout
         .segments
         .iter()


### PR DESCRIPTION
## Summary

Phase 2 of binary-tag support: ID3v2 binary frames now survive **scan → DB → re-synthesis** for both MP3 and WAV (WAV carries ID3 in its `id3 ` chunk).

- **Opaque passthrough, byte-exact.** `PRIV`/`GEOB`/`SYLT`/`MCDI`/`W***`/unknown frames and any non-MusicBrainz `UFID` are preserved verbatim. Extraction uses a self-contained raw ID3 frame-body walker — **not** the `id3` crate's `Content::to_unknown()`, which re-encodes typed frames (forcing `Encoding::UTF8`) and would silently mangle e.g. a Serato `GEOB` analysis blob. The walker is sound because `id3v2_alloc_safe` already rejects unsynchronised tags, extended headers, and non-zero frame flags, so the on-disk body equals the logical body.
- **Promotion to editable text.** `POPM` → `rating` (+ `playcount` when the counter is non-zero) and MusicBrainz `UFID` → `musicbrainz_trackid`. Promotion is lossy by design (POPM owner-email dropped, counter capped at `u32` on rebuild); round-trip tests assert *semantic* survival for promoted frames and *byte-identity* for opaque ones. Promoted keys are excluded from the generic text/`TXXX` emission so they never double-store.
- **Streaming, never materialized.** Opaque payloads are stored in `tags.value_blob` (Phase 1 schema) and served lazily at read time via `Segment::BinaryTag { payload_id, len }`, exactly as `APIC` streams `ArtImage`.

Spec: `docs/superpowers/specs/2026-06-01-binary-tags-design.md` (§5 ID3, §6 query-split). Plan: `docs/superpowers/plans/2026-06-02-binary-tags-phase2-id3.md`.

## Open-handle `payload_id`-reuse gap closed

A file handle held across an out-of-band re-tag could otherwise serve a reused-rowid payload under a stale layout. Closed with two cooperating mechanisms in `facade.rs`: a generation-gated lazy re-resolve (`refresh_gen`), and — for `BinaryTag`-bearing layouts only — a transactional `content_version` guard that wraps the version check and the blob reads in one WAL read snapshot (`begin_read`/`end_read`), with a bounded retry. Plain `Inline`/`BackingAudio` reads pay no per-read cost.

## Testing & validation

- Unit + integration tests across `musefs-db`/`musefs-format`/`musefs-core`; proptest round-trip (incl. non-UTF-8 `GEOB`/`SYLT` bodies, dual-UFID, POPM `counter == 0`).
- Safety test: a held `BinaryTag` handle never serves reused-rowid bytes under stale framing.
- `cargo fmt --all --check` clean; `cargo clippy --all-targets` clean.
- **In-diff mutation gate green** (mirrors `.github/workflows/mutants.yml`): 152 mutants — 134 caught, 18 unviable, **0 missed**. One true-equivalent (the POPM counter fold `(a << 8) | b` ≡ `^`) is documented in `.cargo/mutants.toml`, following the existing flac/crc precedent.

## Out of scope (later phases)

MP4 `----` (Phase 3) and FLAC `APPLICATION`/`CUESHEET` (Phase 4) — their probe arms intentionally write `binary_tags: Vec::new()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve opaque binary metadata frames for MP3/WAV through scan → DB → re-synthesis; promote specific frames to editable text tags (rating, playcount, MusicBrainz ID).
  * Expose binary-tag inputs so syntheses can stream stored binary payloads.
* **Bug Fixes**
  * Prevent stale reads after track updates by making open handles re-resolve and by validating content-version during reads.
* **Documentation**
  * Added design and plan docs detailing binary-tags Phase 2 and read-path consistency.
* **Tests**
  * Extensive tests and fuzzing added for binary-tag round-trips, scanning, ingestion, and read-snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->