### PR TITLE
Replace HeaderCache's hand-rolled sharded LRU with quick_cache (#136)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -212,4 +212,13 @@ exclude_re = [
     # variants ARE caught and stay in scope; anchored on operator+function since
     # both `<` in poll_due are this class.
     'musefs-core/src/facade\.rs:\d+:\d+: replace < with <= in Musefs::poll_due',
+
+    # CACHE_ESTIMATED_ITEMS const arithmetic — equivalent mutant. This is the
+    # `estimated_items_capacity` hint passed to Cache::with_weighter; it sizes
+    # quick_cache's internal hash map but is not a bound and has no effect on
+    # eviction, correctness, or any observable public-API behavior. The `/`→`%`
+    # variant yields 0 (64 MiB is 4 KiB-aligned), `/`→`*` yields ~256 GiB;
+    # quick_cache accepts any usize. The const initializer is outside any
+    # function body, so no test can observe it through the serving path.
+    'musefs-core/src/reader\.rs:70:60: replace / with [%*]',
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -218,7 +218,8 @@ exclude_re = [
     # quick_cache's internal hash map but is not a bound and has no effect on
     # eviction, correctness, or any observable public-API behavior. The `/`→`%`
     # variant yields 0 (64 MiB is 4 KiB-aligned), `/`→`*` yields ~256 GiB;
-    # quick_cache accepts any usize. The const initializer is outside any
-    # function body, so no test can observe it through the serving path.
+    # quick_cache accepts any usize. (cargo-mutants DOES mutate const
+    # initializers — the equivalence rests on unobservability, not on the
+    # const being out of reach.)
     'musefs-core/src/reader\.rs:70:60: replace / with [%*]',
 ]

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -537,3 +537,37 @@ cargo bench -p musefs-core --bench read_throughput
 cargo test -p musefs-core --test proptest_read_fidelity
 cargo test -p musefs-format --features fuzzing
 ```
+
+---
+
+## 2026-06-05 — HeaderCache: hand-rolled sharded LRU → quick_cache (#136)
+
+S3-FIFO byte-weighted cache replaces the 16-shard Mutex LRU; the serve
+path's last shared std lock is gone. `read_throughput` before/after:
+
+| workload | before | after | Δ |
+|----------|-------:|------:|--:|
+| `sequential_read/flac` | 817.12 µs | 809.48 µs | −0.9% |
+| `sequential_read/mp3` | 815.81 µs | 823.02 µs | +0.9% |
+| `sequential_read/m4a` | 821.52 µs | 791.77 µs | −3.6% |
+| `sequential_read/m4a-last` | 825.11 µs | 809.40 µs | −1.9% |
+| `sequential_read/ogg` | 944.80 µs | 981.06 µs | +3.8% |
+| `sequential_read/wav` | 831.54 µs | 814.88 µs | −2.0% |
+| `cold_first_read/flac` | 1.5476 ms | 1.5769 ms | +1.9% |
+| `cold_first_read/mp3` | 1.5412 ms | 1.5501 ms | +0.6% |
+| `cold_first_read/m4a` | 1.5360 ms | 1.5296 ms | −0.4% |
+| `cold_first_read/m4a-last` | 1.5496 ms | 1.5300 ms | −1.3% |
+| `cold_first_read/ogg` | 1.7133 ms | 1.7151 ms | +0.1% |
+| `cold_first_read/wav` | 1.5937 ms | 1.5466 ms | −3.0% |
+| `seek_read/flac` | 553.30 µs | 543.93 µs | −1.7% |
+| `seek_read/mp3` | 539.68 µs | 523.98 µs | −2.9% |
+| `seek_read/m4a` | 559.38 µs | 544.93 µs | −2.6% |
+| `seek_read/m4a-last` | 561.40 µs | 528.78 µs | −5.8% |
+| `seek_read/ogg` | 798.29 µs | 754.28 µs | −5.5% |
+| `seek_read/wav` | 561.63 µs | 567.63 µs | +1.1% |
+| `concurrent_read_walk/m16_plus_walker` | 5.5074 ms | 5.4036 ms | −1.9% |
+
+No workload shows a regression outside noise. `seek_read` formats trend 2–6%
+faster (cache lookup path no longer behind a Mutex). `sequential_read/ogg`
+(+3.8%) and `cold_first_read/flac` (+1.9%) are within Criterion's noise
+threshold (p>0.05, "No change in performance detected").

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +908,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "proptest",
+ "quick_cache",
  "rusqlite",
  "sharded-slab",
  "tempfile",
@@ -1215,6 +1229,18 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick_cache"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
 
 [[package]]
 name = "quote"

--- a/docs/superpowers/plans/2026-06-05-header-cache-quick-cache.md
+++ b/docs/superpowers/plans/2026-06-05-header-cache-quick-cache.md
@@ -62,7 +62,7 @@ quick_cache = "0.6.23"
 
 The patch-level minimum matters: `retain()` does not exist in early 0.6.x (verified absent in 0.6.0/0.6.2/0.6.9). Do NOT set `default-features = false` — the default `parking_lot` feature is wanted (musefs-core already depends on parking_lot 0.12 directly).
 
-- [ ] **Step 2: Verify it builds and the API assumptions hold**
+- [ ] **Step 2: Verify it builds**
 
 ```bash
 cargo build -p musefs-core
@@ -70,13 +70,7 @@ cargo build -p musefs-core
 
 Expected: clean build, `Compiling quick_cache v0.6.x` (x ≥ 23) in the output.
 
-Then confirm the four API signatures this plan leans on exist in the resolved version (one command, no network):
-
-```bash
-cargo doc -p quick_cache --no-deps -q && grep -o 'fn with_weighter\|fn retain\|fn weight\|fn remove' target/doc/quick_cache/sync/struct.Cache.html | sort -u
-```
-
-Expected output contains all of: `fn remove`, `fn retain`, `fn weight`, `fn with_weighter`. If any is missing, STOP and check docs.rs/quick_cache for the resolved version — do not improvise a replacement primitive.
+The real verification of the API surface this plan leans on (`with_weighter(usize, u64, W)`, `retain`, `remove`, `weight() -> u64`, `len()`, the `Weighter` trait signature) is Task 3's build and Task 4's tests — a missing or renamed method fails loudly there. If that happens, STOP and check docs.rs/quick_cache for the resolved version — do not improvise a replacement primitive.
 
 - [ ] **Step 3: Commit**
 
@@ -287,6 +281,9 @@ fn cache_weight_stays_within_budget_after_flood() {
         "total weight {} exceeds the 4096-byte budget",
         cache.cache.weight()
     );
