### PR TITLE
Db<Mode> typestate: read-only vs writable connections at the type level (#130)

### DIFF
--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use parking_lot::ReentrantMutex;
 
-use musefs_db::Db;
+use musefs_db::{Db, ReadOnly};
 
 use crate::error::{CoreError, Result};
 
@@ -39,9 +39,9 @@ pub enum DbPool {
     PerThread {
         id: u64,
         path: PathBuf,
-        poll: ReentrantMutex<Db>,
+        poll: ReentrantMutex<Db<ReadOnly>>,
     },
-    Shared(Arc<ReentrantMutex<Db>>),
+    Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
 }
 
 /// Clears only the *dropping thread's* thread-local connection for this pool —
@@ -58,8 +58,10 @@ impl Drop for DbPool {
     }
 }
 
+type PerPathMap = HashMap<(PathBuf, u64), Rc<Db<ReadOnly>>>;
+
 thread_local! {
-    static PER_PATH: RefCell<HashMap<(PathBuf, u64), Rc<Db>>> = RefCell::new(HashMap::new());
+    static PER_PATH: RefCell<PerPathMap> = RefCell::new(HashMap::new());
 }
 
 impl DbPool {
@@ -67,6 +69,7 @@ impl DbPool {
     /// become per-thread pools (the passed connection is dropped — workers open
     /// their own); in-memory DBs are wrapped in a shared mutex.
     pub fn new(db: Db) -> Result<DbPool> {
+        let db = db.into_read_only();
         match db.path() {
             Some(p) => Ok(DbPool::PerThread {
                 id: NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed),
@@ -84,7 +87,7 @@ impl DbPool {
     /// before it opened. The poll connection is the original writer Db, kept alive
     /// precisely so it can observe incremental changes from other connections.
     /// For `Shared` pools (in-memory), the single shared connection serves both roles.
-    pub fn with_poll<R>(&self, f: impl FnOnce(&Db) -> Result<R>) -> Result<R> {
+    pub fn with_poll<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
         match self {
             DbPool::PerThread { poll, .. } => f(&poll.lock()),
             DbPool::Shared(m) => f(&m.lock()),
@@ -92,7 +95,7 @@ impl DbPool {
     }
 
     /// Run `f` with a read connection.
-    pub fn with<R>(&self, f: impl FnOnce(&Db) -> Result<R>) -> Result<R> {
+    pub fn with<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
         match self {
             DbPool::PerThread { id, path, .. } => PER_PATH.with(|cell| {
                 let db = {
@@ -189,7 +192,7 @@ mod tests {
         let pool = DbPool::PerThread {
             id: u64::MAX,
             path: bad.clone(),
-            poll: ReentrantMutex::new(Db::open_in_memory().unwrap()),
+            poll: ReentrantMutex::new(Db::open_in_memory().unwrap().into_read_only()),
         };
         let msg = pool.with(|_db| Ok(())).unwrap_err().to_string();
         assert!(

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -233,8 +233,8 @@ impl Musefs {
     /// `build_full` and `rebuild_full`. Confining all `Db` access here is what
     /// lets `rebuild_full` hold `inodes` only across the pure-CPU `build_with`.
     #[allow(clippy::type_complexity)]
-    fn render_entries(
-        db: &Db,
+    fn render_entries<M>(
+        db: &Db<M>,
         config: &MountConfig,
     ) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
         let tracks = db.list_tracks()?;
@@ -260,8 +260,8 @@ impl Musefs {
     /// Full rebuild: render every track and build the tree from scratch. Used by
     /// `open`, forced `refresh`, and the Stage B fallback. Returns the tree and the
     /// fresh `track_id -> TrackRenderState` snapshot.
-    fn build_full(
-        db: &Db,
+    fn build_full<M>(
+        db: &Db<M>,
         config: &MountConfig,
         alloc: &mut InodeAllocator,
     ) -> Result<(VirtualTree, HashMap<i64, TrackRenderState>)> {

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -29,7 +29,7 @@ pub(crate) fn tags_to_fields(tags: &[Tag]) -> BTreeMap<String, String> {
 /// Build the synthesis art inputs for a track from `track_art` + art metadata.
 /// Reads metadata only (never the image blob) so resolve stays memory-bounded;
 /// the bytes are streamed at read time.
-pub(crate) fn track_art_to_inputs(db: &Db, track_id: i64) -> Result<Vec<ArtInput>> {
+pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<ArtInput>> {
     let mut inputs = Vec::new();
     for ta in db.get_track_art(track_id)? {
         // `track_art.art_id` is a foreign key into `art` (enforced, no ON DELETE),
@@ -64,7 +64,7 @@ pub(crate) fn track_art_to_inputs(db: &Db, track_id: i64) -> Result<Vec<ArtInput
 /// the payload bytes — only `(rowid, key, byte_len)`; the bytes stream at read
 /// time. Ordered by (key, ordinal), matching `get_binary_tags`.
 #[allow(dead_code)] // wired into the reader resolve arms in Task 2.9
-pub(crate) fn binary_tags_to_inputs(db: &Db, track_id: i64) -> Result<Vec<BinaryTagInput>> {
+pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<BinaryTagInput>> {
     Ok(db
         .get_binary_tags(track_id)?
         .into_iter()
@@ -80,7 +80,7 @@ pub(crate) fn binary_tags_to_inputs(db: &Db, track_id: i64) -> Result<Vec<Binary
 /// compute page CRCs at resolve). Parallel to `track_art_to_inputs`; returns the
 /// same order. Only the Ogg synthesis path calls this — FLAC/MP3/MP4 stream art
 /// via `ArtImage` and never materialize it.
-pub(crate) fn track_art_images(db: &Db, inputs: &[ArtInput]) -> Result<Vec<Vec<u8>>> {
+pub(crate) fn track_art_images<M>(db: &Db<M>, inputs: &[ArtInput]) -> Result<Vec<Vec<u8>>> {
     let mut out = Vec::with_capacity(inputs.len());
     for a in inputs {
         out.push(db.read_art_chunk(a.art_id, 0, a.data_len as usize)?);

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -211,7 +211,7 @@ impl HeaderCache {
     /// Resolve a track to its layout, caching on a content-version miss. Validation
     /// (`stat`) and synthesis run WITHOUT holding the shard lock; the lock is taken
     /// only briefly for the cache get and insert.
-    pub fn resolve(&self, db: &Db, track_id: i64) -> Result<Arc<ResolvedFile>> {
+    pub fn resolve<M>(&self, db: &Db<M>, track_id: i64) -> Result<Arc<ResolvedFile>> {
         let track = db
             .get_track(track_id)?
             .ok_or(CoreError::TrackNotFound(track_id))?;
@@ -234,9 +234,9 @@ impl HeaderCache {
         Ok(resolved)
     }
     /// Build a `ResolvedFile` for `track` (synthesis or passthrough). No lock held.
-    fn build(
+    fn build<M>(
         &self,
-        db: &Db,
+        db: &Db<M>,
         track: &musefs_db::Track,
         meta: &std::fs::Metadata,
     ) -> Result<Arc<ResolvedFile>> {
@@ -418,9 +418,9 @@ impl HeaderCache {
 
 /// Read `size` bytes at virtual `offset` into `out` (appended), opening the
 /// backing file once for this call if the layout needs it.
-pub fn read_at_into(
+pub fn read_at_into<M>(
     resolved: &ResolvedFile,
-    db: &Db,
+    db: &Db<M>,
     offset: u64,
     size: u64,
     out: &mut Vec<u8>,
@@ -443,7 +443,7 @@ pub fn read_at_into(
 }
 
 /// Allocating form of `read_at_into` (tests and non-hot-path callers).
-pub fn read_at(resolved: &ResolvedFile, db: &Db, offset: u64, size: u64) -> Result<Vec<u8>> {
+pub fn read_at<M>(resolved: &ResolvedFile, db: &Db<M>, offset: u64, size: u64) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     read_at_into(resolved, db, offset, size, &mut out)?;
     Ok(out)
@@ -452,9 +452,9 @@ pub fn read_at(resolved: &ResolvedFile, db: &Db, offset: u64, size: u64) -> Resu
 /// The single segment-splicing loop. `file` is `Some` whenever the layout has a
 /// `BackingAudio`/`OggAudio` segment (guaranteed by `read_at`/`read_at_with_file`);
 /// the backing arms treat `None` as a contract violation.
-fn read_segments_into(
+fn read_segments_into<M>(
     resolved: &ResolvedFile,
-    db: &Db,
+    db: &Db<M>,
     file: Option<&std::fs::File>,
     offset: u64,
     size: u64,
@@ -558,9 +558,9 @@ fn read_segments_into(
 }
 
 /// Serve into `out` from an already-open backing `file` (per-handle path).
-pub fn read_at_with_file_into(
+pub fn read_at_with_file_into<M>(
     resolved: &ResolvedFile,
-    db: &Db,
+    db: &Db<M>,
     file: &std::fs::File,
     offset: u64,
     size: u64,
@@ -570,9 +570,9 @@ pub fn read_at_with_file_into(
 }
 
 /// Allocating form of `read_at_with_file_into`.
-pub fn read_at_with_file(
+pub fn read_at_with_file<M>(
     resolved: &ResolvedFile,
-    db: &Db,
+    db: &Db<M>,
     file: &std::fs::File,
     offset: u64,
     size: u64,

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -1,5 +1,5 @@
 use crate::models::{Art, ArtMeta, NewArt, TrackArt};
-use crate::{Db, Result};
+use crate::{Db, ReadWrite, Result};
 use rusqlite::params;
 use sha2::{Digest, Sha256};
 
@@ -13,23 +13,7 @@ fn sha256_hex(data: &[u8]) -> String {
     s
 }
 
-impl Db {
-    pub fn upsert_art(&self, a: &NewArt) -> Result<i64> {
-        let sha = sha256_hex(&a.data);
-        self.conn.execute(
-            "INSERT INTO art (sha256, mime, width, height, byte_len, data)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(sha256) DO NOTHING",
-            params![sha, a.mime, a.width, a.height, a.data.len() as i64, a.data],
-        )?;
-        let id =
-            self.conn
-                .query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| {
-                    r.get(0)
-                })?;
-        Ok(id)
-    }
-
+impl<M> Db<M> {
     pub fn get_art(&self, id: i64) -> Result<Option<Art>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, sha256, mime, width, height, byte_len, data FROM art WHERE id = ?1",
@@ -84,6 +68,40 @@ impl Db {
         Ok(buf)
     }
 
+    pub fn get_track_art(&self, track_id: i64) -> Result<Vec<TrackArt>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT art_id, picture_type, description, ordinal
+             FROM track_art WHERE track_id = ?1 ORDER BY ordinal",
+        )?;
+        let rows = stmt.query_map(params![track_id], |r| {
+            Ok(TrackArt {
+                art_id: r.get(0)?,
+                picture_type: r.get(1)?,
+                description: r.get(2)?,
+                ordinal: r.get(3)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+}
+
+impl Db<ReadWrite> {
+    pub fn upsert_art(&self, a: &NewArt) -> Result<i64> {
+        let sha = sha256_hex(&a.data);
+        self.conn.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(sha256) DO NOTHING",
+            params![sha, a.mime, a.width, a.height, a.data.len() as i64, a.data],
+        )?;
+        let id =
+            self.conn
+                .query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| {
+                    r.get(0)
+                })?;
+        Ok(id)
+    }
+
     pub fn set_track_art(&self, track_id: i64, items: &[TrackArt]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         tx.execute(
@@ -107,22 +125,6 @@ impl Db {
         }
         tx.commit()?;
         Ok(())
-    }
-
-    pub fn get_track_art(&self, track_id: i64) -> Result<Vec<TrackArt>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT art_id, picture_type, description, ordinal
-             FROM track_art WHERE track_id = ?1 ORDER BY ordinal",
-        )?;
-        let rows = stmt.query_map(params![track_id], |r| {
-            Ok(TrackArt {
-                art_id: r.get(0)?,
-                picture_type: r.get(1)?,
-                description: r.get(2)?,
-                ordinal: r.get(3)?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
     /// Delete `art` rows no longer referenced by any `track_art`. Returns the

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -1,5 +1,5 @@
 use crate::models::{BinaryTag, NewArt, NewTrack, StructuralBlock, Tag, TrackArt};
-use crate::{Db, Result};
+use crate::{Db, ReadWrite, Result};
 use rusqlite::{params, Transaction};
 use sha2::{Digest, Sha256};
 
@@ -13,7 +13,7 @@ fn sha256_hex(data: &[u8]) -> String {
     s
 }
 
-impl Db {
+impl Db<ReadWrite> {
     /// Apply the bulk-write pragmas to an open connection. WAL is left untouched
     /// (retained from `open`), so concurrent mount readers keep working. Safe on
     /// in-memory DBs. Intended for a scan-scoped `Db` the caller drops at scan end.

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -16,15 +16,36 @@ pub use models::{
 pub use tracks::ChangelogRead;
 
 use rusqlite::Connection;
+use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-pub struct Db {
+/// Type-state markers for [`Db`]: the connection's write capability, at the
+/// type level. Write APIs exist only on `Db<ReadWrite>`.
+pub struct ReadOnly;
+pub struct ReadWrite;
+
+/// A SQLite connection whose mode parameter says whether write APIs resolve.
+///
+/// Read methods are available in both modes; write methods only on
+/// `Db<ReadWrite>` (the default, so `Db` spelled bare means writable):
+///
+/// ```
+/// let db = musefs_db::Db::open_in_memory().unwrap().into_read_only();
+/// db.data_version().unwrap();
+/// ```
+///
+/// ```compile_fail
+/// let db = musefs_db::Db::open_in_memory().unwrap().into_read_only();
+/// db.upsert_track(unimplemented!());
+/// ```
+pub struct Db<M = ReadWrite> {
     conn: Connection,
     path: Option<PathBuf>,
+    _mode: PhantomData<M>,
 }
 
-impl Db {
+impl Db<ReadWrite> {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Db> {
         let p = path.as_ref().to_path_buf();
         let mut conn = Connection::open(&p)?;
@@ -32,13 +53,18 @@ impl Db {
         Ok(Db {
             conn,
             path: Some(p),
+            _mode: PhantomData,
         })
     }
 
     pub fn open_in_memory() -> Result<Db> {
         let mut conn = Connection::open_in_memory()?;
         Self::configure(&mut conn, false)?;
-        Ok(Db { conn, path: None })
+        Ok(Db {
+            conn,
+            path: None,
+            _mode: PhantomData,
+        })
     }
 
     /// Apply shared connection pragmas, then migrate. `wal` enables write-ahead
@@ -58,6 +84,41 @@ impl Db {
         Ok(())
     }
 
+    /// Degrade to the read-only surface, keeping the same connection. The
+    /// change is type-level only — runtime behavior is unchanged. The only
+    /// intended caller is `musefs_core`'s `DbPool::new`, which strips write
+    /// access from the mount connection before the serve path can see it.
+    pub fn into_read_only(self) -> Db<ReadOnly> {
+        Db {
+            conn: self.conn,
+            path: self.path,
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl Db<ReadOnly> {
+    /// Open an additional read-only connection to an existing file-backed DB.
+    /// WAL (set by the writer) lets these run concurrently without blocking.
+    /// No migration is run — the schema already exists and the connection is RO.
+    /// Note: even with `SQLITE_OPEN_READ_ONLY`, SQLite needs write access to the
+    /// directory (to create/use the `-shm` wal-index) when the DB is in WAL mode;
+    /// a strictly read-only DB directory will make this fail.
+    pub fn open_readonly<P: AsRef<Path>>(path: P) -> Result<Db<ReadOnly>> {
+        let p = path.as_ref().to_path_buf();
+        let conn = Connection::open_with_flags(&p, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        // No configure()/migrate and no foreign_keys pragma: the schema already
+        // exists and no writes are possible on a read-only connection.
+        conn.busy_timeout(Duration::from_secs(5))?;
+        Ok(Db {
+            conn,
+            path: Some(p),
+            _mode: PhantomData,
+        })
+    }
+}
+
+impl<M> Db<M> {
     pub fn user_version(&self) -> Result<i64> {
         Ok(self
             .conn
@@ -73,24 +134,6 @@ impl Db {
     /// The backing file path, or `None` for an in-memory database.
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
-    }
-
-    /// Open an additional read-only connection to an existing file-backed DB.
-    /// WAL (set by the writer) lets these run concurrently without blocking.
-    /// No migration is run — the schema already exists and the connection is RO.
-    /// Note: even with `SQLITE_OPEN_READ_ONLY`, SQLite needs write access to the
-    /// directory (to create/use the `-shm` wal-index) when the DB is in WAL mode;
-    /// a strictly read-only DB directory will make this fail.
-    pub fn open_readonly<P: AsRef<Path>>(path: P) -> Result<Db> {
-        let p = path.as_ref().to_path_buf();
-        let conn = Connection::open_with_flags(&p, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-        // No configure()/migrate and no foreign_keys pragma: the schema already
-        // exists and no writes are possible on a read-only connection.
-        conn.busy_timeout(Duration::from_secs(5))?;
-        Ok(Db {
-            conn,
-            path: Some(p),
-        })
     }
 }
 
@@ -108,7 +151,11 @@ impl Default for Db {
             .expect("set busy_timeout");
         conn.pragma_update(None, "foreign_keys", true)
             .expect("enable foreign_keys");
-        Db { conn, path: None }
+        Db {
+            conn,
+            path: None,
+            _mode: PhantomData,
+        }
     }
 }
 

--- a/musefs-db/src/structural.rs
+++ b/musefs-db/src/structural.rs
@@ -1,28 +1,8 @@
 use crate::models::StructuralBlock;
-use crate::{Db, Result};
+use crate::{Db, ReadWrite, Result};
 use rusqlite::params;
 
-impl Db {
-    /// Replace the track's structural blocks (FLAC STREAMINFO/SEEKTABLE).
-    pub fn set_structural_blocks(&self, track_id: i64, blocks: &[StructuralBlock]) -> Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM structural_blocks WHERE track_id = ?1",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
-                 VALUES (?1, ?2, ?3, ?4)",
-            )?;
-            for b in blocks {
-                stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
-            }
-        }
-        tx.commit()?;
-        Ok(())
-    }
-
+impl<M> Db<M> {
     /// Track ids that have at least one structural block row. Used by `revalidate`
     /// to detect legacy FLAC tracks (scanned under V1) that still need a backfill.
     pub fn track_ids_with_structural_blocks(&self) -> Result<std::collections::HashSet<i64>> {
@@ -49,6 +29,28 @@ impl Db {
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+}
+
+impl Db<ReadWrite> {
+    /// Replace the track's structural blocks (FLAC STREAMINFO/SEEKTABLE).
+    pub fn set_structural_blocks(&self, track_id: i64, blocks: &[StructuralBlock]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM structural_blocks WHERE track_id = ?1",
+            params![track_id],
+        )?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
+                 VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for b in blocks {
+                stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
     }
 }
 

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -1,26 +1,8 @@
 use crate::models::{BinaryTag, BinaryTagRow, Tag};
-use crate::{Db, Result};
+use crate::{Db, ReadWrite, Result};
 use rusqlite::params;
 
-impl Db {
-    pub fn replace_tags(&self, track_id: i64, tags: &[Tag]) -> Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
-            )?;
-            for t in tags {
-                stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
-            }
-        }
-        tx.commit()?;
-        Ok(())
-    }
-
+impl<M> Db<M> {
     pub fn get_tags(&self, track_id: i64) -> Result<Vec<Tag>> {
         let mut stmt = self.conn.prepare(
             "SELECT key, value, ordinal FROM tags \
@@ -100,27 +82,6 @@ impl Db {
         Ok(out)
     }
 
-    /// Replace the track's binary tag rows (value_blob IS NOT NULL); text rows
-    /// (managed by `replace_tags`) are untouched. Binary rows store '' in `value`.
-    pub fn set_binary_tags(&self, track_id: i64, tags: &[BinaryTag]) -> Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
-                 VALUES (?1, ?2, '', ?3, ?4)",
-            )?;
-            for t in tags {
-                stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
-            }
-        }
-        tx.commit()?;
-        Ok(())
-    }
-
     /// Binary tag rows for a track: streaming handle (rowid), key, and payload
     /// length. Ordered by (key, ordinal) to match `get_binary_tags`/synthesis order.
     pub fn get_binary_tags(&self, track_id: i64) -> Result<Vec<BinaryTagRow>> {
@@ -167,6 +128,47 @@ impl Db {
         let mut buf = vec![0u8; len];
         self.read_binary_tag_chunk_into(payload_id, offset, &mut buf)?;
         Ok(buf)
+    }
+}
+
+impl Db<ReadWrite> {
+    pub fn replace_tags(&self, track_id: i64, tags: &[Tag]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
+            params![track_id],
+        )?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for t in tags {
+                stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Replace the track's binary tag rows (value_blob IS NOT NULL); text rows
+    /// (managed by `replace_tags`) are untouched. Binary rows store '' in `value`.
+    pub fn set_binary_tags(&self, track_id: i64, tags: &[BinaryTag]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
+            params![track_id],
+        )?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
+                 VALUES (?1, ?2, '', ?3, ?4)",
+            )?;
+            for t in tags {
+                stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
     }
 }
 

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -1,5 +1,5 @@
 use crate::models::{Format, NewTrack, Track};
-use crate::{Db, Result};
+use crate::{Db, ReadWrite, Result};
 use rusqlite::{params, Row};
 
 const TRACK_COLS: &str = "id, backing_path, format, audio_offset, audio_length, \
@@ -43,36 +43,7 @@ pub struct ChangelogRead {
     pub max_seq: i64,
 }
 
-impl Db {
-    pub fn upsert_track(&self, t: &NewTrack) -> Result<i64> {
-        self.conn.execute(
-            "INSERT INTO tracks
-                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CAST(strftime('%s','now') AS INTEGER))
-             ON CONFLICT(backing_path) DO UPDATE SET
-                format        = excluded.format,
-                audio_offset  = excluded.audio_offset,
-                audio_length  = excluded.audio_length,
-                backing_size  = excluded.backing_size,
-                backing_mtime = excluded.backing_mtime,
-                updated_at    = CAST(strftime('%s','now') AS INTEGER)",
-            params![
-                t.backing_path,
-                t.format.as_str(),
-                t.audio_offset,
-                t.audio_length,
-                t.backing_size,
-                t.backing_mtime,
-            ],
-        )?;
-        let id = self.conn.query_row(
-            "SELECT id FROM tracks WHERE backing_path = ?1",
-            params![t.backing_path],
-            |r| r.get(0),
-        )?;
-        Ok(id)
-    }
-
+impl<M> Db<M> {
     pub fn get_track(&self, id: i64) -> Result<Option<Track>> {
         let sql = format!("SELECT {TRACK_COLS} FROM tracks WHERE id = ?1");
         self.query_optional_track(&sql, params![id])
@@ -119,27 +90,6 @@ impl Db {
             Some(r) => Ok(Some(row_to_track(r)?)),
             None => Ok(None),
         }
-    }
-
-    /// Delete a track row. Foreign keys cascade to its `tags` and `track_art`
-    /// rows; the referenced `art` rows are left for `gc_orphan_art`.
-    pub fn delete_track(&self, id: i64) -> Result<()> {
-        self.conn
-            .execute("DELETE FROM tracks WHERE id = ?1", params![id])?;
-        Ok(())
-    }
-
-    /// Test-only: force a track's format column directly (no rescan), bumping
-    /// data_version. The only way to exercise a format-only change — production
-    /// never mutates format without a rescan. content_version is NOT bumped (no
-    /// trigger fires on the tracks.format column), so this is a pure format-only edit.
-    #[doc(hidden)]
-    pub fn set_format_for_test(&self, id: i64, fmt: Format) -> Result<()> {
-        self.conn.execute(
-            "UPDATE tracks SET format = ?1, updated_at = CAST(strftime('%s','now') AS INTEGER) WHERE id = ?2",
-            params![fmt.as_str(), id],
-        )?;
-        Ok(())
     }
 
     /// Cheap render-key identity scan for incremental refresh: `(id, content_version,
@@ -215,6 +165,58 @@ impl Db {
             out.extend(rows.collect::<rusqlite::Result<Vec<_>>>()?);
         }
         Ok(out)
+    }
+}
+
+impl Db<ReadWrite> {
+    pub fn upsert_track(&self, t: &NewTrack) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO tracks
+                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CAST(strftime('%s','now') AS INTEGER))
+             ON CONFLICT(backing_path) DO UPDATE SET
+                format        = excluded.format,
+                audio_offset  = excluded.audio_offset,
+                audio_length  = excluded.audio_length,
+                backing_size  = excluded.backing_size,
+                backing_mtime = excluded.backing_mtime,
+                updated_at    = CAST(strftime('%s','now') AS INTEGER)",
+            params![
+                t.backing_path,
+                t.format.as_str(),
+                t.audio_offset,
+                t.audio_length,
+                t.backing_size,
+                t.backing_mtime,
+            ],
+        )?;
+        let id = self.conn.query_row(
+            "SELECT id FROM tracks WHERE backing_path = ?1",
+            params![t.backing_path],
+            |r| r.get(0),
+        )?;
+        Ok(id)
+    }
+
+    /// Delete a track row. Foreign keys cascade to its `tags` and `track_art`
+    /// rows; the referenced `art` rows are left for `gc_orphan_art`.
+    pub fn delete_track(&self, id: i64) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM tracks WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    /// Test-only: force a track's format column directly (no rescan), bumping
+    /// data_version. The only way to exercise a format-only change — production
+    /// never mutates format without a rescan. content_version is NOT bumped (no
+    /// trigger fires on the tracks.format column), so this is a pure format-only edit.
+    #[doc(hidden)]
+    pub fn set_format_for_test(&self, id: i64, fmt: Format) -> Result<()> {
+        self.conn.execute(
+            "UPDATE tracks SET format = ?1, updated_at = CAST(strftime('%s','now') AS INTEGER) WHERE id = ?2",
+            params![fmt.as_str(), id],
+        )?;
+        Ok(())
     }
 
     /// Test-only: delete changelog rows up to and including `seq`, simulating the


### PR DESCRIPTION
## Summary

Closes #130.

- `musefs_db::Db` becomes `Db<M = ReadWrite>` with `ReadOnly`/`ReadWrite` marker types: read methods live on `impl<M> Db<M>`, write methods only on `impl Db<ReadWrite>`. The `ReadWrite` default keeps every existing call-site spelling (`Db`, `Db::open`, `&Db`) compiling unchanged — scan, CLI, and all tests are untouched.
- `DbPool::new` degrades the mount connection via the new `into_read_only()` (type-level only; same connection, zero runtime change), and `with`/`with_poll` hand out `&Db<ReadOnly>`.
- The 12 serve-path fns (`reader.rs`, `mapping.rs`, `facade.rs`) are generic over `&Db<M>`; write methods don't resolve for an unconstrained `M`, so the compiler proves the serve-path bodies contain no write call.
- The guarantee is pinned by paired doctests: a passing read call on `Db<ReadOnly>` next to a `compile_fail` write call, so the failure is provably the write-method non-resolution rather than an unrelated compile error.

## Validation

- `cargo test --workspace`: 683 passed (includes the two new doctests)
- `cargo clippy --all-targets` / `cargo fmt --all --check`: clean
- `cargo test -p musefs-fuse -- --ignored` (real mounts): 9 passed
- In-diff mutation gate (CI parity): 31 mutants — 19 caught, 12 unviable, 0 missed
- Manual audit of every shared `impl<M> Db<M>` block for write SQL (the one misplacement the compiler can't catch): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal database connection type-safety by distinguishing between read-only and read-write database operations. This improves code robustness at the architecture level without introducing changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->