### PR TITLE
feat: binary-tags phase 4 — FLAC structural store + streamed APPLICATION/CUESHEET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 mutants-out/
 mutants.out/
 mutants.out.old/
+.worktrees

--- a/docs/superpowers/plans/2026-06-02-binary-tags-phase4-flac.md
+++ b/docs/superpowers/plans/2026-06-02-binary-tags-phase4-flac.md
@@ -1,0 +1,1048 @@
+# Binary Tags Phase 4 — FLAC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make FLAC `APPLICATION`/`CUESHEET` blocks survive the round trip as DB-backed editable blobs, move `STREAMINFO`/`SEEKTABLE` into the read-only structural store, and eliminate the per-resolve FLAC front re-read for rescanned tracks (with a graceful front-read fallback for not-yet-rescanned legacy tracks).
+
+**Architecture:** Scan splits FLAC's preserved metadata blocks into a structural store (`structural_blocks`: STREAMINFO/SEEKTABLE) and binary tags (`tags.value_blob`: APPLICATION/CUESHEET). `flac::synthesize_layout` stops taking a file-derived `FlacScan` and instead assembles from the structural blocks (inline) + regenerated VORBIS_COMMENT + streamed `Segment::BinaryTag` (APPLICATION/CUESHEET) + streamed `ArtImage` (pictures) + backing audio. The reader loads structural blocks from the DB; when absent (legacy track) it falls back to the existing `read_front` + `flac::read_metadata` path, carrying all preserved blocks inline exactly as today.
+
+**Tech Stack:** Rust workspace (musefs-db / musefs-format / musefs-core), rusqlite (SQLite), metaflac (test oracle), proptest.
+
+---
+
+## Context the engineer needs before starting
+
+Phases 1–3 are already merged. The shared foundation **already exists** — do not re-create it:
+
+- `Segment::BinaryTag { payload_id: i64, len: u64 }` (`musefs-format/src/layout.rs`) and `RegionLayout::has_binary_tag()`.
+- `BinaryTagInput { key, payload_id, len }` and `EmbeddedBinaryTag { key, payload }` (`musefs-format/src/input.rs`).
+- `Db::set_binary_tags` / `Db::get_binary_tags` / `Db::read_binary_tag_chunk` and `BulkWriter::set_binary_tags` (`musefs-db/src/tags.rs`, `bulk.rs`).
+- `Db::set_structural_blocks` / `Db::get_structural_blocks` and `StructuralBlock { kind, ordinal, body }` (`musefs-db/src/structural.rs`, `models.rs`).
+- Migration V2 with the `value_blob` column and the `structural_blocks` table (`musefs-db/src/schema.rs`).
+- `MAX_BINARY_TAG_BYTES` and the scan-time filter/ordinal logic for binary tags (`musefs-core/src/scan.rs`).
+- `mapping::binary_tags_to_inputs(db, track_id)` (`musefs-core/src/mapping.rs`).
+- The reader's `read_at` arm for `Segment::BinaryTag`, the `facade.rs` generation-gated re-resolve + transactional `content_version` guard for `has_binary_tag` layouts (the open-handle gap closed in Phase 2), and the `value_blob IS NULL` query-split filter on `tags_grouped`/`tags_for_tracks`.
+- Test helpers in `musefs-format/tests/common/mod.rs`: `flac_block`, `streaminfo_body`, `vorbis_comment_body`, `make_flac`, and `resolve_layout(layout, backing, art_map, binary_tag_map)` (already supports `Segment::BinaryTag`).
+- Test helpers in `musefs-core/tests/common`: `make_flac`, `streaminfo_body`, `vorbis_comment_body` (used by `metrics.rs`).
+
+FLAC block-type constants (`musefs-format/src/flac.rs`, `pub(crate)`): `BLOCK_STREAMINFO=0`, `BLOCK_APPLICATION=2`, `BLOCK_SEEKTABLE=3`, `BLOCK_VORBIS_COMMENT=4`, `BLOCK_CUESHEET=5`, `BLOCK_PICTURE=6`.
+
+**What this phase does NOT touch:** the `facade.rs` open-handle guard (already done in Phase 2 and covers `has_binary_tag` layouts), the `read_at` read path (already handles `BinaryTag`), the query-split filter (already in place), or any new error variant (none is needed — `read_binary_tag_chunk` reuses the art short-read error).
+
+**Crate dependency direction (do not violate):** `musefs-db` ← `musefs-format` ← `musefs-core`. `musefs-format` may use `musefs-db` types, but the format parse output uses format-native types (`EmbeddedBinaryTag`, tuples) — the `StructuralBlock`/`BinaryTag` DB models are built in `musefs-core` (scan) and `musefs-db` (bulk), mirroring the existing art path.
+
+**Pre-push reminder:** run `cargo fmt --all --check` before any push (CI fmt gate). The fuzz crate is out of the workspace — not built by `cargo test`; this phase touches no fuzz target.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `musefs-db/src/bulk.rs` | Batched scan writes in one transaction | **Add** `BulkWriter::set_structural_blocks` (mirror `set_binary_tags`) |
+| `musefs-format/src/flac.rs` | FLAC byte-surgery: parse + synthesis | **Add** `split_preserved`, `structural_block_type`; **rewrite** `synthesize_layout` signature + body (binary-tag emission, canonical order) |
+| `musefs-format/tests/{synthesize_tags,synthesize_art,roundtrip,proptest_flac}.rs` | FLAC synthesis tests | **Mechanical** update to the new `synthesize_layout` signature + **new** binary-tag round-trip tests |
+| `musefs-core/src/reader.rs` | Resolve / layout build | **Rewrite** the `Format::Flac` arm: load `structural_blocks` from DB, legacy front-read fallback, pass `binary_tag_inputs` |
+| `musefs-core/src/scan.rs` | Ingest backing files into the DB | **Add** `Probed.structural_blocks`; populate FLAC arms via `split_preserved`; persist structural blocks in `ingest`/`ingest_bulk` |
+| `musefs-core/tests/flac_binary_tags.rs` | New integration tests | **Create**: scan→DB persistence, end-to-end serve, legacy fallback |
+| `musefs-core/tests/metrics.rs` | Open/read syscall accounting | **Add** a test: rescanned FLAC resolve does zero front reads |
+
+---
+
+## Task 1: `BulkWriter::set_structural_blocks` (musefs-db)
+
+`ingest_bulk` (the scan batch path) needs to write structural blocks, but `BulkWriter` only has `set_binary_tags`. Add the structural twin so the batch path can persist STREAMINFO/SEEKTABLE in the same transaction.
+
+**Files:**
+- Modify: `musefs-db/src/bulk.rs` (import line `1`; add method after `set_binary_tags`, ~`musefs-db/src/bulk.rs:95`)
+- Test: `musefs-db/src/bulk.rs` (in the existing `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module at the bottom of `musefs-db/src/bulk.rs`:
+
+```rust
+    #[test]
+    fn bulk_set_structural_blocks_round_trips() {
+        use crate::StructuralBlock;
+        let db = Db::open_in_memory().unwrap();
+        let id = {
+            let mut bw = db.bulk_writer().unwrap();
+            let id = bw
+                .upsert_track(&NewTrack {
+                    backing_path: "/a.flac".into(),
+                    format: Format::Flac,
+                    audio_offset: 0,
+                    audio_length: 1,
+                    backing_size: 1,
+                    backing_mtime: 0,
+                })
+                .unwrap();
+            bw.set_structural_blocks(
+                id,
+                &[
+                    StructuralBlock { kind: "STREAMINFO".into(), ordinal: 0, body: vec![1, 2] },
+                    StructuralBlock { kind: "SEEKTABLE".into(), ordinal: 0, body: vec![3] },
+                ],
+            )
+            .unwrap();
+            bw.commit().unwrap();
+            id
+        };
+        let got = db.get_structural_blocks(id).unwrap();
+        assert_eq!(got.len(), 2);
+        // get_structural_blocks orders by kind: SEEKTABLE before STREAMINFO.
+        assert_eq!(got[0].kind, "SEEKTABLE");
+        assert_eq!(got[1].body, vec![1, 2]);
+    }
+```
+
+Check the existing `tests` module imports at the top of the module; if `NewTrack`/`Format` are not already imported there, add `use crate::{Db, Format, NewTrack};` to that module (match the existing `bulk_set_binary_tags_round_trips` test's imports). `commit` is the existing `BulkWriter` method — confirm its name in the file (`bw.commit()`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-db bulk_set_structural_blocks_round_trips`
+Expected: FAIL — `no method named set_structural_blocks found for struct BulkWriter`.
+
+- [ ] **Step 3: Add the method**
+
+In `musefs-db/src/bulk.rs`, change the import on line `1` to include `StructuralBlock`:
+
+```rust
+use crate::models::{BinaryTag, NewArt, NewTrack, StructuralBlock, Tag, TrackArt};
+```
+
+Insert this method into `impl BulkWriter<'_>` immediately after `set_binary_tags` (after `musefs-db/src/bulk.rs:95`):
+
+```rust
+    pub fn set_structural_blocks(
+        &mut self,
+        track_id: i64,
+        blocks: &[StructuralBlock],
+    ) -> Result<()> {
+        self.tx.execute(
+            "DELETE FROM structural_blocks WHERE track_id = ?1",
+            params![track_id],
+        )?;
+        let mut stmt = self.tx.prepare(
+            "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for b in blocks {
+            stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-db bulk_set_structural_blocks_round_trips`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-db/src/bulk.rs
+git commit -m "feat(db): BulkWriter::set_structural_blocks for the scan batch path
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `flac::split_preserved` + `flac::structural_block_type` (musefs-format)
+
+The scan path needs to split FLAC's already-parsed preserved blocks into (a) structural blocks (STREAMINFO/SEEKTABLE → `(kind, body)` pairs) and (b) binary tags (APPLICATION/CUESHEET → `EmbeddedBinaryTag`). The reader needs to map a stored structural `kind` string back to a FLAC block type when rebuilding inline blocks. Both keep all FLAC block-type knowledge inside `flac.rs`. These are pure additions — no existing behavior changes.
+
+**Files:**
+- Modify: `musefs-format/src/flac.rs` (import line `146`; add two `pub fn`s near the synthesis helper `push_block_header`)
+- Test: `musefs-format/src/flac.rs` (in the existing `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `musefs-format/src/flac.rs`:
+
+```rust
+    #[test]
+    fn split_preserved_classifies_structural_and_binary() {
+        use super::{split_preserved, structural_block_type, MetadataBlock};
+        // STREAMINFO(0), APPLICATION(2), SEEKTABLE(3), CUESHEET(5) in arbitrary order.
+        let blocks = vec![
+            MetadataBlock { block_type: 0, body: vec![0xAA] },
+            MetadataBlock { block_type: 2, body: b"testDATA".to_vec() },
+            MetadataBlock { block_type: 3, body: vec![0xBB] },
+            MetadataBlock { block_type: 5, body: vec![0xCC; 4] },
+        ];
+        let (structural, binary) = split_preserved(&blocks);
+
+        assert_eq!(
+            structural,
+            vec![
+                ("STREAMINFO".to_string(), vec![0xAA]),
+                ("SEEKTABLE".to_string(), vec![0xBB]),
+            ]
+        );
+        assert_eq!(binary.len(), 2);
+        assert_eq!(binary[0].key, "APPLICATION");
+        assert_eq!(binary[0].payload, b"testDATA");
+        assert_eq!(binary[1].key, "CUESHEET");
+        assert_eq!(binary[1].payload, vec![0xCC; 4]);
+
+        assert_eq!(structural_block_type("STREAMINFO"), Some(0));
+        assert_eq!(structural_block_type("SEEKTABLE"), Some(3));
+        assert_eq!(structural_block_type("APPLICATION"), None);
+        assert_eq!(structural_block_type("bogus"), None);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format split_preserved_classifies_structural_and_binary`
+Expected: FAIL — `cannot find function split_preserved` / `structural_block_type`.
+
+- [ ] **Step 3: Add the functions**
+
+In `musefs-format/src/flac.rs`, extend the import on line `146`:
+
+```rust
+use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+```
+
+Add these two functions next to the synthesis helper `push_block_header` (after `musefs-format/src/flac.rs:154`), so they sit with the synthesis-side code that pairs with them rather than in the parse region. (Insertion order does not affect compilation — Rust `use` is not order-sensitive within a module — but locality keeps the file readable.)
+
+```rust
+/// Map a stored structural-block `kind` string back to its FLAC block type.
+/// Only STREAMINFO/SEEKTABLE live in the structural store; everything else
+/// returns `None` (APPLICATION/CUESHEET are binary tags, not structural).
+pub fn structural_block_type(kind: &str) -> Option<u8> {
+    match kind {
+        "STREAMINFO" => Some(BLOCK_STREAMINFO),
+        "SEEKTABLE" => Some(BLOCK_SEEKTABLE),
+        _ => None,
+    }
+}
+
+/// Split a FLAC file's preserved metadata blocks into the read-only structural
+/// store (STREAMINFO/SEEKTABLE, as `(kind, body)` pairs in file order) and the
+/// editable binary tags (APPLICATION/CUESHEET, as `EmbeddedBinaryTag`s keyed by
+/// block name; `payload` is the full block body, including APPLICATION's 4-byte
+/// app id). Blocks of any other type are ignored (PICTURE/VORBIS_COMMENT are
+/// handled by their own paths and are never in `preserved`).
+pub fn split_preserved(blocks: &[MetadataBlock]) -> (Vec<(String, Vec<u8>)>, Vec<EmbeddedBinaryTag>) {
+    let mut structural = Vec::new();
+    let mut binary = Vec::new();
+    for blk in blocks {
+        match blk.block_type {
+            BLOCK_STREAMINFO => structural.push(("STREAMINFO".to_string(), blk.body.clone())),
+            BLOCK_SEEKTABLE => structural.push(("SEEKTABLE".to_string(), blk.body.clone())),
+            BLOCK_APPLICATION => binary.push(EmbeddedBinaryTag {
+                key: "APPLICATION".to_string(),
+                payload: blk.body.clone(),
+            }),
+            BLOCK_CUESHEET => binary.push(EmbeddedBinaryTag {
+                key: "CUESHEET".to_string(),
+                payload: blk.body.clone(),
+            }),
+            _ => {}
+        }
+    }
+    (structural, binary)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format split_preserved_classifies_structural_and_binary`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/flac.rs
+git commit -m "feat(format): flac::split_preserved + structural_block_type
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Rewrite `flac::synthesize_layout` + reader FLAC arm
+
+This is the core change. `synthesize_layout` drops `FlacScan` and takes structural blocks (inline) + explicit audio bounds + a `binary_tags` slice (streamed APPLICATION/CUESHEET). The canonical block order becomes: `fLaC` + STREAMINFO + (other structural) + VORBIS_COMMENT + APPLICATION/CUESHEET (streamed) + PICTURE (streamed) + backing audio. The reader's `Format::Flac` arm loads structural blocks from the DB and, when empty (legacy track not yet rescanned under V2), falls back to the existing `read_front` + `flac::read_metadata` path, carrying *all* preserved blocks (incl. APPLICATION/CUESHEET) inline — exactly today's behavior.
+
+After this task, **scan does not yet populate `structural_blocks`** (Task 4), so every FLAC track resolves via the legacy fallback. That is correct and tests pass green; Task 4 then activates the fast path.
+
+**Behavior change to call out for reviewers:** re-synthesized FLAC block order is the canonical order above, which may differ from the source file's order. The FLAC spec only mandates STREAMINFO first, so this is valid. Round-trip tests assert payload/round-trip fidelity, **not** byte-identical block ordering.
+
+**Files:**
+- Modify: `musefs-format/src/flac.rs` — `synthesize_layout` (`musefs-format/src/flac.rs:171-238`)
+- Modify: `musefs-core/src/reader.rs` — import line `6`; `Format::Flac` arm (`musefs-core/src/reader.rs:261-271`)
+- Modify (mechanical): `musefs-format/tests/synthesize_tags.rs`, `synthesize_art.rs`, `roundtrip.rs`, `proptest_flac.rs`, and the in-file test `synthesize_layout_picture_block_size_boundary_is_inclusive`
+- Test: `musefs-format/tests/roundtrip.rs` (new binary-tag round-trip tests)
+
+- [ ] **Step 1: Write the failing tests (new binary-tag round-trip)**
+
+Append to `musefs-format/tests/roundtrip.rs` (it already has `mod common;` and the metaflac dev-dep). Add the needed imports at the top — `use musefs_format::{ArtInput, BinaryTagInput, Segment, TagInput};` (extend the existing `use musefs_format::{ArtInput, TagInput};` line on `musefs-format/tests/roundtrip.rs:6`) and `use musefs_format::flac::MetadataBlock;`:
+
+```rust
+#[test]
+fn application_block_streams_and_metaflac_reads_it() {
+    let si = streaminfo_body();
+    let app_body = b"testAPPDATA".to_vec(); // 4-byte app id "test" + payload "APPDATA"
+    let audio = vec![0xABu8; 48];
+
+    let structural = vec![MetadataBlock { block_type: 0, body: si }];
+    let binary = vec![BinaryTagInput {
+        key: "APPLICATION".into(),
+        payload_id: 100,
+        len: app_body.len() as u64,
+    }];
+    let layout = synthesize_layout(
+        &structural,
+        0,
+        audio.len() as u64,
+        &[TagInput::new("title", "T")],
+        &binary,
+        &[],
+    )
+    .unwrap();
+
+    // The APPLICATION payload is streamed, never materialized into an Inline segment.
+    let bt = layout
+        .segments()
+        .iter()
+        .filter(|s| matches!(s, Segment::BinaryTag { .. }))
+        .count();
+    assert_eq!(bt, 1);
+
+    let mut bt_map = std::collections::HashMap::new();
+    bt_map.insert(100i64, app_body.clone());
+    let assembled = resolve_layout(&layout, &audio, &HashMap::new(), &bt_map);
+
+    let tag =
+        metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
+    let (id, data) = tag
+        .blocks()
+        .find_map(|b| match b {
+            metaflac::Block::Application(a) => Some((a.id, a.data.clone())),
+            _ => None,
+        })
+        .expect("application block present");
+    assert_eq!(&id, b"test");
+    assert_eq!(data, b"APPDATA");
+}
+
+#[test]
+fn application_and_cuesheet_framing_is_valid_and_last_block_correct() {
+    // Two streamed binary blocks and no art: the FINAL binary block (CUESHEET)
+    // must carry the last-metadata-block flag, or a re-parse walks into the audio.
+    let si = streaminfo_body();
+    let app_body = b"testAPP1".to_vec();
+    let cue_body = vec![0x11u8; 40];
+    let audio = vec![0xCDu8; 32];
+
+    let structural = vec![MetadataBlock { block_type: 0, body: si }];
+    let binary = vec![
+        BinaryTagInput { key: "APPLICATION".into(), payload_id: 1, len: app_body.len() as u64 },
+        BinaryTagInput { key: "CUESHEET".into(), payload_id: 2, len: cue_body.len() as u64 },
+    ];
+    let layout = synthesize_layout(
+        &structural,
+        0,
+        audio.len() as u64,
+        &[TagInput::new("title", "T")],
+        &binary,
+        &[],
+    )
+    .unwrap();
+
+    assert_eq!(
+        layout
+            .segments()
+            .iter()
+            .filter(|s| matches!(s, Segment::BinaryTag { .. }))
+            .count(),
+        2
+    );
+
+    let mut bt_map = std::collections::HashMap::new();
+    bt_map.insert(1i64, app_body);
+    bt_map.insert(2i64, cue_body);
+    let assembled = resolve_layout(&layout, &audio, &HashMap::new(), &bt_map);
+
+    // The metadata walk (header lengths + last-block flag) must land exactly on the
+    // audio boundary. locate_audio does not interpret cuesheet semantics.
+    let rescan = locate_audio(&assembled).expect("synthesized FLAC must parse");
+    assert_eq!(rescan.audio_offset, layout.header_len());
+}
+
+#[test]
+fn binary_tag_over_24bit_limit_errors() {
+    use musefs_format::FormatError;
+    let structural = vec![MetadataBlock { block_type: 0, body: streaminfo_body() }];
+    let binary = vec![BinaryTagInput {
+        key: "APPLICATION".into(),
+        payload_id: 1,
+        len: 0x0100_0000, // one over the 24-bit FLAC block-length limit (count only; no allocation)
+    }];
+    assert_eq!(
+        synthesize_layout(&structural, 0, 0, &[], &binary, &[]),
+        Err(FormatError::TooLarge)
+    );
+}
+```
+
+Note `roundtrip.rs` already imports `Cursor` and `HashMap` at the top; keep one canonical import (remove the inline `std::collections::HashMap` qualifications if the top-level `use std::collections::HashMap;` is present — check the file head and prefer the existing imports).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-format --test roundtrip`
+Expected: FAIL to compile — `synthesize_layout` takes 3 args, not 6 (old signature).
+
+- [ ] **Step 3: Rewrite `synthesize_layout`**
+
+Replace the body of `synthesize_layout` (`musefs-format/src/flac.rs:171-238`) with:
+
+```rust
+/// Build the ordered segment layout for a synthesized FLAC file. Canonical block
+/// order: `fLaC` + STREAMINFO (first, per the FLAC spec) + any other structural
+/// blocks (inline, verbatim) + a regenerated VORBIS_COMMENT + APPLICATION/CUESHEET
+/// (streamed `Segment::BinaryTag`) + PICTURE blocks (streamed `Segment::ArtImage`)
+/// + the backing audio. The source file's original block order is intentionally
+/// NOT preserved (round-trips assert payload fidelity, not block ordering).
+///
+/// `structural` carries the inline blocks to emit verbatim: STREAMINFO/SEEKTABLE
+/// from the structural store, or — on the legacy fallback path — every preserved
+/// block (incl. APPLICATION/CUESHEET) when binary rows are not yet in the DB.
+pub fn synthesize_layout(
+    structural: &[MetadataBlock],
+    audio_offset: u64,
+    audio_length: u64,
+    tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
+    arts: &[ArtInput],
+) -> Result<RegionLayout> {
+    // STREAMINFO must come first; sort the rest deterministically by block type
+    // (STREAMINFO=0 < APPLICATION=2 < SEEKTABLE=3 < CUESHEET=5).
+    let mut ordered: Vec<&MetadataBlock> = structural.iter().collect();
+    ordered.sort_by_key(|b| b.block_type);
+
+    let nonempty_art = arts.iter().filter(|a| a.data_len > 0).count();
+    let num_blocks = ordered.len() + 1 + binary_tags.len() + nonempty_art; // +1 VORBIS_COMMENT
+    let last_index = num_blocks - 1;
+
+    let mut segments: Vec<Segment> = Vec::new();
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(FLAC_MARKER);
+    let mut idx = 0usize;
+
+    for blk in &ordered {
+        push_block_header(&mut buf, blk.block_type, blk.body.len(), idx == last_index);
+        buf.extend_from_slice(&blk.body);
+        idx += 1;
+    }
+
+    let vc = crate::vorbiscomment::build(tags);
+    push_block_header(&mut buf, BLOCK_VORBIS_COMMENT, vc.len(), idx == last_index);
+    buf.extend_from_slice(&vc);
+    idx += 1;
+
+    for bt in binary_tags {
+        let block_type = match bt.key.as_str() {
+            "APPLICATION" => BLOCK_APPLICATION,
+            "CUESHEET" => BLOCK_CUESHEET,
+            // Unknown opaque key for FLAC: skip defensively rather than emit a
+            // block with a bogus type. (Scan only ever writes the two keys above.)
+            _ => continue,
+        };
+        // FLAC metadata block lengths are 24-bit; guard at the format boundary so an
+        // oversized block is a hard error rather than a silently-truncated file.
+        if bt.len > 0x00FF_FFFF {
+            return Err(FormatError::TooLarge);
+        }
+        push_block_header(&mut buf, block_type, bt.len as usize, idx == last_index);
+        segments.push(Segment::Inline(std::mem::take(&mut buf)));
+        segments.push(Segment::BinaryTag {
+            payload_id: bt.payload_id,
+            len: bt.len,
+        });
+        idx += 1;
+    }
+
+    for art in arts {
+        if art.data_len == 0 {
+            continue; // skip degenerate empty art (see nonempty_art above)
+        }
+        let framing = picture_body_framing(art);
+        let body_len = framing.len() as u64 + art.data_len;
+        if body_len > 0x00FF_FFFF {
+            return Err(FormatError::TooLarge);
+        }
+        push_block_header(&mut buf, BLOCK_PICTURE, body_len as usize, idx == last_index);
+        buf.extend_from_slice(&framing);
+        segments.push(Segment::Inline(std::mem::take(&mut buf)));
+        segments.push(Segment::ArtImage {
+            art_id: art.art_id,
+            len: art.data_len,
+        });
+        idx += 1;
+    }
+
+    if !buf.is_empty() {
+        segments.push(Segment::Inline(buf));
+    }
+    segments.push(Segment::BackingAudio {
+        offset: audio_offset,
+        len: audio_length,
+    });
+
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+}
+```
+
+- [ ] **Step 4: Update the in-format callers (test fallout)**
+
+The signature changed from `synthesize_layout(&scan, &tags, &arts)` to `synthesize_layout(&structural, audio_offset, audio_length, &tags, &binary_tags, &arts)`. `FlacScan` keeps its `preserved`/`audio_offset`/`audio_length` fields (unchanged), so each call site that has a `scan` from `locate_audio` becomes `synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &tags, &[], &arts)`.
+
+`musefs-format/tests/synthesize_tags.rs` — three call sites (`:26`, `:47`, `:71`):
+```rust
+let layout = synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &tags, &[], &[]).unwrap();
+```
+and (`:71`):
+```rust
+let layout = synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &[TagInput::new("title", "X")], &[], &[]).unwrap();
+```
+
+`musefs-format/tests/synthesize_art.rs`:
+- `:36`, `:66`: `synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &[TagInput::new("title", "T")], &[], &[art]).unwrap();`
+- `:117`: same shape with `&[art]` where `art = cover(7, 0)`.
+- `:146`: `synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &[TagInput::new("title", "T")], &[], &[empty, real]).unwrap();`
+- `:84-105` (`synthesize_errors_on_oversized_picture`) builds a `FlacScan` manually; replace the call (`:102-105`) with the structural-slice form and drop the now-unused `FlacScan`:
+```rust
+#[test]
+fn synthesize_errors_on_oversized_picture() {
+    use musefs_format::FormatError;
+    let art = ArtInput {
+        art_id: 1,
+        mime: "image/png".to_string(),
+        description: String::new(),
+        picture_type: 3,
+        width: 0,
+        height: 0,
+        data_len: 0x0100_0000, // just over the 24-bit FLAC PICTURE block limit
+    };
+    assert_eq!(
+        synthesize_layout(&[], 0, 0, &[], &[], &[art]),
+        Err(FormatError::TooLarge)
+    );
+}
+```
+(Remove the `use musefs_format::flac::FlacScan;` line from this test.)
+
+`musefs-format/tests/roundtrip.rs` (`:52`):
+```rust
+let layout = synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &tags, &[], &arts).unwrap();
+```
+
+`musefs-format/tests/proptest_flac.rs` (`:22` and `:36`):
+```rust
+if let Ok(layout) = flac::synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &taginputs, &[], &arts) {
+```
+```rust
+let Ok(layout) = flac::synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &taginputs, &[], &arts) else {
+```
+
+In-file test `synthesize_layout_picture_block_size_boundary_is_inclusive` (`musefs-format/src/flac.rs:817-848`) builds a `FlacScan { audio_offset: 0, audio_length: …, preserved: … }` and calls `synthesize_layout(&scan, &[], &[mk(at_limit)])`. Replace both calls with the structural-slice form, passing `&scan.preserved` (or `&[]` if it builds an empty `preserved`), `scan.audio_offset`, `scan.audio_length`, `&[]` tags, `&[]` binary, and the art slice. Read the test body first and keep its existing `at_limit`/`mk` logic; only the two `synthesize_layout(...)` calls change shape.
+
+- [ ] **Step 5: Run the format tests**
+
+Run: `cargo test -p musefs-format`
+Expected: PASS (including the three new tests from Step 1 and `--features fuzzing` paths via the workspace; if `proptest_flac` is gated, also run `cargo test -p musefs-format --features fuzzing`).
+Run: `cargo test -p musefs-format --features fuzzing --test proptest_flac`
+Expected: PASS.
+
+- [ ] **Step 6: Rewrite the reader `Format::Flac` arm**
+
+In `musefs-core/src/reader.rs`, change the import on line `6` from:
+```rust
+use musefs_format::flac::{self, FlacScan};
+```
+to:
+```rust
+use musefs_format::flac::{self, MetadataBlock};
+```
+
+Replace the `Format::Flac =>` arm (`musefs-core/src/reader.rs:261-271`) with:
+
+```rust
+                    Format::Flac => {
+                        // STREAMINFO/SEEKTABLE come from the structural store, so no
+                        // backing-file read is needed for rescanned tracks. A FLAC
+                        // track migrated to V2 but not yet rescanned has no structural
+                        // rows: fall back to the front re-read and carry every
+                        // preserved block (incl. APPLICATION/CUESHEET) inline, exactly
+                        // as before this phase. The next scan backfills the stores.
+                        let structural: Vec<MetadataBlock> = {
+                            let rows = db.get_structural_blocks(track.id)?;
+                            if rows.is_empty() {
+                                let front = read_front(
+                                    Path::new(&track.backing_path),
+                                    track.audio_offset as u64,
+                                )?;
+                                flac::read_metadata(&front)?.preserved
+                            } else {
+                                rows.into_iter()
+                                    .filter_map(|b| {
+                                        flac::structural_block_type(&b.kind)
+                                            .map(|block_type| MetadataBlock {
+                                                block_type,
+                                                body: b.body,
+                                            })
+                                    })
+                                    .collect()
+                            }
+                        };
+                        flac::synthesize_layout(
+                            &structural,
+                            track.audio_offset as u64,
+                            track.audio_length as u64,
+                            &inputs,
+                            &binary_tag_inputs,
+                            &art_inputs,
+                        )?
+                    }
+```
+
+`binary_tag_inputs` is already computed just above the `match` (`musefs-core/src/reader.rs:255`). On the legacy fallback path it is empty (no `value_blob` rows yet), and APPLICATION/CUESHEET ride through `structural`; on the rescanned path `structural` holds only STREAMINFO/SEEKTABLE and `binary_tag_inputs` carries APPLICATION/CUESHEET.
+
+- [ ] **Step 7: Build and test the workspace**
+
+Run: `cargo build --workspace --all-targets`
+Expected: clean build (every FLAC resolve currently uses the legacy fallback — correct).
+Run: `cargo test -p musefs-core`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-format/src/flac.rs musefs-format/tests/synthesize_tags.rs \
+        musefs-format/tests/synthesize_art.rs musefs-format/tests/roundtrip.rs \
+        musefs-format/tests/proptest_flac.rs musefs-core/src/reader.rs
+git commit -m "feat(format,core): FLAC synthesis from structural store + streamed binary tags
+
+flac::synthesize_layout drops FlacScan for structural blocks + audio bounds +
+streamed APPLICATION/CUESHEET; reader loads structural_blocks from the DB with a
+legacy front-read fallback when absent.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Scan persists FLAC structural blocks + binary tags
+
+Make scan split FLAC's preserved blocks into the structural store and binary tags, so rescanned tracks use the fast (zero-front-read) resolve path. Add `Probed.structural_blocks`, populate it (and `binary_tags`) in both FLAC probe arms via `split_preserved`, and persist structural blocks in `ingest`/`ingest_bulk`.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` — `Probed` struct (`:83-92`); FLAC arms in `probe_full` (`:99-110`) and `probe_prefix` (`:266-273`); all other `Probed { … }` literals; `ingest` (`:374-437`) and `ingest_bulk` (`:439-504`); plus the two test-helper `Probed` literals
+- Test: `musefs-core/tests/flac_binary_tags.rs` (new)
+
+- [ ] **Step 1: Write the failing test (scan → DB persistence)**
+
+Create `musefs-core/tests/flac_binary_tags.rs`:
+
+```rust
+mod common;
+use common::{make_flac, streaminfo_body, vorbis_comment_body};
+use musefs_core::scan_directory;
+
+// Block types: STREAMINFO=0, APPLICATION=2, SEEKTABLE=3, VORBIS_COMMENT=4, CUESHEET=5.
+fn fixture() -> Vec<u8> {
+    let blocks = vec![
+        (0u8, streaminfo_body()),
+        (2u8, b"testAPPLICATION-PAYLOAD".to_vec()),
+        (3u8, vec![0xEE; 36]), // SEEKTABLE
+        (4u8, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
+        (5u8, vec![0x11; 48]), // CUESHEET
+    ];
+    make_flac(&blocks, &vec![0xCD; 4096])
+}
+
+#[test]
+fn scan_splits_flac_into_structural_store_and_binary_tags() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.flac"), fixture()).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+
+    // Exactly one track; fetch its id via the structural query over both tracks.
+    let track_id = 1i64; // first upserted track
+
+    let structural = db.get_structural_blocks(track_id).unwrap();
+    let kinds: Vec<&str> = structural.iter().map(|b| b.kind.as_str()).collect();
+    assert!(kinds.contains(&"STREAMINFO"));
+    assert!(kinds.contains(&"SEEKTABLE"));
+    assert_eq!(structural.len(), 2);
+
+    let binary = db.get_binary_tags(track_id).unwrap();
+    let bkeys: Vec<&str> = binary.iter().map(|b| b.key.as_str()).collect();
+    assert!(bkeys.contains(&"APPLICATION"));
+    assert!(bkeys.contains(&"CUESHEET"));
+    assert_eq!(binary.len(), 2);
+}
+```
+
+`musefs-core/tests/common/mod.rs` already exports `make_flac(blocks: &[(u8, Vec<u8>)], audio: &[u8])`, `streaminfo_body`, and `vorbis_comment_body` (used by `metrics.rs`) — the same helpers as the format-layer `common`. Use them directly as written above. `get_binary_tags` returns `Vec<BinaryTagRow>` whose field is `key` (`musefs-db/src/tags.rs:123`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-core --test flac_binary_tags scan_splits_flac_into_structural_store_and_binary_tags`
+Expected: FAIL — `get_structural_blocks` returns empty / `binary` empty (scan does not yet populate them). If the test does not compile due to a missing `common` helper, fix the helper wiring first (Step 1 note) until it compiles and then fails on the assertions.
+
+- [ ] **Step 3: Add `structural_blocks` to `Probed`**
+
+In `musefs-core/src/scan.rs`, change the `Probed` struct (`:83-92`) to add a field:
+
+```rust
+pub(crate) struct Probed {
+    format: Format,
+    audio_offset: u64,
+    audio_length: u64,
+    tags: Vec<(String, String)>,
+    pictures: Vec<EmbeddedPicture>,
+    binary_tags: Vec<EmbeddedBinaryTag>,
+    /// FLAC STREAMINFO/SEEKTABLE as (kind, body) pairs; empty for other formats.
+    structural_blocks: Vec<(String, Vec<u8>)>,
+}
+```
+
+- [ ] **Step 4: Populate the FLAC probe arms; add the field to every other literal**
+
+`probe_full` FLAC arm (`:99-110`):
+```rust
+    if has_ext(path, "flac") {
+        let scan = flac::locate_audio(bytes).ok()?;
+        let (structural_blocks, binary_tags) = flac::split_preserved(&scan.preserved);
+        Some(Probed {
+            format: Format::Flac,
+            audio_offset: scan.audio_offset,
+            audio_length: scan.audio_length,
+            tags: flac::read_vorbis_comments(bytes).unwrap_or_default(),
+            pictures: flac::read_pictures(bytes).unwrap_or_default(),
+            binary_tags,
+            structural_blocks,
+        })
+    } else if has_ext(path, "mp3") {
+```
+
+`probe_prefix` FLAC arm (`:266-273`):
+```rust
+            Ok(Extent::Complete(meta)) => {
+                let (structural_blocks, binary_tags) = flac::split_preserved(&meta.preserved);
+                Probe::Done(Probed {
+                    format: Format::Flac,
+                    audio_offset: meta.audio_offset,
+                    audio_length: file_len - meta.audio_offset,
+                    tags: flac::read_vorbis_comments(prefix).unwrap_or_default(),
+                    pictures: flac::read_pictures(prefix).unwrap_or_default(),
+                    binary_tags,
+                    structural_blocks,
+                })
+            }
+```
+
+Add `structural_blocks: Vec::new(),` to **every other** `Probed { … }` literal (non-FLAC formats never have structural blocks):
+- `probe_full`: mp3 (`:113`), m4a (`:123`), ogg (`:138`), wav (`:151`)
+- `probe_file`: m4a (`:216`)
+- `probe_prefix`: mp3 (`:283`), ogg (`:303`), wav (`:321`)
+- test helpers: `:903`, `:914`, `:1387` (the `probed_with_mixed_binary_tags` helper)
+
+- [ ] **Step 5: Persist structural blocks in `ingest` and `ingest_bulk`**
+
+In `ingest` (`musefs-core/src/scan.rs:374-437`), after the `db.set_binary_tags(track_id, &binary_tags)?;` line, add:
+
+```rust
+    let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
+    let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
+        .structural_blocks
+        .into_iter()
+        .map(|(kind, body)| {
+            let ord = sb_ordinals.entry(kind.clone()).or_insert(0);
+            let sb = musefs_db::StructuralBlock {
+                kind,
+                ordinal: *ord,
+                body,
+            };
+            *ord += 1;
+            sb
+        })
+        .collect();
+    db.set_structural_blocks(track_id, &structural_blocks)?;
+```
+
+In `ingest_bulk` (`musefs-core/src/scan.rs:439-504`, which takes `probed: &Probed`), after `bw.set_binary_tags(track_id, &binary_tags)?;` add the by-reference form:
+
+```rust
+    let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
+    let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
+        .structural_blocks
+        .iter()
+        .map(|(kind, body)| {
+            let ord = sb_ordinals.entry(kind.clone()).or_insert(0);
+            let sb = musefs_db::StructuralBlock {
+                kind: kind.clone(),
+                ordinal: *ord,
+                body: body.clone(),
+            };
+            *ord += 1;
+            sb
+        })
+        .collect();
+    bw.set_structural_blocks(track_id, &structural_blocks)?;
+```
+
+`HashMap` is already imported at `musefs-core/src/scan.rs:1`. `musefs_db::StructuralBlock` is referenced fully-qualified (matching the existing `musefs_db::BinaryTag` style); no import change needed.
+
+- [ ] **Step 6: Run the persistence test**
+
+Run: `cargo test -p musefs-core --test flac_binary_tags scan_splits_flac_into_structural_store_and_binary_tags`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full core + scan suites**
+
+Run: `cargo test -p musefs-core`
+Expected: PASS (the `probe_full` vs bounded equivalence test still holds — both paths feed `split_preserved` the same `preserved` blocks).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/tests/flac_binary_tags.rs musefs-core/tests/common
+git commit -m "feat(core): scan persists FLAC structural blocks + APPLICATION/CUESHEET binary tags
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: End-to-end serve, legacy fallback, and zero-front-read tests
+
+Lock the full chain: a rescanned FLAC serves a valid file with binary tags streamed and zero backing-file reads at resolve; a legacy track (no structural rows) serves correctly via the front-read fallback.
+
+**Files:**
+- Modify: `musefs-core/tests/flac_binary_tags.rs` (add serve + legacy tests)
+- Modify: `musefs-core/tests/metrics.rs` (add zero-front-read test)
+
+- [ ] **Step 1: Write the end-to-end serve test**
+
+Append to `musefs-core/tests/flac_binary_tags.rs`:
+
+```rust
+use musefs_core::{MountConfig, Musefs, VirtualTree};
+use std::collections::BTreeMap;
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: musefs_core::Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+    }
+}
+
+fn read_whole(fs: &Musefs, inode: u64) -> Vec<u8> {
+    let size = fs.getattr(inode).unwrap().size;
+    let fh = fs.open_handle(inode).unwrap();
+    let mut out = Vec::new();
+    let mut off = 0u64;
+    while off < size {
+        let got = fs.read(inode, fh, off, 64 * 1024).unwrap();
+        if got.is_empty() {
+            break;
+        }
+        off += got.len() as u64;
+        out.extend_from_slice(&got);
+    }
+    fs.release_handle(fh);
+    out
+}
+
+#[test]
+fn rescanned_flac_serves_valid_file_with_binary_tags() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.flac"), fixture()).unwrap();
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let served = read_whole(&fs, inode);
+
+    // Valid FLAC framing, and the APPLICATION block survived the round trip.
+    let tag = metaflac::Tag::read_from(&mut std::io::Cursor::new(&served)).expect("valid FLAC");
+    let (id, data) = tag
+        .blocks()
+        .find_map(|b| match b {
+            metaflac::Block::Application(a) => Some((a.id, a.data.clone())),
+            _ => None,
+        })
+        .expect("application block present");
+    assert_eq!(&id, b"test");
+    assert_eq!(data, b"APPLICATION-PAYLOAD");
+}
+```
+
+`metaflac` is already in `musefs-core`'s `[dev-dependencies]` (`musefs-core/Cargo.toml:25`). `MountConfig`/`Musefs::read(inode, fh, offset, size)`/`open_handle`/`release_handle`/`getattr(...).size`/`lookup` are used exactly as in `musefs-core/tests/metrics.rs` (the canonical usage) and `facade.rs`.
+
+- [ ] **Step 2: Write the legacy-fallback serve test**
+
+Append:
+
+```rust
+use musefs_db::{Format, NewTrack, Tag};
+
+#[test]
+fn legacy_flac_without_structural_rows_serves_via_front_read_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let bytes = fixture();
+    let path = dir.path().join("legacy.flac");
+    std::fs::write(&path, &bytes).unwrap();
+    let meta = std::fs::metadata(&path).unwrap();
+
+    // Simulate a V1-scanned track: a track row + text tags, but NO structural_blocks
+    // and NO binary value_blob rows. Resolve must fall back to the front re-read.
+    let scan = musefs_format::flac::locate_audio(&bytes).unwrap();
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().into_owned(),
+            format: Format::Flac,
+            audio_offset: scan.audio_offset as i64,
+            audio_length: scan.audio_length as i64,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    // Lowercase keys are intentional: synthesis regenerates VORBIS_COMMENT from
+    // these DB tags, not from the file's embedded `ARTIST=...` block (VORBIS_COMMENT
+    // is type 4 and never enters the preserved/structural set). Not a casing bug.
+    db.replace_tags(
+        id,
+        &[Tag::new("artist", "Alice", 0), Tag::new("title", "Song", 0)],
+    )
+    .unwrap();
+    assert!(db.get_structural_blocks(id).unwrap().is_empty());
+
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let served = read_whole(&fs, inode);
+
+    // The legacy path carries every preserved block inline, including APPLICATION.
+    let tag = metaflac::Tag::read_from(&mut std::io::Cursor::new(&served)).expect("valid FLAC");
+    assert!(tag
+        .blocks()
+        .any(|b| matches!(b, metaflac::Block::Application(_))));
+}
+```
+
+Confirm `backing_mtime` matches what scan stores (`mtime_secs` in `scan.rs` computes seconds since the epoch); if the reader's backing-validation compares against a different unit, mirror `scan::mtime_secs` exactly to avoid a spurious `BackingChanged`.
+
+- [ ] **Step 3: Run the serve + legacy tests**
+
+Run: `cargo test -p musefs-core --test flac_binary_tags`
+Expected: PASS (all four tests).
+
+- [ ] **Step 4: Add the zero-front-read metrics test**
+
+Append to `musefs-core/tests/metrics.rs` (already `#![cfg(feature = "metrics")]`; reuse `METRICS_LOCK`, `config`, and the `common` helpers):
+
+```rust
+#[test]
+fn rescanned_flac_resolve_does_no_front_read() {
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let dir = tempfile::tempdir().unwrap();
+    let flac = make_flac(
+        &[
+            (0, streaminfo_body()),
+            (2, b"testAPPDATA".to_vec()), // APPLICATION -> stored as a binary tag
+            (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
+        ],
+        &vec![0xCD_u8; 64 * 1024],
+    );
+    std::fs::write(dir.path().join("a.flac"), &flac).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+
+    // Cold cache: this open_handle forces a resolve. For a rescanned FLAC the
+    // structural store supplies STREAMINFO/SEEKTABLE, so the only open() is the
+    // handle's read fd — NOT a synthesis front re-read (which would make it 2).
+    metrics::reset();
+    let fh = fs.open_handle(inode).unwrap();
+    let s = metrics::snapshot();
+    fs.release_handle(fh);
+    assert_eq!(
+        s.opens, 1,
+        "rescanned FLAC resolve must not re-read the backing front"
+    );
+}
+```
+
+The `common` import at `musefs-core/tests/metrics.rs:4` already brings in `make_flac` (it accepts a `(u8, Vec<u8>)` block list — `baseline_one_open_per_read_call` uses it), `streaminfo_body`, `vorbis_comment_body`. `open_handle` opens the read fd eagerly (`facade.rs:698`: `cache.resolve(...)` then `metrics::on_open()` + `File::open`), so a rescanned FLAC yields exactly 1 open (the fd) and a legacy track would yield 2 (front read + fd). The `s.opens == 1` assertion is correct as written.
+
+- [ ] **Step 5: Run the metrics test**
+
+Run: `cargo test -p musefs-core --features metrics --test metrics rescanned_flac_resolve_does_no_front_read`
+Expected: PASS.
+
+- [ ] **Step 6: Full workspace verification**
+
+Run: `cargo test --workspace`
+Run: `cargo test -p musefs-format --features fuzzing`
+Run: `cargo clippy --all-targets`
+Run: `cargo fmt --all --check`
+Expected: all green / no diff.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/tests/flac_binary_tags.rs musefs-core/tests/metrics.rs
+git commit -m "test(core): FLAC binary-tag serve, legacy front-read fallback, zero-front-read resolve
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (verification against the spec §3–§7, Phase 4)
+
+**Spec coverage:**
+- §5 FLAC parse split (STREAMINFO/SEEKTABLE → structural; APPLICATION/CUESHEET → binary) → Task 2 (`split_preserved`) + Task 4 (scan persistence).
+- §5 `synthesize_layout` signature change (FlacScan → structural blocks + binary inputs) + fixed canonical order + is-last rule → Task 3.
+- §5 APPLICATION/CUESHEET bounded by the 24-bit FLAC block guard → Task 3 (`bt.len > 0x00FF_FFFF`), tested by `binary_tag_over_24bit_limit_errors`.
+- §1 migration backfill + front-read fallback when `structural_blocks` empty → Task 3 reader arm; tested by `legacy_flac_without_structural_rows_serves_via_front_read_fallback`. Backfill on rescan: a plain `scan` re-ingests every file (upsert), populating both stores; tested implicitly by the persistence + serve tests.
+- §7 FLAC resolve re-read elimination (zero front reads for rescanned tracks) → Task 3 + Task 4; tested by `rescanned_flac_resolve_does_no_front_read`.
+- §7 deletion/refactor fallout: `Format::Flac` arm stops unconditionally constructing a `FlacScan` from `read_front` (Task 3); `read_front` retained (still called by the legacy fallback + WAV/Ogg); `synthesize_layout` caller/test fallout enumerated (Task 3, Step 4).
+- §Testing FLAC round-trip locking APPLICATION/CUESHEET + structural store → Task 3 (format round-trip) + Task 5 (serve). Block-reorder-tolerant assertions (payload fidelity, `locate_audio` framing), not byte-identical ordering.
+- §Error handling: no new `CoreError`/`FormatError` variant; reuses `TooLarge`/`InvalidLayout` + the art short-read error. The FUSE `errno()` match is untouched. ✔
+
+**Out of scope (correctly omitted):** Ogg (no binary gap), any payload interpretation, `.cue` ingestion, `facade.rs` open-handle guard (closed in Phase 2, already covers `has_binary_tag`).
+
+**Type/signature consistency:** `synthesize_layout(structural: &[MetadataBlock], audio_offset: u64, audio_length: u64, tags: &[TagInput], binary_tags: &[BinaryTagInput], arts: &[ArtInput])` — used identically in the reader arm, all four test files, and the in-file boundary test. `split_preserved(&[MetadataBlock]) -> (Vec<(String, Vec<u8>)>, Vec<EmbeddedBinaryTag>)` and `structural_block_type(&str) -> Option<u8>` match their call sites in scan + reader. `Probed.structural_blocks: Vec<(String, Vec<u8>)>` matches the `ingest`/`ingest_bulk` consumers.
+
+**Assumptions to verify during execution (the plan flags each inline):** the core `tests/common` `make_flac` block-list helper and `metaflac` dev-dep availability for `musefs-core`; exact `Musefs::read`/`open_handle` argument order and open-accounting (mirror `metrics.rs`); `BinaryTagRow.key` field name; `backing_mtime` unit parity with `scan::mtime_secs`.

--- a/fuzz/fuzz_targets/flac.rs
+++ b/fuzz/fuzz_targets/flac.rs
@@ -16,7 +16,14 @@ fuzz_target!(|data: &[u8]| {
     let mut u = Unstructured::new(data);
     let tags = arb_tags(&mut u).unwrap_or_default();
     let arts = arb_arts(&mut u).unwrap_or_default();
-    if let Ok(layout) = flac::synthesize_layout(&scan, &tags, &arts) {
+    if let Ok(layout) = flac::synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &tags,
+        &[],
+        &arts,
+    ) {
         assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
     }
 });

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use musefs_db::{Db, Format};
-use musefs_format::flac::{self, FlacScan};
+use musefs_format::flac::{self, MetadataBlock};
 use musefs_format::{mp3, mp4, wav, RegionLayout, Segment};
 
 use crate::error::{CoreError, Result};
@@ -260,15 +260,35 @@ impl HeaderCache {
                 // Xing/LAME info frame travels with the backing audio.
                 let layout = match track.format {
                     Format::Flac => {
-                        let front =
-                            read_front(Path::new(&track.backing_path), track.audio_offset as u64)?;
-                        let fmeta = flac::read_metadata(&front)?;
-                        let scan = FlacScan {
-                            audio_offset: track.audio_offset as u64,
-                            audio_length: track.audio_length as u64,
-                            preserved: fmeta.preserved,
+                        let structural: Vec<MetadataBlock> = {
+                            let rows = db.get_structural_blocks(track.id)?;
+                            if rows.is_empty() {
+                                let front = read_front(
+                                    Path::new(&track.backing_path),
+                                    track.audio_offset as u64,
+                                )?;
+                                flac::read_metadata(&front)?.preserved
+                            } else {
+                                rows.into_iter()
+                                    .filter_map(|b| {
+                                        flac::structural_block_type(&b.kind).map(|block_type| {
+                                            MetadataBlock {
+                                                block_type,
+                                                body: b.body,
+                                            }
+                                        })
+                                    })
+                                    .collect()
+                            }
                         };
-                        flac::synthesize_layout(&scan, &inputs, &art_inputs)?
+                        flac::synthesize_layout(
+                            &structural,
+                            track.audio_offset as u64,
+                            track.audio_length as u64,
+                            &inputs,
+                            &binary_tag_inputs,
+                            &art_inputs,
+                        )?
                     }
                     Format::Mp3 => mp3::synthesize_layout(
                         track.audio_offset as u64,

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 
 use musefs_db::{Db, Format};
 use musefs_format::flac::{self, MetadataBlock};
-use musefs_format::{mp3, mp4, wav, RegionLayout, Segment};
+use musefs_format::{mp3, mp4, wav, BinaryTagInput, RegionLayout, Segment};
 
 use crate::error::{CoreError, Result};
 use crate::facade::Mode;
@@ -260,16 +260,23 @@ impl HeaderCache {
                 // Xing/LAME info frame travels with the backing audio.
                 let layout = match track.format {
                     Format::Flac => {
-                        let structural: Vec<MetadataBlock> = {
-                            let rows = db.get_structural_blocks(track.id)?;
+                        let rows = db.get_structural_blocks(track.id)?;
+                        // Fast path: the structural store holds STREAMINFO/SEEKTABLE and
+                        // APPLICATION/CUESHEET stream from value_blob rows. Legacy
+                        // fallback (no structural rows yet): carry every preserved block
+                        // — including APPLICATION/CUESHEET — inline from the front
+                        // re-read, and suppress the streamed binary tags so those blocks
+                        // are not emitted twice.
+                        let (structural, binary_tags): (Vec<MetadataBlock>, &[BinaryTagInput]) =
                             if rows.is_empty() {
                                 let front = read_front(
                                     Path::new(&track.backing_path),
                                     track.audio_offset as u64,
                                 )?;
-                                flac::read_metadata(&front)?.preserved
+                                (flac::read_metadata(&front)?.preserved, &[])
                             } else {
-                                rows.into_iter()
+                                let structural = rows
+                                    .into_iter()
                                     .filter_map(|b| {
                                         flac::structural_block_type(&b.kind).map(|block_type| {
                                             MetadataBlock {
@@ -278,15 +285,15 @@ impl HeaderCache {
                                             }
                                         })
                                     })
-                                    .collect()
-                            }
-                        };
+                                    .collect();
+                                (structural, &binary_tag_inputs)
+                            };
                         flac::synthesize_layout(
                             &structural,
                             track.audio_offset as u64,
                             track.audio_length as u64,
                             &inputs,
-                            &binary_tag_inputs,
+                            binary_tags,
                             &art_inputs,
                         )?
                     }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -90,6 +90,8 @@ pub(crate) struct Probed {
     tags: Vec<(String, String)>,
     pictures: Vec<EmbeddedPicture>,
     binary_tags: Vec<EmbeddedBinaryTag>,
+    /// FLAC STREAMINFO/SEEKTABLE as (kind, body) pairs; empty for other formats.
+    structural_blocks: Vec<(String, Vec<u8>)>,
 }
 
 /// Full-buffer probe (legacy path). Retained as the reference implementation the
@@ -97,13 +99,15 @@ pub(crate) struct Probed {
 pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
     if has_ext(path, "flac") {
         let scan = flac::locate_audio(bytes).ok()?;
+        let (structural_blocks, binary_tags) = flac::split_preserved(&scan.preserved);
         Some(Probed {
             format: Format::Flac,
             audio_offset: scan.audio_offset,
             audio_length: scan.audio_length,
             tags: flac::read_vorbis_comments(bytes).unwrap_or_default(),
             pictures: flac::read_pictures(bytes).unwrap_or_default(),
-            binary_tags: Vec::new(),
+            binary_tags,
+            structural_blocks,
         })
     } else if has_ext(path, "mp3") {
         let bounds = mp3::locate_audio(bytes).ok()?;
@@ -117,6 +121,7 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             tags,
             pictures: mp3::read_pictures(bytes),
             binary_tags,
+            structural_blocks: Vec::new(),
         })
     } else if has_ext(path, "m4a") || has_ext(path, "m4b") {
         let bounds = mp4::locate_audio(bytes).ok()?;
@@ -127,6 +132,7 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             tags: mp4::read_tags(bytes),
             pictures: mp4::read_pictures(bytes),
             binary_tags: mp4::read_binary_tags(bytes),
+            structural_blocks: Vec::new(),
         })
     } else if has_ext(path, "ogg") || has_ext(path, "oga") || has_ext(path, "opus") {
         let scan = ogg::locate_audio(bytes).ok()?;
@@ -142,6 +148,7 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             tags: ogg::read_tags(bytes).unwrap_or_default(),
             pictures: ogg::read_pictures(bytes).unwrap_or_default(),
             binary_tags: Vec::new(),
+            structural_blocks: Vec::new(),
         })
     } else if has_ext(path, "wav") {
         let bounds = wav::locate_audio(bytes).ok()?;
@@ -155,6 +162,7 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
             tags,
             pictures: wav::read_pictures(bytes),
             binary_tags,
+            structural_blocks: Vec::new(),
         })
     } else {
         None
@@ -220,6 +228,7 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
             tags: mp4::read_tags(&scan.moov),
             pictures: mp4::read_pictures(&scan.moov),
             binary_tags: mp4::read_binary_tags(&scan.moov),
+            structural_blocks: Vec::new(),
         }));
     }
 