+    // len() is assumed to count resident entries. If this assertion ever
+    // trips, the diagnosis is the same as the weight() note above: re-read
+    // the spec's eviction-timing section and escalate — don't loosen.
     assert!(
         cache.cache.len() < 64,
         "no eviction happened: all 64 over-budget entries are resident"

--- a/docs/superpowers/plans/2026-06-05-header-cache-quick-cache.md
+++ b/docs/superpowers/plans/2026-06-05-header-cache-quick-cache.md
@@ -1,0 +1,513 @@
+# HeaderCache → quick_cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `HeaderCache`'s hand-rolled sharded LRU in `musefs-core/src/reader.rs` with quick_cache 0.6.23, keeping the five-method public API byte-for-byte stable (issue #136).
+
+**Architecture:** `HeaderCache` keeps its public surface (`new`, `with_budget`, `resolve`, `retain`, `remove`) and its `build` method untouched; only the storage swaps — `Vec<Mutex<Shard>>` + hand-rolled doubly-linked LRU becomes one `quick_cache::sync::Cache<i64, Arc<ResolvedFile>, CacheBytesWeighter>` (S3-FIFO, byte-weighted via `cache_bytes.max(1)`, internally sharded, eager-ish eviction). `facade.rs`, benches, and integration tests need zero changes.
+
+**Tech Stack:** Rust, quick_cache 0.6.23 (pinned: `retain()` is absent in early 0.6.x), criterion benches, cargo-mutants in-diff gate.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md` — read it first; it records the decided trade-offs (S3-FIFO ≠ LRU is accepted; no hot-entry-survival test, it's a flaky-CI trap; budget assertions are end-state only because per-insert-synchronous eviction is undocumented).
+
+**Worktree note:** Execute on a feature branch (main is protected). If using a worktree, create it via superpowers:using-git-worktrees.
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `musefs-core/Cargo.toml` | add `quick_cache = "0.6.23"` |
+| `musefs-core/src/reader.rs` | delete `CACHE_SHARDS`, `LruNode`, `Shard` + its impls; add `CacheBytesWeighter`; rewrite `HeaderCache` internals; delete 11 shard tests; add 2 property tests |
+| `musefs-core/src/lock.rs` | module-doc audit list only (HeaderCache line) |
+| `BENCHMARKS.md` | before/after `read_throughput` table |
+
+Everything else (facade.rs, benches/read_throughput.rs, tests/) compiles unchanged because the public API is stable.
+
+---
+
+### Task 1: Branch + baseline bench
+
+**Files:** none modified.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/cfutro/git/musefs
+git checkout main && git pull
+git checkout -b header-cache-quick-cache
+```
+
+- [ ] **Step 2: Record the baseline serve-path bench**
+
+```bash
+cargo bench -p musefs-core --bench read_throughput 2>&1 | tee /tmp/bench-before.txt
+```
+
+Expected: criterion output with timings for the bench groups (e.g. `cold_first_read/...`, `seek_read/...`). Criterion saves the baseline under `target/criterion/` and will print change estimates on the "after" run. Keep `/tmp/bench-before.txt` for Task 7's BENCHMARKS.md table.
+
+### Task 2: Add the quick_cache dependency
+
+**Files:**
+- Modify: `musefs-core/Cargo.toml` (the `[dependencies]` table, currently lines 12–22)
+
+- [ ] **Step 1: Add the dependency**
+
+In `musefs-core/Cargo.toml`, `[dependencies]` table (keep alphabetical order — insert between `parking_lot` and `sharded-slab`):
+
+```toml
+quick_cache = "0.6.23"
+```
+
+The patch-level minimum matters: `retain()` does not exist in early 0.6.x (verified absent in 0.6.0/0.6.2/0.6.9). Do NOT set `default-features = false` — the default `parking_lot` feature is wanted (musefs-core already depends on parking_lot 0.12 directly).
+
+- [ ] **Step 2: Verify it builds and the API assumptions hold**
+
+```bash
+cargo build -p musefs-core
+```
+
+Expected: clean build, `Compiling quick_cache v0.6.x` (x ≥ 23) in the output.
+
+Then confirm the four API signatures this plan leans on exist in the resolved version (one command, no network):
+
+```bash
+cargo doc -p quick_cache --no-deps -q && grep -o 'fn with_weighter\|fn retain\|fn weight\|fn remove' target/doc/quick_cache/sync/struct.Cache.html | sort -u
+```
+
+Expected output contains all of: `fn remove`, `fn retain`, `fn weight`, `fn with_weighter`. If any is missing, STOP and check docs.rs/quick_cache for the resolved version — do not improvise a replacement primitive.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+Add quick_cache 0.6.23 dependency to musefs-core (#136)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3: Swap the HeaderCache internals
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs` — imports (lines 1–13), the `CACHE_SHARDS`/`LruNode`/`Shard` block (lines 40–158), the `HeaderCache` struct (lines 160–165), `impl HeaderCache`'s non-`build` methods (lines 185–236), and 11 tests in `cache_bound_tests`
+
+The surviving test suite is the safety net for this refactor: `header_cache_resolve_caches_by_content_version`, `resolve_is_safe_under_concurrent_access`, `header_cache_retain_drops_absent_tracks` (this one also catches an inverted `retain` predicate polarity instantly), `header_cache_remove_drops_one_track_only`, `default_cache_budget_is_64_mib`, `read_segments_returns_empty_past_end_of_range`, and the `build_*` tests all pass through the public API and must stay green unmodified.
+
+- [ ] **Step 1: Update the imports**
+
+`HashMap` is used only by `Shard`; after the swap it's dead. Replace line 1 and add the quick_cache imports after the `musefs_format` block (line 8):
+
+```rust
+use std::collections::HashSet;
+```
+
+and (new lines, with the other extern imports):
+
+```rust
+use quick_cache::sync::Cache;
+use quick_cache::Weighter;
+```
+
+`use std::sync::Mutex;` stays — `ResolvedFile::last_page` still uses it.
+
+- [ ] **Step 2: Delete the hand-rolled cache**
+
+Delete all of (current lines 40–158):
+
+- `const CACHE_SHARDS: usize = 16;`
+- `struct LruNode { ... }`
+- `struct Shard { ... }` (with its doc comment)
+- `impl Shard { ... }` (`new`, `unlink`, `push_front`, `get`, `insert`, `retain_keys`, `remove_key`)
+- `impl crate::lock::Clearable for Shard { ... }`
+
+- [ ] **Step 3: Add the weighter and the new struct**
+
+Where the `HeaderCache` struct currently sits (after `ResolvedFile`, before `DEFAULT_CACHE_BUDGET`):
+
+```rust
+/// Weighs an entry by its resident inline bytes. The `.max(1)` is load-bearing:
+/// quick_cache ignores zero-weight entries when evicting, and every
+/// StructureOnly layout has `cache_bytes == 0`, so an unweighted entry would
+/// escape the byte budget entirely.
+#[derive(Clone)]
+struct CacheBytesWeighter;
+
+impl Weighter<i64, Arc<ResolvedFile>> for CacheBytesWeighter {
+    fn weight(&self, _key: &i64, val: &Arc<ResolvedFile>) -> u64 {
+        val.cache_bytes.max(1)
+    }
+}
+
+/// A per-mount cache of resolved files keyed by track id; an entry
+/// self-invalidates when the track's `content_version` changes. Backed by
+/// quick_cache: S3-FIFO eviction, byte-weighted, internally sharded.
+pub struct HeaderCache {
+    cache: Cache<i64, Arc<ResolvedFile>, CacheBytesWeighter>,
+    mode: Mode,
+}
+
+/// Default resident-bytes budget for the header cache (64 MiB).
+pub const DEFAULT_CACHE_BUDGET: u64 = 64 * 1024 * 1024;
+
+/// Item-count sizing hint for quick_cache's internal structures (not a bound):
+/// the default budget over 4 KiB, a typical inline tag region. A const so the
+/// arithmetic is outside any function body (nothing for cargo-mutants to chew
+/// on — the hint has no observable behavior to pin).
+const CACHE_ESTIMATED_ITEMS: usize = (DEFAULT_CACHE_BUDGET / 4096) as usize;
+```
+
+(`DEFAULT_CACHE_BUDGET` is unchanged — shown for placement.)
+
+- [ ] **Step 4: Rewrite the non-`build` methods of `impl HeaderCache`**
+
+`build` is untouched. Replace `new`, `with_budget`, `shard` (deleted), `retain`, `remove`, and `resolve` with:
+
+```rust
+impl HeaderCache {
+    pub fn new(mode: Mode) -> HeaderCache {
+        HeaderCache::with_budget(mode, DEFAULT_CACHE_BUDGET)
+    }
+    pub fn with_budget(mode: Mode, budget: u64) -> HeaderCache {
+        HeaderCache {
+            cache: Cache::with_weighter(CACHE_ESTIMATED_ITEMS, budget, CacheBytesWeighter),
+            mode,
+        }
+    }
+    /// Drop cached resolutions for tracks no longer present (`live` = current ids).
+    pub fn retain(&self, live: &HashSet<i64>) {
+        self.cache.retain(|id, _| live.contains(id));
+    }
+    /// Drop one track's cached resolution (changelog-refresh removal path).
+    pub fn remove(&self, id: i64) {
+        self.cache.remove(&id);
+    }
+    /// Resolve a track to its layout, caching on a content-version miss. Validation
+    /// (`stat`) and synthesis run outside the cache; quick_cache's internal locks
+    /// are only touched by the brief get and insert.
+    pub fn resolve<M>(&self, db: &Db<M>, track_id: i64) -> Result<Arc<ResolvedFile>> {
+        let track = db
+            .get_track(track_id)?
+            .ok_or(CoreError::TrackNotFound(track_id))?;
+
+        // Always validate the backing file first — a stale file is an error even
+        // on a cache hit, because the audio region may have shifted.
+        crate::metrics::on_stat();
+        let meta = std::fs::metadata(&track.backing_path)?;
+        if meta.len() != track.backing_size as u64 || mtime_secs(&meta) != track.backing_mtime {
+            return Err(CoreError::BackingChanged(track.backing_path.clone()));
+        }
+
+        if let Some(hit) = self.cache.get(&track_id) {
+            if hit.content_version == track.content_version {
+                return Ok(hit);
+            }
+        }
+        let resolved = self.build(db, &track, &meta)?;
+        self.cache.insert(track_id, resolved.clone());
+        Ok(resolved)
+    }
+    // ... build() stays exactly as-is ...
+}
+```
+
+Behavior notes (from the spec, deliberate):
+- quick_cache may decline to *admit* a cold entry under pressure; `resolve` returns the freshly built `Arc` regardless, so a non-admitted entry only means a rebuild on next open.
+- No `Mutex<Shard>` remains, so reader.rs no longer calls `crate::lock::lock_or_clear` at all.
+
+- [ ] **Step 5: Delete the 11 implementation-specific tests**
+
+In `mod cache_bound_tests`, delete exactly these (they poke `Shard`/linked-list internals that no longer exist):
+
+1. `shard_evicts_least_recently_used_over_byte_budget`
+2. `shard_insert_reaccounts_bytes_on_reinsert`
+3. `shard_evicts_and_subtracts_evicted_bytes`
+4. `shard_keeps_both_entries_at_exactly_budget`
+5. `shard_never_evicts_the_sole_entry_even_over_budget`
+6. `shard_reset_clears_all_entries`
+7. `shard_remove_key_reaccounts_bytes`
+8. `shard_remove_key_is_noop_for_absent_id`
+9. `shard_retain_keys_drops_dead_and_reaccounts`
+10. `with_budget_divides_evenly_across_shards`
+11. `shard_routes_by_modulo_not_division`
+
+Nothing else in the module is touched. In particular `header_cache_retain_drops_absent_tracks` and `header_cache_remove_drops_one_track_only` are public-API tests and MUST stay (despite names that sound cache-internal), and the `entry()` helper STAYS — it builds `ResolvedFile` directly and Task 4's new tests use it.
+
+- [ ] **Step 6: Run the surviving suite**
+
+```bash
+cargo test -p musefs-core
+```
+
+Expected: PASS, zero failures. Watch specifically for `header_cache_retain_drops_absent_tracks` (catches inverted `retain` polarity — quick_cache keeps entries where the predicate returns `true`, same as std) and `header_cache_resolve_caches_by_content_version` (its `Arc::ptr_eq` now depends on quick_cache admitting a lone small entry into an empty cache — the spec flags this as the test that flexes, not the design, if it ever fails).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/reader.rs
+git commit -m "$(cat <<'EOF'
+Replace HeaderCache's hand-rolled sharded LRU with quick_cache (#136)
+
+The byte-budgeted LRU (HashMap + Option<i64> doubly-linked list with
+manual unlink/push_front surgery, 16 Mutex shards) becomes a single
+quick_cache::sync::Cache: S3-FIFO, byte-weighted by cache_bytes.max(1),
+internally sharded. Public API unchanged. Eviction-order tests that
+asserted the removed mechanism are deleted.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4: Property tests for the budget bound and the zero-weight guard
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs` (`mod cache_bound_tests`)
+
+These replace the *intent* of the deleted eviction tests and are the in-diff mutation gate's teeth against the weigher (`.max(1)` → kill via the zero-weight test; `weight → 1` → kill via the flood test's `len() < 64`).
+
+- [ ] **Step 1: Write the two tests**
+
+Add to `mod cache_bound_tests` (the `entry()` helper already there builds a `ResolvedFile` with `cache_bytes == inline_len`):
+
+```rust
+#[test]
+fn cache_weight_stays_within_budget_after_flood() {
+    let cache = HeaderCache::with_budget(Mode::Synthesis, 4096);
+    for id in 0..64i64 {
+        cache.cache.insert(id, entry(0, 256)); // 64 × 256 B = 16 KiB ≫ 4 KiB
+    }
+    // End-state assertion only: quick_cache does not document per-insert
+    // synchronous eviction, so the per-insert bound is not guaranteed.
+    assert!(
+        cache.cache.weight() <= 4096,
+        "total weight {} exceeds the 4096-byte budget",
+        cache.cache.weight()
+    );
+    assert!(
+        cache.cache.len() < 64,
+        "no eviction happened: all 64 over-budget entries are resident"
+    );
+}
+
+#[test]
+fn zero_cache_bytes_entry_still_weighs_one() {
+    // StructureOnly layouts have cache_bytes == 0; the weigher's .max(1) keeps
+    // them inside the weighted bound instead of escaping it (quick_cache
+    // ignores zero-weight entries when evicting).
+    let cache = HeaderCache::with_budget(Mode::StructureOnly, 1024);
+    cache.cache.insert(1, entry(0, 0));
+    assert_eq!(cache.cache.weight(), 1);
+    assert!(cache.cache.get(&1).is_some());
+}
+```
+
+(Direct `cache.cache.insert` mirrors how the deleted tests drove `Shard` directly; same-module access to the private field is the established pattern here.)
+
+- [ ] **Step 2: Run them**
+
+```bash
+cargo test -p musefs-core cache_bound -- --nocapture
+```
+
+Expected: PASS including the two new tests. If `cache_weight_stays_within_budget_after_flood` fails on the `weight()` assertion, re-read the spec's eviction-timing note before "fixing" anything — the end-state form is the agreed assertion; a failure here means quick_cache's bound is softer than even the end-state guarantee and the design needs revisiting with the user, not a looser test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/src/reader.rs
+git commit -m "$(cat <<'EOF'
+Property tests: cache byte-budget bound and zero-weight guard (#136)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 5: Update lock.rs's poison-audit doc
+
+**Files:**
+- Modify: `musefs-core/src/lock.rs:15` (module doc comment only)
+
+- [ ] **Step 1: Fix the audit line**
+
+The module doc audits "every serving-path `std::sync::Mutex`". Replace line 15:
+
+```rust
+//!   reader.rs HeaderCache shards  -> cat 1 (clear): pure cache, repopulated from the DB.
+```
+
+with:
+
+```rust
+//!   reader.rs HeaderCache         -> n/a since #136: backed by quick_cache's own
+//!                                    internal locking; no std::sync::Mutex to poison.
+```
+
+The `ResolvedFile::last_page` line below it stays — that Mutex still exists.
+
+- [ ] **Step 2: Verify and commit**
+
+```bash
+cargo build -p musefs-core
+git add musefs-core/src/lock.rs
+git commit -m "$(cat <<'EOF'
+lock.rs poison audit: HeaderCache no longer holds std Mutexes (#136)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 6: Workspace validation
+
+**Files:** none expected to change (fmt may touch reader.rs).
+
+- [ ] **Step 1: Format, lint (all targets!), full test suite**
+
+```bash
+cargo fmt --all
+cargo fmt --all --check
+cargo clippy --all-targets
+cargo test
+```
+
+Expected: all clean. `--all-targets` is non-negotiable: `benches/read_throughput.rs` and the `tests/` integration files consume `HeaderCache` and only compile under it (this exact trap has bitten before). The Python contrib trees are untouched by this change — no plugin checks needed.
+
+- [ ] **Step 2: Commit any fmt fallout**
+
+```bash
+git status --short
+# only if fmt changed files:
+git add -u && git commit -m "$(cat <<'EOF'
+cargo fmt (#136)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 7: After-bench + BENCHMARKS.md
+
+**Files:**
+- Modify: `BENCHMARKS.md` (append a dated section; match the existing table style — `| workload | before | after | Δ |`)
+
+- [ ] **Step 1: Run the after-bench**
+
+```bash
+cargo bench -p musefs-core --bench read_throughput 2>&1 | tee /tmp/bench-after.txt
+```
+
+Expected: criterion prints change estimates vs the Task 1 baseline (look for "change: ..." lines; "No change in performance detected" or improvements are both acceptable — this change removes the serve path's last shared lock but the cache was rarely contended in single-reader benches).
+
+- [ ] **Step 2: Record in BENCHMARKS.md**
+
+Append a section in the established format (see the "Ogg representative benches" section near the end of the file for the house style):
+
+```markdown
+## 2026-06-05 — HeaderCache: hand-rolled sharded LRU → quick_cache (#136)
+
+S3-FIFO byte-weighted cache replaces the 16-shard Mutex LRU; the serve
+path's last shared std lock is gone. `read_throughput` before/after:
+
+| workload | before | after | Δ |
+|----------|-------:|------:|--:|
+| <fill from /tmp/bench-before.txt and /tmp/bench-after.txt, one row per criterion group> |
+```
+
+Fill the table with the real numbers — every group criterion reports, not a selection.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add BENCHMARKS.md
+git commit -m "$(cat <<'EOF'
+BENCHMARKS.md: read_throughput before/after for the quick_cache swap (#136)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 8: In-diff mutation gate (CI parity)
+
+**Files:** none (verification only; test additions if mutants escape).
+
+- [ ] **Step 1: Run the gate exactly as CI does**
+
+Always `-j2`, output on /tmp, do NOT set TMPDIR. Sanity-check the diff first — an empty diff mutates nothing and exits 0, a silent false pass:
+
+```bash
+cd /home/cfutro/git/musefs
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff && echo DIFF-OK
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: `DIFF-OK`, then cargo-mutants ends with **0 missed**. The mutable surface is small: the weigher (`.max(1)`, `weight → 0/1` — killed by Task 4's two tests), the `retain` predicate (polarity/constants — killed by `header_cache_retain_drops_absent_tracks`), `remove` (killed by `header_cache_remove_drops_one_track_only`), and `resolve`'s version/metadata comparisons (killed by the surviving resolve/build tests). `CACHE_ESTIMATED_ITEMS` is a const initializer, outside cargo-mutants' reach by construction.
+
+- [ ] **Step 2: If any mutant is MISSED**
+
+Strengthen or add a test in `cache_bound_tests` to kill it (preferred). Only if it is provably equivalent (no observable behavior difference through any public API), add a documented `exclude_re` entry to `.cargo/mutants.toml` following the house style there — every entry carries a per-class rationale. Then re-run Step 1. Commit whatever changed:
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+Kill in-diff mutants for the quick_cache swap (#136)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 9: Push and PR
+
+- [ ] **Step 1: Pre-push check** (per project memory: fmt gate, exit status directly)
+
+```bash
+cargo fmt --all --check && echo FMT-OK
+```
+
+Expected: `FMT-OK`.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin header-cache-quick-cache
+gh pr create --title "Replace HeaderCache's hand-rolled sharded LRU with quick_cache (#136)" --body "$(cat <<'EOF'
+Closes #136.
+
+`HeaderCache`'s 16-shard Mutex LRU (HashMap + Option<i64> doubly-linked
+list with manual unlink/push_front surgery, hand-kept byte accounting)
+is replaced by `quick_cache::sync::Cache`: S3-FIFO eviction, byte-weighted
+by `cache_bytes.max(1)`, internally sharded, all `&self`. Public API
+(`new`/`with_budget`/`resolve`/`retain`/`remove`) is unchanged, so
+facade.rs, benches, and integration tests are untouched.
+
+Design: `docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md`
+
+- Weigher floors at 1: StructureOnly entries have `cache_bytes == 0` and
+  zero-weight entries escape quick_cache's weighted bound.
+- Eviction-order tests asserting the removed mechanism are deleted;
+  end-state budget-bound + zero-weight property tests replace their intent
+  (S3-FIFO admission is probabilistic — exact-victim assertions would flake).
+- lock.rs poison audit updated: no HeaderCache std Mutex remains.
+- BENCHMARKS.md: read_throughput before/after.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. CI must show the required `ci-ok` / `coverage-ok` aggregator checks green before merge (main is ruleset-protected).
+
+---
+
+## Self-review notes (done at planning time)
+
+- **Spec coverage:** dependency+pin (Task 2), struct/weigher/API swap (Task 3), `.max(1)` zero-weight guard (Tasks 3+4), end-state budget test (Task 4), test split survive/rewrite/delete (Tasks 3+4), lock.rs doc (Task 5), clippy `--all-targets`/fmt/workspace tests (Task 6), BENCHMARKS.md (Tasks 1+7), mutation gate (Task 8). The spec's `estimated_items_capacity = budget / 4096` is implemented as the `CACHE_ESTIMATED_ITEMS` const derived from `DEFAULT_CACHE_BUDGET` instead of per-call arithmetic — same intent (a sizing hint), deliberately const so the unobservable arithmetic can't produce unkillable mutants (spec explicitly allows the implementer to adjust).
+- **Type consistency:** `CacheBytesWeighter` (Tasks 3, 4), `cache` field name (Tasks 3, 4), `CACHE_ESTIMATED_ITEMS` (Task 3 only), `with_budget(Mode, u64)` unchanged everywhere.
+- **No placeholders:** every code step carries the actual code; the only deliberate fill-in is the BENCHMARKS.md numbers table, which cannot exist until the benches run.

--- a/docs/superpowers/plans/2026-06-05-header-cache-quick-cache.md
+++ b/docs/superpowers/plans/2026-06-05-header-cache-quick-cache.md
@@ -148,11 +148,18 @@ pub struct HeaderCache {
 pub const DEFAULT_CACHE_BUDGET: u64 = 64 * 1024 * 1024;
 
 /// Item-count sizing hint for quick_cache's internal structures (not a bound):
-/// the default budget over 4 KiB, a typical inline tag region. A const so the
-/// arithmetic is outside any function body (nothing for cargo-mutants to chew
-/// on — the hint has no observable behavior to pin).
+/// the default budget over 4 KiB, a typical inline tag region. The hint has no
+/// observable public-API behavior, so its arithmetic carries an equivalent-mutant
+/// exclusion in .cargo/mutants.toml (cargo-mutants does mutate const initializers).
 const CACHE_ESTIMATED_ITEMS: usize = (DEFAULT_CACHE_BUDGET / 4096) as usize;
 ```
+
+> **Correction (found during Task 8):** this plan originally claimed the const
+> initializer was "outside cargo-mutants' reach". That is FALSE — cargo-mutants
+> mutates const initializer expressions (`/`→`%`, `/`→`*` were generated and
+> MISSED). The hint is still unobservable through any public API, so the outcome
+> is a documented equivalent-mutant `exclude_re` in `.cargo/mutants.toml`, per
+> house convention — not a test.
 
 (`DEFAULT_CACHE_BUDGET` is unchanged — shown for placement.)
 
@@ -444,7 +451,7 @@ grep -q '^@@ ' mutants.diff && echo DIFF-OK
 cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
 ```
 
-Expected: `DIFF-OK`, then cargo-mutants ends with **0 missed**. The mutable surface is small: the weigher (`.max(1)`, `weight → 0/1` — killed by Task 4's two tests), the `retain` predicate (polarity/constants — killed by `header_cache_retain_drops_absent_tracks`), `remove` (killed by `header_cache_remove_drops_one_track_only`), and `resolve`'s version/metadata comparisons (killed by the surviving resolve/build tests). `CACHE_ESTIMATED_ITEMS` is a const initializer, outside cargo-mutants' reach by construction.
+Expected: `DIFF-OK`, then cargo-mutants ends with **0 missed**. The mutable surface is small: the weigher (`.max(1)`, `weight → 0/1` — killed by Task 4's two tests), the `retain` predicate (polarity/constants — killed by `header_cache_retain_drops_absent_tracks`), `remove` (killed by `header_cache_remove_drops_one_track_only`), and `resolve`'s version/metadata comparisons (killed by the surviving resolve/build tests). `CACHE_ESTIMATED_ITEMS`'s initializer IS mutated by cargo-mutants (see the Task 3 correction note) — its `/`→`%`/`*` mutants are equivalent (unobservable sizing hint) and carry a documented `exclude_re` in `.cargo/mutants.toml`.
 
 - [ ] **Step 2: If any mutant is MISSED**
 
@@ -505,6 +512,6 @@ Expected: PR URL printed. CI must show the required `ci-ok` / `coverage-ok` aggr
 
 ## Self-review notes (done at planning time)
 
-- **Spec coverage:** dependency+pin (Task 2), struct/weigher/API swap (Task 3), `.max(1)` zero-weight guard (Tasks 3+4), end-state budget test (Task 4), test split survive/rewrite/delete (Tasks 3+4), lock.rs doc (Task 5), clippy `--all-targets`/fmt/workspace tests (Task 6), BENCHMARKS.md (Tasks 1+7), mutation gate (Task 8). The spec's `estimated_items_capacity = budget / 4096` is implemented as the `CACHE_ESTIMATED_ITEMS` const derived from `DEFAULT_CACHE_BUDGET` instead of per-call arithmetic — same intent (a sizing hint), deliberately const so the unobservable arithmetic can't produce unkillable mutants (spec explicitly allows the implementer to adjust).
+- **Spec coverage:** dependency+pin (Task 2), struct/weigher/API swap (Task 3), `.max(1)` zero-weight guard (Tasks 3+4), end-state budget test (Task 4), test split survive/rewrite/delete (Tasks 3+4), lock.rs doc (Task 5), clippy `--all-targets`/fmt/workspace tests (Task 6), BENCHMARKS.md (Tasks 1+7), mutation gate (Task 8). The spec's `estimated_items_capacity = budget / 4096` is implemented as the `CACHE_ESTIMATED_ITEMS` const derived from `DEFAULT_CACHE_BUDGET` instead of per-call arithmetic — same intent (a sizing hint); the original rationale that a const initializer escapes cargo-mutants proved false during Task 8 — see the correction note in Task 3 Step 3 (spec explicitly allows the implementer to adjust).
 - **Type consistency:** `CacheBytesWeighter` (Tasks 3, 4), `cache` field name (Tasks 3, 4), `CACHE_ESTIMATED_ITEMS` (Task 3 only), `with_budget(Mode, u64)` unchanged everywhere.
 - **No placeholders:** every code step carries the actual code; the only deliberate fill-in is the BENCHMARKS.md numbers table, which cannot exist until the benches run.

--- a/docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md
+++ b/docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md
@@ -48,9 +48,12 @@ All changes in `musefs-core` (`Cargo.toml`, `src/reader.rs`, `src/lock.rs`).
 
 ### Dependency
 
-Add `quick_cache = "0.6"` to `musefs-core/Cargo.toml`, with its
-`parking_lot` feature enabled — `parking_lot` is already a direct dependency
-of musefs-core, so both share one lock implementation.
+Add `quick_cache = "0.6.23"` to `musefs-core/Cargo.toml`. The patch-level
+pin matters: `retain()` — the load-bearing primitive that won quick_cache
+the comparison — does not exist in early 0.6.x (verified absent in 0.6.0,
+0.6.2, 0.6.9); 0.6.23 provably has it. quick_cache's `parking_lot` feature
+is on by default and matches musefs-core's existing direct `parking_lot`
+dependency — do not set `default-features = false`.
 
 ### HeaderCache shape — public API unchanged
 
@@ -103,10 +106,14 @@ weighted bound entirely. Weighting them 1 bounds StructureOnly mounts too —
 the current code never evicts them either, so this is strictly an
 improvement.
 
-`with_budget` passes the budget as the cache's weight capacity. The exact
-constructor surface (`Cache::with_weighter` vs `OptionsBuilder`, and whether
-to pin a shard count) is verified against the real 0.6 API at implementation
-time. quick_cache's per-shard weight capacity is a non-issue here: entries
+`with_budget` passes the budget as the cache's weight capacity, via
+`Cache::with_weighter(estimated_items_capacity, weight_capacity, weighter)`.
+For `estimated_items_capacity` use `budget / 4096` (4 KiB as a typical
+inline tag region) — it is a sizing hint for the admission ghost structures,
+not a bound; the implementer may adjust if profiling says otherwise.
+Whether to pin a shard count is decided against the real 0.6.23 API at
+implementation time. quick_cache's per-shard weight capacity is a non-issue
+here: entries
 are KB-scale inline tag framing (`cache_bytes` counts only
 `Segment::Inline` bytes; art is streamed via `ArtImage`/`OggArtSlice` and
 never counted) against a 64 MiB default budget.
@@ -143,17 +150,31 @@ never counted) against a 64 MiB default budget.
 `header_cache_remove_drops_one_track_only`,
 `default_cache_budget_is_64_mib`, and the `build_*` audio-bounds and
 `cache_bytes`-accounting tests (those test `build`, not the cache).
+One contingency to watch:
+`header_cache_resolve_caches_by_content_version` asserts `Arc::ptr_eq`
+across two back-to-back resolves, which now depends on quick_cache
+*admitting* the lone entry rather than on a guaranteed insert. A single
+small entry in an otherwise empty cache is admitted in practice, but if it
+proves otherwise the test — not the design — is what flexes.
 
 **Rewritten property-style** (intent kept, mechanism-free):
 
 - *Budget bound:* insert entries totaling far over budget through the public
-  path; assert the cache's total weight stays ≤ budget after each insert
-  (eager eviction makes this deterministic — no pending-task drain).
-- *Hot-entry survival:* a repeatedly-`get` entry survives a flood of cold
-  inserts. No exact-victim assertions — S3-FIFO is not LRU.
+  path; assert the cache's total `weight() <= budget` **as an end-state
+  check after the flood**, not after each individual insert. quick_cache
+  does not document whether eviction inside `insert` is strictly synchronous
+  or amortized; the end-state assertion is robust either way. If the
+  implementer confirms per-insert eagerness against 0.6.23, the assertion
+  may be tightened — but the spec'd form must not assume it.
 - *Zero-weight bound:* a `StructureOnly` entry (`cache_bytes == 0`) still
   counts ≥ 1 against the bound, pinning the `.max(1)` weigher behavior
   against mutants.
+
+No hot-entry-survival test: S3-FIFO admission is probabilistic, so "the hot
+entry survives a cold flood" is an exact-victim assertion in disguise and a
+flaky-CI trap. The agreed bar is "bounded by byte budget, sensible eviction"
+— retention guarantees are explicitly out; budget-bound plus zero-weight
+cover the intent, and such a test kills no weigher/retain mutants anyway.
 
 **Deleted with the implementation** (they test the removed linked
 list/sharding): `shard_evicts_least_recently_used_over_byte_budget`,

--- a/docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md
+++ b/docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md
@@ -1,0 +1,179 @@
+# Replace HeaderCache's hand-rolled sharded LRU with quick_cache
+
+**Date:** 2026-06-05
+**Issue:** #136 — `reader.rs` hand-rolls a sharded LRU cache
+**Status:** Approved
+
+## Problem
+
+`HeaderCache` (`musefs-core/src/reader.rs`) implements a byte-budgeted LRU
+from scratch: `CACHE_SHARDS` (8) `Mutex<Shard>`s, each a `HashMap<i64,
+LruNode>` plus a doubly-linked list expressed as `Option<i64>` prev/next
+indices maintained by manual `unlink`/`push_front` pointer surgery, with
+hand-kept byte accounting against a per-shard budget. This is exactly the
+edge-case-prone logic maintained concurrent-cache crates already harden, and
+it drags along local plumbing: shard routing, per-shard budget division, and
+a `Clearable` poison-recovery impl in `lock.rs`. It is also the last shared
+lock on the serve path (taken during every `resolve`).
+
+## Crate choice
+
+Requirements: concurrent `get(&self)` from FUSE worker threads (sync, no
+async runtime), byte-weighted budget (64 MiB default over `cache_bytes`),
+single-key `remove`, prune-to-live-set `retain`, eager eviction preferred so
+the bound holds deterministically, small dependency tree.
+
+A full sweep (2026-06-05) of moka, mini-moka, micro-moka, quick_cache,
+stretto, foyer, clru, lru, schnellru, sieve-cache, and cached landed on
+**quick_cache** (v0.6.x, S3-FIFO eviction): it is the only candidate hitting
+every requirement — internally sharded `&self` API, `u64` `Weighter`, eager
+synchronous eviction on `insert`, native `retain()` predicate, `remove()`,
+2 required deps, no background threads, actively maintained.
+
+Runners-up and dismissals: **moka** (the prior presumption from the v1
+review triage) has lazy/amortized eviction — the byte bound is soft without
+`run_pending_tasks()` — plus an opt-in, also-lazy `invalidate_entries_if`, a
+`u32` weigher, and the heaviest dep tree; **clru** keeps the weighted-LRU
+core but is `&mut self`, so all the Mutex-shard plumbing would survive;
+**sieve-cache** is zero-dep and concurrent but lacks a documented `retain()`
+on its sharded weighted variant; **mini-moka** is stale (last release
+2024-01); **lru** has no byte weighting; **stretto** can miss freshly
+inserted keys (Ristretto write-buffer semantics); **foyer** is an
+async-centric hybrid mem+disk engine; **cached** is a memoization macro
+framework.
+
+## Design
+
+All changes in `musefs-core` (`Cargo.toml`, `src/reader.rs`, `src/lock.rs`).
+
+### Dependency
+
+Add `quick_cache = "0.6"` to `musefs-core/Cargo.toml`, with its
+`parking_lot` feature enabled — `parking_lot` is already a direct dependency
+of musefs-core, so both share one lock implementation.
+
+### HeaderCache shape — public API unchanged
+
+```rust
+pub struct HeaderCache {
+    cache: quick_cache::sync::Cache<i64, Arc<ResolvedFile>, CacheBytesWeighter>,
+    mode: Mode,
+}
+```
+
+The five public methods keep their exact signatures — `new(mode)`,
+`with_budget(mode, budget)`, `resolve(db, track_id)`, `retain(live)`,
+`remove(id)` — so `facade.rs`, `benches/read_throughput.rs`, and the
+integration tests under `tests/` need no changes. Internals map 1:1:
+
+| Today | After |
+|---|---|
+| `self.shard(id).get(id)` | `self.cache.get(&id)` |
+| `self.shard(id).insert(id, v)` | `self.cache.insert(id, v)` (eviction eager, inside the call) |
+| per-shard `retain_keys(live)` loop | `self.cache.retain(\|id, _\| live.contains(id))` |
+| `self.shard(id).remove_key(id)` | `self.cache.remove(&id)` |
+
+Deleted outright: `Shard`, `LruNode`, `CACHE_SHARDS`, `Shard::{new, unlink,
+push_front, get, insert, retain_keys, remove_key}`, `HeaderCache::shard`,
+the `impl Clearable for Shard` in reader.rs, and reader.rs's `lock_or_clear`
+calls. `lock.rs` itself stays — the Ogg last-page memo
+(`ogg_index.rs`) still uses `lock_or_clear` with `Option<T>` — only its
+module doc's mention of HeaderCache shards is updated.
+
+The `resolve` flow is untouched: validate backing size/mtime
+(`BackingChanged`) → cache get + `content_version` check against the freshly
+read track row → on miss/mismatch, `build` with no lock held → insert.
+
+### Weigher and budget semantics
+
+```rust
+#[derive(Clone)]
+struct CacheBytesWeighter;
+impl Weighter<i64, Arc<ResolvedFile>> for CacheBytesWeighter {
+    fn weight(&self, _: &i64, v: &Arc<ResolvedFile>) -> u64 {
+        v.cache_bytes.max(1)
+    }
+}
+```
+
+The `.max(1)` is load-bearing: in `StructureOnly` mode every layout is a
+single `BackingAudio` segment, so `cache_bytes == 0` for *all* entries, and
+quick_cache's documented footgun is that zero-weight entries escape the
+weighted bound entirely. Weighting them 1 bounds StructureOnly mounts too —
+the current code never evicts them either, so this is strictly an
+improvement.
+
+`with_budget` passes the budget as the cache's weight capacity. The exact
+constructor surface (`Cache::with_weighter` vs `OptionsBuilder`, and whether
+to pin a shard count) is verified against the real 0.6 API at implementation
+time. quick_cache's per-shard weight capacity is a non-issue here: entries
+are KB-scale inline tag framing (`cache_bytes` counts only
+`Segment::Inline` bytes; art is streamed via `ArtImage`/`OggArtSlice` and
+never counted) against a 64 MiB default budget.
+
+### Accepted behavior changes
+
+- Eviction policy becomes S3-FIFO instead of strict LRU; victim selection is
+  no longer externally predictable.
+- quick_cache may decline to *admit* a cold entry under pressure. `resolve`
+  already tolerates this shape — it returns the freshly built `Arc`
+  regardless of what the cache did with it, so a non-admitted entry only
+  means a rebuild on the next open. Correctness (`content_version`
+  revalidation, `BackingChanged`) never depended on cache residency.
+- No `Mutex<Shard>` is left to poison; the cache's poison-recovery category
+  in `lock.rs`'s doc comment shrinks to the Ogg memo.
+
+### Invalidation paths — semantics preserved
+
+- **`content_version`:** unchanged. Key stays the `i64` track id; a hit is
+  revalidated against the track row and a mismatch falls through to
+  rebuild + reinsert.
+- **`poll_refresh` prune:** `retain`/`remove` keep their `facade.rs` call
+  sites; quick_cache's `retain` and `remove` are the direct primitives, and
+  both take effect synchronously (no lazy-invalidation window).
+
+## Testing
+
+`cache_bound_tests` splits three ways:
+
+**Survive as-is** (semantics-level, no internals touched):
+`header_cache_resolve_caches_by_content_version`,
+`resolve_is_safe_under_concurrent_access`,
+`header_cache_retain_drops_absent_tracks`,
+`header_cache_remove_drops_one_track_only`,
+`default_cache_budget_is_64_mib`, and the `build_*` audio-bounds and
+`cache_bytes`-accounting tests (those test `build`, not the cache).
+
+**Rewritten property-style** (intent kept, mechanism-free):
+
+- *Budget bound:* insert entries totaling far over budget through the public
+  path; assert the cache's total weight stays ≤ budget after each insert
+  (eager eviction makes this deterministic — no pending-task drain).
+- *Hot-entry survival:* a repeatedly-`get` entry survives a flood of cold
+  inserts. No exact-victim assertions — S3-FIFO is not LRU.
+- *Zero-weight bound:* a `StructureOnly` entry (`cache_bytes == 0`) still
+  counts ≥ 1 against the bound, pinning the `.max(1)` weigher behavior
+  against mutants.
+
+**Deleted with the implementation** (they test the removed linked
+list/sharding): `shard_evicts_least_recently_used_over_byte_budget`,
+`shard_insert_reaccounts_bytes_on_reinsert`,
+`shard_evicts_and_subtracts_evicted_bytes`,
+`shard_keeps_both_entries_at_exactly_budget`,
+`shard_never_evicts_the_sole_entry_even_over_budget`,
+`shard_reset_clears_all_entries`, `shard_remove_key_reaccounts_bytes`,
+`shard_remove_key_is_noop_for_absent_id`,
+`shard_retain_keys_drops_dead_and_reaccounts`,
+`with_budget_divides_evenly_across_shards`,
+`shard_routes_by_modulo_not_division`.
+
+## Validation
+
+`cargo test` (workspace), `cargo clippy --all-targets` (benches and `tests/`
+consume `HeaderCache` and compile only under `--all-targets`),
+`cargo fmt --all --check`, and the in-diff mutation gate
+(`cargo mutants --in-diff … -j2` per CLAUDE.md) — the weigher and the
+`retain` predicate are prime mutant targets the property tests must kill.
+Because this touches the serve path's last shared lock, run
+`benches/read_throughput.rs` before/after and record the comparison in
+BENCHMARKS.md.

--- a/docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md
+++ b/docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md
@@ -7,7 +7,7 @@
 ## Problem
 
 `HeaderCache` (`musefs-core/src/reader.rs`) implements a byte-budgeted LRU
-from scratch: `CACHE_SHARDS` (8) `Mutex<Shard>`s, each a `HashMap<i64,
+from scratch: `CACHE_SHARDS` (16) `Mutex<Shard>`s, each a `HashMap<i64,
 LruNode>` plus a doubly-linked list expressed as `Option<i64>` prev/next
 indices maintained by manual `unlink`/`push_front` pointer surgery, with
 hand-kept byte accounting against a per-shard budget. This is exactly the

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -18,6 +18,7 @@ musefs-db = { path = "../musefs-db", version = "0.2.0" }
 musefs-format = { path = "../musefs-format", version = "0.2.0" }
 once_cell = "1"
 parking_lot = "0.12"
+quick_cache = "0.6.23"
 sharded-slab = "0.1"
 thiserror = "2"
 

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -12,7 +12,8 @@
 //!   facade.rs `snapshot`          -> cat 2 (flag): per-track render state, rebuilt by rebuild_full from the DB.
 //!   facade.rs `last_poll`         -> cat 3 (recover): Instant, replace-only single write.
 //!   facade.rs `last_failed_refresh` -> cat 3 (recover): Option<Instant>, replace-only single write.
-//!   reader.rs HeaderCache shards  -> cat 1 (clear): pure cache, repopulated from the DB.
+//!   reader.rs HeaderCache         -> n/a since #136: backed by quick_cache's own
+//!                                    internal locking; no std::sync::Mutex to poison.
 //!   ResolvedFile::last_page (reader.rs:30, locked in ogg_index.rs as LastPageMemo)
 //!                                 -> cat 1 (clear): deterministic one-entry cache, re-derived.
 //! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -14,7 +14,7 @@
 //!   facade.rs `last_failed_refresh` -> cat 3 (recover): Option<Instant>, replace-only single write.
 //!   reader.rs HeaderCache         -> n/a since #136: backed by quick_cache's own
 //!                                    internal locking; no std::sync::Mutex to poison.
-//!   ResolvedFile::last_page (reader.rs:30, locked in ogg_index.rs as LastPageMemo)
+//!   ResolvedFile::last_page (reader.rs:32, locked in ogg_index.rs as LastPageMemo)
 //!                                 -> cat 1 (clear): deterministic one-entry cache, re-derived.
 //! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
 //! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -1103,6 +1103,39 @@ mod cache_bound_tests {
         std::fs::write(path, &out).unwrap();
         (audio_offset, audio.len() as i64)
     }
+
+    #[test]
+    fn cache_weight_stays_within_budget_after_flood() {
+        let cache = HeaderCache::with_budget(Mode::Synthesis, 4096);
+        for id in 0..64i64 {
+            cache.cache.insert(id, entry(0, 256)); // 64 × 256 B = 16 KiB ≫ 4 KiB
+        }
+        // End-state assertion only: quick_cache does not document per-insert
+        // synchronous eviction, so the per-insert bound is not guaranteed.
+        assert!(
+            cache.cache.weight() <= 4096,
+            "total weight {} exceeds the 4096-byte budget",
+            cache.cache.weight()
+        );
+        // len() is assumed to count resident entries. If this assertion ever
+        // trips, the diagnosis is the same as the weight() note above: re-read
+        // the spec's eviction-timing section and escalate — don't loosen.
+        assert!(
+            cache.cache.len() < 64,
+            "no eviction happened: all 64 over-budget entries are resident"
+        );
+    }
+
+    #[test]
+    fn zero_cache_bytes_entry_still_weighs_one() {
+        // StructureOnly layouts have cache_bytes == 0; the weigher's .max(1) keeps
+        // them inside the weighted bound instead of escaping it (quick_cache
+        // ignores zero-weight entries when evicting).
+        let cache = HeaderCache::with_budget(Mode::StructureOnly, 1024);
+        cache.cache.insert(1, entry(0, 0));
+        assert_eq!(cache.cache.weight(), 1);
+        assert!(cache.cache.get(&1).is_some());
+    }
 }
 
 #[cfg(test)]

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -6,6 +6,8 @@ use std::sync::Mutex;
 use musefs_db::{Db, Format};
 use musefs_format::flac::{self, MetadataBlock};
 use musefs_format::{mp3, mp4, wav, BinaryTagInput, RegionLayout, Segment};
+use quick_cache::sync::Cache;
+use quick_cache::Weighter;
 
 use crate::error::{CoreError, Result};
 use crate::facade::Mode;
@@ -37,135 +39,35 @@ pub struct ResolvedFile {
     pub has_binary_tag: bool,
 }
 
-const CACHE_SHARDS: usize = 16;
+/// Weighs an entry by its resident inline bytes. The `.max(1)` is load-bearing:
+/// quick_cache ignores zero-weight entries when evicting, and every
+/// StructureOnly layout has `cache_bytes == 0`, so an unweighted entry would
+/// escape the byte budget entirely.
+#[derive(Clone)]
+struct CacheBytesWeighter;
 
-struct LruNode {
-    value: Arc<ResolvedFile>,
-    prev: Option<i64>,
-    next: Option<i64>,
-}
-
-/// One LRU shard: a hand-rolled O(1) doubly-linked list keyed by track id with a
-/// byte budget. `head` = most-recently-used, `tail` = least.
-struct Shard {
-    map: HashMap<i64, LruNode>,
-    head: Option<i64>,
-    tail: Option<i64>,
-    bytes: u64,
-    budget: u64,
-}
-
-impl Shard {
-    fn new(budget: u64) -> Shard {
-        Shard {
-            map: HashMap::new(),
-            head: None,
-            tail: None,
-            bytes: 0,
-            budget,
-        }
-    }
-    fn unlink(&mut self, key: i64) {
-        let (prev, next) = {
-            let n = &self.map[&key];
-            (n.prev, n.next)
-        };
-        match prev {
-            Some(p) => self.map.get_mut(&p).unwrap().next = next,
-            None => self.head = next,
-        }
-        match next {
-            Some(nx) => self.map.get_mut(&nx).unwrap().prev = prev,
-            None => self.tail = prev,
-        }
-        let n = self.map.get_mut(&key).unwrap();
-        n.prev = None;
-        n.next = None;
-    }
-    fn push_front(&mut self, key: i64) {
-        let old = self.head;
-        self.map.get_mut(&key).unwrap().next = old;
-        if let Some(h) = old {
-            self.map.get_mut(&h).unwrap().prev = Some(key);
-        }
-        self.head = Some(key);
-        if self.tail.is_none() {
-            self.tail = Some(key);
-        }
-    }
-    fn get(&mut self, key: i64) -> Option<Arc<ResolvedFile>> {
-        if !self.map.contains_key(&key) {
-            return None;
-        }
-        self.unlink(key);
-        self.push_front(key);
-        Some(self.map[&key].value.clone())
-    }
-    fn insert(&mut self, key: i64, value: Arc<ResolvedFile>) {
-        let add = value.cache_bytes;
-        if let Some(old_bytes) = self.map.get(&key).map(|n| n.value.cache_bytes) {
-            // Key exists: unlink from LRU list first (needs &mut self), then update.
-            self.unlink(key);
-            self.bytes -= old_bytes;
-            self.map.get_mut(&key).unwrap().value = value;
-        } else {
-            self.map.insert(
-                key,
-                LruNode {
-                    value,
-                    prev: None,
-                    next: None,
-                },
-            );
-        }
-        self.bytes += add;
-        self.push_front(key);
-        while self.bytes > self.budget && self.map.len() > 1 {
-            let lru = self.tail.unwrap();
-            self.unlink(lru);
-            let n = self.map.remove(&lru).unwrap();
-            self.bytes -= n.value.cache_bytes;
-        }
-    }
-    fn retain_keys(&mut self, live: &HashSet<i64>) {
-        let dead: Vec<i64> = self
-            .map
-            .keys()
-            .copied()
-            .filter(|k| !live.contains(k))
-            .collect();
-        for k in dead {
-            self.unlink(k);
-            if let Some(n) = self.map.remove(&k) {
-                self.bytes -= n.value.cache_bytes;
-            }
-        }
-    }
-    fn remove_key(&mut self, id: i64) {
-        if self.map.contains_key(&id) {
-            self.unlink(id);
-        }
-        if let Some(n) = self.map.remove(&id) {
-            self.bytes -= n.value.cache_bytes;
-        }
+impl Weighter<i64, Arc<ResolvedFile>> for CacheBytesWeighter {
+    fn weight(&self, _key: &i64, val: &Arc<ResolvedFile>) -> u64 {
+        val.cache_bytes.max(1)
     }
 }
 
-impl crate::lock::Clearable for Shard {
-    fn reset(&mut self) {
-        self.retain_keys(&HashSet::new());
-    }
-}
-
-/// A per-mount cache of resolved files, sharded for concurrency and keyed by track
-/// id; an entry self-invalidates when the track's `content_version` changes.
+/// A per-mount cache of resolved files keyed by track id; an entry
+/// self-invalidates when the track's `content_version` changes. Backed by
+/// quick_cache: S3-FIFO eviction, byte-weighted, internally sharded.
 pub struct HeaderCache {
-    shards: Vec<Mutex<Shard>>,
+    cache: Cache<i64, Arc<ResolvedFile>, CacheBytesWeighter>,
     mode: Mode,
 }
 
 /// Default resident-bytes budget for the header cache (64 MiB).
 pub const DEFAULT_CACHE_BUDGET: u64 = 64 * 1024 * 1024;
+
+/// Item-count sizing hint for quick_cache's internal structures (not a bound):
+/// the default budget over 4 KiB, a typical inline tag region. A const so the
+/// arithmetic is outside any function body (nothing for cargo-mutants to chew
+/// on — the hint has no observable behavior to pin).
+const CACHE_ESTIMATED_ITEMS: usize = (DEFAULT_CACHE_BUDGET / 4096) as usize;
 
 fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
     meta.modified()
@@ -188,29 +90,22 @@ impl HeaderCache {
         HeaderCache::with_budget(mode, DEFAULT_CACHE_BUDGET)
     }
     pub fn with_budget(mode: Mode, budget: u64) -> HeaderCache {
-        let per_shard = (budget / CACHE_SHARDS as u64).max(1);
-        let shards = (0..CACHE_SHARDS)
-            .map(|_| Mutex::new(Shard::new(per_shard)))
-            .collect();
-        HeaderCache { shards, mode }
-    }
-    fn shard(&self, track_id: i64) -> std::sync::MutexGuard<'_, Shard> {
-        let idx = (track_id as u64 % CACHE_SHARDS as u64) as usize;
-        crate::lock::lock_or_clear(&self.shards[idx], "header-cache shard")
+        HeaderCache {
+            cache: Cache::with_weighter(CACHE_ESTIMATED_ITEMS, budget, CacheBytesWeighter),
+            mode,
+        }
     }
     /// Drop cached resolutions for tracks no longer present (`live` = current ids).
     pub fn retain(&self, live: &HashSet<i64>) {
-        for s in &self.shards {
-            crate::lock::lock_or_clear(s, "header-cache shard (retain)").retain_keys(live);
-        }
+        self.cache.retain(|id, _| live.contains(id));
     }
     /// Drop one track's cached resolution (changelog-refresh removal path).
     pub fn remove(&self, id: i64) {
-        self.shard(id).remove_key(id);
+        self.cache.remove(&id);
     }
     /// Resolve a track to its layout, caching on a content-version miss. Validation
-    /// (`stat`) and synthesis run WITHOUT holding the shard lock; the lock is taken
-    /// only briefly for the cache get and insert.
+    /// (`stat`) and synthesis run outside the cache; quick_cache's internal locks
+    /// are only touched by the brief get and insert.
     pub fn resolve<M>(&self, db: &Db<M>, track_id: i64) -> Result<Arc<ResolvedFile>> {
         let track = db
             .get_track(track_id)?
@@ -224,13 +119,13 @@ impl HeaderCache {
             return Err(CoreError::BackingChanged(track.backing_path.clone()));
         }
 
-        if let Some(hit) = self.shard(track_id).get(track_id) {
+        if let Some(hit) = self.cache.get(&track_id) {
             if hit.content_version == track.content_version {
                 return Ok(hit);
             }
         }
         let resolved = self.build(db, &track, &meta)?;
-        self.shard(track_id).insert(track_id, resolved.clone());
+        self.cache.insert(track_id, resolved.clone());
         Ok(resolved)
     }
     /// Build a `ResolvedFile` for `track` (synthesis or passthrough). No lock held.
@@ -971,17 +866,6 @@ mod cache_bound_tests {
     }
 
     #[test]
-    fn shard_evicts_least_recently_used_over_byte_budget() {
-        let mut shard = Shard::new(100);
-        shard.insert(1, entry(0, 60));
-        shard.insert(2, entry(0, 60)); // 120 > 100 → evict LRU key 1
-        assert!(shard.get(1).is_none());
-        assert!(shard.get(2).is_some());
-        shard.insert(3, entry(0, 60)); // evicts the now-LRU entry
-        assert!(shard.get(3).is_some());
-    }
-
-    #[test]
     fn header_cache_resolve_caches_by_content_version() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("a.flac");
@@ -1043,57 +927,6 @@ mod cache_bound_tests {
                 });
             }
         });
-    }
-
-    #[test]
-    fn shard_insert_reaccounts_bytes_on_reinsert() {
-        let mut s = Shard::new(1000);
-        s.insert(1, entry(0, 100));
-        assert_eq!(s.bytes, 100);
-        s.insert(1, entry(0, 30));
-        assert_eq!(s.bytes, 30);
-        assert_eq!(s.map.len(), 1);
-    }
-
-    #[test]
-    fn shard_evicts_and_subtracts_evicted_bytes() {
-        let mut s = Shard::new(100);
-        s.insert(1, entry(0, 60));
-        s.insert(2, entry(0, 60));
-        assert!(s.get(1).is_none());
-        assert!(s.get(2).is_some());
-        assert_eq!(s.bytes, 60);
-    }
-
-    #[test]
-    fn shard_keeps_both_entries_at_exactly_budget() {
-        let mut s = Shard::new(100);
-        s.insert(1, entry(0, 50));
-        s.insert(2, entry(0, 50));
-        assert!(s.get(1).is_some());
-        assert!(s.get(2).is_some());
-        assert_eq!(s.bytes, 100);
-    }
-
-    #[test]
-    fn shard_never_evicts_the_sole_entry_even_over_budget() {
-        let mut s = Shard::new(100);
-        s.insert(1, entry(0, 200));
-        assert!(s.get(1).is_some());
-        assert_eq!(s.bytes, 200);
-    }
-
-    #[test]
-    fn shard_reset_clears_all_entries() {
-        use crate::lock::Clearable;
-        let mut s = Shard::new(1000);
-        s.insert(1, entry(0, 100));
-        s.insert(2, entry(0, 100));
-        s.reset();
-        assert!(s.get(1).is_none());
-        assert!(s.get(2).is_none());
-        assert_eq!(s.bytes, 0);
-        assert_eq!(s.map.len(), 0);
     }
 
     #[test]
