### PR TITLE
Derive the Format string mapping with strum (#129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ version = "0.2.0"
 dependencies = [
  "rusqlite",
  "sha2",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -1558,6 +1559,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/docs/superpowers/plans/2026-06-04-db-typestate.md
+++ b/docs/superpowers/plans/2026-06-04-db-typestate.md
@@ -1,0 +1,371 @@
+# `Db<Mode>` Typestate Implementation Plan (#130)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Distinguish read-only from writable DB connections at the type level so a write API on a read-only connection — or a serve path that writes — fails to compile.
+
+**Architecture:** `musefs_db::Db` becomes `Db<M = ReadWrite>` with marker types. Read methods live on `impl<M> Db<M>`, write methods on `impl Db<ReadWrite>`; the `ReadWrite` default keeps every existing call-site spelling (`Db`, `Db::open`, `&Db`) compiling unchanged. In musefs-core, `DbPool` degrades the mount connection to `Db<ReadOnly>` and hands out `&Db<ReadOnly>`; the 12 serve-path fns in `reader.rs`/`facade.rs`/`mapping.rs` become generic over `&Db<M>` (NOT concrete `&Db<ReadOnly>` — `Musefs::open` calls `build_full` on the writable connection before pooling it, and integration tests pass writable in-memory DBs into `resolve`/`read_at`). Write methods don't resolve for an unconstrained `M`, so the serve-path bodies provably contain no write. Purely type-level: zero runtime change.
+
+**Tech Stack:** Rust (`PhantomData` typestate), rusqlite, parking_lot.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-format-strum-db-typestate-design.md` (Part 2)
+
+**Key compile fact used throughout:** type-parameter defaults apply in *type position* (`impl Db`, `db: &Db`, `-> Result<Db>` all mean `Db<ReadWrite>`), while *expression-position* paths infer (`Db::open_readonly(p)` resolves `M = ReadOnly` because the fn exists only on that impl). This is why untouched files keep compiling.
+
+---
+
+### Task 1: Typestate core in `musefs-db/src/lib.rs`
+
+**Files:**
+- Modify: `musefs-db/src/lib.rs`
+- Test: doctests on `Db` (in the same file) + existing `lib.rs` tests
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b db-typestate main
+```
+
+- [ ] **Step 2: Write the guarantee as paired doctests (the failing test)**
+
+In `musefs-db/src/lib.rs`, the struct currently reads:
+
+```rust
+pub struct Db {
+    conn: Connection,
+    path: Option<PathBuf>,
+}
+```
+
+Replace it with the generic struct, markers, and doctests:
+
+```rust
+/// Type-state markers for [`Db`]: the connection's write capability, at the
+/// type level. Write APIs exist only on `Db<ReadWrite>`.
+pub struct ReadOnly;
+pub struct ReadWrite;
+
+/// A SQLite connection whose mode parameter says whether write APIs resolve.
+///
+/// Read methods are available in both modes; write methods only on
+/// `Db<ReadWrite>` (the default, so `Db` spelled bare means writable):
+///
+/// ```
+/// let db = musefs_db::Db::open_in_memory().unwrap().into_read_only();
+/// db.data_version().unwrap();
+/// ```
+///
+/// ```compile_fail
+/// let db = musefs_db::Db::open_in_memory().unwrap().into_read_only();
+/// db.upsert_track(unimplemented!());
+/// ```
+pub struct Db<M = ReadWrite> {
+    conn: Connection,
+    path: Option<PathBuf>,
+    _mode: PhantomData<M>,
+}
+```
+
+Add `use std::marker::PhantomData;` to the imports (after `use rusqlite::Connection;`).
+
+The paired doctests are deliberate: `compile_fail` passes on *any* compile error, so the sibling passing test with the identical `Db<ReadOnly>` spelling proves the failure is specifically the write-method non-resolution, not a typo.
+
+- [ ] **Step 3: Split the `impl Db` block in lib.rs**
+
+The current single `impl Db` block (lines 27-95) holds `open`, `open_in_memory`, `configure`, `user_version`, `data_version`, `path`, `open_readonly`. Split it into three:
+
+```rust
+impl Db<ReadWrite> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Db> {
+        let p = path.as_ref().to_path_buf();
+        let mut conn = Connection::open(&p)?;
+        Self::configure(&mut conn, true)?;
+        Ok(Db {
+            conn,
+            path: Some(p),
+            _mode: PhantomData,
+        })
+    }
+
+    pub fn open_in_memory() -> Result<Db> {
+        let mut conn = Connection::open_in_memory()?;
+        Self::configure(&mut conn, false)?;
+        Ok(Db {
+            conn,
+            path: None,
+            _mode: PhantomData,
+        })
+    }
+
+    // configure() moves here verbatim (doc comment and body unchanged).
+
+    /// Degrade to the read-only surface, keeping the same connection. The
+    /// change is type-level only — runtime behavior is unchanged. The only
+    /// intended caller is `musefs_core`'s `DbPool::new`, which strips write
+    /// access from the mount connection before the serve path can see it.
+    pub fn into_read_only(self) -> Db<ReadOnly> {
+        Db {
+            conn: self.conn,
+            path: self.path,
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl Db<ReadOnly> {
+    // open_readonly() moves here verbatim (doc comment unchanged), with the
+    // construction gaining `_mode: PhantomData` and the return type written
+    // as Result<Db<ReadOnly>>.
+}
+
+impl<M> Db<M> {
+    // user_version(), data_version(), path() move here verbatim.
+}
+```
+
+Also update the `mutants`-feature `Default` impl (line ~98): the header `impl Default for Db` stays (type position — it already means `Db<ReadWrite>`); only its constructor gains `_mode: PhantomData`.
+
+- [ ] **Step 4: Build and run musefs-db tests (unit + doctests)**
+
+```bash
+cargo test -p musefs-db
+```
+
+Expected: PASS, including both doctests — the not-yet-split `impl Db` blocks in the other modules already mean `impl Db<ReadWrite>` via the default, so `upsert_track` is already absent from `Db<ReadOnly>` and the `compile_fail` doctest holds from this commit onward. All four existing `lib.rs` tests (`open_uses_wal_and_busy_timeout`, etc.) pass unchanged. If anything fails to build, a construction site is missing `_mode: PhantomData`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-db/src/lib.rs
+git commit -m "musefs-db: Db<Mode> typestate core (#130)"
+```
+
+### Task 2: Split `tracks.rs` into read and write surfaces
+
+**Files:**
+- Modify: `musefs-db/src/tracks.rs` (the `impl Db` block at line 46)
+
+- [ ] **Step 1: Split the impl block**
+
+`tracks.rs:46` has one `impl Db` block. Split it into two, moving each method **verbatim** (signatures and bodies untouched — only which block they sit in changes):
+
+```rust
+impl<M> Db<M> {
+    // READ surface — moves here:
+    // get_track, get_track_by_path, list_tracks, track_content_version,
+    // begin_read, end_read, list_render_keys, changelog_since,
+    // render_keys_for
+}
+
+impl Db<ReadWrite> {
+    // WRITE surface — moves here:
+    // upsert_track, delete_track, set_format_for_test,
+    // delete_changelog_through_for_test
+}
+```
+
+Add `ReadWrite` to the file's `use crate::...` import of `Db`. `begin_read`/`end_read` go on the READ surface deliberately: they run `BEGIN`/`ROLLBACK` but are called inside the serve path (`facade.rs:914/922`) under `pool.with`, so they must be reachable from `Db<ReadOnly>`.
+
+- [ ] **Step 2: Build and test**
+
+```bash
+cargo test -p musefs-db
+```
+
+Expected: PASS. (The crate compiles between tasks because unsplit `impl Db` blocks in other files still mean `Db<ReadWrite>`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-db/src/tracks.rs
+git commit -m "musefs-db: split tracks.rs read/write surfaces (#130)"
+```
+
+### Task 3: Split `tags.rs`, `art.rs`, `structural.rs`, `bulk.rs`
+
+**Files:**
+- Modify: `musefs-db/src/tags.rs` (impl at line 5)
+- Modify: `musefs-db/src/art.rs` (impl at line 16)
+- Modify: `musefs-db/src/structural.rs` (impl at line 5)
+- Modify: `musefs-db/src/bulk.rs` (impl at line 16)
+
+- [ ] **Step 1: Split each impl block** (same mechanics as Task 2 — methods move verbatim, imports gain `ReadWrite`):
+
+| File | `impl<M> Db<M>` (read) | `impl Db<ReadWrite>` (write) |
+|---|---|---|
+| `tags.rs` | `get_tags`, `tags_for_tracks`, `tags_grouped`, `get_binary_tags`, `read_binary_tag_chunk_into`, `read_binary_tag_chunk` | `replace_tags`, `set_binary_tags` |
+| `art.rs` | `get_art`, `get_art_meta`, `read_art_chunk_into`, `read_art_chunk`, `get_track_art` | `upsert_art`, `set_track_art`, `gc_orphan_art` |
+| `structural.rs` | `track_ids_with_structural_blocks`, `get_structural_blocks` | `set_structural_blocks` |
+| `bulk.rs` | — (nothing) | `apply_bulk_pragmas` (the `pub(crate)` associated fn), `apply_bulk_pragmas_self`, `bulk_writer` |
+
+`bulk.rs` needs no read block — the whole existing `impl Db` block just becomes `impl Db<ReadWrite>`. `BulkWriter` itself is untouched (it holds a `Transaction`, not a `Db`).
+
+- [ ] **Step 2: Build and test**
+
+```bash
+cargo test -p musefs-db
+```
+
+Expected: PASS, including both doctests from Task 1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-db/src/tags.rs musefs-db/src/art.rs musefs-db/src/structural.rs musefs-db/src/bulk.rs
+git commit -m "musefs-db: split remaining read/write surfaces (#130)"
+```
+
+### Task 4: musefs-core — degrade the pool, genericize the serve path
+
+These two halves land as ONE commit: after the pool change alone, core's serve fns (still `&Db` = `&Db<ReadWrite>`) reject the pool's `&Db<ReadOnly>` and the crate doesn't compile.
+
+**Files:**
+- Modify: `musefs-core/src/db_pool.rs`
+- Modify: `musefs-core/src/reader.rs:214,239,423,446,457,563,575`
+- Modify: `musefs-core/src/mapping.rs:32,67,83`
+- Modify: `musefs-core/src/facade.rs:237,264`
+
+- [ ] **Step 1: db_pool.rs holds and hands out `Db<ReadOnly>`**
+
+Change the import (`db_pool.rs:21`):
+
+```rust
+use musefs_db::{Db, ReadOnly};
+```
+
+The enum (line 38), thread-local (line 62), and the three methods change types; `Drop` is untouched. New versions (doc comments stay as they are today):
+
+```rust
+pub enum DbPool {
+    PerThread {
+        id: u64,
+        path: PathBuf,
+        poll: ReentrantMutex<Db<ReadOnly>>,
+    },
+    Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
+}
+```
+
+```rust
+thread_local! {
+    static PER_PATH: RefCell<HashMap<(PathBuf, u64), Rc<Db<ReadOnly>>>> = RefCell::new(HashMap::new());
+}
+```
+
+`new` keeps its `db: Db` (writable) signature and degrades first — the only behavioral-looking change, and it's type-level only:
+
+```rust
+    pub fn new(db: Db) -> Result<DbPool> {
+        let db = db.into_read_only();
+        match db.path() {
+            Some(p) => Ok(DbPool::PerThread {
+                id: NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed),
+                path: p.to_path_buf(),
+                poll: ReentrantMutex::new(db),
+            }),
+            None => Ok(DbPool::Shared(Arc::new(ReentrantMutex::new(db)))),
+        }
+    }
+```
+
+`with_poll` and `with` change only their closure parameter type — bodies stay byte-identical (`Db::open_readonly(path)` inside `with` already produces `Db<ReadOnly>` by inference):
+
+```rust
+    pub fn with_poll<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
+```
+
+```rust
+    pub fn with<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
+```
+
+- [ ] **Step 2: Genericize the 12 serve-path fns**
+
+In each, add `<M>` to the generics and change `db: &Db` to `db: &Db<M>`. Nothing else in the signatures or bodies changes. The full list:
+
+`musefs-core/src/reader.rs`:
+
+```rust
+    pub fn resolve<M>(&self, db: &Db<M>, track_id: i64) -> Result<Arc<ResolvedFile>> {        // line 214
+    fn build<M>(&self, db: &Db<M>, track: &musefs_db::Track, meta: &std::fs::Metadata) -> Result<Arc<ResolvedFile>> {  // line 239
+pub fn read_at_into<M>(resolved: &ResolvedFile, db: &Db<M>, offset: u64, size: u64, out: &mut Vec<u8>) -> Result<()> {  // line 423
+pub fn read_at<M>(resolved: &ResolvedFile, db: &Db<M>, offset: u64, size: u64) -> Result<Vec<u8>> {  // line 446
+fn read_segments_into<M>(resolved: &ResolvedFile, db: &Db<M>, file: Option<&std::fs::File>, offset: u64, size: u64, out: &mut Vec<u8>) -> Result<()> {  // line 457
+pub fn read_at_with_file_into<M>(resolved: &ResolvedFile, db: &Db<M>, file: &std::fs::File, offset: u64, size: u64, out: &mut Vec<u8>) -> Result<()> {  // line 563
+pub fn read_at_with_file<M>(resolved: &ResolvedFile, db: &Db<M>, file: &std::fs::File, offset: u64, size: u64) -> Result<Vec<u8>> {  // line 575
+```
+
+(Where a fn's parameters are listed one-per-line in the source, keep that formatting — only the generic and the `db` parameter's type change.)
+
+`musefs-core/src/mapping.rs`:
+
+```rust
+pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<ArtInput>> {     // line 32
+pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<BinaryTagInput>> {  // line 67
+pub(crate) fn track_art_images<M>(db: &Db<M>, inputs: &[ArtInput]) -> Result<Vec<Vec<u8>>> {   // line 83
+```
+
+`musefs-core/src/facade.rs` (both are private associated fns of `Musefs`; add `<M>` after the fn name):
+
+```rust
+    fn render_entries<M>(db: &Db<M>, ...) // line 236-237 — rest of the signature unchanged
+    fn build_full<M>(db: &Db<M>, ...)     // line 263-264 — rest of the signature unchanged
+```
+
+Do NOT touch `scan.rs` — its `&Db` params correctly stay `Db<ReadWrite>` (it writes), and `Musefs::open(db: Db, ...)` correctly keeps taking the writable connection (it runs reads on it, passes it to `build_full` — instantiating `M = ReadWrite` — then moves it into `DbPool::new`).
+
+- [ ] **Step 3: Build and test core**
+
+```bash
+cargo test -p musefs-core
+```
+
+Expected: PASS with **zero test-file edits** — that absence is itself spec verification ("every existing test spelling compiles as-is"). Tests pass writable in-memory DBs into `resolve`/`read_at` (e.g. `tests/read_at.rs:37`) — the generic accepts them; `reader.rs:1037`'s manual `Db::open_readonly` now yields an honest `Db<ReadOnly>` that the same generic accepts. If a compile error names a fn taking `&Db` receiving a `&Db<ReadOnly>`, that fn was missed in Step 2 — genericize it the same way rather than inserting any conversion.
+
+- [ ] **Step 4: Build the rest of the workspace**
+
+```bash
+cargo test -p musefs-fuse && cargo test -p musefs-cli && cargo test -p musefs
+```
+
+Expected: PASS untouched (they only ever spell `Db` = `Db<ReadWrite>`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/db_pool.rs musefs-core/src/reader.rs musefs-core/src/mapping.rs musefs-core/src/facade.rs
+git commit -m "musefs-core: serve path takes Db<ReadOnly>; helpers generic over mode (#130)"
+```
+
+### Task 5: Workspace validation and mutation gate
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Full workspace check**
+
+```bash
+cargo test --workspace && cargo clippy --all-targets && cargo fmt --all --check
+```
+
+Expected: all pass (this also runs the FLAC/MP3/etc. proptests via feature unification). Check each exit status directly.
+
+- [ ] **Step 2: FUSE end-to-end (real mounts)**
+
+```bash
+cargo test -p musefs-fuse -- --ignored
+```
+
+Expected: PASS (needs `/dev/fuse`; this change touches the serve path's types, so run the real-mount suite even though behavior is provably unchanged).
+
+- [ ] **Step 3: In-diff mutation gate (CI parity)**
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: `grep` succeeds (non-empty diff — an empty diff is a silent false pass), `cargo mutants` exits 0. Do NOT set TMPDIR. Note: the diff is mostly signature/impl-header churn, which yields few mutants — that's expected, not a gate failure.
+
+- [ ] **Step 4: Hand off**
+
+The branch is ready for review/merge — use the superpowers:finishing-a-development-branch skill (PR title: `Db<Mode> typestate: read-only vs writable connections at the type level (#130)`).

--- a/docs/superpowers/plans/2026-06-04-db-typestate.md
+++ b/docs/superpowers/plans/2026-06-04-db-typestate.md
@@ -223,7 +223,7 @@ These two halves land as ONE commit: after the pool change alone, core's serve f
 - Modify: `musefs-core/src/db_pool.rs`
 - Modify: `musefs-core/src/reader.rs:214,239,423,446,457,563,575`
 - Modify: `musefs-core/src/mapping.rs:32,67,83`
-- Modify: `musefs-core/src/facade.rs:237,264`
+- Modify: `musefs-core/src/facade.rs:236,263`
 
 - [ ] **Step 1: db_pool.rs holds and hands out `Db<ReadOnly>`**
 
@@ -278,6 +278,12 @@ thread_local! {
     pub fn with<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
 ```
 
+One in-file unit test constructs `PerThread` directly and needs a one-line edit: in `with_open_failure_includes_path_in_error` (`db_pool.rs:189-192`), change the `poll` initializer to
+
+```rust
+            poll: ReentrantMutex::new(Db::open_in_memory().unwrap().into_read_only()),
+```
+
 - [ ] **Step 2: Genericize the 12 serve-path fns**
 
 In each, add `<M>` to the generics and change `db: &Db` to `db: &Db<M>`. Nothing else in the signatures or bodies changes. The full list:
@@ -319,7 +325,7 @@ Do NOT touch `scan.rs` — its `&Db` params correctly stay `Db<ReadWrite>` (it w
 cargo test -p musefs-core
 ```
 
-Expected: PASS with **zero test-file edits** — that absence is itself spec verification ("every existing test spelling compiles as-is"). Tests pass writable in-memory DBs into `resolve`/`read_at` (e.g. `tests/read_at.rs:37`) — the generic accepts them; `reader.rs:1037`'s manual `Db::open_readonly` now yields an honest `Db<ReadOnly>` that the same generic accepts. If a compile error names a fn taking `&Db` receiving a `&Db<ReadOnly>`, that fn was missed in Step 2 — genericize it the same way rather than inserting any conversion.
+Expected: PASS with **no integration-test-file edits** (the only test change anywhere is the one-line `into_read_only()` in `db_pool.rs`'s own unit test, Step 1) — that absence is itself spec verification ("every existing test spelling compiles as-is"). Tests pass writable in-memory DBs into `resolve`/`read_at` (e.g. `tests/read_at.rs:37`) — the generic accepts them; `reader.rs:1037`'s manual `Db::open_readonly` now yields an honest `Db<ReadOnly>` that the same generic accepts. If a compile error names a fn taking `&Db` receiving a `&Db<ReadOnly>`, that fn was missed in Step 2 — genericize it the same way rather than inserting any conversion.
 
 - [ ] **Step 4: Build the rest of the workspace**
 

--- a/docs/superpowers/plans/2026-06-04-format-strum.md
+++ b/docs/superpowers/plans/2026-06-04-format-strum.md
@@ -1,0 +1,205 @@
+# strum-derived `Format` Implementation Plan (#129)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-written `Format::as_str()`/`parse()` pair with strum derives so the enum↔string mapping cannot drift when a format is added.
+
+**Architecture:** `Format` (musefs-db/src/models.rs) gains `EnumString`/`IntoStaticStr`/`EnumIter` derives with `serialize_all = "lowercase"` (which reproduces every current DB string, including `OggFlac` → `"oggflac"`). `as_str()` stays as a one-line delegate so its three call sites don't change; hand-written `parse()` is deleted and its single production caller (`parse_format_col`) switches to the derived `FromStr`. The DB strings are an external contract (beets/Picard write them), pinned by an explicit test.
+
+**Tech Stack:** Rust, strum 0.28 (new third-party proc-macro dependency in musefs-db — call this out in the PR for supply-chain scrutiny), rusqlite.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-format-strum-db-typestate-design.md` (Part 1)
+
+---
+
+### Task 1: Branch, dependency, and failing tests
+
+**Files:**
+- Modify: `musefs-db/Cargo.toml`
+- Test: `musefs-db/src/models.rs` (the `tests` module at the bottom, lines ~40-67)
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b format-strum main
+```
+
+- [ ] **Step 2: Add the strum dependency**
+
+In `musefs-db/Cargo.toml`, the `[dependencies]` section currently reads:
+
+```toml
+[dependencies]
+rusqlite = { version = "0.40", features = ["bundled", "blob"] }
+sha2 = "0.11"
+thiserror = "2"
+```
+
+Add strum after sha2:
+
+```toml
+[dependencies]
+rusqlite = { version = "0.40", features = ["bundled", "blob"] }
+sha2 = "0.11"
+strum = { version = "0.28", features = ["derive"] }
+thiserror = "2"
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+In `musefs-db/src/models.rs`, replace the entire `#[cfg(test)] mod tests` block (it currently holds three tests: `m4a_round_trips`, `ogg_codecs_round_trip`, `wav_round_trips`) with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::Format;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn every_format_round_trips() {
+        for f in Format::iter() {
+            assert_eq!(f.as_str().parse::<Format>(), Ok(f));
+        }
+    }
+
+    /// The strings are a DB contract — external writers (beets/Picard) store
+    /// them. A variant rename must not silently change the stored string.
+    #[test]
+    fn db_strings_are_pinned() {
+        let expected = [
+            (Format::Flac, "flac"),
+            (Format::Mp3, "mp3"),
+            (Format::M4a, "m4a"),
+            (Format::Opus, "opus"),
+            (Format::Vorbis, "vorbis"),
+            (Format::OggFlac, "oggflac"),
+            (Format::Wav, "wav"),
+        ];
+        assert_eq!(expected.len(), Format::iter().count());
+        for (f, s) in expected {
+            assert_eq!(f.as_str(), s);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+```bash
+cargo test -p musefs-db models
+```
+
+Expected: COMPILE ERROR — `Format::iter()` does not exist yet (E0599, no `iter` on `Format`) and `parse::<Format>()` has no `FromStr` impl (E0277). This is the failing state TDD wants.
+
+### Task 2: Derive the mapping, delete `parse`, switch the call site
+
+**Files:**
+- Modify: `musefs-db/src/models.rs:1-38` (the `Format` enum and `impl Format`)
+- Modify: `musefs-db/src/tracks.rs:10-18` (`parse_format_col`)
+
+- [ ] **Step 1: Derive on the enum and shrink `impl Format`**
+
+In `musefs-db/src/models.rs`, the file currently opens directly with the `Format` enum (no imports above it). Replace the enum and the whole `impl Format` block (which holds `as_str` and `parse`) with:
+
+```rust
+use strum::{EnumIter, EnumString, IntoStaticStr};
+
+/// The DB text representation (the `tracks.format` column) is derived:
+/// `serialize_all = "lowercase"` lowercases the whole variant ident
+/// (`OggFlac` → `"oggflac"`). The strings are an external contract —
+/// beets/Picard write them — pinned by `tests::db_strings_are_pinned`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, IntoStaticStr, EnumIter)]
+#[strum(serialize_all = "lowercase")]
+#[cfg_attr(feature = "mutants", derive(Default))]
+pub enum Format {
+    #[cfg_attr(feature = "mutants", default)]
+    Flac,
+    Mp3,
+    M4a,
+    Opus,
+    Vorbis,
+    OggFlac,
+    Wav,
+}
+
+impl Format {
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+```
+
+Note what changed: the original `Debug, Clone, Copy, PartialEq, Eq` derives and both `cfg_attr(feature = "mutants", ...)` attributes are preserved; `EnumString, IntoStaticStr, EnumIter` and the `#[strum(...)]` attribute are added; `parse()` is gone; `as_str()` delegates to the derived `IntoStaticStr`.
+
+- [ ] **Step 2: Switch `parse_format_col` to the derived `FromStr`**
+
+In `musefs-db/src/tracks.rs`, `parse_format_col` currently reads:
+
+```rust
+fn parse_format_col(fmt: &str) -> rusqlite::Result<Format> {
+    Format::parse(fmt).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            usize::MAX,
+            rusqlite::types::Type::Text,
+            format!("unknown format {fmt}").into(),
+        )
+    })
+}
+```
+
+Change only the first line of the body (the error mapping with its `"unknown format {fmt}"` message stays — it is more diagnostic than strum's generic `ParseError`):
+
+```rust
+fn parse_format_col(fmt: &str) -> rusqlite::Result<Format> {
+    fmt.parse::<Format>().ok().ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            usize::MAX,
+            rusqlite::types::Type::Text,
+            format!("unknown format {fmt}").into(),
+        )
+    })
+}
+```
+
+`parse_format_col` is the **only** production caller of the old `Format::parse` (the row mappers at `tracks.rs:157` and `:212` go through it); nothing else in the workspace calls `Format::parse`, so deleting it breaks no other call site. The three `as_str()` call sites (`tracks.rs:61`, `bulk.rs:59`, `musefs-core/src/facade.rs:228`) are untouched — the method still exists with the same signature.
+
+- [ ] **Step 3: Run the musefs-db tests to verify they pass**
+
+```bash
+cargo test -p musefs-db
+```
+
+Expected: PASS, including `models::tests::every_format_round_trips` and `models::tests::db_strings_are_pinned`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-db/Cargo.toml musefs-db/src/models.rs musefs-db/src/tracks.rs Cargo.lock
+git commit -m "Derive the Format string mapping with strum (#129)"
+```
+
+### Task 3: Workspace validation and mutation gate
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Full workspace check**
+
+```bash
+cargo test --workspace && cargo clippy --all-targets && cargo fmt --all --check
+```
+
+Expected: all pass. (`facade.rs:228` exercises `as_str` through the core suite.) Check the exit status of each directly — do not infer success from quiet output.
+
+- [ ] **Step 2: In-diff mutation gate (CI parity)**
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: `grep` succeeds (non-empty diff — an empty diff is a silent false pass), `cargo mutants` exits 0 with no missed mutants. Do NOT set TMPDIR.
+
+- [ ] **Step 3: Hand off**
+
+The branch is ready for review/merge — use the superpowers:finishing-a-development-branch skill (PR title: `Derive the Format string mapping with strum (#129)`; flag the new strum dependency in the PR body).

--- a/docs/superpowers/specs/2026-06-04-format-strum-db-typestate-design.md
+++ b/docs/superpowers/specs/2026-06-04-format-strum-db-typestate-design.md
@@ -1,0 +1,142 @@
+# Format via strum and Db read/write typestate
+
+**Date:** 2026-06-04
+**Issues:** #129 — `Format` round-trips through hand-written stringly
+`as_str`/`parse`; #130 — read-only vs writable DB connections are not
+distinguished at the type level
+**Status:** Approved
+
+Two independent fixes covered by one spec, shipped as **two separate PRs**
+with no ordering dependency (#129 touches `models.rs` and three call sites;
+#130 restructures `impl Db` blocks across `musefs-db` and serve-path
+signatures in `musefs-core`).
+
+Issue #135 (`backing_path` byte-wise uniqueness) was triaged alongside these
+and closed with a decision, not a change: musefs supports Linux only, so
+backing filesystems are treated as case-sensitive and the BINARY collation is
+intended behavior.
+
+## Part 1 — #129: derive the `Format` string mapping with strum (PR 1)
+
+### Problem
+
+`musefs-db/src/models.rs` maps `Format` to and from its DB text
+representation via a hand-written `as_str()`/`parse()` pair. The mapping is a
+serialization concern maintained by hand in two directions: `as_str`'s match
+is exhaustive (the compiler forces a new arm when a variant is added), but
+`parse` silently stays incomplete, and nothing verifies the pair remains
+symmetric.
+
+### Design
+
+Add `strum` (with the `derive` feature) as a dependency of `musefs-db` and
+derive the mapping:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, IntoStaticStr, EnumIter)]
+#[strum(serialize_all = "lowercase")]
+pub enum Format { Flac, Mp3, M4a, Opus, Vorbis, OggFlac, Wav }
+```
+
+`serialize_all = "lowercase"` yields exactly the current DB strings,
+including `OggFlac` → `"oggflac"`.
+
+- **`as_str()` stays** as a one-line inherent convenience delegating to the
+  derived `IntoStaticStr` (`<&'static str>::from(self)`), so the existing
+  call sites (`tracks.rs:61`, `bulk.rs:59`, `musefs-core/src/facade.rs:228`)
+  do not change.
+- **Hand-written `parse()` is deleted.** Its one production call site — the
+  `parse_format_col` row-mapping helper at `tracks.rs:11` — switches to the
+  derived `FromStr` via `fmt.parse::<Format>().ok()`, keeping its existing
+  `.ok_or_else` mapping to `rusqlite::Error::FromSqlConversionFailure` with
+  the `"unknown format {fmt}"` message unchanged.
+- The `mutants`-feature `Default` derive on `Format` is untouched.
+
+### Testing
+
+The three per-format round-trip unit tests in `models.rs` collapse into two:
+
+1. **Exhaustive round-trip:** `for f in Format::iter()`, assert
+   `f.as_str().parse::<Format>() == Ok(f)`. Symmetry holds by construction
+   for any future variant — adding one cannot dodge this test.
+2. **String pinning:** assert the full explicit `(variant, string)` table.
+   The strings are a DB contract (external writers — beets/Picard — store
+   them); with `serialize_all`, a careless variant rename would silently
+   change the stored string. This test makes that a loud failure.
+
+## Part 2 — #130: `Db<Mode>` typestate (PR 2)
+
+### Problem
+
+`musefs_db::Db` is a single type returned by both `open()` (writable) and
+`open_readonly()`; the capability lives only in a runtime open flag. A write
+API called on a read-only connection — or a serving path handed a writable
+one — compiles fine and only fails (or silently succeeds) at runtime.
+
+### Design: marker-type generic with a `ReadWrite` default
+
+**musefs-db (`lib.rs`):**
+
+```rust
+pub struct ReadOnly;
+pub struct ReadWrite;
+
+pub struct Db<M = ReadWrite> {
+    conn: Connection,
+    path: Option<PathBuf>,
+    _mode: PhantomData<M>,
+}
+```
+
+- `impl Db<ReadWrite>`: `open()`, `open_in_memory()`, `configure()`, and a
+  new `into_read_only(self) -> Db<ReadOnly>` that rewraps the same
+  connection. Degrading is type-level only; runtime behavior of the
+  connection is unchanged.
+- `impl Db<ReadOnly>`: `open_readonly()` (now honestly typed).
+- `impl<M> Db<M>`: `user_version()`, `data_version()`, `path()`.
+- The `mutants`-feature `Default` impl becomes `Default for Db<ReadWrite>`.
+
+**Per-module split** — each `impl Db` block in `tracks.rs`, `tags.rs`,
+`art.rs`, `structural.rs`, `bulk.rs` splits into a read block
+(`impl<M> Db<M>`) and a write block (`impl Db<ReadWrite>`):
+
+- *Read surface* (`impl<M> Db<M>`): `get_track`, `get_track_by_path`,
+  `list_tracks`, `track_content_version`, `begin_read`, `end_read`,
+  `list_render_keys`, `changelog_since`, `render_keys_for`, `get_tags`,
+  `tags_for_tracks`, `tags_grouped`, `get_binary_tags`,
+  `read_binary_tag_chunk_into`, `read_binary_tag_chunk`, `get_art`,
+  `get_art_meta`, `read_art_chunk_into`, `read_art_chunk`, `get_track_art`,
+  `track_ids_with_structural_blocks`, `get_structural_blocks`.
+- *Write surface* (`impl Db<ReadWrite>`): `upsert_track`, `delete_track`,
+  `set_format_for_test`, `delete_changelog_through_for_test`,
+  `replace_tags`, `set_binary_tags`, `upsert_art`, `set_track_art`,
+  `gc_orphan_art`, `set_structural_blocks`, `apply_bulk_pragmas_self`,
+  `bulk_writer` (and `BulkWriter` keeps borrowing the writable type).
+
+**musefs-core (`db_pool.rs`):** `DbPool::new(db: Db)` still takes the
+writable mount connection but immediately degrades it via
+`into_read_only()`:
+
+- `PerThread.poll` becomes `ReentrantMutex<Db<ReadOnly>>`.
+- `Shared` becomes `Arc<ReentrantMutex<Db<ReadOnly>>>`.
+- The thread-local `PER_PATH` cache holds `Rc<Db<ReadOnly>>` (worker threads
+  already open via `open_readonly`).
+- `with` hands out `&Db<ReadOnly>`. Every `&Db` parameter downstream in the
+  serve path (`reader.rs`, `facade.rs`, `mapping.rs`) becomes
+  `&Db<ReadOnly>`, after which the compiler proves the serve path contains
+  no write call.
+
+**What does not change:** `Db` defaults to `ReadWrite`, so `scan.rs`,
+`musefs-cli`, `Musefs::open(db: Db, ...)`, and every existing test spelling
+compile as-is. `error.rs`, the schema/migration machinery, and all runtime
+behavior are untouched — the change is purely type-level. The poll
+connection keeps its WAL/configure setup from `open()`; only its type
+degrades.
+
+### Testing
+
+The existing suites are the regression net — the split compiling against
+them is itself the verification that no read path lost a method and no
+write path gained one. One addition: a `compile_fail` doctest on
+`Db<ReadOnly>` demonstrating that a write API (e.g. `upsert_track`) does not
+resolve, pinning the guarantee against future backsliding.

--- a/docs/superpowers/specs/2026-06-04-format-strum-db-typestate-design.md
+++ b/docs/superpowers/specs/2026-06-04-format-strum-db-typestate-design.md
@@ -30,7 +30,8 @@ symmetric.
 ### Design
 
 Add `strum` (with the `derive` feature) as a dependency of `musefs-db` and
-derive the mapping:
+derive the mapping. This is a new third-party (proc-macro) dependency in the
+contract crate — call it out in the PR for supply-chain scrutiny:
 
 ```rust
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, IntoStaticStr, EnumIter)]
@@ -91,7 +92,8 @@ pub struct Db<M = ReadWrite> {
 - `impl Db<ReadWrite>`: `open()`, `open_in_memory()`, `configure()`, and a
   new `into_read_only(self) -> Db<ReadOnly>` that rewraps the same
   connection. Degrading is type-level only; runtime behavior of the
-  connection is unchanged.
+  connection is unchanged. It must be `pub` (called cross-crate), but its
+  only intended caller is `DbPool::new` — say so in its doc comment.
 - `impl Db<ReadOnly>`: `open_readonly()` (now honestly typed).
 - `impl<M> Db<M>`: `user_version()`, `data_version()`, `path()`.
 - The `mutants`-feature `Default` impl becomes `Default for Db<ReadWrite>`.
@@ -121,10 +123,20 @@ writable mount connection but immediately degrades it via
 - `Shared` becomes `Arc<ReentrantMutex<Db<ReadOnly>>>`.
 - The thread-local `PER_PATH` cache holds `Rc<Db<ReadOnly>>` (worker threads
   already open via `open_readonly`).
-- `with` hands out `&Db<ReadOnly>`. Every `&Db` parameter downstream in the
-  serve path (`reader.rs`, `facade.rs`, `mapping.rs`) becomes
-  `&Db<ReadOnly>`, after which the compiler proves the serve path contains
-  no write call.
+- `with` and `with_poll` both hand out `&Db<ReadOnly>` (the poll closures
+  call only read methods — `data_version`, `changelog_since`; the in-memory
+  `Shared` connection serves both roles).
+- Every `&Db` parameter downstream in the serve path (`reader.rs`,
+  `facade.rs`, `mapping.rs`) becomes **generic `&Db<M>`** — not concrete
+  `&Db<ReadOnly>`. Two callers require this: `Musefs::open` calls
+  `build_full(&db, ...)` on the writable connection *before* it moves into
+  the pool (`facade.rs:189`), and the integration tests pass a writable
+  in-memory `Db` directly into `resolve`/`read_at`/the `mapping.rs` fns
+  (e.g. `tests/read_at.rs:37`). Enforcement is fully preserved: write
+  methods exist only on `impl Db<ReadWrite>`, so they do not resolve for an
+  unconstrained `M` — the compiler proves the serve-path *bodies* contain
+  no write call, regardless of which connection they're handed. The live
+  mount instantiates them at `Db<ReadOnly>` via the pool.
 
 **What does not change:** `Db` defaults to `ReadWrite`, so `scan.rs`,
 `musefs-cli`, `Musefs::open(db: Db, ...)`, and every existing test spelling
@@ -139,4 +151,8 @@ The existing suites are the regression net — the split compiling against
 them is itself the verification that no read path lost a method and no
 write path gained one. One addition: a `compile_fail` doctest on
 `Db<ReadOnly>` demonstrating that a write API (e.g. `upsert_track`) does not
-resolve, pinning the guarantee against future backsliding.
+resolve, pinning the guarantee against future backsliding. Because
+`compile_fail` passes on *any* compile error, keep its body minimal and pair
+it with a sibling **passing** doctest that calls a read method (e.g.
+`data_version()`) on the same `Db<ReadOnly>` spelling — the contrast proves
+the failure is specifically the write-method non-resolution, not a typo.

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 rusqlite = { version = "0.40", features = ["bundled", "blob"] }
 sha2 = "0.11"
+strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 
 [features]

--- a/musefs-db/src/models.rs
+++ b/musefs-db/src/models.rs
@@ -1,4 +1,11 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+use strum::{EnumIter, EnumString, IntoStaticStr};
+
+/// The DB text representation (the `tracks.format` column) is derived:
+/// `serialize_all = "lowercase"` lowercases the whole variant ident
+/// (`OggFlac` → `"oggflac"`). The strings are an external contract —
+/// beets/Picard write them — pinned by `tests::db_strings_are_pinned`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, IntoStaticStr, EnumIter)]
+#[strum(serialize_all = "lowercase")]
 #[cfg_attr(feature = "mutants", derive(Default))]
 pub enum Format {
     #[cfg_attr(feature = "mutants", default)]
@@ -13,57 +20,39 @@ pub enum Format {
 
 impl Format {
     pub fn as_str(self) -> &'static str {
-        match self {
-            Format::Flac => "flac",
-            Format::Mp3 => "mp3",
-            Format::M4a => "m4a",
-            Format::Opus => "opus",
-            Format::Vorbis => "vorbis",
-            Format::OggFlac => "oggflac",
-            Format::Wav => "wav",
-        }
-    }
-
-    pub fn parse(s: &str) -> Option<Format> {
-        match s {
-            "flac" => Some(Format::Flac),
-            "mp3" => Some(Format::Mp3),
-            "m4a" => Some(Format::M4a),
-            "opus" => Some(Format::Opus),
-            "vorbis" => Some(Format::Vorbis),
-            "oggflac" => Some(Format::OggFlac),
-            "wav" => Some(Format::Wav),
-            _ => None,
-        }
+        self.into()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Format;
+    use strum::IntoEnumIterator;
 
     #[test]
-    fn m4a_round_trips() {
-        assert_eq!(Format::M4a.as_str(), "m4a");
-        assert_eq!(Format::parse("m4a"), Some(Format::M4a));
-    }
-
-    #[test]
-    fn ogg_codecs_round_trip() {
-        for (f, s) in [
-            (Format::Opus, "opus"),
-            (Format::Vorbis, "vorbis"),
-            (Format::OggFlac, "oggflac"),
-        ] {
-            assert_eq!(f.as_str(), s);
-            assert_eq!(Format::parse(s), Some(f));
+    fn every_format_round_trips() {
+        for f in Format::iter() {
+            assert_eq!(f.as_str().parse::<Format>(), Ok(f));
         }
     }
 
+    /// The strings are a DB contract — external writers (beets/Picard) store
+    /// them. A variant rename must not silently change the stored string.
     #[test]
-    fn wav_round_trips() {
-        assert_eq!(Format::Wav.as_str(), "wav");
-        assert_eq!(Format::parse("wav"), Some(Format::Wav));
+    fn db_strings_are_pinned() {
+        let expected = [
+            (Format::Flac, "flac"),
+            (Format::Mp3, "mp3"),
+            (Format::M4a, "m4a"),
+            (Format::Opus, "opus"),
+            (Format::Vorbis, "vorbis"),
+            (Format::OggFlac, "oggflac"),
+            (Format::Wav, "wav"),
+        ];
+        assert_eq!(expected.len(), Format::iter().count());
+        for (f, s) in expected {
+            assert_eq!(f.as_str(), s);
+        }
     }
 }
 

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -8,7 +8,7 @@ const TRACK_COLS: &str = "id, backing_path, format, audio_offset, audio_length, 
 /// Parse a `format` column value, mapping an unknown name to the rusqlite
 /// conversion error every row-mapper needs (single source — three readers).
 fn parse_format_col(fmt: &str) -> rusqlite::Result<Format> {
-    Format::parse(fmt).ok_or_else(|| {
+    fmt.parse::<Format>().ok().ok_or_else(|| {
         rusqlite::Error::FromSqlConversionFailure(
             usize::MAX,
             rusqlite::types::Type::Text,

--- a/musefs-db/tests/format.rs
+++ b/musefs-db/tests/format.rs
@@ -4,7 +4,10 @@ use musefs_db::Format;
 fn format_round_trips_through_db_string() {
     assert_eq!(Format::Flac.as_str(), "flac");
     assert_eq!(Format::Mp3.as_str(), "mp3");
-    assert_eq!(Format::parse("flac"), Some(Format::Flac));
-    assert_eq!(Format::parse("mp3"), Some(Format::Mp3));
-    assert_eq!(Format::parse("ogg"), None);
+    assert_eq!("flac".parse::<Format>(), Ok(Format::Flac));
+    assert_eq!("mp3".parse::<Format>(), Ok(Format::Mp3));
+    assert_eq!(
+        "ogg".parse::<Format>(),
+        Err(strum::ParseError::VariantNotFound)
+    );
 }


### PR DESCRIPTION
## Summary

Closes #129.

- `Format` (musefs-db) derives its DB string mapping with strum: `EnumString` + `IntoStaticStr` + `EnumIter`, `serialize_all = "lowercase"` (reproduces every current string, including `OggFlac` → `"oggflac"`).
- `as_str()` stays as a one-line delegate, so its call sites are untouched; hand-written `parse()` is deleted and `parse_format_col` uses the derived `FromStr` (same `"unknown format"` error mapping).
- Tests: an exhaustive `Format::iter()` round-trip (symmetry by construction for any future variant) plus an explicit string-pinning test — the strings are a DB contract written by external tools (beets/Picard), so a variant rename must fail loudly.
- Also carries the approved design spec and implementation plans for #129/#130 (docs commits this branch was cut from).

## New dependency

`strum 0.28` (+ `strum_macros`) — a new third-party proc-macro dependency in musefs-db, the contract crate. Note that `FromStr::Err = strum::ParseError` makes strum a *public* dependency: a future strum major bump is a semver-visible change.

## Validation

- `cargo test --workspace`: 681 passed, 21 ignored
- `cargo clippy --all-targets` / `cargo fmt --all --check`: clean
- In-diff mutation gate (CI parity): 3 mutants — 2 caught, 1 unviable, 0 missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning documentation for database type-safety enhancements and format-parsing improvements.

* **Refactor**
  * Refactored Format enum parsing to use standard Rust derive macros for improved maintainability.

* **Tests**
  * Updated format parsing validation and round-trip test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->