### PR TITLE
Phase 0+1: stop plugin data loss + error/poison conventions (#82, #95, #96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,9 @@ tracks whose backing file is gone, and GC orphaned art. `--revalidate` selects i
 
 - Errors: each crate has its own `error.rs` with a `thiserror` enum; `core` wraps
   lower layers in `CoreError`. The CLI is the only `anyhow` consumer.
+- Internal error paths do not discard diagnostics: no `Result<_, ()>`, and no
+  `.map_err(|_| …)` that drops a source. Each error variant carries its source
+  (`#[from]`) or a static reason describing the broken invariant.
 - Adding a format: implement probe + `synthesize_layout` in `musefs-format`
   (mirror an existing module — `flac.rs`, `mp3.rs`, `mp4.rs`, `ogg/`, `wav.rs`),
   returning a `RegionLayout`; add the variant to `musefs-db`'s `Format` enum, then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "dashmap",
  "id3",
  "im",
+ "log",
  "metaflac",
  "musefs-db",
  "musefs-format",

--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -168,7 +168,9 @@ def prune_missing(conn, track_ids=None):
 def replace_tags(conn, track_id, pairs):
     """Replace all tags for a track. Duplicate keys get incrementing ordinals
     (mirroring musefs scan ingest)."""
-    conn.execute("DELETE FROM tags WHERE track_id = ?", (track_id,))
+    # Scope to the plugin-owned text rows: scanner-written binary tags
+    # (value_blob NOT NULL) must survive a sync (#82).
+    conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
     ordinals = {}
     rows = []
     for key, value in pairs:

--- a/contrib/beets/tests/test_db.py
+++ b/contrib/beets/tests/test_db.py
@@ -164,3 +164,50 @@ def test_connect_enables_foreign_keys_unlike_raw_sqlite(db_path):
         assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
     finally:
         conn.close()
+
+
+def test_replace_tags_preserves_binary_rows(db_path, make_track):
+    # A scanner-written binary tag row (value_blob NOT NULL, value '') must
+    # survive a plugin sync that replaces text tags. Regression test for #82.
+    tid = make_track("/music/a.flac")
+    conn = connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) "
+            "VALUES (?, 'APPLICATION', '', ?, 0)",
+            (tid, b"\x00\x01\x02binary"),
+        )
+        # Seed a committed text row too, to prove text rows are still replaced.
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, 'title', 'Old', 0)",
+            (tid,),
+        )
+        conn.commit()
+
+        replace_tags(conn, tid, [("title", "New")])
+        conn.commit()
+
+        binary = conn.execute(
+            "SELECT value, value_blob FROM tags WHERE track_id=? AND key='APPLICATION'",
+            (tid,),
+        ).fetchall()
+        assert binary == [("", b"\x00\x01\x02binary")]
+
+        titles = conn.execute(
+            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+        ).fetchall()
+        assert titles == [("New",)]
+    finally:
+        conn.close()
+
+
+def test_default_vocabulary_disjoint_from_binary_keys():
+    # The scoped delete is collision-free for the default vocabulary because
+    # DIRECT_FIELDS values never coincide with the scanner's binary tag keys
+    # (uppercase ID3/FLAC keys, MP4 '----:...'). Documents the #82 assumption.
+    from beetsplug._core import DIRECT_FIELDS
+
+    binary_keys = {"APPLICATION", "CUESHEET", "PRIV", "GEOB", "APIC"}
+    text_keys = set(DIRECT_FIELDS.values())
+    assert text_keys.isdisjoint(binary_keys)
+    assert not any(k.startswith("----") for k in text_keys)

--- a/contrib/picard/musefs/_core.py
+++ b/contrib/picard/musefs/_core.py
@@ -198,7 +198,9 @@ def track_id_for_path(conn, key):
 def replace_tags(conn, track_id, pairs):
     """Replace all tags for a track. Duplicate keys get incrementing ordinals
     (mirroring musefs scan ingest)."""
-    conn.execute("DELETE FROM tags WHERE track_id = ?", (track_id,))
+    # Scope to the plugin-owned text rows: scanner-written binary tags
+    # (value_blob NOT NULL) must survive a sync (#82).
+    conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
     ordinals = {}
     rows = []
     for key, value in pairs:

--- a/contrib/picard/tests/test_core_db.py
+++ b/contrib/picard/tests/test_core_db.py
@@ -3,9 +3,11 @@ import sqlite3
 import pytest
 
 from musefs._core import (
+    DIRECT_FIELDS,
     SchemaMismatch,
     check_schema_version,
     realpath_key,
+    replace_tags,
     sniff_mime,
 )
 
@@ -48,3 +50,44 @@ def test_sniff_mime_magic_bytes():
 def test_sniff_mime_extension_fallback():
     assert sniff_mime(b"nope", "cover.PNG") == "image/png"
     assert sniff_mime(b"nope", "cover.bin") == "application/octet-stream"
+
+
+def test_replace_tags_preserves_binary_rows(db_path, make_track):
+    # Regression test for #82: a plugin sync must not delete scanner-written
+    # binary tags (value_blob NOT NULL).
+    tid = make_track("/music/a.flac")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) "
+            "VALUES (?, 'APPLICATION', '', ?, 0)",
+            (tid, b"\x00\x01\x02binary"),
+        )
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, 'title', 'Old', 0)",
+            (tid,),
+        )
+        conn.commit()
+
+        replace_tags(conn, tid, [("title", "New")])
+        conn.commit()
+
+        binary = conn.execute(
+            "SELECT value, value_blob FROM tags WHERE track_id=? AND key='APPLICATION'",
+            (tid,),
+        ).fetchall()
+        assert binary == [("", b"\x00\x01\x02binary")]
+
+        titles = conn.execute(
+            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+        ).fetchall()
+        assert titles == [("New",)]
+    finally:
+        conn.close()
+
+
+def test_default_vocabulary_disjoint_from_binary_keys():
+    binary_keys = {"APPLICATION", "CUESHEET", "PRIV", "GEOB", "APIC"}
+    text_keys = set(DIRECT_FIELDS.values())
+    assert text_keys.isdisjoint(binary_keys)
+    assert not any(k.startswith("----") for k in text_keys)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,14 +123,16 @@ correctness in batches by code area → then perf/cleanup → docs last. The plu
 (Python) and core (Rust) tracks are independent codebases and can run in
 parallel. Most of the Rust items came out of the v1 multi-model review triage.
 