@@ -263,14 +272,18 @@ enum Probe {
 fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 128]>) -> Probe {
     if has_ext(path, "flac") {
         match flac::read_metadata_bounded(prefix) {
-            Ok(Extent::Complete(meta)) => Probe::Done(Probed {
-                format: Format::Flac,
-                audio_offset: meta.audio_offset,
-                audio_length: file_len - meta.audio_offset,
-                tags: flac::read_vorbis_comments(prefix).unwrap_or_default(),
-                pictures: flac::read_pictures(prefix).unwrap_or_default(),
-                binary_tags: Vec::new(),
-            }),
+            Ok(Extent::Complete(meta)) => {
+                let (structural_blocks, binary_tags) = flac::split_preserved(&meta.preserved);
+                Probe::Done(Probed {
+                    format: Format::Flac,
+                    audio_offset: meta.audio_offset,
+                    audio_length: file_len - meta.audio_offset,
+                    tags: flac::read_vorbis_comments(prefix).unwrap_or_default(),
+                    pictures: flac::read_pictures(prefix).unwrap_or_default(),
+                    binary_tags,
+                    structural_blocks,
+                })
+            }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
             Err(_) => Probe::Skip,
         }
@@ -287,6 +300,7 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
                     tags,
                     pictures: mp3::read_pictures(prefix),
                     binary_tags,
+                    structural_blocks: Vec::new(),
                 })
             }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
