### PR TITLE
Phase 6 PR 3: serve-path copy elimination (#70)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -121,37 +121,29 @@ exclude_re = [
     # eprintln on stderr. The fallback's build_with is itself directly tested; this
     # injection point exists only to drive that branch, with nothing observable to
     # assert in this config.
-    'musefs-core/src/facade\.rs:510:9: replace Musefs::force_apply_failure_for_test with \(\)',
+    'musefs-core/src/facade\.rs:738:9: replace Musefs::force_apply_failure_for_test with \(\)',
     # apply_changes path-stable guard `&self.path_of(ino) == new_path` -> false: a
     # `changed` id whose rendered path is unchanged would be treated as a move
     # (remove + re-insert at the same path) instead of a no-op. Re-interning the same
     # path yields the same inode and rebuild_subtree re-canonicalizes the parent, so
     # the resulting tree is identical — a pure short-circuit optimization.
-    'musefs-core/src/tree\.rs:354:30: replace match guard .* with false in VirtualTree::apply_changes',
-    # add-side dirty propagation `id < self.introducing_id(child)` -> `<=`: `<=` is a
-    # strict superset of `<`, so it can only mark MORE ancestor dirs dirty. Every
-    # dirty dir is rebuilt to the same canonical layout build_with would produce, so
-    # over-marking changes only the work done, not the tree.
-    'musefs-core/src/tree\.rs:389:45: replace < with <= in VirtualTree::apply_changes',
+    'musefs-core/src/tree\.rs:470:30: replace match guard .* with false in VirtualTree::apply_changes',
+    # (The add-side/remove-side dirty-propagation walks formerly inline in
+    # apply_changes now live in dirty_min_flip_ancestors; their equivalent and
+    # hang-class mutants are covered by the description-anchored
+    # dirty_min_flip_ancestors entries at the top of this list.)
     #
-    # Non-terminating mutants (reported as TIMEOUT, never a clean kill): each turns a
+    # Non-terminating mutant (reported as TIMEOUT, never a clean kill): turns a
     # bounded upward walk into an infinite loop, because the root is its own parent
-    # (root.parent == ROOT) and these guards are exactly what stops the walk at root.
-    # cargo-mutants can only ever flag them via the 22s auto-timeout; they cannot be
-    # "caught" by an assertion, so they are excluded rather than left to flake the
+    # (root.parent == ROOT) and this guard is exactly what stops the walk at root.
+    # cargo-mutants can only ever flag it via the 22s auto-timeout; it cannot be
+    # "caught" by an assertion, so it is excluded rather than left to flake the
     # gate on the timeout budget.
     #
-    # remove/move-side dirty propagation `child != ROOT && introducing_id(child) == id`
-    # -> `||`: the `||` keeps looping once child reaches ROOT whenever ROOT's global
-    # min id equals `id`, and child stays ROOT forever.
-    'musefs-core/src/tree\.rs:376:43: replace && with \|\| in VirtualTree::apply_changes',
-    # add-side dirty propagation `child != ROOT && id < introducing_id(child)` -> `||`:
-    # same non-terminating root walk as above.
-    'musefs-core/src/tree\.rs:389:39: replace && with \|\| in VirtualTree::apply_changes',
     # ancestor_in's loop terminator `cur == Self::ROOT` -> `!=`: the walk never breaks
     # at root (root.parent == root), so a node with no ancestor in the set loops
     # forever instead of returning false.
-    'musefs-core/src/tree\.rs:455:20: replace == with != in VirtualTree::ancestor_in',
+    'musefs-core/src/tree\.rs:596:20: replace == with != in VirtualTree::ancestor_in',
 
     # SP4 storage-aware serving — equivalent mutant in serve_ogg_window's last-page
     # memo. `total_len = header_len + payload_len` only sets the memoized page's

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -460,14 +460,15 @@ MUSEFS_BENCH_TIER=ci \
 Four stacked serve-path optimizations, none touching synthesis or layout (served
 audio stays byte-identical by construction):
 
-1. **DB chunk readers write directly into caller buffers** (`read_exact_at`
+1. **DB chunk readers write directly into caller buffers** (`read_at_exact`
    fills the caller's `&mut [u8]` slice instead of allocating a throwaway
    `Vec<u8>` + `extend_from_slice`).
-2. **`read_segments` fills the caller's buffer** — each `BackingAudio` run
-   writes directly into the output `Vec`'s pre-reserved tail instead of a
-   temporary alloc + memcpy per splice.
+2. **`read_segments` fills the caller's buffer** — the `ArtImage`,
+   `BinaryTag`, and raw `OggArtSlice` arms write into the output `Vec`'s
+   resized tail instead of a temporary alloc + memcpy per chunk
+   (`BackingAudio`/`OggAudio`/`Inline` already wrote into `out`).
 3. **`Musefs::read_into` serves into a caller buffer** — the FUSE layer passes
-   a `&mut [u8]` destination and the core fills it in place, avoiding an
+   a `&mut Vec<u8>` destination and the core fills it in place, avoiding an
    intermediate `Vec` allocation for the entire read.
 4. **FUSE per-worker thread-local scratch buffer** — each worker reuses a
    single `Vec<u8>` across reads instead of allocating a fresh one per `read()`

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -450,3 +450,89 @@ MUSEFS_BENCH_TIER=ci \
   cargo test -p musefs-core --release --features metrics --test bench_ingest \
   -- --ignored --nocapture bench_cold_scan_and_revalidate
 ```
+
+---
+
+## Phase 6 PR 3 — Serve-path copies (#70)
+
+*Measured 2026-06-04 (same box, lightly loaded · tempfs · Criterion `ci` tier).*
+
+Four stacked serve-path optimizations, none touching synthesis or layout (served
+audio stays byte-identical by construction):
+
+1. **DB chunk readers write directly into caller buffers** (`read_exact_at`
+   fills the caller's `&mut [u8]` slice instead of allocating a throwaway
+   `Vec<u8>` + `extend_from_slice`).
+2. **`read_segments` fills the caller's buffer** — each `BackingAudio` run
+   writes directly into the output `Vec`'s pre-reserved tail instead of a
+   temporary alloc + memcpy per splice.
+3. **`Musefs::read_into` serves into a caller buffer** — the FUSE layer passes
+   a `&mut [u8]` destination and the core fills it in place, avoiding an
+   intermediate `Vec` allocation for the entire read.
+4. **FUSE per-worker thread-local scratch buffer** — each worker reuses a
+   single `Vec<u8>` across reads instead of allocating a fresh one per `read()`
+   syscall.
+
+Note: fuser 0.17 already sends a borrowed iovec (`read` receives `&mut [u8]`);
+the win here is chunk direct-write + allocation elimination, not a fuser-layer
+copy.
+
+- **Before** = `main` @ `2d4faf3` (pre-#70): throwaway allocs per splice, fresh
+  `Vec` per FUSE read.
+- **After** = `phase6-pr3-serve-copies` @ `32be8f0`: direct-write into caller
+  buffers, thread-local scratch.
+
+### `sequential_read` — per-format median (the >10%-rise regression gate)
+
+`ci` tier, 4 MiB single-track files, 128 KiB reads, `fh=0` (no-handle path →
+each read resolves via the header cache). The regression gate is a **>10% rise**
+run-over-run.
+
+| format    | before (µs) | after (µs) | Δ        | note |
+|-----------|------------:|-----------:|---------:|------|
+| flac      | 940         | 837        | −10.9%   | improved |
+| mp3       | 919         | 808        | −12.1%   | improved |
+| m4a       | 921         | 827        | −10.2%   | improved |
+| m4a-last  | 950         | 828        | −12.8%   | improved |
+| ogg       | 1123        | 969        | −13.7%   | improved |
+| wav       | 934         | 819        | −12.3%   | improved |
+
+No format breaches the >10% *rise* gate. All formats improve 10–14% from
+eliminating per-splice alloc+copy and per-read `Vec` allocation.
+
+### `concurrent_read_walk/m16_plus_walker` — contention signal
+
+16 reader threads streaming distinct files + one metadata walker, sharing one
+`Arc<Musefs>`. Burst-concurrency wall time (includes thread spawn/join):
+
+| | before (ms) | after (ms) | Δ |
+|---|---:|---:|---:|
+| m16_plus_walker | 7.92 | 8.32 | +5.0% (p=0.17, no change detected) |
+
+Within noise; the thread-local scratch buffer is per-worker, so contention on
+the shared state is unchanged.
+
+### Ogg representative benches (SP4 regression gate)
+
+`cold_first_read` and `seek_read` (fresh mount per iteration):
+
+| workload | before | after | Δ |
+|----------|-------:|------:|--:|
+| `cold_first_read/ogg` | 1.857 ms | 1.719 ms | −7.4% |
+| `seek_read/ogg` | 783 µs | 776 µs | −0.9% |
+
+Both held or improved.
+
+### Gates
+
+- Byte-identical: `proptest_read_fidelity` (17) + `musefs-format --features
+  fuzzing` (317) green.
+
+```bash
+# Both benches (Criterion records its own before/after baseline):
+cargo bench -p musefs-core --bench read_throughput
+
+# Byte-identical gates:
+cargo test -p musefs-core --test proptest_read_fidelity
+cargo test -p musefs-format --features fuzzing
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,12 @@ cargo test -p musefs-fuse -- --ignored   # FUSE end-to-end; needs /dev/fuse + li
 cargo clippy --all-targets               # lint
 cargo fmt                                # format
 
+# In-diff mutation gate (CI parity). Always -j2, output on /tmp, and do NOT
+# set TMPDIR (the default is correct). Sanity-check mutants.diff is non-empty
+# first — an empty diff mutates nothing and exits 0, a silent false pass.
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+
 # Property tests (proptest): byte-identical invariant + tag round-trip. The
 # format-layer proptests need the `fuzzing` feature; `cargo test --workspace`
 # also runs them via feature unification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,8 @@ cargo fmt                                # format
 # set TMPDIR (the default is correct). Sanity-check mutants.diff is non-empty
 # first — an empty diff mutates nothing and exits 0, a silent false pass.
 git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
 cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
-
 # Property tests (proptest): byte-identical invariant + tag round-trip. The
 # format-layer proptests need the `fuzzing` feature; `cargo test --workspace`
 # also runs them via feature unification.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -199,7 +199,12 @@ parallel. Most of the Rust items came out of the v1 multi-model review triage.
 - ~~#68 — `ingest_bulk` copies each picture's bytes (scan perf)~~ — done:
   the writer drains the owned `Unit` batch by value (move, not clone).
   Wall-time win on art-bearing corpora. See BENCHMARKS.md "Phase 6 PR 2".
-- #70 — zero-copy serve path (deferred SP3 residual; largest scope).
+- ~~#70 — zero-copy serve path (deferred SP3 residual; largest scope)~~ — done:
+  DB chunk readers write directly into caller buffers; `read_segments` fills
+  the caller's buffer instead of allocating; `Musefs::read_into` serves into
+  a caller buffer; FUSE per-worker thread-local scratch buffer eliminates
+  per-read `Vec` allocation. 10–14% `sequential_read` improvement across all
+  formats. See BENCHMARKS.md "Phase 6 PR 3".
 
 **Phase 7 — Docs**
 - #64 — README/architecture rework. Last, so it documents settled behavior (and is

--- a/docs/superpowers/plans/2026-06-03-phase6-pr3-serve-copies.md
+++ b/docs/superpowers/plans/2026-06-03-phase6-pr3-serve-copies.md
@@ -26,8 +26,8 @@ git checkout main && git pull && git checkout -b phase6-pr3-serve-copies
 ### Task 2: DB chunk readers — `*_into` variants
 
 **Files:**
-- Modify: `musefs-db/src/art.rs` (`read_art_chunk`, art.rs:69)
-- Modify: `musefs-db/src/tags.rs` (`read_binary_tag_chunk`, tags.rs:140)
+- Modify: `musefs-db/src/art.rs` (`read_art_chunk`, art.rs:75)
+- Modify: `musefs-db/src/tags.rs` (`read_binary_tag_chunk`, tags.rs:146)
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -122,7 +122,7 @@ git commit -m "feat(db): chunk readers write into caller buffers (#70)"
 ### Task 3: Thread the output buffer through the reader
 
 **Files:**
-- Modify: `musefs-core/src/reader.rs` (`read_at` :406, `read_segments` :427, `read_at_with_file` :531)
+- Modify: `musefs-core/src/reader.rs` (`read_at` :422, `read_segments` :443, `read_at_with_file` :546)
 
 The behavior gate is the existing suite: `tests/read_at.rs`, `tests/reader.rs`, `proptest_read_fidelity`, and the `--features metrics` serve-site counter tests — all must pass unchanged (counters fire identically; only buffer destinations change).
 
@@ -266,7 +266,7 @@ git commit -m "perf(core): read_segments fills the caller's buffer; chunk arms d
 ### Task 4: `Musefs::read_into`
 
 **Files:**
-- Modify: `musefs-core/src/facade.rs` (`read`, facade.rs:725)
+- Modify: `musefs-core/src/facade.rs` (`read`, facade.rs:874)
 
 - [ ] **Step 1: Convert `read` to `read_into` + wrapper**
 
@@ -334,7 +334,7 @@ git commit -m "feat(core): Musefs::read_into serves into a caller buffer (#70)"
 ### Task 5: FUSE per-worker scratch buffer
 
 **Files:**
-- Modify: `musefs-fuse/src/lib.rs` (`impl Filesystem for MusefsFs/read`, lib.rs:277)
+- Modify: `musefs-fuse/src/lib.rs` (`impl Filesystem for MusefsFs/read`, lib.rs:278)
 
 - [ ] **Step 1: Implement the thread-local buffer**
 
@@ -454,13 +454,26 @@ Expected: all clean.
 cd /home/cfutro/git/musefs
 git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
 grep -c '^diff --git ' mutants.diff && grep -c '^@@ ' mutants.diff   # sanity: non-empty
-TMPDIR=/home/cfutro/.cache/mutants-tmp cargo mutants --in-diff mutants.diff -j4 \
+TMPDIR=/home/cfutro/.cache/mutants-tmp cargo mutants --in-diff mutants.diff -j$(nproc) \
   --exclude 'musefs-latencyfs/**' --output mutants-out/in-diff
 cat mutants-out/in-diff/mutants.out/missed.txt
 rm -rf /home/cfutro/.cache/mutants-tmp mutants-out mutants.diff
 ```
 
-Expected: 0 missed (kill survivors with targeted tests, commit, regenerate the diff, re-run).
+Expected: 0 missed AND 0 timeouts — CI's gate fails on either (kill survivors
+with targeted tests, commit, regenerate the diff, re-run; a proven-equivalent
+or hang-class survivor gets a justified mutants.toml exclusion per the
+SP3/PR 1 precedent). The gate runs the **mutated crate's own** test suite:
+musefs-db mutants (Task 2) need musefs-db tests to kill them — the Task 2
+unit tests are in `musefs-db/tests/`, which satisfies this.
+
+mutants.toml anchor note: the stale SP2 anchors (facade.rs
+force_apply_failure_for_test, tree.rs match guard / ancestor_in) were
+re-derived when this branch was opened. This PR's edits all land *below* the
+anchored facade.rs sites (≤738) and touch no other anchored file at an
+anchored line, so no further re-anchoring should be needed — but if any task
+inserts lines above an anchored site, re-derive per the PR 2 procedure
+(`cargo mutants --list -f <file>` and match by description).
 
 - [ ] **Step 3: Fuzz-target build check**
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -8,7 +8,7 @@ use musefs_db::{Db, Format};
 use crate::db_pool::DbPool;
 use crate::error::{CoreError, Result};
 use crate::mapping::tags_to_fields;
-use crate::reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
+use crate::reader::{read_at_into, read_at_with_file_into, HeaderCache, ResolvedFile};
 use crate::refresh_diff::{partition_changelog, ChangeSet, TrackRenderState};
 use crate::template::render_path;
 use crate::tree::{InodeAllocator, NodeKind, VirtualTree};
@@ -871,7 +871,17 @@ impl Musefs {
             .collect())
     }
 
-    pub fn read(&self, inode: u64, fh: u64, offset: u64, size: u64) -> Result<Vec<u8>> {
+    /// Serve a read into `out` (cleared first). The FUSE layer passes a reused
+    /// per-worker buffer so the hot path allocates nothing per read (#70).
+    pub fn read_into(
+        &self,
+        inode: u64,
+        fh: u64,
+        offset: u64,
+        size: u64,
+        out: &mut Vec<u8>,
+    ) -> Result<()> {
+        out.clear();
         // Fast path: serve from the per-handle fd + cached layout (no open/stat).
         if fh != 0 {
             let handle = self.handles.get((fh - 1) as usize).map(|g| Arc::clone(&g));
@@ -879,6 +889,7 @@ impl Musefs {
                 // Bounded retry absorbs a refresh landing mid-read; out-of-band
                 // re-tags are human/batch-paced, so >1 attempt is already rare.
                 for _attempt in 0..4 {
+                    out.clear();
                     let cur = self.refresh_gen.load(Ordering::Acquire);
                     if h.gen.load(Ordering::Acquire) != cur {
                         // A refresh changed something; re-resolve (cheap content_version
@@ -894,7 +905,7 @@ impl Musefs {
                     }
                     let resolved = h.resolved.load();
                     let r: &ResolvedFile = &resolved;
-                    let served = self.pool.with(|db| -> Result<Option<Vec<u8>>> {
+                    let served = self.pool.with(|db| -> Result<Option<()>> {
                         if r.has_binary_tag {
                             // Snapshot-consistent: version check + blob reads see one
                             // WAL snapshot, so a reused rowid can't be served.
@@ -903,16 +914,18 @@ impl Musefs {
                                 if db.track_content_version(h.track_id)? != r.content_version {
                                     return Ok(None); // stale layout — retry after re-resolve
                                 }
-                                Ok(Some(read_at_with_file(r, db, &h.file, offset, size)?))
+                                read_at_with_file_into(r, db, &h.file, offset, size, out)?;
+                                Ok(Some(()))
                             })();
                             let _ = db.end_read(); // always release the snapshot
                             res
                         } else {
-                            Ok(Some(read_at_with_file(r, db, &h.file, offset, size)?))
+                            read_at_with_file_into(r, db, &h.file, offset, size, out)?;
+                            Ok(Some(()))
                         }
                     })?;
-                    if let Some(bytes) = served {
-                        return Ok(bytes);
+                    if served.is_some() {
+                        return Ok(());
                     }
                     // Stale layout: force a re-resolve next iteration against the live version.
                     let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
@@ -940,8 +953,15 @@ impl Musefs {
         };
         self.pool.with(|db| {
             let resolved = self.cache.resolve(db, track_id)?;
-            read_at(&resolved, db, offset, size)
+            read_at_into(&resolved, db, offset, size, out)
         })
+    }
+
+    /// Allocating form of `read_into`.
+    pub fn read(&self, inode: u64, fh: u64, offset: u64, size: u64) -> Result<Vec<u8>> {
+        let mut out = Vec::new();
+        self.read_into(inode, fh, offset, size, &mut out)?;
+        Ok(out)
     }
 
     /// Open a file handle: resolve + validate the layout and open the backing fd

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -416,12 +416,17 @@ impl HeaderCache {
     }
 }
 
-/// Read `size` bytes starting at virtual `offset` from a resolved file, opening
-/// the backing file once for this call (only if the layout has a backing/ogg
-/// segment). Prefer `read_at_with_file` when a backing fd is already held.
-pub fn read_at(resolved: &ResolvedFile, db: &Db, offset: u64, size: u64) -> Result<Vec<u8>> {
+/// Read `size` bytes at virtual `offset` into `out` (appended), opening the
+/// backing file once for this call if the layout needs it.
+pub fn read_at_into(
+    resolved: &ResolvedFile,
+    db: &Db,
+    offset: u64,
+    size: u64,
+    out: &mut Vec<u8>,
+) -> Result<()> {
     if offset >= resolved.total_len || size == 0 {
-        return Ok(Vec::new());
+        return Ok(());
     }
     let needs_file = resolved
         .layout
@@ -431,29 +436,37 @@ pub fn read_at(resolved: &ResolvedFile, db: &Db, offset: u64, size: u64) -> Resu
     if needs_file {
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
-        read_segments(resolved, db, Some(&file), offset, size)
+        read_segments_into(resolved, db, Some(&file), offset, size, out)
     } else {
-        read_segments(resolved, db, None, offset, size)
+        read_segments_into(resolved, db, None, offset, size, out)
     }
+}
+
+/// Allocating form of `read_at_into` (tests and non-hot-path callers).
+pub fn read_at(resolved: &ResolvedFile, db: &Db, offset: u64, size: u64) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    read_at_into(resolved, db, offset, size, &mut out)?;
+    Ok(out)
 }
 
 /// The single segment-splicing loop. `file` is `Some` whenever the layout has a
 /// `BackingAudio`/`OggAudio` segment (guaranteed by `read_at`/`read_at_with_file`);
 /// the backing arms treat `None` as a contract violation.
-fn read_segments(
+fn read_segments_into(
     resolved: &ResolvedFile,
     db: &Db,
     file: Option<&std::fs::File>,
     offset: u64,
     size: u64,
-) -> Result<Vec<u8>> {
+    out: &mut Vec<u8>,
+) -> Result<()> {
     use std::os::unix::fs::FileExt;
 
     if offset >= resolved.total_len || size == 0 {
-        return Ok(Vec::new());
+        return Ok(());
     }
     let end = offset.saturating_add(size).min(resolved.total_len);
-    let mut out = Vec::with_capacity((end - offset) as usize);
+    out.reserve((end - offset) as usize);
 
     let mut seg_start = 0u64;
     for seg in &resolved.layout.segments {
@@ -482,14 +495,16 @@ fn read_segments(
                     crate::metrics::on_pread(n as u64);
                 }
                 Segment::ArtImage { art_id, .. } => {
-                    let chunk = db.read_art_chunk(*art_id, within, n)?;
+                    let start = out.len();
+                    out.resize(start + n, 0);
+                    db.read_art_chunk_into(*art_id, within, &mut out[start..])?;
                     crate::metrics::on_art_chunk();
-                    out.extend_from_slice(&chunk);
                 }
                 Segment::BinaryTag { payload_id, .. } => {
-                    let chunk = db.read_binary_tag_chunk(*payload_id, within, n)?;
+                    let start = out.len();
+                    out.resize(start + n, 0);
+                    db.read_binary_tag_chunk_into(*payload_id, within, &mut out[start..])?;
                     crate::metrics::on_binary_tag_chunk();
-                    out.extend_from_slice(&chunk);
                 }
                 Segment::OggAudio {
                     offset: ao,
@@ -504,7 +519,7 @@ fn read_segments(
                         *seq_delta,
                         within,
                         within + n as u64,
-                        &mut out,
+                        &mut *out,
                         Some(&resolved.last_page),
                     )?;
                 }
@@ -526,9 +541,10 @@ fn read_segments(
                         ));
                     } else {
                         // Raw image bytes (OggFLAC PICTURE block).
-                        let chunk = db.read_art_chunk(*art_id, *offset + within, n)?;
+                        let start = out.len();
+                        out.resize(start + n, 0);
+                        db.read_art_chunk_into(*art_id, *offset + within, &mut out[start..])?;
                         crate::metrics::on_art_chunk();
-                        out.extend_from_slice(&chunk);
                     }
                 }
             }
@@ -538,11 +554,22 @@ fn read_segments(
             break;
         }
     }
-    Ok(out)
+    Ok(())
 }
 
-/// Serve a byte range from a resolved file using an already-open backing `file`
-/// (the per-handle read path — no open syscall here).
+/// Serve into `out` from an already-open backing `file` (per-handle path).
+pub fn read_at_with_file_into(
+    resolved: &ResolvedFile,
+    db: &Db,
+    file: &std::fs::File,
+    offset: u64,
+    size: u64,
+    out: &mut Vec<u8>,
+) -> Result<()> {
+    read_segments_into(resolved, db, Some(file), offset, size, out)
+}
+
+/// Allocating form of `read_at_with_file_into`.
 pub fn read_at_with_file(
     resolved: &ResolvedFile,
     db: &Db,
@@ -550,7 +577,9 @@ pub fn read_at_with_file(
     offset: u64,
     size: u64,
 ) -> Result<Vec<u8>> {
-    read_segments(resolved, db, Some(file), offset, size)
+    let mut out = Vec::new();
+    read_at_with_file_into(resolved, db, file, offset, size, &mut out)?;
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -1190,9 +1219,9 @@ mod cache_bound_tests {
     fn read_segments_returns_empty_past_end_of_range() {
         let db = musefs_db::Db::open_in_memory().unwrap();
         let resolved = entry(0, 10);
-        let out = read_segments(&resolved, &db, None, 11, 1).unwrap();
+        let out = read_at(&resolved, &db, 11, 1).unwrap();
         assert!(out.is_empty());
-        let out0 = read_segments(&resolved, &db, None, 0, 0).unwrap();
+        let out0 = read_at(&resolved, &db, 0, 0).unwrap();
         assert!(out0.is_empty());
     }
 

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::write_flac;
-use musefs_core::{read_at, HeaderCache, Mode};
+use musefs_core::{read_at, read_at_with_file, HeaderCache, Mode};
 use musefs_db::{Db, Format, NewTrack, Tag};
 
 fn setup() -> (tempfile::TempDir, Db, i64) {
@@ -128,4 +128,53 @@ fn read_at_streams_art_image_segments() {
 
     // A window that lands entirely inside the art segment (offset 4 -> art[2..5]).
     assert_eq!(read_at(&resolved, &db, 4, 3).unwrap(), vec![3, 4, 5]);
+}
+
+#[test]
+fn out_of_range_read_short_circuits_before_opening_the_backing_file() {
+    let (_dir, db, id) = setup();
+    let cache = HeaderCache::new(Mode::Synthesis);
+    let resolved = cache.resolve(&db, id).unwrap();
+    // Past-EOF and zero-size reads must return empty without ever opening the
+    // backing file; deleting it makes any open attempt an error.
+    std::fs::remove_file(&resolved.backing_path).unwrap();
+
+    assert!(read_at(&resolved, &db, resolved.total_len, 100)
+        .unwrap()
+        .is_empty());
+    assert!(read_at(&resolved, &db, 10, 0).unwrap().is_empty());
+}
+
+#[test]
+fn read_at_with_file_out_of_range_and_zero_size_return_empty() {
+    let (_dir, db, id) = setup();
+    let cache = HeaderCache::new(Mode::Synthesis);
+    let resolved = cache.resolve(&db, id).unwrap();
+    let file = std::fs::File::open(&resolved.backing_path).unwrap();
+
+    // The per-handle path has no outer guard: read_segments_into itself must
+    // bail on offset > total_len (its window arithmetic would underflow).
+    for (off, size) in [
+        (resolved.total_len + 5, 100u64),
+        (resolved.total_len, 1),
+        (10, 0),
+    ] {
+        assert!(read_at_with_file(&resolved, &db, &file, off, size)
+            .unwrap()
+            .is_empty());
+    }
+}
+
+#[test]
+fn read_at_reserves_only_the_served_window() {
+    let (_dir, db, id) = setup();
+    let cache = HeaderCache::new(Mode::Synthesis);
+    let resolved = cache.resolve(&db, id).unwrap();
+
+    // A short tail read must reserve ~window-size capacity, not anything
+    // scaled by the offset: FUSE workers retain this buffer across reads, so
+    // an over-reserve would inflate every worker's resident memory.
+    let got = read_at(&resolved, &db, resolved.total_len - 7, 50).unwrap();
+    assert_eq!(got.len(), 7);
+    assert!(got.capacity() < resolved.total_len as usize);
 }

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -67,15 +67,20 @@ impl Db {
         }
     }
 
-    /// Stream `len` bytes of an art blob starting at `offset` via SQLite
-    /// incremental blob I/O, so image bytes are never fully materialized. The
-    /// caller derives `offset`/`len` from the stored `byte_len`, so a short read
-    /// means the row no longer matches the layout — `read_at_exact` surfaces that
-    /// as an error rather than silently zero-filling.
-    pub fn read_art_chunk(&self, art_id: i64, offset: u64, len: usize) -> Result<Vec<u8>> {
+    /// Stream art-blob bytes at `offset` directly into `buf` via SQLite incremental
+    /// blob I/O — no intermediate allocation (#70). A short read means the row no
+    /// longer matches the layout; `read_at_exact` surfaces that as an error rather
+    /// than silently zero-filling.
+    pub fn read_art_chunk_into(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()> {
         let blob = self.conn.blob_open("main", "art", "data", art_id, true)?;
+        blob.read_at_exact(buf, offset as usize)?;
+        Ok(())
+    }
+
+    /// Allocating convenience form of `read_art_chunk_into` (non-hot-path callers).
+    pub fn read_art_chunk(&self, art_id: i64, offset: u64, len: usize) -> Result<Vec<u8>> {
         let mut buf = vec![0u8; len];
-        blob.read_at_exact(&mut buf, offset as usize)?;
+        self.read_art_chunk_into(art_id, offset, &mut buf)?;
         Ok(buf)
     }
 

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -138,22 +138,34 @@ impl Db {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
-    /// Stream `len` bytes of a binary tag payload at `offset` via incremental blob
-    /// I/O — payloads are never fully materialized. A short read means the row
-    /// changed underneath the resolved layout; `read_at_exact` surfaces it as an
-    /// error rather than zero-filling. (`payload_id` is the `tags` rowid; see the
-    /// spec's "payload_id validity invariant".)
+    /// Stream binary-tag bytes at `offset` directly into `buf` via incremental blob
+    /// I/O — no intermediate allocation (#70). A short read means the row changed
+    /// underneath the resolved layout; `read_at_exact` surfaces it as an error rather
+    /// than zero-filling. (`payload_id` is the `tags` rowid; see the spec's
+    /// "payload_id validity invariant".)
+    pub fn read_binary_tag_chunk_into(
+        &self,
+        payload_id: i64,
+        offset: u64,
+        buf: &mut [u8],
+    ) -> Result<()> {
+        let blob = self
+            .conn
+            .blob_open("main", "tags", "value_blob", payload_id, true)?;
+        blob.read_at_exact(buf, offset as usize)?;
+        Ok(())
+    }
+
+    /// Allocating convenience form of `read_binary_tag_chunk_into` (non-hot-path
+    /// callers).
     pub fn read_binary_tag_chunk(
         &self,
         payload_id: i64,
         offset: u64,
         len: usize,
     ) -> Result<Vec<u8>> {
-        let blob = self
-            .conn
-            .blob_open("main", "tags", "value_blob", payload_id, true)?;
         let mut buf = vec![0u8; len];
-        blob.read_at_exact(&mut buf, offset as usize)?;
+        self.read_binary_tag_chunk_into(payload_id, offset, &mut buf)?;
         Ok(buf)
     }
 }

--- a/musefs-db/tests/art.rs
+++ b/musefs-db/tests/art.rs
@@ -213,3 +213,19 @@ fn set_track_art_replaces_links() {
     db.set_track_art(t, &[]).unwrap();
     assert!(db.get_track_art(t).unwrap().is_empty());
 }
+
+#[test]
+fn read_art_chunk_into_matches_vec_variant_and_errors_on_short_read() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_art(&jpeg((0u8..64).collect())).unwrap();
+
+    let expected = db.read_art_chunk(id, 3, 5).unwrap();
+    let mut buf = vec![0u8; 5];
+    db.read_art_chunk_into(id, 3, &mut buf).unwrap();
+    assert_eq!(buf, expected);
+    assert_eq!(buf, vec![3, 4, 5, 6, 7]);
+
+    // Reading past the blob end must error, not zero-fill (read_at_exact contract).
+    let mut over = vec![0u8; 128];
+    assert!(db.read_art_chunk_into(id, 3, &mut over).is_err());
+}

--- a/musefs-db/tests/tags.rs
+++ b/musefs-db/tests/tags.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::new_track;
-use musefs_db::{Db, Tag};
+use musefs_db::{BinaryTag, Db, Tag};
 
 #[test]
 fn replace_then_get_returns_tags_ordered() {
@@ -95,4 +95,31 @@ fn tags_grouped_preserves_key_ordinal_order_for_multivalue() {
         ]),
         "multi-value group must be ordered by (key, ordinal), matching get_tags"
     );
+}
+
+#[test]
+fn read_binary_tag_chunk_into_matches_vec_variant_and_errors_on_short_read() {
+    let db = Db::open_in_memory().unwrap();
+    let track = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    db.set_binary_tags(
+        track,
+        &[BinaryTag {
+            key: "APIC".into(),
+            payload: (0u8..64).collect(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+    let payload_id = db.get_binary_tags(track).unwrap()[0].rowid;
+
+    let expected = db.read_binary_tag_chunk(payload_id, 3, 5).unwrap();
+    let mut buf = vec![0u8; 5];
+    db.read_binary_tag_chunk_into(payload_id, 3, &mut buf)
+        .unwrap();
+    assert_eq!(buf, expected);
+
+    let mut over = vec![0u8; 128];
+    assert!(db
+        .read_binary_tag_chunk_into(payload_id, 3, &mut over)
+        .is_err());
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -20,6 +20,15 @@ use musefs_core::Attr;
 use musefs_core::CoreError;
 use musefs_core::Musefs;
 
+/// Per-worker read scratch buffer: each threadpool worker reuses one Vec across
+/// reads (filled by `Musefs::read_into`, sent as fuser's borrowed iovec), so the
+/// hot path allocates nothing per read. Capacity is clamped after use so one
+/// giant read doesn't pin memory for the worker's lifetime.
+const MAX_RETAINED_READ_BUF: usize = 2 * 1024 * 1024;
+thread_local! {
+    static READ_BUF: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
 /// Fuse-layer mount knobs: kernel tuning + page-cache policy. Distinct from
 /// `musefs_core::MountConfig`, which governs how the virtual tree is rendered.
 #[derive(Debug, Clone)]
@@ -287,11 +296,18 @@ impl Filesystem for MusefsFs {
         reply: ReplyData,
     ) {
         let core = Arc::clone(&self.core);
-        self.pool
-            .execute(move || match core.read(ino.0, fh.0, offset, size as u64) {
-                Ok(bytes) => reply.data(&bytes),
-                Err(e) => reply.error(errno(&e)),
+        self.pool.execute(move || {
+            READ_BUF.with(|b| {
+                let mut buf = b.borrow_mut();
+                match core.read_into(ino.0, fh.0, offset, size as u64, &mut buf) {
+                    Ok(()) => reply.data(&buf),
+                    Err(e) => reply.error(errno(&e)),
+                }
+                if buf.capacity() > MAX_RETAINED_READ_BUF {
+                    buf.shrink_to(MAX_RETAINED_READ_BUF);
+                }
             });
+        });
     }
 
     fn readdir(


### PR DESCRIPTION
Closes #70.

Half A: art/binary-tag chunk reads land directly in the output buffer's
reserved tail via new Db::read_*_chunk_into (the base64 Ogg-art arm keeps
its input buffer — it's a transform). Half B: the output buffer threads
from a per-FUSE-worker thread_local scratch Vec down through
Musefs::read_into -> read_at_into -> read_segments_into, eliminating the
per-read allocation; capacity is clamped at 2 MiB after use.

Scope note: fuser 0.17's ReplyData::data already sends a borrowed iovec
(ResponseSlice -> with_iovec), so the issue's second claimed copy ("into
the kernel's FUSE reply buffer") does not exist at this fuser version; the
remaining kernel-boundary writev is not eliminable from userspace.

Bench: BENCHMARKS.md "Phase 6 PR 3" (sequential_read per format,
concurrent_read_walk, ogg cold/seek — all within the >10% gate).
Spec: docs/superpowers/specs/2026-06-03-phase6-perf-sps-design.md.

In-diff mutation gate: 39/39 caught (three initial survivors in the new
reader guards killed by targeted tests pinning the short-circuit,
per-handle out-of-range, and reserve-arithmetic contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a zero-allocation read API enabling reads into caller-provided buffers and reused thread-local read buffers.

* **Performance**
  * Zero-copy/zero-allocation serve-path completed; measured read latency and throughput improved.

* **Documentation**
  * Roadmap and benchmarks updated with serve-path details and new benchmark results and gate commands.

* **Tests**
  * Added and expanded tests for out-of-range, zero-length, and streaming read behaviors.

* **Chores**
  * Mutation-testing CI gate instructions and exclusions updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->