-**Phase 0 — Stop the bleeding**
-- #82 — plugin `replace_tags` wipes scanner-written binary tags (active data loss
-  introduced by the binary-tags work; everything else waits behind it).
+**Phase 0 — Stop the bleeding** — *done (PR #97)*
+- ~~#82 — plugin `replace_tags` wipes scanner-written binary tags~~ — done (PR #97):
+  scoped the delete to plugin-owned text rows (`value_blob IS NULL`) in both plugins.
 
-**Phase 1 — Cheap policy decisions (resolve before writing the code they shape)**
-- #96 — mutex poison-recovery policy (shapes the lock code in #89/#90/#94).
-- #95 — internal error-type convention (`Result<(),()>`, `InvalidLayout`); decide
-  it so the new error paths in #91/#92 adopt it from the start.
+**Phase 1 — Cheap policy decisions (resolve before writing the code they shape)** — *done (PR #97)*
+- ~~#96 — mutex poison-recovery policy~~ — done (PR #97): recover-by-reset helpers
+  (`lock.rs`) over the VFS serving-path mutexes; shapes the lock code in #89/#90/#94.
+- ~~#95 — internal error-type convention (`Result<(),()>`, `InvalidLayout`)~~ — done
+  (PR #97): `LayoutError`/`RebuildError` carry diagnostics; convention recorded in
+  `CLAUDE.md`, so the new error paths in #91/#92 adopt it from the start.
 
 **Phase 2 — Plugin correctness batch** *(parallel track; shared `_core.py` surface)*
 - #83 — beets reconciliation hook not fail-safe (except breadth + scan timeout).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -115,6 +115,59 @@ modifying or duplicating the original audio bytes.
 
 ---
 
+## Open issue backlog (prioritized)
+
+Suggested order for the currently-open issues. Driving logic: stop active data
+loss first → make the cheap policy decisions that shape later code → fix
+correctness in batches by code area → then perf/cleanup → docs last. The plugin
+(Python) and core (Rust) tracks are independent codebases and can run in
+parallel. Most of the Rust items came out of the v1 multi-model review triage.
+
+**Phase 0 — Stop the bleeding**
+- #82 — plugin `replace_tags` wipes scanner-written binary tags (active data loss
+  introduced by the binary-tags work; everything else waits behind it).
+
+**Phase 1 — Cheap policy decisions (resolve before writing the code they shape)**
+- #96 — mutex poison-recovery policy (shapes the lock code in #89/#90/#94).
+- #95 — internal error-type convention (`Result<(),()>`, `InvalidLayout`); decide
+  it so the new error paths in #91/#92 adopt it from the start.
+
+**Phase 2 — Plugin correctness batch** *(parallel track; shared `_core.py` surface)*
+- #83 — beets reconciliation hook not fail-safe (except breadth + scan timeout).
+- #84 — Picard drops multi-value tags.
+- #85 — Picard comma field-map mangling.
+- #86 — beets `genre`/`genres` duplication.
+- #87 — Picard O(n) subprocess (perf rider on the same plugin pass).
+
+**Phase 3 — Safety net + small Rust hardening** *(low-risk, independent)*
+- #88 — Ogg fuzz art coverage (quick win; lands coverage before later Ogg touches).
+- #93 — `byte_budget` overflow asymmetry.
+- #92 — `byte_len` non-negative guard.
+- #91 — MP4 `moov`/`ftyp` alloc cap.
+- #94 — DbPool thread-local footguns (after #96 is decided).
+
+**Phase 4 — Concurrency correctness**
+- #90 — `rebuild_full` holds `inodes` across DB I/O (mirror the incremental path).
+- #89 — `fire_poll_refresh` floods the threadpool (synchronous debounce).
+
+**Phase 5 — Metrics**
+- #71 — Ogg serve path records no pread/byte metrics (instrumentation blind today).
+- #76 — metric counters covered only by direct-call tests (locks in #71's fix).
+
+**Phase 6 — Performance optimization SPs** *(bench-tracked: before/after in
+`BENCHMARKS.md` + the tracking README)*
+- #69 — refresh O(library)→O(changed); adjacent to #90 (same facade rebuild path),
+  do right after it. Biggest latency win.
+- #67 — bounded probe reads an ID3v1 tail per file (scan perf).
+- #68 — `ingest_bulk` copies each picture's bytes (scan perf).
+- #70 — zero-copy serve path (deferred SP3 residual; largest scope).
+
+**Phase 7 — Docs**
+- #64 — README/architecture rework. Last, so it documents settled behavior (and is
+  affected by the Phase 2 plugin changes).
+
+---
+
 ## Post-MVP (explicitly deferred)
 
 These are intentionally **out of scope for v0.1.0**. They are recorded here so the

--- a/docs/superpowers/plans/2026-06-03-phase0-1-data-loss-and-conventions.md
+++ b/docs/superpowers/plans/2026-06-03-phase0-1-data-loss-and-conventions.md
@@ -359,7 +359,7 @@ to:
 - [ ] **Step 7: Run tests + clippy to verify pass**
 
 Run: `cargo test -p musefs-format 2>&1 | tail -20 && cargo clippy -p musefs-format --all-targets -- -D warnings 2>&1 | tail -5`
-Expected: all tests PASS; clippy clean. (If clippy flags `redundant_closure`/`needless_question_mark` anywhere, address per its suggestion.)
+Expected: all tests PASS; clippy clean. `needless_question_mark` does NOT fire on `Ok(RegionLayout::validated(segments)?)` because `?` performs the `LayoutError → FormatError` conversion (the lint only triggers when the inner and outer error types are identical). Keep the `Ok(...?)` form — do **not** "simplify" it to a bare `RegionLayout::validated(segments)`, which returns `Result<_, LayoutError>` and won't typecheck against the `Result<RegionLayout>` (= `FormatError`) return type. If some future clippy version objects, use `.map_err(FormatError::from)`.
 
 - [ ] **Step 8: Commit**
 
@@ -420,7 +420,7 @@ pub enum RebuildError {
 
 - [ ] **Step 4: Change the two signatures and the four `ok_or` sites**
 
-In `rebuild_subtree` (`tree.rs:300-306`): delete the `#[allow(clippy::result_unit_err)]` line and change the return type to `std::result::Result<(), RebuildError>`. At line 326 change:
+In `rebuild_subtree` (`tree.rs:300-306`): delete the `#[allow(clippy::result_unit_err)]` line and change the return type to `std::result::Result<(), RebuildError>`. At line 326 change (the enclosing loop is `for id in ids` over an owned `Vec<i64>`, so `id` is already `i64` — pass it by value, no `*`):
 
 ```rust
             let path = new_paths.get(&id).ok_or(())?;
@@ -429,7 +429,7 @@ In `rebuild_subtree` (`tree.rs:300-306`): delete the `#[allow(clippy::result_uni
 to:
 
 ```rust
-            let path = new_paths.get(&id).ok_or(RebuildError::MissingRenderedPath(*id))?;
+            let path = new_paths.get(&id).ok_or(RebuildError::MissingRenderedPath(id))?;
 ```
 
 In `apply_changes` (`tree.rs:336-344`): delete its `#[allow(clippy::result_unit_err)]` line and change the return type to `std::result::Result<(), RebuildError>`. Change the three sites:
@@ -462,16 +462,7 @@ Then the fallback arm (line 345-346):
                 eprintln!("musefs: incremental tree mutation failed; falling back to full rebuild");
 ```
 
-Change to bind and log the reason:
-
-```rust
-            Err(reason) => {
-                log::warn!(
-                    "musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild"
-                );
-```
-
-> This introduces the first `log::` use in `musefs-core`. Task C1 adds the `log` dependency. If Part C has not run yet, temporarily keep `eprintln!("musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild");` here and convert it to `log::warn!` in Task C4. **Recommended:** run Part C before this conversion, or use `eprintln!` now. For this task, use `eprintln!` with the `{reason:?}` interpolation so no new dependency is needed:
+Change to bind the reason and interpolate it. **Keep `eprintln!` here** — `musefs-core` does not depend on `log` until Task C1, so a `log::warn!` in this commit would fail to compile (`error[E0433]: use of undeclared crate log`). Task C4 Step 2 converts this single `eprintln!` to `log::warn!` after C1 adds the dependency.
 
 ```rust
             Err(reason) => {
@@ -957,10 +948,13 @@ to:
 - [ ] **Step 3: Run tests + clippy**
 
 Run: `cargo test -p musefs-core 2>&1 | tail -20 && cargo clippy -p musefs-core --all-targets -- -D warnings 2>&1 | tail -5`
-Expected: all PASS; clippy clean. Confirm no `unwrap_or_else(std::sync::PoisonError::into_inner)` remains in `facade.rs`/`reader.rs`:
+Expected: all PASS; clippy clean. Confirm no un-policied serving-path lock acquisition remains:
 
 Run: `grep -rn "PoisonError::into_inner" musefs-core/src/facade.rs musefs-core/src/reader.rs`
 Expected: no matches.
+
+Run: `grep -rn "\.lock()\.unwrap()" musefs-core/src/facade.rs musefs-core/src/reader.rs musefs-core/src/ogg_index.rs`
+Expected: only the test-code sites in `ogg_index.rs` (e.g. ~653/666/698) remain; no serving-path `.lock().unwrap()`.
 
 - [ ] **Step 4: Commit**
 
@@ -985,7 +979,8 @@ Append to the module doc-comment in `musefs-core/src/lock.rs` a table classifyin
 //!   facade.rs `last_poll`         -> cat 3 (recover): Instant, replace-only single write.
 //!   facade.rs `last_failed_refresh` -> cat 3 (recover): Option<Instant>, replace-only single write.
 //!   reader.rs HeaderCache shards  -> cat 1 (clear): pure cache, repopulated from the DB.
-//!   ogg_index.rs LastPageMemo     -> cat 1 (clear): deterministic one-entry cache, re-derived.
+//!   ResolvedFile::last_page (reader.rs:30, locked in ogg_index.rs as LastPageMemo)
+//!                                 -> cat 1 (clear): deterministic one-entry cache, re-derived.
 //! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
 //! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,
 //! not on the FUSE serving path).

--- a/docs/superpowers/plans/2026-06-03-phase0-1-data-loss-and-conventions.md
+++ b/docs/superpowers/plans/2026-06-03-phase0-1-data-loss-and-conventions.md
@@ -1,0 +1,1027 @@
+# Phase 0 + Phase 1: Data Loss & Conventions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the plugin data-loss regression (#82) and settle two foundational conventions — internal error diagnostics (#95) and mutex poison-recovery (#96) — before the later issues that inherit them.
+
+**Architecture:** Three independent parts. Part A is a one-line SQL scope fix in two Python plugins. Part B enriches two Rust error types (`musefs-format` `LayoutError`/`FormatError`, `musefs-core` `tree.rs`). Part C implements "recover-by-reset" poison handling in `musefs-core` via a small `lock.rs` helper module with three categories (clear caches, flag-and-rebuild VFS state, recover scalars).
+
+**Tech Stack:** Rust (workspace crates `musefs-format`, `musefs-core`; `thiserror`, `log`), Python 3 + pytest (beets/picard plugins, `sqlite3`).
+
+**Source spec:** `docs/superpowers/specs/2026-06-03-phase0-1-data-loss-and-conventions-design.md`
+
+**Conventions for every task below:**
+- Work test-first (TDD): write the failing test, see it fail for the right reason, implement the minimum, see it pass, commit.
+- Rust: run `cargo test -p <crate>` for the touched crate; before each commit run `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` (the pre-commit hook enforces fmt/clippy/test/ruff — a failed hook means the commit did NOT happen; fix and re-commit, never `--amend`, never `--no-verify`).
+- Python: run `python -m pytest` from inside the plugin dir; `ruff check` + `ruff format --check` are enforced by the same hook.
+- Stage files by name; never `git add -A`.
+
+---
+
+## Part A — #82: preserve scanner-written binary tags (Python plugins)
+
+The two plugins have a byte-identical `replace_tags` that does an unscoped
+`DELETE FROM tags WHERE track_id = ?`, destroying scanner-written binary rows
+(`value_blob IS NOT NULL`). Scope the delete to the plugin-owned text rows
+(`value_blob IS NULL`). Same change in both copies; each gets its own tests.
+
+### Task A1: beets plugin — scope the delete + tests
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/_core.py:171`
+- Test: `contrib/beets/tests/test_db.py` (append)
+
+- [ ] **Step 1: Write the failing test (binary row survives)**
+
+Append to `contrib/beets/tests/test_db.py`:
+
+```python
+def test_replace_tags_preserves_binary_rows(db_path, make_track):
+    # A scanner-written binary tag row (value_blob NOT NULL, value '') must
+    # survive a plugin sync that replaces text tags. Regression test for #82.
+    tid = make_track("/music/a.flac")
+    conn = connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) "
+            "VALUES (?, 'APPLICATION', '', ?, 0)",
+            (tid, b"\x00\x01\x02binary"),
+        )
+        # Seed a committed text row too, to prove text rows are still replaced.
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) "
+            "VALUES (?, 'title', 'Old', 0)",
+            (tid,),
+        )
+        conn.commit()
+
+        replace_tags(conn, tid, [("title", "New")])
+        conn.commit()
+
+        binary = conn.execute(
+            "SELECT value, value_blob FROM tags "
+            "WHERE track_id=? AND key='APPLICATION'",
+            (tid,),
+        ).fetchall()
+        assert binary == [("", b"\x00\x01\x02binary")]
+
+        titles = conn.execute(
+            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+        ).fetchall()
+        assert titles == [("New",)]
+    finally:
+        conn.close()
+
+
+def test_default_vocabulary_disjoint_from_binary_keys():
+    # The scoped delete is collision-free for the default vocabulary because
+    # DIRECT_FIELDS values never coincide with the scanner's binary tag keys
+    # (uppercase ID3/FLAC keys, MP4 '----:...'). Documents the #82 assumption.
+    from beetsplug._core import DIRECT_FIELDS
+
+    binary_keys = {"APPLICATION", "CUESHEET", "PRIV", "GEOB", "APIC"}
+    text_keys = set(DIRECT_FIELDS.values())
+    assert text_keys.isdisjoint(binary_keys)
+    assert not any(k.startswith("----") for k in text_keys)
+```
+
+- [ ] **Step 2: Run the tests to verify the first one fails**
+
+Run: `cd contrib/beets && python -m pytest tests/test_db.py::test_replace_tags_preserves_binary_rows tests/test_db.py::test_default_vocabulary_disjoint_from_binary_keys -v`
+Expected: `test_replace_tags_preserves_binary_rows` FAILS (the binary row was deleted, so `binary == []` ≠ expected); the disjointness test PASSES already.
+
+- [ ] **Step 3: Scope the delete**
+
+In `contrib/beets/beetsplug/_core.py`, in `replace_tags` (line 171), change:
+
+```python
+    conn.execute("DELETE FROM tags WHERE track_id = ?", (track_id,))
+```
+
+to:
+
+```python
+    # Scope to the plugin-owned text rows: scanner-written binary tags
+    # (value_blob NOT NULL) must survive a sync (#82).
+    conn.execute(
+        "DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,)
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd contrib/beets && python -m pytest tests/test_db.py -v`
+Expected: all PASS (including the pre-existing `test_replace_tags_*`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add contrib/beets/beetsplug/_core.py contrib/beets/tests/test_db.py
+git commit -m "fix(beets): preserve scanner-written binary tags on sync (#82)"
+```
+
+### Task A2: picard plugin — scope the delete + tests
+
+**Files:**
+- Modify: `contrib/picard/musefs/_core.py:201`
+- Test: `contrib/picard/tests/test_core_db.py` (append)
+
+- [ ] **Step 1: Write the failing test (binary row survives)**
+
+The picard tests use the same `db_path`/`make_track` fixtures (`contrib/picard/tests/conftest.py`). Add `replace_tags` and `DIRECT_FIELDS` to the import block at the top of `contrib/picard/tests/test_core_db.py`:
+
+```python
+from musefs._core import (
+    DIRECT_FIELDS,
+    SchemaMismatch,
+    check_schema_version,
+    realpath_key,
+    replace_tags,
+    sniff_mime,
+)
+```
+
+Then append:
+
+```python
+def test_replace_tags_preserves_binary_rows(db_path, make_track):
+    # Regression test for #82: a plugin sync must not delete scanner-written
+    # binary tags (value_blob NOT NULL).
+    tid = make_track("/music/a.flac")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) "
+            "VALUES (?, 'APPLICATION', '', ?, 0)",
+            (tid, b"\x00\x01\x02binary"),
+        )
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) "
+            "VALUES (?, 'title', 'Old', 0)",
+            (tid,),
+        )
+        conn.commit()
+
+        replace_tags(conn, tid, [("title", "New")])
+        conn.commit()
+
+        binary = conn.execute(
+            "SELECT value, value_blob FROM tags "
+            "WHERE track_id=? AND key='APPLICATION'",
+            (tid,),
+        ).fetchall()
+        assert binary == [("", b"\x00\x01\x02binary")]
+
+        titles = conn.execute(
+            "SELECT value FROM tags WHERE track_id=? AND key='title'", (tid,)
+        ).fetchall()
+        assert titles == [("New",)]
+    finally:
+        conn.close()
+
+
+def test_default_vocabulary_disjoint_from_binary_keys():
+    binary_keys = {"APPLICATION", "CUESHEET", "PRIV", "GEOB", "APIC"}
+    text_keys = set(DIRECT_FIELDS.values())
+    assert text_keys.isdisjoint(binary_keys)
+    assert not any(k.startswith("----") for k in text_keys)
+```
+
+(`sqlite3` is already imported at the top of `test_core_db.py`.)
+
+- [ ] **Step 2: Run the tests to verify the first one fails**
+
+Run: `cd contrib/picard && python -m pytest tests/test_core_db.py::test_replace_tags_preserves_binary_rows tests/test_core_db.py::test_default_vocabulary_disjoint_from_binary_keys -v`
+Expected: `test_replace_tags_preserves_binary_rows` FAILS; disjointness test PASSES.
+
+- [ ] **Step 3: Scope the delete**
+
+In `contrib/picard/musefs/_core.py`, in `replace_tags` (line 201), change:
+
+```python
+    conn.execute("DELETE FROM tags WHERE track_id = ?", (track_id,))
+```
+
+to:
+
+```python
+    # Scope to the plugin-owned text rows: scanner-written binary tags
+    # (value_blob NOT NULL) must survive a sync (#82).
+    conn.execute(
+        "DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,)
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd contrib/picard && python -m pytest tests/test_core_db.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add contrib/picard/musefs/_core.py contrib/picard/tests/test_core_db.py
+git commit -m "fix(picard): preserve scanner-written binary tags on sync (#82)"
+```
+
+---
+
+## Part B — #95: internal error types carry diagnostics (Rust)
+
+### Task B1: `musefs-format` — carry `LayoutError` through `FormatError`
+
+`LayoutError` (`musefs-format/src/layout.rs`) currently derives only
+`Debug, Clone, PartialEq, Eq` — no `Display`/`Error`, which `#[from]` and the
+`{0}` format require. Make it a `thiserror` error, then make
+`FormatError::InvalidLayout` carry it and add a `ProducerBug` variant for the one
+manual guard (mp4.rs:822).
+
+**Files:**
+- Modify: `musefs-format/src/layout.rs:1-8`
+- Modify: `musefs-format/src/error.rs:2-18`
+- Modify (collapse to `?`): `musefs-format/src/flac.rs:303`, `mp3.rs:410`, `wav.rs:252`, `ogg/mod.rs:275`, `mp4.rs:835`
+- Modify (manual guard → ProducerBug): `musefs-format/src/mp4.rs:822`
+- Test: `musefs-format/src/error.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append a test module at the end of `musefs-format/src/error.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::FormatError;
+    use crate::layout::LayoutError;
+
+    #[test]
+    fn invalid_layout_carries_inner_layout_error() {
+        let e: FormatError = LayoutError::EmptySegment.into();
+        assert!(matches!(e, FormatError::InvalidLayout(LayoutError::EmptySegment)));
+        // Display includes the inner reason, not just a generic string.
+        assert!(e.to_string().contains("zero length"));
+    }
+
+    #[test]
+    fn producer_bug_carries_reason() {
+        let e = FormatError::ProducerBug("no leading Inline");
+        assert!(e.to_string().contains("no leading Inline"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-format invalid_layout_carries_inner_layout_error 2>&1 | head -30`
+Expected: FAILS to COMPILE — `FormatError::InvalidLayout` takes no arguments and `From<LayoutError>` is not implemented.
+
+- [ ] **Step 3: Make `LayoutError` a `thiserror` error**
+
+In `musefs-format/src/layout.rs`, replace lines 1-8:
+
+```rust
+/// Validation errors discovered in a layout at synthesis time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LayoutError {
+    /// A segment reported zero length.
+    EmptySegment,
+    /// Total length overflowed u64.
+    TotalOverflow,
+}
+```
+
+with:
+
+```rust
+/// Validation errors discovered in a layout at synthesis time.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LayoutError {
+    /// A segment reported zero length.
+    #[error("a segment reported zero length")]
+    EmptySegment,
+    /// Total length overflowed u64.
+    #[error("total layout length overflowed u64")]
+    TotalOverflow,
+}
+```
+
+- [ ] **Step 4: Make `FormatError::InvalidLayout` carry the source + add `ProducerBug`**
+
+In `musefs-format/src/error.rs`, replace the `InvalidLayout` variant (line 17-18):
+
+```rust
+    #[error("synthesized region layout violates producer invariants")]
+    InvalidLayout,
+```
+
+with:
+
+```rust
+    #[error("synthesized region layout violates producer invariants: {0}")]
+    InvalidLayout(#[from] crate::layout::LayoutError),
+    #[error("producer invariant violated: {0}")]
+    ProducerBug(&'static str),
+```
+
+- [ ] **Step 5: Collapse the five `validated(...).map_err(...)` sites to `?`**
+
+In each of `flac.rs:303`, `mp3.rs:410`, `wav.rs:252`, `ogg/mod.rs:275`, `mp4.rs:835`, change:
+
+```rust
+    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+```
+
+to:
+
+```rust
+    Ok(RegionLayout::validated(segments)?)
+```
+
+(These are the trailing expression of functions returning `Result<RegionLayout>` = `Result<RegionLayout, FormatError>`; `?` converts `LayoutError` via the new `#[from]`, and the value is re-wrapped in `Ok`.)
+
+- [ ] **Step 6: Replace the manual mp4 guard with `ProducerBug`**
+
+In `musefs-format/src/mp4.rs:822`, change:
+
+```rust
+        // build_udta always yields a leading Inline; anything else is a producer bug.
+        return Err(FormatError::InvalidLayout);
+```
+
+to:
+
+```rust
+        // build_udta always yields a leading Inline; anything else is a producer bug.
+        return Err(FormatError::ProducerBug(
+            "build_udta did not yield a leading Inline framing segment",
+        ));
+```
+
+- [ ] **Step 7: Run tests + clippy to verify pass**
+
+Run: `cargo test -p musefs-format 2>&1 | tail -20 && cargo clippy -p musefs-format --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: all tests PASS; clippy clean. (If clippy flags `redundant_closure`/`needless_question_mark` anywhere, address per its suggestion.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-format/src/layout.rs musefs-format/src/error.rs \
+        musefs-format/src/flac.rs musefs-format/src/mp3.rs \
+        musefs-format/src/wav.rs musefs-format/src/ogg/mod.rs \
+        musefs-format/src/mp4.rs
+git commit -m "feat(format): carry LayoutError diagnostics through FormatError (#95)"
+```
+
+### Task B2: `musefs-core/tree.rs` — `RebuildError` instead of `Result<(), ()>`
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs` (add `RebuildError`; change `rebuild_subtree` @301, `apply_changes` @337; four `ok_or(())` sites @326/352/384/403)
+- Modify: `musefs-core/src/facade.rs:315-316` (test-injection arm), `:345-346` (fallback log)
+- Test: `musefs-core/src/tree.rs` (inline `#[cfg(test)]`, alongside existing tree tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `#[cfg(test)]` area of `musefs-core/src/tree.rs` (near the other `rebuild_subtree_*` tests):
+
+```rust
+#[test]
+fn rebuild_subtree_reports_missing_rendered_path() {
+    use std::collections::HashMap;
+    let mut alloc = InodeAllocator::new();
+    let mut tree = VirtualTree::build_with(&[(10, "Alice/Song.flac".into())], &mut alloc);
+    let dir = tree.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let new_paths: HashMap<i64, String> = HashMap::new(); // omits track 10
+    let err = tree.rebuild_subtree(dir, &new_paths, &mut alloc).unwrap_err();
+    assert_eq!(err, RebuildError::MissingRenderedPath(10));
+}
+```
+
+(This mirrors the existing `rebuild_subtree_*` tests' setup: `InodeAllocator::new()`, `VirtualTree::build_with(&[(id, path)], &mut alloc)`, `tree.lookup(VirtualTree::ROOT, "Alice")`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core rebuild_subtree_reports_missing_rendered_path 2>&1 | head -30`
+Expected: FAILS to COMPILE — `RebuildError` does not exist and `rebuild_subtree` returns `Result<(), ()>`.
+
+- [ ] **Step 3: Define `RebuildError`**
+
+Add near the top of `musefs-core/src/tree.rs` (after the imports, before `VirtualTree`):
+
+```rust
+/// Why an incremental tree mutation could not complete; the caller falls back to
+/// a full rebuild. Carries diagnostics instead of `()` (#95).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebuildError {
+    /// A track collected for rebuild had no entry in `new_paths`.
+    MissingRenderedPath(i64),
+    /// Test-only injected failure (`force_apply_fail`).
+    TestInjected,
+}
+```
+
+- [ ] **Step 4: Change the two signatures and the four `ok_or` sites**
+
+In `rebuild_subtree` (`tree.rs:300-306`): delete the `#[allow(clippy::result_unit_err)]` line and change the return type to `std::result::Result<(), RebuildError>`. At line 326 change:
+
+```rust
+            let path = new_paths.get(&id).ok_or(())?;
+```
+
+to:
+
+```rust
+            let path = new_paths.get(&id).ok_or(RebuildError::MissingRenderedPath(*id))?;
+```
+
+In `apply_changes` (`tree.rs:336-344`): delete its `#[allow(clippy::result_unit_err)]` line and change the return type to `std::result::Result<(), RebuildError>`. Change the three sites:
+
+- Line 352: `let new_path = new_paths.get(&id).ok_or(())?;` →
+  `let new_path = new_paths.get(&id).ok_or(RebuildError::MissingRenderedPath(id))?;`
+- Line 384: `let rendered = new_paths.get(&id).ok_or(())?;` →
+  `let rendered = new_paths.get(&id).ok_or(RebuildError::MissingRenderedPath(id))?;`
+- Line 403: `let rendered = new_paths.get(&id).ok_or(())?;` →
+  `let rendered = new_paths.get(&id).ok_or(RebuildError::MissingRenderedPath(id))?;`
+
+(The `self.rebuild_subtree(d, new_paths, alloc)?;` at line 423 now propagates `RebuildError` unchanged — both functions share the type.)
+
+- [ ] **Step 5: Update the facade caller (test injection + fallback log)**
+
+In `musefs-core/src/facade.rs`, the test-injection arm (line 315-316) currently reads:
+
+```rust
+        let applied = if self.force_apply_fail.swap(false, Ordering::AcqRel) {
+            Err(()) // test injection
+        } else {
+```
+
+Change `Err(())` to `Err(crate::tree::RebuildError::TestInjected)`.
+
+Then the fallback arm (line 345-346):
+
+```rust
+            Err(()) => {
+                eprintln!("musefs: incremental tree mutation failed; falling back to full rebuild");
+```
+
+Change to bind and log the reason:
+
+```rust
+            Err(reason) => {
+                log::warn!(
+                    "musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild"
+                );
+```
+
+> This introduces the first `log::` use in `musefs-core`. Task C1 adds the `log` dependency. If Part C has not run yet, temporarily keep `eprintln!("musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild");` here and convert it to `log::warn!` in Task C4. **Recommended:** run Part C before this conversion, or use `eprintln!` now. For this task, use `eprintln!` with the `{reason:?}` interpolation so no new dependency is needed:
+
+```rust
+            Err(reason) => {
+                eprintln!(
+                    "musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild"
+                );
+```
+
+- [ ] **Step 6: Run tests + clippy to verify pass**
+
+Run: `cargo test -p musefs-core 2>&1 | tail -20 && cargo clippy -p musefs-core --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: all PASS; clippy clean (the `result_unit_err` allows are gone with no new warnings).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/tree.rs musefs-core/src/facade.rs
+git commit -m "feat(core): RebuildError carries tree-mutation diagnostics (#95)"
+```
+
+### Task B3: record the convention in `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md` (the `## Conventions` section)
+
+- [ ] **Step 1: Add the convention bullet**
+
+In `CLAUDE.md`, under `## Conventions`, after the `- Errors:` bullet, add:
+
+```markdown
+- Internal error paths do not discard diagnostics: no `Result<_, ()>`, and no
+  `.map_err(|_| …)` that drops a source. Each error variant carries its source
+  (`#[from]`) or a static reason describing the broken invariant.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: record the no-discarded-diagnostics error convention (#95)"
+```
+
+---
+
+## Part C — #96: mutex poison recovery-by-reset (Rust)
+
+Only `std::sync::Mutex` fields in `musefs-core` `facade.rs` and `reader.rs` are in
+scope (the VFS-serving state). Out of scope, by spec: `byte_budget.rs` (→ #93),
+`db_pool.rs` (→ #94), and `scan.rs` test/scan-internal locks. Three recovery
+categories, each a helper in a new `lock.rs` module.
+
+### Task C1: add `log` dep + the `lock.rs` helper module
+
+**Files:**
+- Modify: `musefs-core/Cargo.toml` (add `log`)
+- Create: `musefs-core/src/lock.rs`
+- Modify: `musefs-core/src/lib.rs` (add `mod lock;`)
+- Test: inline in `musefs-core/src/lock.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `musefs-core/src/lock.rs` with the test first (the impls come in Step 4):
+
+```rust
+//! Poison-recovery policy for the daemon's in-memory mutexes (#96).
+//!
+//! musefs is read-only and the SQLite store is the source of truth, so on a
+//! poisoned lock we reset the guarded state to a known-good value rather than
+//! serve possibly-inconsistent state:
+//!   * caches  -> `lock_or_clear`  (clear; next access cold-resolves from the DB)
+//!   * VFS state -> `lock_or_flag` (schedule a full rebuild via `poll_refresh`)
+//!   * scalars -> `lock_recover`   (replace-only writes can't be half-written)
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
+
+/// State that can be reset to empty for `lock_or_clear`.
+pub(crate) trait Clearable {
+    fn reset(&mut self);
+}
+
+impl<T> Clearable for Option<T> {
+    fn reset(&mut self) {
+        *self = None;
+    }
+}
+
+/// Category 3 — transient scalar. Recover the inner value, logging the poison.
+pub(crate) fn lock_recover<'a, T>(m: &'a Mutex<T>, what: &str) -> MutexGuard<'a, T> {
+    m.lock().unwrap_or_else(|e| {
+        log::error!("recovered poisoned scalar lock ({what}); continuing on inner value");
+        e.into_inner()
+    })
+}
+
+/// Category 1 — cache. On poison, clear the cache so the next access
+/// cold-resolves; a cleared cache cannot be inconsistent.
+pub(crate) fn lock_or_clear<'a, T: Clearable>(m: &'a Mutex<T>, what: &str) -> MutexGuard<'a, T> {
+    match m.lock() {
+        Ok(g) => g,
+        Err(e) => {
+            log::error!("cleared poisoned cache lock ({what})");
+            let mut g = e.into_inner();
+            g.reset();
+            g
+        }
+    }
+}
+
+/// Category 2 — rebuildable VFS state. On poison, flag a full rebuild (run by the
+/// next `poll_refresh`) and recover the inner value for best-effort completion.
+pub(crate) fn lock_or_flag<'a, T>(
+    m: &'a Mutex<T>,
+    needs_rebuild: &AtomicBool,
+    what: &str,
+) -> MutexGuard<'a, T> {
+    m.lock().unwrap_or_else(|e| {
+        log::error!("poisoned VFS-state lock ({what}); scheduling full rebuild");
+        needs_rebuild.store(true, Ordering::Release);
+        e.into_inner()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn poison<T: Send + 'static>(m: Arc<Mutex<T>>) {
+        let m2 = Arc::clone(&m);
+        let _ = std::thread::spawn(move || {
+            let _g = m2.lock().unwrap();
+            panic!("poison it");
+        })
+        .join();
+        assert!(m.is_poisoned());
+    }
+
+    #[test]
+    fn recover_returns_inner_after_poison() {
+        let m = Arc::new(Mutex::new(7u32));
+        poison(Arc::clone(&m));
+        assert_eq!(*lock_recover(&m, "scalar"), 7);
+    }
+
+    #[test]
+    fn clear_empties_cache_after_poison() {
+        let m = Arc::new(Mutex::new(Some(42u32)));
+        poison(Arc::clone(&m));
+        assert!(lock_or_clear(&m, "cache").is_none());
+    }
+
+    #[test]
+    fn flag_set_after_poison() {
+        let m = Arc::new(Mutex::new(0u32));
+        let flag = AtomicBool::new(false);
+        poison(Arc::clone(&m));
+        let _g = lock_or_flag(&m, &flag, "vfs");
+        assert!(flag.load(Ordering::Acquire));
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module + dependency**
+
+Add to `musefs-core/Cargo.toml` under `[dependencies]`:
+
+```toml
+log = "0.4"
+```
+
+Add to `musefs-core/src/lib.rs` (with the other `mod` declarations):
+
+```rust
+mod lock;
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core lock:: 2>&1 | tail -20`
+Expected: the three `lock::tests::*` PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/Cargo.toml musefs-core/src/lock.rs musefs-core/src/lib.rs Cargo.lock
+git commit -m "feat(core): lock.rs poison recovery-by-reset helpers (#96)"
+```
+
+### Task C2: category 1 — clear caches on poison (reader + ogg_index)
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs` (`HeaderCache::shard` @183-188, `retain` @190-196; add `Clearable for Shard`)
+- Modify: `musefs-core/src/ogg_index.rs:58, 181, 195` (the `LastPageMemo` accesses)
+
+- [ ] **Step 1: Make `Shard` clearable + use `lock_or_clear` in `shard()`**
+
+In `musefs-core/src/reader.rs`, add a `Clearable` impl for `Shard` (place it next to the `Shard` definition). `Shard` already has `retain_keys`; clearing means dropping all entries — use whatever the struct's reset is. If `Shard` has no `clear`, add one that empties its map and LRU list and resets its byte counter:
+
+```rust
+impl crate::lock::Clearable for Shard {
+    fn reset(&mut self) {
+        self.retain_keys(&std::collections::HashSet::new());
+    }
+}
+```
+
+> `retain_keys(&empty_set)` drops every entry, which is exactly the "clear" semantics we want and reuses existing, tested pruning logic.
+
+Change `HeaderCache::shard` (lines 183-188) from:
+
+```rust
+    fn shard(&self, track_id: i64) -> std::sync::MutexGuard<'_, Shard> {
+        let idx = (track_id as u64 % CACHE_SHARDS as u64) as usize;
+        self.shards[idx]
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+```
+
+to:
+
+```rust
+    fn shard(&self, track_id: i64) -> std::sync::MutexGuard<'_, Shard> {
+        let idx = (track_id as u64 % CACHE_SHARDS as u64) as usize;
+        crate::lock::lock_or_clear(&self.shards[idx], "header-cache shard")
+    }
+```
+
+In `retain` (lines 190-196) change:
+
+```rust
+    pub fn retain(&self, live: &HashSet<i64>) {
+        for s in &self.shards {
+            s.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .retain_keys(live);
+        }
+    }
+```
+
+to:
+
+```rust
+    pub fn retain(&self, live: &HashSet<i64>) {
+        for s in &self.shards {
+            crate::lock::lock_or_clear(s, "header-cache shard (retain)").retain_keys(live);
+        }
+    }
+```
+
+- [ ] **Step 2: Use `lock_or_clear` for the `LastPageMemo` (category-1 cache)**
+
+In `musefs-core/src/ogg_index.rs`, the three `m.lock().unwrap()` sites on the
+`LastPageMemo` (`Mutex<Option<(u64,u64,Vec<u8>)>>`, already `Clearable` via the
+blanket `Option<T>` impl) become `lock_or_clear`:
+
+- Line 58: `let guard = m.lock().unwrap();` →
+  `let guard = crate::lock::lock_or_clear(m, "ogg last-page memo");`
+- Line 181: `let g = m.lock().unwrap();` →
+  `let g = crate::lock::lock_or_clear(m, "ogg last-page memo");`
+- Line 195: `*m.lock().unwrap() = Some((page_rel, total_len, patched_hdr.clone()));` →
+  `*crate::lock::lock_or_clear(m, "ogg last-page memo") = Some((page_rel, total_len, patched_hdr.clone()));`
+
+(The test at `ogg_index.rs:653` uses `.lock().unwrap()` on a local memo and may stay as-is — it is test code asserting a populated memo, not a serving-path recovery.)
+
+- [ ] **Step 3: Run tests + clippy**
+
+Run: `cargo test -p musefs-core 2>&1 | tail -20 && cargo clippy -p musefs-core --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: all PASS; clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/src/reader.rs musefs-core/src/ogg_index.rs
+git commit -m "feat(core): clear header-cache + ogg memo on poison (#96)"
+```
+
+### Task C3: category 2 — flag VFS state + self-healing rebuild
+
+Add a `needs_rebuild: AtomicBool` field, route the `inodes`/`snapshot` locks
+through `lock_or_flag`, and extend `poll_refresh_notify` so a set flag bypasses
+the three early-return gates and forces a full rebuild.
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (struct field + initializer; lock sites @243, @259, @313, @426, @457; `poll_refresh_notify` @384; new `force_full_rebuild` helper)
+- Test: `musefs-core/src/facade.rs` (inline `#[cfg(test)]`, or the crate's existing facade test file if one exists)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the inline `#[cfg(test)] mod tests` in `facade.rs` (it reuses
+the same temp-dir + `scan_directory` + `Musefs::open` scaffolding as the existing
+`open_handle_reresolves_after_content_version_bump` test):
+
+```rust
+#[test]
+fn needs_rebuild_flag_forces_full_rebuild_on_next_poll() {
+    use crate::scan::scan_directory;
+    use id3::TagLike;
+    use std::collections::BTreeMap;
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let mut tag = id3::Tag::new();
+        tag.set_artist("Pix");
+        tag.set_title("Song");
+        let mut bytes = Vec::new();
+        tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+        bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+        std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+    }
+    let db_path = dir.path().join("m.db");
+    {
+        let db = musefs_db::Db::open(&db_path).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+    }
+    let cfg = MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+    };
+    let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+    // data_version is unchanged since open, so a normal poll is a no-op.
+    assert!(!fs.poll_refresh().unwrap(), "baseline poll must be a no-op");
+
+    // Simulate recovery from a poisoned VFS-state lock.
+    fs.mark_needs_rebuild_for_test();
+    assert!(fs.poll_refresh().unwrap(), "a set needs_rebuild flag must force a rebuild");
+    assert!(!fs.needs_rebuild_is_set_for_test(), "flag cleared after rebuild");
+}
+```
+
+Add the two `#[doc(hidden)]` test accessors next to the existing
+`force_rebuild_errors_for_test` (facade.rs:518):
+
+```rust
+    #[doc(hidden)]
+    pub fn mark_needs_rebuild_for_test(&self) {
+        self.needs_rebuild.store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    #[doc(hidden)]
+    pub fn needs_rebuild_is_set_for_test(&self) -> bool {
+        self.needs_rebuild.load(std::sync::atomic::Ordering::Acquire)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core needs_rebuild_flag_forces_full_rebuild_on_next_poll 2>&1 | head -30`
+Expected: FAILS to COMPILE — the `needs_rebuild` field and accessors don't exist yet.
+
+- [ ] **Step 3: Add the `needs_rebuild` field + initializer**
+
+In the `Musefs` struct (`facade.rs`, near `force_apply_fail` at line 147) add:
+
+```rust
+    /// Set when a poisoned VFS-state lock is recovered; the next `poll_refresh`
+    /// forces a full rebuild from the DB and clears it (#96).
+    needs_rebuild: AtomicBool,
+```
+
+In every `Musefs { … }` constructor literal (the one near line 180 where
+`force_apply_fail: AtomicBool::new(false)` is set — and any other constructor),
+add:
+
+```rust
+            needs_rebuild: AtomicBool::new(false),
+```
+
+- [ ] **Step 4: Route `inodes`/`snapshot` locks through `lock_or_flag`**
+
+Replace each of these `*.lock().unwrap_or_else(std::sync::PoisonError::into_inner)` acquisitions with the helper:
+
+- `facade.rs:243` (snapshot write in `refresh`): the expression `self.snapshot.lock().unwrap_or_else(std::sync::PoisonError::into_inner)` becomes `crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot")`.
+- `facade.rs:259` (inodes in `rebuild_full`): becomes `crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes")`.
+- `facade.rs:313` (inodes in `rebuild_incremental`): becomes `crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes")`.
+- `facade.rs:426` (snapshot read in `poll_refresh_notify`): becomes `crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot")`.
+- `facade.rs:457` (snapshot write in `poll_refresh_notify`): becomes `crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot")`.
+
+Each retains its surrounding `.clone()` / `= value` usage — only the guard acquisition changes. Example for line 240-243:
+
+```rust
+        *crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot") = snapshot;
+```
+
+- [ ] **Step 5: Add `force_full_rebuild` and the gate-bypass in `poll_refresh_notify`**
+
+Add a private helper to the `impl Musefs` block (near `rebuild_full`):
+
+```rust
+    /// Full rebuild used to self-heal after a poisoned VFS-state lock: rebuild
+    /// from the DB, publish the tree, diff for cache invalidation, and clear the
+    /// flag. Bypasses the poll gates (the caller checks `needs_rebuild`).
+    fn force_full_rebuild(&self, on_changed: &mut impl FnMut(u64)) -> Result<bool> {
+        let old_tree = self.tree.load_full();
+        let old_snapshot = crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot").clone();
+        let new_snapshot = self.rebuild_full()?;
+        let new_tree = self.tree.load();
+        let live = new_tree.track_ids();
+        self.cache.retain(&live);
+        self.size_cache.retain(|k, _| live.contains(k));
+        Self::notify_changed(&old_snapshot, &new_snapshot, &old_tree, &new_tree, on_changed);
+        *crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot") = new_snapshot;
+        self.refresh_gen.fetch_add(1, Ordering::AcqRel);
+        self.needs_rebuild.store(false, Ordering::Release);
+        self.stamp_successful_poll();
+        Ok(true)
+    }
+```
+
+At the very top of `poll_refresh_notify` (before the debounce gate at line 385), insert:
+
+```rust
+        // A poisoned VFS-state lock scheduled a full rebuild: do it now,
+        // bypassing the debounce / backoff / data_version gates (#96).
+        if self.needs_rebuild.load(Ordering::Acquire) {
+            // Single-flight with the same flag the normal path uses.
+            if self
+                .refreshing
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                return Ok(false);
+            }
+            let _guard = RefreshGuard(&self.refreshing);
+            return self.force_full_rebuild(&mut on_changed);
+        }
+```
+
+- [ ] **Step 6: Run the test + full crate tests + clippy**
+
+Run: `cargo test -p musefs-core 2>&1 | tail -25 && cargo clippy -p musefs-core --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: the new test PASSES; all existing `poll_refresh`/facade tests still PASS; clippy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/facade.rs
+git commit -m "feat(core): flag + self-heal VFS state on lock poison (#96)"
+```
+
+### Task C4: category 3 — recover scalars + finish the log migration
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` scalar lock sites: `389` (last_poll read), `398` (last_failed_refresh read), `434` (last_failed_refresh write), `510` (last_poll write), `515` (last_failed_refresh write), `543` (last_poll write, test helper); and the `eprintln!` fallback at `346` from Task B2.
+- Modify: `musefs-core/src/db_pool.rs`? — **no** (out of scope, #94).
+
+- [ ] **Step 1: Route the scalar locks through `lock_recover`**
+
+Replace each `*.lock().unwrap_or_else(std::sync::PoisonError::into_inner)` on a scalar mutex with `lock_recover`:
+
+- Line 389 (`last_poll` debounce read): `self.last_poll.lock().unwrap_or_else(std::sync::PoisonError::into_inner)` → `crate::lock::lock_recover(&self.last_poll, "last_poll")`.
+- Line 398 (`last_failed_refresh` read): → `crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")`.
+- Line 434 (`last_failed_refresh` write): → `crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")`.
+- Line 510 (`last_poll` write in `stamp_successful_poll`): → `crate::lock::lock_recover(&self.last_poll, "last_poll")`.
+- Line 515 (`last_failed_refresh` write in `stamp_successful_poll`): → `crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")`.
+- Line 543 (`last_poll` write in `expire_poll_debounce_for_test`): → `crate::lock::lock_recover(&self.last_poll, "last_poll")`.
+
+Each keeps its surrounding `*… = value` / `.elapsed()` / `if let Some(..) = *…` usage; only the acquisition changes.
+
+- [ ] **Step 2: Convert the Task B2 fallback `eprintln!` to `log::warn!`**
+
+Now that `log` is a dependency (Task C1), change the fallback arm in `poll_refresh_notify` (the `Err(reason) =>` block, ~line 345) from:
+
+```rust
+                eprintln!(
+                    "musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild"
+                );
+```
+
+to:
+
+```rust
+                log::warn!(
+                    "incremental tree mutation failed ({reason:?}); falling back to full rebuild"
+                );
+```
+
+- [ ] **Step 3: Run tests + clippy**
+
+Run: `cargo test -p musefs-core 2>&1 | tail -20 && cargo clippy -p musefs-core --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: all PASS; clippy clean. Confirm no `unwrap_or_else(std::sync::PoisonError::into_inner)` remains in `facade.rs`/`reader.rs`:
+
+Run: `grep -rn "PoisonError::into_inner" musefs-core/src/facade.rs musefs-core/src/reader.rs`
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/src/facade.rs
+git commit -m "feat(core): recover scalar locks on poison; route logs via log crate (#96)"
+```
+
+### Task C5: audit comment + scope note
+
+**Files:**
+- Modify: `musefs-core/src/lock.rs` (append the audit) or `musefs-core/src/facade.rs` (module-level comment)
+
+- [ ] **Step 1: Record the per-lock audit**
+
+Append to the module doc-comment in `musefs-core/src/lock.rs` a table classifying every `Mutex` reached on the serving path and why its reset is correct:
+
+```rust
+//! Audit (every serving-path `std::sync::Mutex`):
+//!   facade.rs `inodes`            -> cat 2 (flag): InodeAllocator, rebuilt by build_full from the DB.
+//!   facade.rs `snapshot`          -> cat 2 (flag): per-track render state, rebuilt by rebuild_full from the DB.
+//!   facade.rs `last_poll`         -> cat 3 (recover): Instant, replace-only single write.
+//!   facade.rs `last_failed_refresh` -> cat 3 (recover): Option<Instant>, replace-only single write.
+//!   reader.rs HeaderCache shards  -> cat 1 (clear): pure cache, repopulated from the DB.
+//!   ogg_index.rs LastPageMemo     -> cat 1 (clear): deterministic one-entry cache, re-derived.
+//! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
+//! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,
+//! not on the FUSE serving path).
+```
+
+- [ ] **Step 2: Verify build + commit**
+
+Run: `cargo test -p musefs-core 2>&1 | tail -5`
+Expected: PASS.
+
+```bash
+git add musefs-core/src/lock.rs
+git commit -m "docs(core): audit serving-path locks for poison policy (#96)"
+```
+
+### Task C6: full-workspace verification
+
+- [ ] **Step 1: Run the whole workspace test + lint suite**
+
+Run: `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5 && cargo test --workspace 2>&1 | tail -30`
+Expected: fmt clean, clippy clean, all tests PASS (the `#[ignore]`d FUSE e2e tests stay ignored).
+
+- [ ] **Step 2: (optional) Run the FUSE e2e suite if `/dev/fuse` is available**
+
+Run: `cargo test -p musefs-fuse -- --ignored 2>&1 | tail -20`
+Expected: PASS (real mounts; requires `/dev/fuse` + libfuse). If the environment lacks `/dev/fuse`, note it and rely on the workspace suite.
+
+- [ ] **Step 3: Confirm the fuzz crate still builds (signatures changed in Part B)**
+
+Run: `cargo +nightly fuzz build mp4 2>&1 | tail -5` (the format-layer error change is the only fuzz-visible surface; mp4 exercises `ProducerBug`/`InvalidLayout`).
+Expected: builds. If nightly/cargo-fuzz is unavailable, note it — CI's fuzz smoke job covers it.
+
+---
+
+## Notes for the executor
+
+- **Part ordering:** A, B, then C is the spec's sequence, but A (Python) is fully independent and can run in parallel. Within Part B, do B1 before B2 only if convenient — they touch different crates. **Do Task C1 before B2's commit if you want `log::warn!` in the fallback immediately**; otherwise B2 uses `eprintln!` and C4 converts it (the plan is written for that path).
+- **No `--amend`, no `--no-verify`.** A failed pre-commit hook means the commit didn't happen: fix, re-stage, new commit.
+- If any cited line number has drifted (the spec/plan were written against a specific tree state), locate the symbol by name (`replace_tags`, `synthesize_layout`, `apply_changes`, `poll_refresh_notify`, `HeaderCache::shard`) rather than trusting the number.

--- a/docs/superpowers/specs/2026-06-03-phase0-1-data-loss-and-conventions-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase0-1-data-loss-and-conventions-design.md
@@ -1,0 +1,250 @@
+# Phase 0 + Phase 1: Stop Data Loss, Settle Two Foundational Conventions
+
+**Date:** 2026-06-03
+**Issues:** #82 (active data loss), #95 (error diagnostics), #96 (mutex poison policy)
+**Status:** Design approved; ready for implementation planning.
+
+## Overview
+
+This spec covers the first two phases of the open-issue backlog (see
+`docs/ROADMAP.md`). It does two things:
+
+1. **Stops active data loss** introduced by the binary-tags work (#77–#81): a
+   plugin sync currently deletes scanner-written binary tags.
+2. **Settles two foundational conventions** — internal error diagnostics (#95)
+   and mutex poison-recovery policy (#96) — *before* the later issues that
+   inherit them are written (#89/#90/#91/#92/#94).
+
+Two independent codebases are touched and can progress in parallel:
+
+- **Python plugins** — #82 (`contrib/beets/`, `contrib/picard/`).
+- **Rust core/format** — #95, #96 (`musefs-format`, `musefs-core`).
+
+The cardinal project invariant (original audio bytes are never copied or
+modified) is untouched by all three changes.
+
+## #82 — Preserve scanner-written binary tags
+
+### Problem
+
+Both `contrib/beets/beetsplug/_core.py:171` and
+`contrib/picard/musefs/_core.py:201` implement `replace_tags` with a byte-identical
+body that does an unscoped delete:
+
+```python
+conn.execute("DELETE FROM tags WHERE track_id = ?", (track_id,))
+```
+
+Schema V2 (`musefs-db/src/schema.rs:79-80`) added the `value_blob` column and
+defines binary tag rows as exactly those with `value_blob IS NOT NULL` (binary
+rows store `''` in `value`). The Rust scanner writes binary tags (ID3 APIC/opaque
+frames, MP4 `----`, FLAC APPLICATION/CUESHEET) as such rows. The plugins only ever
+write **text** rows (`value` set, `value_blob` left NULL).
+
+Because the delete is unscoped, a plugin sync removes the scanner-written binary
+rows along with the text rows it intends to replace. Since `--revalidate` skips
+unchanged backing files, a later scan does not re-add them, so binary tags are
+permanently lost after the first sync.
+
+### Fix
+
+Scope the delete to the plugin-owned (text) rows in **both** files:
+
+```python
+conn.execute(
+    "DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,)
+)
+```
+
+The `(track_id, key, ordinal)` primary key cannot collide between a surviving
+binary row and a re-inserted text row, because binary keys (ID3 opaque/APIC,
+MP4 `----`, FLAC APPLICATION/CUESHEET) are disjoint from canonical text tag keys.
+
+### Out of scope
+
+The two `_core.py` modules are near-duplicates. Deduplicating them into a shared
+module is a separate concern and is **not** part of this work; the one-line fix is
+applied independently to each copy.
+
+### Testing
+
+For each plugin, add a test that:
+
+1. Seeds a track with one binary tag row (`value_blob IS NOT NULL`) and one text
+   tag row.
+2. Runs a `replace_tags` / sync.
+3. Asserts the binary row survives unchanged and the text rows are replaced.
+
+## #95 — Internal error types carry diagnostics
+
+### Problem
+
+Two internal error paths discard context:
+
+- **`musefs-format`** — `RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)`
+  at five synthesis sites (flac.rs:303, mp3.rs:410, wav.rs:252, ogg/mod.rs:275,
+  mp4.rs:835) throws away the inner `LayoutError`, which distinguishes
+  `EmptySegment` from `TotalOverflow`. `FormatError::InvalidLayout` is a unit
+  variant. A sixth site (mp4.rs:822) is a manual `return Err(FormatError::InvalidLayout)`
+  guarding a *producer invariant* (`build_udta` must yield a leading `Inline`
+  segment) — this is not a `LayoutError`.
+- **`musefs-core/src/tree.rs`** — `rebuild_subtree` and `apply_changes` return
+  `Result<(), ()>` (with `#[allow(clippy::result_unit_err)]`). When a tree mutation
+  fails and the caller falls back to a full rebuild (`facade.rs:345`), there is no
+  information about why.
+
+### Fix — `musefs-format`
+
+Make `InvalidLayout` carry its source and add a distinct variant for the producer
+guard:
+
+```rust
+#[error("synthesized region layout violates producer invariants: {0}")]
+InvalidLayout(#[from] LayoutError),
+
+#[error("producer invariant violated: {0}")]
+ProducerBug(&'static str),
+```
+
+- The five `validated(...).map_err(|_| ...)` sites collapse to `?` (via `#[from]`).
+- The manual guard at mp4.rs:822 becomes
+  `return Err(FormatError::ProducerBug("build_udta did not yield a leading Inline framing segment"));`.
+
+### Fix — `musefs-core/tree.rs`
+
+Replace the unit error with a named enum (and drop the
+`#[allow(clippy::result_unit_err)]` attributes):
+
+```rust
+pub enum RebuildError {
+    /// A track collected for rebuild had no entry in `new_paths`.
+    MissingRenderedPath(i64),
+    /// Test-only injected failure (facade `force_apply_fail`).
+    TestInjected,
+}
+```
+
+- `rebuild_subtree` and `apply_changes` return `Result<(), RebuildError>`.
+- The three `new_paths.get(&id).ok_or(())` sites become
+  `.ok_or(RebuildError::MissingRenderedPath(id))`.
+- The `force_apply_fail` test-injection arm (`facade.rs:316`) yields
+  `Err(RebuildError::TestInjected)`.
+- The fallback site (`facade.rs:345-346`) logs the actual `RebuildError` instead of
+  the generic `eprintln!` string.
+
+### Convention
+
+Record in this spec and in `CLAUDE.md` ("Conventions"):
+
+> Internal error paths do not discard diagnostics. No `Result<_, ()>`; no
+> `.map_err(|_| …)` that drops a source. Each error variant carries its source
+> (`#[from]`) or a static reason describing the broken invariant.
+
+Issues #91 and #92 adopt this convention from the start.
+
+### Testing
+
+- `musefs-format`: assert that a synthesis path producing an invalid layout
+  surfaces the specific `LayoutError` (e.g. `EmptySegment` vs `TotalOverflow`)
+  through `FormatError::InvalidLayout`, and that the mp4 producer guard surfaces
+  `ProducerBug`.
+- `musefs-core`: assert `rebuild_subtree` returns `MissingRenderedPath(id)` when a
+  collected track is absent from `new_paths`.
+
+## #96 — Mutex poison recovery-by-reset
+
+### Decision
+
+The codebase recovers from poisoned mutexes throughout with
+`.unwrap_or_else(std::sync::PoisonError::into_inner)`, silently continuing on the
+inner value. Every external reviewer flagged this as a daemon-correctness risk:
+after a panic *while mutating* global VFS state, the daemon serves from
+potentially-inconsistent state.
+
+The adopted policy is **recover-by-reset**: on a poisoned lock, reset the guarded
+state to a known-good value rather than serve suspect state, and log at every
+site. This is provably correct here because every datum under these mutexes is
+either derivable from the SQLite store (the source of truth) or a single-word
+scalar. It is preferred over:
+
+- **Plain log-and-recover** — treats the symptom (visibility) without restoring
+  correctness.
+- **Fail-fast (EIO / crash)** — more invasive (threads error paths through call
+  sites that cannot fail today) and worse UX (unmounts a read-only convenience
+  filesystem on a possibly-benign panic).
+- **`parking_lot::Mutex`** — cleans the call sites but *deletes* the poison
+  signal entirely, foreclosing both logging and any future fail-fast, while
+  leaving the underlying inconsistent-state behavior unchanged.
+
+### Mechanism — three recovery categories
+
+Each state-mutating lock is classified into one of three categories, each with a
+defined, correct recovery action. Recovery is logged at every site.
+
+1. **Caches** (header-layout LRU shards, size cache) → `lock_or_clear()`.
+   On poison, take the inner guard, `.clear()` it, and return it. The next access
+   cold-resolves from the DB. A cleared cache cannot be inconsistent, so this is
+   provably safe.
+
+2. **Rebuildable VFS state** (inode allocator) → `lock_or_flag()`.
+   On poison, set an `AtomicBool needs_rebuild`, log, and return the inner guard so
+   the current op completes best-effort (no rebuild while holding the poisoned
+   lock — avoids reentrancy/deadlock). `poll_refresh` already fires on every
+   metadata op (`lookup`/`readdir`); it forces `rebuild_full` when the flag is set,
+   regardless of `data_version`, and clears the flag. The state therefore
+   self-heals within one metadata-op cycle — no `EIO` to the kernel, no daemon
+   crash, no unmount. Inodes are stable across rebuilds by design, so an open
+   handle survives.
+
+3. **Transient scalars** (`last_poll`, `last_data_version`) → recover inner.
+   These are single-word replace-only writes that cannot be left half-written, so
+   `into_inner` recovery is already correct.
+
+### Audit
+
+As part of this work, perform a one-time audit of every state-mutating lock,
+recording in a module-level comment which category it falls into and why the reset
+is correct (e.g. "outright replacement" per gemini's safe case, or "rebuilt from
+DB on next refresh"). This documents the policy at the point of use.
+
+### Logging
+
+`musefs-fuse` already depends on `log = "0.4"`; `musefs-core` does not (it has a
+single `eprintln!` at `facade.rs:346`). Add `log = "0.4"` to `musefs-core` and
+route poison-recovery messages (and the existing fallback message) through
+`log::error!` / `log::warn!`.
+
+### Deferred to #93
+
+`ByteBudget` is the one lock whose correct reset is subtle: after a panic between
+its guard check and the `in_flight` increment, the true in-flight count is
+unknowable. Its reset semantics are scoped into **#93** (the `byte_budget`
+overflow-asymmetry issue), following the same category-2/3 pattern established
+here.
+
+### Testing
+
+Unit tests per recovery category:
+
+- `lock_or_clear`: a poisoned cache lock is observed cleared on the next access.
+- `lock_or_flag`: a poisoned VFS-state lock sets `needs_rebuild`, and the next
+  `poll_refresh` performs a full rebuild that restores a consistent tree.
+- transient scalar: a poisoned scalar lock recovers the inner value unchanged.
+
+The `#[ignore]` FUSE end-to-end mount suite must remain green.
+
+## Sequencing
+
+1. **#82** first — stops live data loss; fully independent; can run on the plugin
+   track in parallel with the Rust track.
+2. **#95** — lands the error-diagnostics convention that #91/#92 will follow.
+3. **#96** — largest scope; depends on nothing from #95.
+
+Each change ships test-driven with the project's existing review gates.
+
+## Out of scope
+
+- Deduplicating the two `_core.py` plugin modules.
+- `ByteBudget` reset semantics (belongs to #93).
+- Migration to `parking_lot::Mutex`.
+- Any other backlog issue (Phases 2–7).

--- a/docs/superpowers/specs/2026-06-03-phase0-1-data-loss-and-conventions-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase0-1-data-loss-and-conventions-design.md
@@ -56,9 +56,17 @@ conn.execute(
 )
 ```
 
-The `(track_id, key, ordinal)` primary key cannot collide between a surviving
-binary row and a re-inserted text row, because binary keys (ID3 opaque/APIC,
-MP4 `----`, FLAC APPLICATION/CUESHEET) are disjoint from canonical text tag keys.
+For the **default** tag vocabulary, the `(track_id, key, ordinal)` primary key
+cannot collide between a surviving binary row and a re-inserted text row: the
+built-in keys (`DIRECT_FIELDS` in `_core.py`) are lowercase canonical names,
+disjoint from the binary key set (ID3 `PRIV`/`GEOB`/`APIC`, MP4 `----:…`, FLAC
+`APPLICATION`/`CUESHEET`). A user-configured `musefs_fields` / `extra_fields`
+mapping is unconstrained, so a key like `"PRIV"` *could* collide with a surviving
+binary row. The failure mode is **benign and safe**: SQLite raises an
+`IntegrityError` that aborts the sync transaction with no data loss (the binary
+rows are preserved, the partial text write is rolled back). We do not add key
+validation now (YAGNI); we only document this and pin the default-vocabulary
+disjointness with a test.
 
 ### Out of scope
 
@@ -74,6 +82,10 @@ For each plugin, add a test that:
    tag row.
 2. Runs a `replace_tags` / sync.
 3. Asserts the binary row survives unchanged and the text rows are replaced.
+
+Plus a static assertion that the default tag vocabulary (`DIRECT_FIELDS`) is
+disjoint from the known binary key set, documenting why the scoped delete is
+collision-free without an explicit guard.
 
 ## #95 — Internal error types carry diagnostics
 
@@ -95,8 +107,22 @@ Two internal error paths discard context:
 
 ### Fix — `musefs-format`
 
-Make `InvalidLayout` carry its source and add a distinct variant for the producer
-guard:
+First, make `LayoutError` (`layout.rs`) a real error type — it currently derives
+only `Debug, Clone, PartialEq, Eq` and implements neither `Display` nor
+`std::error::Error`, which `#[from]`/`{0}` interpolation require:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LayoutError {
+    #[error("a segment reported zero length")]
+    EmptySegment,
+    #[error("total layout length overflowed u64")]
+    TotalOverflow,
+}
+```
+
+Then make `InvalidLayout` carry its source and add a distinct variant for the
+producer guard:
 
 ```rust
 #[error("synthesized region layout violates producer invariants: {0}")]
@@ -125,8 +151,11 @@ pub enum RebuildError {
 ```
 
 - `rebuild_subtree` and `apply_changes` return `Result<(), RebuildError>`.
-- The three `new_paths.get(&id).ok_or(())` sites become
-  `.ok_or(RebuildError::MissingRenderedPath(id))`.
+- The **four** `new_paths.get(&id).ok_or(())` sites (`tree.rs:326` in
+  `rebuild_subtree`; `352`, `384`, `403` in `apply_changes`) become
+  `.ok_or(RebuildError::MissingRenderedPath(id))`. The `rebuild_subtree(...)?`
+  propagation at `tree.rs:423` works unchanged once both functions share the
+  `RebuildError` type.
 - The `force_apply_fail` test-injection arm (`facade.rs:316`) yields
   `Err(RebuildError::TestInjected)`.
 - The fallback site (`facade.rs:345-346`) logs the actual `RebuildError` instead of
@@ -157,15 +186,17 @@ Issues #91 and #92 adopt this convention from the start.
 
 The codebase recovers from poisoned mutexes throughout with
 `.unwrap_or_else(std::sync::PoisonError::into_inner)`, silently continuing on the
-inner value. Every external reviewer flagged this as a daemon-correctness risk:
-after a panic *while mutating* global VFS state, the daemon serves from
-potentially-inconsistent state.
+inner value (the one exception is `ByteBudget`, which uses `.lock().unwrap()` and
+*panics* on poison — deferred to #93, below). Every external reviewer flagged the
+recovery pattern as a daemon-correctness risk: after a panic *while mutating*
+global VFS state, the daemon serves from potentially-inconsistent state.
 
 The adopted policy is **recover-by-reset**: on a poisoned lock, reset the guarded
 state to a known-good value rather than serve suspect state, and log at every
 site. This is provably correct here because every datum under these mutexes is
-either derivable from the SQLite store (the source of truth) or a single-word
-scalar. It is preferred over:
+either derivable from the SQLite store (the source of truth — including the
+`snapshot` render state, rebuilt by the refresh path) or a single-word scalar. It
+is preferred over:
 
 - **Plain log-and-recover** — treats the symptom (visibility) without restoring
   correctness.
@@ -178,27 +209,40 @@ scalar. It is preferred over:
 
 ### Mechanism — three recovery categories
 
-Each state-mutating lock is classified into one of three categories, each with a
-defined, correct recovery action. Recovery is logged at every site.
+Only `std::sync::Mutex` fields participate. Atomics (`last_data_version:
+AtomicI64`, `refresh_gen`, `refreshing`, …) and the `DashMap` (`size_cache`)
+cannot poison and are outside this taxonomy. The poison-bearing mutexes, by
+category — each with a defined, correct recovery action, logged at every site:
 
-1. **Caches** (header-layout LRU shards, size cache) → `lock_or_clear()`.
-   On poison, take the inner guard, `.clear()` it, and return it. The next access
-   cold-resolves from the DB. A cleared cache cannot be inconsistent, so this is
-   provably safe.
+1. **Caches** → `lock_or_clear()`.
+   The header-layout LRU shards (`reader.rs` `HeaderCache`) and the per-entry Ogg
+   `ResolvedFile::last_page` cache (`reader.rs:30`). On poison, take the inner
+   guard, `.clear()` it / reset it to `None`, and return it. The next access
+   cold-resolves from the DB / re-reads the page. A cleared cache cannot be
+   inconsistent, so this is provably safe. (`size_cache` is a `DashMap`, not a
+   mutex — no treatment needed; its staleness is already handled by `retain` on
+   refresh, `facade.rs:444`.)
 
-2. **Rebuildable VFS state** (inode allocator) → `lock_or_flag()`.
-   On poison, set an `AtomicBool needs_rebuild`, log, and return the inner guard so
-   the current op completes best-effort (no rebuild while holding the poisoned
-   lock — avoids reentrancy/deadlock). `poll_refresh` already fires on every
-   metadata op (`lookup`/`readdir`); it forces `rebuild_full` when the flag is set,
-   regardless of `data_version`, and clears the flag. The state therefore
-   self-heals within one metadata-op cycle — no `EIO` to the kernel, no daemon
-   crash, no unmount. Inodes are stable across rebuilds by design, so an open
-   handle survives.
+2. **Rebuildable VFS state** → `lock_or_flag()`.
+   The inode allocator (`inodes`, `facade.rs:142`) and the render-state map
+   (`snapshot`, `facade.rs:145`) — both reconstructible from the DB. On poison,
+   set an `AtomicBool needs_rebuild`, log, and return the inner guard so the
+   current op completes best-effort (no rebuild while holding the poisoned lock —
+   avoids reentrancy/deadlock). `poll_refresh_notify` already fires on every
+   metadata op (`lookup`/`getattr`/`readdir` → `fire_poll_refresh`,
+   `musefs-fuse/src/lib.rs:194/212/272`). It must be extended so that, when
+   `needs_rebuild` is set, it **bypasses its three early-return gates** — the
+   debounce gate (`facade.rs:385`), the failed-refresh backoff (`395`), and the
+   `data_version`-equality gate (`405`) — and performs a **full** rebuild
+   (`rebuild_full`, `facade.rs:249`) instead of the usual `rebuild_incremental`
+   (`428`), then clears the flag. The state self-heals within one metadata-op
+   cycle — no `EIO` to the kernel, no daemon crash, no unmount. Inodes are stable
+   across rebuilds by design, so an open handle survives.
 
-3. **Transient scalars** (`last_poll`, `last_data_version`) → recover inner.
-   These are single-word replace-only writes that cannot be left half-written, so
-   `into_inner` recovery is already correct.
+3. **Transient scalars** → recover inner.
+   `last_poll: Mutex<Instant>` (`facade.rs:131`) and `last_failed_refresh:
+   Mutex<Option<Instant>>` (`facade.rs:133`) are replace-only single-word writes
+   that cannot be left half-written, so `into_inner` recovery is already correct.
 
 ### Audit
 
@@ -239,6 +283,10 @@ The `#[ignore]` FUSE end-to-end mount suite must remain green.
    track in parallel with the Rust track.
 2. **#95** — lands the error-diagnostics convention that #91/#92 will follow.
 3. **#96** — largest scope; depends on nothing from #95.
+
+(The ROADMAP lists Phase 1 as #96-then-#95; #95 and #96 are independent, so the
+order is a free choice. This spec does #95 first because it is the smaller,
+lower-risk change and lands the error convention sooner.)
 
 Each change ships test-driven with the project's existing review gates.
 

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -13,6 +13,7 @@ metrics = []
 arc-swap = "1"
 dashmap = "6"
 im = "15"
+log = "0.4"
 musefs-db = { path = "../musefs-db", version = "0.2.0" }
 musefs-format = { path = "../musefs-format", version = "0.2.0" }
 once_cell = "1"

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -313,7 +313,7 @@ impl Musefs {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut tree = (*self.tree.load_full()).clone(); // O(1) im clone
         let applied = if self.force_apply_fail.swap(false, Ordering::AcqRel) {
-            Err(()) // test injection
+            Err(crate::tree::RebuildError::TestInjected) // test injection
         } else {
             tree.apply_changes(
                 &new_paths,
@@ -342,8 +342,10 @@ impl Musefs {
                 }
                 tree
             }
-            Err(()) => {
-                eprintln!("musefs: incremental tree mutation failed; falling back to full rebuild");
+            Err(reason) => {
+                eprintln!(
+                    "musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild"
+                );
                 let mut entries: Vec<(i64, String)> =
                     new_paths.iter().map(|(&id, p)| (id, p.clone())).collect();
                 entries.sort_by_key(|(id, _)| *id);

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -364,8 +364,8 @@ impl Musefs {
                 tree
             }
             Err(reason) => {
-                eprintln!(
-                    "musefs: incremental tree mutation failed ({reason:?}); falling back to full rebuild"
+                log::warn!(
+                    "incremental tree mutation failed ({reason:?}); falling back to full rebuild"
                 );
                 let mut entries: Vec<(i64, String)> =
                     new_paths.iter().map(|(&id, p)| (id, p.clone())).collect();
@@ -421,19 +421,13 @@ impl Musefs {
         }
 
         if !self.poll_interval.is_zero()
-            && self
-                .last_poll
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .elapsed()
+            && crate::lock::lock_recover(&self.last_poll, "last_poll").elapsed()
                 < self.poll_interval
         {
             return Ok(false);
         }
-        if let Some(last_failed) = *self
-            .last_failed_refresh
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        if let Some(last_failed) =
+            *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
         {
             if last_failed.elapsed() < self.refresh_retry_backoff {
                 return Ok(false);
@@ -463,10 +457,7 @@ impl Musefs {
         let (new_snapshot, change) = match self.rebuild_incremental(&old_snapshot) {
             Ok(v) => v,
             Err(err) => {
-                *self
-                    .last_failed_refresh
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh") =
                     Some(std::time::Instant::now());
                 return Err(err);
             }
@@ -536,15 +527,9 @@ impl Musefs {
 
     fn stamp_successful_poll(&self) {
         if !self.poll_interval.is_zero() {
-            *self
-                .last_poll
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = std::time::Instant::now();
+            *crate::lock::lock_recover(&self.last_poll, "last_poll") = std::time::Instant::now();
         }
-        *self
-            .last_failed_refresh
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh") = None;
     }
 
     #[doc(hidden)]
@@ -581,10 +566,7 @@ impl Musefs {
         let past = std::time::Instant::now()
             .checked_sub(self.poll_interval)
             .expect("poll_interval exceeds monotonic clock base; cannot backdate last_poll");
-        *self
-            .last_poll
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = past;
+        *crate::lock::lock_recover(&self.last_poll, "last_poll") = past;
     }
 
     pub fn lookup(&self, parent: u64, name: &str) -> Option<u64> {

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1026,6 +1026,10 @@ mod tests {
         // Simulate recovery from a poisoned VFS-state lock.
         fs.mark_needs_rebuild_for_test();
         assert!(
+            fs.needs_rebuild_is_set_for_test(),
+            "flag reads set after marking"
+        );
+        assert!(
             fs.poll_refresh().unwrap(),
             "a set needs_rebuild flag must force a rebuild"
         );

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -265,6 +265,11 @@ impl Musefs {
     /// from the DB, publish the tree, diff for cache invalidation, and clear the
     /// flag. Bypasses the poll gates (the caller checks `needs_rebuild`).
     fn force_full_rebuild(&self, on_changed: &mut impl FnMut(u64)) -> Result<bool> {
+        // Read data_version before rebuilding so a successful self-heal also advances
+        // the poll stamp: a write that commits mid-rebuild then leaves a newer version
+        // for the next poll (one extra rebuild, never a skipped change), rather than
+        // forcing an unconditional rebuild on every subsequent poll.
+        let version = self.pool.with_poll(|db| Ok(db.data_version()?))?;
         let old_tree = self.tree.load_full();
         let old_snapshot =
             crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot").clone();
@@ -281,6 +286,7 @@ impl Musefs {
             on_changed,
         );
         *crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot") = new_snapshot;
+        self.last_data_version.store(version, Ordering::Release);
         self.refresh_gen.fetch_add(1, Ordering::AcqRel);
         self.needs_rebuild.store(false, Ordering::Release);
         self.stamp_successful_poll();
@@ -1023,6 +1029,15 @@ mod tests {
         // data_version is unchanged since open, so a normal poll is a no-op.
         assert!(!fs.poll_refresh().unwrap(), "baseline poll must be a no-op");
 
+        // Advance data_version out-of-band so the forced rebuild has newer DB state
+        // to incorporate and stamp; the trailing normal poll then proves it stamped.
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            let track_id = db.list_tracks().unwrap().into_iter().next().unwrap().id;
+            db.replace_tags(track_id, &[musefs_db::Tag::new("comment", "hi", 0)])
+                .unwrap();
+        }
+
         // Simulate recovery from a poisoned VFS-state lock.
         fs.mark_needs_rebuild_for_test();
         assert!(
@@ -1036,6 +1051,13 @@ mod tests {
         assert!(
             !fs.needs_rebuild_is_set_for_test(),
             "flag cleared after rebuild"
+        );
+
+        // The forced rebuild incorporated the out-of-band write and stamped its
+        // data_version, so a subsequent normal poll detects no change.
+        assert!(
+            !fs.poll_refresh().unwrap(),
+            "forced rebuild must stamp data_version (next poll is a no-op)"
         );
     }
 }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -145,6 +145,9 @@ pub struct Musefs {
     snapshot: Mutex<HashMap<i64, TrackRenderState>>,
     force_rebuild_error: AtomicBool,
     force_apply_fail: AtomicBool,
+    /// Set when a poisoned VFS-state lock is recovered; the next `poll_refresh`
+    /// forces a full rebuild from the DB and clears it (#96).
+    needs_rebuild: AtomicBool,
 }
 
 /// Map a `sharded_slab::Slab` insert result to a FUSE file handle. The slab key
@@ -179,6 +182,7 @@ impl Musefs {
             snapshot: Mutex::new(snapshot),
             force_rebuild_error: AtomicBool::new(false),
             force_apply_fail: AtomicBool::new(false),
+            needs_rebuild: AtomicBool::new(false),
         })
     }
 
@@ -237,10 +241,7 @@ impl Musefs {
     /// `poll_refresh` whose change-diff relies on that snapshot.
     pub fn refresh(&self) -> Result<()> {
         let snapshot = self.rebuild_full()?;
-        *self
-            .snapshot
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = snapshot;
+        *crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot") = snapshot;
         Ok(())
     }
 
@@ -253,14 +254,37 @@ impl Musefs {
             ));
         }
         let (tree, snapshot) = self.pool.with(|db| {
-            let mut alloc = self
-                .inodes
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
             Self::build_full(db, &self.config, &mut alloc)
         })?;
         self.tree.store(Arc::new(tree));
         Ok(snapshot)
+    }
+
+    /// Full rebuild used to self-heal after a poisoned VFS-state lock: rebuild
+    /// from the DB, publish the tree, diff for cache invalidation, and clear the
+    /// flag. Bypasses the poll gates (the caller checks `needs_rebuild`).
+    fn force_full_rebuild(&self, on_changed: &mut impl FnMut(u64)) -> Result<bool> {
+        let old_tree = self.tree.load_full();
+        let old_snapshot =
+            crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot").clone();
+        let new_snapshot = self.rebuild_full()?;
+        let new_tree = self.tree.load();
+        let live = new_tree.track_ids();
+        self.cache.retain(&live);
+        self.size_cache.retain(|k, _| live.contains(k));
+        Self::notify_changed(
+            &old_snapshot,
+            &new_snapshot,
+            &old_tree,
+            &new_tree,
+            on_changed,
+        );
+        *crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot") = new_snapshot;
+        self.refresh_gen.fetch_add(1, Ordering::AcqRel);
+        self.needs_rebuild.store(false, Ordering::Release);
+        self.stamp_successful_poll();
+        Ok(true)
     }
 
     /// Incremental rebuild (Stage A): scan render keys, diff against the previous
@@ -307,10 +331,7 @@ impl Musefs {
             .map(|(&id, s)| (id, s.path.clone()))
             .collect();
 
-        let mut alloc = self
-            .inodes
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
         let mut tree = (*self.tree.load_full()).clone(); // O(1) im clone
         let applied = if self.force_apply_fail.swap(false, Ordering::AcqRel) {
             Err(crate::tree::RebuildError::TestInjected) // test injection
@@ -384,6 +405,21 @@ impl Musefs {
     /// Single-flighted: if a rebuild is already in progress, concurrent callers
     /// return `Ok(false)` immediately.
     pub fn poll_refresh_notify(&self, mut on_changed: impl FnMut(u64)) -> Result<bool> {
+        // A poisoned VFS-state lock scheduled a full rebuild: do it now,
+        // bypassing the debounce / backoff / data_version gates (#96).
+        if self.needs_rebuild.load(Ordering::Acquire) {
+            // Single-flight with the same flag the normal path uses.
+            if self
+                .refreshing
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                return Ok(false);
+            }
+            let _guard = RefreshGuard(&self.refreshing);
+            return self.force_full_rebuild(&mut on_changed);
+        }
+
         if !self.poll_interval.is_zero()
             && self
                 .last_poll
@@ -422,11 +458,8 @@ impl Musefs {
         let _guard = RefreshGuard(&self.refreshing);
 
         let old_tree = self.tree.load_full();
-        let old_snapshot = self
-            .snapshot
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
+        let old_snapshot =
+            crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot").clone();
         let (new_snapshot, change) = match self.rebuild_incremental(&old_snapshot) {
             Ok(v) => v,
             Err(err) => {
@@ -453,10 +486,7 @@ impl Musefs {
             &mut on_changed,
         );
 
-        *self
-            .snapshot
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = new_snapshot;
+        *crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot") = new_snapshot;
 
         self.last_data_version.store(version, Ordering::Release);
         if !change.is_empty() {
@@ -525,6 +555,18 @@ impl Musefs {
     #[doc(hidden)]
     pub fn force_apply_failure_for_test(&self, on: bool) {
         self.force_apply_fail.store(on, Ordering::Release);
+    }
+
+    #[doc(hidden)]
+    pub fn mark_needs_rebuild_for_test(&self) {
+        self.needs_rebuild
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    #[doc(hidden)]
+    pub fn needs_rebuild_is_set_for_test(&self) -> bool {
+        self.needs_rebuild
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     #[doc(hidden)]
@@ -964,5 +1006,50 @@ mod tests {
             );
         }
         fs.release_handle(fh);
+    }
+
+    #[test]
+    fn needs_rebuild_flag_forces_full_rebuild_on_next_poll() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+        // data_version is unchanged since open, so a normal poll is a no-op.
+        assert!(!fs.poll_refresh().unwrap(), "baseline poll must be a no-op");
+
+        // Simulate recovery from a poisoned VFS-state lock.
+        fs.mark_needs_rebuild_for_test();
+        assert!(
+            fs.poll_refresh().unwrap(),
+            "a set needs_rebuild flag must force a rebuild"
+        );
+        assert!(
+            !fs.needs_rebuild_is_set_for_test(),
+            "flag cleared after rebuild"
+        );
     }
 }

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -2,6 +2,7 @@ mod byte_budget;
 mod db_pool;
 mod error;
 mod facade;
+mod lock;
 mod mapping;
 pub mod metrics;
 mod ogg_index;

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -6,6 +6,18 @@
 //!   * caches  -> `lock_or_clear`  (clear; next access cold-resolves from the DB)
 //!   * VFS state -> `lock_or_flag` (schedule a full rebuild via `poll_refresh`)
 //!   * scalars -> `lock_recover`   (replace-only writes can't be half-written)
+//!
+//! Audit (every serving-path `std::sync::Mutex`):
+//!   facade.rs `inodes`            -> cat 2 (flag): InodeAllocator, rebuilt by build_full from the DB.
+//!   facade.rs `snapshot`          -> cat 2 (flag): per-track render state, rebuilt by rebuild_full from the DB.
+//!   facade.rs `last_poll`         -> cat 3 (recover): Instant, replace-only single write.
+//!   facade.rs `last_failed_refresh` -> cat 3 (recover): Option<Instant>, replace-only single write.
+//!   reader.rs HeaderCache shards  -> cat 1 (clear): pure cache, repopulated from the DB.
+//!   ResolvedFile::last_page (reader.rs:30, locked in ogg_index.rs as LastPageMemo)
+//!                                 -> cat 1 (clear): deterministic one-entry cache, re-derived.
+//! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
+//! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,
+//! not on the FUSE serving path).
 
 #![allow(dead_code)]
 

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -18,8 +18,10 @@
 //! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
 //! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,
 //! not on the FUSE serving path).
-
-#![allow(dead_code)]
+//!
+//! Recovery is one-shot: each helper calls `Mutex::clear_poison` after restoring
+//! the guarded state to a known-good value, so normal (non-clearing) operation
+//! resumes on the next acquisition rather than degrading permanently.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard};
@@ -39,6 +41,7 @@ impl<T> Clearable for Option<T> {
 pub(crate) fn lock_recover<'a, T>(m: &'a Mutex<T>, what: &str) -> MutexGuard<'a, T> {
     m.lock().unwrap_or_else(|e| {
         log::error!("recovered poisoned scalar lock ({what}); continuing on inner value");
+        m.clear_poison();
         e.into_inner()
     })
 }
@@ -50,6 +53,7 @@ pub(crate) fn lock_or_clear<'a, T: Clearable>(m: &'a Mutex<T>, what: &str) -> Mu
         Ok(g) => g,
         Err(e) => {
             log::error!("cleared poisoned cache lock ({what})");
+            m.clear_poison();
             let mut g = e.into_inner();
             g.reset();
             g
@@ -67,6 +71,7 @@ pub(crate) fn lock_or_flag<'a, T>(
     m.lock().unwrap_or_else(|e| {
         log::error!("poisoned VFS-state lock ({what}); scheduling full rebuild");
         needs_rebuild.store(true, Ordering::Release);
+        m.clear_poison();
         e.into_inner()
     })
 }
@@ -91,6 +96,7 @@ mod tests {
         let m = Arc::new(Mutex::new(7u32));
         poison(&m);
         assert_eq!(*lock_recover(&m, "scalar"), 7);
+        assert!(!m.is_poisoned(), "poison cleared after recovery");
     }
 
     #[test]
@@ -98,6 +104,7 @@ mod tests {
         let m = Arc::new(Mutex::new(Some(42u32)));
         poison(&m);
         assert!(lock_or_clear(&m, "cache").is_none());
+        assert!(!m.is_poisoned(), "poison cleared after clearing the cache");
     }
 
     #[test]
@@ -105,7 +112,10 @@ mod tests {
         let m = Arc::new(Mutex::new(0u32));
         let flag = AtomicBool::new(false);
         poison(&m);
-        let _g = lock_or_flag(&m, &flag, "vfs");
-        assert!(flag.load(Ordering::Acquire));
+        {
+            let _g = lock_or_flag(&m, &flag, "vfs");
+            assert!(flag.load(Ordering::Acquire));
+        }
+        assert!(!m.is_poisoned(), "poison cleared after flagging a rebuild");
     }
 }

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -1,0 +1,99 @@
+//! Poison-recovery policy for the daemon's in-memory mutexes (#96).
+//!
+//! musefs is read-only and the SQLite store is the source of truth, so on a
+//! poisoned lock we reset the guarded state to a known-good value rather than
+//! serve possibly-inconsistent state:
+//!   * caches  -> `lock_or_clear`  (clear; next access cold-resolves from the DB)
+//!   * VFS state -> `lock_or_flag` (schedule a full rebuild via `poll_refresh`)
+//!   * scalars -> `lock_recover`   (replace-only writes can't be half-written)
+
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
+
+/// State that can be reset to empty for `lock_or_clear`.
+pub(crate) trait Clearable {
+    fn reset(&mut self);
+}
+
+impl<T> Clearable for Option<T> {
+    fn reset(&mut self) {
+        *self = None;
+    }
+}
+
+/// Category 3 — transient scalar. Recover the inner value, logging the poison.
+pub(crate) fn lock_recover<'a, T>(m: &'a Mutex<T>, what: &str) -> MutexGuard<'a, T> {
+    m.lock().unwrap_or_else(|e| {
+        log::error!("recovered poisoned scalar lock ({what}); continuing on inner value");
+        e.into_inner()
+    })
+}
+
+/// Category 1 — cache. On poison, clear the cache so the next access
+/// cold-resolves; a cleared cache cannot be inconsistent.
+pub(crate) fn lock_or_clear<'a, T: Clearable>(m: &'a Mutex<T>, what: &str) -> MutexGuard<'a, T> {
+    match m.lock() {
+        Ok(g) => g,
+        Err(e) => {
+            log::error!("cleared poisoned cache lock ({what})");
+            let mut g = e.into_inner();
+            g.reset();
+            g
+        }
+    }
+}
+
+/// Category 2 — rebuildable VFS state. On poison, flag a full rebuild (run by the
+/// next `poll_refresh`) and recover the inner value for best-effort completion.
+pub(crate) fn lock_or_flag<'a, T>(
+    m: &'a Mutex<T>,
+    needs_rebuild: &AtomicBool,
+    what: &str,
+) -> MutexGuard<'a, T> {
+    m.lock().unwrap_or_else(|e| {
+        log::error!("poisoned VFS-state lock ({what}); scheduling full rebuild");
+        needs_rebuild.store(true, Ordering::Release);
+        e.into_inner()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn poison<T: Send + 'static>(m: &Arc<Mutex<T>>) {
+        let m2 = Arc::clone(m);
+        let _ = std::thread::spawn(move || {
+            let _g = m2.lock().unwrap();
+            panic!("poison it");
+        })
+        .join();
+        assert!(m.is_poisoned());
+    }
+
+    #[test]
+    fn recover_returns_inner_after_poison() {
+        let m = Arc::new(Mutex::new(7u32));
+        poison(&m);
+        assert_eq!(*lock_recover(&m, "scalar"), 7);
+    }
+
+    #[test]
+    fn clear_empties_cache_after_poison() {
+        let m = Arc::new(Mutex::new(Some(42u32)));
+        poison(&m);
+        assert!(lock_or_clear(&m, "cache").is_none());
+    }
+
+    #[test]
+    fn flag_set_after_poison() {
+        let m = Arc::new(Mutex::new(0u32));
+        let flag = AtomicBool::new(false);
+        poison(&m);
+        let _g = lock_or_flag(&m, &flag, "vfs");
+        assert!(flag.load(Ordering::Acquire));
+    }
+}

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -55,7 +55,7 @@ fn find_page_start(
         return Ok(audio_offset);
     }
     if let Some(m) = memo {
-        let guard = m.lock().unwrap();
+        let guard = crate::lock::lock_or_clear(m, "ogg last-page memo");
         if let Some((rel, total_len, _)) = guard.as_ref() {
             let start = audio_offset + *rel;
             if start <= abs_target && abs_target < start + *total_len {
@@ -178,7 +178,7 @@ pub fn serve_ogg_window(
         // correct. The lock is released before patching so concurrent readers never
         // serialize on the CRC work.
         let cached = memo.and_then(|m| {
-            let g = m.lock().unwrap();
+            let g = crate::lock::lock_or_clear(m, "ogg last-page memo");
             g.as_ref()
                 .filter(|(mp, _, _)| *mp == page_rel)
                 .map(|(_, _, h)| h.clone())
@@ -192,7 +192,8 @@ pub fn serve_ogg_window(
         };
         if let Some(m) = memo {
             let total_len = (header_len + payload_len) as u64;
-            *m.lock().unwrap() = Some((page_rel, total_len, patched_hdr.clone()));
+            *crate::lock::lock_or_clear(m, "ogg last-page memo") =
+                Some((page_rel, total_len, patched_hdr.clone()));
         }
 
         let hdr_end = page_rel + header_len as u64;

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -1029,6 +1029,51 @@ mod cache_bound_tests {
     }
 
     #[test]
+    fn shard_reset_clears_all_entries() {
+        use crate::lock::Clearable;
+        let mut s = Shard::new(1000);
+        s.insert(1, entry(0, 100));
+        s.insert(2, entry(0, 100));
+        s.reset();
+        assert!(s.get(1).is_none());
+        assert!(s.get(2).is_none());
+        assert_eq!(s.bytes, 0);
+        assert_eq!(s.map.len(), 0);
+    }
+
+    #[test]
+    fn header_cache_retain_drops_absent_tracks() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Db::open_in_memory().unwrap();
+        let mk = |name: &str| {
+            let path = dir.path().join(name);
+            let (audio_offset, audio_length) = write_flac_local(&path);
+            let meta = std::fs::metadata(&path).unwrap();
+            db.upsert_track(&NewTrack {
+                backing_path: path.to_string_lossy().to_string(),
+                format: Format::Flac,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len() as i64,
+                backing_mtime: mtime_secs(&meta),
+            })
+            .unwrap()
+        };
+        let keep = mk("keep.flac");
+        let gone = mk("gone.flac");
+        let cache = HeaderCache::new(Mode::Synthesis);
+        let keep_a = cache.resolve(&db, keep).unwrap();
+        let gone_a = cache.resolve(&db, gone).unwrap();
+
+        let live: HashSet<i64> = [keep].into_iter().collect();
+        cache.retain(&live);
+
+        // The kept track stays the same cached Arc; the dropped one re-resolves fresh.
+        assert!(Arc::ptr_eq(&keep_a, &cache.resolve(&db, keep).unwrap()));
+        assert!(!Arc::ptr_eq(&gone_a, &cache.resolve(&db, gone).unwrap()));
+    }
+
+    #[test]
     fn shard_retain_keys_drops_dead_and_reaccounts() {
         use std::collections::HashSet;
         let mut s = Shard::new(1000);

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -143,6 +143,12 @@ impl Shard {
     }
 }
 
+impl crate::lock::Clearable for Shard {
+    fn reset(&mut self) {
+        self.retain_keys(&HashSet::new());
+    }
+}
+
 /// A per-mount cache of resolved files, sharded for concurrency and keyed by track
 /// id; an entry self-invalidates when the track's `content_version` changes.
 pub struct HeaderCache {
@@ -182,16 +188,12 @@ impl HeaderCache {
     }
     fn shard(&self, track_id: i64) -> std::sync::MutexGuard<'_, Shard> {
         let idx = (track_id as u64 % CACHE_SHARDS as u64) as usize;
-        self.shards[idx]
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        crate::lock::lock_or_clear(&self.shards[idx], "header-cache shard")
     }
     /// Drop cached resolutions for tracks no longer present (`live` = current ids).
     pub fn retain(&self, live: &HashSet<i64>) {
         for s in &self.shards {
-            s.lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .retain_keys(live);
+            crate::lock::lock_or_clear(s, "header-cache shard (retain)").retain_keys(live);
         }
     }
     /// Resolve a track to its layout, caching on a content-version miss. Validation

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1,5 +1,15 @@
 use im::{HashMap as ImHashMap, OrdMap};
 
+/// Why an incremental tree mutation could not complete; the caller falls back to
+/// a full rebuild. Carries diagnostics instead of `()` (#95).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebuildError {
+    /// A track collected for rebuild had no entry in `new_paths`.
+    MissingRenderedPath(i64),
+    /// Test-only injected failure (`force_apply_fail`).
+    TestInjected,
+}
+
 /// Assigns stable inodes keyed by rendered path, persisted across tree rebuilds:
 /// an unchanged path keeps its inode, a new path gets a fresh one, and a retired
 /// inode is never recycled (a stale FUSE handle can't alias a different node).
@@ -297,13 +307,12 @@ impl VirtualTree {
     /// RENDERED path from `new_paths`. `ensure_dir` reuses ancestors above `dir`, so
     /// only `dir`'s subtree is rebuilt. Errs if a collected track has no entry in
     /// `new_paths` (caller falls back to a full rebuild). See SP2 Component 3.
-    #[allow(clippy::result_unit_err)]
     pub fn rebuild_subtree(
         &mut self,
         dir: u64,
         new_paths: &std::collections::HashMap<i64, String>,
         alloc: &mut InodeAllocator,
-    ) -> std::result::Result<(), ()> {
+    ) -> std::result::Result<(), RebuildError> {
         let mut ids = Vec::new();
         let mut stack = vec![dir];
         while let Some(n) = stack.pop() {
@@ -323,7 +332,9 @@ impl VirtualTree {
         }
         ids.sort_unstable();
         for id in ids {
-            let path = new_paths.get(&id).ok_or(())?;
+            let path = new_paths
+                .get(&id)
+                .ok_or(RebuildError::MissingRenderedPath(id))?;
             self.insert_file(id, path, alloc);
         }
         Ok(())
@@ -333,7 +344,6 @@ impl VirtualTree {
     /// full `build_with` over the same final track set. `new_paths` maps every CURRENT
     /// track id to its rendered path. Returns Err(()) on any inconsistency (caller
     /// falls back to full build). See SP2 Component 3.
-    #[allow(clippy::result_unit_err)]
     pub fn apply_changes(
         &mut self,
         new_paths: &std::collections::HashMap<i64, String>,
@@ -341,7 +351,7 @@ impl VirtualTree {
         added: &[i64],
         removed: &[i64],
         alloc: &mut InodeAllocator,
-    ) -> std::result::Result<(), ()> {
+    ) -> std::result::Result<(), RebuildError> {
         use std::collections::HashSet;
         let mut dirty: HashSet<u64> = HashSet::new();
 
@@ -349,7 +359,9 @@ impl VirtualTree {
         let mut moved_out: Vec<i64> = Vec::new(); // remove old position
         let mut moved_in: Vec<i64> = Vec::new(); // insert new position
         for &id in changed {
-            let new_path = new_paths.get(&id).ok_or(())?;
+            let new_path = new_paths
+                .get(&id)
+                .ok_or(RebuildError::MissingRenderedPath(id))?;
             match self.inode_of_track(id) {
                 Some(ino) if &self.path_of(ino) == new_path => { /* path stable: nothing */ }
                 Some(_) => {
@@ -381,7 +393,9 @@ impl VirtualTree {
             }
         }
         for &id in added.iter().chain(moved_in.iter()) {
-            let rendered = new_paths.get(&id).ok_or(())?;
+            let rendered = new_paths
+                .get(&id)
+                .ok_or(RebuildError::MissingRenderedPath(id))?;
             let d = self.deepest_existing_ancestor(rendered);
             dirty.insert(d);
             // propagate up while `id` would become the new min.
@@ -400,7 +414,9 @@ impl VirtualTree {
             }
         }
         for &id in added.iter().chain(moved_in.iter()) {
-            let rendered = new_paths.get(&id).ok_or(())?;
+            let rendered = new_paths
+                .get(&id)
+                .ok_or(RebuildError::MissingRenderedPath(id))?;
             self.insert_file(id, rendered, alloc);
         }
 
@@ -638,6 +654,19 @@ mod tests {
             }
         }
         out
+    }
+
+    #[test]
+    fn rebuild_subtree_reports_missing_rendered_path() {
+        use std::collections::HashMap;
+        let mut alloc = InodeAllocator::new();
+        let mut tree = VirtualTree::build_with(&[(10, "Alice/Song.flac".into())], &mut alloc);
+        let dir = tree.lookup(VirtualTree::ROOT, "Alice").unwrap();
+        let new_paths: HashMap<i64, String> = HashMap::new(); // omits track 10
+        let err = tree
+            .rebuild_subtree(dir, &new_paths, &mut alloc)
+            .unwrap_err();
+        assert_eq!(err, RebuildError::MissingRenderedPath(10));
     }
 
     #[test]

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -342,8 +342,8 @@ impl VirtualTree {
 
     /// Apply an incremental change set in place, producing a tree byte-identical to a
     /// full `build_with` over the same final track set. `new_paths` maps every CURRENT
-    /// track id to its rendered path. Returns Err(()) on any inconsistency (caller
-    /// falls back to full build). See SP2 Component 3.
+    /// track id to its rendered path. Returns `Err(RebuildError)` on any inconsistency
+    /// (caller falls back to full build). See SP2 Component 3.
     pub fn apply_changes(
         &mut self,
         new_paths: &std::collections::HashMap<i64, String>,

--- a/musefs-format/src/error.rs
+++ b/musefs-format/src/error.rs
@@ -14,8 +14,33 @@ pub enum FormatError {
     NotMp4,
     #[error("not a supported WAV/RIFF file")]
     NotWav,
-    #[error("synthesized region layout violates producer invariants")]
-    InvalidLayout,
+    #[error("synthesized region layout violates producer invariants: {0}")]
+    InvalidLayout(#[from] crate::layout::LayoutError),
+    #[error("producer invariant violated: {0}")]
+    ProducerBug(&'static str),
 }
 
 pub type Result<T> = std::result::Result<T, FormatError>;
+
+#[cfg(test)]
+mod tests {
+    use super::FormatError;
+    use crate::layout::LayoutError;
+
+    #[test]
+    fn invalid_layout_carries_inner_layout_error() {
+        let e: FormatError = LayoutError::EmptySegment.into();
+        assert!(matches!(
+            e,
+            FormatError::InvalidLayout(LayoutError::EmptySegment)
+        ));
+        // Display includes the inner reason, not just a generic string.
+        assert!(e.to_string().contains("zero length"));
+    }
+
+    #[test]
+    fn producer_bug_carries_reason() {
+        let e = FormatError::ProducerBug("no leading Inline");
+        assert!(e.to_string().contains("no leading Inline"));
+    }
+}

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -300,7 +300,7 @@ pub fn synthesize_layout(
         len: audio_length,
     });
 
-    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+    Ok(RegionLayout::validated(segments)?)
 }
 
 /// Read the existing VORBIS_COMMENT block from a complete FLAC file, returning

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -1,9 +1,11 @@
 /// Validation errors discovered in a layout at synthesis time.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum LayoutError {
     /// A segment reported zero length.
+    #[error("a segment reported zero length")]
     EmptySegment,
     /// Total length overflowed u64.
+    #[error("total layout length overflowed u64")]
     TotalOverflow,
 }
 

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -407,7 +407,7 @@ pub fn synthesize_layout(
         offset: audio_offset,
         len: audio_length,
     });
-    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+    Ok(RegionLayout::validated(segments)?)
 }
 
 /// Returns false when `data` begins with an ID3v2 tag whose declared frame sizes

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -819,7 +819,9 @@ pub fn synthesize_layout(
     let mut udta_iter = udta_segments.into_iter();
     let Some(Segment::Inline(first)) = udta_iter.next() else {
         // build_udta always yields a leading Inline; anything else is a producer bug.
-        return Err(FormatError::InvalidLayout);
+        return Err(FormatError::ProducerBug(
+            "build_udta did not yield a leading Inline framing segment",
+        ));
     };
     head.extend_from_slice(&first);
     let mut segments: Vec<Segment> = vec![Segment::Inline(head)];
@@ -832,7 +834,7 @@ pub fn synthesize_layout(
         offset: scan.mdat_payload_offset,
         len: scan.mdat_payload_len,
     });
-    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+    Ok(RegionLayout::validated(segments)?)
 }
 
 #[cfg(test)]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -272,7 +272,7 @@ pub fn synthesize_layout(
         len: audio_length,
         seq_delta,
     });
-    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+    Ok(RegionLayout::validated(segments)?)
 }
 
 /// Build the FLAC PICTURE block *body prefix* (everything before the image data:

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -249,7 +249,7 @@ pub fn synthesize_layout(
     header.extend_from_slice(b"WAVE");
     segments.insert(0, Segment::Inline(header));
 
-    RegionLayout::validated(segments).map_err(|_| FormatError::InvalidLayout)
+    Ok(RegionLayout::validated(segments)?)
 }
 
 /// RIFF `INFO` subchunk FourCC -> canonical (lowercase) tag key. Inverse of


### PR DESCRIPTION
Implements the Phase 0 + Phase 1 plan: stop the plugin data-loss regression and settle the two foundational conventions (internal error diagnostics, mutex poison-recovery) that later issues inherit.

Closes #82
Closes #95
Closes #96

## Part A — #82: preserve scanner-written binary tags
Both the beets and picard plugins' `replace_tags` did an unscoped `DELETE FROM tags WHERE track_id = ?`, wiping scanner-written binary rows (`value_blob NOT NULL`) on every sync. Scoped the delete to plugin-owned text rows (`AND value_blob IS NULL`). Regression tests in both plugins (binary row survives; default vocabulary is disjoint from binary keys).

## Part B — #95: internal error types carry diagnostics
- `musefs-format`: `LayoutError` is now a `thiserror` error; `FormatError::InvalidLayout` carries it (`#[from]`), and a new `ProducerBug(&'static str)` replaces the one manual `InvalidLayout` guard in `mp4.rs`. The five `validated(...).map_err(|_| InvalidLayout)` sites collapse to `?`.
- `musefs-core`: `tree.rs` replaces `Result<(), ()>` with `RebuildError` (carries the missing track id / test-injection reason); the facade fallback log now interpolates the reason.
- Recorded the no-discarded-diagnostics convention in `CLAUDE.md`.

## Part C — #96: mutex poison recovery-by-reset
New `musefs-core/src/lock.rs` with three policies for the VFS serving-path mutexes:
- **clear** (`lock_or_clear`) — caches (header-cache shards, Ogg last-page memo): reset to empty so the next access cold-resolves from the DB.
- **flag** (`lock_or_flag`) — VFS state (`inodes`, `snapshot`): set a `needs_rebuild` flag so the next `poll_refresh` forces a full rebuild from the DB (new `force_full_rebuild`, bypassing the poll gates).
- **recover** (`lock_recover`) — scalars (`last_poll`, `last_failed_refresh`): replace-only writes can't be half-written.

Recovery is one-shot: each helper calls `Mutex::clear_poison` after restoring known-good state, so a single poison event doesn't degrade the daemon permanently. Module doc carries a per-lock audit and the out-of-scope notes (#93/#94/scan). `log` added as a dependency; the serving path no longer uses `eprintln!` or bare `.lock().unwrap()`.

## Verification
- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, `cargo test --workspace` all clean.
- All eight format-layer fuzz targets build against the new `FormatError`.
- beets/picard pytest suites pass.
- In-diff mutation gate (`cargo mutants --in-diff`) run locally over the 54 changed-line mutants; survivors driven to zero (added tests for `Shard::reset`, `HeaderCache::retain`, and the `needs_rebuild` flag's set-direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin tag sync now preserves existing binary tag data instead of deleting it.

* **Improvements**
  * Error handling now preserves and surfaces underlying diagnostics.
  * Daemon resilience improved: poisoned-lock recovery triggers safe rebuilds, clearer logging, and retry behavior.

* **Documentation**
  * Added prioritized roadmap, plan, and design spec for Phase 0–1 data-loss and conventions work.

* **Tests**
  * Added tests covering tag preservation, error diagnostics, and lock-recovery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->