### PR TITLE
Scope mutants canary to harness-only changes

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -23,6 +23,39 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    # Cheap gate: decide whether the mutation harness itself changed. The `canary`
+    # job exercises scripts/mutants.sh end to end, so it only earns its cost when
+    # that wrapper (or this workflow) can have regressed — not on every crate PR,
+    # where it's redundant with `in-diff` and just pays a second multi-minute
+    # `cargo install cargo-mutants`. The workflow-level `paths` filter can't
+    # express this (it governs all jobs and `in-diff` must run on crate changes),
+    # so we compute it here and gate `canary` below. Mirrors ci.yml's `changes`.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      harness: ${{ steps.filter.outputs.harness }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          # Full history so the three-dot merge base is present (same reason as
+          # the in-diff job); a shallow clone often lacks it and the diff fails.
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only "$BASE_SHA...HEAD")"
+          echo "Changed files:"; echo "$changed"
+          # harness=true iff scripts/mutants.sh or this workflow changed.
+          if printf '%s\n' "$changed" | grep -qxE 'scripts/mutants\.sh|\.github/workflows/mutants\.yml'; then
+            echo "harness=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "harness=false" >> "$GITHUB_OUTPUT"
+          fi
+
   in-diff:
     # Per-PR: mutate only the lines changed in this PR. Fast gate.
     if: github.event_name == 'pull_request'
@@ -81,8 +114,11 @@ jobs:
     # source-tree copy, --output dir, report) cheaply via --check on the smallest
     # crate. Catches the copy-recursion / output-dir class of bugs the --list
     # smoke test can't (list mode neither copies the tree nor creates output).
-    # cargo-check only, no test runs, so it stays fast.
-    if: github.event_name == 'pull_request'
+    # cargo-check only, no test runs, so it stays fast. Gated on the `changes`
+    # job: only runs when scripts/mutants.sh or this workflow changed, since the
+    # harness logic can't regress on an ordinary crate edit.
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
## What

The `canary` job in `mutants.yml` exercises the real `scripts/mutants.sh` pipeline (out-of-repo scratch, source-tree copy, `--output` dir) to catch the copy-recursion / output-dir bug class that the `--list` smoke test can't. But it fired on **every** PR touching `musefs-db/`, `musefs-core/`, or `musefs-format/` — i.e. most Rust PRs — where it's redundant with the `in-diff` gate and just pays a second multi-minute `cargo install cargo-mutants`.

## Change

Add a cheap `changes` job (mirroring `ci.yml`'s pattern) that diffs the merge base and outputs `harness=true` only when `scripts/mutants.sh` or `mutants.yml` itself changed. Gate `canary` on it via `needs: changes`.

GitHub's workflow-level `paths:` filter can't express this on its own — it governs all jobs, and `in-diff` must keep running on crate changes — hence the per-job gate.

## Why it's safe

- The harness logic can only regress when `scripts/mutants.sh` or this workflow changes, so that's the only time the canary earns its cost.
- `in-diff` (per-PR gate) and the scheduled `full` campaign are untouched.
- No required status check depends on the mutants jobs (only `ci-ok`/`coverage-ok` are required), so gating `canary` carries no branch-protection deadlock risk.

## Verification

- `python3 -c "import yaml; ..."` confirms the YAML parses and the job wiring (`canary.needs == changes`, gated `if`).
- Tested the harness-path regex against sample paths: matches `scripts/mutants.sh` and `.github/workflows/mutants.yml` exactly (whole-line, so `scripts/mutants.sh.bak` does **not** match), rejects crate/doc paths.
- Pre-commit hooks (fmt / clippy / `cargo test --workspace` / ruff) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize mutation testing job execution based on file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->