### PR TITLE
Phase 4 — concurrency correctness (#89, #90)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -187,4 +187,16 @@ exclude_re = [
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
     'musefs-core/src/ogg_index\.rs:204:15: replace < with <= in serve_ogg_window',
     'musefs-core/src/ogg_index\.rs:213:15: replace < with <= in serve_ogg_window',
+
+    # Phase 4 poll_due (#89) — equivalent `<`->`<=` on the two wall-clock gates
+    # (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <
+    # refresh_retry_backoff`). The operators differ only when `Instant::elapsed()`
+    # equals the bound at the exact nanosecond it is sampled — a measure-zero
+    # boundary no deterministic test can construct: the `*_for_test` hooks backdate
+    # the stamp by exactly the bound, but time advances before the comparison runs,
+    # so elapsed() is already strictly greater under both operators. (The mirrored
+    # gates in poll_refresh_notify have the same property.) The `<`->`>`/`==`
+    # variants ARE caught and stay in scope; anchored on operator+function since
+    # both `<` in poll_due are this class.
+    'musefs-core/src/facade\.rs:\d+:\d+: replace < with <= in Musefs::poll_due',
 ]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,9 +167,15 @@ parallel. Most of the Rust items came out of the v1 multi-model review triage.
 - ~~#94 — DbPool thread-local footguns~~ — done (PR #104): `with()` is re-entrancy-safe
   via `Rc<Db>` and open failures carry path context (`CoreError::DbOpen`).
 
-**Phase 4 — Concurrency correctness**
-- #90 — `rebuild_full` holds `inodes` across DB I/O (mirror the incremental path).
-- #89 — `fire_poll_refresh` floods the threadpool (synchronous debounce).
+**Phase 4 — Concurrency correctness** — *done*
+- ~~#90 — `rebuild_full` holds `inodes` across DB I/O~~ — done: `render_entries`
+  does the DB read + render under the pool connection; `rebuild_full` locks
+  `inodes` only across the pure-CPU `build_with` (mirrors the incremental path),
+  removing the documented lock-order exception.
+- ~~#89 — `fire_poll_refresh` floods the threadpool~~ — done: a synchronous
+  `poll_due()` gate on the dispatch thread skips submission within the debounce
+  window, and a `poll_pending` single-flight gate bounds in-flight poll tasks to
+  one (robust even with `--poll-interval-ms 0`).
 
 **Phase 5 — Metrics**
 - #71 — Ogg serve path records no pread/byte metrics (instrumentation blind today).

