### PR TITLE
Phase 6 PR 2: scan perf pair (#67, #68)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -32,7 +32,7 @@ exclude_globs = [
 # test can kill (they alter performance or batching granularity, not observable
 # results, or live in unreachable defensive branches). Documented per class.
 # Anchored on file:line:col so only the proven-equivalent sites are suppressed;
-# killable siblings (e.g. flac `|`->`&`, scan 711 `+`->`*`) stay in scope.
+# killable siblings (e.g. flac `|`->`&`, scan 871 `+`->`*`) stay in scope.
 exclude_re = [
     # dirty_min_flip_ancestors (add-side walk) `id < introducing_id(child)`: the
     # `<`->`<=` boundary is unreachable-different. Equality needs the walked id to
@@ -59,15 +59,15 @@ exclude_re = [
     # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
     # block end past the prefix), so `up_to.min(file_len)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
-    'musefs-core/src/scan\.rs:225:31:',
+    'musefs-core/src/scan\.rs:263:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < file_len`: when
     # it differs, the only effect is a redundant whole-file re-read that feeds the
     # same `probe_full` result. The >8-retry path that could diverge is unreachable
     # given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
-    'musefs-core/src/scan\.rs:232:30:',
+    'musefs-core/src/scan\.rs:270:30:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
-    'musefs-core/src/scan\.rs:493:46:',
+    'musefs-core/src/scan\.rs:624:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -75,23 +75,23 @@ exclude_re = [
     # cadence mutation persists the identical track set. The win is fewer commits
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
-    'musefs-core/src/scan\.rs:573:29:',
-    'musefs-core/src/scan\.rs:575:32:',
-    'musefs-core/src/scan\.rs:575:47:',
-    'musefs-core/src/scan\.rs:575:62:',
-    'musefs-core/src/scan\.rs:583:37:',
-    'musefs-core/src/scan\.rs:585:40:',
-    'musefs-core/src/scan\.rs:585:55:',
-    'musefs-core/src/scan\.rs:585:70:',
+    'musefs-core/src/scan\.rs:715:29:',
+    'musefs-core/src/scan\.rs:717:32:',
+    'musefs-core/src/scan\.rs:717:47:',
+    'musefs-core/src/scan\.rs:717:62:',
+    'musefs-core/src/scan\.rs:725:37:',
+    'musefs-core/src/scan\.rs:727:40:',
+    'musefs-core/src/scan\.rs:727:55:',
+    'musefs-core/src/scan\.rs:727:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
     # from a deterministic test. With skip_failed identically 0, the `failed =
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
-    'musefs-core/src/scan\.rs:672:25:',
-    'musefs-core/src/scan\.rs:676:25:',
-    'musefs-core/src/scan\.rs:711:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:831:25:',
+    'musefs-core/src/scan\.rs:835:25:',
+    'musefs-core/src/scan\.rs:871:29: replace \+ with -',
     # flac::read_metadata_bounded 24-bit block-length assembly: the three length
     # bytes occupy disjoint bit ranges after shifting, so `|`, `^`, and `+` are
     # bit-for-bit identical there (the `|`->`&` variant collapses to 0 and IS

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -404,8 +404,8 @@ Two stacked scan-path optimizations, neither touching served bytes:
    `read_exact` per non-MP3 file, saving exactly 128 bytes of scan I/O each.
 2. **#68 — Move-not-clone ingest.** `ingest_bulk` previously cloned each
    picture's bytes (`Vec::clone`) because the batch held `&Probed` borrows.
-   The owned `Unit` variant now drains into the writer via `std::mem::take`,
-   moving the payload instead of copying it.
+   The writer now drains the owned `Unit` batch by value, moving the payload
+   into the DB structs instead of copying it.
 
 - **Before** = `main` @ `e7ae912` (post-#69): reads ID3v1 tail for all formats; clones picture bytes.
 - **After** = `phase6-pr2-scan-pair` @ `9b49a63`: tail gated to `.mp3`; picture bytes moved.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -389,3 +389,64 @@ cargo test -p musefs-core --release --test bench_refresh \
 cargo test -p musefs-core --release --test bench_refresh \
   bench_refresh_one_vs_many -- --ignored --nocapture
 ```
+
+---
+
+## Phase 6 PR 2 — Scan pair (#67, #68)
+
+*Measured 2026-06-04 (same box, lightly loaded · tempfs · `ci` tier).*
+
+Two stacked scan-path optimizations, neither touching served bytes:
+
+1. **#67 — Lazy ID3v1 tail.** The bounded probe path issued a 128-byte
+   `read_exact` at the file tail for *every* front-anchored file, but only MP3
+   consumes the ID3v1 frame. Gating the tail read to `.mp3` files drops one
+   `read_exact` per non-MP3 file, saving exactly 128 bytes of scan I/O each.
+2. **#68 — Move-not-clone ingest.** `ingest_bulk` previously cloned each
+   picture's bytes (`Vec::clone`) because the batch held `&Probed` borrows.
+   The owned `Unit` variant now drains into the writer via `std::mem::take`,
+   moving the payload instead of copying it.
+
+- **Before** = `main` @ `e7ae912` (post-#69): reads ID3v1 tail for all formats; clones picture bytes.
+- **After** = `phase6-pr2-scan-pair` @ `9b49a63`: tail gated to `.mp3`; picture bytes moved.
+- Harness: `cargo test -p musefs-core --release --features metrics --test bench_ingest -- --ignored --nocapture bench_cold_scan_and_revalidate`. Three independent runs; `bytes_read` = `scan_bytes_read`.
+
+### Scan — `ci` tier (200 tracks × 4 KiB, no embedded art), tempfs
+
+| format    | before wall (ms, 3 runs) | after wall (ms, 3 runs) | before bytes_read | after bytes_read | Δ bytes/file |
+|-----------|-------------------------:|------------------------:|------------------:|-----------------:|-------------:|
+| flac      | 32 / 30 / 34            | 30 / 29 / 28           | 870 600           | 845 000          | **−128 B**   |
+| mp3       | 21 / 21 / 20            | 23 / 23 / 22           | 847 200           | 847 200          | 0 (tail still read) |
+| m4a       | 27 / 29 / 24            | 25 / 28 / 28           | 0                 | 0                | n/a          |
+| m4a-last  | 28 / 27 / 25            | 28 / 34 / 25           | 0                 | 0                | n/a          |
+| ogg       | 20 / 22 / 22            | 23 / 22 / 20           | 873 000           | 847 400          | **−128 B**   |
+| wav       | 24 / 23 / 20            | 23 / 22 / 23           | 853 600           | 828 000          | **−128 B**   |
+
+**#67 signal:** Non-MP3 formats (flac, ogg, wav) show exactly −128 bytes/file in
+`bytes_read` — the 128-byte ID3v1 tail read is no longer issued for those formats.
+MP3 is unchanged (it still consumes the tail). M4A is 0 in both directions (it
+uses a seek-reader, not the front-anchored probe path).
+
+**#68 signal:** Structural (move vs clone) — wall times are within run-to-run noise
+on the `ci` tier because the 4 KiB test files have no embedded art, so there is no
+picture payload to move. The win appears on art-bearing corpora (the `bandwidth`
+tier from SP1 §2 or real libraries) where the clone was O(art-size) per file.
+
+**Wall time:** held or improved across all formats; no >10% rise.
+
+`opens`/`preads` stay at 0 on the scan path (they are serve-path counters),
+matching the documented expectation.
+
+```bash
+# Before (main):
+git checkout main
+MUSEFS_BENCH_TIER=ci \
+  cargo test -p musefs-core --release --features metrics --test bench_ingest \
+  -- --ignored --nocapture bench_cold_scan_and_revalidate
+
+# After (branch):
+git checkout phase6-pr2-scan-pair
+MUSEFS_BENCH_TIER=ci \
+  cargo test -p musefs-core --release --features metrics --test bench_ingest \
+  -- --ignored --nocapture bench_cold_scan_and_revalidate
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -193,8 +193,12 @@ parallel. Most of the Rust items came out of the v1 multi-model review triage.
   `track_changes` changelog ring (MIGRATION_V3) + in-place snapshot mutation +
   collision-gated `apply_changes` dirtying; refresh-1 flat at 0–1 ms across
   100..20000 tracks (was ~160 ms linear). See BENCHMARKS.md "Phase 6 PR 1".
-- #67 — bounded probe reads an ID3v1 tail per file (scan perf).
-- #68 — `ingest_bulk` copies each picture's bytes (scan perf).
+- ~~#67 — bounded probe reads an ID3v1 tail per file (scan perf)~~ — done:
+  gated the 128-byte tail read to `.mp3` files only; non-MP3 formats save
+  −128 B/file in `scan_bytes_read`. See BENCHMARKS.md "Phase 6 PR 2".
+- ~~#68 — `ingest_bulk` copies each picture's bytes (scan perf)~~ — done:
+  owned `Unit` variants drain into the writer via `std::mem::take` (move, not
+  clone). Wall-time win on art-bearing corpora. See BENCHMARKS.md "Phase 6 PR 2".
 - #70 — zero-copy serve path (deferred SP3 residual; largest scope).
 
 **Phase 7 — Docs**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -197,8 +197,8 @@ parallel. Most of the Rust items came out of the v1 multi-model review triage.
   gated the 128-byte tail read to `.mp3` files only; non-MP3 formats save
   −128 B/file in `scan_bytes_read`. See BENCHMARKS.md "Phase 6 PR 2".
 - ~~#68 — `ingest_bulk` copies each picture's bytes (scan perf)~~ — done:
-  owned `Unit` variants drain into the writer via `std::mem::take` (move, not
-  clone). Wall-time win on art-bearing corpora. See BENCHMARKS.md "Phase 6 PR 2".
+  the writer drains the owned `Unit` batch by value (move, not clone).
+  Wall-time win on art-bearing corpora. See BENCHMARKS.md "Phase 6 PR 2".
 - #70 — zero-copy serve path (deferred SP3 residual; largest scope).
 
 **Phase 7 — Docs**

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -202,15 +202,6 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
     Ok(Some(buf))
 }
 
-/// Bounded probe of one backing file: open once, read a bounded window, dispatch
-/// per format, widening on `NeedMore`. Never reads the audio payload (M4A uses
-/// the seek reader; front-anchored formats read only the metadata extent).
-/// Returns `Ok(None)` for an unsupported/unparseable file (to be skipped).
-///
-/// Metrics note: `on_scan_read` counts the front-anchored prefix/widen/tail
-/// reads only. The M4A seek reader does its own positioned reads internally, so
-/// its bytes are not reflected in `SCAN_BYTES_READ` (only `on_scan_open` fires
-/// for M4A); its win shows up in wall time and peak RSS instead.
 fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();
@@ -238,8 +229,14 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
         }));
     }
 