@@ -307,6 +321,7 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
                     tags: ogg::read_tags(prefix).unwrap_or_default(),
                     pictures: ogg::read_pictures(prefix).unwrap_or_default(),
                     binary_tags: Vec::new(),
+                    structural_blocks: Vec::new(),
                 })
             }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
@@ -325,6 +340,7 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
                     tags,
                     pictures: wav::read_pictures(prefix),
                     binary_tags,
+                    structural_blocks: Vec::new(),
                 })
             }
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
@@ -406,6 +422,23 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
         .collect();
     db.set_binary_tags(track_id, &binary_tags)?;
 
+    let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
+    let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
+        .structural_blocks
+        .into_iter()
+        .map(|(kind, body)| {
+            let ord = sb_ordinals.entry(kind.clone()).or_insert(0);
+            let sb = musefs_db::StructuralBlock {
+                kind,
+                ordinal: *ord,
+                body,
+            };
+            *ord += 1;
+            sb
+        })
+        .collect();
+    db.set_structural_blocks(track_id, &structural_blocks)?;
+
     let mut track_arts = Vec::new();
     // Filter before enumerating so skipped (oversized) art doesn't leave gaps
     // in the stored ordinals.
@@ -475,6 +508,23 @@ fn ingest_bulk(
         })
         .collect();
     bw.set_binary_tags(track_id, &binary_tags)?;
