### PR TITLE
DbPool: reentrant locks + documented Drop contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
  "musefs-latencyfs",
  "ogg",
  "once_cell",
+ "parking_lot",
  "proptest",
  "rusqlite",
  "sharded-slab",

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 musefs-db = { path = "../musefs-db", version = "0.2.0" }
 musefs-format = { path = "../musefs-format", version = "0.2.0" }
 once_cell = "1"
+parking_lot = "0.12"
 sharded-slab = "0.1"
 thiserror = "2"
 

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -14,7 +14,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::ReentrantMutex;
 
 use musefs_db::Db;
 
@@ -22,22 +24,28 @@ use crate::error::{CoreError, Result};
 
 static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
 
+/// `with` and `with_poll` may nest freely, on any variant: `PerThread` reads
+/// hand out thread-local `Rc` clones, and both mutexes are reentrant.
+///
+/// Lifetime contract (#127, accepted by design): `PerThread` read connections
+/// are owned by the threads that opened them and live until those threads
+/// exit. Dropping the pool clears only the dropping thread's connection, so a
+/// caller that creates and drops many pools on long-lived shared threads
+/// strands connections (one fd + SQLite cache each) until those threads exit.
+/// Fine for musefs — a mount's worker pool lives exactly as long as the mount;
+/// closing the gap would need a cross-thread registry, deliberately not built
+/// (`Rc<Db>` is `!Send`, so another thread's entry is unreachable anyway).
 pub enum DbPool {
     PerThread {
         id: u64,
         path: PathBuf,
-        poll: Mutex<Db>,
+        poll: ReentrantMutex<Db>,
     },
-    Shared(Arc<Mutex<Db>>),
+    Shared(Arc<ReentrantMutex<Db>>),
 }
 
-/// Clears only the *dropping thread's* thread-local connection for this pool.
-/// Connections this pool opened on other worker threads persist until those
-/// threads exit — accepted, because a mount's worker pool lives for the whole
-/// mount, so a connection's lifetime already matches its thread's. A future
-/// caller that creates and drops many pools over long-lived shared threads would
-/// leak; closing that would need a cross-thread registry, intentionally not built
-/// here.
+/// Clears only the *dropping thread's* thread-local connection for this pool —
+/// see the lifetime contract on [`DbPool`].
 impl Drop for DbPool {
     fn drop(&mut self) {
         if let DbPool::PerThread { id, path, .. } = self {
@@ -63,9 +71,9 @@ impl DbPool {
             Some(p) => Ok(DbPool::PerThread {
                 id: NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed),
                 path: p.to_path_buf(),
-                poll: Mutex::new(db),
+                poll: ReentrantMutex::new(db),
             }),
-            None => Ok(DbPool::Shared(Arc::new(Mutex::new(db)))),
+            None => Ok(DbPool::Shared(Arc::new(ReentrantMutex::new(db)))),
         }
     }
 
@@ -76,15 +84,10 @@ impl DbPool {
     /// before it opened. The poll connection is the original writer Db, kept alive
     /// precisely so it can observe incremental changes from other connections.
     /// For `Shared` pools (in-memory), the single shared connection serves both roles.
-    ///
-    /// Note: `std::sync::Mutex` is not reentrant — do not call `with_poll` from
-    /// inside a `with` closure on the `Shared` variant (it would deadlock).
     pub fn with_poll<R>(&self, f: impl FnOnce(&Db) -> Result<R>) -> Result<R> {
         match self {
-            DbPool::PerThread { poll, .. } => f(&poll
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)),
-            DbPool::Shared(m) => f(&m.lock().unwrap_or_else(std::sync::PoisonError::into_inner)),
+            DbPool::PerThread { poll, .. } => f(&poll.lock()),
+            DbPool::Shared(m) => f(&m.lock()),
         }
     }
 
@@ -108,7 +111,7 @@ impl DbPool {
                 f(&db)
             }),
             DbPool::Shared(m) => {
-                let db = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                let db = m.lock();
                 f(&db)
             }
         }
@@ -170,6 +173,8 @@ mod tests {
         assert!(r >= 0);
     }
 