@@ -1160,59 +993,8 @@ mod cache_bound_tests {
     }
 
     #[test]
-    fn shard_remove_key_reaccounts_bytes() {
-        let mut s = Shard::new(1000);
-        s.insert(1, entry(0, 100));
-        s.insert(2, entry(0, 100));
-        s.remove_key(1);
-        assert!(s.get(1).is_none());
-        assert!(s.get(2).is_some());
-        assert_eq!(s.bytes, 100);
-    }
-
-    #[test]
-    fn shard_remove_key_is_noop_for_absent_id() {
-        let mut s = Shard::new(1000);
-        s.insert(1, entry(0, 100));
-        s.remove_key(999); // must not panic
-        assert_eq!(s.bytes, 100);
-    }
-
-    #[test]
-    fn shard_retain_keys_drops_dead_and_reaccounts() {
-        use std::collections::HashSet;
-        let mut s = Shard::new(1000);
-        s.insert(1, entry(0, 100));
-        s.insert(2, entry(0, 100));
-        s.insert(3, entry(0, 100));
-        let live: HashSet<i64> = [2, 3].into_iter().collect();
-        s.retain_keys(&live);
-        assert!(s.get(1).is_none());
-        assert!(s.get(2).is_some());
-        assert!(s.get(3).is_some());
-        assert_eq!(s.bytes, 200);
-    }
-
-    #[test]
     fn default_cache_budget_is_64_mib() {
         assert_eq!(DEFAULT_CACHE_BUDGET, 67_108_864);
-    }
-
-    #[test]
-    fn with_budget_divides_evenly_across_shards() {
-        let cache = HeaderCache::with_budget(Mode::Synthesis, 16_384);
-        assert_eq!(cache.shard(0).budget, 1024);
-    }
-
-    #[test]
-    fn shard_routes_by_modulo_not_division() {
-        let cache = HeaderCache::with_budget(Mode::Synthesis, 16 * 1024 * 1024);
-        cache.shard(1).insert(1, entry(0, 50));
-        assert!(
-            cache.shard(17).bytes > 0,
-            "17 and 1 must map to the same shard"
-        );
-        assert_eq!(cache.shard(2).bytes, 0, "2 maps to a different shard");
     }
 
     #[test]

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -64,9 +64,9 @@ pub struct HeaderCache {
 pub const DEFAULT_CACHE_BUDGET: u64 = 64 * 1024 * 1024;
 
 /// Item-count sizing hint for quick_cache's internal structures (not a bound):
-/// the default budget over 4 KiB, a typical inline tag region. A const so the
-/// arithmetic is outside any function body (nothing for cargo-mutants to chew
-/// on — the hint has no observable behavior to pin).
+/// the default budget over 4 KiB, a typical inline tag region. The hint has no
+/// observable public-API behavior, so its arithmetic carries an equivalent-mutant
+/// exclusion in .cargo/mutants.toml (cargo-mutants does mutate const initializers).
 const CACHE_ESTIMATED_ITEMS: usize = (DEFAULT_CACHE_BUDGET / 4096) as usize;
 
 fn mtime_secs(meta: &std::fs::Metadata) -> i64 {


### PR DESCRIPTION
Closes #136.

`HeaderCache`'s 16-shard Mutex LRU (HashMap + Option<i64> doubly-linked
list with manual unlink/push_front surgery, hand-kept byte accounting)
is replaced by `quick_cache::sync::Cache`: S3-FIFO eviction, byte-weighted
by `cache_bytes.max(1)`, internally sharded, all `&self`. Public API
(`new`/`with_budget`/`resolve`/`retain`/`remove`) is unchanged, so
facade.rs, benches, and integration tests are untouched.

Design: `docs/superpowers/specs/2026-06-05-header-cache-quick-cache-design.md`

- Weigher floors at 1: StructureOnly entries have `cache_bytes == 0` and
  zero-weight entries escape quick_cache's weighted bound.
- Eviction-order tests asserting the removed mechanism are deleted;
  end-state budget-bound + zero-weight property tests replace their intent
  (S3-FIFO admission is probabilistic — exact-victim assertions would flake).
- lock.rs poison audit updated: no HeaderCache std Mutex remains.
- BENCHMARKS.md: read_throughput before/after.
- `.cargo/mutants.toml`: documented equivalent-mutant exclusion for the
  `CACHE_ESTIMATED_ITEMS` sizing-hint arithmetic (unobservable through any
  public API; cargo-mutants does mutate const initializers). In-diff gate:
  6 mutants — 4 caught, 2 unviable, 0 missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal header cache implementation with improved performance characteristics while maintaining full backward compatibility with the public API.

* **Documentation**
  * Added performance benchmark results documenting cache improvements across various workload patterns with no observed regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->