+
+    let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
+    let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
+        .structural_blocks
+        .iter()
+        .map(|(kind, body)| {
+            let ord = sb_ordinals.entry(kind.clone()).or_insert(0);
+            let sb = musefs_db::StructuralBlock {
+                kind: kind.clone(),
+                ordinal: *ord,
+                body: body.clone(),
+            };
+            *ord += 1;
+            sb
+        })
+        .collect();
+    bw.set_structural_blocks(track_id, &structural_blocks)?;
 
     let mut track_arts = Vec::new();
     let accepted = probed
@@ -907,6 +957,7 @@ mod scan_unit_tests {
             tags: Vec::new(),
             pictures: vec![pic(3), pic(5)],
             binary_tags: Vec::new(),
+            structural_blocks: Vec::new(),
         };
         assert_eq!(art_weight(&probed), 8);
 
@@ -918,6 +969,7 @@ mod scan_unit_tests {
             tags: Vec::new(),
             pictures: Vec::new(),
             binary_tags: Vec::new(),
+            structural_blocks: Vec::new(),
         };
         assert_eq!(art_weight(&empty), 0);
     }
@@ -1404,6 +1456,7 @@ mod hardening_tests {
                     payload: vec![0u8; MAX_BINARY_TAG_BYTES + 1],
                 },
             ],