-    // Front-anchored formats: read a window, widen on NeedMore.
-    let tail = read_tail_128(&file, file_len)?;
+    // Front-anchored formats: read a window, widen on NeedMore. Only the MP3
+    // arm of probe_prefix consumes the ID3v1 tail, and dispatch is by
+    // extension — so only .mp3 pays the tail read (#67).
+    let tail = if has_ext(path, "mp3") {
+        read_tail_128(&file, file_len)?
+    } else {
+        None
+    };
     let mut want = (scan_window() as u64).min(file_len) as usize;
     let mut prefix = read_window(&file, want)?;
     for _ in 0..MAX_WIDEN_RETRIES {

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -493,13 +493,14 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     Ok(())
 }
 
-/// Like `ingest`, but writes through a batch `BulkWriter`.
+/// Like `ingest`, but writes through a batch `BulkWriter`. Takes `probed` by
+/// value so picture/binary-tag/structural-block bytes are moved, not cloned (#68).
 fn ingest_bulk(
     bw: &mut musefs_db::BulkWriter<'_>,
     abs_path: &str,
     meta_len: u64,
     meta_mtime: i64,
-    probed: &Probed,
+    probed: Probed,
 ) -> Result<()> {
     let track_id = bw.upsert_track(&NewTrack {
         backing_path: abs_path.to_string(),
@@ -521,12 +522,12 @@ fn ingest_bulk(
 
     let binary_tags: Vec<musefs_db::BinaryTag> = probed
         .binary_tags
-        .iter()
+        .into_iter()
         .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
         .enumerate()
         .map(|(ordinal, b)| musefs_db::BinaryTag {
-            key: b.key.clone(),
-            payload: b.payload.clone(),
+            key: b.key,
+            payload: b.payload,
             ordinal: ordinal as i64,
         })
         .collect();
@@ -535,13 +536,13 @@ fn ingest_bulk(
     let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
     let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
         .structural_blocks
-        .iter()
+        .into_iter()
         .map(|(kind, body)| {
             let ord = sb_ordinals.entry(kind.clone()).or_insert(0);
             let sb = musefs_db::StructuralBlock {
-                kind: kind.clone(),
+                kind,
                 ordinal: *ord,
-                body: body.clone(),
+                body,
             };
             *ord += 1;
             sb
@@ -552,14 +553,14 @@ fn ingest_bulk(
     let mut track_arts = Vec::new();
     let accepted = probed
         .pictures
-        .iter()
+        .into_iter()
         .filter(|p| p.data.len() <= MAX_ART_BYTES);
     for (ordinal, pic) in accepted.enumerate() {
         let art_id = bw.upsert_art(&NewArt {
-            mime: pic.mime.clone(),
+            mime: pic.mime,
             width: (pic.width != 0).then_some(pic.width as i64),
             height: (pic.height != 0).then_some(pic.height as i64),
-            data: pic.data.clone(),
+            data: pic.data,
         })?;
         let picture_type = if pic.picture_type <= 20 {
             pic.picture_type as i64
@@ -569,7 +570,7 @@ fn ingest_bulk(
         track_arts.push(TrackArt {
             art_id,
             picture_type,
-            description: pic.description.clone(),
+            description: pic.description,
             ordinal: ordinal as i64,
         });
     }
@@ -676,13 +677,24 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
             return Ok(());
         }
         let mut bw = db.bulk_writer()?;
-        for u in batch.iter() {
-            ingest_bulk(&mut bw, &u.abs_path, u.meta_len, u.meta_mtime, &u.probed)?;
+        // Budget weights are released only after commit, and ingest_bulk consumes
+        // the Probed — capture each unit's weight before the move (#68).
+        let mut weights = Vec::with_capacity(batch.len());
+        for Unit {
+            abs_path,
+            meta_len,
+            meta_mtime,
+            probed,
+            weight,
+        } in batch.drain(..)
+        {
+            weights.push(weight);
+            ingest_bulk(&mut bw, &abs_path, meta_len, meta_mtime, probed)?;
             *scanned += 1;
         }
         bw.commit()?;
-        for u in batch.drain(..) {
-            budget.release(u.weight);
+        for w in weights {
+            budget.release(w);
         }
         *batch_bytes = 0;
         Ok(())
@@ -1537,7 +1549,7 @@ mod hardening_tests {
         let db = Db::open_in_memory().unwrap();
         {
             let mut bw = db.bulk_writer().unwrap();
-            ingest_bulk(&mut bw, "/a.mp3", 1, 0, &probed_with_mixed_binary_tags()).unwrap();
+            ingest_bulk(&mut bw, "/a.mp3", 1, 0, probed_with_mixed_binary_tags()).unwrap();
             bw.commit().unwrap();
         }
         let tid = db.list_tracks().unwrap()[0].id;
@@ -1608,7 +1620,7 @@ mod hardening_tests {
                 "/a.flac",
                 1,
                 0,
-                &probed_with_duplicate_structural_kind(),
+                probed_with_duplicate_structural_kind(),
             )
             .unwrap();
             bw.commit().unwrap();

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -202,6 +202,15 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
     Ok(Some(buf))
 }
 
+/// Bounded probe of one backing file: open once, read a bounded window, dispatch
+/// per format, widening on `NeedMore`. Never reads the audio payload (M4A uses
+/// the seek reader; front-anchored formats read only the metadata extent).
+/// Returns `Ok(None)` for an unsupported/unparseable file (to be skipped).
+///
+/// Metrics note: `on_scan_read` counts the front-anchored prefix/widen/tail
+/// reads only. The M4A seek reader does its own positioned reads internally, so
+/// its bytes are not reflected in `SCAN_BYTES_READ` (only `on_scan_open` fires
+/// for M4A); its win shows up in wall time and peak RSS instead.
 fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -416,7 +416,9 @@ fn oggflac_raw_art_serve_increments_art_chunks() {
 /// one positioned read of exactly the file's length.
 #[test]
 fn scan_reads_no_id3v1_tail_for_flac() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let dir = tempfile::tempdir().unwrap();
     // Minimal valid FLAC padded to 300 bytes: marker + last STREAMINFO + audio.
     let mut b = b"fLaC".to_vec();
@@ -442,7 +444,9 @@ fn scan_reads_no_id3v1_tail_for_flac() {
 /// #67 inverse: MP3 keeps its tail read (prefix + 128-byte ID3v1 trailer).
 #[test]
 fn scan_still_reads_id3v1_tail_for_mp3() {
-    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     use common::corpus::{prepare_format, CorpusParams, Format as CFormat};
     let tmp = tempfile::tempdir().unwrap();
     let params = CorpusParams::single(CFormat::Mp3, 1, 1);

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -410,3 +410,68 @@ fn oggflac_raw_art_serve_increments_art_chunks() {
         "serving OggArtSlice (raw OggFLAC PICTURE) must increment art_chunks"
     );
 }
+
+/// #67: only .mp3 consumes the ID3v1 tail; non-MP3 formats must not pay the
+/// 128-byte tail read. A 300-byte FLAC (< the 1 MiB window) probes in exactly
+/// one positioned read of exactly the file's length.
+#[test]
+fn scan_reads_no_id3v1_tail_for_flac() {
+    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    // Minimal valid FLAC padded to 300 bytes: marker + last STREAMINFO + audio.
+    let mut b = b"fLaC".to_vec();
+    b.push(0x80); // last-block flag | STREAMINFO
+    b.extend_from_slice(&[0, 0, 34]);
+    b.extend(std::iter::repeat_n(0u8, 34));
+    b.extend(std::iter::repeat_n(0x55u8, 300 - b.len())); // audio payload
+    let path = dir.path().join("t.flac");
+    std::fs::write(&path, &b).unwrap();
+    let len = std::fs::metadata(&path).unwrap().len();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    metrics::reset();
+    scan_directory(&db, dir.path()).unwrap();
+    let s = metrics::snapshot();
+    assert_eq!(
+        s.scan_preads, 1,
+        "flac: one bounded prefix read, no tail read"
+    );
+    assert_eq!(s.scan_bytes_read, len, "no +128 ID3v1 tail for non-mp3");
+}
+
+/// #67 inverse: MP3 keeps its tail read (prefix + 128-byte ID3v1 trailer).
+#[test]
+fn scan_still_reads_id3v1_tail_for_mp3() {
+    let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    use common::corpus::{prepare_format, CorpusParams, Format as CFormat};
+    let tmp = tempfile::tempdir().unwrap();
+    let params = CorpusParams::single(CFormat::Mp3, 1, 1);
+    let target = prepare_format(&params, tmp.path(), params.format_mix[0]);
+    let mp3 = std::fs::read_dir(&target.corpus_dir)
+        .unwrap()
+        .flat_map(|e| {
+            let p = e.unwrap().path();
+            if p.is_dir() {
+                std::fs::read_dir(p)
+                    .unwrap()
+                    .map(|e| e.unwrap().path())
+                    .collect()
+            } else {
+                vec![p]
+            }
+        })
+        .find(|p| p.extension().is_some_and(|x| x == "mp3"))
+        .expect("generated mp3");
+    let len = std::fs::metadata(&mp3).unwrap().len();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    metrics::reset();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let s = metrics::snapshot();
+    // Corpus tracks are far below the default 1 MiB scan window (this test must
+    // not set MUSEFS_SCAN_WINDOW): one prefix read + the tail. read_tail_128
+    // always reads 128 bytes when file_len >= 128, trailer present or not, so
+    // the +128 assertion is robust.
+    assert_eq!(s.scan_preads, 2, "mp3: prefix read + ID3v1 tail read");
+    assert_eq!(s.scan_bytes_read, len + 128, "mp3 keeps the 128-byte tail");
+}


### PR DESCRIPTION
Closes #67, closes #68.

#67: probe_file gates the eager ID3v1 tail read on the .mp3 extension —
the only consumer — saving one syscall + 128 B per non-MP3 file.
#68: the bulk-ingest writer drains its batch by value, moving picture/
binary-tag/structural-block bytes into the DB structs instead of cloning;
budget weights are captured before the move (release-after-commit order
preserved).

Bench: BENCHMARKS.md "Phase 6 PR 2" (per-format bench_ingest before/after).
Spec: docs/superpowers/specs/2026-06-03-phase6-perf-sps-design.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized scan performance for non-MP3 audio formats by eliminating unnecessary tail metadata reads
  * Improved bulk data ingestion efficiency by reducing memory copying during file scanning

* **Documentation**
  * Added benchmark documentation detailing scan optimization results and methodology
  * Updated roadmap marking performance enhancements as complete

* **Tests**
  * Added validation tests for MP3-specific versus non-MP3 scan behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->