--- a/docs/superpowers/plans/2026-06-03-phase4-concurrency-correctness.md
+++ b/docs/superpowers/plans/2026-06-03-phase4-concurrency-correctness.md
@@ -1,0 +1,571 @@
+# Phase 4 — Concurrency Correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop two contention/starvation problems on the musefs serving path: a full tree rebuild holding the `inodes` lock across DB I/O (#90), and every FUSE metadata op flooding the worker pool with no-op poll tasks (#89).
+
+**Architecture:** #90 — split the DB-read+render phase of a full rebuild out of the `inodes`-locked region (mirroring the already-correct incremental path), so `inodes` is held only across the pure-CPU tree build. #89 — gate `fire_poll_refresh` on a cheap synchronous `Musefs::poll_due()` predicate checked on the dispatch thread, plus a `poll_pending: Arc<AtomicBool>` single-flight gate (cleared by an RAII guard) so at most one poll task is ever queued/running.
+
+**Tech Stack:** Rust workspace (`musefs-core`, `musefs-fuse`); SQLite via `musefs-db`; `fuser` + `threadpool`; `tempfile`/`id3` in tests. Conventions in `CLAUDE.md` (thiserror per-crate errors, Serena symbolic tools for reading code).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-phase4-concurrency-correctness-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `musefs-core/src/facade.rs`
+  - #90: add private `Musefs::render_entries`; rewrite `build_full` and `rebuild_full`; update the lock-order comment (~lines 387-398).
+  - #89: add public `Musefs::poll_due`; add a one-line cross-reference comment on `poll_refresh_notify`'s gate block; add two `*_for_test` hooks; add unit tests in the existing `mod tests`.
+- **Modify** `musefs-fuse/src/lib.rs`
+  - #89: add `use std::sync::atomic::{AtomicBool, Ordering};`; add `poll_pending: Arc<AtomicBool>` field + init in `MusefsFs::new`; define `PollPendingGuard`; rewrite `fire_poll_refresh`; add unit tests in the existing `mod tests`.
+
+No new files. Both crates already have a `#[cfg(test)] mod tests` (`facade.rs:772`, `lib.rs:385`).
+
+---
+
+## Task 1: #90 — move DB I/O out of the `inodes`-locked region
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (`build_full` ~205-231, `rebuild_full` ~247-261, lock-order comment ~387-398)
+- Test: `musefs-core/src/facade.rs` (`mod tests` ~772)
+
+The fix is a behavior-preserving refactor: extract the DB-read+render phase into an allocator-free `render_entries`, have `build_full` wrap it, and have `rebuild_full` lock `inodes` only around `VirtualTree::build_with`. Existing rebuild/refresh tests prove behavior is unchanged; the new unit test pins the extracted DB→entries boundary.
+
+- [ ] **Step 1: Write the failing test for the extracted `render_entries`**
+
+Add to `mod tests` in `musefs-core/src/facade.rs`:
+
+```rust
+    #[test]
+    fn render_entries_returns_paths_and_snapshot() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+        let db = musefs_db::Db::open(dir.path().join("m.db")).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+        };
+
+        let (entries, snapshot) = Musefs::render_entries(&db, &cfg).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, "Pix/Song");
+        let id = entries[0].0;
+        assert_eq!(snapshot[&id].path, "Pix/Song");
+        assert!(snapshot[&id].content_version >= 1);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails (does not compile)**
+
+Run: `cargo test -p musefs-core render_entries_returns_paths_and_snapshot`
+Expected: FAIL — compile error `no function or associated item named 'render_entries' found for struct 'Musefs'`.
+
+- [ ] **Step 3: Add `render_entries` and rewrite `build_full`**
+
+In `impl Musefs`, replace the existing `build_full` (currently ~205-231) with these two functions:
+
+```rust
+    /// DB read + path render with no allocator: the lock-free phase shared by
+    /// `build_full` and `rebuild_full`. Confining all `Db` access here is what
+    /// lets `rebuild_full` hold `inodes` only across the pure-CPU `build_with`.
+    fn render_entries(
+        db: &Db,
+        config: &MountConfig,
+    ) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
+        let tracks = db.list_tracks()?;
+        let mut tags_by_track = db.tags_grouped()?;
+        let mut entries = Vec::with_capacity(tracks.len());
+        let mut snapshot = HashMap::with_capacity(tracks.len());
+        for t in &tracks {
+            let tags = tags_by_track.remove(&t.id).unwrap_or_default();
+            let path = Self::render_one(config, t.format, &tags);
+            snapshot.insert(
+                t.id,
+                TrackRenderState {
+                    content_version: t.content_version,
+                    format: t.format,
+                    path: path.clone(),
+                },
+            );
+            entries.push((t.id, path));
+        }
+        Ok((entries, snapshot))
+    }
+
+    /// Full rebuild: render every track and build the tree from scratch. Used by
+    /// `open`, forced `refresh`, and the Stage B fallback. Returns the tree and the
+    /// fresh `track_id -> TrackRenderState` snapshot.
+    fn build_full(
+        db: &Db,
+        config: &MountConfig,
+        alloc: &mut InodeAllocator,
+    ) -> Result<(VirtualTree, HashMap<i64, TrackRenderState>)> {
+        let (entries, snapshot) = Self::render_entries(db, config)?;
+        Ok((VirtualTree::build_with(&entries, alloc), snapshot))
+    }
+```
+
+- [ ] **Step 4: Rewrite `rebuild_full` to lock `inodes` only around `build_with`**
+
+Replace the body of `rebuild_full` (currently ~247-261) with:
+
+```rust
+    /// Rebuild + publish the tree via a full render; returns the fresh snapshot
+    /// (the caller decides whether/how to diff it). Mirrors `rebuild_incremental`'s
+    /// ordering: read + render under the pool connection, then lock `inodes` only
+    /// across the pure-CPU `build_with` (#90).
+    fn rebuild_full(&self) -> Result<HashMap<i64, TrackRenderState>> {
+        if self.force_rebuild_error.load(Ordering::Acquire) {
+            return Err(CoreError::BackingChanged(
+                "forced refresh failure".to_string(),
+            ));
+        }
+        let (entries, snapshot) = self.pool.with(|db| Self::render_entries(db, &self.config))?;
+        let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
+        let tree = VirtualTree::build_with(&entries, &mut alloc);
+        drop(alloc);
+        self.tree.store(Arc::new(tree));
+        Ok(snapshot)
+    }
+```
+
+- [ ] **Step 5: Update the lock-order comment to drop the exception**
+
+In the lock-order comment (~387-398), replace this sentence:
+
+```
+// inside `pool.with` during `refresh` — the one intentional exception where a
+// pool connection is held around an in-memory lock. `handles` is a lock-free
+```
+
+with:
+
+```
+// Both rebuild paths (`rebuild_full`, `rebuild_incremental`) release the pool
+// connection before locking `inodes`, so the order is uniform: a pool connection
+// is never held around an in-memory lock. `handles` is a lock-free
+```
+
+- [ ] **Step 6: Run the new test and the rebuild/refresh regression tests**
+
+Run: `cargo test -p musefs-core render_entries_returns_paths_and_snapshot open_handle_reresolves_after_content_version_bump`
+Expected: PASS (2 passed). Then run the whole crate to confirm no regression:
+Run: `cargo test -p musefs-core`
+Expected: PASS (all green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/facade.rs
+git commit -m "fix(core): release pool conn before locking inodes in rebuild_full (#90)
+
+Extract the DB-read+render phase into render_entries so rebuild_full
+holds the inodes lock only across the pure-CPU build_with, mirroring
+rebuild_incremental. Removes the documented lock-order exception."
+```
+
+---
+
+## Task 2: #89 (core) — add the synchronous `poll_due()` predicate
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (add `poll_due` and two test hooks in `impl Musefs`; one-line comment on `poll_refresh_notify`'s gate block ~429)
+- Test: `musefs-core/src/facade.rs` (`mod tests`)
+
+`poll_due` mirrors `poll_refresh_notify`'s early-return gates (`needs_rebuild` → interval debounce → failure backoff) with no DB access. The two `*_for_test` hooks let the backoff branch be tested deterministically, companions to the existing `expire_poll_debounce_for_test`.
+
+- [ ] **Step 1: Write the failing `poll_due` unit tests**
+
+Add to `mod tests` in `musefs-core/src/facade.rs`:
+
+```rust
+    fn fs_with_poll_interval(interval: std::time::Duration) -> (tempfile::TempDir, Musefs) {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: interval,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
+        (dir, fs)
+    }
+
+    #[test]
+    fn poll_due_false_within_interval_true_after_expiry() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::from_secs(3600));
+        assert!(!fs.poll_due(), "fresh open is within the debounce window");
+        fs.expire_poll_debounce_for_test();
+        assert!(fs.poll_due(), "past the debounce window");
+    }
+
+    #[test]
+    fn poll_due_true_when_needs_rebuild_regardless_of_interval() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::from_secs(3600));
+        assert!(!fs.poll_due());
+        fs.mark_needs_rebuild_for_test();
+        assert!(fs.poll_due(), "needs_rebuild bypasses the debounce");
+    }
+
+    #[test]
+    fn poll_due_true_when_interval_zero() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::ZERO);
+        assert!(fs.poll_due(), "zero interval disables the debounce");
+    }
+
+    #[test]
+    fn poll_due_respects_failure_backoff_window() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::from_secs(3600));
+        fs.expire_poll_debounce_for_test(); // get past the debounce gate first
+        fs.fail_refresh_now_for_test();
+        assert!(!fs.poll_due(), "inside the retry backoff window");
+        fs.expire_refresh_backoff_for_test();
+        assert!(fs.poll_due(), "past the retry backoff window");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (do not compile)**
+
+Run: `cargo test -p musefs-core poll_due_`
+Expected: FAIL — compile errors: `no method named 'poll_due'`, `no method named 'fail_refresh_now_for_test'`, `no method named 'expire_refresh_backoff_for_test'`.
+
+- [ ] **Step 3: Add `poll_due` and the two test hooks**
+
+In `impl Musefs`, add `poll_due` (place it just above `poll_refresh`, ~before line 400):
+
+```rust
+    /// Cheap, synchronous "is a `data_version` poll worth dispatching?" predicate
+    /// for the FUSE dispatch thread to gate `fire_poll_refresh` on, so a
+    /// metadata-op storm doesn't flood the worker pool with no-op poll tasks (#89).
+    /// Mirrors the early-return gates in `poll_refresh_notify` — keep the two in
+    /// sync. Advisory only: no DB access, no `data_version` read, no rebuild. A
+    /// stale `true` costs at most one task the inner gate short-circuits, and
+    /// `needs_rebuild` is checked first so a self-heal is never debounced away.
+    pub fn poll_due(&self) -> bool {
+        if self.needs_rebuild.load(Ordering::Acquire) {
+            return true;
+        }
+        if !self.poll_interval.is_zero()
+            && crate::lock::lock_recover(&self.last_poll, "last_poll").elapsed()
+                < self.poll_interval
+        {
+            return false;
+        }
+        if let Some(last_failed) =
+            *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
+        {
+            if last_failed.elapsed() < self.refresh_retry_backoff {
+                return false;
+            }
+        }
+        true
+    }
+```
+
+Add the two hooks next to the existing `expire_poll_debounce_for_test` (~571):
+
+```rust
+    /// Stamps a failed-refresh time of "now" so the backoff gate is active, for
+    /// tests exercising `poll_due`'s backoff branch without a real failure.
+    #[doc(hidden)]
+    pub fn fail_refresh_now_for_test(&self) {
+        *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh") =
+            Some(std::time::Instant::now());
+    }
+
+    /// Backdates the failed-refresh stamp past the retry-backoff window so the
+    /// backoff gate no longer blocks (companion to `expire_poll_debounce_for_test`).
+    #[doc(hidden)]
+    pub fn expire_refresh_backoff_for_test(&self) {
+        let past = std::time::Instant::now()
+            .checked_sub(self.refresh_retry_backoff)
+            .expect("refresh_retry_backoff exceeds monotonic clock base");
+        *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh") = Some(past);
+    }
+```
+
+- [ ] **Step 4: Add the cross-reference comment on `poll_refresh_notify`'s gate**
+
+In `poll_refresh_notify`, immediately above the `if !self.poll_interval.is_zero()` debounce check (~429), add:
+
+```rust
+        // These early-return gates are mirrored by the cheap `poll_due` pre-check
+        // the FUSE layer runs on the dispatch thread (#89); keep the two in sync.
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-core poll_due_`
+Expected: PASS (4 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/facade.rs
+git commit -m "feat(core): add synchronous poll_due() debounce predicate (#89)
+
+poll_due mirrors poll_refresh_notify's early-return gates (needs_rebuild,
+interval debounce, failure backoff) with no DB access, so the FUSE layer
+can gate poll submission on the dispatch thread."
+```
+
+---
+
+## Task 3: #89 (fuse) — synchronous gate + single-flight in `fire_poll_refresh`
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` (imports ~6-9; `MusefsFs` struct ~116-126; `MusefsFs::new` ~128-146; `fire_poll_refresh` ~151-176; add `PollPendingGuard`)
+- Test: `musefs-fuse/src/lib.rs` (`mod tests` ~385)
+
+Gate `fire_poll_refresh` on `core.poll_due()` (submit nothing when not due), then a `poll_pending` single-flight `compare_exchange` so at most one poll task is queued/running; an RAII `PollPendingGuard` clears the flag on every exit path including panic.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `musefs-fuse/src/lib.rs`:
+
+```rust
+    fn test_fs() -> (tempfile::TempDir, MusefsFs) {
+        use musefs_core::{Mode, MountConfig, Musefs};
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: std::collections::BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            // Zero interval => poll_due() is always true, isolating the gate.
+            poll_interval: std::time::Duration::ZERO,
+        };
+        let core = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
+        (dir, MusefsFs::new(core, FuseConfig::default()))
+    }
+
+    #[test]
+    fn poll_pending_guard_clears_flag_on_panic() {
+        let flag = Arc::new(AtomicBool::new(true));
+        let f = Arc::clone(&flag);
+        let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = PollPendingGuard(&f);
+            panic!("boom");
+        }));
+        assert!(r.is_err());
+        assert!(!flag.load(Ordering::SeqCst), "guard must clear the flag on unwind");
+    }
+
+    #[test]
+    fn fire_poll_refresh_single_flights_when_pending() {
+        let (_d, fs) = test_fs();
+        // Simulate a poll already in flight; the gate must reject new submissions.
+        fs.poll_pending.store(true, Ordering::SeqCst);
+        let queued = fs.pool.queued_count();
+        let active = fs.pool.active_count();
+        for _ in 0..50 {
+            fs.fire_poll_refresh();
+        }
+        assert_eq!(fs.pool.queued_count(), queued, "no task should be queued");
+        assert_eq!(fs.pool.active_count(), active, "no task should be started");
+    }
+
+    #[test]
+    fn fire_poll_refresh_clears_gate_after_task() {
+        let (_d, fs) = test_fs();
+        assert!(!fs.poll_pending.load(Ordering::SeqCst));
+        fs.fire_poll_refresh(); // poll_due() true (zero interval): gate taken, task runs
+        fs.pool.join(); // block until the poll task completes
+        assert!(
+            !fs.poll_pending.load(Ordering::SeqCst),
+            "guard must clear the gate after the task finishes"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (do not compile)**
+
+Run: `cargo test -p musefs-fuse poll_pending fire_poll_refresh`
+Expected: FAIL — compile errors: `cannot find type 'PollPendingGuard'`, `no field 'poll_pending'`, unresolved `AtomicBool`/`Ordering`.
+
+- [ ] **Step 3: Add imports and the `PollPendingGuard` type**
+
+Change the `std::sync` import line (~8) to add the atomics:
+
+```rust
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+```
+
+Add this type just above `pub struct MusefsFs` (~115):
+
+```rust
+/// Clears the `fire_poll_refresh` single-flight gate when the poll task ends,
+/// on every exit path including a panic in `poll_refresh_notify` (#89).
+struct PollPendingGuard<'a>(&'a AtomicBool);
+
+impl Drop for PollPendingGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+```
+
+- [ ] **Step 4: Add the `poll_pending` field and initialize it**
+
+Add to the `MusefsFs` struct (after the `notifier` field, ~125):
+
+```rust
+    /// Single-flight gate for `fire_poll_refresh`: at most one poll task is
+    /// queued/running at a time, so a metadata-op storm can't flood the pool (#89).
+    poll_pending: Arc<AtomicBool>,
+```
+
+Add to the `MusefsFs { … }` literal in `MusefsFs::new` (after `notifier: Arc::new(OnceLock::new()),`, ~144):
+
+```rust
+            poll_pending: Arc::new(AtomicBool::new(false)),
+```
+
+- [ ] **Step 5: Rewrite `fire_poll_refresh`**
+
+Replace the whole `fire_poll_refresh` method (~151-176) with:
+
+```rust
+    /// Fire `poll_refresh` on the worker pool (off the dispatch thread), but only
+    /// when due: a cheap synchronous `poll_due()` check gates submission so a
+    /// metadata-op storm doesn't flood the pool, and a `poll_pending` single-flight
+    /// gate bounds in-flight poll tasks to one (#89). When keep-cache is enabled,
+    /// also drop the kernel page cache for every inode whose content changed.
+    fn fire_poll_refresh(&self) {
+        if !self.core.poll_due() {
+            return;
+        }
+        if self
+            .poll_pending
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return; // a poll task is already queued/running
+        }
+        let core = Arc::clone(&self.core);
+        let pending = Arc::clone(&self.poll_pending);
+        if self.config.keep_cache {
+            let notifier = Arc::clone(&self.notifier);
+            self.pool.execute(move || {
+                let _guard = PollPendingGuard(&pending);
+                if let Err(e) = core.poll_refresh_notify(|ino| {
+                    if let Some(n) = notifier.get() {
+                        if let Err(inval_err) = n.inval_inode(INodeNo(ino), 0, 0) {
+                            log::warn!("inval_inode({ino}) failed: {inval_err}");
+                        }
+                    }
+                }) {
+                    log::warn!("poll_refresh_notify failed: {e}");
+                }
+            });
+        } else {
+            self.pool.execute(move || {
+                let _guard = PollPendingGuard(&pending);
+                if let Err(e) = core.poll_refresh() {
+                    log::warn!("poll_refresh failed: {e}");
+                }
+            });
+        }
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-fuse poll_pending fire_poll_refresh`
+Expected: PASS (3 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-fuse/src/lib.rs
+git commit -m "fix(fuse): gate fire_poll_refresh with poll_due + single-flight (#89)
+
+Check the cheap synchronous poll_due() on the dispatch thread before
+submitting, and bound in-flight poll tasks to one via a poll_pending
+gate cleared by an RAII guard, so a metadata-op storm no longer floods
+the worker pool."
+```
+
+---
+
+## Task 4: Full verification + roadmap
+
+**Files:**
+- Modify: `docs/ROADMAP.md` (Phase 4 section ~170-172)
+
+- [ ] **Step 1: Format and lint the whole workspace**
+
+Run: `cargo fmt --all --check`
+Expected: clean (no diff). If it reports a diff, run `cargo fmt --all` and re-stage.
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean (no warnings).
+
+- [ ] **Step 2: Run the full workspace test suite**
+
+Run: `cargo test --workspace`
+Expected: PASS (all crates green, including the new Task 1–3 tests).
+
+- [ ] **Step 3: Run the FUSE end-to-end mount suite**
+
+These are `#[ignore]`d real mounts; the dev server has `/dev/fuse`.
+
+Run: `cargo test -p musefs-fuse -- --ignored`
+Expected: PASS — including `keep_cache_mount_reflects_retag_after_refresh` and the concurrency mount tests that exercise `fire_poll_refresh` end to end.
+
+- [ ] **Step 4: Mark Phase 4 done in the roadmap**
+
+In `docs/ROADMAP.md`, replace the Phase 4 block:
+
+```
+**Phase 4 — Concurrency correctness**
+- #90 — `rebuild_full` holds `inodes` across DB I/O (mirror the incremental path).
+- #89 — `fire_poll_refresh` floods the threadpool (synchronous debounce).
+```
+
+with:
+
+```
+**Phase 4 — Concurrency correctness** — *done*
+- ~~#90 — `rebuild_full` holds `inodes` across DB I/O~~ — done: `render_entries`
+  does the DB read + render under the pool connection; `rebuild_full` locks
+  `inodes` only across the pure-CPU `build_with` (mirrors the incremental path),
+  removing the documented lock-order exception.
+- ~~#89 — `fire_poll_refresh` floods the threadpool~~ — done: a synchronous
+  `poll_due()` gate on the dispatch thread skips submission within the debounce
+  window, and a `poll_pending` single-flight gate bounds in-flight poll tasks to
+  one (robust even with `--poll-interval-ms 0`).
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ROADMAP.md
+git commit -m "docs: mark Phase 4 (#89, #90) done in roadmap"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** #90 fix (render_entries extraction + rebuild_full rewrite + lock-order comment) → Task 1. #89 `poll_due` (core, with the listed gate cases incl. interval-zero and backoff) → Task 2. #89 `poll_pending` field + `MusefsFs::new` init + `PollPendingGuard` + `fire_poll_refresh` rewrite → Task 3. Spec's testing section: #90 structural boundary covered by `render_entries` unit test + existing regression tests (no DB-injection/blocking seam exists, per spec — no runtime "not blocked" assertion); #89 `poll_due` deterministic core tests; #89 gate single-flight + guard-on-panic deterministic fuse tests; existing `#[ignore]` mount tests as end-to-end → Task 4 Step 3.
+- **Type consistency:** `render_entries(&Db, &MountConfig) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)>` used identically in Task 1 test and `build_full`/`rebuild_full`. `PollPendingGuard(&AtomicBool)` defined in Task 3 Step 3, constructed in the rewrite (Step 5) and the panic test (Step 1). `poll_pending: Arc<AtomicBool>` field name consistent across struct, init, rewrite, and tests. `poll_due` signature `pub fn poll_due(&self) -> bool` consistent between Task 2 (def) and Task 3 (call `self.core.poll_due()`).
+- **No placeholders:** every code/command step contains full content and exact commands with expected output.

--- a/docs/superpowers/plans/2026-06-03-phase4-concurrency-correctness.md
+++ b/docs/superpowers/plans/2026-06-03-phase4-concurrency-correctness.md
@@ -304,7 +304,7 @@ Add the two hooks next to the existing `expire_poll_debounce_for_test` (~571):
 
 - [ ] **Step 4: Add the cross-reference comment on `poll_refresh_notify`'s gate**
 
-In `poll_refresh_notify`, immediately above the `if !self.poll_interval.is_zero()` debounce check (~429), add:
+In `poll_refresh_notify`, immediately above the **first** early-return gate — the `if self.needs_rebuild.load(...)` block (~414), so the comment scopes all the gates `poll_due` mirrors, not just the interval one — add:
 
 ```rust
         // These early-return gates are mirrored by the cheap `poll_due` pre-check
@@ -336,6 +336,8 @@ can gate poll submission on the dispatch thread."
 - Test: `musefs-fuse/src/lib.rs` (`mod tests` ~385)
 
 Gate `fire_poll_refresh` on `core.poll_due()` (submit nothing when not due), then a `poll_pending` single-flight `compare_exchange` so at most one poll task is queued/running; an RAII `PollPendingGuard` clears the flag on every exit path including panic.
+
+> **Note:** the single-flight test below deliberately supersedes the spec's barrier sketch (spec §"Piece 2", which called `queued_count`/`active_count` racy for observing task *lifecycle*). When the gate is pre-set to `true`, `fire_poll_refresh` submits *nothing*, so asserting the counts are *unchanged* is not racy — there is no task lifecycle to observe. Guard-clears-after-task is covered separately via `pool.join()`.
 
 - [ ] **Step 1: Write the failing tests**
 

--- a/docs/superpowers/specs/2026-06-03-phase4-concurrency-correctness-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase4-concurrency-correctness-design.md
@@ -26,9 +26,10 @@ untouched. The full `#[ignore]` e2e mount suite stays green.
 
 ## #90 — `rebuild_full` holds the `inodes` lock across DB I/O
 
-**Problem.** In `musefs-core/src/facade.rs`, `rebuild_full` acquires the `inodes`
-mutex *inside* the `pool.with(|db| …)` closure (`facade.rs:255-258`) and holds it
-across `build_full`'s DB reads (`list_tracks()` + `tags_grouped()`). On a slow
+**Problem.** In `musefs-core/src/facade.rs`, `rebuild_full` (`facade.rs:247-261`)
+acquires the `inodes` mutex *inside* the `pool.with(|db| …)` closure (the lock +
+`build_full` call at `facade.rs:256-257`) and holds it across `build_full`'s DB
+reads (`list_tracks()` + `tags_grouped()`). On a slow
 backing store the lock is held for the whole DB scan, blocking concurrent
 first-touch inode allocation.
 
@@ -88,10 +89,23 @@ fn rebuild_full(&self) -> Result<HashMap<i64, TrackRenderState>> {
 ```
 
 `build_full` (the other caller, `open()` at `facade.rs:163`) stays as a thin
-wrapper over `render_entries` + `build_with`, so its existing signature
-(`db, config, alloc`) is preserved. `open()` runs single-threaded at init with a
-fresh local `InodeAllocator` — no contention — so it is unaffected either way.
-`force_full_rebuild` calls `rebuild_full`, so it inherits the fix for free.
+wrapper over `render_entries` + `build_with`, preserving its existing signature
+(`db, config, alloc`) so `open()` is unchanged:
+
+```rust
+fn build_full(
+    db: &Db,
+    config: &MountConfig,
+    alloc: &mut InodeAllocator,
+) -> Result<(VirtualTree, HashMap<i64, TrackRenderState>)> {
+    let (entries, snapshot) = Self::render_entries(db, config)?;
+    Ok((VirtualTree::build_with(&entries, alloc), snapshot))
+}
+```
+
+`open()` runs single-threaded at init with a fresh local `InodeAllocator` — no
+contention — so it is unaffected either way. `force_full_rebuild` calls
+`rebuild_full`, so it inherits the fix for free.
 
 **Lock-order comment.** Update `facade.rs:387-398` to drop the "one intentional
 exception" sentence: the order is now uniform — the pool connection
@@ -176,8 +190,13 @@ measurable gain.
 
 ### Piece 2 — single-flight submission gate (musefs-fuse/src/lib.rs)
 
-Add a shared `poll_pending: Arc<AtomicBool>` to `MusefsFs` (an `Arc` because it
-must be cloned into the `'static` worker closure to be cleared on completion).
+Add a shared `poll_pending: Arc<AtomicBool>` field to `MusefsFs` (an `Arc`
+because it must be cloned into the `'static` worker closure to be cleared on
+completion). **Initialize it in `MusefsFs::new` (`musefs-fuse/src/lib.rs:128-145`,
+an explicit field-list constructor):** `poll_pending: Arc::new(AtomicBool::new(false))`
+— omitting this is a compile error, so it is part of the change, not just the
+`fire_poll_refresh` rewrite shown below.
+
 Rewrite `fire_poll_refresh`:
 
 ```rust
@@ -219,23 +238,39 @@ bound holds even with `--poll-interval-ms 0`.
 
 ## Testing
 
-- **#90:** assert the `inodes` lock is *not* held across DB I/O. Preferred seam:
-  use a slow/blocking DB injection (or the existing `force_*` test hooks) so a
-  rebuild's DB scan is in flight, and assert a concurrent first-touch inode
-  allocation is not blocked during it. If no clean blocking seam exists, fall
-  back to a structural test asserting `render_entries` performs all DB access and
-  `build_with` runs under the lock with no `Db` access in scope. Existing
+- **#90 (primary — structural invariant):** the deliverable test asserts the
+  code shape that makes the lock-held-across-I/O bug impossible: all `Db` access
+  is confined to `render_entries`, and `rebuild_full` calls `build_with` (the
+  only `inodes`-locked region) with no `Db`/`pool` in scope. There is no
+  DB-injection mock or blocking-read seam today, and the `force_*` test hooks
+  (`force_rebuild_error`, `force_apply_fail`, `needs_rebuild`) only make a rebuild
+  *fail* or *trigger* — none make a DB read *block* mid-scan — so a runtime
+  "concurrent allocation isn't blocked" assertion is **not** in scope for this PR.
+  The structural invariant is the honest, achievable guarantee. Existing
   rebuild/refresh tests (incremental + full + force-rebuild + self-heal) stay
-  green.
-- **#89, `poll_due()`:** unit-test it returns `false` inside the interval; `true`
-  past it; `true` when `needs_rebuild` is set (regardless of interval); `false`
-  inside the failure backoff window and `true` past it; and `true` when
-  `poll_interval` is zero.
-- **#89, single-flight gate:** a test that a burst of `fire_poll_refresh` calls
-  submits at most one task while one is pending — asserted via a task counter on
-  the pool, mirroring the existing direct-call metric/test style — and that the
-  gate is released after the task completes (and after a panicking task, via the
-  guard).
+  green and continue to prove behavior is unchanged.
+- **#89, `poll_due()` (core, deterministic):** unit-test it returns `false`
+  inside the interval; `true` past it; `true` when `needs_rebuild` is set
+  (regardless of interval); `false` inside the failure backoff window and `true`
+  past it; and `true` when `poll_interval` is zero. These are pure
+  state-comparison tests on the core facade, fully deterministic.
+- **#89, single-flight gate (fuse, in-crate test):** `fire_poll_refresh` is
+  **private**, so the test lives in a `#[cfg(test)] mod` inside
+  `musefs-fuse/src/lib.rs` (not `tests/`, which can't see it). It constructs a
+  `MusefsFs` over a temp-DB core via `MusefsFs::new` (no real mount needed) and
+  validates the gate **deterministically** — racy `ThreadPool::queued_count` /
+  `active_count` are unsuitable. Approach: occupy the single pool worker with a
+  barrier-blocked task that pins `poll_pending == true`, fire a burst of
+  `fire_poll_refresh` calls, and assert each is rejected by the
+  `compare_exchange` (no second task is admitted) by observing `poll_pending`
+  stays `true`; then release the barrier and assert the guard drops it back to
+  `false`. Add a separate test that a panicking task body still clears the gate
+  (the `PollPendingGuard` `Drop` runs on unwind).
+- **#89, end-to-end:** the existing `#[ignore]` mount tests that exercise
+  `fire_poll_refresh` through a live `/dev/fuse` mount —
+  `musefs-fuse/tests/keep_cache.rs` and the `metrics`-gated
+  `musefs-fuse/tests/concurrency.rs` — stay green, covering the real
+  metadata-op → poll path end to end.
 - **Suite:** `cargo test` workspace green; the full `#[ignore]` e2e mount suite
   green on `/dev/fuse`; `cargo clippy --all-targets` clean; `cargo fmt --all
   --check` clean.

--- a/docs/superpowers/specs/2026-06-03-phase4-concurrency-correctness-design.md
+++ b/docs/superpowers/specs/2026-06-03-phase4-concurrency-correctness-design.md
@@ -1,0 +1,252 @@
+# Phase 4 — Concurrency correctness
+
+**Date:** 2026-06-03
+**Scope:** Roadmap "Phase 4 — Concurrency correctness" — issues #90, #89. Two
+independent fixes in different crates (`musefs-core`, `musefs-fuse`), both about
+keeping the dispatch/serving path from being starved under load. Ships as **one
+batched PR** (matching how Phases 0–3 each landed).
+
+## Goal
+
+Stop two distinct ways the serving path degrades under concurrent / high-rate
+access:
+
+- **#90** — a full tree rebuild holds the `inodes` mutex across DB I/O, blocking
+  concurrent first-touch inode allocation for the duration of a (possibly slow,
+  e.g. NFS) DB scan.
+- **#89** — every FUSE metadata op submits a poll closure to the bounded worker
+  pool, so a metadata-op storm (a `find . -type f`, a media-manager library scan)
+  floods the pool with no-op tasks that compete with real read/`getattr` I/O.
+
+Neither is a user-visible behavior change for correctly-served files; both remove
+contention/starvation under load. The byte-identical-audio invariant is
+untouched. The full `#[ignore]` e2e mount suite stays green.
+
+---
+
+## #90 — `rebuild_full` holds the `inodes` lock across DB I/O
+
+**Problem.** In `musefs-core/src/facade.rs`, `rebuild_full` acquires the `inodes`
+mutex *inside* the `pool.with(|db| …)` closure (`facade.rs:255-258`) and holds it
+across `build_full`'s DB reads (`list_tracks()` + `tags_grouped()`). On a slow
+backing store the lock is held for the whole DB scan, blocking concurrent
+first-touch inode allocation.
+
+`rebuild_incremental` already does the opposite (`facade.rs:308-340`): it scans
+render keys + fetches tags from the DB first, releases the pool connection, and
+only *then* locks `inodes` around the pure-CPU `apply_changes` / `build_with`.
+The lock-order comment at `facade.rs:387-398` even calls out `rebuild_full` /
+`refresh` as "the one intentional exception where a pool connection is held
+around an in-memory lock." This fix removes that exception.
+
+**Fix.** Restructure `rebuild_full` to mirror `rebuild_incremental`: do the
+DB read + path render first, outside any in-memory lock; then lock `inodes` only
+around `VirtualTree::build_with`.
+
+Extract the DB-read + render phase of `build_full` into a small allocator-free
+helper that returns `(entries: Vec<(i64, String)>, snapshot: HashMap<i64,
+TrackRenderState>)`:
+
+```rust
+// allocator-free: pure DB read + path render
+fn render_entries(
+    db: &Db,
+    config: &MountConfig,
+) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
+    let tracks = db.list_tracks()?;
+    let mut tags_by_track = db.tags_grouped()?;
+    let mut entries = Vec::with_capacity(tracks.len());
+    let mut snapshot = HashMap::with_capacity(tracks.len());
+    for t in &tracks {
+        let tags = tags_by_track.remove(&t.id).unwrap_or_default();
+        let path = Self::render_one(config, t.format, &tags);
+        snapshot.insert(t.id, TrackRenderState {
+            content_version: t.content_version,
+            format: t.format,
+            path: path.clone(),
+        });
+        entries.push((t.id, path));
+    }
+    Ok((entries, snapshot))
+}
+```
+
+`rebuild_full` becomes:
+
+```rust
+fn rebuild_full(&self) -> Result<HashMap<i64, TrackRenderState>> {
+    if self.force_rebuild_error.load(Ordering::Acquire) {
+        return Err(CoreError::BackingChanged("forced refresh failure".to_string()));
+    }
+    let (entries, snapshot) = self.pool.with(|db| Self::render_entries(db, &self.config))?;
+    let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
+    let tree = VirtualTree::build_with(&entries, &mut alloc);
+    drop(alloc);
+    self.tree.store(Arc::new(tree));
+    Ok(snapshot)
+}
+```
+
+`build_full` (the other caller, `open()` at `facade.rs:163`) stays as a thin
+wrapper over `render_entries` + `build_with`, so its existing signature
+(`db, config, alloc`) is preserved. `open()` runs single-threaded at init with a
+fresh local `InodeAllocator` — no contention — so it is unaffected either way.
+`force_full_rebuild` calls `rebuild_full`, so it inherits the fix for free.
+
+**Lock-order comment.** Update `facade.rs:387-398` to drop the "one intentional
+exception" sentence: the order is now uniform — the pool connection
+(`pool.with` / `with_poll`) is always released before any in-memory lock
+(`inodes`, header-cache shards) is acquired, in *both* rebuild paths.
+
+---
+
+## #89 — `fire_poll_refresh` submits a threadpool task on every metadata op
+
+**Problem.** In `musefs-fuse/src/lib.rs`, `fire_poll_refresh` (`lib.rs:151-176`)
+is called from `lookup`, `getattr`, and `readdir`, and *unconditionally*
+`pool.execute()`s a closure (`Arc::clone(core)` + boxed closure + channel-send +
+worker wakeup). The poll-interval debounce is only checked *inside* the submitted
+closure (`poll_refresh_notify`, `facade.rs:429-431`), not before submission. A
+metadata-op storm floods the bounded worker pool with tasks that merely acquire
+`last_poll`, compare a timestamp, and return — competing with real read/`getattr`
+I/O for worker threads.
+
+**Chosen approach (synchronous debounce + single-flight gate).** Two pieces:
+
+1. a cheap synchronous predicate checked on the dispatch thread *before*
+   submitting (the "synchronous debounce" the roadmap names), and
+2. a single-flight gate so at most **one** poll task is ever queued/running.
+
+Both pieces are kept because each covers a case the other misses:
+- The synchronous predicate skips submission entirely in the common debounced
+  case (no pool task at all), but on its own a burst right after a real DB change
+  — before the poll task stamps `last_poll` — could still submit several
+  concurrent tasks that each run a `data_version` pragma.
+- The single-flight gate bounds outstanding tasks to one regardless, and is the
+  *only* protection when `--poll-interval-ms 0` disables the time-debounce (then
+  the predicate is a no-op that returns `true` every op).
+
+### Piece 1 — `Musefs::poll_due()` (musefs-core/src/facade.rs)
+
+Add a pure, cheap predicate that performs exactly the early-return gate checks
+`poll_refresh_notify` already does — and nothing else (no DB access, no
+`data_version`, no rebuild):
+
+```rust
+/// Cheap, synchronous "is a poll worth submitting?" check for the dispatch
+/// thread to gate `fire_poll_refresh` on. Mirrors the early-return gates in
+/// `poll_refresh_notify`; keep the two in sync. Advisory only — a stale `true`
+/// just costs one task that the inner gate short-circuits; `needs_rebuild` is
+/// checked first so a self-heal is never skipped.
+pub fn poll_due(&self) -> bool {
+    if self.needs_rebuild.load(Ordering::Acquire) {
+        return true;
+    }
+    if !self.poll_interval.is_zero()
+        && crate::lock::lock_recover(&self.last_poll, "last_poll").elapsed()
+            < self.poll_interval
+    {
+        return false;
+    }
+    if let Some(last_failed) =
+        *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
+    {
+        if last_failed.elapsed() < self.refresh_retry_backoff {
+            return false;
+        }
+    }
+    true
+}
+```
+
+`poll_refresh_notify` keeps its own internal gates **unchanged** — it is public
+API and must stay correct if called directly (the no-callback `poll_refresh`,
+tests, a future caller). `poll_due` is purely an advisory pre-filter. A
+cross-reference comment is added on both so they are kept in sync.
+
+The timestamp stays `Mutex<Instant>` (not converted to a lock-free `AtomicU64`):
+the mutex is uncontended (its only writer is the once-per-interval poll worker,
+which holds it for a trivial assignment, never across I/O), so the per-op cost is
+~tens of ns — deep in the noise of a microsecond-scale FUSE round-trip, and
+strictly cheaper than the `Arc::clone` + boxed closure + channel-send it replaces
+in the debounced case. An `AtomicU64`-nanos variant was considered and rejected
+as a micro-optimization that, done properly, would also drag in
+`last_failed_refresh` (an `Option<Instant>` needing a sentinel encoding) for no
+measurable gain.
+
+### Piece 2 — single-flight submission gate (musefs-fuse/src/lib.rs)
+
+Add a shared `poll_pending: Arc<AtomicBool>` to `MusefsFs` (an `Arc` because it
+must be cloned into the `'static` worker closure to be cleared on completion).
+Rewrite `fire_poll_refresh`:
+
+```rust
+fn fire_poll_refresh(&self) {
+    if !self.core.poll_due() {
+        return; // synchronous debounce on the dispatch thread — submit nothing
+    }
+    if self
+        .poll_pending
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return; // a poll task is already queued/running
+    }
+    let core = Arc::clone(&self.core);
+    let pending = Arc::clone(&self.poll_pending);
+    // existing keep_cache vs plain branch, with the body wrapped so the gate is
+    // cleared on every exit path (incl. panic) via a small drop guard:
+    self.pool.execute(move || {
+        let _guard = PollPendingGuard(&pending); // clears poll_pending on drop
+        // ... existing poll_refresh_notify (keep_cache) / poll_refresh body ...
+    });
+}
+```
+
+`PollPendingGuard` is a tiny RAII type whose `Drop` does
+`pending.store(false, Ordering::Release)`, so a panic inside `poll_refresh_notify`
+cannot wedge the gate `true` forever.
+
+**Resulting behavior.** Per metadata op the dispatch thread does only the cheap
+`poll_due()` check and, in the common debounced case, submits nothing. When a poll
+is due, exactly one task is in flight at a time. A whole-library metadata scan
+(read-only against musefs's store, so `data_version` never changes) thus costs at
+most ~one trivial `data_version`-pragma task per `poll_interval`, leaving the
+worker pool free for the scan's actual `getattr`/`open`/`read` work — and the
+bound holds even with `--poll-interval-ms 0`.
+
+---
+
+## Testing
+
+- **#90:** assert the `inodes` lock is *not* held across DB I/O. Preferred seam:
+  use a slow/blocking DB injection (or the existing `force_*` test hooks) so a
+  rebuild's DB scan is in flight, and assert a concurrent first-touch inode
+  allocation is not blocked during it. If no clean blocking seam exists, fall
+  back to a structural test asserting `render_entries` performs all DB access and
+  `build_with` runs under the lock with no `Db` access in scope. Existing
+  rebuild/refresh tests (incremental + full + force-rebuild + self-heal) stay
+  green.
+- **#89, `poll_due()`:** unit-test it returns `false` inside the interval; `true`
+  past it; `true` when `needs_rebuild` is set (regardless of interval); `false`
+  inside the failure backoff window and `true` past it; and `true` when
+  `poll_interval` is zero.
+- **#89, single-flight gate:** a test that a burst of `fire_poll_refresh` calls
+  submits at most one task while one is pending — asserted via a task counter on
+  the pool, mirroring the existing direct-call metric/test style — and that the
+  gate is released after the task completes (and after a panicking task, via the
+  guard).
+- **Suite:** `cargo test` workspace green; the full `#[ignore]` e2e mount suite
+  green on `/dev/fuse`; `cargo clippy --all-targets` clean; `cargo fmt --all
+  --check` clean.
+
+---
+
+## Out of scope
+
+- The lock-free `AtomicU64`-nanos timestamp variant (considered, rejected above).
+- #69 (`poll_refresh` rebuild O(library) → O(changed)) — a separate Phase 6
+  performance SP; it shares the facade rebuild path but is bench-tracked and
+  sequenced after this.
+- Any change to `poll_refresh_notify`'s internal rebuild logic or single-flight
+  (`refreshing`) semantics.

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -412,6 +412,33 @@ impl Musefs {
     // the read guard before the `insert`; `retain` is never called while a `Ref`
     // is held), so it imposes no problematic lock ordering / no cross-lock cycle.
 
+    /// Cheap, synchronous "is a `data_version` poll worth dispatching?" predicate
+    /// for the FUSE dispatch thread to gate `fire_poll_refresh` on, so a
+    /// metadata-op storm doesn't flood the worker pool with no-op poll tasks (#89).
+    /// Mirrors the early-return gates in `poll_refresh_notify` — keep the two in
+    /// sync. Advisory only: no DB access, no `data_version` read, no rebuild. A
+    /// stale `true` costs at most one task the inner gate short-circuits, and
+    /// `needs_rebuild` is checked first so a self-heal is never debounced away.
+    pub fn poll_due(&self) -> bool {
+        if self.needs_rebuild.load(Ordering::Acquire) {
+            return true;
+        }
+        if !self.poll_interval.is_zero()
+            && crate::lock::lock_recover(&self.last_poll, "last_poll").elapsed()
+                < self.poll_interval
+        {
+            return false;
+        }
+        if let Some(last_failed) =
+            *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
+        {
+            if last_failed.elapsed() < self.refresh_retry_backoff {
+                return false;
+            }
+        }
+        true
+    }
+
     /// See `poll_refresh_notify`; this is the no-callback form.
     pub fn poll_refresh(&self) -> Result<bool> {
         self.poll_refresh_notify(|_| {})
@@ -426,6 +453,8 @@ impl Musefs {
     /// Single-flighted: if a rebuild is already in progress, concurrent callers
     /// return `Ok(false)` immediately.
     pub fn poll_refresh_notify(&self, mut on_changed: impl FnMut(u64)) -> Result<bool> {
+        // These early-return gates are mirrored by the cheap `poll_due` pre-check
+        // the FUSE layer runs on the dispatch thread (#89); keep the two in sync.
         // A poisoned VFS-state lock scheduled a full rebuild: do it now,
         // bypassing the debounce / backoff / data_version gates (#96).
         if self.needs_rebuild.load(Ordering::Acquire) {
@@ -588,6 +617,24 @@ impl Musefs {
             .checked_sub(self.poll_interval)
             .expect("poll_interval exceeds monotonic clock base; cannot backdate last_poll");
         *crate::lock::lock_recover(&self.last_poll, "last_poll") = past;
+    }
+
+    /// Stamps a failed-refresh time of "now" so the backoff gate is active, for
+    /// tests exercising `poll_due`'s backoff branch without a real failure.
+    #[doc(hidden)]
+    pub fn fail_refresh_now_for_test(&self) {
+        *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh") =
+            Some(std::time::Instant::now());
+    }
+
+    /// Backdates the failed-refresh stamp past the retry-backoff window so the
+    /// backoff gate no longer blocks (companion to `expire_poll_debounce_for_test`).
+    #[doc(hidden)]
+    pub fn expire_refresh_backoff_for_test(&self) {
+        let past = std::time::Instant::now()
+            .checked_sub(self.refresh_retry_backoff)
+            .expect("refresh_retry_backoff exceeds monotonic clock base");
+        *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh") = Some(past);
     }
 
     pub fn lookup(&self, parent: u64, name: &str) -> Option<u64> {
@@ -1108,5 +1155,50 @@ mod tests {
             !fs.poll_refresh().unwrap(),
             "forced rebuild must stamp data_version (next poll is a no-op)"
         );
+    }
+
+    fn fs_with_poll_interval(interval: std::time::Duration) -> (tempfile::TempDir, Musefs) {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: interval,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
+        (dir, fs)
+    }
+
+    #[test]
+    fn poll_due_false_within_interval_true_after_expiry() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::from_hours(1));
+        assert!(!fs.poll_due(), "fresh open is within the debounce window");
+        fs.expire_poll_debounce_for_test();
+        assert!(fs.poll_due(), "past the debounce window");
+    }
+
+    #[test]
+    fn poll_due_true_when_needs_rebuild_regardless_of_interval() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::from_hours(1));
+        assert!(!fs.poll_due());
+        fs.mark_needs_rebuild_for_test();
+        assert!(fs.poll_due(), "needs_rebuild bypasses the debounce");
+    }
+
+    #[test]
+    fn poll_due_true_when_interval_zero() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::ZERO);
+        assert!(fs.poll_due(), "zero interval disables the debounce");
+    }
+
+    #[test]
+    fn poll_due_respects_failure_backoff_window() {
+        let (_d, fs) = fs_with_poll_interval(std::time::Duration::from_hours(1));
+        fs.expire_poll_debounce_for_test(); // get past the debounce gate first
+        fs.fail_refresh_now_for_test();
+        assert!(!fs.poll_due(), "inside the retry backoff window");
+        fs.expire_refresh_backoff_for_test();
+        assert!(fs.poll_due(), "past the retry backoff window");
     }
 }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -260,7 +260,11 @@ impl Musefs {
     /// Rebuild + publish the tree via a full render; returns the fresh snapshot
     /// (the caller decides whether/how to diff it). Mirrors `rebuild_incremental`'s
     /// ordering: read + render under the pool connection, then lock `inodes` only
-    /// across the pure-CPU `build_with` (#90).
+    /// across the pure-CPU `build_with` (#90). That leaves the read→publish window
+    /// uncovered by any lock, so overlapping calls could publish a stale tree:
+    /// callers must be serialized, which they are — the production path runs inside
+    /// `poll_refresh_notify`'s `refreshing` CAS, and `refresh` documents the same
+    /// no-concurrent-rebuild contract.
     fn rebuild_full(&self) -> Result<HashMap<i64, TrackRenderState>> {
         if self.force_rebuild_error.load(Ordering::Acquire) {
             return Err(CoreError::BackingChanged(

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -258,7 +258,9 @@ impl Musefs {
     }
 
     /// Rebuild + publish the tree via a full render; returns the fresh snapshot
-    /// (the caller decides whether/how to diff it).
+    /// (the caller decides whether/how to diff it). Mirrors `rebuild_incremental`'s
+    /// ordering: read + render under the pool connection, then lock `inodes` only
+    /// across the pure-CPU `build_with` (#90).
     fn rebuild_full(&self) -> Result<HashMap<i64, TrackRenderState>> {
         if self.force_rebuild_error.load(Ordering::Acquire) {
             return Err(CoreError::BackingChanged(

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -203,14 +203,14 @@ impl Musefs {
         )
     }
 
-    /// Full rebuild: render every track and build the tree from scratch. Used by
-    /// `open`, forced `refresh`, and the Stage B fallback. Returns the tree and the
-    /// fresh `track_id -> TrackRenderState` snapshot.
-    fn build_full(
+    /// DB read + path render with no allocator: the lock-free phase shared by
+    /// `build_full` and `rebuild_full`. Confining all `Db` access here is what
+    /// lets `rebuild_full` hold `inodes` only across the pure-CPU `build_with`.
+    #[allow(clippy::type_complexity)]
+    fn render_entries(
         db: &Db,
         config: &MountConfig,
-        alloc: &mut InodeAllocator,
-    ) -> Result<(VirtualTree, HashMap<i64, TrackRenderState>)> {
+    ) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
         let tracks = db.list_tracks()?;
         let mut tags_by_track = db.tags_grouped()?;
         let mut entries = Vec::with_capacity(tracks.len());
@@ -228,6 +228,18 @@ impl Musefs {
             );
             entries.push((t.id, path));
         }
+        Ok((entries, snapshot))
+    }
+
+    /// Full rebuild: render every track and build the tree from scratch. Used by
+    /// `open`, forced `refresh`, and the Stage B fallback. Returns the tree and the
+    /// fresh `track_id -> TrackRenderState` snapshot.
+    fn build_full(
+        db: &Db,
+        config: &MountConfig,
+        alloc: &mut InodeAllocator,
+    ) -> Result<(VirtualTree, HashMap<i64, TrackRenderState>)> {
+        let (entries, snapshot) = Self::render_entries(db, config)?;
         Ok((VirtualTree::build_with(&entries, alloc), snapshot))
     }
 
@@ -253,10 +265,12 @@ impl Musefs {
                 "forced refresh failure".to_string(),
             ));
         }
-        let (tree, snapshot) = self.pool.with(|db| {
-            let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
-            Self::build_full(db, &self.config, &mut alloc)
-        })?;
+        let (entries, snapshot) = self
+            .pool
+            .with(|db| Self::render_entries(db, &self.config))?;
+        let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
+        let tree = VirtualTree::build_with(&entries, &mut alloc);
+        drop(alloc);
         self.tree.store(Arc::new(tree));
         Ok(snapshot)
     }
@@ -385,9 +399,10 @@ impl Musefs {
     }
 
     // Lock order: acquire a DbPool connection (`pool.with`/`with_poll`) FIRST, then
-    // any in-memory lock (`inodes`, the header cache's shards). `inodes` is held
-    // inside `pool.with` during `refresh` — the one intentional exception where a
-    // pool connection is held around an in-memory lock. `handles` is a lock-free
+    // any in-memory lock (`inodes`, the header cache's shards). Both rebuild paths
+    // (`rebuild_full`, `rebuild_incremental`) release the pool connection before
+    // locking `inodes`, so the order is uniform: a pool connection is never held
+    // around an in-memory lock. `handles` is a lock-free
     // `sharded_slab::Slab`: its `get` guard is cloned-from and dropped before any
     // pool call, so it never participates in lock ordering. Slab keys are
     // generation-encoded, so a reused slot produces a different key; a stale `fh`
@@ -994,6 +1009,40 @@ mod tests {
             );
         }
         fs.release_handle(fh);
+    }
+
+    #[test]
+    fn render_entries_returns_paths_and_snapshot() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+        let db = musefs_db::Db::open(dir.path().join("m.db")).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+        };
+
+        let (entries, snapshot) = Musefs::render_entries(&db, &cfg).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, "Pix/Song.mp3");
+        let id = entries[0].0;
+        assert_eq!(snapshot[&id].path, "Pix/Song.mp3");
+        assert!(snapshot[&id].content_version >= 1);
     }
 
     #[test]

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::ffi::OsStr;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
 
@@ -108,6 +109,15 @@ pub fn to_file_attr(attr: &Attr, uid: u32, gid: u32, fallback_mtime: SystemTime)
         flags: 0,
     }
 }
+/// Clears the `fire_poll_refresh` single-flight gate when the poll task ends,
+/// on every exit path including a panic in `poll_refresh_notify` (#89).
+struct PollPendingGuard<'a>(&'a AtomicBool);
+
+impl Drop for PollPendingGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
 
 /// A `fuser::Filesystem` that serves a `musefs_core::Musefs`. fuser dispatches
 /// on one thread; blocking ops (read/getattr/lookup-attr) are offloaded to a