+            structural_blocks: Vec::new(),
         }
     }
 

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -384,8 +384,19 @@ struct Unit {
     weight: u64,
 }
 
-fn art_weight(p: &Probed) -> u64 {
-    p.pictures.iter().map(|pic| pic.data.len() as u64).sum()
+/// In-memory byte weight of a `Probed`, used for batch backpressure
+/// (`MUSEFS_BATCH_BYTES`). Counts every buffered payload — pictures plus FLAC
+/// structural blocks and binary tags — so large preserved blocks can't slip the
+/// budget the way picture-only accounting did.
+fn payload_weight(p: &Probed) -> u64 {
+    let pictures: u64 = p.pictures.iter().map(|pic| pic.data.len() as u64).sum();
+    let binary: u64 = p.binary_tags.iter().map(|t| t.payload.len() as u64).sum();
+    let structural: u64 = p
+        .structural_blocks
+        .iter()
+        .map(|(_, body)| body.len() as u64)
+        .sum();
+    pictures + binary + structural
 }
 
 /// Upsert a track from a probed backing file: write the track row, replace its
@@ -619,7 +630,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                         failed.fetch_add(1, Ordering::Relaxed);
                         continue;
                     };
-                    let weight = art_weight(&probed);
+                    let weight = payload_weight(&probed);
                     budget.acquire(weight); // backpressure on in-flight art bytes
                     let unit = Unit {
                         abs_path: abs.to_string_lossy().into_owned(),
@@ -937,11 +948,11 @@ mod scan_unit_tests {
         std::env::remove_var("MUSEFS_BATCH_BYTES");
     }
 
-    // --- art_weight() (lines 340-342) ---
+    // --- payload_weight() ---
 
-    // kills scan L341 art_weight body→0/→1 (sum of picture data lengths)
+    // Sums picture + binary-tag + structural-block byte lengths (batch backpressure).
     #[test]
-    fn art_weight_sums_picture_byte_lengths() {
+    fn payload_weight_sums_all_buffered_payloads() {
         let pic = |n: usize| EmbeddedPicture {
             mime: "image/png".to_string(),
             picture_type: 3,
@@ -956,10 +967,14 @@ mod scan_unit_tests {
             audio_length: 0,
             tags: Vec::new(),
             pictures: vec![pic(3), pic(5)],
-            binary_tags: Vec::new(),
-            structural_blocks: Vec::new(),
+            binary_tags: vec![EmbeddedBinaryTag {
+                key: "APPLICATION".into(),
+                payload: vec![0u8; 4],
+            }],
+            structural_blocks: vec![("SEEKTABLE".into(), vec![0u8; 2])],
         };
-        assert_eq!(art_weight(&probed), 8);
+        // 3 + 5 (pictures) + 4 (binary) + 2 (structural) = 14.
+        assert_eq!(payload_weight(&probed), 14);
 
         // Empty → 0, distinguishes the →1 constant (which ignores the input).
         let empty = Probed {
@@ -971,7 +986,7 @@ mod scan_unit_tests {
             binary_tags: Vec::new(),
             structural_blocks: Vec::new(),
         };
-        assert_eq!(art_weight(&empty), 0);
+        assert_eq!(payload_weight(&empty), 0);
     }
 
     /// Minimal-but-valid m4a that `mp4::locate_audio` accepts (one `soun` trak),

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1505,6 +1505,77 @@ mod hardening_tests {
         assert_eq!(rows[0].key, "PRIV");
         assert_eq!(rows[0].byte_len, 3);
     }
+
+    /// Probed with two structural blocks of the SAME kind, to make the per-kind
+    /// ordinal increment (`*ord += 1`) observable. A real FLAC carries only one
+    /// STREAMINFO/SEEKTABLE, so a duplicate kind is the only input under which the
+    /// second block's ordinal differs from the first; without it the increment's
+    /// mutants survive.
+    fn probed_with_duplicate_structural_kind() -> Probed {
+        Probed {
+            format: musefs_db::Format::Flac,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: Vec::new(),
+            pictures: Vec::new(),
+            binary_tags: Vec::new(),
+            structural_blocks: vec![
+                ("SEEKTABLE".to_string(), vec![0xA1]),
+                ("SEEKTABLE".to_string(), vec![0xB2]),
+            ],
+        }
+    }
+
+    #[test]
+    fn ingest_assigns_sequential_structural_ordinals_per_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.flac");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let db = Db::open_in_memory().unwrap();
+
+        ingest(
+            &db,
+            &path.to_string_lossy(),
+            &meta,
+            probed_with_duplicate_structural_kind(),
+        )
+        .unwrap();
+
+        let tid = db.list_tracks().unwrap()[0].id;
+        let got = db.get_structural_blocks(tid).unwrap();
+        // Rows come back ORDER BY kind, ordinal: the two same-kind blocks must hold
+        // ordinals 0 then 1 (the `-=`/`*=` mutants collapse or invert this).
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].ordinal, 0);
+        assert_eq!(got[0].body, vec![0xA1]);
+        assert_eq!(got[1].ordinal, 1);
+        assert_eq!(got[1].body, vec![0xB2]);
+    }
+
+    #[test]
+    fn ingest_bulk_assigns_sequential_structural_ordinals_per_kind() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            ingest_bulk(
+                &mut bw,
+                "/a.flac",
+                1,
+                0,
+                &probed_with_duplicate_structural_kind(),
+            )
+            .unwrap();
+            bw.commit().unwrap();
+        }
+        let tid = db.list_tracks().unwrap()[0].id;
+        let got = db.get_structural_blocks(tid).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].ordinal, 0);
+        assert_eq!(got[0].body, vec![0xA1]);
+        assert_eq!(got[1].ordinal, 1);
+        assert_eq!(got[1].body, vec![0xB2]);
+    }
 }
 
 #[cfg(test)]

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -1,6 +1,7 @@
 mod common;
 use common::{make_flac, streaminfo_body, vorbis_comment_body};
