### PR TITLE
Log serve-path failures instead of collapsing silently to errno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +720,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +859,7 @@ name = "musefs"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "env_logger",
  "musefs-cli",
 ]
 
@@ -1088,6 +1136,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -86,6 +86,21 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
     }
 }
 
+/// Log a serve-path failure before it collapses to an errno reply, so the
+/// cause (e.g. the offending path in `BackingChanged`, or an `Io` error with
+/// no raw OS errno) is not lost. Routine tree-shape misses — a stale inode
+/// after a refresh, kernel path probing — stay at debug to avoid noise.
+fn reply_errno(op: &str, ino: u64, err: &CoreError) -> fuser::Errno {
+    match err {
+        CoreError::NoEntry(_)
+        | CoreError::TrackNotFound(_)
+        | CoreError::IsDir(_)
+        | CoreError::NotADir(_) => log::debug!("{op}({ino}) failed: {err}"),
+        _ => log::warn!("{op}({ino}) failed: {err}"),
+    }
+    errno(err)
+}
+
 /// Translate a core `Attr` into a `fuser::FileAttr`. Read-only perms (`0o555`
 /// dirs, `0o444` files). A zero `mtime_secs` (e.g. synthetic directories) falls
 /// back to `fallback_mtime` so tools don't see a 1970 timestamp.
@@ -246,7 +261,7 @@ impl Filesystem for MusefsFs {
         let (uid, gid, mt, ttl) = (self.uid, self.gid, self.mount_time, self.config.ttl);
         self.pool.execute(move || match core.getattr(child) {
             Ok(attr) => reply.entry(&ttl, &to_file_attr(&attr, uid, gid, mt), Generation(0)),
-            Err(e) => reply.error(errno(&e)),
+            Err(e) => reply.error(reply_errno("lookup", child, &e)),
         });
     }
 
@@ -256,7 +271,7 @@ impl Filesystem for MusefsFs {
         let (uid, gid, mt, ttl) = (self.uid, self.gid, self.mount_time, self.config.ttl);
         self.pool.execute(move || match core.getattr(ino.0) {
             Ok(attr) => reply.attr(&ttl, &to_file_attr(&attr, uid, gid, mt)),
-            Err(e) => reply.error(errno(&e)),
+            Err(e) => reply.error(reply_errno("getattr", ino.0, &e)),
         });
     }
 
@@ -265,7 +280,7 @@ impl Filesystem for MusefsFs {
         let flags = open_flags(self.config.keep_cache);
         self.pool.execute(move || match core.open_handle(ino.0) {
             Ok(fh) => reply.opened(FileHandle(fh), flags),
-            Err(e) => reply.error(errno(&e)),
+            Err(e) => reply.error(reply_errno("open", ino.0, &e)),
         });
     }
 
@@ -281,6 +296,20 @@ impl Filesystem for MusefsFs {
     ) {
         // Cheap (a map remove); no need to offload to the pool.
         self.core.release_handle(fh.0);
+        reply.ok();
+    }
+
+    fn flush(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _lock_owner: LockOwner,
+        reply: ReplyEmpty,
+    ) {
+        // Read-only filesystem: nothing to flush. fuser's default replies
+        // ENOSYS and logs a warn on every close(), which would drown the
+        // serve-failure log lines.
         reply.ok();
     }
 
@@ -301,7 +330,7 @@ impl Filesystem for MusefsFs {
                 let mut buf = b.borrow_mut();
                 match core.read_into(ino.0, fh.0, offset, size as u64, &mut buf) {
                     Ok(()) => reply.data(&buf),
-                    Err(e) => reply.error(errno(&e)),
+                    Err(e) => reply.error(reply_errno("read", ino.0, &e)),
                 }
                 if buf.capacity() > MAX_RETAINED_READ_BUF {
                     buf.shrink_to(MAX_RETAINED_READ_BUF);
@@ -321,7 +350,7 @@ impl Filesystem for MusefsFs {
         self.fire_poll_refresh();
         let entries = match self.core.readdir(ino.0) {
             Ok(e) => e,
-            Err(e) => return reply.error(errno(&e)),
+            Err(e) => return reply.error(reply_errno("readdir", ino.0, &e)),
         };
         let parent = self.core.parent(ino.0).unwrap_or(ino.0);
 

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+env_logger = "0.11"
 musefs-cli = { path = "../musefs-cli", version = "0.2.0" }
 
 [lints]

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -2,6 +2,10 @@ use clap::Parser;
 use musefs_cli::{run, Cli};
 
 fn main() {
+    // The library crates report serve-path failures through the `log` facade;
+    // without a sink they vanish. Default to `warn` so they surface on stderr,
+    // overridable via RUST_LOG.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
     if let Err(e) = run(Cli::parse()) {
         eprintln!("musefs: {e:#}");
         std::process::exit(1);


### PR DESCRIPTION
Fixes #128.

Serve-path failures (`CoreError::BackingChanged`, `CoreError::Io` with no raw OS error, `Db`, `Format`) reached the kernel as a bare errno with no log line, so a track that stopped playing mid-stream left no trace of why.

- **musefs-fuse**: new `reply_errno(op, ino, err)` used at all five `reply.error` sites — real serve failures log at **warn** with the full error Display (which carries the offending path for `BackingChanged` and the io cause even when there's no raw OS errno); routine tree-shape misses (stale-inode `ENOENT` class) log at **debug**. `errno()` itself stays pure.
- **musefs binary**: nothing ever initialized a `log` sink, so every existing `log::warn!` in the workspace was silently dropped. The binary now inits `env_logger` defaulting to `warn`, overridable via `RUST_LOG`.
- **musefs-fuse**: `flush` implemented as a no-op `ok()` — once a logger exists, fuser's default `flush` warns `[Not Implemented]` on every `close()`, drowning the useful lines.

Verified end-to-end with a real mount: truncating the backing file mid-mount makes `cat` fail with EIO and stderr shows exactly one line — `WARN musefs_fuse] open(3) failed: backing file changed since scan: /tmp/.../song.wav`. Full suite green: 682 tests + 9 mounted e2e, clippy, fmt; the in-diff mutation gate finds zero mutants in scope (both touched crates are mutation-excluded thin glue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved error reporting with enhanced contextual information when file system operations encounter failures.
  * Added support for environment-variable-based logging control to manage verbosity levels.
  * Reduced spurious warnings and achieved cleaner logging output during standard file system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->