### PR TITLE
test(picard): skip Qt-fixture tests when pytest-qt is absent

### DIFF
--- a/contrib/picard/tests/test_callback_flow.py
+++ b/contrib/picard/tests/test_callback_flow.py
@@ -1,6 +1,7 @@
 import pytest
 
 pytest.importorskip("picard")
+pytest.importorskip("pytestqt")  # qapp fixture, via picard_config
 
 
 def test_callback_runs_sync_and_logs_summary(

--- a/contrib/picard/tests/test_options_page.py
+++ b/contrib/picard/tests/test_options_page.py
@@ -1,6 +1,7 @@
 import pytest
 
 pytest.importorskip("picard")
+pytest.importorskip("pytestqt")  # qtbot fixture
 
 
 def test_options_page_load_reflects_config(qtbot, picard_config):


### PR DESCRIPTION
Closes #102.

The three Qt-fixture tests (`test_options_page.py` ×2 via `qtbot`, `test_callback_flow.py` via `qapp` through `picard_config`) errored at setup with `fixture 'qtbot'/'qapp' not found` when pytest-qt isn't installed, instead of skipping like the rest of the real-Picard surface does via `importorskip("picard")`.

Adds a module-level `pytest.importorskip("pytestqt")` guard to both modules, mirroring the existing pattern.

Verified:
- Real-Picard env without pytest-qt (where the bug reproduced): 3 errors → 0, now `36 passed, 2 skipped` (module-level skips report once per module)
- Default venv route from CLAUDE.md: unchanged `29 passed, 6 skipped`; ruff check/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conditional guards to test execution to ensure test suite only runs when required dependencies are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->