-use musefs_core::scan_directory;
+use musefs_core::{scan_directory, MountConfig, Musefs, VirtualTree};
+use std::collections::BTreeMap;
 
 // Block types: STREAMINFO=0, APPLICATION=2, SEEKTABLE=3, VORBIS_COMMENT=4, CUESHEET=5.
 fn fixture() -> Vec<u8> {
@@ -39,4 +40,118 @@ fn scan_splits_flac_into_structural_store_and_binary_tags() {
     assert!(bkeys.contains(&"APPLICATION"));
     assert!(bkeys.contains(&"CUESHEET"));
     assert_eq!(binary.len(), 2);
+}
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: musefs_core::Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+    }
+}
+
+fn read_whole(fs: &Musefs, inode: u64) -> Vec<u8> {
+    let size = fs.getattr(inode).unwrap().size;
+    let fh = fs.open_handle(inode).unwrap();
+    let mut out = Vec::new();
+    let mut off = 0u64;
+    while off < size {
+        let got = fs.read(inode, fh, off, 64 * 1024).unwrap();
+        if got.is_empty() {
+            break;
+        }
+        off += got.len() as u64;
+        out.extend_from_slice(&got);
+    }
+    fs.release_handle(fh);
+    out
+}
+
+// Fixture without CUESHEET (whose dummy body is too short for metaflac to parse).
+fn serve_fixture() -> Vec<u8> {
+    let blocks = vec![
+        (0u8, streaminfo_body()),
+        (2u8, b"testAPPLICATION-PAYLOAD".to_vec()),
+        (3u8, vec![0xEE; 36]), // SEEKTABLE
+        (
+            4u8,
+            vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"]),
+        ),
+    ];
+    make_flac(&blocks, &vec![0xCD; 4096])
+}
+
+#[test]
+fn rescanned_flac_serves_valid_file_with_binary_tags() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.flac"), serve_fixture()).unwrap();
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let served = read_whole(&fs, inode);
+
+    // Valid FLAC framing, and the APPLICATION block survived the round trip.
+    let tag = metaflac::Tag::read_from(&mut std::io::Cursor::new(&served)).expect("valid FLAC");
+    let (id, data) = tag
+        .blocks()
+        .find_map(|b| match b {
+            metaflac::Block::Application(a) => Some((a.id.clone(), a.data.clone())),
+            _ => None,
+        })
+        .expect("application block present");
+    assert_eq!(&id, b"test");
+    assert_eq!(data, b"APPLICATION-PAYLOAD");
+}
+
+use musefs_db::{Format, NewTrack, Tag};
+
+#[test]
+fn legacy_flac_without_structural_rows_serves_via_front_read_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let bytes = serve_fixture();
+    let path = dir.path().join("legacy.flac");
+    std::fs::write(&path, &bytes).unwrap();
+    let meta = std::fs::metadata(&path).unwrap();
+
+    // Simulate a V1-scanned track: a track row + text tags, but NO structural_blocks
+    // and NO binary value_blob rows. Resolve must fall back to the front re-read.
+    let scan = musefs_format::flac::locate_audio(&bytes).unwrap();
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: path.to_string_lossy().into_owned(),
+            format: Format::Flac,
+            audio_offset: scan.audio_offset as i64,
+            audio_length: scan.audio_length as i64,
+            backing_size: meta.len() as i64,
+            backing_mtime: meta
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+        })
+        .unwrap();
+    db.replace_tags(
+        id,
+        &[Tag::new("artist", "Alice", 0), Tag::new("title", "Song", 0)],
+    )
+    .unwrap();
+    assert!(db.get_structural_blocks(id).unwrap().is_empty());
+
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let served = read_whole(&fs, inode);
+
+    // The legacy path carries every preserved block inline, including APPLICATION.
+    let tag = metaflac::Tag::read_from(&mut std::io::Cursor::new(&served)).expect("valid FLAC");
+    assert!(tag
+        .blocks()
+        .any(|b| matches!(b, metaflac::Block::Application(_))));
 }

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -1,0 +1,42 @@
+mod common;
+use common::{make_flac, streaminfo_body, vorbis_comment_body};
+use musefs_core::scan_directory;
+
+// Block types: STREAMINFO=0, APPLICATION=2, SEEKTABLE=3, VORBIS_COMMENT=4, CUESHEET=5.
+fn fixture() -> Vec<u8> {
+    let blocks = vec![
+        (0u8, streaminfo_body()),
+        (2u8, b"testAPPLICATION-PAYLOAD".to_vec()),
+        (3u8, vec![0xEE; 36]), // SEEKTABLE
+        (
+            4u8,
+            vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"]),
+        ),
+        (5u8, vec![0x11; 48]), // CUESHEET
+    ];
+    make_flac(&blocks, &vec![0xCD; 4096])
+}
+
+#[test]
+fn scan_splits_flac_into_structural_store_and_binary_tags() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.flac"), fixture()).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+
+    // Exactly one track; fetch its id via the structural query over both tracks.
+    let track_id = 1i64; // first upserted track
+
+    let structural = db.get_structural_blocks(track_id).unwrap();
+    let kinds: Vec<&str> = structural.iter().map(|b| b.kind.as_str()).collect();
+    assert!(kinds.contains(&"STREAMINFO"));
+    assert!(kinds.contains(&"SEEKTABLE"));
+    assert_eq!(structural.len(), 2);
+
+    let binary = db.get_binary_tags(track_id).unwrap();
+    let bkeys: Vec<&str> = binary.iter().map(|b| b.key.as_str()).collect();
+    assert!(bkeys.contains(&"APPLICATION"));
+    assert!(bkeys.contains(&"CUESHEET"));
+    assert_eq!(binary.len(), 2);
+}

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -26,8 +26,8 @@ fn scan_splits_flac_into_structural_store_and_binary_tags() {
     let db = musefs_db::Db::open_in_memory().unwrap();
     scan_directory(&db, dir.path()).unwrap();
 
-    // Exactly one track; fetch its id via the structural query over both tracks.
-    let track_id = 1i64; // first upserted track
+    // Derive the id from DB state rather than assuming row-id ordering.
+    let track_id = db.list_tracks().unwrap()[0].id;
 
     let structural = db.get_structural_blocks(track_id).unwrap();
     let kinds: Vec<&str> = structural.iter().map(|b| b.kind.as_str()).collect();

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -207,3 +207,39 @@ fn layout_cache_survives_unrelated_refresh() {
         "warm cache: only the handle fd open, no re-synthesis open"
     );
 }
+
+#[test]
+fn rescanned_flac_resolve_does_no_front_read() {
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let dir = tempfile::tempdir().unwrap();
+    let flac = make_flac(
+        &[
+            (0, streaminfo_body()),
+            (2, b"testAPPDATA".to_vec()), // APPLICATION -> stored as a binary tag
+            (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
+        ],
+        &vec![0xCD_u8; 64 * 1024],
+    );
+    std::fs::write(dir.path().join("a.flac"), &flac).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+
+    // Cold cache: this open_handle forces a resolve. For a rescanned FLAC the
+    // structural store supplies STREAMINFO/SEEKTABLE, so the only open() is the
+    // handle's read fd — NOT a synthesis front re-read (which would make it 2).
+    metrics::reset();
+    let fh = fs.open_handle(inode).unwrap();
+    let s = metrics::snapshot();
+    fs.release_handle(fh);
+    assert_eq!(
+        s.opens, 1,
+        "rescanned FLAC resolve must not re-read the backing front"
+    );
+}

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -1,4 +1,4 @@
-use crate::models::{BinaryTag, NewArt, NewTrack, Tag, TrackArt};
+use crate::models::{BinaryTag, NewArt, NewTrack, StructuralBlock, Tag, TrackArt};
 use crate::{Db, Result};
 use rusqlite::{params, Transaction};
 use sha2::{Digest, Sha256};
@@ -90,6 +90,25 @@ impl BulkWriter<'_> {
         )?;
         for t in tags {
             stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
+        }
+        Ok(())
+    }
+
+    pub fn set_structural_blocks(
+        &mut self,
+        track_id: i64,
+        blocks: &[StructuralBlock],
+    ) -> Result<()> {
+        self.tx.execute(
+            "DELETE FROM structural_blocks WHERE track_id = ?1",
+            params![track_id],
+        )?;
+        let mut stmt = self.tx.prepare(
+            "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for b in blocks {
+            stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
         }
         Ok(())
     }
@@ -319,6 +338,48 @@ mod tests {
             db.get_tags(tid).unwrap(),
             vec![crate::Tag::new("artist", "A", 0)]
         );