+    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
+    // If these hang, the fix has regressed.
     #[test]
     fn reentrant_with_does_not_panic() {
         let dir = tempfile::tempdir().unwrap();
@@ -186,12 +191,57 @@ mod tests {
         let pool = DbPool::PerThread {
             id: u64::MAX,
             path: bad.clone(),
-            poll: Mutex::new(Db::open_in_memory().unwrap()),
+            poll: ReentrantMutex::new(Db::open_in_memory().unwrap()),
         };
         let msg = pool.with(|_db| Ok(())).unwrap_err().to_string();
         assert!(
             msg.contains("/nonexistent-musefs-dir/does-not-exist.db"),
             "open error must name the failing path, got: {msg}"
         );
+    }
+
+    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
+    // If these hang, the fix has regressed.
+    #[test]
+    fn nested_with_on_shared_pool() {
+        let pool = DbPool::new(Db::open_in_memory().unwrap()).unwrap();
+        let r: Result<i64> = pool.with(|_outer| pool.with(|db| Ok(db.data_version()?)));
+        assert!(r.is_ok(), "nested with on Shared must not deadlock");
+    }
+
+    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
+    // If these hang, the fix has regressed.
+    #[test]
+    fn with_poll_inside_with_on_shared_pool() {
+        let pool = DbPool::new(Db::open_in_memory().unwrap()).unwrap();
+        let r: Result<i64> = pool.with(|_outer| pool.with_poll(|db| Ok(db.data_version()?)));
+        assert!(
+            r.is_ok(),
+            "with_poll inside with on Shared must not deadlock"
+        );
+    }
+
+    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
+    // If these hang, the fix has regressed.
+    #[test]
+    fn nested_with_poll_on_per_thread_pool() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("np.db");
+        Db::open(&path).unwrap();
+        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
+        let r: Result<i64> = pool.with_poll(|_outer| pool.with_poll(|db| Ok(db.data_version()?)));
+        assert!(r.is_ok(), "nested with_poll on PerThread must not deadlock");
+    }
+
+    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
+    // If these hang, the fix has regressed.
+    #[test]
+    fn nested_with_on_per_thread_pool() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("np.db");
+        Db::open(&path).unwrap();
+        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
+        let r: Result<i64> = pool.with(|_outer| pool.with(|db| Ok(db.data_version()?)));
+        assert!(r.is_ok(), "nested with on PerThread must not deadlock");
     }
 }

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -173,8 +173,6 @@ mod tests {
         assert!(r >= 0);
     }
 
-    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
-    // If these hang, the fix has regressed.
     #[test]
     fn reentrant_with_does_not_panic() {
         let dir = tempfile::tempdir().unwrap();
@@ -200,8 +198,6 @@ mod tests {
         );
     }
 
-    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
-    // If these hang, the fix has regressed.
     #[test]
     fn nested_with_on_shared_pool() {
         let pool = DbPool::new(Db::open_in_memory().unwrap()).unwrap();
@@ -209,8 +205,6 @@ mod tests {
         assert!(r.is_ok(), "nested with on Shared must not deadlock");
     }
 
-    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
-    // If these hang, the fix has regressed.
     #[test]
     fn with_poll_inside_with_on_shared_pool() {
         let pool = DbPool::new(Db::open_in_memory().unwrap()).unwrap();
@@ -221,8 +215,6 @@ mod tests {
         );
     }
 
-    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
-    // If these hang, the fix has regressed.
     #[test]
     fn nested_with_poll_on_per_thread_pool() {
         let dir = tempfile::tempdir().unwrap();
@@ -231,17 +223,5 @@ mod tests {
         let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
         let r: Result<i64> = pool.with_poll(|_outer| pool.with_poll(|db| Ok(db.data_version()?)));
         assert!(r.is_ok(), "nested with_poll on PerThread must not deadlock");
-    }
-
-    // These test the deadlock scenario; they pass after the ReentrantMutex migration (Task 7).
-    // If these hang, the fix has regressed.
-    #[test]
-    fn nested_with_on_per_thread_pool() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("np.db");
-        Db::open(&path).unwrap();
-        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
-        let r: Result<i64> = pool.with(|_outer| pool.with(|db| Ok(db.data_version()?)));
-        assert!(r.is_ok(), "nested with on PerThread must not deadlock");
     }
 }


### PR DESCRIPTION
Closes #127.

Two residuals after #94:

- **Nested-call deadlock (fixed):** `with`/`with_poll` on the `Shared` variant
  (and `with_poll` nesting on `PerThread`) deadlocked on a non-reentrant
  `std::sync::Mutex`, while nested `with` already worked on `PerThread` — a
  test-vs-prod asymmetry. Both mutexes are now `parking_lot::ReentrantMutex`
  (already compiled via fuser), so nesting is legal on every variant; the
  poison-recovery dance at these two sites goes away with it.
- **Drop leaving other threads' connections (accepted by design, now
  documented):** cross-thread cleanup is unreachable (`Rc<Db>` is `!Send`) and
  only matters for an embedder that drops many pools on long-lived shared
  threads, which doesn't exist; the lifetime contract is now spelled out on
  the `DbPool` type instead of an internal comment.

Verification: workspace tests (682 passed), clippy, fmt, and the in-diff
mutation gate (2 mutants, both unviable — generic returns can't be defaulted;
0 missed).

Spec: docs/superpowers/specs/2026-06-04-inode-prune-dbpool-residuals-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling to prevent potential deadlocks when nested database operations are executed, enhancing application reliability and stability.

* **Tests**
  * Added comprehensive tests validating that nested database operations execute safely without causing application hangs across different connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->