### PR TITLE
Phase 3: safety net + small Rust hardening (#88, #91-#94)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-phase3-hardening.md
+++ b/docs/superpowers/plans/2026-06-03-phase3-hardening.md
@@ -1,0 +1,622 @@
+# Phase 3 — Safety net + small Rust hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close five independent low-risk hardening issues (#88, #91, #92, #93, #94) in one PR: a fuzz-coverage gap, a byte-budget overflow asymmetry, a missing non-negative guard on an externally-writable DB column, an unbounded MP4 metadata allocation, and two DbPool footguns.
+
+**Architecture:** Five self-contained changes across `musefs-core`, `musefs-format`, and the out-of-workspace `fuzz` crate. No serve-path or byte-identical-audio semantics change. Each task is TDD where a behavior is observable; #93 and the fuzz target #88 are verified differently (existing tests / `cargo fuzz build`) because there is nothing new to assert with a Rust unit test.
+
+**Tech Stack:** Rust (workspace), `thiserror`, `rusqlite` (dev-dep, already present), `cargo-fuzz` (nightly, for #88), `log`.
+
+**Branch:** `phase3-hardening` (already created; the design spec is committed there).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-03-phase3-hardening-design.md`
+
+---
+
+## File Structure
+
+- `musefs-core/src/byte_budget.rs` — Task 1 (#93): one-line saturating-add fix.
+- `musefs-core/src/mapping.rs` — Task 2 (#92): non-negative guard on art `byte_len` + test.
+- `musefs-format/src/mp4.rs` — Task 3 (#91): metadata-size cap const, `Mp4ScanError` variant, cap check, tests.
+- `musefs-core/src/scan.rs` — Task 3 (#91): clear `log::warn!` on the new cap error at the swallow site.
+- `musefs-core/src/error.rs` — Task 4 (#94b): new `CoreError::DbOpen` variant carrying the path.
+- `musefs-core/src/db_pool.rs` — Task 4 (#94a/b/c): `Rc<Db>` thread-local + re-entrancy-safe `with`, path-context open error, Drop doc note + tests.
+- `fuzz/fuzz_targets/ogg.rs` — Task 5 (#88): build `OggArt`s with image bytes so the art path is fuzzed.
+
+---
+
+## Task 1: #93 — `byte_budget` saturating-add symmetry
+
+**Files:**
+- Modify: `musefs-core/src/byte_budget.rs:32`
+
+The guard at line 29 already uses `saturating_add`; the mutation at line 32 is a plain `+=`. This is an internal-consistency fix with **no observable behavior** (art weights are file-bounded, so `in_flight` never approaches `u64::MAX`). There is therefore nothing to assert in a new unit test — the existing tests in the file already pin additive accumulation and every guard mutant, and `saturating_add` remains additive below saturation. TDD's "write a failing test first" does not apply when no new behavior is observable; we make the change and prove the existing suite still passes.
+
+- [ ] **Step 1: Make the change**
+
+In `musefs-core/src/byte_budget.rs`, in `ByteBudget::acquire`, change the increment line:
+
+```rust
+        *in_flight = in_flight.saturating_add(n);
+```
+
+(was `*in_flight += n;`)
+
+- [ ] **Step 2: Run the existing byte_budget tests to verify they still pass**
+
+Run: `cargo test -p musefs-core byte_budget`
+Expected: PASS — `oversized_item_admitted_when_idle`, `blocked_acquire_proceeds_after_release`, `accumulates_additively_then_blocks`, `exact_cap_is_admitted`, `over_cap_blocks` all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/src/byte_budget.rs
+git commit -m "fix(byte_budget): make acquire increment saturating to match its guard (#93)"
+```
+
+---
+
+## Task 2: #92 — non-negative guard on art `byte_len`
+
+**Files:**
+- Modify: `musefs-core/src/mapping.rs` (`track_art_to_inputs`, ~lines 30-51, and its test module)
+- Test: `musefs-core/src/mapping.rs` (`#[cfg(test)] mod tests`)
+
+Only the art path is guarded. The binary-tag `byte_len` (`binary_tags_to_inputs`) is `length(value_blob)` in SQL (`tags.rs:127`), always ≥ 0, so it needs no guard. `art.byte_len` is a stored column (`schema.rs:31`) an external write can forge negative.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside `musefs-core/src/mapping.rs`'s `#[cfg(test)] mod tests` block. The negative value can't be made through the public API (`upsert_art` derives `byte_len` from `data.len()`), so we corrupt it via a second raw `rusqlite` connection — exactly the "external malformed write" the contract warns about. `rusqlite` is already a musefs-core dev-dependency.
+
+```rust
+    #[test]
+    fn track_art_to_inputs_skips_negative_byte_len() {
+        use musefs_db::{NewArt, NewTrack, TrackArt};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art.db");
+        let db = Db::open(&path).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let good = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3, 4],
+            })
+            .unwrap();
+        let bad = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![9, 9, 9, 9, 9],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[
+                TrackArt { art_id: good, picture_type: 3, description: String::new(), ordinal: 0 },
+                TrackArt { art_id: bad, picture_type: 3, description: String::new(), ordinal: 1 },
+            ],
+        )
+        .unwrap();
+
+        // Simulate an external malformed write: byte_len is a stored column.
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad]).unwrap();
+        drop(raw);
+
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        assert_eq!(inputs.len(), 1, "the negative-byte_len art row must be skipped");
+        assert_eq!(inputs[0].art_id, good);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core track_art_to_inputs_skips_negative_byte_len`
+Expected: FAIL — currently both rows are included (`inputs.len() == 2`); the corrupted row casts `-1 → u64::MAX`.
+
+- [ ] **Step 3: Add the guard**
+
+In `musefs-core/src/mapping.rs`, in `track_art_to_inputs`, inside the existing `if let Some(meta) = db.get_art_meta(ta.art_id)?` arm, add the guard before the `inputs.push(...)`:
+
+```rust
+        if let Some(meta) = db.get_art_meta(ta.art_id)? {
+            // A negative byte_len is a malformed external write to the contract
+            // column; skip the row rather than cast it to a huge u64 segment
+            // length (which would fail layout validation and break the track).
+            if meta.byte_len < 0 {
+                continue;
+            }
+            inputs.push(ArtInput {
+                art_id: ta.art_id,
+                mime: meta.mime,
+                description: ta.description,
+                picture_type: ta.picture_type as u32,
+                width: meta.width.unwrap_or(0) as u32,
+                height: meta.height.unwrap_or(0) as u32,
+                data_len: meta.byte_len as u64,
+            });
+        }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core track_art_to_inputs_skips_negative_byte_len`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/mapping.rs
+git commit -m "fix(mapping): skip art rows with negative byte_len from malformed DB writes (#92)"
+```
+
+---
+
+## Task 3: #91 — cap MP4 `moov`/`ftyp` metadata allocation
+
+**Files:**
+- Modify: `musefs-format/src/mp4.rs` (module const, `Mp4ScanError` enum ~line 89, `read_structure_from` ~lines 244-313, test module ~line 841)
+- Modify: `musefs-core/src/scan.rs` (`probe_file` MP4 arm, ~lines 219-222)
+
+The cap is checked on the declared box length **before** `region()` allocates. The test exploits that `read_structure_from`'s `file_len` argument is independent of the reader's real length: a large `file_len` clears `box_header`'s `total_len > remaining` check, so the new cap (not `Malformed`) is what fires.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two tests to `musefs-format/src/mp4.rs`'s `#[cfg(test)] mod tests` block (which has `use super::*;`):
+
+```rust
+    #[test]
+    fn read_structure_from_rejects_oversized_moov() {
+        use std::io::Cursor;
+        // ftyp(16) + mdat(16) + moov(declares 600 MiB). The moov box "ends" exactly
+        // at the (large, lied-about) file_len so the header walk terminates cleanly,
+        // then the cap check fires before any payload region is allocated/read.
+        let moov_size: u32 = 600 * 1024 * 1024; // 629_145_600 > 512 MiB cap
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"ftyp");
+        buf.extend_from_slice(&[0u8; 8]); // ftyp payload (not read during the walk)
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"mdat");
+        buf.extend_from_slice(&[0u8; 8]); // mdat payload
+        buf.extend_from_slice(&moov_size.to_be_bytes());
+        buf.extend_from_slice(b"moov");
+        // No moov payload in the buffer: the cap check must return before region().
+        assert_eq!(buf.len(), 40);
+        let file_len = 32 + moov_size as u64;
+        let mut cur = Cursor::new(buf);
+        match read_structure_from(&mut cur, file_len).unwrap_err() {
+            Mp4ScanError::MetadataTooLarge { box_kind, size, cap } => {
+                assert_eq!(box_kind, "moov");
+                assert_eq!(size, moov_size as u64);
+                assert_eq!(cap, 512 * 1024 * 1024);
+            }
+            other => panic!("expected MetadataTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_structure_from_admits_box_at_exactly_the_cap() {
+        use std::io::Cursor;
+        // size == cap: the guard is strict `>`, so it does NOT trip. The read then
+        // proceeds and hits EOF on the short buffer → Io, never MetadataTooLarge.
+        let cap: u32 = 512 * 1024 * 1024;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"ftyp");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"mdat");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&cap.to_be_bytes());
+        buf.extend_from_slice(b"moov");
+        let file_len = 32 + cap as u64;
+        let mut cur = Cursor::new(buf);
+        let err = read_structure_from(&mut cur, file_len).unwrap_err();
+        assert!(
+            matches!(err, Mp4ScanError::Io(_)),
+            "exact-cap box must pass the strict `>` guard (got {err:?})"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (compile error)**
+
+Run: `cargo test -p musefs-format read_structure_from_rejects_oversized_moov`
+Expected: FAIL to compile — `Mp4ScanError::MetadataTooLarge` does not exist yet.
+
+- [ ] **Step 3: Add the const and the error variant**
+
+In `musefs-format/src/mp4.rs`, add the module-level const (place it near the top of the file, after the imports / above the first item):
+
+```rust
+/// Upper bound on a single MP4 metadata box (`ftyp`/`moov`) allocation. A corrupt
+/// or pathologically large box is rejected (the file is skipped at scan, logged)
+/// rather than forcing a multi-hundred-MB allocation. 512 MiB leaves generous
+/// headroom for the sample tables of very long audiobooks.
+const MAX_MP4_METADATA_BYTES: u64 = 512 * 1024 * 1024;
+```
+
+Add the variant to the `Mp4ScanError` enum (after the existing `Format` variant):
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum Mp4ScanError {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Format(#[from] FormatError),
+    #[error("MP4 {box_kind} box is {size} bytes, exceeds the {cap}-byte metadata cap")]
+    MetadataTooLarge {
+        box_kind: &'static str,
+        size: u64,
+        cap: u64,
+    },
+}
+```
+
+- [ ] **Step 4: Add the cap check in `read_structure_from`**
+
+In `read_structure_from`, immediately after the three `ok_or` unwraps and **before** the `usize::try_from` / `region(...)` reads, insert:
+
+```rust
+    let (ftyp_s, ftyp_h) = ftyp.ok_or(FormatError::NotMp4)?;
+    let (moov_s, moov_h) = moov.ok_or(FormatError::NotMp4)?;
+    let (mdat_s, mdat_h) = mdat.ok_or(FormatError::NotMp4)?;
+
+    // Reject an oversized metadata box before allocating for it (mirrors mp3.rs's
+    // id3v2_alloc_safe philosophy). The check is on the declared length, so a
+    // corrupt header never drives the allocation.
+    for (box_kind, total_len) in [("ftyp", ftyp_h.total_len), ("moov", moov_h.total_len)] {
+        if total_len > MAX_MP4_METADATA_BYTES {
+            return Err(Mp4ScanError::MetadataTooLarge {
+                box_kind,
+                size: total_len,
+                cap: MAX_MP4_METADATA_BYTES,
+            });
+        }
+    }
+```
+
+(The existing `usize::try_from(...)` lines and the three `region(...)` reads follow unchanged.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-format read_structure_from`
+Expected: PASS — both new tests plus the existing `read_structure_from_*` tests are green.
+
+- [ ] **Step 6: Add the clear `log::warn!` at the scan swallow site**
+
+In `musefs-core/src/scan.rs`, in `probe_file`'s MP4 arm, replace the silent swallow:
+
+```rust
+        let mut f = &file;
+        let Ok(scan) = mp4::read_structure_from(&mut f, file_len) else {
+            return Ok(None);
+        };
+```
+
+with a match that loudly logs the new cap case (all other errors keep the existing silent skip, so the change is scoped to the new variant):
+
+```rust
+        let mut f = &file;
+        let scan = match mp4::read_structure_from(&mut f, file_len) {
+            Ok(s) => s,
+            Err(e) => {
+                if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
+                    log::warn!("skipping {}: {e}", path.display());
+                }
+                return Ok(None);
+            }
+        };
+```
+
+Note: the `MetadataTooLarge` branch at the scan site is only reachable for a genuinely >512 MiB file (scan passes the file's real length, so a small corrupt file hits `box_header`'s `Malformed` first). It is verified by inspection plus the unaffected existing MP4 scan tests, not a multi-hundred-MB fixture.
+
+- [ ] **Step 7: Verify the whole crates build and scan tests are unaffected**
+
+Run: `cargo test -p musefs-format -p musefs-core mp4`
+Expected: PASS — new mp4 tests green, existing MP4 scan tests (normal files) unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-format/src/mp4.rs musefs-core/src/scan.rs
+git commit -m "fix(mp4): cap moov/ftyp metadata allocation at 512 MiB, log skips (#91)"
+```
+
+---
+
+## Task 4: #94 — DbPool re-entrancy + open-error path context
+
+**Files:**
+- Modify: `musefs-core/src/error.rs` (add `CoreError::DbOpen`)
+- Modify: `musefs-core/src/db_pool.rs` (imports, `PER_PATH` value type, `with`, `Drop` doc, tests)
+
+Fixes (a) the re-entrant `with()` panic via `Rc<Db>`, and (b) the path-less open error via a new typed `CoreError` variant. (c) the cross-thread Drop leak is documented-and-accepted. The `Shared` variant's re-entrancy (a mutex deadlock) is out of scope; tests use `PerThread` (file-backed) only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two tests to `musefs-core/src/db_pool.rs`'s `#[cfg(test)] mod tests` block (which has `use super::*;` and `use musefs_db::Db;`):
+
+```rust
+    #[test]
+    fn reentrant_with_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("re.db");
+        Db::open(&path).unwrap(); // create + migrate (writer, sets WAL)
+        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
+        // Nested with() on the same thread must not panic on a second borrow_mut.
+        let r: Result<i64> = pool.with(|_outer| pool.with(|db| Ok(db.data_version()?)));
+        assert!(r.is_ok(), "re-entrant with() must not panic or error");
+    }
+
+    #[test]
+    fn with_open_failure_includes_path_in_error() {
+        // Build a PerThread pool whose path can't be opened. `poll` is unused by
+        // `with` (only by `with_poll`), so an in-memory Db satisfies the field.
+        let bad = std::path::PathBuf::from("/nonexistent-musefs-dir/does-not-exist.db");
+        let pool = DbPool::PerThread {
+            id: u64::MAX, // unique key; won't collide with any real pool's thread-local
+            path: bad.clone(),
+            poll: Mutex::new(Db::open_in_memory().unwrap()),
+        };
+        let msg = pool.with(|_db| Ok(())).unwrap_err().to_string();
+        assert!(
+            msg.contains("/nonexistent-musefs-dir/does-not-exist.db"),
+            "open error must name the failing path, got: {msg}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-core db_pool`
+Expected: FAIL — `reentrant_with_does_not_panic` panics with `already borrowed: BorrowMutError`; `with_open_failure_includes_path_in_error` fails to compile (`CoreError::DbOpen` doesn't exist) or, once that compiles, the message lacks the path.
+
+- [ ] **Step 3: Add the `CoreError::DbOpen` variant**
+
+In `musefs-core/src/error.rs`, add a variant to the `CoreError` enum (after `Db`):
+
+```rust
+    #[error("failed to open database at {path}")]
+    DbOpen {
+        path: std::path::PathBuf,
+        #[source]
+        source: musefs_db::DbError,
+    },
+```
+
+- [ ] **Step 4: Switch the thread-local to `Rc<Db>` and make `with` re-entrancy-safe**
+
+In `musefs-core/src/db_pool.rs`, add the imports near the top (with the other `use` lines):
+
+```rust
+use std::rc::Rc;
+
+use crate::error::CoreError;
+```
+
+Change the `PER_PATH` thread-local value type:
+
+```rust
+thread_local! {
+    static PER_PATH: RefCell<HashMap<(PathBuf, u64), Rc<Db>>> = RefCell::new(HashMap::new());
+}
+```
+
+Replace the `with` method body with the version that clones the `Rc` out before calling `f` and attaches the path to an open failure:
+
+```rust
+    /// Run `f` with a read connection.
+    ///
+    /// The `RefCell` borrow does not span `f`: the connection `Rc` is cloned out
+    /// first, so a re-entrant `with()` on the same thread is safe. (The `Shared`
+    /// variant remains non-reentrant — a second `m.lock()` deadlocks — but real
+    /// mounts are always `PerThread`.)
+    pub fn with<R>(&self, f: impl FnOnce(&Db) -> Result<R>) -> Result<R> {
+        match self {
+            DbPool::PerThread { id, path, .. } => PER_PATH.with(|cell| {
+                let db = {
+                    let mut map = cell.borrow_mut();
+                    if let std::collections::hash_map::Entry::Vacant(e) =
+                        map.entry((path.clone(), *id))
+                    {
+                        let db = Db::open_readonly(path).map_err(|source| CoreError::DbOpen {
+                            path: path.clone(),
+                            source,
+                        })?;
+                        e.insert(Rc::new(db));
+                    }
+                    Rc::clone(map.get(&(path.clone(), *id)).unwrap())
+                };
+                f(&db)
+            }),
+            DbPool::Shared(m) => {
+                let db = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                f(&db)
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Document the accepted cross-thread Drop limitation (#94c)**
+
+In `musefs-core/src/db_pool.rs`, add a doc comment above `impl Drop for DbPool` (leave the body unchanged):
+
+```rust
+/// Clears only the *dropping thread's* thread-local connection for this pool.
+/// Connections this pool opened on other worker threads persist until those
+/// threads exit — accepted, because a mount's worker pool lives for the whole
+/// mount, so a connection's lifetime already matches its thread's. A future
+/// caller that creates and drops many pools over long-lived shared threads would
+/// leak; closing that would need a cross-thread registry, intentionally not built
+/// here.
+impl Drop for DbPool {
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-core db_pool`
+Expected: PASS — both new tests plus the existing `db_pool` tests (`shared_pool_for_in_memory_db`, `same_thread_two_pools_keyed_by_path`, `per_thread_pool_for_file_db`) green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/error.rs musefs-core/src/db_pool.rs
+git commit -m "fix(db_pool): re-entrancy-safe with() via Rc<Db> + path-context open error (#94)"
+```
+
+---
+
+## Task 5: #88 — fuzz the Ogg art-synthesis path
+
+**Files:**
+- Modify: `fuzz/fuzz_targets/ogg.rs`
+
+The fuzz crate is **out of the workspace**, so `cargo build`/`clippy`/`test` do not compile it. Ogg's `synthesize_layout` takes `&[OggArt]` (each `OggArt { meta: &ArtInput, image: &[u8] }`), unlike flac/mp3 which take `&[ArtInput]` — so the fix fabricates image byte buffers and builds `OggArt` borrows, upholding `image.len() == meta.data_len` (the invariant `reader.rs:347` maintains).
+
+- [ ] **Step 1: Rewrite the fuzz target to exercise the art path**
+
+Replace the full contents of `fuzz/fuzz_targets/ogg.rs` with:
+
+```rust
+#![no_main]
+use arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use musefs_format::ogg::OggArt;
+use musefs_format::{fuzz_check::assert_backing_covers_audio, ogg, ArtInput};
+use musefs_fuzz::{arb_tags, MAX_INPUT};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > MAX_INPUT {
+        return;
+    }
+    let _ = ogg::read_tags(data);
+    let _ = ogg::read_pictures(data);
+    let scan = match ogg::locate_audio(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let header = match ogg::read_metadata(data) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+    let mut u = Unstructured::new(data);
+    let tags = arb_tags(&mut u).unwrap_or_default();
+
+    // Fabricate embedded images so the page-renumber + CRC-recompute + base64
+    // art path is reached. Each OggArt borrows an ArtInput and its raw bytes,
+    // with data_len == image length (the invariant reader.rs upholds).
+    let n = u.int_in_range(0..=2u8).unwrap_or(0);
+    let mut images: Vec<Vec<u8>> = Vec::new();
+    let mut inputs: Vec<ArtInput> = Vec::new();
+    for i in 0..n {
+        let len = u.int_in_range(0..=8192usize).unwrap_or(0);
+        let bytes = u.bytes(len).map(<[u8]>::to_vec).unwrap_or_default();
+        inputs.push(ArtInput {
+            art_id: i as i64,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: u.int_in_range(0..=20u32).unwrap_or(3),
+            width: 0,
+            height: 0,
+            data_len: bytes.len() as u64,
+        });
+        images.push(bytes);
+    }
+    let arts: Vec<OggArt> = inputs
+        .iter()
+        .zip(images.iter())
+        .map(|(meta, image)| OggArt { meta, image: image.as_slice() })
+        .collect();
+
+    if let Ok(layout) =
+        ogg::synthesize_layout(&header, scan.audio_offset, scan.audio_length, &tags, &arts)
+    {
+        assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
+    }
+});
+```
+
+- [ ] **Step 2: Verify the fuzz target compiles (requires nightly + cargo-fuzz)**
+
+Run: `cargo +nightly fuzz build ogg`
+Expected: builds cleanly. (This is the only thing that compiles the out-of-workspace fuzz crate; a normal `cargo build` will NOT catch a break here.)
+
+- [ ] **Step 3: Short smoke run to confirm the art path is reached and panic-free**
+
+Run: `cargo +nightly fuzz run ogg -- -runs=200000 -max_total_time=30`
+Expected: completes with no crash/panic. (A few seconds; confirms the new art construction doesn't panic on adversarial input.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fuzz/fuzz_targets/ogg.rs
+git commit -m "test(fuzz): exercise Ogg art synthesis path with arbitrary images (#88)"
+```
+
+---
+
+## Final verification (run after all five tasks)
+
+- [ ] **Workspace tests, lint, format**
+
+```bash
+cargo test --workspace
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all --check
+```
+Expected: all green. (`cargo fmt --all --check` is the CI fmt gate — a pre-push must.)
+
+- [ ] **FUSE e2e regression (no serve-path semantics changed, but confirm)**
+
+Run: `cargo test -p musefs-fuse -- --ignored`
+Expected: PASS on `/dev/fuse` (requires libfuse). No read/synthesis semantics changed, so this is a regression check.
+
+- [ ] **In-diff mutation gate (matches the `ci-ok`-required check on `main`)**
+
+Run the repo's in-diff mutation gate locally (`-j$(nproc)`, `TMPDIR` under `/home`), and sanity-check that the diff it tests is non-empty so it isn't a silent false pass.
+
+- [ ] **Open the PR**
+
+```bash
+git push -u origin phase3-hardening
+gh pr create --base main --title "Phase 3: safety net + small Rust hardening (#88, #91-#94)" --body "$(cat <<'EOF'
+Implements Roadmap Phase 3. Five independent low-risk hardening fixes:
+
+- #93 byte_budget: saturating-add symmetry in `acquire`.
+- #92 mapping: skip art rows with negative `byte_len` from malformed external writes.
+- #91 mp4: cap `moov`/`ftyp` metadata allocation at 512 MiB; clearly logged skip at scan.
+- #94 db_pool: re-entrancy-safe `with()` via `Rc<Db>` + path-context open error; cross-thread Drop leak documented-and-accepted.
+- #88 fuzz: exercise the Ogg art-synthesis path (image bytes + `OggArt`).
+
+Spec: `docs/superpowers/specs/2026-06-03-phase3-hardening-design.md`.
+Reviewed by spec-plan-reviewer; byte-identical-audio invariant unchanged.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes for the implementer
+
+- **Serena tools:** This project uses Serena for code reads/edits. Use `get_symbols_overview` / `find_symbol` to read, and `replace_symbol_body` / `replace_content` / `insert_*_symbol` to edit Rust files, rather than the built-in Read/Edit.
+- **One commit per task** (five total), then the final-verification steps. Don't squash.
+- **Don't `--no-verify`.** The pre-commit hook runs fmt + clippy + workspace tests; if it fails, fix and make a new commit.
+- **#88 needs nightly** (`cargo +nightly fuzz`). If the toolchain is missing, install `cargo-fuzz` and a nightly toolchain; do not skip the build check — CI's smoke job is otherwise the only thing that compiles the fuzz crate.

--- a/docs/superpowers/plans/2026-06-03-phase3-hardening.md
+++ b/docs/superpowers/plans/2026-06-03-phase3-hardening.md
@@ -185,7 +185,7 @@ Add these two tests to `musefs-format/src/mp4.rs`'s `#[cfg(test)] mod tests` blo
         // ftyp(16) + mdat(16) + moov(declares 600 MiB). The moov box "ends" exactly
         // at the (large, lied-about) file_len so the header walk terminates cleanly,
         // then the cap check fires before any payload region is allocated/read.
-        let moov_size: u32 = 600 * 1024 * 1024; // 629_145_600 > 512 MiB cap
+        let moov_size: u32 = 600 * 1024 * 1024; // 629_145_600 > 256 MiB cap
         let mut buf = Vec::new();
         buf.extend_from_slice(&16u32.to_be_bytes());
         buf.extend_from_slice(b"ftyp");
@@ -203,7 +203,7 @@ Add these two tests to `musefs-format/src/mp4.rs`'s `#[cfg(test)] mod tests` blo
             Mp4ScanError::MetadataTooLarge { box_kind, size, cap } => {
                 assert_eq!(box_kind, "moov");
                 assert_eq!(size, moov_size as u64);
-                assert_eq!(cap, 512 * 1024 * 1024);
+                assert_eq!(cap, 256 * 1024 * 1024);
             }
             other => panic!("expected MetadataTooLarge, got {other:?}"),
         }
@@ -214,7 +214,7 @@ Add these two tests to `musefs-format/src/mp4.rs`'s `#[cfg(test)] mod tests` blo
         use std::io::Cursor;
         // size == cap: the guard is strict `>`, so it does NOT trip. The read then
         // proceeds and hits EOF on the short buffer → Io, never MetadataTooLarge.
-        let cap: u32 = 512 * 1024 * 1024;
+        let cap: u32 = 256 * 1024 * 1024;
         let mut buf = Vec::new();
         buf.extend_from_slice(&16u32.to_be_bytes());
         buf.extend_from_slice(b"ftyp");
@@ -226,9 +226,9 @@ Add these two tests to `musefs-format/src/mp4.rs`'s `#[cfg(test)] mod tests` blo
         buf.extend_from_slice(b"moov");
         let file_len = 32 + cap as u64;
         let mut cur = Cursor::new(buf);
-        // region() does `vec![0u8; 512 MiB]` here, but it's alloc_zeroed (lazy zero
+        // region() does `vec![0u8; 256 MiB]` here, but it's alloc_zeroed (lazy zero
         // pages) and read_exact writes only ~8 bytes before EOF, so just one page is
-        // faulted in — no real 512 MiB RSS spike.
+        // faulted in — no real 256 MiB RSS spike.
         let err = read_structure_from(&mut cur, file_len).unwrap_err();
         assert!(
             matches!(err, Mp4ScanError::Io(_)),
@@ -249,9 +249,9 @@ In `musefs-format/src/mp4.rs`, add the module-level const (place it near the top
 ```rust
 /// Upper bound on a single MP4 metadata box (`ftyp`/`moov`) allocation. A corrupt
 /// or pathologically large box is rejected (the file is skipped at scan, logged)
-/// rather than forcing a multi-hundred-MB allocation. 512 MiB leaves generous
+/// rather than forcing a multi-hundred-MB allocation. 256 MiB leaves generous
 /// headroom for the sample tables of very long audiobooks.
-const MAX_MP4_METADATA_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_MP4_METADATA_BYTES: u64 = 256 * 1024 * 1024;
 ```
 
 Add the variant to the `Mp4ScanError` enum (after the existing `Format` variant):
@@ -328,7 +328,7 @@ with a match that loudly logs the new cap case (all other errors keep the existi
         };
 ```
 
-Note: the `MetadataTooLarge` branch at the scan site is only reachable for a genuinely >512 MiB file (scan passes the file's real length, so a small corrupt file hits `box_header`'s `Malformed` first). It is verified by inspection plus the unaffected existing MP4 scan tests, not a multi-hundred-MB fixture.
+Note: the `MetadataTooLarge` branch at the scan site is only reachable for a genuinely >256 MiB file (scan passes the file's real length, so a small corrupt file hits `box_header`'s `Malformed` first). It is verified by inspection plus the unaffected existing MP4 scan tests, not a multi-hundred-MB fixture.
 
 - [ ] **Step 7: Handle the new variant in the serve-path match (`reader.rs`)**
 
@@ -367,7 +367,7 @@ Expected: PASS — `musefs-core` compiles (the `reader.rs` arm closes E0004), ne
 
 ```bash
 git add musefs-format/src/mp4.rs musefs-core/src/scan.rs musefs-core/src/reader.rs
-git commit -m "fix(mp4): cap moov/ftyp metadata allocation at 512 MiB, log skips (#91)"
+git commit -m "fix(mp4): cap moov/ftyp metadata allocation at 256 MiB, log skips (#91)"
 ```
 
 ---
@@ -632,7 +632,7 @@ Implements Roadmap Phase 3. Five independent low-risk hardening fixes:
 
 - #93 byte_budget: saturating-add symmetry in `acquire`.
 - #92 mapping: skip art rows with negative `byte_len` from malformed external writes.
-- #91 mp4: cap `moov`/`ftyp` metadata allocation at 512 MiB; clearly logged skip at scan.
+- #91 mp4: cap `moov`/`ftyp` metadata allocation at 256 MiB; clearly logged skip at scan.
 - #94 db_pool: re-entrancy-safe `with()` via `Rc<Db>` + path-context open error; cross-thread Drop leak documented-and-accepted.
 - #88 fuzz: exercise the Ogg art-synthesis path (image bytes + `OggArt`).
 

--- a/docs/superpowers/plans/2026-06-03-phase3-hardening.md
+++ b/docs/superpowers/plans/2026-06-03-phase3-hardening.md
@@ -72,7 +72,7 @@ Add this test inside `musefs-core/src/mapping.rs`'s `#[cfg(test)] mod tests` blo
 ```rust
     #[test]
     fn track_art_to_inputs_skips_negative_byte_len() {
-        use musefs_db::{NewArt, NewTrack, TrackArt};
+        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("art.db");
         let db = Db::open(&path).unwrap();
@@ -170,6 +170,7 @@ git commit -m "fix(mapping): skip art rows with negative byte_len from malformed
 **Files:**
 - Modify: `musefs-format/src/mp4.rs` (module const, `Mp4ScanError` enum ~line 89, `read_structure_from` ~lines 244-313, test module ~line 841)
 - Modify: `musefs-core/src/scan.rs` (`probe_file` MP4 arm, ~lines 219-222)
+- Modify: `musefs-core/src/reader.rs` (serve-path `Mp4ScanError` match, lines 321-324) — **required**: this is the only other `Mp4ScanError` consumer and its match is exhaustive/wildcard-free, so the new variant breaks compilation of `musefs-core` until this arm is added.
 
 The cap is checked on the declared box length **before** `region()` allocates. The test exploits that `read_structure_from`'s `file_len` argument is independent of the reader's real length: a large `file_len` clears `box_header`'s `total_len > remaining` check, so the new cap (not `Malformed`) is what fires.
 
@@ -225,6 +226,9 @@ Add these two tests to `musefs-format/src/mp4.rs`'s `#[cfg(test)] mod tests` blo
         buf.extend_from_slice(b"moov");
         let file_len = 32 + cap as u64;
         let mut cur = Cursor::new(buf);
+        // region() does `vec![0u8; 512 MiB]` here, but it's alloc_zeroed (lazy zero
+        // pages) and read_exact writes only ~8 bytes before EOF, so just one page is
+        // faulted in — no real 512 MiB RSS spike.
         let err = read_structure_from(&mut cur, file_len).unwrap_err();
         assert!(
             matches!(err, Mp4ScanError::Io(_)),
@@ -326,15 +330,43 @@ with a match that loudly logs the new cap case (all other errors keep the existi
 
 Note: the `MetadataTooLarge` branch at the scan site is only reachable for a genuinely >512 MiB file (scan passes the file's real length, so a small corrupt file hits `box_header`'s `Malformed` first). It is verified by inspection plus the unaffected existing MP4 scan tests, not a multi-hundred-MB fixture.
 
-- [ ] **Step 7: Verify the whole crates build and scan tests are unaffected**
+- [ ] **Step 7: Handle the new variant in the serve-path match (`reader.rs`)**
+
+`read_structure_from` is also called at serve/resolve time in `musefs-core/src/reader.rs`, where the error is mapped by an **exhaustive, wildcard-free** match. Adding `MetadataTooLarge` makes that match non-exhaustive (`error[E0004]`), so `musefs-core` will not compile until this arm is added. At `musefs-core/src/reader.rs:321-324`, change:
+
+```rust
+                        let scan = mp4::read_structure_from(&mut f, len).map_err(|e| match e {
+                            mp4::Mp4ScanError::Io(io) => CoreError::Io(io),
+                            mp4::Mp4ScanError::Format(fe) => CoreError::Format(fe),
+                        })?;
+```
+
+to add the new arm:
+
+```rust
+                        let scan = mp4::read_structure_from(&mut f, len).map_err(|e| match e {
+                            mp4::Mp4ScanError::Io(io) => CoreError::Io(io),
+                            mp4::Mp4ScanError::Format(fe) => CoreError::Format(fe),
+                            // Unreachable in practice at serve time (an ingested file
+                            // already passed the cap at scan, and backing-file drift is
+                            // caught by the size/mtime BackingChanged guard first), but
+                            // the match must stay exhaustive. Collapse to Malformed like
+                            // the Format arm — the scan path carries the detailed warn.
+                            mp4::Mp4ScanError::MetadataTooLarge { .. } => {
+                                CoreError::Format(musefs_format::FormatError::Malformed)
+                            }
+                        })?;
+```
+
+- [ ] **Step 8: Verify both crates build and scan tests are unaffected**
 
 Run: `cargo test -p musefs-format -p musefs-core mp4`
-Expected: PASS — new mp4 tests green, existing MP4 scan tests (normal files) unchanged.
+Expected: PASS — `musefs-core` compiles (the `reader.rs` arm closes E0004), new mp4 tests green, existing MP4 scan tests (normal files) unchanged.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
-git add musefs-format/src/mp4.rs musefs-core/src/scan.rs
+git add musefs-format/src/mp4.rs musefs-core/src/scan.rs musefs-core/src/reader.rs
 git commit -m "fix(mp4): cap moov/ftyp metadata allocation at 512 MiB, log skips (#91)"
 ```
 

--- a/docs/superpowers/specs/2026-06-03-phase3-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase3-hardening-design.md
@@ -74,30 +74,38 @@ reachably observable.
 
 ## #92 — `mapping.rs` casts `byte_len as u64` without a non-negative guard
 
-**Problem.** `musefs-core/src/mapping.rs` builds `data_len: meta.byte_len as u64`
-(art, line 45) and `len: row.byte_len as u64` (binary tags, line 63) from an
-`i64` DB column. The SQLite store is the documented contract external tools write
-to; a negative `byte_len` from a malformed/external row casts to a huge `u64`
-(e.g. `-1 → u64::MAX`), which would drive a bogus segment length.
+**Problem.** `musefs-core/src/mapping.rs::track_art_to_inputs` builds
+`data_len: meta.byte_len as u64` (line 45) from `art.byte_len`, an `i64` **stored
+column** (`art.byte_len INTEGER NOT NULL`, `schema.rs:31`). The SQLite store is
+the documented contract external tools write to; a negative `byte_len` from a
+malformed/external row casts to a huge `u64` (e.g. `-1 → u64::MAX`), which would
+drive a bogus segment length.
 
-**Fix.** **Skip the malformed row** rather than clamp. A negative `byte_len` is a
-contract violation for that single row; dropping it lets the track still
-synthesize without that art/tag (graceful degradation). Clamping to `0` was
-rejected: a `len: 0` `ArtImage` fails layout validation downstream, which would
-make the *whole track* unreadable instead of just losing the bad row.
+**Scope — art only, NOT binary tags.** The sibling cast `len: row.byte_len as u64`
+in `binary_tags_to_inputs` (line 63) is **safe and needs no guard**: that
+`byte_len` is computed as `length(value_blob)` in SQL (`tags.rs:127`), which is
+always ≥ 0 — a negative value is unrepresentable, so a guard there would be
+unreachable defensive code. Only the stored `art.byte_len` column is externally
+forgeable into a negative.
+
+**Fix.** **Skip the malformed art row** rather than clamp. A negative `byte_len`
+is a contract violation for that single row; dropping it lets the track still
+synthesize without that art (graceful degradation). Clamping to `0` was rejected:
+a `len: 0` `ArtImage` fails layout validation downstream, which would make the
+*whole track* unreadable instead of just losing the bad row.
 
 - `track_art_to_inputs`: inside the existing `if let Some(meta)` arm, skip the
-  push when `meta.byte_len < 0` (the row is filtered out of `inputs`).
-- `binary_tags_to_inputs`: replace the `.map(...)` with a `.filter_map(...)` (or
-  filter) that drops rows with `row.byte_len < 0`.
+  push (`continue`) when `meta.byte_len < 0`, so the row is filtered out of
+  `inputs`.
 
-**Verification.** New unit tests in `mapping.rs`: insert a row with a negative
-`byte_len` via raw SQL (bypassing the scanner, which only writes real sizes) and
-assert the resulting `inputs` omits that row while keeping well-formed siblings.
-Heads-up: `binary_tags_to_inputs` is still `#[allow(dead_code)]` (wired into the
-reader resolve arms in a later task, per its comment), so until then the new unit
-test is the *only* thing exercising its guard — no behavioral-regression risk, just
-note that coverage rests entirely on the test.
+**Verification.** New unit test in `mapping.rs`. The negative `byte_len` cannot be
+produced through the public `Db` API (`upsert_art` derives `byte_len` from
+`data.len()`), so the test simulates an external malformed write: create a
+**file-backed** `Db`, upsert a track + a valid art row + `set_track_art`, then open
+a second raw `rusqlite::Connection` to the same path and
+`UPDATE art SET byte_len = -1`. `rusqlite` is already a musefs-core dev-dependency.
+Assert `track_art_to_inputs` omits the corrupted row while keeping a well-formed
+sibling art row.
 
 ---
 
@@ -151,9 +159,12 @@ cap, so the test must exploit that `file_len` is a **parameter** of
 `file_len` (so `remaining` clears `box_header`) over a short in-memory cursor whose
 `moov` header declares `total_len` > 512 MiB. The cap check fires before `region`'s
 `read_exact`, so the result is `MetadataTooLarge` with **no** giant allocation and
-no EOF. Confirm a normal-sized fixture is unaffected. Scan-level test asserts such a
-file is skipped (counts toward `skipped`, not ingested) and that the `log::warn!`
-fires.
+no EOF. A boundary test (box size == cap exactly) confirms the guard is strict
+`>` (it proceeds to `region`, hitting `Io`/EOF on the short buffer — *not*
+`MetadataTooLarge`). The scan-site `log::warn!` branch is reachable only with a
+genuinely >512 MiB file (scan passes the file's *real* length, so a small fixture
+hits `box_header`'s `Malformed` first) — verified by inspection plus the unaffected
+existing MP4 scan tests, not a multi-hundred-MB fixture.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-03-phase3-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase3-hardening-design.md
@@ -122,7 +122,7 @@ within a large file) there is still no upper bound comparable to
 path is shared by scan **and** serve-time resolve (`reader.rs:320`; Phase 6 made
 resolve seek the `moov`), so the cap guards both.
 
-**Fix.** Add a `const MAX_MP4_METADATA_BYTES: u64 = 512 * 1024 * 1024;` (512 MiB).
+**Fix.** Add a `const MAX_MP4_METADATA_BYTES: u64 = 256 * 1024 * 1024;` (256 MiB).
 Generous headroom for extreme audiobooks (tens of hours → tens of MB of sample
 tables) while rejecting corrupt multi-GB boxes. Before the `ftyp_bytes`/
 `moov_bytes` reads in `read_structure_from`, reject when either box's declared
@@ -157,12 +157,12 @@ check would intercept a huge box over a small file as `Malformed` *before* the n
 cap, so the test must exploit that `file_len` is a **parameter** of
 `read_structure_from` independent of the reader's real length: pass a large
 `file_len` (so `remaining` clears `box_header`) over a short in-memory cursor whose
-`moov` header declares `total_len` > 512 MiB. The cap check fires before `region`'s
+`moov` header declares `total_len` > 256 MiB. The cap check fires before `region`'s
 `read_exact`, so the result is `MetadataTooLarge` with **no** giant allocation and
 no EOF. A boundary test (box size == cap exactly) confirms the guard is strict
 `>` (it proceeds to `region`, hitting `Io`/EOF on the short buffer — *not*
 `MetadataTooLarge`). The scan-site `log::warn!` branch is reachable only with a
-genuinely >512 MiB file (scan passes the file's *real* length, so a small fixture
+genuinely >256 MiB file (scan passes the file's *real* length, so a small fixture
 hits `box_header`'s `Malformed` first) — verified by inspection plus the unaffected
 existing MP4 scan tests, not a multi-hundred-MB fixture.
 

--- a/docs/superpowers/specs/2026-06-03-phase3-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase3-hardening-design.md
@@ -1,0 +1,247 @@
+# Phase 3 — Safety net + small Rust hardening
+
+**Date:** 2026-06-03
+**Scope:** Roadmap "Phase 3 — Safety net + small Rust hardening" — issues #88,
+#91, #92, #93, #94. Low-risk, independent fixes. Ships as **one batched PR**
+(matching how Phases 0–2 each landed).
+
+## Goal
+
+Close five latent-hardening issues surfaced by the v1 multi-model review and the
+fuzz triage. None are user-visible behavior changes for well-formed inputs; each
+removes a way a malformed input, a malformed external DB row, or a future caller
+could cause an OOM, a silent overflow, a panic, or an unhelpful error. The
+byte-identical-audio invariant is untouched.
+
+---
+
+## #88 — Ogg fuzz target does not exercise art synthesis
+
+**Problem.** `fuzz/fuzz_targets/ogg.rs` calls
+`ogg::synthesize_layout(&header, …, &tags, &[])` with an empty art slice. The
+flac/mp3/mp4/wav targets all pass `arb_arts(&mut u)`. Ogg's art path — page
+renumber + per-page CRC recompute + incremental base64 windowing — is the most
+complex art synthesis of any format and is never reached by the fuzzer.
+
+**Fix (NOT a one-liner — ogg's signature differs from flac/mp3).** flac/mp3 take
+`arts: &[ArtInput]`, so they pass `arb_arts(&mut u)` directly. Ogg's
+`synthesize_layout` instead takes `arts: &[OggArt]`
+(`musefs-format/src/ogg/mod.rs:240`), where
+`OggArt<'a> { meta: &'a ArtInput, image: &'a [u8] }` carries the **raw image
+bytes** (ogg needs them to recompute per-page CRCs — `arb_arts` carries only a
+`data_len`, no bytes). The real caller (`reader.rs:347`) zips `art_inputs` with
+the stored image blobs, so the held invariant is `image.len() == meta.data_len`.
+
+The fuzz target must therefore, locally (not in `arb_arts`, because of the
+borrow lifetimes):
+1. Generate a small vec (0..=2) of arbitrary image byte buffers — `Vec<Vec<u8>>`,
+   each bounded (≤ ~8 KiB, matching `arb_arts`'s `data_len` bound) — and a
+   parallel `Vec<ArtInput>` whose `data_len == bytes.len()` (with arbitrary
+   `mime`/`picture_type`/dims as in `arb_arts`). The byte buffers and the
+   `ArtInput`s must outlive the `OggArt` slice.
+2. Build `let arts: Vec<OggArt> = inputs.iter().zip(images.iter()).map(|(meta, img)|
+   OggArt { meta, image: img.as_slice() }).collect();`
+3. Pass `&arts` as the 5th argument to `synthesize_layout`.
+
+This exercises the page-renumber + CRC-recompute + incremental-base64 art path
+the empty slice never reached.
+
+**Verification.** The fuzz crate is out-of-workspace, so a normal
+`cargo build`/`clippy` will *not* compile it — only CI's smoke job would catch a
+break. Verify locally with `cargo +nightly fuzz build ogg`, then a short
+`cargo +nightly fuzz run ogg -- -runs=100000` to confirm the art path is reached
+and stays panic-free.
+
+---
+
+## #93 — `byte_budget` increment is non-saturating while its guard saturates
+
+**Problem.** In `musefs-core/src/byte_budget.rs::acquire`, the wait guard tests
+`in_flight.saturating_add(n) > self.cap`, but the state mutation is a plain
+`*in_flight += n`. `release` already uses `saturating_sub`. The two disagree on
+overflow; the existing comment even claims the saturating style is mirrored.
+
+**Fix.** Change `*in_flight += n` to `*in_flight = in_flight.saturating_add(n)`.
+No observable change (art weights are file-bounded; `in_flight` never approaches
+`u64::MAX`), purely an internal-consistency fix.
+
+**Verification.** The existing `byte_budget` unit tests (which pin additive
+accumulation and every guard mutant) continue to pass unchanged — `saturating_add`
+is still additive below the saturation point. No new test; the asymmetry is not
+reachably observable.
+
+---
+
+## #92 — `mapping.rs` casts `byte_len as u64` without a non-negative guard
+
+**Problem.** `musefs-core/src/mapping.rs` builds `data_len: meta.byte_len as u64`
+(art, line 45) and `len: row.byte_len as u64` (binary tags, line 63) from an
+`i64` DB column. The SQLite store is the documented contract external tools write
+to; a negative `byte_len` from a malformed/external row casts to a huge `u64`
+(e.g. `-1 → u64::MAX`), which would drive a bogus segment length.
+
+**Fix.** **Skip the malformed row** rather than clamp. A negative `byte_len` is a
+contract violation for that single row; dropping it lets the track still
+synthesize without that art/tag (graceful degradation). Clamping to `0` was
+rejected: a `len: 0` `ArtImage` fails layout validation downstream, which would
+make the *whole track* unreadable instead of just losing the bad row.
+
+- `track_art_to_inputs`: inside the existing `if let Some(meta)` arm, skip the
+  push when `meta.byte_len < 0` (the row is filtered out of `inputs`).
+- `binary_tags_to_inputs`: replace the `.map(...)` with a `.filter_map(...)` (or
+  filter) that drops rows with `row.byte_len < 0`.
+
+**Verification.** New unit tests in `mapping.rs`: insert a row with a negative
+`byte_len` via raw SQL (bypassing the scanner, which only writes real sizes) and
+assert the resulting `inputs` omits that row while keeping well-formed siblings.
+Heads-up: `binary_tags_to_inputs` is still `#[allow(dead_code)]` (wired into the
+reader resolve arms in a later task, per its comment), so until then the new unit
+test is the *only* thing exercising its guard — no behavioral-regression risk, just
+note that coverage rests entirely on the test.
+
+---
+
+## #91 — MP4 `moov`/`ftyp` bytes read with no metadata-size cap
+
+**Problem.** `musefs-format/src/mp4.rs::read_structure_from`'s `region()` helper
+allocates `vec![0u8; len]` for the `ftyp`/`moov` boxes, where `len` is the
+declared box length. `box_header` (`mp4.rs:59`) already rejects
+`total_len > remaining` (`remaining = file_len - pos`), so the allocation is
+bounded by the file's real length — but for a genuinely large file (a real
+multi-hundred-MB audiobook, or a backing file whose `moov` is corrupt-but-large
+within a large file) there is still no upper bound comparable to
+`mp3.rs::id3v2_alloc_safe`: a real 600 MB `moov` forces a 600 MB allocation. This
+path is shared by scan **and** serve-time resolve (`reader.rs:320`; Phase 6 made
+resolve seek the `moov`), so the cap guards both.
+
+**Fix.** Add a `const MAX_MP4_METADATA_BYTES: u64 = 512 * 1024 * 1024;` (512 MiB).
+Generous headroom for extreme audiobooks (tens of hours → tens of MB of sample
+tables) while rejecting corrupt multi-GB boxes. Before the `ftyp_bytes`/
+`moov_bytes` reads in `read_structure_from`, reject when either box's declared
+`total_len` exceeds the cap, returning a new distinct error variant:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum Mp4ScanError {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Format(#[from] FormatError),
+    #[error("MP4 {box_kind} box is {size} bytes, exceeds the {cap}-byte metadata cap")]
+    MetadataTooLarge { box_kind: &'static str, size: u64, cap: u64 },
+}
+```
+
+The check runs **before** allocation (on the declared `total_len`), so a corrupt
+header never allocates.
+
+**Clear logging (per requirement).** `scan.rs:221` currently swallows the error
+silently (`let Ok(scan) = … else { return Ok(None) }`). Replace that with a match
+that, on `Mp4ScanError::MetadataTooLarge`, emits
+`log::warn!("skipping {path}: {e}")` (naming the file, box, size, and cap) before
+returning `Ok(None)`; all other errors keep the current silent-skip behavior so
+this change is scoped to the new case only. This is the first scan-site use of
+`log::warn!`, consistent with the existing `log::warn!`/`error!` usage in
+`facade.rs`/`lock.rs`.
+
+**Verification.** New `mp4.rs` unit test. Note `box_header`'s `total_len > remaining`
+check would intercept a huge box over a small file as `Malformed` *before* the new
+cap, so the test must exploit that `file_len` is a **parameter** of
+`read_structure_from` independent of the reader's real length: pass a large
+`file_len` (so `remaining` clears `box_header`) over a short in-memory cursor whose
+`moov` header declares `total_len` > 512 MiB. The cap check fires before `region`'s
+`read_exact`, so the result is `MetadataTooLarge` with **no** giant allocation and
+no EOF. Confirm a normal-sized fixture is unaffected. Scan-level test asserts such a
+file is skipped (counts toward `skipped`, not ingested) and that the `log::warn!`
+fires.
+
+---
+
+## #94 — DbPool thread-local lifecycle footguns
+
+Three latent issues in `musefs-core/src/db_pool.rs`'s `PerThread` path. Decision:
+fix the two cheap/real ones; document-and-accept the third (genuinely unreachable
+under our thread model, and only fixable with a cross-thread registry we don't
+want to add for a case that can't currently occur).
+
+**(a) Re-entrant `with()` panic — FIX.** `with()` holds
+`PER_PATH.borrow_mut()` across the user closure `f`. A re-entrant `with()` on the
+same thread (the natural "second query inside a closure" pattern) panics on the
+second `borrow_mut` with an opaque `BorrowMutError`. Not reachable today (every
+closure is a single leaf read), but a sharp landmine for future callers and cheap
+to disarm.
+
+*Fix:* the `PerThread` connections live in the `PER_PATH` thread-local, typed
+`HashMap<(PathBuf, u64), Db>`. Change the value type to `Rc<Db>`
+(`HashMap<(PathBuf, u64), Rc<Db>>`). In `with`, clone the `Rc` out **while
+holding the borrow**, drop the borrow, then call `f(&db)`. The borrow no longer
+spans `f`, so re-entrancy is safe. `Rc` (not `Arc`) — the map is thread-local.
+`Db` is only ever borrowed as `&Db` through the pool (no `&mut`/ownership), so
+`Rc<Db>` is sufficient and behavior-preserving for all current callers.
+
+*Scope — `PerThread` only.* The same re-entrancy hazard exists on the `Shared`
+variant (`DbPool::Shared(Arc<Mutex<Db>>)`), but there it is a **mutex deadlock**
+on the second `m.lock()`, not a `RefCell` panic, and the `Rc` fix does not touch
+it. `Shared` is the in-memory test-only fallback (a real mount is always
+`PerThread`), and the module already carries a doc comment warning about re-entry.
+We **document-and-accept** the `Shared` deadlock (extend that warning); we do not
+fix it. The re-entrancy test (below) therefore runs against a **file-backed
+(`PerThread`) temp DB** only — running it against a `Shared` pool would deadlock by
+design.
+
+**(b) Open error lacks path context — FIX.** `Db::open_readonly(path)` returns
+`Result<Db, DbError>`; at the `with` site the `?` converts via
+`CoreError::Db(#[from] DbError)`, which is `#[error(transparent)]`, so *which* DB
+path failed is structurally lost. An open failure is a real reachable runtime path
+(permissions, deleted/corrupt DB under a live mount). Honoring the CLAUDE.md
+convention (no `map_err` that drops the source) while surfacing the path requires a
+**new typed `CoreError` variant** — `#[from]` alone cannot carry the path:
+
+```rust
+#[error("failed to open database at {path}")]
+DbOpen { path: PathBuf, #[source] source: DbError },
+```
+
+At the open call site in `with`, map the open error into `DbOpen { path:
+path.clone(), source }` (carrying, not dropping, the source). The `{path}`
+interpolation makes the verification's "`Display` contains the path" hold while the
+typed `#[source]` preserves the underlying `DbError`.
+
+**(c) Cross-thread Drop leak — DOCUMENT + ACCEPT.** `Drop` clears only the
+dropping thread's thread-local entry; connections opened on other worker threads
+persist until those threads exit. Under a FUSE mount the worker pool lives for the
+whole mount and is torn down at unmount, so a connection's lifetime already
+matches its thread's — the "leak" is unreachable. It would only bite a future
+caller creating/dropping many `DbPool`s over long-lived shared threads. Closing it
+properly needs a cross-thread connection registry; not worth that machinery for an
+unreachable case. Record the limitation in a doc comment on `impl Drop for DbPool`
+so a future caller who *does* hit that pattern is warned.
+
+**Verification.** New `db_pool.rs` tests (file-backed temp DB):
+- re-entrancy: `pool.with(|_| pool.with(|_| Ok(())))` does not panic and returns
+  the inner result.
+- path context: opening a nonexistent/unreadable path yields an error whose
+  `Display` contains the path string.
+
+---
+
+## Cross-cutting verification
+
+- `cargo test --workspace`, `cargo clippy --all-targets`, `cargo fmt --all --check`
+  (the CI fmt gate is a pre-push must — see prepush-checks note).
+- `cargo +nightly fuzz build ogg` (+ short run) for #88, since the fuzz crate is
+  out of the workspace.
+- In-diff mutation gate locally before push (`-j$(nproc)`, `TMPDIR` under /home),
+  sanity-checking the diff so it isn't a silent false pass — `main` is protected
+  by the `ci-ok` aggregator which includes the mutation gate.
+- The `#[ignore]` FUSE e2e suite is unaffected (no read/synthesis-path semantics
+  change), but run it once on `/dev/fuse` as a regression check before merge.
+
+## Out of scope
+
+- No cross-thread DbPool registry (see #94c).
+- No fix for `Shared`-variant re-entrancy (mutex deadlock); documented-and-accepted
+  alongside #94a since real mounts are always `PerThread`.
+- No change to the existing oversized-art silent-skip path in scan (#91 only adds
+  logging for the new MP4 metadata-cap case).
+- No new format support, no serve-path semantics change.

--- a/fuzz/fuzz_targets/ogg.rs
+++ b/fuzz/fuzz_targets/ogg.rs
@@ -1,7 +1,8 @@
 #![no_main]
 use arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
-use musefs_format::{fuzz_check::assert_backing_covers_audio, ogg};
+use musefs_format::ogg::OggArt;
+use musefs_format::{fuzz_check::assert_backing_covers_audio, ogg, ArtInput};
 use musefs_fuzz::{arb_tags, MAX_INPUT};
 
 fuzz_target!(|data: &[u8]| {
@@ -20,8 +21,32 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut u = Unstructured::new(data);
     let tags = arb_tags(&mut u).unwrap_or_default();
+
+    let n = u.int_in_range(0..=2u8).unwrap_or(0);
+    let mut images: Vec<Vec<u8>> = Vec::new();
+    let mut inputs: Vec<ArtInput> = Vec::new();
+    for i in 0..n {
+        let len = u.int_in_range(0..=8192usize).unwrap_or(0);
+        let bytes = u.bytes(len).map(<[u8]>::to_vec).unwrap_or_default();
+        inputs.push(ArtInput {
+            art_id: i as i64,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: u.int_in_range(0..=20u32).unwrap_or(3),
+            width: 0,
+            height: 0,
+            data_len: bytes.len() as u64,
+        });
+        images.push(bytes);
+    }
+    let arts: Vec<OggArt> = inputs
+        .iter()
+        .zip(images.iter())
+        .map(|(meta, image)| OggArt { meta, image: image.as_slice() })
+        .collect();
+
     if let Ok(layout) =
-        ogg::synthesize_layout(&header, scan.audio_offset, scan.audio_length, &tags, &[])
+        ogg::synthesize_layout(&header, scan.audio_offset, scan.audio_length, &tags, &arts)
     {
         assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
     }

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -29,7 +29,7 @@ impl ByteBudget {
         while *in_flight != 0 && in_flight.saturating_add(n) > self.cap {
             in_flight = self.cv.wait(in_flight).unwrap();
         }
-        *in_flight += n;
+        *in_flight = in_flight.saturating_add(n);
     }
 
     /// Release `n` previously reserved bytes.

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -12,12 +12,13 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use musefs_db::Db;
 
-use crate::error::Result;
+use crate::error::{CoreError, Result};
 
 static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -30,6 +31,13 @@ pub enum DbPool {
     Shared(Arc<Mutex<Db>>),
 }
 
+/// Clears only the *dropping thread's* thread-local connection for this pool.
+/// Connections this pool opened on other worker threads persist until those
+/// threads exit — accepted, because a mount's worker pool lives for the whole
+/// mount, so a connection's lifetime already matches its thread's. A future
+/// caller that creates and drops many pools over long-lived shared threads would
+/// leak; closing that would need a cross-thread registry, intentionally not built
+/// here.
 impl Drop for DbPool {
     fn drop(&mut self) {
         if let DbPool::PerThread { id, path, .. } = self {
@@ -43,7 +51,7 @@ impl Drop for DbPool {
 }
 
 thread_local! {
-    static PER_PATH: RefCell<HashMap<(PathBuf, u64), Db>> = RefCell::new(HashMap::new());
+    static PER_PATH: RefCell<HashMap<(PathBuf, u64), Rc<Db>>> = RefCell::new(HashMap::new());
 }
 
 impl DbPool {
@@ -84,13 +92,20 @@ impl DbPool {
     pub fn with<R>(&self, f: impl FnOnce(&Db) -> Result<R>) -> Result<R> {
         match self {
             DbPool::PerThread { id, path, .. } => PER_PATH.with(|cell| {
-                let mut map = cell.borrow_mut();
-                if let std::collections::hash_map::Entry::Vacant(e) = map.entry((path.clone(), *id))
-                {
-                    let db = Db::open_readonly(path)?;
-                    e.insert(db);
-                }
-                f(map.get(&(path.clone(), *id)).unwrap())
+                let db = {
+                    let mut map = cell.borrow_mut();
+                    if let std::collections::hash_map::Entry::Vacant(e) =
+                        map.entry((path.clone(), *id))
+                    {
+                        let db = Db::open_readonly(path).map_err(|source| CoreError::DbOpen {
+                            path: path.clone(),
+                            source,
+                        })?;
+                        e.insert(Rc::new(db));
+                    }
+                    Rc::clone(map.get(&(path.clone(), *id)).unwrap())
+                };
+                f(&db)
             }),
             DbPool::Shared(m) => {
                 let db = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -153,5 +168,30 @@ mod tests {
                 .unwrap()
         });
         assert!(r >= 0);
+    }
+
+    #[test]
+    fn reentrant_with_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("re.db");
+        Db::open(&path).unwrap();
+        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
+        let r: Result<i64> = pool.with(|_outer| pool.with(|db| Ok(db.data_version()?)));
+        assert!(r.is_ok(), "re-entrant with() must not panic or error");
+    }
+
+    #[test]
+    fn with_open_failure_includes_path_in_error() {
+        let bad = std::path::PathBuf::from("/nonexistent-musefs-dir/does-not-exist.db");
+        let pool = DbPool::PerThread {
+            id: u64::MAX,
+            path: bad.clone(),
+            poll: Mutex::new(Db::open_in_memory().unwrap()),
+        };
+        let msg = pool.with(|_db| Ok(())).unwrap_err().to_string();
+        assert!(
+            msg.contains("/nonexistent-musefs-dir/does-not-exist.db"),
+            "open error must name the failing path, got: {msg}"
+        );
     }
 }

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -4,6 +4,12 @@ use thiserror::Error;
 pub enum CoreError {
     #[error(transparent)]
     Db(#[from] musefs_db::DbError),
+    #[error("failed to open database at {path}")]
+    DbOpen {
+        path: std::path::PathBuf,
+        #[source]
+        source: musefs_db::DbError,
+    },
     #[error(transparent)]
     Format(#[from] musefs_format::FormatError),
     #[error("io error: {0}")]

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -12,6 +12,12 @@ pub enum CoreError {
     },
     #[error(transparent)]
     Format(#[from] musefs_format::FormatError),
+    #[error("MP4 {box_kind} box is {size} bytes, exceeds the {cap}-byte metadata cap")]
+    Mp4MetadataTooLarge {
+        box_kind: &'static str,
+        size: u64,
+        cap: u64,
+    },
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("backing file changed since scan: {0}")]

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -35,6 +35,12 @@ pub(crate) fn track_art_to_inputs(db: &Db, track_id: i64) -> Result<Vec<ArtInput
         // `track_art.art_id` is a foreign key into `art` (enforced, no ON DELETE),
         // so the row always exists; the `if let` is defensive, not a real branch.
         if let Some(meta) = db.get_art_meta(ta.art_id)? {
+            // A negative byte_len is a malformed external write to the contract
+            // column; skip the row rather than cast it to a huge u64 segment
+            // length (which would fail layout validation and break the track).
+            if meta.byte_len < 0 {
+                continue;
+            }
             inputs.push(ArtInput {
                 art_id: ta.art_id,
                 mime: meta.mime,
@@ -190,5 +196,71 @@ mod tests {
             !fields.contains_key("priv"),
             "binary PRIV leaked into fields: {fields:?}"
         );
+    }
+
+    #[test]
+    fn track_art_to_inputs_skips_negative_byte_len() {
+        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art.db");
+        let db = Db::open(&path).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let good = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3, 4],
+            })
+            .unwrap();
+        let bad = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![9, 9, 9, 9, 9],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[
+                TrackArt {
+                    art_id: good,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 0,
+                },
+                TrackArt {
+                    art_id: bad,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 1,
+                },
+            ],
+        )
+        .unwrap();
+
+        // Simulate an external malformed write: byte_len is a stored column.
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
+            .unwrap();
+        drop(raw);
+
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        assert_eq!(
+            inputs.len(),
+            1,
+            "the negative-byte_len art row must be skipped"
+        );
+        assert_eq!(inputs[0].art_id, good);
     }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -39,6 +39,11 @@ pub(crate) fn track_art_to_inputs(db: &Db, track_id: i64) -> Result<Vec<ArtInput
             // column; skip the row rather than cast it to a huge u64 segment
             // length (which would fail layout validation and break the track).
             if meta.byte_len < 0 {
+                log::warn!(
+                    "skipping art {} on track {track_id}: negative byte_len {} (malformed DB write)",
+                    ta.art_id,
+                    meta.byte_len
+                );
                 continue;
             }
             inputs.push(ArtInput {

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -230,6 +230,17 @@ mod tests {
                 data: vec![9, 9, 9, 9, 9],
             })
             .unwrap();
+        // A zero-byte_len row pins the guard's strict `<`: only *negative* is
+        // skipped, so byte_len == 0 must still be kept (distinguishes `< 0` from
+        // `<= 0`).
+        let zero = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![5, 5, 5],
+            })
+            .unwrap();
         db.set_track_art(
             tid,
             &[
@@ -245,22 +256,30 @@ mod tests {
                     description: String::new(),
                     ordinal: 1,
                 },
+                TrackArt {
+                    art_id: zero,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 2,
+                },
             ],
         )
         .unwrap();
 
-        // Simulate an external malformed write: byte_len is a stored column.
+        // Simulate external malformed writes: byte_len is a stored column.
         let raw = rusqlite::Connection::open(&path).unwrap();
         raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
+            .unwrap();
+        raw.execute("UPDATE art SET byte_len = 0 WHERE id = ?1", [zero])
             .unwrap();
         drop(raw);
 
         let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        let ids: Vec<i64> = inputs.iter().map(|a| a.art_id).collect();
         assert_eq!(
-            inputs.len(),
-            1,
-            "the negative-byte_len art row must be skipped"
+            ids,
+            vec![good, zero],
+            "negative byte_len is skipped; zero is kept (strict `<`)"
         );
-        assert_eq!(inputs[0].art_id, good);
     }
 }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -321,6 +321,9 @@ impl HeaderCache {
                         let scan = mp4::read_structure_from(&mut f, len).map_err(|e| match e {
                             mp4::Mp4ScanError::Io(io) => CoreError::Io(io),
                             mp4::Mp4ScanError::Format(fe) => CoreError::Format(fe),
+                            mp4::Mp4ScanError::MetadataTooLarge { .. } => {
+                                CoreError::Format(musefs_format::FormatError::Malformed)
+                            }
                         })?;
                         mp4::synthesize_layout(&scan, &inputs, &binary_tag_inputs, &art_inputs)?
                     }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -321,9 +321,20 @@ impl HeaderCache {
                         let scan = mp4::read_structure_from(&mut f, len).map_err(|e| match e {
                             mp4::Mp4ScanError::Io(io) => CoreError::Io(io),
                             mp4::Mp4ScanError::Format(fe) => CoreError::Format(fe),
-                            mp4::Mp4ScanError::MetadataTooLarge { .. } => {
-                                CoreError::Format(musefs_format::FormatError::Malformed)
-                            }
+                            // Unreachable in practice (an ingested file already
+                            // passed the cap at scan, and backing-file drift is
+                            // caught by the size/mtime BackingChanged guard first),
+                            // but preserve the box/size/cap diagnostics rather than
+                            // erasing them into a generic Malformed.
+                            mp4::Mp4ScanError::MetadataTooLarge {
+                                box_kind,
+                                size,
+                                cap,
+                            } => CoreError::Mp4MetadataTooLarge {
+                                box_kind,
+                                size,
+                                cap,
+                            },
                         })?;
                         mp4::synthesize_layout(&scan, &inputs, &binary_tag_inputs, &art_inputs)?
                     }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -218,8 +218,14 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
     // M4A: seek reader, never touches mdat.
     if has_ext(path, "m4a") || has_ext(path, "m4b") {
         let mut f = &file;
-        let Ok(scan) = mp4::read_structure_from(&mut f, file_len) else {
-            return Ok(None);
+        let scan = match mp4::read_structure_from(&mut f, file_len) {
+            Ok(s) => s,
+            Err(e) => {
+                if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
+                    log::warn!("skipping {}: {e}", path.display());
+                }
+                return Ok(None);
+            }
         };
         return Ok(Some(Probed {
             format: Format::M4a,

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -8,6 +8,8 @@ use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture,
 use crate::layout::{RegionLayout, Segment};
 use std::io::{self, Read, Seek, SeekFrom};
 
+const MAX_MP4_METADATA_BYTES: u64 = 512 * 1024 * 1024;
+
 fn be_u32(b: &[u8], pos: usize) -> Result<u32> {
     let s = b.get(pos..pos + 4).ok_or(FormatError::Malformed)?;
     Ok(u32::from_be_bytes(s.try_into().unwrap()))
@@ -91,6 +93,12 @@ pub enum Mp4ScanError {
     Io(#[from] io::Error),
     #[error(transparent)]
     Format(#[from] FormatError),
+    #[error("MP4 {box_kind} box is {size} bytes, exceeds the {cap}-byte metadata cap")]
+    MetadataTooLarge {
+        box_kind: &'static str,
+        size: u64,
+        cap: u64,
+    },
 }
 
 fn read_box(buf: &[u8], pos: usize) -> Result<BoxRef> {
@@ -291,6 +299,16 @@ pub fn read_structure_from<R: Read + Seek>(
     let (ftyp_s, ftyp_h) = ftyp.ok_or(FormatError::NotMp4)?;
     let (moov_s, moov_h) = moov.ok_or(FormatError::NotMp4)?;
     let (mdat_s, mdat_h) = mdat.ok_or(FormatError::NotMp4)?;
+
+    for (box_kind, total_len) in [("ftyp", ftyp_h.total_len), ("moov", moov_h.total_len)] {
+        if total_len > MAX_MP4_METADATA_BYTES {
+            return Err(Mp4ScanError::MetadataTooLarge {
+                box_kind,
+                size: total_len,
+                cap: MAX_MP4_METADATA_BYTES,
+            });
+        }
+    }
 
     // `try_from` rather than `as usize`: on a 32-bit target an oversized box would
     // truncate silently; a box larger than `usize` is malformed for our purposes.
@@ -2158,5 +2176,57 @@ mod tests {
             synthesize_layout(&scan, &tags, &[], &[art(max_len + 1)]),
             Err(FormatError::TooLarge)
         ));
+    }
+
+    #[test]
+    fn read_structure_from_rejects_oversized_moov() {
+        use std::io::Cursor;
+        let moov_size: u32 = 600 * 1024 * 1024;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"ftyp");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"mdat");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&moov_size.to_be_bytes());
+        buf.extend_from_slice(b"moov");
+        assert_eq!(buf.len(), 40);
+        let file_len = 32 + moov_size as u64;
+        let mut cur = Cursor::new(buf);
+        match read_structure_from(&mut cur, file_len).unwrap_err() {
+            Mp4ScanError::MetadataTooLarge {
+                box_kind,
+                size,
+                cap,
+            } => {
+                assert_eq!(box_kind, "moov");
+                assert_eq!(size, moov_size as u64);
+                assert_eq!(cap, 512 * 1024 * 1024);
+            }
+            other => panic!("expected MetadataTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_structure_from_admits_box_at_exactly_the_cap() {
+        use std::io::Cursor;
+        let cap: u32 = 512 * 1024 * 1024;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"ftyp");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"mdat");
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&cap.to_be_bytes());
+        buf.extend_from_slice(b"moov");
+        let file_len = 32 + cap as u64;
+        let mut cur = Cursor::new(buf);
+        let err = read_structure_from(&mut cur, file_len).unwrap_err();
+        assert!(
+            matches!(err, Mp4ScanError::Io(_)),
+            "exact-cap box must pass the strict `>` guard (got {err:?})"
+        );
     }
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -8,7 +8,7 @@ use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture,
 use crate::layout::{RegionLayout, Segment};
 use std::io::{self, Read, Seek, SeekFrom};
 
-const MAX_MP4_METADATA_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_MP4_METADATA_BYTES: u64 = 256 * 1024 * 1024;
 
 fn be_u32(b: &[u8], pos: usize) -> Result<u32> {
     let s = b.get(pos..pos + 4).ok_or(FormatError::Malformed)?;
@@ -2202,7 +2202,7 @@ mod tests {
             } => {
                 assert_eq!(box_kind, "moov");
                 assert_eq!(size, moov_size as u64);
-                assert_eq!(cap, 512 * 1024 * 1024);
+                assert_eq!(cap, 256 * 1024 * 1024);
             }
             other => panic!("expected MetadataTooLarge, got {other:?}"),
         }
@@ -2211,7 +2211,7 @@ mod tests {
     #[test]
     fn read_structure_from_admits_box_at_exactly_the_cap() {
         use std::io::Cursor;
-        let cap: u32 = 512 * 1024 * 1024;
+        let cap: u32 = 256 * 1024 * 1024;
         let mut buf = Vec::new();
         buf.extend_from_slice(&16u32.to_be_bytes());
         buf.extend_from_slice(b"ftyp");

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -71,6 +71,7 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         CoreError::BackingChanged(_)
         | CoreError::Db(_)
         | CoreError::DbOpen { .. }
+        | CoreError::Mp4MetadataTooLarge { .. }
         | CoreError::Format(_) => fuser::Errno::EIO,
     }
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -68,7 +68,10 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         CoreError::NotADir(_) => fuser::Errno::ENOTDIR,
         CoreError::HandleTableFull => fuser::Errno::ENFILE,
         CoreError::Io(e) => fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)),
-        CoreError::BackingChanged(_) | CoreError::Db(_) | CoreError::Format(_) => fuser::Errno::EIO,
+        CoreError::BackingChanged(_)
+        | CoreError::Db(_)
+        | CoreError::DbOpen { .. }
+        | CoreError::Format(_) => fuser::Errno::EIO,
     }
 }
 


### PR DESCRIPTION
Implements Roadmap Phase 3. Five independent low-risk hardening fixes:

Closes #88, closes #91, closes #92, closes #93, closes #94.

- **#93 byte_budget** — saturating-add symmetry in `acquire` (matches the guard).
- **#92 mapping** — skip art rows with negative `byte_len` from malformed external writes.
- **#91 mp4** — cap `moov`/`ftyp` metadata allocation at **256 MiB**; clearly logged skip at scan.
- **#94 db_pool** — re-entrancy-safe `with()` via `Rc<Db>` + path-context open error (`CoreError::DbOpen`); cross-thread `Drop` leak documented-and-accepted (see comment on #94).
- **#88 fuzz** — exercise the Ogg art-synthesis path (image bytes + `OggArt`).

The new `CoreError::DbOpen` variant also required an arm in `musefs-fuse`'s exhaustive `errno()` match (maps to `EIO`, alongside `Db`).

Spec: `docs/superpowers/specs/2026-06-03-phase3-hardening-design.md`.
Byte-identical-audio invariant unchanged; no serve-path semantics changed.

Verification: `cargo test --workspace` (627 pass), `clippy --all-targets -D warnings`, `fmt --all --check`, `cargo +nightly fuzz build ogg`, and the in-diff mutation gate (12 caught / 0 missed / 0 timeout) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 3 hardening plan and design spec with concrete tasks and verification steps.

* **Bug Fixes**
  * Enforced a 256 MiB cap on MP4 metadata to avoid excessive allocations and added targeted warning/skip behavior.
  * Improved database connection safety and clearer DB-open error reporting that includes failing paths.
  * Robustly skips malformed/corrupted art metadata that could break track/layout handling.

* **Tests**
  * Extended fuzzing to exercise artwork synthesis and added unit tests for edge cases and re-entrancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->