+    }
+
+    #[test]
+    fn bulk_set_structural_blocks_round_trips() {
+        use crate::StructuralBlock;
+        let db = Db::open_in_memory().unwrap();
+        let id = {
+            let mut bw = db.bulk_writer().unwrap();
+            let id = bw
+                .upsert_track(&NewTrack {
+                    backing_path: "/a.flac".into(),
+                    format: Format::Flac,
+                    audio_offset: 0,
+                    audio_length: 1,
+                    backing_size: 1,
+                    backing_mtime: 0,
+                })
+                .unwrap();
+            bw.set_structural_blocks(
+                id,
+                &[
+                    StructuralBlock {
+                        kind: "STREAMINFO".into(),
+                        ordinal: 0,
+                        body: vec![1, 2],
+                    },
+                    StructuralBlock {
+                        kind: "SEEKTABLE".into(),
+                        ordinal: 0,
+                        body: vec![3],
+                    },
+                ],
+            )
+            .unwrap();
+            bw.commit().unwrap();
+            id
+        };
+        let got = db.get_structural_blocks(id).unwrap();
+        assert_eq!(got.len(), 2);
+        // get_structural_blocks orders by kind: SEEKTABLE before STREAMINFO.
+        assert_eq!(got[0].kind, "SEEKTABLE");
+        assert_eq!(got[1].body, vec![1, 2]);
     }
 
     #[test]

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -143,7 +143,7 @@ pub fn locate_audio(data: &[u8]) -> Result<FlacScan> {
     })
 }
 