@@ -123,6 +133,9 @@ pub struct MusefsFs {
     // Set once, right after the session is created (the fs is moved into the
     // session, so the notifier can only be obtained afterward via this shared cell).
     notifier: Arc<OnceLock<Notifier>>,
+    /// Single-flight gate for `fire_poll_refresh`: at most one poll task is
+    /// queued/running at a time, so a metadata-op storm can't flood the pool (#89).
+    poll_pending: Arc<AtomicBool>,
 }
 
 impl MusefsFs {
@@ -142,6 +155,7 @@ impl MusefsFs {
             mount_time: SystemTime::now(),
             config,
             notifier: Arc::new(OnceLock::new()),
+            poll_pending: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -149,14 +163,28 @@ impl MusefsFs {
         Arc::clone(&self.notifier)
     }
 
-    /// Fire `poll_refresh` on the worker pool (off the dispatch thread). When
-    /// keep-cache is enabled, also drop the kernel page cache for every inode whose
-    /// content changed, so an external re-tag never serves stale cached bytes.
+    /// Fire `poll_refresh` on the worker pool (off the dispatch thread), but only
+    /// when due: a cheap synchronous `poll_due()` check gates submission so a
+    /// metadata-op storm doesn't flood the pool, and a `poll_pending` single-flight
+    /// gate bounds in-flight poll tasks to one (#89). When keep-cache is enabled,
+    /// also drop the kernel page cache for every inode whose content changed.
     fn fire_poll_refresh(&self) {
+        if !self.core.poll_due() {
+            return;
+        }
+        if self
+            .poll_pending
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return; // a poll task is already queued/running
+        }
         let core = Arc::clone(&self.core);
+        let pending = Arc::clone(&self.poll_pending);
         if self.config.keep_cache {
             let notifier = Arc::clone(&self.notifier);
             self.pool.execute(move || {
+                let _guard = PollPendingGuard(&pending);
                 if let Err(e) = core.poll_refresh_notify(|ino| {
                     if let Some(n) = notifier.get() {
                         if let Err(inval_err) = n.inval_inode(INodeNo(ino), 0, 0) {
@@ -169,6 +197,7 @@ impl MusefsFs {
             });
         } else {
             self.pool.execute(move || {
+                let _guard = PollPendingGuard(&pending);
                 if let Err(e) = core.poll_refresh() {
                     log::warn!("poll_refresh failed: {e}");
                 }
@@ -455,6 +484,63 @@ mod tests {
     fn open_flags_sets_keep_cache_bit_only_when_enabled() {
         assert_eq!(open_flags(false), FopenFlags::empty());
         assert_eq!(open_flags(true), FopenFlags::FOPEN_KEEP_CACHE);
+    }
+
+    fn test_fs() -> (tempfile::TempDir, MusefsFs) {
+        use musefs_core::{Mode, MountConfig, Musefs};
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: std::collections::BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            // Zero interval => poll_due() is always true, isolating the gate.
+            poll_interval: std::time::Duration::ZERO,
+        };
+        let core =
+            Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
+        (dir, MusefsFs::new(core, FuseConfig::default()))
+    }
+
+    #[test]
+    fn poll_pending_guard_clears_flag_on_panic() {
+        let flag = Arc::new(AtomicBool::new(true));
+        let f = Arc::clone(&flag);
+        let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = PollPendingGuard(&f);
+            panic!("boom");
+        }));
+        assert!(r.is_err());
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "guard must clear the flag on unwind"
+        );
+    }
+
+    #[test]
+    fn fire_poll_refresh_single_flights_when_pending() {
+        let (_d, fs) = test_fs();
+        // Simulate a poll already in flight; the gate must reject new submissions.
+        fs.poll_pending.store(true, Ordering::SeqCst);
+        let queued = fs.pool.queued_count();
+        let active = fs.pool.active_count();
+        for _ in 0..50 {
+            fs.fire_poll_refresh();
+        }
+        assert_eq!(fs.pool.queued_count(), queued, "no task should be queued");
+        assert_eq!(fs.pool.active_count(), active, "no task should be started");
+    }
+
+    #[test]
+    fn fire_poll_refresh_clears_gate_after_task() {
+        let (_d, fs) = test_fs();
+        assert!(!fs.poll_pending.load(Ordering::SeqCst));
+        fs.fire_poll_refresh(); // poll_due() true (zero interval): gate taken, task runs
+        fs.pool.join(); // block until the poll task completes
+        assert!(
+            !fs.poll_pending.load(Ordering::SeqCst),
+            "guard must clear the gate after the task finishes"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #89. Closes #90.

## What

**#90 — `rebuild_full` held the `inodes` lock across DB I/O.** The DB-read+render phase is extracted into an allocator-free `Musefs::render_entries`; `rebuild_full` now releases the pool connection before locking `inodes` only across the pure-CPU `VirtualTree::build_with`, mirroring `rebuild_incremental`. This removes the documented lock-order exception — a pool connection is never held around an in-memory lock. The now-unlocked read→publish window relies on the existing caller serialization (`refreshing` CAS / `refresh`'s contract), documented at `rebuild_full`.

**#89 — every FUSE metadata op flooded the worker pool with no-op poll tasks.** Two gates in `fire_poll_refresh`:
- a cheap synchronous `Musefs::poll_due()` checked on the dispatch thread (mirrors `poll_refresh_notify`'s early-return gates: `needs_rebuild` → interval debounce → failure backoff; no DB access), so nothing is submitted within the debounce window;
- a `poll_pending` single-flight `compare_exchange` cleared by an RAII `PollPendingGuard` (clears on panic too), bounding in-flight poll tasks to one — robust even with `--poll-interval-ms 0`.

Also: design doc + implementation plan, roadmap marked done, and a `.cargo/mutants.toml` exemption for the two equivalent `<`→`<=` wall-clock-gate mutants in `poll_due` (the operators differ only when `Instant::elapsed()` equals the bound at the exact sampled nanosecond — not constructible deterministically; the `<`→`>`/`==` variants are caught and stay in scope).

## Testing

- New unit tests: `render_entries` DB→entries boundary (core); `poll_due` gate matrix — debounce expiry, `needs_rebuild` bypass, zero interval, failure backoff (core); single-flight rejection, guard-clears-on-panic, gate-clears-after-task (fuse).
- `cargo test --workspace` green (core 237 passed); FUSE e2e mount suite (`-- --ignored`, real mounts) 9 passed.
- `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean.
- In-diff mutation gate run locally: 48 mutants — 18 caught, 28 unviable, 0 timeouts, 2 missed → both analyzed equivalent and exempted as above (list verified to drop exactly those two, 48→46).
- Reviewed by a code-review subagent against the plan: no Critical/Important findings; both Minor items addressed (mount-suite claim re-verified; serialization note added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 4 concurrency roadmap with completed improvements and design specifications

* **Performance & Stability**
  * Reduced lock contention in rebuild operations for improved responsiveness
  * Implemented adaptive polling to prevent excessive task queueing during metadata operations, even with aggressive polling intervals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->