### PR TITLE
Fh newtype: file-handle non-zero invariant in the type (#134)

### DIFF
--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -74,7 +74,7 @@ fn bench_sequential_read(c: &mut Criterion) {
             b.iter(|| {
                 let mut off = 0u64;
                 while off < size {
-                    let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
+                    let got = std::hint::black_box(fs.read(inode, None, off, chunk).unwrap());
                     if got.is_empty() {
                         break;
                     }
@@ -134,7 +134,7 @@ fn bench_concurrent_read_and_walk(c: &mut Criterion) {
                         let size = fs.getattr(ino).unwrap().size;
                         let mut off = 0u64;
                         while off < size {
-                            let got = fs.read(ino, fh, off, 128 * 1024).unwrap();
+                            let got = fs.read(ino, Some(fh), off, 128 * 1024).unwrap();
                             if got.is_empty() {
                                 break;
                             }
@@ -192,7 +192,7 @@ fn read_whole(fs: &Musefs, inode: u64) {
     let chunk = 128 * 1024u64;
     let mut off = 0u64;
     while off < size {
-        let got = std::hint::black_box(fs.read(inode, 0, off, chunk).unwrap());
+        let got = std::hint::black_box(fs.read(inode, None, off, chunk).unwrap());
         if got.is_empty() {
             break;
         }
@@ -233,7 +233,8 @@ fn bench_seek_read(c: &mut Criterion) {
             b.iter_batched(
                 || cold_fixture(fmt, bytes),
                 |(fs, inode, _dir)| {
-                    let _ = std::hint::black_box(fs.read(inode, 0, seek_off, 128 * 1024).unwrap());
+                    let _ =
+                        std::hint::black_box(fs.read(inode, None, seek_off, 128 * 1024).unwrap());
                 },
                 criterion::BatchSize::PerIteration,
             );

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -156,12 +157,42 @@ pub struct Musefs {
     last_seq: AtomicI64,
 }
 
-/// Map a `sharded_slab::Slab` insert result to a FUSE file handle. The slab key
-/// is offset by one so the wire `fh` is always non-zero (`fh == 0` means "no
-/// handle" — `read` falls back to inode resolution). `None` means the slab is at
-/// capacity, surfaced as an explicit error rather than a panic.
-fn fh_from_key(key: Option<usize>) -> Result<u64> {
-    key.map(|k| k as u64 + 1).ok_or(CoreError::HandleTableFull)
+/// A FUSE file handle: the sharded-slab key offset by one, so the wire value
+/// is never 0 (`0` on the wire means "no handle" — `read` falls back to inode
+/// resolution).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fh(NonZeroU64);
+
+impl Fh {
+    /// Sole site of the `+1`: slab key → wire-safe non-zero handle.
+    /// `NonZeroU64::MIN.saturating_add` is panic-free, overflow-proof, and
+    /// non-zero by construction.
+    fn from_slab_key(key: usize) -> Fh {
+        Fh(NonZeroU64::MIN.saturating_add(key as u64))
+    }
+
+    /// Sole site of the `-1`: handle → slab key.
+    fn slab_key(self) -> usize {
+        (self.0.get() - 1) as usize
+    }
+
+    /// The raw wire value handed to the kernel.
+    pub fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// Wire → type, for the FUSE layer's boundary conversion.
+impl From<NonZeroU64> for Fh {
+    fn from(raw: NonZeroU64) -> Fh {
+        Fh(raw)
+    }
+}
+
+/// Map a `sharded_slab::Slab` insert result to a file handle. `None` means the
+/// slab is at capacity, surfaced as an explicit error rather than a panic.
+fn fh_from_key(key: Option<usize>) -> Result<Fh> {
+    key.map(Fh::from_slab_key).ok_or(CoreError::HandleTableFull)
 }
 
 /// Outcome of a successful changelog-driven incremental refresh: everything
@@ -878,15 +909,15 @@ impl Musefs {
     pub fn read_into(
         &self,
         inode: u64,
-        fh: u64,
+        fh: Option<Fh>,
         offset: u64,
         size: u64,
         out: &mut Vec<u8>,
     ) -> Result<()> {
         out.clear();
         // Fast path: serve from the per-handle fd + cached layout (no open/stat).
-        if fh != 0 {
-            let handle = self.handles.get((fh - 1) as usize).map(|g| Arc::clone(&g));
+        if let Some(fh) = fh {
+            let handle = self.handles.get(fh.slab_key()).map(|g| Arc::clone(&g));
             if let Some(h) = handle {
                 // Bounded retry absorbs a refresh landing mid-read; out-of-band
                 // re-tags are human/batch-paced, so >1 attempt is already rare.
@@ -960,16 +991,16 @@ impl Musefs {
     }
 
     /// Allocating form of `read_into`.
-    pub fn read(&self, inode: u64, fh: u64, offset: u64, size: u64) -> Result<Vec<u8>> {
+    pub fn read(&self, inode: u64, fh: Option<Fh>, offset: u64, size: u64) -> Result<Vec<u8>> {
         let mut out = Vec::new();
         self.read_into(inode, fh, offset, size, &mut out)?;
         Ok(out)
     }
 
     /// Open a file handle: resolve + validate the layout and open the backing fd
-    /// once, store it, and return a non-zero handle id. Subsequent `read`s with
-    /// this handle reuse the fd (no per-read open/stat).
-    pub fn open_handle(&self, inode: u64) -> Result<u64> {
+    /// once, store it, and return a handle. Subsequent `read`s with this handle
+    /// reuse the fd (no per-read open/stat).
+    pub fn open_handle(&self, inode: u64) -> Result<Fh> {
         let track_id = {
             let tree = self.tree.load();
             match tree.node(inode) {
@@ -999,10 +1030,8 @@ impl Musefs {
     }
 
     /// Drop an open handle (closes its backing fd when the last reference goes).
-    pub fn release_handle(&self, fh: u64) {
-        if fh != 0 {
-            self.handles.remove((fh - 1) as usize);
-        }
+    pub fn release_handle(&self, fh: Fh) {
+        self.handles.remove(fh.slab_key());
     }
 }
 
@@ -1012,12 +1041,17 @@ mod tests {
     use musefs_format::{RegionLayout, Segment};
 
     #[test]
-    fn fh_from_key_offsets_by_one_and_maps_full_to_error() {
+    fn fh_round_trips_slab_key_and_maps_full_to_error() {
         // None (slab at capacity) -> HandleTableFull.
         assert!(matches!(fh_from_key(None), Err(CoreError::HandleTableFull)));
-        // Some(key) -> key + 1, so the fh is always non-zero (0 == "no handle").
-        assert_eq!(fh_from_key(Some(0)).unwrap(), 1);
-        assert_eq!(fh_from_key(Some(41)).unwrap(), 42);
+        // Wire value is the slab key + 1, so the kernel never sees 0 ("no
+        // handle"). Non-zero needs no runtime assertion — NonZeroU64 makes a
+        // zero handle unrepresentable.
+        assert_eq!(fh_from_key(Some(0)).unwrap().get(), 1);
+        assert_eq!(fh_from_key(Some(41)).unwrap().get(), 42);
+        // The two private conversion methods invert each other.
+        assert_eq!(Fh::from_slab_key(0).slab_key(), 0);
+        assert_eq!(Fh::from_slab_key(41).slab_key(), 41);
     }
 
     #[test]
@@ -1083,7 +1117,7 @@ mod tests {
         let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
         let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
         let fh = fs.open_handle(file_inode).unwrap();
-        let len_before = fs.read(file_inode, fh, 0, 1 << 20).unwrap().len();
+        let len_before = fs.read(file_inode, Some(fh), 0, 1 << 20).unwrap().len();
         assert!(len_before > 0, "baseline read must be non-empty");
 
         // Out-of-band re-tag: a long comment grows the synthesized ID3v2 region.
@@ -1102,7 +1136,7 @@ mod tests {
         );
 
         // Same handle: must re-resolve and serve the larger layout.
-        let len_after = fs.read(file_inode, fh, 0, 1 << 20).unwrap().len();
+        let len_after = fs.read(file_inode, Some(fh), 0, 1 << 20).unwrap().len();
         assert!(
             len_after > len_before,
             "handle did not re-resolve: {len_before} -> {len_after}"
@@ -1178,7 +1212,7 @@ mod tests {
 
         // Open the handle and read the original synthesized file (carries needle_a).
         let fh = fs.open_handle(file_inode).unwrap();
-        let whole_a = fs.read(file_inode, fh, 0, 1 << 20).unwrap();
+        let whole_a = fs.read(file_inode, Some(fh), 0, 1 << 20).unwrap();
         assert!(
             whole_a.windows(needle_a.len()).any(|w| w == needle_a),
             "baseline must carry the original PRIV body"
@@ -1206,7 +1240,7 @@ mod tests {
 
         // What a freshly resolved handle serves for the *current* DB state.
         let fh2 = fs.open_handle(file_inode).unwrap();
-        let whole_b = fs.read(file_inode, fh2, 0, 1 << 20).unwrap();
+        let whole_b = fs.read(file_inode, Some(fh2), 0, 1 << 20).unwrap();
         fs.release_handle(fh2);
         assert!(
             whole_b.windows(needle_b.len()).any(|w| w == needle_b),
@@ -1225,7 +1259,7 @@ mod tests {
         // The stale handle: either a clean error, or — via the guard's forced
         // re-resolve — byte-identical to the fresh resolve. Never torn bytes.
         // Err is acceptable too (the guard can surface a retryable error).
-        if let Ok(bytes) = fs.read(file_inode, fh, 0, 1 << 20) {
+        if let Ok(bytes) = fs.read(file_inode, Some(fh), 0, 1 << 20) {
             assert_eq!(
                 bytes, whole_b,
                 "stale handle served torn/reused-rowid bytes instead of re-resolving"

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -14,7 +14,7 @@ mod tree;
 
 pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
-pub use facade::{Attr, Mode, MountConfig, Musefs};
+pub use facade::{Attr, Fh, Mode, MountConfig, Musefs};
 pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -222,7 +222,7 @@ fn bench_read_under_latency() {
         if whole {
             let mut off = 0u64;
             while off < size {
-                let got = fs.read(inode, 0, off, 128 * 1024).unwrap();
+                let got = fs.read(inode, None, off, 128 * 1024).unwrap();
                 if got.is_empty() {
                     break;
                 }
@@ -230,7 +230,7 @@ fn bench_read_under_latency() {
             }
         } else {
             let off = (size * 7 / 8).min(size.saturating_sub(128 * 1024));
-            let _ = fs.read(inode, 0, off, 128 * 1024).unwrap();
+            let _ = fs.read(inode, None, off, 128 * 1024).unwrap();
         }
         let ms = t0.elapsed().as_millis();
         let s = metrics::snapshot();

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -51,7 +51,7 @@ fn lookup_getattr_readdir_and_read_through_the_facade() {
     assert!(fattr.size > 0);
 
     // Reading the whole file yields a valid FLAC whose TITLE is the synthesized value.
-    let bytes = fs.read(file_inode, 0, 0, fattr.size).unwrap();
+    let bytes = fs.read(file_inode, None, 0, fattr.size).unwrap();
     assert_eq!(bytes.len() as u64, fattr.size);
     let tag = metaflac::Tag::read_from(&mut std::io::Cursor::new(&bytes)).unwrap();
     assert_eq!(
@@ -137,7 +137,7 @@ fn reads_a_synthesized_mp3_through_the_facade() {
     assert_eq!(name, "Old.mp3");
 
     let attr = fs.getattr(file_inode).unwrap();
-    let whole = fs.read(file_inode, 0, 0, attr.size).unwrap();
+    let whole = fs.read(file_inode, None, 0, attr.size).unwrap();
     assert_eq!(whole.len() as u64, attr.size);
 
     // The synthesized file is a valid ID3v2.4 stream carrying the DB tags, and the
@@ -170,7 +170,7 @@ fn reads_a_synthesized_m4a_through_the_facade() {
     assert_eq!(name, "Orig M4A.m4a");
 
     let attr = fs.getattr(file_inode).unwrap();
-    let whole = fs.read(file_inode, 0, 0, attr.size).unwrap();
+    let whole = fs.read(file_inode, None, 0, attr.size).unwrap();
     assert_eq!(whole.len() as u64, attr.size);
 
     // The original audio frames are spliced in verbatim at the tail of the
@@ -225,7 +225,7 @@ fn serves_flac_with_embedded_art_through_the_facade() {
     let artist = fs.lookup(VirtualTree::ROOT, "Art").unwrap();
     let (_name, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
     let attr = fs.getattr(file_inode).unwrap();
-    let whole = fs.read(file_inode, 0, 0, attr.size).unwrap();
+    let whole = fs.read(file_inode, None, 0, attr.size).unwrap();
     assert_eq!(whole.len() as u64, attr.size);
 
     // The synthesized FLAC carries the embedded picture with the original bytes.
@@ -263,7 +263,7 @@ fn serves_mp3_with_embedded_art_through_the_facade() {
     let artist = fs.lookup(VirtualTree::ROOT, "Pix").unwrap();
     let (_name, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
     let attr = fs.getattr(file_inode).unwrap();
-    let whole = fs.read(file_inode, 0, 0, attr.size).unwrap();
+    let whole = fs.read(file_inode, None, 0, attr.size).unwrap();
     assert_eq!(whole.len() as u64, attr.size);
 
     // The synthesized MP3 carries the embedded APIC picture with the original bytes.
@@ -344,14 +344,13 @@ fn open_handle_read_and_release_roundtrip() {
     let size = fs.getattr(file_inode).unwrap().size;
 
     let fh = fs.open_handle(file_inode).unwrap();
-    assert!(fh != 0);
-    let via_handle = fs.read(file_inode, fh, 0, size).unwrap();
-    let via_fallback = fs.read(file_inode, 0, 0, size).unwrap();
+    let via_handle = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    let via_fallback = fs.read(file_inode, None, 0, size).unwrap();
     assert_eq!(via_handle, via_fallback);
     assert_eq!(via_handle.len() as u64, size);
 
     fs.release_handle(fh);
-    let after = fs.read(file_inode, fh, 0, size).unwrap(); // unknown fh → fallback
+    let after = fs.read(file_inode, Some(fh), 0, size).unwrap(); // unknown fh → fallback
     assert_eq!(after, via_fallback);
 }
 
@@ -364,7 +363,7 @@ fn stale_fh_after_release_and_reopen_falls_back() {
     let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
     let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
     let size = fs.getattr(file_inode).unwrap().size;
-    let canonical = fs.read(file_inode, 0, 0, size).unwrap(); // inode fallback bytes
+    let canonical = fs.read(file_inode, None, 0, size).unwrap(); // inode fallback bytes
 
     let fh_a = fs.open_handle(file_inode).unwrap();
     fs.release_handle(fh_a);
@@ -374,10 +373,10 @@ fn stale_fh_after_release_and_reopen_falls_back() {
     assert_ne!(fh_a, fh_b);
     // A read on the stale fh_a misses the slab (None) and falls back to inode
     // resolution — correct bytes, never fh_b's handle, never a panic.
-    let via_stale = fs.read(file_inode, fh_a, 0, size).unwrap();
+    let via_stale = fs.read(file_inode, Some(fh_a), 0, size).unwrap();
     assert_eq!(via_stale, canonical);
     // The live handle still serves correctly.
-    let via_live = fs.read(file_inode, fh_b, 0, size).unwrap();
+    let via_live = fs.read(file_inode, Some(fh_b), 0, size).unwrap();
     assert_eq!(via_live, canonical);
 
     fs.release_handle(fh_b);
@@ -962,7 +961,6 @@ fn open_handle_returns_distinct_ids_and_rejects_dirs() {
     let fh1 = fs.open_handle(file_inode).unwrap();
     let fh2 = fs.open_handle(file_inode).unwrap();
     assert_ne!(fh1, fh2, "each open must yield a fresh handle id");
-    assert!(fh1 != 0 && fh2 != 0);
 
     assert!(matches!(fs.open_handle(artist), Err(CoreError::IsDir(_))));
 }
@@ -985,7 +983,7 @@ fn read_uses_cached_handle_after_backing_grows() {
             .unwrap();
         f.write_all(&[0u8; 64]).unwrap();
     }
-    let via_handle = fs.read(file_inode, fh, 0, size).unwrap();
+    let via_handle = fs.read(file_inode, Some(fh), 0, size).unwrap();
     assert_eq!(via_handle.len() as u64, size);
 }
 
@@ -1009,7 +1007,7 @@ fn release_handle_forces_fallback_on_next_read() {
         f.write_all(&[0u8; 64]).unwrap();
     }
     assert!(matches!(
-        fs.read(file_inode, fh, 0, size),
+        fs.read(file_inode, Some(fh), 0, size),
         Err(CoreError::BackingChanged(_))
     ));
 }

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -58,7 +58,7 @@ fn read_whole(fs: &Musefs, inode: u64) -> Vec<u8> {
     let mut out = Vec::new();
     let mut off = 0u64;
     while off < size {
-        let got = fs.read(inode, fh, off, 64 * 1024).unwrap();
+        let got = fs.read(inode, Some(fh), off, 64 * 1024).unwrap();
         if got.is_empty() {
             break;
         }

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -37,7 +37,7 @@ fn read_all_and_snapshot(dir: &std::path::Path, artist_dir: &str) -> metrics::Sn
     metrics::reset();
     let mut off = 0u64;
     while off < size {
-        let got = fs.read(inode, 0, off, 16 * 1024).unwrap();
+        let got = fs.read(inode, None, off, 16 * 1024).unwrap();
         if got.is_empty() {
             break;
         }
@@ -92,7 +92,7 @@ fn baseline_one_open_per_read_call() {
     let mut off = 0u64;
     let mut reads = 0u64;
     while off < size {
-        let got = fs.read(file_inode, 0, off, chunk).unwrap();
+        let got = fs.read(file_inode, None, off, chunk).unwrap();
         if got.is_empty() {
             break;
         }
@@ -139,7 +139,7 @@ fn handle_reuses_one_open_and_no_per_read_stat() {
     let mut off = 0u64;
     let mut reads = 0u64;
     while off < size {
-        let got = fs.read(file_inode, fh, off, chunk).unwrap();
+        let got = fs.read(file_inode, Some(fh), off, chunk).unwrap();
         if got.is_empty() {
             break;
         }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -18,7 +18,9 @@ use fuser::{
 };
 use musefs_core::Attr;
 use musefs_core::CoreError;
+use musefs_core::Fh;
 use musefs_core::Musefs;
+use std::num::NonZeroU64;
 
 /// Per-worker read scratch buffer: each threadpool worker reuses one Vec across
 /// reads (filled by `Musefs::read_into`, sent as fuser's borrowed iovec), so the
@@ -279,7 +281,7 @@ impl Filesystem for MusefsFs {
         let core = Arc::clone(&self.core);
         let flags = open_flags(self.config.keep_cache);
         self.pool.execute(move || match core.open_handle(ino.0) {
-            Ok(fh) => reply.opened(FileHandle(fh), flags),
+            Ok(fh) => reply.opened(FileHandle(fh.get()), flags),
             Err(e) => reply.error(reply_errno("open", ino.0, &e)),
         });
     }
@@ -295,7 +297,9 @@ impl Filesystem for MusefsFs {
         reply: ReplyEmpty,
     ) {
         // Cheap (a map remove); no need to offload to the pool.
-        self.core.release_handle(fh.0);
+        if let Some(fh) = NonZeroU64::new(fh.0) {
+            self.core.release_handle(Fh::from(fh));
+        }
         reply.ok();
     }
 
@@ -328,7 +332,13 @@ impl Filesystem for MusefsFs {
         self.pool.execute(move || {
             READ_BUF.with(|b| {
                 let mut buf = b.borrow_mut();
-                match core.read_into(ino.0, fh.0, offset, size as u64, &mut buf) {
+                match core.read_into(
+                    ino.0,
+                    NonZeroU64::new(fh.0).map(Fh::from),
+                    offset,
+                    size as u64,
+                    &mut buf,
+                ) {
                     Ok(()) => reply.data(&buf),
                     Err(e) => reply.error(reply_errno("read", ino.0, &e)),
                 }


### PR DESCRIPTION
Closes #134.

`fh_from_key` offset sharded-slab keys by `+1` so the kernel never sees a file handle of 0 ("no handle"), and the reverse `-1` lived at two other sites behind `fh != 0` sentinel checks — the invariant existed only as arithmetic in three places plus a comment.

## Changes

- New `pub struct Fh(NonZeroU64)` in `musefs-core`: the private `from_slab_key`/`slab_key` methods are now the only places the `±1` offset exists, and a zero handle is unrepresentable rather than checked.
- Facade API reshaped: `open_handle → Result<Fh>`, `read`/`read_into` take `Option<Fh>` (replacing the `fh == 0` sentinel; `None` preserves the inode-resolution fallback), `release_handle(Fh)` loses its guard entirely.
- `musefs-fuse` converts at the wire boundary (`NonZeroU64::new(fh.0).map(Fh::from)`); the kernel sees the same raw `u64`s as before. Stale-handle semantics unchanged — a `Some(fh)` whose slab slot was reused still misses the lookup and falls back.
- Test ripple: sentinel `0` → `None` and live handles → `Some(fh)` across the core integration tests, in-file tests, and the `read_throughput` bench; the two `assert!(fh != 0)` assertions are deleted (the type subsumes them), `assert_ne!` distinctness checks retained.

Design spec: `docs/superpowers/specs/2026-06-05-cli-mount-args-fh-newtype-design.md` (Part 2).

## Validation

- `cargo test` (workspace): 684 passed.
- FUSE e2e (`cargo test -p musefs-fuse -- --ignored`, real mounts): 9 passed.
- In-diff mutation gate: 8 caught, 3 unviable, 0 missed — the `±1` arithmetic and the `read_into` fast-path guard are pinned.
- `cargo clippy --all-targets`, `cargo fmt --all --check`, `cargo +nightly fuzz build flac`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated public file handle management APIs. The `read`, `read_into`, `open_handle`, and `release_handle` methods now use a type-safe file handle representation instead of raw numeric values. Optional handles in read operations are now properly distinguished through `Option` types, improving API clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->