-use crate::input::{ArtInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
 
 pub(crate) fn push_block_header(out: &mut Vec<u8>, block_type: u8, body_len: usize, is_last: bool) {
@@ -210,26 +210,36 @@ fn picture_body_framing(art: &ArtInput) -> Vec<u8> {
 }
 
 /// Build the ordered segment layout for a synthesized FLAC file:
-/// `fLaC` + preserved structural blocks + a regenerated VORBIS_COMMENT + PICTURE
-/// blocks (one `ArtImage` segment each) + the backing audio.
+/// `fLaC` + structural blocks (sorted by type) + a regenerated VORBIS_COMMENT +
+/// streamed APPLICATION/CUESHEET binary tags + PICTURE blocks (one `ArtImage`
+/// segment each) + the backing audio.  Structural blocks must be only
+/// STREAMINFO/SEEKTABLE; APPLICATION/CUESHEET ride through `binary_tags`.
 pub fn synthesize_layout(
-    scan: &FlacScan,
+    structural: &[MetadataBlock],
+    audio_offset: u64,
+    audio_length: u64,
     tags: &[TagInput],
+    binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<RegionLayout> {
-    // exclude zero-byte art: an empty PICTURE block is meaningless and would fail
-    // layout validation (EmptySegment), making the track unreadable.
+    let mut ordered: Vec<&MetadataBlock> = structural.iter().collect();
+    ordered.sort_by_key(|b| b.block_type);
+
+    let valid_binary: Vec<&BinaryTagInput> = binary_tags
+        .iter()
+        .filter(|bt| matches!(bt.key.as_str(), "APPLICATION" | "CUESHEET"))
+        .collect();
+
     let nonempty_art = arts.iter().filter(|a| a.data_len > 0).count();
-    let num_blocks = scan.preserved.len() + 1 + nonempty_art; // preserved + VORBIS_COMMENT + pictures
+    let num_blocks = ordered.len() + 1 + valid_binary.len() + nonempty_art;
     let last_index = num_blocks - 1;
 
     let mut segments: Vec<Segment> = Vec::new();
     let mut buf: Vec<u8> = Vec::new();
     buf.extend_from_slice(FLAC_MARKER);
-
     let mut idx = 0usize;
 
-    for blk in &scan.preserved {
+    for blk in &ordered {
         push_block_header(&mut buf, blk.block_type, blk.body.len(), idx == last_index);
         buf.extend_from_slice(&blk.body);
         idx += 1;
@@ -240,15 +250,30 @@ pub fn synthesize_layout(
     buf.extend_from_slice(&vc);
     idx += 1;
 
+    for bt in valid_binary {
+        let block_type = match bt.key.as_str() {
+            "APPLICATION" => BLOCK_APPLICATION,
+            "CUESHEET" => BLOCK_CUESHEET,
+            _ => continue,
+        };
+        if bt.len > 0x00FF_FFFF {
+            return Err(FormatError::TooLarge);
+        }
+        push_block_header(&mut buf, block_type, bt.len as usize, idx == last_index);
+        segments.push(Segment::Inline(std::mem::take(&mut buf)));
+        segments.push(Segment::BinaryTag {
+            payload_id: bt.payload_id,
+            len: bt.len,
+        });
+        idx += 1;
+    }
+
     for art in arts {
         if art.data_len == 0 {
-            continue; // skip degenerate empty art (see nonempty_art above)
+            continue;
         }
         let framing = picture_body_framing(art);
         let body_len = framing.len() as u64 + art.data_len;
-        // FLAC metadata block lengths are 24-bit (max ~16 MiB). Ingestion caps art
-        // well under this, but guard at the format boundary so an oversized block is
-        // a hard error rather than a silently-truncated (corrupt) file.
         if body_len > 0x00FF_FFFF {
             return Err(FormatError::TooLarge);
         }
@@ -271,8 +296,8 @@ pub fn synthesize_layout(
         segments.push(Segment::Inline(buf));
     }
     segments.push(Segment::BackingAudio {
-        offset: scan.audio_offset,
-        len: scan.audio_length,
+        offset: audio_offset,
+        len: audio_length,
     });
 
     RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
@@ -901,12 +926,7 @@ mod tests {
     #[test]
     fn synthesize_layout_picture_block_size_boundary_is_inclusive() {
         // body_len = picture_body_framing(art).len() + art.data_len. The guard at
-        // flac.rs:155 rejects body_len > 0x00FF_FFFF (FLAC's 24-bit block length).
-        let scan = FlacScan {
-            audio_offset: 0,
-            audio_length: 0,
-            preserved: vec![],
-        };
+        // flac.rs rejects body_len > 0x00FF_FFFF (FLAC's 24-bit block length).
         let mk = |data_len: u64| ArtInput {
             art_id: 1,
             mime: "image/png".to_string(),
@@ -923,10 +943,10 @@ mod tests {
         let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
                                                   // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
                                                   // (data_len is only a count; no large allocation occurs.)
-        assert!(synthesize_layout(&scan, &[], &[mk(at_limit)]).is_ok());
+        assert!(synthesize_layout(&[], 0, 0, &[], &[], &[mk(at_limit)]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
         assert_eq!(
-            synthesize_layout(&scan, &[], &[mk(at_limit + 1)]),
+            synthesize_layout(&[], 0, 0, &[], &[], &[mk(at_limit + 1)]),
             Err(FormatError::TooLarge)
         );
     }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -950,4 +950,24 @@ mod tests {
             Err(FormatError::TooLarge)
         );
     }
+
+    #[test]
+    fn synthesize_layout_binary_tag_block_size_boundary_is_inclusive() {
+        // The binary-tag guard rejects bt.len > 0x00FF_FFFF (FLAC's 24-bit block
+        // length). `len` is only a count — no payload is allocated — so the exact
+        // boundary is cheap to pin. Mirrors the PICTURE boundary test; the `>`
+        // accepts the inclusive limit while the `>=` mutant rejects it.
+        let mk = |len: u64| BinaryTagInput {
+            key: "APPLICATION".to_string(),
+            payload_id: 1,
+            len,
+        };
+        // len == 0x00FF_FFFF exactly must succeed.
+        assert!(synthesize_layout(&[], 0, 0, &[], &[mk(0x00FF_FFFF)], &[]).is_ok());
+        // one byte over must still error, pinning the high side of the boundary.
+        assert_eq!(
+            synthesize_layout(&[], 0, 0, &[], &[mk(0x0100_0000)], &[]),
+            Err(FormatError::TooLarge)
+        );
+    }
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -143,7 +143,7 @@ pub fn locate_audio(data: &[u8]) -> Result<FlacScan> {
     })
 }
 
-use crate::input::{ArtInput, EmbeddedPicture, TagInput};
+use crate::input::{ArtInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
 
 pub(crate) fn push_block_header(out: &mut Vec<u8>, block_type: u8, body_len: usize, is_last: bool) {
@@ -152,6 +152,46 @@ pub(crate) fn push_block_header(out: &mut Vec<u8>, block_type: u8, body_len: usi
     out.push(((body_len >> 16) & 0xFF) as u8);
     out.push(((body_len >> 8) & 0xFF) as u8);
     out.push((body_len & 0xFF) as u8);
+}
+
+/// Map a stored structural-block `kind` string back to its FLAC block type.
+/// Only STREAMINFO/SEEKTABLE live in the structural store; everything else
+/// returns `None` (APPLICATION/CUESHEET are binary tags, not structural).
+pub fn structural_block_type(kind: &str) -> Option<u8> {
+    match kind {
+        "STREAMINFO" => Some(BLOCK_STREAMINFO),
+        "SEEKTABLE" => Some(BLOCK_SEEKTABLE),
+        _ => None,
+    }
+}
+
+/// Split a FLAC file's preserved metadata blocks into the read-only structural
+/// store (STREAMINFO/SEEKTABLE, as `(kind, body)` pairs in file order) and the
+/// editable binary tags (APPLICATION/CUESHEET, as `EmbeddedBinaryTag`s keyed by
+/// block name; `payload` is the full block body, including APPLICATION's 4-byte
+/// app id). Blocks of any other type are ignored (PICTURE/VORBIS_COMMENT are
+/// handled by their own paths and are never in `preserved`).
+pub fn split_preserved(
+    blocks: &[MetadataBlock],
+) -> (Vec<(String, Vec<u8>)>, Vec<EmbeddedBinaryTag>) {
+    let mut structural = Vec::new();
+    let mut binary = Vec::new();
+    for blk in blocks {
+        match blk.block_type {
+            BLOCK_STREAMINFO => structural.push(("STREAMINFO".to_string(), blk.body.clone())),
+            BLOCK_SEEKTABLE => structural.push(("SEEKTABLE".to_string(), blk.body.clone())),
+            BLOCK_APPLICATION => binary.push(EmbeddedBinaryTag {
+                key: "APPLICATION".to_string(),
+                payload: blk.body.clone(),
+            }),
+            BLOCK_CUESHEET => binary.push(EmbeddedBinaryTag {
+                key: "CUESHEET".to_string(),
+                payload: blk.body.clone(),
+            }),
+            _ => {}
+        }
+    }
+    (structural, binary)
 }
 
 fn picture_body_framing(art: &ArtInput) -> Vec<u8> {
@@ -813,6 +853,49 @@ mod tests {
             }
             other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn split_preserved_classifies_structural_and_binary() {
+        use super::{split_preserved, structural_block_type, MetadataBlock};
+        // STREAMINFO(0), APPLICATION(2), SEEKTABLE(3), CUESHEET(5) in arbitrary order.
+        let blocks = vec![
+            MetadataBlock {
+                block_type: 0,
+                body: vec![0xAA],
+            },
+            MetadataBlock {
+                block_type: 2,
+                body: b"testDATA".to_vec(),
+            },
+            MetadataBlock {
+                block_type: 3,
+                body: vec![0xBB],
+            },
+            MetadataBlock {
+                block_type: 5,
+                body: vec![0xCC; 4],
+            },
+        ];
+        let (structural, binary) = split_preserved(&blocks);
+
+        assert_eq!(
+            structural,
+            vec![
+                ("STREAMINFO".to_string(), vec![0xAA]),
+                ("SEEKTABLE".to_string(), vec![0xBB]),
+            ]
+        );
+        assert_eq!(binary.len(), 2);
+        assert_eq!(binary[0].key, "APPLICATION");
+        assert_eq!(binary[0].payload, b"testDATA");
+        assert_eq!(binary[1].key, "CUESHEET");
+        assert_eq!(binary[1].payload, vec![0xCC; 4]);
+
+        assert_eq!(structural_block_type("STREAMINFO"), Some(0));
+        assert_eq!(structural_block_type("SEEKTABLE"), Some(3));
+        assert_eq!(structural_block_type("APPLICATION"), None);
+        assert_eq!(structural_block_type("bogus"), None);
     }
 
     #[test]

--- a/musefs-format/tests/proptest_flac.rs
+++ b/musefs-format/tests/proptest_flac.rs
@@ -19,7 +19,7 @@ proptest! {
         let scan = flac::locate_audio(&file).unwrap();
         let taginputs: Vec<TagInput> = tags.iter().map(|(k, v)| TagInput::new(k, v)).collect();
         let arts: Vec<ArtInput> = Vec::new();
-        if let Ok(layout) = flac::synthesize_layout(&scan, &taginputs, &arts) {
+        if let Ok(layout) = flac::synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &taginputs, &[], &arts) {
             assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
         }
     }
@@ -33,7 +33,7 @@ proptest! {
         let scan = flac::locate_audio(&file).unwrap();
         let taginputs: Vec<TagInput> = tags.iter().map(|(k, v)| TagInput::new(k, v)).collect();
         let arts: Vec<ArtInput> = Vec::new();
-        let Ok(layout) = flac::synthesize_layout(&scan, &taginputs, &arts) else {
+        let Ok(layout) = flac::synthesize_layout(&scan.preserved, scan.audio_offset, scan.audio_length, &taginputs, &[], &arts) else {
             return Ok(());
         };
         let mut front = Vec::new();

--- a/musefs-format/tests/roundtrip.rs
+++ b/musefs-format/tests/roundtrip.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use std::io::Cursor;
 
 use common::{flac_block, make_flac, resolve_layout, streaminfo_body, vorbis_comment_body};
+use musefs_format::flac::MetadataBlock;
 use musefs_format::flac::{locate_audio, synthesize_layout};
-use musefs_format::{ArtInput, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, Segment, TagInput};
 
 #[test]
 fn full_roundtrip_preserved_blocks_multivalue_tags_and_two_pictures() {
@@ -49,7 +50,15 @@ fn full_roundtrip_preserved_blocks_multivalue_tags_and_two_pictures() {
         },
     ];
 
-    let layout = synthesize_layout(&scan, &tags, &arts).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &tags,
+        &[],
+        &arts,
+    )
+    .unwrap();
 
     let mut art_map = HashMap::new();
     art_map.insert(1i64, front.clone());
@@ -88,4 +97,121 @@ fn full_roundtrip_preserved_blocks_multivalue_tags_and_two_pictures() {
     let _ = flac_block(3, &seektable, false); // documents intent; body equality checked via scan below
     assert_eq!(scan.preserved[1].block_type, 3);
     assert_eq!(scan.preserved[1].body, seektable);
+}
+
+#[test]
+fn application_block_streams_and_metaflac_reads_it() {
+    let si = streaminfo_body();
+    let app_body = b"testAPPDATA".to_vec(); // 4-byte app id "test" + payload "APPDATA"
+    let audio = vec![0xABu8; 48];
+
+    let structural = vec![MetadataBlock {
+        block_type: 0,
+        body: si,
+    }];
+    let binary = vec![BinaryTagInput {
+        key: "APPLICATION".into(),
+        payload_id: 100,
+        len: app_body.len() as u64,
+    }];
+    let layout = synthesize_layout(
+        &structural,
+        0,
+        audio.len() as u64,
+        &[TagInput::new("title", "T")],
+        &binary,
+        &[],
+    )
+    .unwrap();
+
+    let bt = layout
+        .segments()
+        .iter()
+        .filter(|s| matches!(s, Segment::BinaryTag { .. }))
+        .count();
+    assert_eq!(bt, 1);
+
+    let mut bt_map = std::collections::HashMap::new();
+    bt_map.insert(100i64, app_body.clone());
+    let assembled = resolve_layout(&layout, &audio, &HashMap::new(), &bt_map);
+
+    let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
+    let (id, data) = tag
+        .blocks()
+        .find_map(|b| match b {
+            metaflac::Block::Application(a) => Some((a.id.clone(), a.data.clone())),
+            _ => None,
+        })
+        .expect("application block present");
+    assert_eq!(&id, b"test");
+    assert_eq!(data, b"APPDATA");
+}
+
+#[test]
+fn application_and_cuesheet_framing_is_valid_and_last_block_correct() {
+    let si = streaminfo_body();
+    let app_body = b"testAPP1".to_vec();
+    let cue_body = vec![0x11u8; 40];
+    let audio = vec![0xCDu8; 32];
+
+    let structural = vec![MetadataBlock {
+        block_type: 0,
+        body: si,
+    }];
+    let binary = vec![
+        BinaryTagInput {
+            key: "APPLICATION".into(),
+            payload_id: 1,
+            len: app_body.len() as u64,
+        },
+        BinaryTagInput {
+            key: "CUESHEET".into(),
+            payload_id: 2,
+            len: cue_body.len() as u64,
+        },
+    ];
+    let layout = synthesize_layout(
+        &structural,
+        0,
+        audio.len() as u64,
+        &[TagInput::new("title", "T")],
+        &binary,
+        &[],
+    )
+    .unwrap();
+
+    assert_eq!(
+        layout
+            .segments()
+            .iter()
+            .filter(|s| matches!(s, Segment::BinaryTag { .. }))
+            .count(),
+        2
+    );
+
+    let mut bt_map = std::collections::HashMap::new();
+    bt_map.insert(1i64, app_body);
+    bt_map.insert(2i64, cue_body);
+    let assembled = resolve_layout(&layout, &audio, &HashMap::new(), &bt_map);
+
+    let rescan = locate_audio(&assembled).expect("synthesized FLAC must parse");
+    assert_eq!(rescan.audio_offset, layout.header_len());
+}
+
+#[test]
+fn binary_tag_over_24bit_limit_errors() {
+    use musefs_format::FormatError;
+    let structural = vec![MetadataBlock {
+        block_type: 0,
+        body: streaminfo_body(),
+    }];
+    let binary = vec![BinaryTagInput {
+        key: "APPLICATION".into(),
+        payload_id: 1,
+        len: 0x0100_0000,
+    }];
+    assert_eq!(
+        synthesize_layout(&structural, 0, 0, &[], &binary, &[]),
+        Err(FormatError::TooLarge)
+    );
 }

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -33,7 +33,15 @@ fn art_becomes_an_artimage_segment_and_lengths_are_exact() {
 
     let image = vec![0x77u8; 1234];
     let art = cover(42, image.len() as u64);
-    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &[TagInput::new("title", "T")],
+        &[],
+        &[art],
+    )
+    .unwrap();
 
     let art_segs: Vec<&Segment> = layout
         .segments
@@ -63,7 +71,15 @@ fn metaflac_reads_synthesized_picture() {
 
     let image = vec![0x77u8; 1234];
     let art = cover(42, image.len() as u64);
-    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &[TagInput::new("title", "T")],
+        &[],
+        &[art],
+    )
+    .unwrap();
 
     let mut art_map = HashMap::new();
     art_map.insert(42i64, image.clone());
@@ -82,13 +98,7 @@ fn metaflac_reads_synthesized_picture() {
 
 #[test]
 fn synthesize_errors_on_oversized_picture() {
-    use musefs_format::flac::FlacScan;
     use musefs_format::FormatError;
-    let scan = FlacScan {
-        audio_offset: 0,
-        audio_length: 0,
-        preserved: vec![],
-    };
     // data_len is only a count here (bytes are streamed), so this needs no allocation.
     let art = ArtInput {
         art_id: 1,
@@ -100,7 +110,7 @@ fn synthesize_errors_on_oversized_picture() {
         data_len: 0x0100_0000, // just over the 24-bit FLAC PICTURE block limit
     };
     assert_eq!(
-        synthesize_layout(&scan, &[], &[art]),
+        synthesize_layout(&[], 0, 0, &[], &[], &[art]),
         Err(FormatError::TooLarge)
     );
 }
@@ -114,7 +124,15 @@ fn zero_byte_art_is_skipped_so_the_track_still_serves() {
     // emit an empty PICTURE block (which would fail layout validation and brick the
     // track).
     let art = cover(7, 0); // data_len == 0
-    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[art]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &[TagInput::new("title", "T")],
+        &[],
+        &[art],
+    )
+    .unwrap();
 
     // No ArtImage segment was emitted.
     assert!(!layout
@@ -143,7 +161,15 @@ fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
     let image = vec![0x55u8; 64];
     let empty = cover(1, 0);
     let real = cover(2, image.len() as u64);
-    let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[empty, real]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &[TagInput::new("title", "T")],
+        &[],
+        &[empty, real],
+    )
+    .unwrap();
 
     let art_segs: Vec<_> = layout
         .segments

--- a/musefs-format/tests/synthesize_tags.rs
+++ b/musefs-format/tests/synthesize_tags.rs
@@ -23,7 +23,15 @@ fn measured_lengths_match_assembled_bytes() {
         TagInput::new("title", "New Title"),
         TagInput::new("artist", "A"),
     ];
-    let layout = synthesize_layout(&scan, &tags, &[]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &tags,
+        &[],
+        &[],
+    )
+    .unwrap();
 
     let assembled = resolve_layout(&layout, &file, &HashMap::new(), &HashMap::new());
     assert_eq!(assembled.len() as u64, layout.total_len());
@@ -44,7 +52,15 @@ fn metaflac_reads_synthesized_vorbis_comments_and_preserves_streaminfo() {
         TagInput::new("artist", "First"),
         TagInput::new("artist", "Second"),
     ];
-    let layout = synthesize_layout(&scan, &tags, &[]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &tags,
+        &[],
+        &[],
+    )
+    .unwrap();
     let assembled = resolve_layout(&layout, &file, &HashMap::new(), &HashMap::new());
 
     let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
@@ -68,7 +84,15 @@ fn metaflac_reads_synthesized_vorbis_comments_and_preserves_streaminfo() {
 fn vorbis_comment_block_is_the_last_metadata_block_when_no_art() {
     let (file, _audio) = fixture();
     let scan = locate_audio(&file).unwrap();
-    let layout = synthesize_layout(&scan, &[TagInput::new("title", "X")], &[]).unwrap();
+    let layout = synthesize_layout(
+        &scan.preserved,
+        scan.audio_offset,
+        scan.audio_length,
+        &[TagInput::new("title", "X")],
+        &[],
+        &[],
+    )
+    .unwrap();
 
     assert_eq!(layout.segments.len(), 2);
     assert!(matches!(layout.segments[0], Segment::Inline(_)));


### PR DESCRIPTION
## Summary

Phase 4 of the binary-tags work, scoped to FLAC. Makes FLAC `APPLICATION`/`CUESHEET` blocks survive the round trip as DB-backed editable binary tags, moves `STREAMINFO`/`SEEKTABLE` into the read-only structural store, and eliminates the per-resolve FLAC front re-read for rescanned tracks (with a graceful front-read fallback for not-yet-rescanned legacy tracks).

Implements `docs/superpowers/plans/2026-06-02-binary-tags-phase4-flac.md`.

### What changed
- **`musefs-db`**: `BulkWriter::set_structural_blocks` for the scan batch path (mirrors `set_binary_tags`).
- **`musefs-format/flac`**: `split_preserved` (STREAMINFO/SEEKTABLE → structural; APPLICATION/CUESHEET → binary tags) and `structural_block_type`. `synthesize_layout` drops `FlacScan` and now takes structural blocks + explicit audio bounds + a streamed `binary_tags` slice. Canonical block order: `fLaC` + STREAMINFO + other structural + VORBIS_COMMENT + streamed APPLICATION/CUESHEET + streamed PICTURE + backing audio.
- **`musefs-core/reader`**: `Format::Flac` arm loads `structural_blocks` from the DB; when absent (legacy track not yet rescanned under V2) it falls back to the existing `read_front` + `read_metadata` path, carrying every preserved block inline exactly as before.
- **`musefs-core/scan`**: `Probed.structural_blocks`; FLAC probe arms split preserved blocks via `split_preserved`; `ingest`/`ingest_bulk` persist structural blocks.

### Behavior note
Re-synthesized FLAC block order is the fixed canonical order above, which may differ from the source file's order. The FLAC spec only mandates STREAMINFO first, so this is valid — round-trip tests assert payload fidelity and `locate_audio` framing, not byte-identical block ordering.

## Testing
- `cargo test --workspace` — 599+ passing
- `cargo test -p musefs-format --features fuzzing` — green (proptest_flac included)
- `cargo clippy --all-targets`, `cargo fmt --all --check` — clean
- New coverage: format round-trip via the `metaflac` oracle (APPLICATION/CUESHEET framing + last-block flag), end-to-end serve, legacy front-read fallback, and a zero-front-read metrics assertion for rescanned FLAC.

### Mutation testing
Ran the in-diff mutation gate (`cargo mutants --in-diff`) as CI would. The first pass surfaced 5 survivors in the new code (the binary-tag 24-bit guard's inclusive boundary, and the per-kind structural ordinal increment in `ingest`/`ingest_bulk`). Added three targeted tests to kill them; re-run confirms the gate is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FLAC handling improved: preserves editable binary tags (APPLICATION, CUESHEET) separately from structural metadata (STREAMINFO, SEEKTABLE) and avoids redundant front-reads when serving rescanned tracks.

* **Documentation**
  * Added a detailed implementation plan for the FLAC binary-tag / structural-block rollout.

* **Tests**
  * New end-to-end and unit tests covering FLAC binary-tag classification, roundtrip/rescan behavior, and a metrics test ensuring rescanned FLAC resolves without extra front reads.

* **Chores**
  * Updated ignore rules to exclude a worktrees directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->