### PR TITLE
Test-suite idiom cleanups (#139)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -59,15 +59,15 @@ exclude_re = [
     # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
     # block end past the prefix), so `up_to.min(file_len)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
-    'musefs-core/src/scan\.rs:263:31:',
+    'musefs-core/src/scan\.rs:254:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < file_len`: when
     # it differs, the only effect is a redundant whole-file re-read that feeds the
     # same `probe_full` result. The >8-retry path that could diverge is unreachable
     # given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
-    'musefs-core/src/scan\.rs:270:30:',
+    'musefs-core/src/scan\.rs:261:30:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
-    'musefs-core/src/scan\.rs:624:46:',
+    'musefs-core/src/scan\.rs:619:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -75,23 +75,23 @@ exclude_re = [
     # cadence mutation persists the identical track set. The win is fewer commits
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
-    'musefs-core/src/scan\.rs:715:29:',
-    'musefs-core/src/scan\.rs:717:32:',
-    'musefs-core/src/scan\.rs:717:47:',
-    'musefs-core/src/scan\.rs:717:62:',
-    'musefs-core/src/scan\.rs:725:37:',
-    'musefs-core/src/scan\.rs:727:40:',
-    'musefs-core/src/scan\.rs:727:55:',
-    'musefs-core/src/scan\.rs:727:70:',
+    'musefs-core/src/scan\.rs:710:29:',
+    'musefs-core/src/scan\.rs:712:32:',
+    'musefs-core/src/scan\.rs:712:47:',
+    'musefs-core/src/scan\.rs:712:62:',
+    'musefs-core/src/scan\.rs:720:37:',
+    'musefs-core/src/scan\.rs:722:40:',
+    'musefs-core/src/scan\.rs:722:55:',
+    'musefs-core/src/scan\.rs:722:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
     # from a deterministic test. With skip_failed identically 0, the `failed =
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
-    'musefs-core/src/scan\.rs:831:25:',
-    'musefs-core/src/scan\.rs:835:25:',
-    'musefs-core/src/scan\.rs:871:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:826:25:',
+    'musefs-core/src/scan\.rs:830:25:',
+    'musefs-core/src/scan\.rs:866:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -98,6 +98,13 @@ exclude_re = [
     # bit-for-bit identical for every input (same equivalence as the flac assembly
     # above). The `<<`->`>>` and `> 0` siblings in this fn ARE caught and stay in scope.
     'musefs-format/src/mp3\.rs:\d+:\d+: replace \| with \^ in classify_binary_frame',
+    # fuzz_check fixtures::flac_block header byte
+    # `(if is_last { 0x80 } else { 0 }) | (block_type & 0x7F)` -> `^`: the right
+    # operand is masked to bits 0-6 and the left is bit 7 or zero, so the operands
+    # are bit-disjoint and `|`/`^` agree for every input (mutation-eligible since
+    # the #139 consolidation moved the fixture from tests/ into src/fuzz_check.rs).
+    # The `|`->`&` sibling IS caught and stays in scope.
+    'musefs-format/src/fuzz_check\.rs:\d+:\d+: replace \| with \^ in fixtures::flac_block',
 
     # SP2 incremental tree refresh — equivalent mutants in apply_changes & friends.
     # The whole design contract is "the incrementally-mutated tree is byte-identical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,9 @@ git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
 grep -q '^@@ ' mutants.diff
 cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
 # Property tests (proptest): byte-identical invariant + tag round-trip. The
-# format-layer proptests need the `fuzzing` feature; `cargo test --workspace`
-# also runs them via feature unification.
-cargo test -p musefs-format --features fuzzing
+# format-layer proptests are gated on the `fuzzing` feature, which
+# musefs-format's self-dev-dependency enables for all of its test builds.
+cargo test -p musefs-format
 cargo test -p musefs-core --test proptest_read_fidelity
 
 # Coverage-guided fuzzing (needs nightly + cargo-fuzz; the fuzz/ crate is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "metaflac",
  "mp4",
  "musefs-db",
+ "musefs-format",
  "proptest",
  "thiserror 2.0.18",
 ]

--- a/docs/superpowers/plans/2026-06-06-test-idiom-cleanups.md
+++ b/docs/superpowers/plans/2026-06-06-test-idiom-cleanups.md
@@ -165,9 +165,11 @@ b. Delete the `ENV_LOCK` static and its doc comment:
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 ```
 
-c. Delete the whole `scan_window_default_and_env` test (with its `// --- scan_window() ... ---` section header and kills-comments) and the whole `batch_bytes_cap_default_and_env` test (with its section header and kills-comments).
+c. Delete two **non-adjacent** blocks (the `read_tail_128` tests, `write_temp`, and `effective_jobs` test sit between them — leave those untouched):
+   - the `// --- scan_window() / WINDOW ... ---` section header, its kills-comments, and the whole `scan_window_default_and_env` test;
+   - the `// --- batch_bytes_cap() / BATCH_BYTES ... ---` section header, its kills-comments, and the whole `batch_bytes_cap_default_and_env` test.
 
-d. In their place (where the `scan_window` section header was), add:
+d. Where the `scan_window` section header was (before the `read_tail_128` section), add:
 
 ```rust
     // --- ScanOptions defaults (WINDOW L16, BATCH_BYTES L12) ---
@@ -479,25 +481,38 @@ c. `musefs-core/tests/metrics.rs` (~line 476):
     // keep the default ScanOptions::window): one prefix read + the tail. read_tail_128
 ```
 
-- [ ] **Step 13: Re-anchor the three `mutants.toml` line:col excludes**
+- [ ] **Step 13: Re-anchor ALL TWELVE `mutants.toml` `scan.rs` line:col excludes**
 
