### PR TITLE
Group the mount CLI knobs into a clap MountArgs struct (#132)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-cli-mount-args.md
+++ b/docs/superpowers/plans/2026-06-05-cli-mount-args.md
@@ -1,0 +1,252 @@
+# CLI MountArgs Grouping Implementation Plan (#132)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group the ten `musefs mount` CLI knobs into a `#[derive(clap::Args)] MountArgs` struct so `parse_mount_config` and `run_mount` drop their `#[allow(clippy::too_many_arguments)]` and the same-typed integer knobs stop being ordering hazards.
+
+**Architecture:** Single-file refactor in `musefs-cli/src/lib.rs`. The inline fields of the `Command::Mount` variant move verbatim (attributes and doc comments included) into a new `MountArgs` struct; the variant becomes `Mount(MountArgs)`; `parse_mount_config` takes `&MountArgs`, `run_mount` takes `MountArgs`. The `CliMode → Mode` conversion moves from `run` into `parse_mount_config`. CLI parsing behavior is byte-for-byte identical.
+
+**Tech Stack:** Rust, clap 4 derive (`Args`, `Subcommand`, `ValueEnum`).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md` (Part 1).
+
+**Branch:** create `cli-mount-args` off `main` before Task 1 (`git checkout -b cli-mount-args main`). This PR also carries the spec document.
+
+---
+
+### Task 1: Commit the design spec
+
+The spec rides this PR's branch (main is protected; specs land with the first feature PR per repo convention).
+
+**Files:**
+- Add: `docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md` (already written)
+
+- [ ] **Step 1: Commit the spec**
+
+```bash
+git add docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md
+git commit -m "$(cat <<'EOF'
+docs: spec for CLI MountArgs grouping (#132) and Fh newtype (#134)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2: MountArgs struct, tuple variant, and the new conversion unit test
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs` (Command enum at :39, `parse_mount_config` at :131, `run_mount` at :160, `run` at :193, tests module at :228)
+
+The whole change is one compilation unit — the signature changes ripple through four functions and the tests module, so they land together. TDD here means writing the new test first; it fails to compile until the refactor exists, then passes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module at the bottom of `musefs-cli/src/lib.rs` (after `scan_command_parses_multiple_paths`):
+
+```rust
+    #[test]
+    fn mount_args_parse_into_configs() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "mount",
+            "/mnt/muse",
+            "--db",
+            "/tmp/x.db",
+            "--poll-interval-ms",
+            "250",
+            "--attr-ttl-ms",
+            "750",
+            "--max-readahead-kib",
+            "64",
+            "--max-background",
+            "32",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (config, fuse_config) = parse_mount_config(&args);
+        // Defaults survive the move into the struct.
+        assert_eq!(config.template, "$artist/$title");
+        assert_eq!(config.default_fallback, "Unknown");
+        assert_eq!(config.mode, musefs_core::Mode::Synthesis);
+        assert!(!fuse_config.keep_cache);
+        // ms → Duration.
+        assert_eq!(config.poll_interval, std::time::Duration::from_millis(250));
+        assert_eq!(fuse_config.ttl, std::time::Duration::from_millis(750));
+        // KiB → bytes.
+        assert_eq!(fuse_config.max_readahead, 64 * 1024);
+        assert_eq!(fuse_config.max_background, 32);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-cli mount_args_parse_into_configs`
+Expected: compile error — `Command::Mount` is not a tuple variant and `parse_mount_config` does not accept `&MountArgs`.
+
+- [ ] **Step 3: Implement the refactor**
+
+In `musefs-cli/src/lib.rs`:
+
+**(a)** Insert the `MountArgs` struct between the `Cli` struct and the `Command` enum. Every field, `#[arg(...)]` attribute, and doc comment is moved verbatim from the current `Mount` variant:
+
+```rust
+/// Flags for `musefs mount`, grouped so the mount plumbing passes one value
+/// instead of ten ordering-fragile positional parameters.
+#[derive(clap::Args, Debug)]
+pub struct MountArgs {
+    /// Empty directory to mount at.
+    pub mountpoint: PathBuf,
+    /// Path to the SQLite database.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Path template, e.g. "$albumartist/$album/$title".
+    #[arg(long, default_value = "$artist/$title")]
+    pub template: String,
+    /// Fallback value substituted for any missing template field.
+    #[arg(long, default_value = "Unknown")]
+    pub default_fallback: String,
+    /// How file contents are served.
+    #[arg(long, value_enum, default_value_t = CliMode::Synthesis)]
+    pub mode: CliMode,
+    /// Debounce window (ms) for picking up external DB edits.
+    #[arg(long, default_value_t = 1000)]
+    pub poll_interval_ms: u64,
+    /// Entry/attr cache TTL (ms) the kernel may trust before re-validating.
+    /// Higher cuts lookup/getattr traffic but slows visibility of DB edits.
+    #[arg(long, default_value_t = 1000)]
+    pub attr_ttl_ms: u64,
+    /// Kernel read-ahead window (KiB). Larger hides HDD/NFS latency while
+    /// streaming; clamped to the kernel maximum at mount.
+    #[arg(long, default_value_t = 512)]
+    pub max_readahead_kib: u32,
+    /// Max outstanding background (readahead/async) requests the kernel queues.
+    #[arg(long, default_value_t = 64)]
+    pub max_background: u16,
+    /// Keep the kernel page cache across opens. External re-tags auto-invalidate
+    /// the affected inodes on refresh, so cached bytes are dropped when content
+    /// changes.
+    #[arg(long)]
+    pub keep_cache: bool,
+}
+```
+
+**(b)** Replace the `Mount { ... }` variant in `Command` with the tuple variant (keep the variant's own doc comment):
+
+```rust
+    /// Mount a read-only FUSE view of the store.
+    Mount(MountArgs),
+```
+
+**(c)** Replace `parse_mount_config` — the `#[allow(clippy::too_many_arguments)]` is dropped, and the `CliMode → Mode` conversion now happens here:
+
+```rust
+/// Parse mount CLI flags into `MountConfig` and `FuseConfig`. Pure function —
+/// no DB access, no mounting. Exported for unit testing.
+pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseConfig) {
+    let config = MountConfig {
+        template: args.template.clone(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: args.default_fallback.clone(),
+        mode: args.mode.into(),
+        poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
+    };
+    let fuse_config = musefs_fuse::FuseConfig {
+        ttl: std::time::Duration::from_millis(args.attr_ttl_ms),
+        max_readahead: args.max_readahead_kib.saturating_mul(1024),
+        max_background: args.max_background,
+        keep_cache: args.keep_cache,
+    };
+    (config, fuse_config)
+}
+```
+
+**(d)** Replace `run_mount` — the `#[allow(clippy::too_many_arguments)]` is dropped:
+
+```rust
+/// Build a `Musefs` from the DB at `args.db` and mount it (blocking) at
+/// `args.mountpoint`.
+pub fn run_mount(args: MountArgs) -> Result<()> {
+    let db = Db::open(&args.db)
+        .with_context(|| format!("opening database at {}", args.db.display()))?;
+    let (config, fuse_config) = parse_mount_config(&args);
+    let core = Musefs::open(db, config).context("building the virtual filesystem")?;
+    musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
+        .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
+    Ok(())
+}
+```
+
+**(e)** In `run`, replace the entire `Command::Mount { ... } => run_mount(...)` arm (the ten-field destructure and the call, including the `mode.into()` — the conversion moved into `parse_mount_config`) with:
+
+```rust
+        Command::Mount(args) => run_mount(args),
+```
+
+**(f)** In the two existing scan tests, change both panic arms (lib.rs:243 and :263) from:
+
+```rust
+            Command::Mount { .. } => panic!("expected Scan"),
+```
+
+to:
+
+```rust
+            Command::Mount(..) => panic!("expected Scan"),
+```
+
+- [ ] **Step 4: Run the crate tests to verify they pass**
+
+Run: `cargo test -p musefs-cli`
+Expected: PASS — all three tests (`scan_command_parses_jobs_flag`, `scan_command_parses_multiple_paths`, `mount_args_parse_into_configs`).
+
+- [ ] **Step 5: Verify the CLI surface is unchanged**
+
+Run: `cargo run -p musefs -- mount --help`
+Expected: identical flags, defaults, and help text as before (`--template` default `$artist/$title`, `--poll-interval-ms` default `1000`, etc.). The clap derive on a tuple-variant `Args` struct produces the same parser.
+
+- [ ] **Step 6: Lint and format**
+
+Run: `cargo clippy --all-targets -p musefs-cli && cargo fmt --all && cargo fmt --all --check`
+Expected: clippy clean with **no** `too_many_arguments` allow left in the file (`grep -c too_many_arguments musefs-cli/src/lib.rs` → 0); fmt check exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-cli/src/lib.rs
+git commit -m "$(cat <<'EOF'
+Group the mount CLI knobs into a clap MountArgs struct (#132)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3: Full validation gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Workspace tests**
+
+Run: `cargo test`
+Expected: PASS (the binary crate's `run` dispatch and any cross-crate users compile against the new signatures).
+
+- [ ] **Step 2: Workspace clippy + fmt**
+
+Run: `cargo clippy --all-targets && cargo fmt --all --check`
+Expected: clean, exit 0 (check the exit status directly — CI gates on it).
+
+- [ ] **Step 3: In-diff mutation gate (CI parity)**
+
+Always `-j2`, output on /tmp, do NOT set TMPDIR. Sanity-check the diff is non-empty first — an empty diff mutates nothing and exits 0, a silent false pass:
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: zero missed mutants. The `mount_args_parse_into_configs` test is what catches mutations of `from_millis` and `saturating_mul(1024)`; if a mutant survives, strengthen that test rather than excluding the mutant.

--- a/docs/superpowers/plans/2026-06-05-fh-newtype.md
+++ b/docs/superpowers/plans/2026-06-05-fh-newtype.md
@@ -1,0 +1,303 @@
+# Fh File-Handle Newtype Implementation Plan (#134)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the FUSE file-handle non-zero invariant out of `+1`/`-1` arithmetic scattered across three sites in `musefs-core/src/facade.rs` and into an `Fh(NonZeroU64)` newtype whose two private conversion methods are the only places the offset exists.
+
+**Architecture:** `musefs-core` gains a public `Fh` newtype; the facade API changes shape (`open_handle → Result<Fh>`, `read`/`read_into` take `Option<Fh>` replacing the `fh == 0` sentinel, `release_handle` takes `Fh`). `musefs-fuse` converts at the wire boundary: the kernel still sees raw `u64`s, identical to today. Stale-handle semantics are unchanged — a `Some(fh)` whose slab slot was reused still misses the lookup and falls back to inode resolution.
+
+**Tech Stack:** Rust, `std::num::NonZeroU64`, `sharded_slab`, fuser.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md` (Part 2).
+
+**Branch:** create `fh-newtype` off `main` before Task 1 (`git checkout -b fh-newtype main`). Independent of the #132 branch — no ordering dependency. If the #132 PR has not merged yet when this branch is cut, the spec document is not on `main`; that's fine — this plan does not touch the spec.
+
+---
+
+### Task 1: The `Fh` newtype and core facade API in `musefs-core`
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (imports at :1, `fh_from_key` at :158, `read_into` at :875, `read` at :962, `open_handle` at :968, `release_handle` at :1000, unit tests at :1013 and the two handle-reuse tests at ~:1085 and ~:1180)
+- Modify: `musefs-core/src/lib.rs` (re-export at :17)
+
+The signature changes and their in-crate consumers must land together to compile; TDD here means rewriting the handle unit test against the newtype first, watching it fail to compile, then implementing.
+
+- [ ] **Step 1: Rewrite the failing unit test**
+
+In `musefs-core/src/facade.rs`'s `#[cfg(test)] mod tests`, replace the whole `fh_from_key_offsets_by_one_and_maps_full_to_error` test with:
+
+```rust
+    #[test]
+    fn fh_round_trips_slab_key_and_maps_full_to_error() {
+        // None (slab at capacity) -> HandleTableFull.
+        assert!(matches!(fh_from_key(None), Err(CoreError::HandleTableFull)));
+        // Wire value is the slab key + 1, so the kernel never sees 0 ("no
+        // handle"). Non-zero needs no runtime assertion — NonZeroU64 makes a
+        // zero handle unrepresentable.
+        assert_eq!(fh_from_key(Some(0)).unwrap().get(), 1);
+        assert_eq!(fh_from_key(Some(41)).unwrap().get(), 42);
+        // The two private conversion methods invert each other.
+        assert_eq!(Fh::from_slab_key(0).slab_key(), 0);
+        assert_eq!(Fh::from_slab_key(41).slab_key(), 41);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core --lib fh_round_trips`
+Expected: compile error — `Fh` does not exist and `fh_from_key` returns `Result<u64>`, which has no `.get()`.
+
+- [ ] **Step 3: Implement `Fh` and the facade API change**
+
+All in `musefs-core/src/facade.rs`:
+
+**(a)** Add to the imports at the top:
+
+```rust
+use std::num::NonZeroU64;
+```
+
+**(b)** Replace `fh_from_key` (at :158) with the newtype and the rewritten helper. The helper stays standalone because its `None` arm is only unit-testable as a function — a full slab can't practically be produced in a test:
+
+```rust
+/// A FUSE file handle: the sharded-slab key offset by one, so the wire value
+/// is never 0 (`0` on the wire means "no handle" — `read` falls back to inode
+/// resolution).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fh(NonZeroU64);
+
+impl Fh {
+    /// Sole site of the `+1`: slab key → wire-safe non-zero handle.
+    /// `NonZeroU64::MIN.saturating_add` is panic-free, overflow-proof, and
+    /// non-zero by construction.
+    fn from_slab_key(key: usize) -> Fh {
+        Fh(NonZeroU64::MIN.saturating_add(key as u64))
+    }
+
+    /// Sole site of the `-1`: handle → slab key.
+    fn slab_key(self) -> usize {
+        (self.0.get() - 1) as usize
+    }
+
+    /// The raw wire value handed to the kernel.
+    pub fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// Wire → type, for the FUSE layer's boundary conversion.
+impl From<NonZeroU64> for Fh {
+    fn from(raw: NonZeroU64) -> Fh {
+        Fh(raw)
+    }
+}
+
+/// Map a `sharded_slab::Slab` insert result to a file handle. `None` means the
+/// slab is at capacity, surfaced as an explicit error rather than a panic.
+fn fh_from_key(key: Option<usize>) -> Result<Fh> {
+    key.map(Fh::from_slab_key).ok_or(CoreError::HandleTableFull)
+}
+```
+
+**(c)** `open_handle` (at :968): change only the signature's return type — the body, including the final `fh_from_key(self.handles.insert(...))` expression, is unchanged:
+
+```rust
+    pub fn open_handle(&self, inode: u64) -> Result<Fh> {
+```
+
+Also update the last line of its doc comment from "return a non-zero handle id" to "return a handle" (the type now says non-zero).
+
+**(d)** `read_into` (at :875): change the parameter `fh: u64` to `fh: Option<Fh>`, and the fast-path guard from:
+
+```rust
+        if fh != 0 {
+            let handle = self.handles.get((fh - 1) as usize).map(|g| Arc::clone(&g));
+```
+
+to:
+
+```rust
+        if let Some(fh) = fh {
+            let handle = self.handles.get(fh.slab_key()).map(|g| Arc::clone(&g));
+```
+
+Everything else in the body (the retry loop, the fallback path) is untouched. The trailing comment "Fallback (no prior open, or unknown handle)" still reads correctly.
+
+**(e)** `read` (at :962): change the parameter the same way — body unchanged:
+
+```rust
+    pub fn read(&self, inode: u64, fh: Option<Fh>, offset: u64, size: u64) -> Result<Vec<u8>> {
+```
+
+**(f)** `release_handle` (at :1000): the sentinel guard disappears — an absent handle is now unrepresentable at the call site:
+
+```rust
+    /// Drop an open handle (closes its backing fd when the last reference goes).
+    pub fn release_handle(&self, fh: Fh) {
+        self.handles.remove(fh.slab_key());
+    }
+```
+
+**(g)** In `musefs-core/src/lib.rs:17`, add `Fh` to the facade re-export:
+
+```rust
+pub use facade::{Attr, Fh, Mode, MountConfig, Musefs};
+```
+
+**(h)** Update the two handle-reuse tests in `facade.rs`'s own tests module — wrap the handle in `Some(...)` at each `fs.read` call (five sites; `open_handle`/`release_handle` calls need no change):
+
+- ~:1086 and ~:1105 (the refresh/re-resolve test): `fs.read(file_inode, fh, 0, 1 << 20)` → `fs.read(file_inode, Some(fh), 0, 1 << 20)`
+- ~:1181, ~:1209, ~:1228 (the rowid-reuse test): same wrap for `fh` and `fh2`.
+
+- [ ] **Step 4: Run the unit test to verify it passes**
+
+Run: `cargo test -p musefs-core --lib fh_round_trips`
+Expected: PASS.
+
+**Do not commit yet.** The repo's pre-commit hook (`.githooks/pre-commit`) runs `cargo test --workspace`, which cannot compile until the integration tests (Task 2) and the FUSE boundary (Task 3) are updated. The single commit happens at the end of Task 3.
+
+### Task 2: Integration-test ripple in `musefs-core/tests/`
+
+**Files:**
+- Modify: `musefs-core/tests/facade.rs`
+- Modify: `musefs-core/tests/metrics.rs`
+- Modify: `musefs-core/tests/flac_binary_tags.rs`
+- Modify: `musefs-core/tests/bench_ingest.rs`
+- Modify: `musefs-core/benches/read_throughput.rs` (a declared `[[bench]]` with `harness = false` — NOT compiled by `cargo build` or `cargo test -p musefs-core`, but IS compiled by `cargo clippy --all-targets` and therefore by the pre-commit hook; missing it makes the first commit fail)
+
+- [ ] **Step 1: Apply the mechanical substitutions**
+
+Sentinel `0` → `None` (the fallback-path reads):
+
+- `tests/facade.rs:54, :140, :173, :228, :266, :349, :367` — `fs.read(file_inode, 0, …)` → `fs.read(file_inode, None, …)`
+- `tests/metrics.rs:40, :95` — same
+- `tests/bench_ingest.rs:225, :233` — same
+- `benches/read_throughput.rs:77, :195, :236` — same
+
+Live handle → `Some(…)`:
+
+- `tests/facade.rs:348` `Some(fh)`, `:354` `Some(fh)` (stale-after-release read — keep the `// unknown fh → fallback` comment), `:377` `Some(fh_a)`, `:380` `Some(fh_b)`, `:988` `Some(fh)`, `:1012` `Some(fh)`
+- `tests/metrics.rs:142` `Some(fh)`
+- `tests/flac_binary_tags.rs:61` `Some(fh)`
+- `benches/read_throughput.rs:137` `Some(fh)` (the `open_handle`/`release_handle` calls at `:133`/`:143` need no change)
+
+`release_handle`/`open_handle` call sites need no change (`fh` variables are now `Fh` values throughout).
+
+- [ ] **Step 2: Delete the two now-untypeable non-zero assertions**
+
+The `NonZeroU64` wrapper subsumes them; the adjacent `assert_ne!` distinctness checks are retained (they rely on `Fh`'s `PartialEq, Eq` derives):
+
+- `tests/facade.rs:347`: delete `assert!(fh != 0);`
+- `tests/facade.rs:965`: delete `assert!(fh1 != 0 && fh2 != 0);` (the test `open_handle_returns_distinct_ids_and_rejects_dirs` keeps its name and its `assert_ne!(fh1, fh2, …)`)
+
+- [ ] **Step 3: Run the crate's full test suite, then verify the bench compiles**
+
+Run: `cargo test -p musefs-core`
+Expected: PASS — unit tests, integration tests, and proptests all compile and pass.
+
+Run: `cargo clippy -p musefs-core --all-targets`
+Expected: clean — this is what compiles `benches/read_throughput.rs` (`cargo test`/`cargo build` skip it; the pre-commit hook's workspace clippy does not).
+
+**Do not commit yet** — `musefs-fuse` still doesn't compile against the new facade API; the workspace-wide pre-commit hook would fail. Commit comes at the end of Task 3.
+
+### Task 3: FUSE wire-boundary conversion in `musefs-fuse`
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` (imports at :19-21, `open` at :278, `release` at :287, `read` at :317)
+
+- [ ] **Step 1: Apply the boundary conversions**
+
+**(a)** Add to the imports (next to the existing `musefs_core` imports at :19-21):
+
+```rust
+use std::num::NonZeroU64;
+```
+
+```rust
+use musefs_core::Fh;
+```
+
+**(b)** `open` (:278): the core now returns `Fh`; unwrap to the wire value:
+
+```rust
+            Ok(fh) => reply.opened(FileHandle(fh.get()), flags),
+```
+
+**(c)** `release` (:287): convert and skip the core call on `None`, preserving today's `fh == 0` no-op:
+
+```rust
+        // Cheap (a map remove); no need to offload to the pool.
+        if let Some(fh) = NonZeroU64::new(fh.0) {
+            self.core.release_handle(Fh::from(fh));
+        }
+        reply.ok();
+```
+
+**(d)** `read` (:317): convert the raw wire value to `Option<Fh>` — `None` (wire 0) preserves today's inode-resolution fallback:
+
+```rust
+                match core.read_into(ino.0, NonZeroU64::new(fh.0).map(Fh::from), offset, size as u64, &mut buf) {
+```
+
+(If rustfmt wraps this line, let it.)
+
+- [ ] **Step 2: Run the FUSE crate tests and workspace build**
+
+Run: `cargo test -p musefs-fuse && cargo build`
+Expected: PASS / clean build (the `#[ignore]`d e2e tests compile but don't run here).
+
+- [ ] **Step 3: Commit the whole change**
+
+The first commit on the branch — Tasks 1–3 together, because the pre-commit hook runs `cargo fmt --check`, workspace clippy `-D warnings`, and `cargo test --workspace`, all of which need the full change present:
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/src/lib.rs musefs-core/tests/facade.rs musefs-core/tests/metrics.rs musefs-core/tests/flac_binary_tags.rs musefs-core/tests/bench_ingest.rs musefs-core/benches/read_throughput.rs musefs-fuse/src/lib.rs
+git commit -m "$(cat <<'EOF'
+Fh newtype: file-handle non-zero invariant in the type (#134)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If the hook fails, the commit didn't happen — fix the issue, re-stage, and create a NEW commit (never `--amend`, never `--no-verify`).
+
+### Task 4: Full validation gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Workspace tests**
+
+Run: `cargo test`
+Expected: PASS across all crates.
+
+- [ ] **Step 2: FUSE end-to-end tests (real mounts)**
+
+This PR touches the open/read/release path, so run the `#[ignore]`d e2e suite (needs `/dev/fuse` + libfuse; available on this machine):
+
+Run: `cargo test -p musefs-fuse -- --ignored`
+Expected: PASS (e.g. `end_to_end_read_through_mount`).
+
+- [ ] **Step 3: Workspace clippy + fmt**
+
+Run: `cargo clippy --all-targets && cargo fmt --all && cargo fmt --all --check`
+Expected: clean, exit 0 (check the exit status directly — CI gates on it).
+
+- [ ] **Step 4: In-diff mutation gate (CI parity)**
+
+Always `-j2`, output on /tmp, do NOT set TMPDIR. Sanity-check the diff is non-empty first — an empty diff mutates nothing and exits 0, a silent false pass:
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: zero missed mutants. The `fh_round_trips_slab_key_and_maps_full_to_error` unit test pins the `±1` arithmetic in `from_slab_key`/`slab_key`; the handle-roundtrip integration tests (`open_handle_read_and_release_roundtrip`, `stale_fh_after_release_and_reopen_falls_back`) catch mutations of the `read_into` fast-path guard and `release_handle`. If a mutant survives, strengthen the relevant test rather than excluding the mutant.
+
+- [ ] **Step 5: Fuzz targets still build**
+
+The `fuzz/` crate is outside the workspace, so format-layer/core signature changes break it only in CI's smoke job. `Fh` is not used by fuzz targets, but verify cheaply:
+
+Run: `cargo +nightly fuzz build flac`
+Expected: builds clean.

--- a/docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md
+++ b/docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md
@@ -1,0 +1,155 @@
+# CLI MountArgs grouping and Fh file-handle newtype
+
+**Date:** 2026-06-05
+**Issues:** #132 — CLI mount plumbing suppresses `too_many_arguments` instead
+of grouping a config; #134 — FUSE file-handle non-zero invariant enforced by
+arithmetic, not the type
+**Status:** Approved
+
+Two independent fixes covered by one spec, shipped as **two separate PRs**
+with no ordering dependency (#132 is confined to `musefs-cli/src/lib.rs`;
+#134 changes the `Musefs` facade surface in `musefs-core` and its consumers).
+
+## Part 1 — #132: group the mount knobs into a clap `MountArgs` struct (PR 1)
+
+### Problem
+
+`parse_mount_config` (8 parameters) and `run_mount` (10) in
+`musefs-cli/src/lib.rs` carry every mount knob positionally under
+`#[allow(clippy::too_many_arguments)]`. The call chain re-lists the same
+fields three times (the `Command::Mount` destructure in `run`, the
+`run_mount` call, the `parse_mount_config` call), and the same-typed integer
+knobs (`poll_interval_ms`, `attr_ttl_ms`, `max_readahead_kib`) are exposed to
+silent argument-ordering mistakes at each site.
+
+### Design
+
+All changes in `musefs-cli/src/lib.rs`:
+
+1. **New `#[derive(clap::Args, Debug)] pub struct MountArgs`** carrying all
+   ten current `Mount` fields — `mountpoint`, `db`, `template`,
+   `default_fallback`, `mode`, `poll_interval_ms`, `attr_ttl_ms`,
+   `max_readahead_kib`, `max_background`, `keep_cache` — with their existing
+   `#[arg(...)]` attributes and doc comments moved verbatim.
+2. **`Command::Mount` becomes a tuple variant** `Mount(MountArgs)`.
+3. **`parse_mount_config(args: &MountArgs) -> (MountConfig, FuseConfig)`** —
+   the `#[allow]` is dropped. Stays pure and exported. The two `String`
+   fields are cloned out of the borrow (once per mount; negligible), and the
+   `mode: CliMode` converts via the existing `From<CliMode> for Mode` impl
+   inside the function. Note the conversion *moves*: today `run` calls
+   `mode.into()` before passing `Mode` down — that call site disappears
+   along with the destructure.
+4. **`run_mount(args: MountArgs) -> Result<()>`** — the `#[allow]` is
+   dropped; `db` and `mountpoint` are read from the struct.
+5. **`run`'s arm collapses** to `Command::Mount(args) => run_mount(args)`.
+
+CLI behavior is byte-for-byte identical: `#[derive(clap::Args)]` on a
+tuple-variant struct yields the same flags, defaults, and help text as the
+inline variant fields.
+
+### Testing
+
+- The two existing scan tests' `Command::Mount { .. } => panic!(...)` arms
+  become `Command::Mount(..)`.
+- **One new unit test** (making `parse_mount_config`'s "exported for unit
+  testing" doc comment finally true, and covering the in-diff mutation
+  surface): `Cli::try_parse_from` a mount invocation with explicit
+  `--poll-interval-ms`, `--attr-ttl-ms`, and `--max-readahead-kib` values →
+  `parse_mount_config` → assert `MountConfig.poll_interval` and
+  `FuseConfig.ttl` are the expected `Duration`s and `max_readahead` is the
+  KiB value × 1024. This pins the ms→`Duration` and KiB→bytes conversions
+  against mutants (`saturating_mul(1024)` → `*`/`/`/swap mutations).
+
+## Part 2 — #134: `Fh` newtype owning the non-zero invariant (PR 2)
+
+### Problem
+
+`fh_from_key` in `musefs-core/src/facade.rs` offsets sharded-slab keys by
+`+1` so the kernel never sees a file handle of 0 (`fh == 0` is musefs's "no
+handle" convention — `read` falls back to inode resolution). The reverse
+`-1` lives at two other sites (`read_into`, `release_handle`), each guarded
+by an `fh != 0` sentinel check. The invariant exists only as arithmetic in
+three places plus a comment.
+
+### Design
+
+**New public type in `musefs-core/src/facade.rs`:**
+
+```rust
+/// A FUSE file handle: the sharded-slab key offset by one, so the wire
+/// value is never 0 (0 on the wire means "no handle").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fh(NonZeroU64);
+
+impl Fh {
+    fn from_slab_key(key: usize) -> Fh   // the +1 — sole site
+    fn slab_key(self) -> usize           // the -1 — sole site
+    pub fn get(self) -> u64              // wire value for the FUSE layer
+}
+impl From<NonZeroU64> for Fh             // wire → type at the FUSE boundary
+```
+
+`from_slab_key` constructs via `NonZeroU64::MIN.saturating_add(key as u64)`
+— panic-free, overflow-proof, and non-zero by construction. The two
+conversion methods are private: the offset arithmetic cannot leak outside
+the type.
+
+**Facade API changes:**
+
+- `open_handle(...) -> Result<Fh>` — the `fh_from_key` helper stays (its
+  `None` arm is only unit-testable as a standalone function; a full slab
+  can't practically be produced in a test) but becomes
+  `fn fh_from_key(key: Option<usize>) -> Result<Fh>`, i.e.
+  `key.map(Fh::from_slab_key).ok_or(CoreError::HandleTableFull)` — no
+  arithmetic of its own anymore.
+- `read` / `read_into` take `fh: Option<Fh>` — the `fh != 0` sentinel check
+  becomes `if let Some(fh)`, slab lookup via `fh.slab_key()`. `None`
+  preserves today's fallback to inode resolution.
+- `release_handle(fh: Fh)` — the sentinel guard disappears; an absent handle
+  is unrepresentable at the call site.
+
+Stale-handle semantics are unchanged: a `Some(fh)` whose generation-encoded
+slab slot was reused or removed still misses the slab lookup and falls back
+exactly as a raw stale `u64` does today.
+
+**FUSE layer (`musefs-fuse/src/lib.rs`)** converts at the wire boundary:
+
+- `open`: `reply.opened(FileHandle(fh.get()), flags)`.
+- `read`: passes `NonZeroU64::new(fh.0).map(Fh::from)` into `read_into`.
+- `release`: converts the same way and skips the core call on `None`,
+  preserving today's `fh == 0` no-op.
+
+**Ripple — test updates in `musefs-core`:** `tests/facade.rs`,
+`tests/flac_binary_tags.rs`, `tests/metrics.rs`, `tests/bench_ingest.rs`,
+`benches/read_throughput.rs` (compiled only under `--all-targets` — easy to
+miss), and the two handle-reuse tests in `src/facade.rs`'s own `#[cfg(test)]`
+module switch `fs.read(inode, 0, …)` → `fs.read(inode, None, …)` and
+`fs.read(inode, fh, …)` → `fs.read(inode, Some(fh), …)`. Two assertions are
+not mechanical and are **deleted**: the `assert!(fh != 0)` at
+`tests/facade.rs:347` and `assert!(fh1 != 0 && fh2 != 0)` at `:965` no
+longer type-check against `Fh` — the `NonZeroU64` wrapper subsumes them.
+The handle-distinctness checks (`assert_ne!` at `:374` and `:964`) are
+retained; they rely on the `PartialEq, Eq` derives on `Fh`, which are
+load-bearing for exactly this reason.
+
+### Testing
+
+The existing `fh_from_key_offsets_by_one_and_maps_full_to_error` unit test
+is rewritten against the newtype:
+
+1. **Round-trip:** `Fh::from_slab_key(k).slab_key() == k` for `k = 0` and a
+   non-trivial key, and `Fh::from_slab_key(0).get() == 1` /
+   `from_slab_key(41).get() == 42` (pins the wire offset).
+2. **Capacity error:** `fh_from_key(None)` still maps to
+   `CoreError::HandleTableFull`, as today.
+
+The non-zero half of the old test ("fh is always non-zero") needs no
+runtime assertion anymore — `NonZeroU64` makes it unrepresentable.
+
+## Validation (both PRs)
+
+`cargo test` (workspace), `cargo clippy --all-targets`,
+`cargo fmt --all --check`, and the in-diff mutation gate
+(`cargo mutants --in-diff … -j2`) per CLAUDE.md. The FUSE e2e tests
+(`cargo test -p musefs-fuse -- --ignored`) are worth one run on PR 2 since
+it touches the open/read/release path.

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -37,6 +37,45 @@ pub struct Cli {
     pub command: Command,
 }
 
+/// Flags for `musefs mount`, grouped so the mount plumbing passes one value
+/// instead of ten ordering-fragile positional parameters.
+#[derive(clap::Args, Debug)]
+pub struct MountArgs {
+    /// Empty directory to mount at.
+    pub mountpoint: PathBuf,
+    /// Path to the SQLite database.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Path template, e.g. "$albumartist/$album/$title".
+    #[arg(long, default_value = "$artist/$title")]
+    pub template: String,
+    /// Fallback value substituted for any missing template field.
+    #[arg(long, default_value = "Unknown")]
+    pub default_fallback: String,
+    /// How file contents are served.
+    #[arg(long, value_enum, default_value_t = CliMode::Synthesis)]
+    pub mode: CliMode,
+    /// Debounce window (ms) for picking up external DB edits.
+    #[arg(long, default_value_t = 1000)]
+    pub poll_interval_ms: u64,
+    /// Entry/attr cache TTL (ms) the kernel may trust before re-validating.
+    /// Higher cuts lookup/getattr traffic but slows visibility of DB edits.
+    #[arg(long, default_value_t = 1000)]
+    pub attr_ttl_ms: u64,
+    /// Kernel read-ahead window (KiB). Larger hides HDD/NFS latency while
+    /// streaming; clamped to the kernel maximum at mount.
+    #[arg(long, default_value_t = 512)]
+    pub max_readahead_kib: u32,
+    /// Max outstanding background (readahead/async) requests the kernel queues.
+    #[arg(long, default_value_t = 64)]
+    pub max_background: u16,
+    /// Keep the kernel page cache across opens. External re-tags auto-invalidate
+    /// the affected inodes on refresh, so cached bytes are dropped when content
+    /// changes.
+    #[arg(long)]
+    pub keep_cache: bool,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Walk a backing directory, ingesting FLAC/MP3 files into the SQLite store.
@@ -56,41 +95,7 @@ pub enum Command {
         jobs: usize,
     },
     /// Mount a read-only FUSE view of the store.
-    Mount {
-        /// Empty directory to mount at.
-        mountpoint: PathBuf,
-        /// Path to the SQLite database.
-        #[arg(long)]
-        db: PathBuf,
-        /// Path template, e.g. "$albumartist/$album/$title".
-        #[arg(long, default_value = "$artist/$title")]
-        template: String,
-        /// Fallback value substituted for any missing template field.
-        #[arg(long, default_value = "Unknown")]
-        default_fallback: String,
-        /// How file contents are served.
-        #[arg(long, value_enum, default_value_t = CliMode::Synthesis)]
-        mode: CliMode,
-        /// Debounce window (ms) for picking up external DB edits.
-        #[arg(long, default_value_t = 1000)]
-        poll_interval_ms: u64,
-        /// Entry/attr cache TTL (ms) the kernel may trust before re-validating.
-        /// Higher cuts lookup/getattr traffic but slows visibility of DB edits.
-        #[arg(long, default_value_t = 1000)]
-        attr_ttl_ms: u64,
-        /// Kernel read-ahead window (KiB). Larger hides HDD/NFS latency while
-        /// streaming; clamped to the kernel maximum at mount.
-        #[arg(long, default_value_t = 512)]
-        max_readahead_kib: u32,
-        /// Max outstanding background (readahead/async) requests the kernel queues.
-        #[arg(long, default_value_t = 64)]
-        max_background: u16,
-        /// Keep the kernel page cache across opens. External re-tags auto-invalidate
-        /// the affected inodes on refresh, so cached bytes are dropped when content
-        /// changes.
-        #[arg(long)]
-        keep_cache: bool,
-    },
+    Mount(MountArgs),
 }
 
 /// Open (creating/migrating) the DB at `db_path` once, then scan each target in
@@ -131,63 +136,33 @@ pub fn run_scan(db_path: &Path, targets: &[PathBuf], revalidate: bool, jobs: usi
 
 /// Parse mount CLI flags into `MountConfig` and `FuseConfig`. Pure function —
 /// no DB access, no mounting. Exported for unit testing.
-#[allow(clippy::too_many_arguments)]
-pub fn parse_mount_config(
-    template: String,
-    default_fallback: String,
-    mode: musefs_core::Mode,
-    poll_interval_ms: u64,
-    attr_ttl_ms: u64,
-    max_readahead_kib: u32,
-    max_background: u16,
-    keep_cache: bool,
-) -> (MountConfig, musefs_fuse::FuseConfig) {
+pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseConfig) {
     let config = MountConfig {
-        template,
+        template: args.template.clone(),
         fallbacks: BTreeMap::new(),
-        default_fallback,
-        mode,
-        poll_interval: std::time::Duration::from_millis(poll_interval_ms),
+        default_fallback: args.default_fallback.clone(),
+        mode: args.mode.into(),
+        poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
     };
     let fuse_config = musefs_fuse::FuseConfig {
-        ttl: std::time::Duration::from_millis(attr_ttl_ms),
-        max_readahead: max_readahead_kib.saturating_mul(1024),
-        max_background,
-        keep_cache,
+        ttl: std::time::Duration::from_millis(args.attr_ttl_ms),
+        max_readahead: args.max_readahead_kib.saturating_mul(1024),
+        max_background: args.max_background,
+        keep_cache: args.keep_cache,
     };
     (config, fuse_config)
 }
 
-/// Build a `Musefs` from the DB at `db_path` and mount it (blocking) at
-/// `mountpoint`.
-#[allow(clippy::too_many_arguments)]
-pub fn run_mount(
-    db_path: &Path,
-    mountpoint: &Path,
-    template: String,
-    default_fallback: String,
-    mode: musefs_core::Mode,
-    poll_interval_ms: u64,
-    attr_ttl_ms: u64,
-    max_readahead_kib: u32,
-    max_background: u16,
-    keep_cache: bool,
-) -> Result<()> {
+/// Build a `Musefs` from the DB at `args.db` and mount it (blocking) at
+/// `args.mountpoint`.
+#[allow(clippy::needless_pass_by_value)]
+pub fn run_mount(args: MountArgs) -> Result<()> {
     let db =
-        Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
-    let (config, fuse_config) = parse_mount_config(
-        template,
-        default_fallback,
-        mode,
-        poll_interval_ms,
-        attr_ttl_ms,
-        max_readahead_kib,
-        max_background,
-        keep_cache,
-    );
+        Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
+    let (config, fuse_config) = parse_mount_config(&args);
     let core = Musefs::open(db, config).context("building the virtual filesystem")?;
-    musefs_fuse::mount_with(core, mountpoint, "musefs", fuse_config)
-        .with_context(|| format!("mounting at {}", mountpoint.display()))?;
+    musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
+        .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
     Ok(())
 }
 
@@ -200,29 +175,7 @@ pub fn run(cli: Cli) -> Result<()> {
             revalidate,
             jobs,
         } => run_scan(&db, &targets, revalidate, jobs),
-        Command::Mount {
-            mountpoint,
-            db,
-            template,
-            default_fallback,
-            mode,
-            poll_interval_ms,
-            attr_ttl_ms,
-            max_readahead_kib,
-            max_background,
-            keep_cache,
-        } => run_mount(
-            &db,
-            &mountpoint,
-            template,
-            default_fallback,
-            mode.into(),
-            poll_interval_ms,
-            attr_ttl_ms,
-            max_readahead_kib,
-            max_background,
-            keep_cache,
-        ),
+        Command::Mount(args) => run_mount(args),
     }
 }
 
@@ -240,7 +193,7 @@ mod tests {
                 assert_eq!(jobs, 3);
                 assert_eq!(targets, vec![PathBuf::from("/m")]);
             }
-            Command::Mount { .. } => panic!("expected Scan"),
+            Command::Mount(..) => panic!("expected Scan"),
         }
     }
 
@@ -260,7 +213,43 @@ mod tests {
                     ]
                 );
             }
-            Command::Mount { .. } => panic!("expected Scan"),
+            Command::Mount(..) => panic!("expected Scan"),
         }
+    }
+
+    #[test]
+    fn mount_args_parse_into_configs() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "mount",
+            "/mnt/muse",
+            "--db",
+            "/tmp/x.db",
+            "--poll-interval-ms",
+            "250",
+            "--attr-ttl-ms",
+            "750",
+            "--max-readahead-kib",
+            "64",
+            "--max-background",
+            "32",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (config, fuse_config) = parse_mount_config(&args);
+        // Defaults survive the move into the struct.
+        assert_eq!(config.template, "$artist/$title");
+        assert_eq!(config.default_fallback, "Unknown");
+        assert_eq!(config.mode, musefs_core::Mode::Synthesis);
+        assert!(!fuse_config.keep_cache);
+        // ms → Duration.
+        assert_eq!(config.poll_interval, std::time::Duration::from_millis(250));
+        assert_eq!(fuse_config.ttl, std::time::Duration::from_millis(750));
+        // KiB → bytes.
+        assert_eq!(fuse_config.max_readahead, 64 * 1024);
+        assert_eq!(fuse_config.max_background, 32);
     }
 }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -155,11 +155,10 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
 
 /// Build a `Musefs` from the DB at `args.db` and mount it (blocking) at
 /// `args.mountpoint`.
-#[allow(clippy::needless_pass_by_value)]
-pub fn run_mount(args: MountArgs) -> Result<()> {
+pub fn run_mount(args: &MountArgs) -> Result<()> {
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
-    let (config, fuse_config) = parse_mount_config(&args);
+    let (config, fuse_config) = parse_mount_config(args);
     let core = Musefs::open(db, config).context("building the virtual filesystem")?;
     musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
         .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
@@ -175,7 +174,7 @@ pub fn run(cli: Cli) -> Result<()> {
             revalidate,
             jobs,
         } => run_scan(&db, &targets, revalidate, jobs),
-        Command::Mount(args) => run_mount(args),
+        Command::Mount(args) => run_mount(&args),
     }
 }
 

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use musefs_cli::{Cli, Command};
+use musefs_cli::{Cli, Command, MountArgs};
 
 #[test]
 fn parses_scan_and_mount_invocations() {
@@ -9,7 +9,7 @@ fn parses_scan_and_mount_invocations() {
             assert_eq!(targets, vec![std::path::PathBuf::from("/music")]);
             assert_eq!(db.to_str(), Some("/tmp/m.db"));
         }
-        Command::Mount { .. } => panic!("expected scan"),
+        Command::Mount(..) => panic!("expected scan"),
     }
 
     let cli = Cli::parse_from([
@@ -22,17 +22,11 @@ fn parses_scan_and_mount_invocations() {
         "$album/$title",
     ]);
     match cli.command {
-        Command::Mount {
-            mountpoint,
-            db,
-            template,
-            default_fallback,
-            ..
-        } => {
-            assert_eq!(mountpoint.to_str(), Some("/mnt/x"));
-            assert_eq!(db.to_str(), Some("/tmp/m.db"));
-            assert_eq!(template, "$album/$title");
-            assert_eq!(default_fallback, "Unknown"); // default applied
+        Command::Mount(args) => {
+            assert_eq!(args.mountpoint.to_str(), Some("/mnt/x"));
+            assert_eq!(args.db.to_str(), Some("/tmp/m.db"));
+            assert_eq!(args.template, "$album/$title");
+            assert_eq!(args.default_fallback, "Unknown"); // default applied
         }
         Command::Scan { .. } => panic!("expected mount"),
     }
@@ -52,28 +46,20 @@ fn parses_mode_and_revalidate_flags() {
         "structure-only",
     ]);
     match cli.command {
-        Command::Mount { mode, .. } => assert_eq!(mode, CliMode::StructureOnly),
+        Command::Mount(args) => assert_eq!(args.mode, CliMode::StructureOnly),
         Command::Scan { .. } => panic!("expected mount"),
     }
 
     // Mode defaults to synthesis; tuning knobs have conservative defaults.
     let cli = Cli::parse_from(["musefs", "mount", "/mnt/x", "--db", "/tmp/m.db"]);
     match cli.command {
-        Command::Mount {
-            mode,
-            poll_interval_ms,
-            attr_ttl_ms,
-            max_readahead_kib,
-            max_background,
-            keep_cache,
-            ..
-        } => {
-            assert_eq!(mode, CliMode::Synthesis);
-            assert_eq!(poll_interval_ms, 1000); // default
-            assert_eq!(attr_ttl_ms, 1000); // default
-            assert_eq!(max_readahead_kib, 512); // default
-            assert_eq!(max_background, 64); // default
-            assert!(!keep_cache); // default off
+        Command::Mount(args) => {
+            assert_eq!(args.mode, CliMode::Synthesis);
+            assert_eq!(args.poll_interval_ms, 1000); // default
+            assert_eq!(args.attr_ttl_ms, 1000); // default
+            assert_eq!(args.max_readahead_kib, 512); // default
+            assert_eq!(args.max_background, 64); // default
+            assert!(!args.keep_cache); // default off
         }
         Command::Scan { .. } => panic!("expected mount"),
     }
@@ -96,19 +82,12 @@ fn parses_mode_and_revalidate_flags() {
         "--keep-cache",
     ]);
     match cli.command {
-        Command::Mount {
-            poll_interval_ms,
-            attr_ttl_ms,
-            max_readahead_kib,
-            max_background,
-            keep_cache,
-            ..
-        } => {
-            assert_eq!(poll_interval_ms, 500);
-            assert_eq!(attr_ttl_ms, 2000);
-            assert_eq!(max_readahead_kib, 1024);
-            assert_eq!(max_background, 128);
-            assert!(keep_cache);
+        Command::Mount(args) => {
+            assert_eq!(args.poll_interval_ms, 500);
+            assert_eq!(args.attr_ttl_ms, 2000);
+            assert_eq!(args.max_readahead_kib, 1024);
+            assert_eq!(args.max_background, 128);
+            assert!(args.keep_cache);
         }
         Command::Scan { .. } => panic!("expected mount"),
     }
@@ -124,12 +103,12 @@ fn parses_mode_and_revalidate_flags() {
     ]);
     match cli.command {
         Command::Scan { revalidate, .. } => assert!(revalidate),
-        Command::Mount { .. } => panic!("expected scan"),
+        Command::Mount(..) => panic!("expected scan"),
     }
     let cli = Cli::parse_from(["musefs", "scan", "/music", "--db", "/tmp/m.db"]);
     match cli.command {
         Command::Scan { revalidate, .. } => assert!(!revalidate),
-        Command::Mount { .. } => panic!("expected scan"),
+        Command::Mount(..) => panic!("expected scan"),
     }
 }
 
@@ -139,16 +118,19 @@ use std::time::Duration;
 
 #[test]
 fn parse_mount_config_defaults_are_sensible() {
-    let (config, fuse_config) = parse_mount_config(
-        "$artist/$title".to_string(),
-        "Unknown".to_string(),
-        Mode::Synthesis,
-        1000,
-        1000,
-        512,
-        64,
-        false,
-    );
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$artist/$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        mode: musefs_cli::CliMode::Synthesis,
+        poll_interval_ms: 1000,
+        attr_ttl_ms: 1000,
+        max_readahead_kib: 512,
+        max_background: 64,
+        keep_cache: false,
+    };
+    let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
     assert_eq!(config.default_fallback, "Unknown");
     assert_eq!(config.mode, Mode::Synthesis);
@@ -162,16 +144,19 @@ fn parse_mount_config_defaults_are_sensible() {
 
 #[test]
 fn parse_mount_config_keep_cache_sets_flag() {
-    let (config, fuse_config) = parse_mount_config(
-        "$title".to_string(),
-        "Unknown".to_string(),
-        Mode::StructureOnly,
-        250,
-        5000,
-        256,
-        32,
-        true,
-    );
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        mode: musefs_cli::CliMode::StructureOnly,
+        poll_interval_ms: 250,
+        attr_ttl_ms: 5000,
+        max_readahead_kib: 256,
+        max_background: 32,
+        keep_cache: true,
+    };
+    let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
     assert_eq!(config.poll_interval, Duration::from_millis(250));
     assert!(fuse_config.keep_cache);
@@ -181,15 +166,18 @@ fn parse_mount_config_keep_cache_sets_flag() {
 
 #[test]
 fn parse_mount_config_saturating_readahead() {
-    let (_, fuse_config) = parse_mount_config(
-        "$title".to_string(),
-        "Unknown".to_string(),
-        Mode::Synthesis,
-        1000,
-        1000,
-        u32::MAX,
-        64,
-        false,
-    );
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        mode: musefs_cli::CliMode::Synthesis,
+        poll_interval_ms: 1000,
+        attr_ttl_ms: 1000,
+        max_readahead_kib: u32::MAX,
+        max_background: 64,
+        keep_cache: false,
+    };
+    let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
 }


### PR DESCRIPTION
Closes #132.

`parse_mount_config` (8 args) and `run_mount` (10) carried every mount knob positionally under `#[allow(clippy::too_many_arguments)]`, exposing the same-typed integer knobs (`poll_interval_ms` / `attr_ttl_ms` / `max_readahead_kib`) to silent argument-ordering mistakes at three re-listing sites.

## Changes

- New `#[derive(clap::Args)] pub struct MountArgs` carrying all ten mount fields with their attributes and doc comments moved verbatim; `Command::Mount` becomes a tuple variant. CLI surface (flags, defaults, help text) is unchanged — verified against `mount --help`.
- `parse_mount_config(&MountArgs)` and `run_mount(&MountArgs)`: both `too_many_arguments` allows are gone, and no new suppression replaces them. The `CliMode → Mode` conversion moves from `run` into `parse_mount_config`.
- `run`'s mount arm collapses from a ten-field destructure to `Command::Mount(args) => run_mount(&args)`.
- Tests adapted: the `tests/cli.rs` parse tests now build `MountArgs` with named struct literals (ordering-proof by construction), and a new in-module test pins the ms→`Duration` and KiB→bytes conversions through a real `try_parse_from`.
- Also carries the design spec and implementation plans for #132 and #134 (the spec covers both; #134 ships separately).

## Validation

- `cargo test` (workspace), `cargo clippy --all-targets`, `cargo fmt --all --check` — clean (also enforced per-commit by the pre-commit hook).
- In-diff mutation gate: no mutants generated — `mutants.toml` permanently excludes `musefs-cli/**` (thin-dispatch policy, docs/audits/2026-05-29-test-audit.md).
- `grep -c 'allow(clippy' musefs-cli/src/lib.rs` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**: Added comprehensive implementation plans and detailed design specifications documenting upcoming CLI and core improvements.

* **Chores**: Refactored CLI mount command handling to reorganize parameter structure and internal processing.

* **Tests**: Updated test suites to verify restructured CLI command parsing and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->