-`.cargo/mutants.toml` pins three equivalent-mutant excludes by `scan.rs` line:col; the deletions above shift them. After `cargo fmt --all`, recompute:
+`.cargo/mutants.toml` pins **twelve** equivalent-mutant excludes by `scan.rs` line:col, and every one sits below the first deletion (~line 172), so all twelve shift. Re-anchoring only some leaves the rest silently stale: the in-diff gate stays green (those lines aren't in the diff) but the later full mutation leg reports them MISSED.
 
-Run: `grep -n 'max(want + 1)' musefs-core/src/scan.rs` → new line of the widen-progress site (col stays `31` if indentation is unchanged — verify against the old entry's column by checking the character offset of the `+`-operator's mutated expression start; if unsure, run the gate in Step 15 and read the reported line:col from any MISSED mutant at that site).
-Run: `grep -n '(prefix.len() as u64) < file_len' musefs-core/src/scan.rs` → new line for the fallback-guard exclude (old `270:30`).
-Run: `grep -n 'sync_channel::<Unit>(jobs \* 2)' musefs-core/src/scan.rs` → new line for the channel-capacity exclude (old `624:46`).
+After `cargo fmt --all`, recompute each anchor's new line by grepping its source content. Columns are unchanged (only whole lines above were added/removed; indentation is untouched):
 
-Update the three entries:
+| Old anchor | Content to grep for | Notes |
+|---|---|---|
+| `263:31` | `.max(want + 1)` | unique; widen progress in `probe_file` |
+| `270:30` | `(prefix.len() as u64) < file_len` | unique; post-loop fallback guard |
+| `624:46` | `sync_channel::<Unit>(jobs * 2)` | unique; channel capacity in `run_pipeline` |
+| `715:29` | `batch_bytes += unit.weight;` | **first** of 2 matches (try_recv branch) |
+| `717:32`, `717:47`, `717:62` | `if batch.len() >= BATCH_FILES \|\| batch_bytes >= cap {` | **first** of 2 matches; three cols on one line |
+| `725:37` | `batch_bytes += unit.weight;` | **second** of 2 matches (recv branch, deeper indent) |
+| `727:40`, `727:55`, `727:70` | `if batch.len() >= BATCH_FILES \|\| batch_bytes >= cap {` | **second** of 2 matches; three cols on one line |
+| `831:25` | `skip_failed += 1;` | **first** of 2 matches (`revalidate_with` stat failure) |
+| `835:25` | `skip_failed += 1;` | **second** of 2 matches (canonicalize failure) |
+| `871:29` | `failed: scan.failed + skip_failed,` | unique; entry reads `:871:29: replace \+ with -` — keep that suffix |
 
-```toml
-    'musefs-core/src/scan\.rs:263:31:',
-    ...
-    'musefs-core/src/scan\.rs:270:30:',
-    ...
-    'musefs-core/src/scan\.rs:624:46:',
+```bash
+grep -nF '.max(want + 1)' musefs-core/src/scan.rs
+grep -nF '(prefix.len() as u64) < file_len' musefs-core/src/scan.rs
+grep -nF 'sync_channel::<Unit>(jobs * 2)' musefs-core/src/scan.rs
+grep -nF 'batch_bytes += unit.weight;' musefs-core/src/scan.rs            # 2 matches: first→715-group, second→725-group
+grep -nF 'batch.len() >= BATCH_FILES || batch_bytes >= cap' musefs-core/src/scan.rs  # 2 matches: first→717-group, second→727-group
+grep -nF 'skip_failed += 1;' musefs-core/src/scan.rs                      # 2 matches: first→831, second→835
+grep -nF 'failed: scan.failed + skip_failed,' musefs-core/src/scan.rs
 ```
 
-replacing `263`, `270`, and `624` with the new line numbers (columns are unchanged when only lines above were removed).
+Edit each of the twelve `'musefs-core/src/scan\.rs:<line>:<col>:'` entries in `.cargo/mutants.toml`, substituting the new line numbers and keeping every column (and the `871` entry's ` replace \+ with -` suffix) exactly as is.
+
+Cross-check: if Step 15's gate (or the full mutation leg) reports a MISSED mutant at one of these sites, copy the exact `file:line:col:` from the report into the corresponding entry and re-run.
 
 - [ ] **Step 14: Run the workspace tests**
 
@@ -688,7 +703,10 @@ The fuzz crate consumes `fuzz_check::fixtures` and is not compiled by workspace 
 Run: `cargo +nightly fuzz build`
 Expected: all targets build (the `fixtures::flac()` signature is unchanged; this catches any accidental breakage).
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 8: Format, then commit**
+
+Run: `cargo fmt --all && cargo fmt --all --check`
+Expected: exit 0 (the fmt gate is CI-enforced; never commit unformatted code).
 
 ```bash
 git add musefs-format/Cargo.toml musefs-format/src/fuzz_check.rs \
@@ -781,6 +799,9 @@ In `bench_concurrent_read_and_walk`:
 Run: `cargo clippy -p musefs-core --benches`
 Expected: clean (this compiles `read_throughput.rs`; plain `cargo test` does not build `harness = false` benches).
 
+Run: `cargo fmt --all && cargo fmt --all --check`
+Expected: exit 0.
+
 - [ ] **Step 4: Commit**
 
 ```bash
@@ -857,6 +878,9 @@ Expected: builds clean.
 
 Run: `cargo +nightly fuzz run b64 -- -max_total_time=30`
 Expected: no crashes in 30 seconds (the windowed-encode property still holds).
+
+Run: `cd fuzz && cargo fmt --check; cd ..`
+Expected: exit 0 (the fuzz crate is outside the workspace, so `cargo fmt --all` from the root does not cover it; format it in place with `cd fuzz && cargo fmt` if the check fails).
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-06-06-test-idiom-cleanups.md
+++ b/docs/superpowers/plans/2026-06-06-test-idiom-cleanups.md
@@ -1,0 +1,917 @@
+# Test-Suite Idiom Cleanups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the four cleanups from issue #139 per the approved spec at `docs/superpowers/specs/2026-06-06-test-idiom-cleanups-design.md`: inject scan knobs via `ScanOptions` (deleting the `MUSEFS_SCAN_WINDOW`/`MUSEFS_BATCH_BYTES` env vars), consolidate triplicated FLAC fixture helpers into `fuzz_check::fixtures`, stop leaking the bench `TempDir`, and make the `b64` fuzz target's bounds locally underflow-safe.
+
+**Architecture:** Behavior-preserving refactors; the existing test suite is the safety net. Work happens on the `test-idiom-cleanups` branch (already created, carries the spec). One commit per task. The only new test is a `ScanOptions::default()` assertion that preserves mutation-kill coverage for the `WINDOW`/`BATCH_BYTES` constants.
+
+**Tech Stack:** Rust workspace (cargo, clippy, rustfmt), cargo-mutants in-diff gate, cargo-fuzz (nightly, out-of-workspace `fuzz/` crate).
+
+**Out of scope (do not touch):** `common_corpus_smoke.rs`'s `ENV_LOCK` and `MUSEFS_BENCH_*` handling (those tests deliberately test env parsing of the bench-corpus config surface); the *different-signature* `make_flac(comments, audio)`/`flac_block` local variants in `musefs-cli/tests/scan.rs` and `musefs-fuse/tests/{concurrency,mount,keep_cache}.rs`.
+
+---
+
+### Task 1: Inject scan knobs via `ScanOptions`; delete the env vars
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (struct ~line 368, `scan_window()` ~173, `batch_bytes_cap()` ~382, `probe_file` ~214, `run_pipeline` ~612, `payload_weight` doc ~399, unit tests ~880–995, `jobs1_and_jobs_n` test ~1766)
+- Modify: `musefs-cli/src/lib.rs` (`run_scan`, ~line 108)
+- Modify: `musefs-core/tests/probe_equivalence.rs` (~lines 60–64)
+- Modify: `musefs-core/tests/scan_counters.rs` (ENV_LOCK ~14, three env-using tests, two `jobs: 4` literals)
+- Modify: `musefs-core/tests/pipeline_backpressure.rs` (~lines 51–70)
+- Modify: `musefs-core/tests/bench_ingest.rs` (three `ScanOptions` literals: ~28, ~130, ~215)
+- Modify: `musefs-core/src/lock.rs` (registry comment ~line 20)
+- Modify: `musefs-core/tests/common/corpus.rs` (stale comment ~line 100)
+- Modify: `musefs-core/tests/metrics.rs` (stale comment ~line 476)
+- Modify: `.cargo/mutants.toml` (three line:col anchors into scan.rs)
+
+- [ ] **Step 1: Extend `ScanOptions` and replace its derived `Default` with a manual impl**
+
+In `musefs-core/src/scan.rs`, replace:
+
+```rust
+/// Knobs for a scan. `jobs == 0` means "use available parallelism".
+#[derive(Debug, Clone, Default)]
+pub struct ScanOptions {
+    pub jobs: usize,
+}
+```
+
+with:
+
+```rust
+/// Knobs for a scan. `jobs == 0` means "use available parallelism".
+#[derive(Debug, Clone)]
+pub struct ScanOptions {
+    pub jobs: usize,
+    /// Initial probe read window in bytes; widened on `NeedMore`.
+    pub window: usize,
+    /// In-flight art-byte budget and per-batch byte-flush threshold.
+    pub batch_bytes: u64,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            jobs: 0,
+            window: WINDOW,
+            batch_bytes: BATCH_BYTES,
+        }
+    }
+}
+```
+
+(`WINDOW` is `const WINDOW: usize = 1 << 20;` at scan.rs:16, `BATCH_BYTES` is `const BATCH_BYTES: u64 = 64 << 20;` at scan.rs:12 — both already exist above.)
+
+- [ ] **Step 2: Delete the two env-reading functions**
+
+Delete `scan_window()` **including its doc comment** (scan.rs ~lines 172–179):
+
+```rust
+/// Effective initial window: `MUSEFS_SCAN_WINDOW` (bytes) if set, else `WINDOW`.
+fn scan_window() -> usize {
+    std::env::var("MUSEFS_SCAN_WINDOW")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(WINDOW)
+}
+```
+
+Delete `batch_bytes_cap()` **including its doc comment** (~lines 379–389):
+
+```rust
+/// In-flight art-byte budget (and per-batch byte-flush threshold). Overridable via
+/// `MUSEFS_BATCH_BYTES` so tests can exercise the backpressure path without 64 MiB
+/// of fixture art; defaults to `BATCH_BYTES`.
+fn batch_bytes_cap() -> u64 {
+    std::env::var("MUSEFS_BATCH_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(BATCH_BYTES)
+}
+```
+
+- [ ] **Step 3: Thread `window` into `probe_file`; read `batch_bytes` from opts**
+
+`probe_file` signature (scan.rs ~214) gains the window parameter:
+
+```rust
+fn probe_file(path: &Path, file_len: u64, window: usize) -> std::io::Result<Option<Probed>> {
+```
+
+Inside it (~line 249), replace:
+
+```rust
+    let mut want = (scan_window() as u64).min(file_len) as usize;
+```
+
+with:
+
+```rust
+    let mut want = (window as u64).min(file_len) as usize;
+```
+
+In `run_pipeline` (~line 616), replace:
+
+```rust
+    let jobs = effective_jobs(opts.jobs);
+    let cap = batch_bytes_cap();
+```
+
+with:
+
+```rust
+    let jobs = effective_jobs(opts.jobs);
+    let window = opts.window;
+    let cap = opts.batch_bytes;
+```
+
+(`window` is a `Copy` `usize`, so each `move` worker closure captures its own copy; no `Arc` needed.) Then update the single call site inside the worker loop (~line 640):
+
+```rust
+            match probe_file(&path, meta.len(), window) {
+```
+
+- [ ] **Step 4: Fix the `payload_weight` doc comment**
+
+It references the deleted env var (~line 399). Change:
+
+```rust
+/// In-memory byte weight of a `Probed`, used for batch backpressure
+/// (`MUSEFS_BATCH_BYTES`). Counts every buffered payload — pictures plus FLAC
+```
+
+to:
+
+```rust
+/// In-memory byte weight of a `Probed`, used for batch backpressure
+/// (`ScanOptions::batch_bytes`). Counts every buffered payload — pictures plus FLAC
+```
+
+- [ ] **Step 5: Update the `scan.rs` unit tests**
+
+In `mod scan_unit_tests` (~line 881):
+
+a. Remove `use std::sync::Mutex;` from the module imports (only `ENV_LOCK` used it).
+
+b. Delete the `ENV_LOCK` static and its doc comment:
+
+```rust
+    /// Env is process-global: serialize the env-mutating tests so they never
+    /// observe each other's `MUSEFS_*` vars.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+```
+
+c. Delete the whole `scan_window_default_and_env` test (with its `// --- scan_window() ... ---` section header and kills-comments) and the whole `batch_bytes_cap_default_and_env` test (with its section header and kills-comments).
+
+d. In their place (where the `scan_window` section header was), add:
+
+```rust
+    // --- ScanOptions defaults (WINDOW L16, BATCH_BYTES L12) ---
+
+    // kills the WINDOW `<<`→`>>` and BATCH_BYTES initializer mutants: the
+    // right-hand sides are decimal literals, so a mutated const/Default
+    // initializer cannot flow to both sides of the assertion.
+    #[test]
+    fn scan_options_defaults() {
+        let d = ScanOptions::default();
+        assert_eq!(d.jobs, 0, "jobs default = use available parallelism");
+        assert_eq!(d.window, 1_048_576, "window default = 1 MiB");
+        assert_eq!(d.batch_bytes, 67_108_864, "batch_bytes default = 64 MiB");
+    }
+```
+
+**Important:** the decimal-literal right-hand sides are load-bearing — `assert_eq!(d.window, WINDOW)` would let a `1 << 20`→`1 >> 20` const mutant survive the in-diff gate (it flows to both sides).
+
+e. In the `jobs1_and_jobs_n_produce_equivalent_state` test (~line 1766), the field-shorthand literal:
+
+```rust
+            scan_directory_with(&db, dir.path(), &ScanOptions { jobs }).unwrap();
+```
+
+becomes:
+
+```rust
+            scan_directory_with(
+                &db,
+                dir.path(),
+                &ScanOptions {
+                    jobs,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+```
+
+- [ ] **Step 6: Run the core unit tests**
+
+Run: `cargo test -p musefs-core --lib`
+Expected: PASS (including the new `scan_options_defaults`). If anything still references `scan_window`/`batch_bytes_cap`/`ENV_LOCK`, it fails to compile — fix per the steps above.
+
+- [ ] **Step 7: Update the production literal in `musefs-cli`**
+
+In `musefs-cli/src/lib.rs` `run_scan` (~line 108), replace:
+
+```rust
+    let opts = musefs_core::ScanOptions { jobs };
+```
+
+with:
+
+```rust
+    let opts = musefs_core::ScanOptions {
+        jobs,
+        ..Default::default()
+    };
+```
+
+Behavior is unchanged: the CLI never set the env vars, so it always got `WINDOW`/`BATCH_BYTES` — exactly what `Default` now supplies.
+
+- [ ] **Step 8: Update `probe_equivalence.rs` (no-options API → `scan_directory_with`)**
+
+Replace (~lines 60–64):
+
+```rust
+        // Bounded scan with a 64-byte window → widen path fires on every file.
+        std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
+        let bounded_db = Db::open_in_memory().unwrap();
+        musefs_core::scan_directory(&bounded_db, dir.path()).unwrap();
+        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+```
+
+with:
+
+```rust
+        // Bounded scan with a 64-byte window → widen path fires on every file.
+        let bounded_db = Db::open_in_memory().unwrap();
+        musefs_core::scan_directory_with(
+            &bounded_db,
+            dir.path(),
+            &musefs_core::ScanOptions {
+                window: 64,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+```
+
+(Keep using fully-qualified `musefs_core::` paths — the file's other scan calls are written that way.)
+
+- [ ] **Step 9: Update `scan_counters.rs`**
+
+a. Delete the lock (~lines 13–14):
+
+```rust
+/// Serialize env-mutating tests: `MUSEFS_*` vars are process-global.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+```
+
+b. `widen_then_fallback_matches_oracle_under_tiny_window`: delete `let _g = ENV_LOCK.lock().unwrap();` and replace:
+
+```rust
+    std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
+    let bounded_db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&bounded_db, dir.path()).unwrap();
+    std::env::remove_var("MUSEFS_SCAN_WINDOW");
+```
+
+with:
+
+```rust
+    let bounded_db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_with(
+        &bounded_db,
+        dir.path(),
+        &ScanOptions {
+            window: 64,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+```
+
+c. `widen_preserves_art_bytes_vs_oracle`: delete `let _g = ENV_LOCK.lock().unwrap();` and replace:
+
+```rust
+    // Tiny window forces a multi-step widen to reach the 4 KiB picture body.
+    std::env::set_var("MUSEFS_SCAN_WINDOW", "16");
+    let db = Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    std::env::remove_var("MUSEFS_SCAN_WINDOW");
+```
+
+with:
+
+```rust
+    // Tiny window forces a multi-step widen to reach the 4 KiB picture body.
+    let db = Db::open_in_memory().unwrap();
+    scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            window: 16,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+```
+
+d. `scans_more_than_batch_files_persists_all_once`: both occurrences of
+
+```rust
+    let stats = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+```
+
+(the second is `let stats2 = ...`) become:
+
+```rust
+    let stats = scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            jobs: 4,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+```
+
+e. `byte_threshold_flush_persists_all_art`: delete `let _g = ENV_LOCK.lock().unwrap();`; in its doc comment change ``/// Byte-threshold flushing: with a tiny `MUSEFS_BATCH_BYTES` and art-bearing`` to ``/// Byte-threshold flushing: with a tiny `batch_bytes` and art-bearing``; and replace:
+
+```rust
+    // Cap below a couple files' cumulative art so the byte branch flushes often.
+    std::env::set_var("MUSEFS_BATCH_BYTES", "100");
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+    std::env::remove_var("MUSEFS_BATCH_BYTES");
+```
+
+with:
+
+```rust
+    // Cap below a couple files' cumulative art so the byte branch flushes often.
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            jobs: 4,
+            batch_bytes: 100,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+```
+
+(`scan_directory` stays imported — `revalidate_unchanged_count_matches_file_count` and others still call it.)
+
+- [ ] **Step 10: Update `pipeline_backpressure.rs`**
+
+Replace (~lines 48–58, keeping the explanatory comment):
+
+```rust
+    // Cap the in-flight budget below two files' cumulative art (6 bytes each), so a
+    // second concurrent `acquire` blocks while the writer's batch sits below the
+    // flush threshold — the exact pre-fix deadlock window.
+    std::env::set_var("MUSEFS_BATCH_BYTES", "8");
+
+    let root = dir.path().to_path_buf();
+    let handle = std::thread::spawn(move || {
+        let db = Db::open_in_memory().unwrap();
+        scan_directory_with(&db, &root, &ScanOptions { jobs: 4 }).unwrap();
+        db.list_tracks().unwrap().len()
+    });
+```
+
+with:
+
+```rust
+    // Cap the in-flight budget below two files' cumulative art (6 bytes each), so a
+    // second concurrent `acquire` blocks while the writer's batch sits below the
+    // flush threshold — the exact pre-fix deadlock window.
+    let root = dir.path().to_path_buf();
+    let handle = std::thread::spawn(move || {
+        let db = Db::open_in_memory().unwrap();
+        scan_directory_with(
+            &db,
+            &root,
+            &ScanOptions {
+                jobs: 4,
+                batch_bytes: 8,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        db.list_tracks().unwrap().len()
+    });
+```
+
+And delete the trailing `std::env::remove_var("MUSEFS_BATCH_BYTES");` (~line 70, after the watchdog loop).
+
+- [ ] **Step 11: Update `bench_ingest.rs` literals**
+
+a. ~line 28: `let opts = ScanOptions { jobs };` →
+
+```rust
+    let opts = ScanOptions {
+        jobs,
+        ..Default::default()
+    };
+```
+
+b. ~lines 130–135, inside the `scan_directory_with(` call:
+
+```rust
+        &ScanOptions {
+            jobs: std::env::var("MUSEFS_BENCH_JOBS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+        },
+```
+
+→ add the rest-spread:
+
+```rust
+        &ScanOptions {
+            jobs: std::env::var("MUSEFS_BENCH_JOBS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+            ..Default::default()
+        },
+```
+
+c. ~line 215: `&ScanOptions { jobs: 0 }` → `&ScanOptions::default()` (`jobs: 0` is the default).
+
+- [ ] **Step 12: Scrub stale comments**
+
+a. `musefs-core/src/lock.rs` (~line 20):
+
+```rust
+//! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,
+//! not on the FUSE serving path).
+```
+
+→
+
+```rust
+//! poison), db_pool.rs (#94), scan.rs work-queue (scan-internal, not on the
+//! FUSE serving path).
+```
+
+b. `musefs-core/tests/common/corpus.rs` (~line 100): in `CorpusParams::single`'s doc, change ``/// time). The tiny `MUSEFS_SCAN_WINDOW=64` still forces the widen path on`` to ``/// time). The tiny `ScanOptions::window` (64) still forces the widen path on``.
+
+c. `musefs-core/tests/metrics.rs` (~line 476):
+
+```rust
+    // Corpus tracks are far below the default 1 MiB scan window (this test must
+    // not set MUSEFS_SCAN_WINDOW): one prefix read + the tail. read_tail_128
+```
+
+→
+
+```rust
+    // Corpus tracks are far below the default 1 MiB scan window (this test must
+    // keep the default ScanOptions::window): one prefix read + the tail. read_tail_128
+```
+
+- [ ] **Step 13: Re-anchor the three `mutants.toml` line:col excludes**
+
+`.cargo/mutants.toml` pins three equivalent-mutant excludes by `scan.rs` line:col; the deletions above shift them. After `cargo fmt --all`, recompute:
+
+Run: `grep -n 'max(want + 1)' musefs-core/src/scan.rs` → new line of the widen-progress site (col stays `31` if indentation is unchanged — verify against the old entry's column by checking the character offset of the `+`-operator's mutated expression start; if unsure, run the gate in Step 15 and read the reported line:col from any MISSED mutant at that site).
+Run: `grep -n '(prefix.len() as u64) < file_len' musefs-core/src/scan.rs` → new line for the fallback-guard exclude (old `270:30`).
+Run: `grep -n 'sync_channel::<Unit>(jobs \* 2)' musefs-core/src/scan.rs` → new line for the channel-capacity exclude (old `624:46`).
+
+Update the three entries:
+
+```toml
+    'musefs-core/src/scan\.rs:263:31:',
+    ...
+    'musefs-core/src/scan\.rs:270:30:',
+    ...
+    'musefs-core/src/scan\.rs:624:46:',
+```
+
+replacing `263`, `270`, and `624` with the new line numbers (columns are unchanged when only lines above were removed).
+
+- [ ] **Step 14: Run the workspace tests**
+
+Run: `cargo test --workspace`
+Expected: PASS — and the formerly env-serialized tests now run in parallel.
+
+Run: `cargo fmt --all && cargo clippy --all-targets`
+Expected: clean (clippy compiles `bench_ingest.rs` and the benches).
+
+- [ ] **Step 15: Run the in-diff mutation gate**
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: exit 0, no MISSED mutants. If a MISSED mutant appears at one of the three re-anchored sites, the line:col in Step 13 is off — copy the exact `file:line:col:` from the report into the corresponding `mutants.toml` entry and re-run.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/src/lock.rs musefs-cli/src/lib.rs \
+  musefs-core/tests/probe_equivalence.rs musefs-core/tests/scan_counters.rs \
+  musefs-core/tests/pipeline_backpressure.rs musefs-core/tests/bench_ingest.rs \
+  musefs-core/tests/common/corpus.rs musefs-core/tests/metrics.rs .cargo/mutants.toml
+git commit -m "$(cat <<'EOF'
+Inject scan window/batch-bytes via ScanOptions; drop MUSEFS_* env knobs (#139)
+
+The env vars existed only for tests; tests now inject through the
+existing ScanOptions, so the ENV_LOCK serialization (and two unguarded
+env mutations) disappear.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Consolidate FLAC fixture helpers into `fuzz_check::fixtures`
+
+**Files:**
+- Modify: `musefs-format/Cargo.toml` (self-dev-dependency)
+- Modify: `musefs-format/src/fuzz_check.rs` (`fixtures` module, ~lines 57–102)
+- Modify: `musefs-format/tests/common/mod.rs` (drop 4 fns, add re-export)
+- Modify: `musefs-core/tests/common/mod.rs` (drop 4 fns, add re-export)
+- Modify: `CLAUDE.md` (proptest command note)
+
+- [ ] **Step 1: Add the self-dev-dependency**
+
+In `musefs-format/Cargo.toml`, add to `[dev-dependencies]` (path-only, no version — stripped on publish):
+
+```toml
+# Self-dependency: turns the `fuzzing` feature on for this crate's own test
+# builds, so tests/ can use fuzz_check and the proptests run without an
+# explicit --features flag.
+musefs-format = { path = ".", features = ["fuzzing"] }
+```
+
+- [ ] **Step 2: Rewrite the `fixtures` FLAC helpers in `fuzz_check.rs`**
+
+In `musefs-format/src/fuzz_check.rs`, inside `pub mod fixtures`, replace the three private helpers and `flac()` — i.e. everything from `fn flac_block(` through the end of `pub fn flac(...) { ... }` (currently ~lines 58–102), keeping `bx` and everything after it untouched — with the public, better-commented versions plus the new `make_flac`:
+
+```rust
+    /// Build a FLAC metadata block (4-byte header + body) independently of production code.
+    pub fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+        let mut out = Vec::new();
+        let first = (if is_last { 0x80 } else { 0 }) | (block_type & 0x7F);
+        out.push(first);
+        let len = body.len();
+        out.push(((len >> 16) & 0xFF) as u8);
+        out.push(((len >> 8) & 0xFF) as u8);
+        out.push((len & 0xFF) as u8);
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// A structurally valid STREAMINFO body: 44100 Hz, 2 channels, 16-bit, unknown frame/sample counts.
+    pub fn streaminfo_body() -> Vec<u8> {
+        let mut b = vec![
+            0x10, 0x00, // min block size = 4096
+            0x10, 0x00, // max block size = 4096
+            0x00, 0x00, 0x00, // min frame size = 0 (unknown)
+            0x00, 0x00, 0x00, // max frame size = 0 (unknown)
+            0x0A, 0xC4, 0x42, 0xF0, // sample_rate=44100, channels=2, bps=16, top of total samples
+            0x00, 0x00, 0x00, 0x00, // remaining total-samples bits = 0
+        ];
+        b.extend_from_slice(&[0u8; 16]); // MD5 signature = 0
+        b
+    }
+
+    /// Minimal VORBIS_COMMENT body with the given already-formatted `KEY=value` comments.
+    pub fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        out.extend_from_slice(vendor.as_bytes());
+        out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+        for c in comments {
+            out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+            out.extend_from_slice(c.as_bytes());
+        }
+        out
+    }
+
+    /// Assemble a full FLAC byte stream: marker + blocks (last-flag auto-set on the final block) + audio.
+    pub fn make_flac(blocks: &[(u8, Vec<u8>)], audio: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"fLaC");
+        for (i, (bt, body)) in blocks.iter().enumerate() {
+            let is_last = i == blocks.len() - 1;
+            out.extend_from_slice(&flac_block(*bt, body, is_last));
+        }
+        out.extend_from_slice(audio);
+        out
+    }
+
+    /// FLAC = `fLaC` + STREAMINFO + VORBIS_COMMENT + `audio`.
+    pub fn flac(audio: &[u8]) -> Vec<u8> {
+        make_flac(
+            &[
+                (0, streaminfo_body()),
+                (4, vorbis_comment_body("orig", &["TITLE=Orig"])),
+            ],
+            audio,
+        )
+    }
+```
+
+(The original `flac()` built STREAMINFO with `is_last=false` and VORBIS_COMMENT with `is_last=true`; `make_flac` auto-sets the last flag on the final block — byte-identical output. The in-file `flac_fixture_parses` unit test confirms.)
+
+- [ ] **Step 3: Replace the four helpers in `musefs-format/tests/common/mod.rs` with a re-export**
+
+Delete `flac_block`, `streaminfo_body`, `vorbis_comment_body`, `make_flac` (lines 7–57) and add after the existing `use musefs_format::{RegionLayout, Segment};`:
+
+```rust
+pub use musefs_format::fuzz_check::fixtures::{
+    flac_block, make_flac, streaminfo_body, vorbis_comment_body,
+};
+```
+
+`resolve_layout` stays unchanged.
+
+- [ ] **Step 4: Replace the four helpers in `musefs-core/tests/common/mod.rs` with the same re-export**
+
+Delete the four functions (lines 8–48, between `pub mod report;` and `write_flac`) and add in their place:
+
+```rust
+pub use musefs_format::fuzz_check::fixtures::{
+    flac_block, make_flac, streaminfo_body, vorbis_comment_body,
+};
+```
+
+The in-module callers (`write_flac`, `write_oggflac_with_art`) resolve through the `pub use` unchanged, as do `common::*` users in dependent test files and the `#[path]`-included benches (musefs-core's dev-dep on musefs-format already enables `fuzzing`).
+
+- [ ] **Step 5: Run both crates' tests**
+
+Run: `cargo test -p musefs-format`
+Expected: PASS, **and** the proptest targets (`proptest_flac`, `proptest_mp3`, `proptest_mp4`, `proptest_ogg`, `proptest_wav`) now appear in the run without `--features fuzzing` (they are `#![cfg(feature = "fuzzing")]`; the self-dev-dep turns the feature on).
+
+Run: `cargo test -p musefs-core`
+Expected: PASS.
+
+- [ ] **Step 6: Update CLAUDE.md**
+
+Replace:
+
+```
+# Property tests (proptest): byte-identical invariant + tag round-trip. The
+# format-layer proptests need the `fuzzing` feature; `cargo test --workspace`
+# also runs them via feature unification.
+cargo test -p musefs-format --features fuzzing
+```
+
+with:
+
+```
+# Property tests (proptest): byte-identical invariant + tag round-trip. The
+# format-layer proptests are gated on the `fuzzing` feature, which
+# musefs-format's self-dev-dependency enables for all of its test builds.
+cargo test -p musefs-format
+```
+
+- [ ] **Step 7: Build the out-of-workspace fuzz targets**
+
+The fuzz crate consumes `fuzz_check::fixtures` and is not compiled by workspace builds:
+
+Run: `cargo +nightly fuzz build`
+Expected: all targets build (the `fixtures::flac()` signature is unchanged; this catches any accidental breakage).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-format/Cargo.toml musefs-format/src/fuzz_check.rs \
+  musefs-format/tests/common/mod.rs musefs-core/tests/common/mod.rs \
+  CLAUDE.md Cargo.lock
+git commit -m "$(cat <<'EOF'
+Consolidate FLAC fixture helpers into fuzz_check::fixtures (#139)
+
+Three copies (format tests/common, core tests/common, fuzz_check's
+private set) become one. The self-dev-dependency turns the fuzzing
+feature on for musefs-format's own test builds, so the proptests now
+run under a plain `cargo test -p musefs-format`.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(Include `Cargo.lock` only if the self-dev-dep changed it.)
+
+---
+
+### Task 3: Bench fixture returns its `TempDir` instead of leaking it
+
+**Files:**
+- Modify: `musefs-core/benches/read_throughput.rs` (`fixture` ~line 38, callers ~lines 74 and ~102)
+
+- [ ] **Step 1: Change `fixture()` to return the `TempDir`**
+
+Signature:
+
+```rust
+fn fixture(
+    format: Format,
+    bytes_per_track: usize,
+    tracks: usize,
+) -> (Arc<Musefs>, Vec<u64>, tempfile::TempDir) {
+```
+
+And replace the tail of the function:
+
+```rust
+    // Keep the tempdir alive for the duration of the bench by leaking it. Each
+    // fixture call leaks one; a full run accumulates at most ALL_FORMATS.len()+1
+    // (sequential per-format + concurrent), all reclaimed when the process exits.
+    std::mem::forget(dir);
+    (fs, inodes)
+}
+```
+
+with:
+
+```rust
+    (fs, inodes, dir)
+}
+```
+
+(This matches the sibling `cold_fixture()`, which already returns its `TempDir`.)
+
+- [ ] **Step 2: Update the two callers**
+
+In `bench_sequential_read`:
+
+```rust
+        let (fs, inodes) = fixture(fmt, 4 * 1024 * 1024, 1);
+```
+
+→
+
+```rust
+        let (fs, inodes, _dir) = fixture(fmt, 4 * 1024 * 1024, 1);
+```
+
+In `bench_concurrent_read_and_walk`:
+
+```rust
+    let (fs, inodes) = fixture(Format::Flac, 1024 * 1024, m.max(2));
+```
+
+→
+
+```rust
+    let (fs, inodes, _dir) = fixture(Format::Flac, 1024 * 1024, m.max(2));
+```
+
+**Must be `_dir`, not `_`** — a bare `_` pattern drops the `TempDir` immediately and the bench would read from a deleted directory.
+
+- [ ] **Step 3: Compile-check the bench**
+
+Run: `cargo clippy -p musefs-core --benches`
+Expected: clean (this compiles `read_throughput.rs`; plain `cargo test` does not build `harness = false` benches).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/benches/read_throughput.rs
+git commit -m "$(cat <<'EOF'
+Stop leaking the bench fixture TempDir (#139)
+
+Return it from fixture() and let callers hold it, matching
+cold_fixture().
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Locally-evident bounds in the `b64` fuzz target
+
+**Files:**
+- Modify: `fuzz/fuzz_targets/b64.rs` (lines 20–32)
+
+- [ ] **Step 1: Rewrite the guard and bounds**
+
+Replace:
+
+```rust
+    let total = b64_len(img.len() as u64);
+    if total == 0 {
+        return;
+    }
+    let full = encode_b64_slice(&img, 0, total as usize);
+    let out_off = match u.int_in_range(0..=total - 1) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let take = match u.int_in_range(1..=total - out_off) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+```
+
+with:
+
+```rust
+    let total = b64_len(img.len() as u64);
+    let full = encode_b64_slice(&img, 0, total as usize);
+    // img is non-empty so total >= 4; checked_sub keeps each bound
+    // underflow-safe on its own, independent of statement order.
+    let Some(max_off) = total.checked_sub(1) else {
+        return;
+    };
+    let out_off = match u.int_in_range(0..=max_off) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let Some(max_take) = total.checked_sub(out_off) else {
+        return;
+    };
+    let take = match u.int_in_range(1..=max_take) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+```
+
+(The old `total == 0` guard was dead — `img` is rejected when empty at lines 17–19, so `total >= 4` always; the first `checked_sub` subsumes it.)
+
+- [ ] **Step 2: Build the fuzz target**
+
+Run: `cargo +nightly fuzz build b64`
+Expected: builds clean.
+
+- [ ] **Step 3: Smoke-run the target briefly**
+
+Run: `cargo +nightly fuzz run b64 -- -max_total_time=30`
+Expected: no crashes in 30 seconds (the windowed-encode property still holds).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fuzz/fuzz_targets/b64.rs
+git commit -m "$(cat <<'EOF'
+Make b64 fuzz bounds locally underflow-safe (#139)
+
+checked_sub instead of bare subtractions whose non-underflow depended
+on a guard and a prior range several statements away; the dead
+total==0 guard goes away.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Full verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Workspace gates**
+
+```bash
+cargo test --workspace
+cargo clippy --all-targets
+cargo fmt --all --check
+```
+
+Expected: all exit 0 (check the exit status of each directly — the fmt gate is CI-enforced).
+
+- [ ] **Step 2: In-diff mutation gate over the full branch**
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: exit 0, no MISSED. (Do not set TMPDIR; the `grep -q '^@@ '` sanity check guards against an empty diff silently passing. `mutants.diff` is untracked scratch — do not commit it.)
+
+- [ ] **Step 3: Fuzz-crate build (full)**
+
+```bash
+cargo +nightly fuzz build
+```
+
+Expected: all targets build — guards the `fuzz_check::fixtures` consumers the workspace build doesn't compile.
+
+- [ ] **Step 4: Confirm no env-var stragglers**
+
+```bash
+grep -rn "MUSEFS_SCAN_WINDOW\|MUSEFS_BATCH_BYTES" --include='*.rs' .
+```
+
+Expected: no matches anywhere in the repo's Rust sources.

--- a/docs/superpowers/specs/2026-06-06-test-idiom-cleanups-design.md
+++ b/docs/superpowers/specs/2026-06-06-test-idiom-cleanups-design.md
@@ -1,0 +1,120 @@
+# Test-suite idiom cleanups (issue #139)
+
+**Date:** 2026-06-06
+**Issue:** [#139](https://github.com/Sohex/musefs/issues/139)
+**Status:** Approved
+
+## Problem
+
+Four test-suite idiom problems, all flagged in issue #139:
+
+1. **Env-var coupled scan tests.** `musefs-core/src/scan.rs` reads
+   `MUSEFS_SCAN_WINDOW` (`scan_window()`) and `MUSEFS_BATCH_BYTES`
+   (`batch_bytes_cap()`) from the process environment. Tests configure the
+   scanner by mutating process-global env under a shared `ENV_LOCK` mutex,
+   which serializes them and risks cross-test leakage. Both env vars exist
+   *only* so tests can exercise these paths — no CLI, doc, or CI consumer
+   exists.
+2. **Triplicated FLAC fixture helpers.** `flac_block`, `streaminfo_body`,
+   `vorbis_comment_body`, and `make_flac` are duplicated between
+   `musefs-format/tests/common/mod.rs` and `musefs-core/tests/common/mod.rs`,
+   and `musefs_format::fuzz_check` carries a third private `flac_block` under
+   its `fixtures::flac()` builder.
+3. **Leaked bench TempDir.** The criterion fixture in
+   `musefs-core/benches/read_throughput.rs` keeps its `TempDir` alive via
+   `std::mem::forget`, leaking a directory handle per call.
+4. **Order-fragile fuzz bounds.** `fuzz/fuzz_targets/b64.rs` computes
+   `int_in_range` bounds with bare subtractions (`total - 1`,
+   `total - out_off`) whose non-underflow depends on a guard and a prior
+   range several statements away; a reorder would underflow silently.
+
+## Design
+
+### 1. Inject scan knobs via `ScanOptions`; delete the env vars
+
+- `ScanOptions` gains `window: usize` and `batch_bytes: u64`. A manual
+  `Default` impl supplies `WINDOW` (1<<20), `BATCH_BYTES` (64<<20), and the
+  current `jobs` default.
+- Delete `scan_window()` and `batch_bytes_cap()` (env read + zero-filter
+  parsing). The probe path takes `window` as a parameter, threaded from
+  `scan_directory_with` / `revalidate_with` (which already carry
+  `&ScanOptions`); the batch pipeline reads `opts.batch_bytes` directly.
+- The `MUSEFS_SCAN_WINDOW` and `MUSEFS_BATCH_BYTES` env vars are removed
+  entirely (decision: no fallback layer — they had no non-test consumers).
+- No validation on the new fields: they are test-only injection points and
+  the `Default` values are the only production path.
+
+Test updates:
+
+- `scan.rs` unit tests drop their `ENV_LOCK`. `scan_window_default_and_env`
+  and `batch_bytes_cap_default_and_env` are replaced by one test asserting
+  `ScanOptions::default()` field values — this keeps the constant/initializer
+  mutants killed (the in-diff mutation gate mutates `Default` impl
+  initializers).
+- `scan_counters.rs`, `probe_equivalence.rs`, and `pipeline_backpressure.rs`
+  pass options instead of mutating env; their `ENV_LOCK`s and
+  `set_var`/`remove_var` calls go away. Existing `ScanOptions { jobs: 4 }`
+  struct literals become `ScanOptions { jobs: 4, ..Default::default() }`.
+- The lock-registry comment in `musefs-core/src/lock.rs` that names
+  "scan.rs ENV_LOCK" is updated.
+- Out of scope: `common_corpus_smoke.rs` keeps its `ENV_LOCK` — those tests
+  deliberately exercise `MUSEFS_BENCH_*` env *parsing*, which is a real
+  user-facing bench-config surface, not test plumbing.
+
+### 2. Consolidate FLAC fixtures into `fuzz_check::fixtures`
+
+- Move the four helpers into `musefs_format::fuzz_check::fixtures` as
+  `pub fn`s, keeping the better-commented bodies (the musefs-format copy).
+- Rewrite the existing `fixtures::flac()` on top of them and delete
+  `fuzz_check`'s private `flac_block` — three copies become one.
+- Add a self-dev-dependency to musefs-format
+  (`musefs-format = { path = ".", features = ["fuzzing"] }`) so the
+  feature-gated `fuzz_check` module is visible to musefs-format's own
+  `tests/` directory. musefs-core's dev-dep already enables the feature.
+- Both `tests/common/mod.rs` files replace their local copies with
+  `pub use musefs_format::fuzz_check::fixtures::{flac_block, streaminfo_body,
+  vorbis_comment_body, make_flac};` — call sites in dependent test files do
+  not change.
+- Side effect (documented in CLAUDE.md): feature unification from the
+  self-dev-dependency means plain `cargo test -p musefs-format` now runs the
+  format-layer proptests; the explicit `--features fuzzing` flag is no longer
+  required. Update CLAUDE.md's test-commands section accordingly.
+
+Rejected alternatives: a cross-crate `#[path]` include (brittle, leaves the
+`fuzz_check` copy untouched) and a new `musefs-test-fixtures` workspace crate
+(a new workspace member for ~40 lines, doesn't absorb the existing
+`fuzz_check` fixtures).
+
+### 3. Bench fixture returns its `TempDir`
+
+`fixture()` in `musefs-core/benches/read_throughput.rs` returns
+`(Arc<Musefs>, Vec<u64>, TempDir)`; each caller binds the dir (`_dir`) so it
+lives for the bench's scope. `std::mem::forget(dir)` and its justifying
+comment are removed.
+
+### 4. Locally-evident bounds in the `b64` fuzz target
+
+Replace the bare subtractions with `checked_sub` + early return:
+
+```rust
+let Some(max_off) = total.checked_sub(1) else { return };
+let out_off = match u.int_in_range(0..=max_off) { ... };
+let Some(max_take) = total.checked_sub(out_off) else { return };
+let take = match u.int_in_range(1..=max_take) { ... };
+```
+
+The standalone `total == 0` guard becomes redundant (subsumed by the first
+`checked_sub`) and is dropped. Behavior is identical; underflow-safety no
+longer depends on statement order.
+
+## Verification
+
+One branch, one commit per item. Gates:
+
+- `cargo test --workspace`
+- `cargo clippy --all-targets` (compiles the bench)
+- `cargo fmt --all --check`
+- In-diff mutation gate: `-j2`, output under `/tmp/mutants-out/in-diff`,
+  default TMPDIR, `mutants.diff` sanity-checked non-empty first
+- `cargo +nightly fuzz build b64` — the fuzz crate is outside the workspace,
+  so workspace builds do not compile it

--- a/docs/superpowers/specs/2026-06-06-test-idiom-cleanups-design.md
+++ b/docs/superpowers/specs/2026-06-06-test-idiom-cleanups-design.md
@@ -36,37 +36,64 @@ Four test-suite idiom problems, all flagged in issue #139:
   `Default` impl supplies `WINDOW` (1<<20), `BATCH_BYTES` (64<<20), and the
   current `jobs` default.
 - Delete `scan_window()` and `batch_bytes_cap()` (env read + zero-filter
-  parsing). The probe path takes `window` as a parameter, threaded from
-  `scan_directory_with` / `revalidate_with` (which already carry
-  `&ScanOptions`); the batch pipeline reads `opts.batch_bytes` directly.
+  parsing). Threading chain: `scan_directory_with` / `revalidate_with` →
+  `run_pipeline` (already takes `&ScanOptions`; reads `opts.batch_bytes`
+  where it called `batch_bytes_cap()`) → `probe_file`, whose signature gains
+  the `window` parameter (it is the sole `scan_window()` consumer).
 - The `MUSEFS_SCAN_WINDOW` and `MUSEFS_BATCH_BYTES` env vars are removed
   entirely (decision: no fallback layer — they had no non-test consumers).
 - No validation on the new fields: they are test-only injection points and
   the `Default` values are the only production path.
 
+Call-site blast radius — adding required fields breaks **every**
+`ScanOptions` struct literal workspace-wide, not just the env-mutating tests:
+
+- **Production:** `musefs-cli/src/lib.rs` (`run_scan`) constructs a literal;
+  it gains `..Default::default()` (behavior unchanged — defaults are what
+  the env-free production path always got).
+- Tests with literals: `pipeline_backpressure.rs`,
+  `scan_counters.rs` (several), `bench_ingest.rs` (several), and the
+  in-file `scan.rs` test `jobs1_and_jobs_n_produce_equivalent_state`. Both
+  spellings occur: `ScanOptions { jobs: 4 }` → add `..Default::default()`,
+  and field-shorthand `ScanOptions { jobs }` →
+  `ScanOptions { jobs, ..Default::default() }`. `bench_ingest.rs` is in
+  scope only for these mechanical edits (it must compile under
+  `cargo test --workspace`).
+- Tests that today combine the **no-options** API with env mutation switch
+  APIs instead: `probe_equivalence.rs` and two `scan_counters.rs` tests call
+  `scan_directory(&db, dir)` under `MUSEFS_SCAN_WINDOW`; they become
+  `scan_directory_with(&db, dir, &ScanOptions { window: 64, ..Default::default() })`
+  (likewise for `MUSEFS_BATCH_BYTES` → `batch_bytes`).
+
 Test updates:
 
 - `scan.rs` unit tests drop their `ENV_LOCK`. `scan_window_default_and_env`
   and `batch_bytes_cap_default_and_env` are replaced by one test asserting
-  `ScanOptions::default()` field values — this keeps the constant/initializer
-  mutants killed (the in-diff mutation gate mutates `Default` impl
-  initializers).
-- `scan_counters.rs`, `probe_equivalence.rs`, and `pipeline_backpressure.rs`
-  pass options instead of mutating env; their `ENV_LOCK`s and
-  `set_var`/`remove_var` calls go away. Existing `ScanOptions { jobs: 4 }`
-  struct literals become `ScanOptions { jobs: 4, ..Default::default() }`.
-- The lock-registry comment in `musefs-core/src/lock.rs` that names
-  "scan.rs ENV_LOCK" is updated.
+  `ScanOptions::default()` field values **against decimal literals**
+  (`1_048_576`, `67_108_864`), not against `WINDOW`/`BATCH_BYTES` — the
+  in-diff mutation gate mutates const and `Default` initializers, and a
+  `== WINDOW` assertion lets a `<<`→`>>` const mutant flow to both sides and
+  survive.
+- Env-lock reality check: only `scan_counters.rs` has a test-file `ENV_LOCK`
+  (deleted); `probe_equivalence.rs` and `pipeline_backpressure.rs` call
+  `set_var`/`remove_var` **unguarded** today — a latent cross-test race this
+  change fixes as a side benefit.
+- Stale references scrubbed: the lock-registry comment in
+  `musefs-core/src/lock.rs` naming "scan.rs ENV_LOCK", plus comments
+  mentioning the deleted env vars in `tests/common/corpus.rs`,
+  `tests/metrics.rs`, and `tests/scan_counters.rs`.
 - Out of scope: `common_corpus_smoke.rs` keeps its `ENV_LOCK` — those tests
   deliberately exercise `MUSEFS_BENCH_*` env *parsing*, which is a real
   user-facing bench-config surface, not test plumbing.
 
 ### 2. Consolidate FLAC fixtures into `fuzz_check::fixtures`
 
-- Move the four helpers into `musefs_format::fuzz_check::fixtures` as
-  `pub fn`s, keeping the better-commented bodies (the musefs-format copy).
-- Rewrite the existing `fixtures::flac()` on top of them and delete
-  `fuzz_check`'s private `flac_block` — three copies become one.
+- Consolidate into `musefs_format::fuzz_check::fixtures`: its existing
+  private `flac_block` / `streaminfo_body` / `vorbis_comment_body` are
+  overwritten with the better-commented bodies (the musefs-format
+  `tests/common` copy) and made `pub`; `make_flac` is **added** (it has no
+  `fuzz_check` counterpart today — `fixtures::flac()` inlines its assembly).
+- Rewrite `fixtures::flac()` on top of `make_flac` — three copies become one.
 - Add a self-dev-dependency to musefs-format
   (`musefs-format = { path = ".", features = ["fuzzing"] }`) so the
   feature-gated `fuzz_check` module is visible to musefs-format's own
@@ -74,7 +101,9 @@ Test updates:
 - Both `tests/common/mod.rs` files replace their local copies with
   `pub use musefs_format::fuzz_check::fixtures::{flac_block, streaminfo_body,
   vorbis_comment_body, make_flac};` — call sites in dependent test files do
-  not change.
+  not change, and the `pub use` keeps in-module callers (`write_flac`,
+  `write_oggflac_with_art` in musefs-core's `common/mod.rs`) resolving
+  unchanged.
 - Side effect (documented in CLAUDE.md): feature unification from the
   self-dev-dependency means plain `cargo test -p musefs-format` now runs the
   format-layer proptests; the explicit `--features fuzzing` flag is no longer
@@ -88,9 +117,10 @@ Rejected alternatives: a cross-crate `#[path]` include (brittle, leaves the
 ### 3. Bench fixture returns its `TempDir`
 
 `fixture()` in `musefs-core/benches/read_throughput.rs` returns
-`(Arc<Musefs>, Vec<u64>, TempDir)`; each caller binds the dir (`_dir`) so it
-lives for the bench's scope. `std::mem::forget(dir)` and its justifying
-comment are removed.
+`(Arc<Musefs>, Vec<u64>, TempDir)`; its two callers (`bench_sequential_read`,
+the concurrent bench) bind the dir (`_dir`) so it lives for the bench's
+scope. `std::mem::forget(dir)` and its justifying comment are removed. The
+sibling `cold_fixture()` already returns its `TempDir` and is the model.
 
 ### 4. Locally-evident bounds in the `b64` fuzz target
 
@@ -103,8 +133,10 @@ let Some(max_take) = total.checked_sub(out_off) else { return };
 let take = match u.int_in_range(1..=max_take) { ... };
 ```
 
-The standalone `total == 0` guard becomes redundant (subsumed by the first
-`checked_sub`) and is dropped. Behavior is identical; underflow-safety no
+The standalone `total == 0` guard is dead code — `img` is guaranteed
+non-empty, so `total = b64_len(img.len()) >= 4` always — and is dropped; the
+first `checked_sub` covers the case anyway. `let full = encode_b64_slice(…)`
+stays before the bounds block. Behavior is identical; underflow-safety no
 longer depends on statement order.
 
 ## Verification

--- a/fuzz/fuzz_targets/b64.rs
+++ b/fuzz/fuzz_targets/b64.rs
@@ -18,15 +18,20 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
     let total = b64_len(img.len() as u64);
-    if total == 0 {
-        return;
-    }
     let full = encode_b64_slice(&img, 0, total as usize);
-    let out_off = match u.int_in_range(0..=total - 1) {
+    // img is non-empty so total >= 4; checked_sub keeps each bound
+    // underflow-safe on its own, independent of statement order.
+    let Some(max_off) = total.checked_sub(1) else {
+        return;
+    };
+    let out_off = match u.int_in_range(0..=max_off) {
         Ok(v) => v,
         Err(_) => return,
     };
-    let take = match u.int_in_range(1..=total - out_off) {
+    let Some(max_take) = total.checked_sub(out_off) else {
+        return;
+    };
+    let take = match u.int_in_range(1..=max_take) {
         Ok(v) => v,
         Err(_) => return,
     };

--- a/fuzz/fuzz_targets/mp3.rs
+++ b/fuzz/fuzz_targets/mp3.rs
@@ -19,9 +19,13 @@ fuzz_target!(|data: &[u8]| {
     let tags = arb_tags(&mut u).unwrap_or_default();
     let binary = arb_binary_tags(&mut u).unwrap_or_default();
     let arts = arb_arts(&mut u).unwrap_or_default();
-    if let Ok(layout) =
-        mp3::synthesize_layout(bounds.audio_offset, bounds.audio_length, &tags, &binary, &arts)
-    {
+    if let Ok(layout) = mp3::synthesize_layout(
+        bounds.audio_offset,
+        bounds.audio_length,
+        &tags,
+        &binary,
+        &arts,
+    ) {
         assert_backing_covers_audio(bounds.audio_offset, bounds.audio_length, &layout);
     }
 });

--- a/fuzz/fuzz_targets/ogg.rs
+++ b/fuzz/fuzz_targets/ogg.rs
@@ -42,7 +42,10 @@ fuzz_target!(|data: &[u8]| {
     let arts: Vec<OggArt> = inputs
         .iter()
         .zip(images.iter())
-        .map(|(meta, image)| OggArt { meta, image: image.as_slice() })
+        .map(|(meta, image)| OggArt {
+            meta,
+            image: image.as_slice(),
+        })
         .collect();
 
     if let Ok(layout) =

--- a/fuzz/src/bin/generate_seeds.rs
+++ b/fuzz/src/bin/generate_seeds.rs
@@ -29,7 +29,11 @@ fn main() {
     write("mp4", "seed_binary", &fixtures::m4a(&[0x01; 96]));
     // Multi-art seed: a covr atom with two `data` children reaches the
     // read_pictures inner loop from the corpus, not only via mutation.
-    write("mp4", "seed_two_covers", &fixtures::m4a_two_covers(&[9u8; 32]));
+    write(
+        "mp4",
+        "seed_two_covers",
+        &fixtures::m4a_two_covers(&[9u8; 32]),
+    );
     write("ogg", "seed0", &fixtures::ogg_opus());
     write("ogg_page", "seed0", &fixtures::ogg_opus());
     write("vorbiscomment", "seed0", &fixtures::ogg_opus());

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -106,7 +106,10 @@ pub enum Command {
 pub fn run_scan(db_path: &Path, targets: &[PathBuf], revalidate: bool, jobs: usize) -> Result<()> {
     let db =
         Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
-    let opts = musefs_core::ScanOptions { jobs };
+    let opts = musefs_core::ScanOptions {
+        jobs,
+        ..Default::default()
+    };
     for target in targets {
         if revalidate {
             let stats = musefs_core::revalidate_with(&db, target, &opts)

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -35,7 +35,11 @@ fn collect_file_inodes(fs: &Musefs, dir: u64, out: &mut Vec<u64>) {
 /// A small single-format generated corpus, scanned into an in-memory DB and
 /// mounted. Returns the fs plus all file inodes (discovered by a format-agnostic
 /// tree walk).
-fn fixture(format: Format, bytes_per_track: usize, tracks: usize) -> (Arc<Musefs>, Vec<u64>) {
+fn fixture(
+    format: Format,
+    bytes_per_track: usize,
+    tracks: usize,
+) -> (Arc<Musefs>, Vec<u64>, tempfile::TempDir) {
     let p = CorpusParams {
         albums: 1,
         tracks_per_album: tracks,
@@ -53,18 +57,14 @@ fn fixture(format: Format, bytes_per_track: usize, tracks: usize) -> (Arc<Musefs
     let mut inodes = Vec::new();
     collect_file_inodes(&fs, VirtualTree::ROOT, &mut inodes);
     assert!(!inodes.is_empty(), "fixture: no file inodes for {format:?}");
-    // Keep the tempdir alive for the duration of the bench by leaking it. Each
-    // fixture call leaks one; a full run accumulates at most ALL_FORMATS.len()+1
-    // (sequential per-format + concurrent), all reclaimed when the process exits.
-    std::mem::forget(dir);
-    (fs, inodes)
+    (fs, inodes, dir)
 }
 
 fn bench_sequential_read(c: &mut Criterion) {
     let mut group = c.benchmark_group("sequential_read");
     let chunk = 128 * 1024u64;
     for fmt in bench_formats() {
-        let (fs, inodes) = fixture(fmt, 4 * 1024 * 1024, 1);
+        let (fs, inodes, _dir) = fixture(fmt, 4 * 1024 * 1024, 1);
         let inode = inodes[0];
         let size = fs.getattr(inode).unwrap().size;
         group.throughput(Throughput::Bytes(size));
@@ -93,7 +93,7 @@ fn bench_concurrent_read_and_walk(c: &mut Criterion) {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(num_streams);
-    let (fs, inodes) = fixture(Format::Flac, 1024 * 1024, m.max(2));
+    let (fs, inodes, _dir) = fixture(Format::Flac, 1024 * 1024, m.max(2));
 
     // Each iteration streams `m` whole files (reader i reads inodes[i]); the
     // walker does metadata-only ops and contributes no bytes.

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -17,8 +17,8 @@
 //!   ResolvedFile::last_page (reader.rs:32, locked in ogg_index.rs as LastPageMemo)
 //!                                 -> cat 1 (clear): deterministic one-entry cache, re-derived.
 //! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
-//! poison), db_pool.rs (#94), scan.rs ENV_LOCK / work-queue (test/scan-internal,
-//! not on the FUSE serving path).
+//! poison), db_pool.rs (#94), scan.rs work-queue (scan-internal, not on the
+//! FUSE serving path).
 //!
 //! Recovery is one-shot: each helper calls `Mutex::clear_poison` after restoring
 //! the guarded state to a known-good value, so normal (non-clearing) operation

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -169,15 +169,6 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
     }
 }
 
-/// Effective initial window: `MUSEFS_SCAN_WINDOW` (bytes) if set, else `WINDOW`.
-fn scan_window() -> usize {
-    std::env::var("MUSEFS_SCAN_WINDOW")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(WINDOW)
-}
-
 /// Read `[0, len)` of `path` into a buffer, counting the read. A short read at
 /// EOF is fine (`len` may exceed the file size).
 fn read_window(file: &std::fs::File, len: usize) -> std::io::Result<Vec<u8>> {
@@ -211,7 +202,7 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
 /// reads only. The M4A seek reader does its own positioned reads internally, so
 /// its bytes are not reflected in `SCAN_BYTES_READ` (only `on_scan_open` fires
 /// for M4A); its win shows up in wall time and peak RSS instead.
-fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
+fn probe_file(path: &Path, file_len: u64, window: usize) -> std::io::Result<Option<Probed>> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();
 
@@ -246,7 +237,7 @@ fn probe_file(path: &Path, file_len: u64) -> std::io::Result<Option<Probed>> {
     } else {
         None
     };
-    let mut want = (scan_window() as u64).min(file_len) as usize;
+    let mut want = (window as u64).min(file_len) as usize;
     let mut prefix = read_window(&file, want)?;
     for _ in 0..MAX_WIDEN_RETRIES {
         match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
@@ -364,9 +355,23 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
 }
 
 /// Knobs for a scan. `jobs == 0` means "use available parallelism".
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ScanOptions {
     pub jobs: usize,
+    /// Initial probe read window in bytes; widened on `NeedMore`.
+    pub window: usize,
+    /// In-flight art-byte budget and per-batch byte-flush threshold.
+    pub batch_bytes: u64,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            jobs: 0,
+            window: WINDOW,
+            batch_bytes: BATCH_BYTES,
+        }
+    }
 }
 
 fn effective_jobs(jobs: usize) -> usize {
@@ -374,17 +379,6 @@ fn effective_jobs(jobs: usize) -> usize {
         return jobs;
     }
     std::thread::available_parallelism().map_or(1, std::num::NonZero::get)
-}
-
-/// In-flight art-byte budget (and per-batch byte-flush threshold). Overridable via
-/// `MUSEFS_BATCH_BYTES` so tests can exercise the backpressure path without 64 MiB
-/// of fixture art; defaults to `BATCH_BYTES`.
-fn batch_bytes_cap() -> u64 {
-    std::env::var("MUSEFS_BATCH_BYTES")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(BATCH_BYTES)
 }
 
 /// One probed file ready to write, plus its art-byte weight for backpressure.
@@ -397,7 +391,7 @@ struct Unit {
 }
 
 /// In-memory byte weight of a `Probed`, used for batch backpressure
-/// (`MUSEFS_BATCH_BYTES`). Counts every buffered payload — pictures plus FLAC
+/// (`ScanOptions::batch_bytes`). Counts every buffered payload — pictures plus FLAC
 /// structural blocks and binary tags — so large preserved blocks can't slip the
 /// budget the way picture-only accounting did.
 fn payload_weight(p: &Probed) -> u64 {
@@ -614,7 +608,8 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
     use std::sync::Arc;
 
     let jobs = effective_jobs(opts.jobs);
-    let cap = batch_bytes_cap();
+    let window = opts.window;
+    let cap = opts.batch_bytes;
     let budget = Arc::new(ByteBudget::new(cap));
     let skipped = Arc::new(AtomicU64::new(0));
     let failed = Arc::new(AtomicU64::new(0));
@@ -637,7 +632,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                 failed.fetch_add(1, Ordering::Relaxed);
                 continue;
             };
-            match probe_file(&path, meta.len()) {
+            match probe_file(&path, meta.len(), window) {
                 Ok(Some(probed)) => {
                     let Ok(abs) = std::fs::canonicalize(&path) else {
                         failed.fetch_add(1, Ordering::Relaxed);
@@ -881,39 +876,18 @@ pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
 mod scan_unit_tests {
     use super::*;
     use std::io::Write;
-    use std::sync::Mutex;
 
-    /// Env is process-global: serialize the env-mutating tests so they never
-    /// observe each other's `MUSEFS_*` vars.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // --- ScanOptions defaults (WINDOW L16, BATCH_BYTES L12) ---
 
-    // --- scan_window() / WINDOW (lines 16, 149-154) ---
-
-    // kills scan L16 WINDOW `<<`→`>>` (default must be 1<<20, not 1>>20==0)
-    // kills scan L153 filter `>`→`>=`/`==`/`<`
+    // kills the WINDOW `<<`→`>>` and BATCH_BYTES initializer mutants: the
+    // right-hand sides are decimal literals, so a mutated const/Default
+    // initializer cannot flow to both sides of the assertion.
     #[test]
-    fn scan_window_default_and_env() {
-        let _g = ENV_LOCK.lock().unwrap();
-        // Default (unset): WINDOW == 1<<20. `1>>20` == 0 → distinguishes the shift.
-        std::env::remove_var("MUSEFS_SCAN_WINDOW");
-        assert_eq!(scan_window(), 1 << 20);
-        assert_eq!(scan_window(), 1_048_576);
-
-        // "0" is filtered out (`0 > 0` is false) → falls back to WINDOW.
-        // Under `>=`/`==`, `0` would be kept and returned (wrong).
-        std::env::set_var("MUSEFS_SCAN_WINDOW", "0");
-        assert_eq!(
-            scan_window(),
-            1 << 20,
-            "zero must be filtered → default window"
-        );
-
-        // "5" passes the filter (`5 > 0`) → returned verbatim. Under `<`,
-        // `5 < 0` is false → 5 would be filtered → default (wrong).
-        std::env::set_var("MUSEFS_SCAN_WINDOW", "5");
-        assert_eq!(scan_window(), 5, "positive override must pass the filter");
-
-        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+    fn scan_options_defaults() {
+        let d = ScanOptions::default();
+        assert_eq!(d.jobs, 0, "jobs default = use available parallelism");
+        assert_eq!(d.window, 1_048_576, "window default = 1 MiB");
+        assert_eq!(d.batch_bytes, 67_108_864, "batch_bytes default = 64 MiB");
     }
 
     // --- read_tail_128() (lines 170-178) ---
@@ -965,29 +939,6 @@ mod scan_unit_tests {
         assert_eq!(effective_jobs(0), par);
         assert_eq!(effective_jobs(4), 4);
         assert_eq!(effective_jobs(1), 1);
-    }
-
-    // --- batch_bytes_cap() / BATCH_BYTES (lines 323-329) ---
-
-    // kills scan L324 batch_bytes_cap body→0/→1 (default must be BATCH_BYTES)
-    // kills scan L327 filter `>`→`>=`/`==`/`<`
-    #[test]
-    fn batch_bytes_cap_default_and_env() {
-        let _g = ENV_LOCK.lock().unwrap();
-        std::env::remove_var("MUSEFS_BATCH_BYTES");
-        assert_eq!(batch_bytes_cap(), BATCH_BYTES);
-        assert_eq!(batch_bytes_cap(), 64 << 20);
-        assert_eq!(batch_bytes_cap(), 67_108_864);
-
-        // "0" filtered (`0 > 0` false) → default. Kills `>=`/`==`.
-        std::env::set_var("MUSEFS_BATCH_BYTES", "0");
-        assert_eq!(batch_bytes_cap(), BATCH_BYTES);
-
-        // "5" passes (`5 > 0`) → 5. Kills `<`.
-        std::env::set_var("MUSEFS_BATCH_BYTES", "5");
-        assert_eq!(batch_bytes_cap(), 5);
-
-        std::env::remove_var("MUSEFS_BATCH_BYTES");
     }
 
     // --- payload_weight() ---
@@ -1763,7 +1714,15 @@ mod bounded_probe_tests {
         }
         let norm = |jobs: usize| {
             let db = Db::open_in_memory().unwrap();
-            scan_directory_with(&db, dir.path(), &ScanOptions { jobs }).unwrap();
+            scan_directory_with(
+                &db,
+                dir.path(),
+                &ScanOptions {
+                    jobs,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
             let mut rows: Vec<(String, i64, i64)> = db
                 .list_tracks()
                 .unwrap()

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -25,7 +25,10 @@ fn run_one(target: &Target, tier: &str, format: &str, storage: &str) {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
-    let opts = ScanOptions { jobs };
+    let opts = ScanOptions {
+        jobs,
+        ..Default::default()
+    };
 
     metrics::reset();
     let t0 = Instant::now();
@@ -132,6 +135,7 @@ fn bench_scan_under_latency() {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -212,7 +216,7 @@ fn bench_read_under_latency() {
         common::corpus::generate(backing.path(), &params);
         let mount = LatencyMount::new(backing.path(), &profile).unwrap();
         let db = Db::open_in_memory().unwrap();
-        scan_directory_with(&db, &mount.path(), &ScanOptions { jobs: 0 }).unwrap();
+        scan_directory_with(&db, &mount.path(), &ScanOptions::default()).unwrap();
         let fs = Musefs::open(db, cfg()).unwrap();
         let inode = first_inode(&fs, VirtualTree::ROOT).expect("an ogg inode");
         let size = fs.getattr(inode).unwrap().size;

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -97,7 +97,7 @@ impl CorpusParams {
     /// A small single-format corpus used by the equivalence property. `art_bytes`
     /// is honored only by the FLAC generator (the MP3/M4A/Ogg/WAV corpus files
     /// carry no embedded art or in-file tags — those ride via the DB at scan
-    /// time). The tiny `MUSEFS_SCAN_WINDOW=64` still forces the widen path on
+    /// time). The tiny `ScanOptions::window` (64) still forces the widen path on
     /// every format, via the format's own trigger: FLAC the metadata-block walk,
     /// MP3 the ID3v2 tag size, OGG the geometric grow, WAV the whole-file gate.
     pub fn single(fmt: Format, albums: usize, tracks_per_album: usize) -> Self {

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -5,47 +5,9 @@ use std::path::Path;
 pub mod corpus;
 pub mod report;
 
-pub fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
-    out.extend_from_slice(body);
-    out
-}
-
-pub fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-pub fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-pub fn make_flac(blocks: &[(u8, Vec<u8>)], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    for (i, (bt, body)) in blocks.iter().enumerate() {
-        out.extend_from_slice(&flac_block(*bt, body, i == blocks.len() - 1));
-    }
-    out.extend_from_slice(audio);
-    out
-}
+pub use musefs_format::fuzz_check::fixtures::{
+    flac_block, make_flac, streaminfo_body, vorbis_comment_body,
+};
 
 /// Write a simple FLAC (STREAMINFO + comment + audio) to `path`,
 /// returning (audio_offset, audio_length).

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -473,7 +473,7 @@ fn scan_still_reads_id3v1_tail_for_mp3() {
     scan_directory(&db, &target.corpus_dir).unwrap();
     let s = metrics::snapshot();
     // Corpus tracks are far below the default 1 MiB scan window (this test must
-    // not set MUSEFS_SCAN_WINDOW): one prefix read + the tail. read_tail_128
+    // keep the default ScanOptions::window): one prefix read + the tail. read_tail_128
     // always reads 128 bytes when file_len >= 128, trailer present or not, so
     // the +128 assertion is robust.
     assert_eq!(s.scan_preads, 2, "mp3: prefix read + ID3v1 tail read");

--- a/musefs-core/tests/pipeline_backpressure.rs
+++ b/musefs-core/tests/pipeline_backpressure.rs
@@ -48,12 +48,19 @@ fn pipeline_completes_under_art_backpressure() {
     // Cap the in-flight budget below two files' cumulative art (6 bytes each), so a
     // second concurrent `acquire` blocks while the writer's batch sits below the
     // flush threshold — the exact pre-fix deadlock window.
-    std::env::set_var("MUSEFS_BATCH_BYTES", "8");
-
     let root = dir.path().to_path_buf();
     let handle = std::thread::spawn(move || {
         let db = Db::open_in_memory().unwrap();
-        scan_directory_with(&db, &root, &ScanOptions { jobs: 4 }).unwrap();
+        scan_directory_with(
+            &db,
+            &root,
+            &ScanOptions {
+                jobs: 4,
+                batch_bytes: 8,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         db.list_tracks().unwrap().len()
     });
 
@@ -67,6 +74,5 @@ fn pipeline_completes_under_art_backpressure() {
         std::thread::sleep(Duration::from_millis(20));
     }
     let scanned = handle.join().unwrap();
-    std::env::remove_var("MUSEFS_BATCH_BYTES");
     assert_eq!(scanned, 8, "all art-bearing files should ingest");
 }

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -58,10 +58,16 @@ fn bounded_probe_equivalent_to_full_for_every_format() {
         let oracle = normalized(&oracle_db);
 
         // Bounded scan with a 64-byte window → widen path fires on every file.
-        std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
         let bounded_db = Db::open_in_memory().unwrap();
-        musefs_core::scan_directory(&bounded_db, dir.path()).unwrap();
-        std::env::remove_var("MUSEFS_SCAN_WINDOW");
+        musefs_core::scan_directory_with(
+            &bounded_db,
+            dir.path(),
+            &musefs_core::ScanOptions {
+                window: 64,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         let bounded = normalized(&bounded_db);
 
         assert_eq!(

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -10,9 +10,6 @@ use musefs_core::{
 };
 use musefs_db::Db;
 
-/// Serialize env-mutating tests: `MUSEFS_*` vars are process-global.
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 /// Minimal valid FLAC: marker + last STREAMINFO (34-byte body) + audio payload.
 fn flac_minimal(audio: &[u8]) -> Vec<u8> {
     let mut b = b"fLaC".to_vec();
@@ -74,7 +71,6 @@ fn rows(db: &Db) -> Vec<(String, i64, i64)> {
 // kills scan L232 `(prefix.len() as u64) < file_len`→`<=`/`==`/`>` (oracle match)
 #[test]
 fn widen_then_fallback_matches_oracle_under_tiny_window() {
-    let _g = ENV_LOCK.lock().unwrap();
     let dir = tempfile::tempdir().unwrap();
     // Big-art FLAC: bounded probe must widen well past a 64-byte window.
     std::fs::write(
@@ -94,10 +90,16 @@ fn widen_then_fallback_matches_oracle_under_tiny_window() {
     scan_directory_full_oracle(&oracle_db, dir.path()).unwrap();
     let oracle = rows(&oracle_db);
 
-    std::env::set_var("MUSEFS_SCAN_WINDOW", "64");
     let bounded_db = Db::open_in_memory().unwrap();
-    let stats = scan_directory(&bounded_db, dir.path()).unwrap();
-    std::env::remove_var("MUSEFS_SCAN_WINDOW");
+    let stats = scan_directory_with(
+        &bounded_db,
+        dir.path(),
+        &ScanOptions {
+            window: 64,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     assert_eq!(stats.scanned, 2);
     assert_eq!(rows(&bounded_db), oracle, "bounded widen/fallback diverged");
@@ -112,7 +114,6 @@ fn widen_then_fallback_matches_oracle_under_tiny_window() {
 // kills scan L225 `want + 1` (widen must make progress to reach the art body)
 #[test]
 fn widen_preserves_art_bytes_vs_oracle() {
-    let _g = ENV_LOCK.lock().unwrap();
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(
         dir.path().join("art.flac"),
@@ -127,10 +128,16 @@ fn widen_preserves_art_bytes_vs_oracle() {
     let o_sha = oracle_db.get_art(o_art[0].art_id).unwrap().unwrap().sha256;
 
     // Tiny window forces a multi-step widen to reach the 4 KiB picture body.
-    std::env::set_var("MUSEFS_SCAN_WINDOW", "16");
     let db = Db::open_in_memory().unwrap();
-    scan_directory(&db, dir.path()).unwrap();
-    std::env::remove_var("MUSEFS_SCAN_WINDOW");
+    scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            window: 16,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let track = db.list_tracks().unwrap().into_iter().next().unwrap();
     assert_eq!(track.audio_offset, o_track.audio_offset);
@@ -164,7 +171,15 @@ fn scans_more_than_batch_files_persists_all_once() {
         .unwrap();
     }
     let db = Db::open_in_memory().unwrap();
-    let stats = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+    let stats = scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            jobs: 4,
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert_eq!(stats.scanned, n as u64, "every file must be scanned once");
     assert_eq!(
         db.list_tracks().unwrap().len(),
@@ -174,19 +189,26 @@ fn scans_more_than_batch_files_persists_all_once() {
 
     // Idempotent re-scan: still exactly n rows (catches duplicate writes from a
     // wrong flush cadence).
-    let stats2 = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
+    let stats2 = scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            jobs: 4,
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert_eq!(stats2.scanned, n as u64);
     assert_eq!(db.list_tracks().unwrap().len(), n);
 }
 
-/// Byte-threshold flushing: with a tiny `MUSEFS_BATCH_BYTES` and art-bearing
+/// Byte-threshold flushing: with a tiny `batch_bytes` and art-bearing
 /// files, the byte branch (`batch_bytes >= cap`, L575/585) drives flushes. All
 /// tracks and their art must persist. Guards the `batch_bytes +=` accumulation
 /// (L573/583, `+=`→`*=`) and the `||` flush disjunction.
 // kills scan L573/583 `batch_bytes += unit.weight` `+=`→`*=`; L575/585 byte branch
 #[test]
 fn byte_threshold_flush_persists_all_art() {
-    let _g = ENV_LOCK.lock().unwrap();
     let n = 20usize;
     let dir = tempfile::tempdir().unwrap();
     for i in 0..n {
@@ -197,10 +219,17 @@ fn byte_threshold_flush_persists_all_art() {
         .unwrap();
     }
     // Cap below a couple files' cumulative art so the byte branch flushes often.
-    std::env::set_var("MUSEFS_BATCH_BYTES", "100");
     let db = Db::open_in_memory().unwrap();
-    let stats = scan_directory_with(&db, dir.path(), &ScanOptions { jobs: 4 }).unwrap();
-    std::env::remove_var("MUSEFS_BATCH_BYTES");
+    let stats = scan_directory_with(
+        &db,
+        dir.path(),
+        &ScanOptions {
+            jobs: 4,
+            batch_bytes: 100,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     assert_eq!(stats.scanned, n as u64);
     let tracks = db.list_tracks().unwrap();

--- a/musefs-format/Cargo.toml
+++ b/musefs-format/Cargo.toml
@@ -23,6 +23,10 @@ crc = "3"
 hound = "3"
 musefs-db = { path = "../musefs-db", version = "0.2.0" }
 proptest = "1"
+# Self-dependency: turns the `fuzzing` feature on for this crate's own test
+# builds, so tests/ can use fuzz_check and the proptests run without an
+# explicit --features flag.
+musefs-format = { path = ".", features = ["fuzzing"] }
 
 [lints]
 workspace = true

--- a/musefs-format/src/fuzz_check.rs
+++ b/musefs-format/src/fuzz_check.rs
@@ -55,9 +55,11 @@ pub fn assert_backing_covers_audio(audio_offset: u64, audio_length: u64, layout:
 /// (RIFF/WAVE with a `fmt ` + `data` chunk); MP3 is a bare MPEG frame sync;
 /// Ogg is lifted from `musefs-format/src/ogg/mod.rs`'s `opus_headers` helper.
 pub mod fixtures {
-    fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+    /// Build a FLAC metadata block (4-byte header + body) independently of production code.
+    pub fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
         let mut out = Vec::new();
-        out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
+        let first = (if is_last { 0x80 } else { 0 }) | (block_type & 0x7F);
+        out.push(first);
         let len = body.len();
         out.push(((len >> 16) & 0xFF) as u8);
         out.push(((len >> 8) & 0xFF) as u8);
@@ -66,16 +68,23 @@ pub mod fixtures {
         out
     }
 
-    fn streaminfo_body() -> Vec<u8> {
+    /// A structurally valid STREAMINFO body: 44100 Hz, 2 channels, 16-bit, unknown frame/sample counts.
+    pub fn streaminfo_body() -> Vec<u8> {
         let mut b = vec![
-            0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0,
-            0x00, 0x00, 0x00, 0x00,
+            0x10, 0x00, // min block size = 4096
+            0x10, 0x00, // max block size = 4096
+            0x00, 0x00, 0x00, // min frame size = 0 (unknown)
+            0x00, 0x00, 0x00, // max frame size = 0 (unknown)
+            0x0A, 0xC4, 0x42,
+            0xF0, // sample_rate=44100, channels=2, bps=16, top of total samples
+            0x00, 0x00, 0x00, 0x00, // remaining total-samples bits = 0
         ];
-        b.extend_from_slice(&[0u8; 16]);
+        b.extend_from_slice(&[0u8; 16]); // MD5 signature = 0
         b
     }
 
-    fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+    /// Minimal VORBIS_COMMENT body with the given already-formatted `KEY=value` comments.
+    pub fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
         out.extend_from_slice(vendor.as_bytes());
@@ -87,17 +96,27 @@ pub mod fixtures {
         out
     }
 
-    /// FLAC = `fLaC` + STREAMINFO + VORBIS_COMMENT + `audio`.
-    pub fn flac(audio: &[u8]) -> Vec<u8> {
-        let mut out = b"fLaC".to_vec();
-        out.extend(flac_block(0, &streaminfo_body(), false));
-        out.extend(flac_block(
-            4,
-            &vorbis_comment_body("orig", &["TITLE=Orig"]),
-            true,
-        ));
+    /// Assemble a full FLAC byte stream: marker + blocks (last-flag auto-set on the final block) + audio.
+    pub fn make_flac(blocks: &[(u8, Vec<u8>)], audio: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"fLaC");
+        for (i, (bt, body)) in blocks.iter().enumerate() {
+            let is_last = i == blocks.len() - 1;
+            out.extend_from_slice(&flac_block(*bt, body, is_last));
+        }
         out.extend_from_slice(audio);
         out
+    }
+
+    /// FLAC = `fLaC` + STREAMINFO + VORBIS_COMMENT + `audio`.
+    pub fn flac(audio: &[u8]) -> Vec<u8> {
+        make_flac(
+            &[
+                (0, streaminfo_body()),
+                (4, vorbis_comment_body("orig", &["TITLE=Orig"])),
+            ],
+            audio,
+        )
     }
 
     fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {

--- a/musefs-format/tests/common/mod.rs
+++ b/musefs-format/tests/common/mod.rs
@@ -4,57 +4,7 @@ use std::collections::HashMap;
 
 use musefs_format::{RegionLayout, Segment};
 
-/// Build a FLAC metadata block (4-byte header + body) independently of production code.
-pub fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    let first = (if is_last { 0x80 } else { 0 }) | (block_type & 0x7F);
-    out.push(first);
-    let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
-    out.extend_from_slice(body);
-    out
-}
-
-/// A structurally valid STREAMINFO body: 44100 Hz, 2 channels, 16-bit, unknown frame/sample counts.
-pub fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, // min block size = 4096
-        0x10, 0x00, // max block size = 4096
-        0x00, 0x00, 0x00, // min frame size = 0 (unknown)
-        0x00, 0x00, 0x00, // max frame size = 0 (unknown)
-        0x0A, 0xC4, 0x42, 0xF0, // sample_rate=44100, channels=2, bps=16, top of total samples
-        0x00, 0x00, 0x00, 0x00, // remaining total-samples bits = 0
-    ];
-    b.extend_from_slice(&[0u8; 16]); // MD5 signature = 0
-    b
-}
-
-/// Minimal VORBIS_COMMENT body with the given already-formatted `KEY=value` comments.
-pub fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-/// Assemble a full FLAC byte stream: marker + blocks (last-flag auto-set on the final block) + audio.
-pub fn make_flac(blocks: &[(u8, Vec<u8>)], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    for (i, (bt, body)) in blocks.iter().enumerate() {
-        let is_last = i == blocks.len() - 1;
-        out.extend_from_slice(&flac_block(*bt, body, is_last));
-    }
-    out.extend_from_slice(audio);
-    out
-}
+pub use musefs_format::fuzz_check::fixtures::{make_flac, streaminfo_body, vorbis_comment_body};
 
 /// Resolve a RegionLayout into concrete bytes, given the original backing bytes, an
 /// art-id -> image-bytes map, and a payload-id -> bytes map for binary tag segments.

--- a/musefs-format/tests/flac_pictures.rs
+++ b/musefs-format/tests/flac_pictures.rs
@@ -1,24 +1,5 @@
 use musefs_format::flac::read_pictures;
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
+use musefs_format::fuzz_check::fixtures::{flac_block, streaminfo_body};
 
 fn picture_body(pic_type: u32, mime: &str, desc: &str, w: u32, h: u32, data: &[u8]) -> Vec<u8> {
     let mut b = Vec::new();

--- a/musefs-format/tests/roundtrip.rs
+++ b/musefs-format/tests/roundtrip.rs
@@ -2,9 +2,10 @@ mod common;
 use std::collections::HashMap;
 use std::io::Cursor;
 
-use common::{flac_block, make_flac, resolve_layout, streaminfo_body, vorbis_comment_body};
+use common::{make_flac, resolve_layout, streaminfo_body, vorbis_comment_body};
 use musefs_format::flac::MetadataBlock;
 use musefs_format::flac::{locate_audio, synthesize_layout};
+use musefs_format::fuzz_check::fixtures::flac_block;
 use musefs_format::{ArtInput, BinaryTagInput, Segment, TagInput};
 
 #[test]


### PR DESCRIPTION
Closes #139. Four test-suite idiom cleanups per the included spec/plan (`docs/superpowers/{specs,plans}/2026-06-06-test-idiom-cleanups*`):

1. **Inject scan knobs via `ScanOptions`; delete the `MUSEFS_*` env vars.** `ScanOptions` gains `window`/`batch_bytes` (manual `Default` = `WINDOW`/`BATCH_BYTES`); `scan_window()`/`batch_bytes_cap()` and the `MUSEFS_SCAN_WINDOW`/`MUSEFS_BATCH_BYTES` env reads are gone (test-only knobs, no other consumers). Tests configure via the options struct instead of mutating process env — the `ENV_LOCK` serialization (and two previously *unguarded* env-mutating tests, a latent race) go away. `common_corpus_smoke.rs` keeps its lock: `MUSEFS_BENCH_*` parsing is a real config surface.
2. **Consolidate the FLAC fixture helpers into `fuzz_check::fixtures`.** Four scattered copies (format tests/common, core tests/common, fuzz_check's private set, and locals in `flac_pictures.rs`) become one `pub` set. A self-dev-dependency turns the `fuzzing` feature on for musefs-format's own test builds, so the format proptests now run under plain `cargo test -p musefs-format` (CLAUDE.md updated).
3. **Stop leaking the bench fixture `TempDir`.** `read_throughput.rs::fixture` returns the dir instead of `std::mem::forget`ing it; callers bind `_dir` for the bench's scope.
4. **Locally underflow-safe `b64` fuzz bounds.** Bare `total - 1` / `total - out_off` become `checked_sub` + early return, so each bound is safe independent of statement order; the dead `total == 0` guard is dropped.

Follow-ups baked in: all 14 `scan.rs` line:col `mutants.toml` anchors re-pointed after the line shifts, plus one new documented exclude — moving `flac_block` into `src/fuzz_check.rs` made it mutation-eligible and surfaced a provably equivalent `|`→`^` mutant (bit-disjoint operands; the `|`→`&` sibling is caught).

## Verification

- `cargo test --workspace` — 71 suites green (format proptests now included by default)
- `cargo clippy --all-targets`, `cargo fmt --all --check` (+ fuzz-crate fmt) — clean
- In-diff mutation gate (`-j2`, fresh `mutants.diff`) — 21 mutants: 19 caught, 2 unviable, 0 missed
- `cargo +nightly fuzz build` — all targets build
- Straggler grep — no `MUSEFS_SCAN_WINDOW`/`MUSEFS_BATCH_BYTES`/`ENV_LOCK` references left outside docs and the out-of-scope smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized duplicated FLAC fixture helpers into a shared test utility module.
  * Replaced environment-variable-driven scan configuration with explicit configuration injection via `ScanOptions`.

* **Bug Fixes**
  * Fixed potential underflow in base64 fuzz target validation bounds.
  * Fixed benchmark fixture resource leak.

* **Documentation**
  * Added test-suite idiom cleanup plan and design specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->