### PR TITLE
Establish and enforce an integer-conversion convention (#133)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -59,15 +59,15 @@ exclude_re = [
     # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
     # block end past the prefix), so `up_to.min(file_len)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
-    'musefs-core/src/scan\.rs:254:31:',
+    'musefs-core/src/scan\.rs:255:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < file_len`: when
     # it differs, the only effect is a redundant whole-file re-read that feeds the
     # same `probe_full` result. The >8-retry path that could diverge is unreachable
     # given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
-    'musefs-core/src/scan\.rs:261:30:',
+    'musefs-core/src/scan\.rs:262:30:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
-    'musefs-core/src/scan\.rs:619:46:',
+    'musefs-core/src/scan\.rs:620:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -75,29 +75,35 @@ exclude_re = [
     # cadence mutation persists the identical track set. The win is fewer commits
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
-    'musefs-core/src/scan\.rs:710:29:',
-    'musefs-core/src/scan\.rs:712:32:',
-    'musefs-core/src/scan\.rs:712:47:',
-    'musefs-core/src/scan\.rs:712:62:',
-    'musefs-core/src/scan\.rs:720:37:',
-    'musefs-core/src/scan\.rs:722:40:',
-    'musefs-core/src/scan\.rs:722:55:',
-    'musefs-core/src/scan\.rs:722:70:',
+    'musefs-core/src/scan\.rs:711:29:',
+    'musefs-core/src/scan\.rs:713:32:',
+    'musefs-core/src/scan\.rs:713:47:',
+    'musefs-core/src/scan\.rs:713:62:',
+    'musefs-core/src/scan\.rs:721:37:',
+    'musefs-core/src/scan\.rs:723:40:',
+    'musefs-core/src/scan\.rs:723:55:',
+    'musefs-core/src/scan\.rs:723:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
     # from a deterministic test. With skip_failed identically 0, the `failed =
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
-    'musefs-core/src/scan\.rs:826:25:',
-    'musefs-core/src/scan\.rs:830:25:',
-    'musefs-core/src/scan\.rs:866:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:827:25:',
+    'musefs-core/src/scan\.rs:831:25:',
+    'musefs-core/src/scan\.rs:867:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are
     # bit-for-bit identical for every input (same equivalence as the flac assembly
     # above). The `<<`->`>>` and `> 0` siblings in this fn ARE caught and stay in scope.
     'musefs-format/src/mp3\.rs:\d+:\d+: replace \| with \^ in classify_binary_frame',
+    # synchsafe_decode's four ORed operands `u32::from(b[n] & 0x7F)` are each
+    # shifted by 21/14/7/0 into NON-OVERLAPPING 7-bit windows of the 28-bit result,
+    # so the operands are bit-disjoint and `|`/`^` agree for every input (same
+    # equivalence class as classify_binary_frame above). Description-anchored so
+    # `cargo fmt` line drift can't silently retire it.
+    'replace \| with \^ in synchsafe_decode',
     # fuzz_check fixtures::flac_block header byte
     # `(if is_last { 0x80 } else { 0 }) | (block_type & 0x7F)` -> `^`: the right
     # operand is masked to bits 0-6 and the left is bit 7 or zero, so the operands
@@ -122,13 +128,13 @@ exclude_re = [
     # eprintln on stderr. The fallback's build_with is itself directly tested; this
     # injection point exists only to drive that branch, with nothing observable to
     # assert in this config.
-    'musefs-core/src/facade\.rs:738:9: replace Musefs::force_apply_failure_for_test with \(\)',
+    'musefs-core/src/facade\.rs:777:9: replace Musefs::force_apply_failure_for_test with \(\)',
     # apply_changes path-stable guard `&self.path_of(ino) == new_path` -> false: a
     # `changed` id whose rendered path is unchanged would be treated as a move
     # (remove + re-insert at the same path) instead of a no-op. Re-interning the same
     # path yields the same inode and rebuild_subtree re-canonicalizes the parent, so
     # the resulting tree is identical — a pure short-circuit optimization.
-    'musefs-core/src/tree\.rs:470:30: replace match guard .* with false in VirtualTree::apply_changes',
+    'musefs-core/src/tree\.rs:489:30: replace match guard .* with false in VirtualTree::apply_changes',
     # (The add-side/remove-side dirty-propagation walks formerly inline in
     # apply_changes now live in dirty_min_flip_ancestors; their equivalent and
     # hang-class mutants are covered by the description-anchored
@@ -144,7 +150,7 @@ exclude_re = [
     # ancestor_in's loop terminator `cur == Self::ROOT` -> `!=`: the walk never breaks
     # at root (root.parent == root), so a node with no ancestor in the set loops
     # forever instead of returning false.
-    'musefs-core/src/tree\.rs:596:20: replace == with != in VirtualTree::ancestor_in',
+    'musefs-core/src/tree\.rs:615:20: replace == with != in VirtualTree::ancestor_in',
 
     # SP4 storage-aware serving — equivalent mutant in serve_ogg_window's last-page
     # memo. `total_len = header_len + payload_len` only sets the memoized page's
@@ -156,7 +162,7 @@ exclude_re = [
     # 0 disables the short-circuit (falls to the scan, also correct). So the served
     # output is byte-identical either way. (`+`->`-` underflows and is caught.) Pinned
     # by line:col — one of several `+` in this fn; the others ARE caught.
-    'musefs-core/src/ogg_index\.rs:202:41: replace \+ with \* in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:205:41: replace \+ with \* in serve_ogg_window',
 
     # SP4 crc_shift_zeros — equivalent mutants inherent to the loop/matrix hybrid.
     # crc_shift_zeros has two code paths (a per-step loop and a GF(2) matrix-power)
@@ -199,8 +205,8 @@ exclude_re = [
     # byte-identical proptest_read_fidelity pass with both mutations applied). They
     # were reported TIMEOUT under the parallel gate's load, not as a real hang. Pinned
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
-    'musefs-core/src/ogg_index\.rs:213:15: replace < with <= in serve_ogg_window',
-    'musefs-core/src/ogg_index\.rs:222:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:216:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:225:15: replace < with <= in serve_ogg_window',
 
     # Phase 4 poll_due (#89) — equivalent `<`->`<=` on the two wall-clock gates
     # (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <
@@ -222,5 +228,25 @@ exclude_re = [
     # quick_cache accepts any usize. (cargo-mutants DOES mutate const
     # initializers — the equivalence rests on unobservability, not on the
     # const being out of reach.)
-    'musefs-core/src/reader\.rs:70:60: replace / with [%*]',
+    'musefs-core/src/reader\.rs:71:60: replace / with [%*]',
+
+    # wav walk_chunks advance guard `next <= buf.len() as u64` -> `true`: forcing
+    # the guard true sets `pos = next` even when `next > buf.len()`, but the loop's
+    # `while pos + 8 <= buf.len()` test is then immediately false (next can't wrap —
+    # checked_add guards overflow and usize_from doesn't truncate on 64-bit), so the
+    # walk ends on the next iteration with the IDENTICAL output Vec the original's
+    # `break` produced (the chunk header was pushed before the advance). Equivalent;
+    # the in-file note in wav.rs's test module documents the hand-apply confirmation.
+    # The sole match guard in walk_chunks, so description-anchored.
+    'replace match guard next <= buf.len\(\) as u64 with true in walk_chunks',
+
+    # fuzz_check fixtures::wav RIFF-size sum `4 + fmt_chunk.len() + data_chunk.len()`
+    # `+`->`*`: the computed `riff_size` is written into the RIFF header's size field,
+    # but NO in-workspace WAV parser reads it — `riff_wave_start` only checks the
+    # "RIFF"/"WAVE" magic (bytes 0-3 / 8-11, never the 4-7 size word) and `walk_chunks`
+    # ignores it entirely, walking chunk-to-chunk by each chunk's own declared length.
+    # So any value the mutated sum produces is unobservable through the format API the
+    # in-diff gate builds. The two `+` in fixtures::wav are this one expression; both
+    # `+` elsewhere are absent (`samples.len() * 2` is `*`), so description-anchored.
+    'replace \+ with \* in fixtures::wav',
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -34,6 +34,19 @@ exclude_globs = [
 # Anchored on file:line:col so only the proven-equivalent sites are suppressed;
 # killable siblings (e.g. flac `|`->`&`, scan 871 `+`->`*`) stay in scope.
 exclude_re = [
+    # musefs-format's sanctioned u64->usize helper: replacing its body with a
+    # constant (`-> 0` / `-> 1`) is a MACHINE-KILLER, not an equivalent mutant.
+    # The format parsers assign absolute walk positions through it
+    # (`pos = usize_from(next)` in wav::walk_chunks, mp4's box walk, the ogg
+    # page scan); a constant return pins the position forever while the loop
+    # pushes a record per iteration — an allocation bomb that OOMs the HOST
+    # (observed: 26.7G RSS + 11.5G swap killing a tmux session twice; two CI
+    # runners died with "runner received a shutdown signal") faster than
+    # cargo-mutants' test timeout can fire. The helper's correctness is pinned
+    # instead by its unit test plus every slice/alloc consumer. musefs-db's
+    # sibling helper stays IN scope: core uses it only for slice bounds, so its
+    # constant-return mutants die by prompt panic (verified caught).
+    'musefs-format/src/convert\.rs:\d+:\d+: replace usize_from -> usize',
     # dirty_min_flip_ancestors (add-side walk) `id < introducing_id(child)`: the
     # `<`->`<=` boundary is unreachable-different. Equality needs the walked id to
     # BE the subtree's introducing id, which only a moved-in id can satisfy (pure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,3 +218,12 @@ tracks whose backing file is gone, and GC orphaned art. `--revalidate` selects i
   `fuzz_check::fixtures::<fmt>()` minimal file, a `fuzz/fuzz_targets/<fmt>.rs`
   target with a seed in `generate_seeds`, a `musefs-format/tests/proptest_<fmt>.rs`,
   and a manifest row in `musefs-core/tests/interop_emit.rs`.
+- Integer conversions: the four clippy cast lints are deny-via-CI. Widenings
+  use `From`; `u64 -> usize` only via the sanctioned `usize_from` helpers
+  (`musefs_db::convert`, re-exported by core; musefs-format and latencyfs carry
+  crate-local siblings — the workspace is declared 64-bit-only); genuine
+  narrowings use `try_from` (`?` for input-dependent values, `.expect` for
+  structurally bounded ones, `.unwrap` in tests); deliberate bit-truncation
+  keeps `as` under a reasoned `#[expect]`. Non-negative db row fields are
+  unsigned; rusqlite's checked conversions (feature `fallible_uint`) validate
+  at the row boundary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,20 @@ cargo test -p musefs-fuse -- --ignored   # FUSE end-to-end; needs /dev/fuse + li
 cargo clippy --all-targets               # lint
 cargo fmt                                # format
 
-# In-diff mutation gate (CI parity). Always -j2, output on /tmp, and do NOT
-# set TMPDIR (the default is correct). Sanity-check mutants.diff is non-empty
-# first — an empty diff mutates nothing and exits 0, a silent false pass.
+# In-diff mutation gate (CI parity). Always -j2, output on /tmp. Run it inside
+# a memory-capped cgroup with TMPDIR on real disk: /tmp is a RAM-backed tmpfs
+# here, and some mutants are allocation bombs (a constant-return on a parser
+# position helper spins a collect-loop) that OOM the whole host faster than the
+# test timeout — this killed two tmux sessions and two CI runners before the
+# bomb class got a documented exclude in .cargo/mutants.toml. Sanity-check
+# mutants.diff is non-empty first — an empty diff mutates nothing and exits 0,
+# a silent false pass. Don't pipe the run through tail/grep (masks exit code).
 git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
 grep -q '^@@ ' mutants.diff
-cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+mkdir -p ~/.cache/musefs-mutants-tmp
+TMPDIR="$HOME/.cache/musefs-mutants-tmp" systemd-run --user --scope --collect \
+    -p MemoryMax=10G -p MemorySwapMax=0 \
+    cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
 # Property tests (proptest): byte-identical invariant + tag round-trip. The
 # format-layer proptests are gated on the `fuzzing` feature, which
 # musefs-format's self-dev-dependency enables for all of its test builds.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,17 @@ repository = "https://github.com/Sohex/musefs"
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 
-# Explicit `as` casts are deliberate throughout the byte/offset arithmetic
-# (audio bounds, chunk sizes, FUSE inode/size fields); flagging every one is noise.
-cast_possible_truncation = "allow"
-cast_sign_loss = "allow"
-cast_possible_wrap = "allow"
-cast_lossless = "allow"
+# Integer-conversion convention (docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md):
+# widenings use `From`; u64->usize goes through a sanctioned usize_from helper
+# (64-bit-only, compile-time guarded; `musefs_db::convert` for db/core/fuse/cli,
+# a crate-local sibling in musefs-format, a local copy in standalone latencyfs);
+# genuine narrowings use `try_from` (`?` on input-dependent values,
+# `.expect`/`.unwrap` on structurally bounded ones and in tests); deliberate
+# bit-truncation carries a per-site `#[expect]`.
+cast_possible_truncation = "warn"
+cast_sign_loss = "warn"
+cast_possible_wrap = "warn"
+cast_lossless = "warn"
 
 # Doc conventions this project does not adopt.
 missing_errors_doc = "allow"

--- a/docs/superpowers/plans/2026-06-06-integer-cast-convention.md
+++ b/docs/superpowers/plans/2026-06-06-integer-cast-convention.md
@@ -327,27 +327,36 @@ skip-with-warn behavior. Rewrite it (keep the existing setup code that
 creates the db, track, and two art rows; replace name, the `UPDATE`, and the
 assertions):
 
+The existing test already corrupts rows through a **second raw
+`rusqlite::Connection`** on the same db file (`mapping.rs:280` — `Db.conn` is
+private to musefs-db and unreachable from this crate; keep that pattern and
+the file-backed `Db::open(&path)` it requires). Keep the whole setup
+(tempdir, track `tid`, art rows `good`/`bad`/`zero`, `set_track_art`) and
+replace the final corrupt-and-assert portion:
+
 ```rust
-    #[test]
-    fn track_art_to_inputs_errors_on_negative_byte_len() {
-        // ... existing setup: tempdir, Db::open, upsert_track -> tid,
-        //     upsert_art -> good, upsert_art -> bad, set_track_art ...
-        // (byte_len is derived from data, so corrupt it directly — a
-        // malformed external write to the contract column.)
-        db.conn
-            .execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
+        // byte_len == 0 is valid and must still be served (was the old
+        // strict-`<` pin; now pins that zero passes the u64 row-read).
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.execute("UPDATE art SET byte_len = 0 WHERE id = ?1", [zero])
             .unwrap();
-        let err = track_art_to_inputs(&db, tid);
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        let ids: Vec<i64> = inputs.iter().map(|a| a.art_id).collect();
+        assert_eq!(ids, vec![good, bad, zero]);
+
+        // A negative byte_len is a malformed external write to the contract
+        // column: it now errors at row-read instead of being skipped.
+        raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
+            .unwrap();
+        drop(raw);
         assert!(
-            err.is_err(),
-            "negative byte_len must error at row-read, not be skipped: {err:?}"
+            super::track_art_to_inputs(&db, tid).is_err(),
+            "negative byte_len must error at row-read, not be skipped"
         );
-    }
 ```
 
-Keep whatever zero-byte_len assertion the old test made for the `good` row in
-a separate, passing form if it still applies (byte_len == 0 remains valid and
-must still produce an input).
+(Match the `[good, bad, zero]` order to the ordinal order the existing setup
+establishes; rename the test to `track_art_to_inputs_errors_on_negative_byte_len`.)
 
 - [ ] **Step 2: Run the test to verify it fails**
 
@@ -506,15 +515,21 @@ git commit -m "Make ordinals u64 and picture_type u32 across db rows (#133)"
 
 - [ ] **Step 1: Restructure the migration loop (no cast at all)**
 
-`schema.rs:128/140` cast loop indices (`(i + 1) as i64`) for `user_version`
-targets. Restructure with a typed counter — pattern (adapt to the actual loop
-shape at those lines):
+`schema.rs:128` is the fast-path binding (a separate site from the loop):
+
+```rust
+let latest = i64::try_from(MIGRATIONS.len()).expect("migration count fits i64");
+```
+
+`schema.rs:140` casts the loop index (`(i + 1) as i64`) for `user_version`
+targets. Restructure with a typed counter, **preserving the
+`if current < target { … }` body** the real loop carries (lines ~139-145):
 
 ```rust
 for (target, migration) in (1i64..).zip(MIGRATIONS) {
 ```
 
-so `target` is born i64 and both casts disappear. `schema.rs:461` is a test:
+so `target` is born i64 and the cast disappears. `schema.rs:461` is a test:
 `MIGRATIONS.len() as i64` → `i64::try_from(MIGRATIONS.len()).unwrap()`.
 
 - [ ] **Step 2: Route blob offsets through the helper**
@@ -744,17 +759,20 @@ git commit -m "Apply cast convention to MP3/ID3 synthesis (#133)"
 `604,608` (`---- ` atom), `680,685` (`covr`/`data` sizes), `731,733,737`
 (`udta`/`meta`/`ilst` — these three sit right after an existing
 `return Err(FormatError::TooLarge)` guard), `836` (`new_moov_size`):
-all become `u32::try_from(x).map_err(|_| FormatError::TooLarge)?`. Where a
-fn is currently infallible (`build_dash_atom`-style returning `Vec<u8>`),
-make it return `Result<Vec<u8>, FormatError>` and `?` at callers — every
-transitive caller already returns `Result<_, FormatError>`. Where the
-explicit guard makes the `try_from` infallible, you may delete the guard if
-and only if the `try_from` error carries the same semantics (it does:
-`TooLarge`); otherwise keep both.
+all become `u32::try_from(x).map_err(|_| FormatError::TooLarge)?`. This
+makes the currently-infallible atom builders fallible; the exact set whose
+signatures flip from `Vec<u8>` to `Result<Vec<u8>, FormatError>` is:
+`boxed` (:529), `text_atom` (:536), `number_atom` (:547), `freeform_atom`
+(:565), `freeform_binary_prefix` (:593). Verified: their only transitive
+consumers are `build_udta` (:622) and `synthesize_layout` (:803), both
+already `Result<_, FormatError>` — the `?` cascade stops there. Where an
+explicit `> u32::MAX` guard makes the `try_from` infallible (:731-737, :836),
+you may delete the guard if and only if the `try_from` error carries the
+same semantics (it does: `TooLarge`); otherwise keep both.
 `530,872,916` (`usize → u32`): same `TooLarge` pattern.
-`785` (`i64 → u32`): inspect the site — it converts a parsed value; use
-`u32::try_from(x).map_err(|_| FormatError::Malformed)?` since it's file
-input, not synthesized size.
+`785` (`i64 → u32`, in `patch_chunk_offsets`): a patched stco chunk offset
+that leaves u32 range means the synthesized header grew past what stco can
+express — `u32::try_from(x).map_err(|_| FormatError::TooLarge)?`.
 
 - [ ] **Step 4: Test-module sites** (`1306-1321,2070-2071,2307,2365-2394`):
 `.unwrap()` / `From` per the test rule.
@@ -802,6 +820,21 @@ index into the alphabet, bounded by `% 64`-style masking):
 `u8::try_from(...).expect("…mask bound…")` matching what the expression
 guarantees. `65,72,73,76` (test-mod slicing): `usize_from` or
 `.try_from(...).unwrap()`.
+
+crc.rs has a **second site the original sweep under-counted**: `crc32()` at
+`crc.rs:31`:
+
+```rust
+        crc = (crc << 8) ^ TABLE[(((crc >> 24) as u8) ^ b) as usize];
+```
+
+→ restructure (high byte of the accumulator; `to_be_bytes()[0]` is exactly
+`(crc >> 24) as u8`, and `usize::from` covers the u8→usize widening that
+`cast_lossless` would otherwise flag):
+
+```rust
+        crc = (crc << 8) ^ TABLE[usize::from(crc.to_be_bytes()[0] ^ b)];
+```
 
 crc.rs:`11` (`(i as u32) << 24` in a `const fn` — `try_from` is not const):
 restructure the loop variable:
@@ -1018,7 +1051,8 @@ failed gate after fixing):
 
 Run: `cargo fmt --all --check`
 Expected: exit 0 (check the exit status directly, not just output).
-If it fails: `cargo fmt --all`, re-check, and amend the fix into a new commit.
+If it fails: `cargo fmt --all`, re-check, and put the fix in a new commit
+(never `--amend`).
 
 - [ ] **Step 2: Workspace tests + proptests**
 

--- a/docs/superpowers/plans/2026-06-06-integer-cast-convention.md
+++ b/docs/superpowers/plans/2026-06-06-integer-cast-convention.md
@@ -1,0 +1,1076 @@
+# Integer Cast Convention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish and enforce an integer-conversion convention (spec:
+`docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md`, issue
+#133): flip the four clippy cast lints to `warn`, migrate all ~451 existing
+violations, and make non-negative db row fields unsigned so i64 never crosses
+the db boundary upward.
+
+**Architecture:** Type-driven at the db boundary (rusqlite 0.40's checked
+`FromSql`/`ToSql` for unsigned types validates rows once), a single sanctioned
+`convert::usize_from` helper for the 64-bit-guarded `u64→usize` class, `From`
+for widenings, `try_from` for genuine narrowings. The lint flip lands last,
+once the workspace is warning-clean.
+
+**Tech Stack:** Rust workspace (musefs-db/format/core/fuse/cli/latencyfs),
+rusqlite 0.40, clippy via `[workspace.lints.clippy]`, CI runs
+`cargo clippy --all-targets -- -D warnings`.
+
+---
+
+## Shared context for every task (read first)
+
+**The convention** (final state, enforced from Task 13 on):
+
+1. Widening (`u8/u16/u32` → wider): `From` (`u64::from(x)`), never `as`.
+2. usize↔u64: 64-bit-only is declared by a compile-time guard.
+   `usize as u64` stays as-is (clippy-clean). `u64 → usize` only via
+   `convert::usize_from(v)`.
+3. Genuine narrowing (`u64→u32`, `usize→u32`, `→u8`): prefer restructuring
+   (`to_be_bytes`, typed loop counters); else `u32::try_from(x)` —
+   `.map_err(|_| FormatError::TooLarge)?` (or the appropriate error) where the
+   value is input-dependent, `.expect("…invariant…")` where structurally
+   bounded (e.g. `x % 255`), plain `.unwrap()` in `#[cfg(test)]` code and
+   test-fixture builders.
+4. i64 stays at the db edge; row structs expose unsigned fields.
+5. Deliberate bit-truncation keeps `as` with
+   `#[expect(clippy::…, reason = "…")]`.
+
+**Until Task 13 flips the lints, violations are invisible to plain builds.**
+To see the remaining violations for a path at any time, run:
+
+```bash
+cargo clippy --all-targets --message-format=short -- \
+  -W clippy::cast_possible_truncation -W clippy::cast_sign_loss \
+  -W clippy::cast_possible_wrap -W clippy::cast_lossless 2>&1 \
+  | grep -E '^musefs-format/src/mp3' | sort -u        # adjust the grep per task
+```
+
+Per-file site lists in tasks below come from this command run against the
+pre-migration tree (line numbers will drift as you edit — re-run the command
+scoped to your file rather than trusting stale line numbers).
+
+**Line numbers in `src/` files above ~900 are usually inside `#[cfg(test)] mod
+tests`** — apply the test rule (`.unwrap()`) there even though the file lives
+in `src/`.
+
+**`#[expect]` is self-checking**: if the lint stops firing at that site, the
+build errors with "unfulfilled lint expectation". Never add an `#[expect]` for
+a lint that doesn't currently fire there.
+
+**Commits:** every task ends in its own commit. Trailer for all commits:
+
+```
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+### Task 1: `convert` module + 64-bit guard in musefs-db, re-export in core
+
+**Files:**
+- Create: `musefs-db/src/convert.rs`
+- Modify: `musefs-db/src/lib.rs:1-8` (mod list)
+- Modify: `musefs-core/src/lib.rs:15-25` (re-export list)
+
+- [ ] **Step 1: Write the module with its unit test**
+
+Create `musefs-db/src/convert.rs`:
+
+```rust
+//! Sanctioned integer conversions, justified by the 64-bit-only guard below.
+
+// musefs supports 64-bit targets only; this is the compile-time declaration
+// of that boundary. It makes u64 <-> usize conversions lossless by
+// construction everywhere in the workspace.
+const _: () = assert!(
+    std::mem::size_of::<usize>() == 8,
+    "musefs supports 64-bit targets only"
+);
+
+/// The workspace's only sanctioned `u64 -> usize` cast (see the guard above).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "u64 -> usize is lossless on 64-bit targets; guarded by the const assert above"
+)]
+#[inline]
+#[must_use]
+pub fn usize_from(v: u64) -> usize {
+    v as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::usize_from;
+
+    #[test]
+    fn usize_from_is_lossless_across_the_range() {
+        assert_eq!(usize_from(0), 0);
+        assert_eq!(usize_from(u64::from(u32::MAX) + 1), 4_294_967_296);
+        assert_eq!(usize_from(u64::MAX), usize::MAX);
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module and the re-export**
+
+In `musefs-db/src/lib.rs`, the mod list (lines 1-8) gains one line (keep
+alphabetical order):
+
+```rust
+mod art;
+mod bulk;
+pub mod convert;
+mod error;
+...
+```
+
+In `musefs-core/src/lib.rs`, add to the `pub use` block (after line 16):
+
+```rust
+pub use musefs_db::convert;
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `cargo test -p musefs-db convert`
+Expected: PASS (1 test). Also confirms the `#[expect]` is fulfilled (an
+unfulfilled expectation is a warning that CI would deny).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-db/src/convert.rs musefs-db/src/lib.rs musefs-core/src/lib.rs
+git commit -m "Add sanctioned u64->usize conversion behind a 64-bit guard (#133)"
+```
+
+---
+
+### Task 2: Flip `Track`/`NewTrack` audio bounds to u64 (TDD)
+
+**Files:**
+- Modify: `musefs-db/src/models.rs:86-106` (Track, NewTrack)
+- Modify: `musefs-db/src/tracks.rs` (add test)
+- Modify: `musefs-core/src/reader.rs:118,148-162,303` and its test module
+- Modify: `musefs-core/src/scan.rs:414-416,502-504,1677`
+- Modify: consumers that compile-break (core `tests/`, `benches/`, cli `tests/`)
+
+- [ ] **Step 1: Write the failing test**
+
+In `musefs-db/src/tracks.rs`, inside the existing `#[cfg(test)] mod tests`
+(the `Db` struct's `conn` field is crate-root-private, so in-crate test
+modules can reach it):
+
+```rust
+#[test]
+fn negative_audio_bounds_error_at_row_read() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db
+        .upsert_track(&NewTrack {
+            backing_path: "/x.flac".into(),
+            format: Format::Flac,
+            audio_offset: 0,
+            audio_length: 1,
+            backing_size: 1,
+            backing_mtime: 0,
+        })
+        .unwrap();
+    // Simulate a malformed external write to a contract column.
+    db.conn
+        .execute("UPDATE tracks SET audio_offset = -1 WHERE id = ?1", [id])
+        .unwrap();
+    assert!(
+        db.get_track(id).is_err(),
+        "negative audio_offset must fail row-read, not wrap"
+    );
+}
+```
+
+(Match the imports of the surrounding test module; add `Format`/`NewTrack` if
+not already imported.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-db negative_audio_bounds`
+Expected: FAIL — `get_track` currently returns `Ok(Some(track))` with
+`audio_offset == -1` (the field is i64, nothing rejects it).
+
+- [ ] **Step 3: Flip the field types**
+
+In `musefs-db/src/models.rs`:
+
+```rust
+pub struct Track {
+    pub id: i64,
+    pub backing_path: String,
+    pub format: Format,
+    pub audio_offset: u64,
+    pub audio_length: u64,
+    pub backing_size: u64,
+    pub backing_mtime: i64,
+    pub content_version: i64,
+    pub updated_at: i64,
+}
+```
+
+and the same three fields in `NewTrack`. No change to `tracks.rs` row mapping
+or `params![]` writes — rusqlite's `FromSql for u64` / `ToSql for u64` are
+inferred from the field types and do the checked conversion.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-db negative_audio_bounds`
+Expected: PASS (`FromSqlError::OutOfRange` surfaces through `DbError`).
+
+- [ ] **Step 5: Fix compile fallout in musefs-core src**
+
+`cargo build -p musefs-core` and fix each error. The known sites:
+
+`reader.rs:148-162` — the Synthesis-mode guard loses its negative arms (they
+are now unrepresentable) but **keeps** the overflow/file-size check. Replace:
+
+```rust
+                // Guard the stored audio bounds before any cast/allocation: a negative
+                // bound, or an audio region that runs past the end of the backing file,
+                // means the row no longer matches the file. Only synthesis splices at
+                // these bounds, so the check is scoped to this mode.
+                if track.audio_offset < 0
+                    || track.audio_length < 0
+                    || (track.audio_offset as u64).saturating_add(track.audio_length as u64)
+                        > meta.len()
+                {
+                    return Err(CoreError::BackingChanged(track.backing_path.clone()));
+                }
+```
+
+with:
+
+```rust
+                // Guard the stored audio bounds before any cast/allocation: an audio
+                // region that runs past the end of the backing file means the row no
+                // longer matches the file (negative bounds are unrepresentable — the
+                // row-read already rejected them). Only synthesis splices at these
+                // bounds, so the check is scoped to this mode.
+                if track
+                    .audio_offset
+                    .saturating_add(track.audio_length)
+                    > meta.len()
+                {
+                    return Err(CoreError::BackingChanged(track.backing_path.clone()));
+                }
+```
+
+`reader.rs:118`: `track.backing_size as u64` → `track.backing_size`.
+`reader.rs:303`: `backing_size: track.backing_size as u64` →
+`backing_size: track.backing_size`.
+All other `track.audio_offset as u64` / `track.audio_length as u64` reads in
+`reader.rs` (lines ~182, 201-210, 251-278): drop the ` as u64`.
+
+`scan.rs:414-416` and `scan.rs:502-504` (the two `NewTrack` constructions):
+
+```rust
+        audio_offset: probed.audio_offset,
+        audio_length: probed.audio_length,
+        backing_size: meta.len(),
+```
+
+(second site uses `backing_size: meta_len`). `probed.audio_offset/length` are
+already u64; `meta.len()`/`meta_len` are u64.
+
+- [ ] **Step 6: Fix compile fallout in test/bench/cli code**
+
+Run `cargo clippy --all-targets 2>&1 | grep -E '^error'` and fix. Expected
+fallout (all are `Track`/`NewTrack` literals or comparisons against the
+flipped fields):
+
+- `musefs-core/src/reader.rs` test module (~588, 627-628, 684-685, 723):
+  `audio_offset: audio_offset as i64` → `audio_offset: audio_offset` (the
+  locals are already u64).
+- `musefs-core/src/scan.rs:1677` (test): `track.audio_length as usize` →
+  `usize::try_from(track.audio_length).unwrap()`.
+- `musefs-core/tests/common/mod.rs:18-20,206-208` (`usize as i64` into
+  NewTrack fields): `len as i64` → `len as u64` (usize→u64 is clippy-clean).
+- `musefs-fuse`, `musefs-cli` tests: same pattern — fixture `NewTrack`
+  literals flip `as i64` → `as u64` or drop casts where the source is u64.
+
+- [ ] **Step 7: Run the affected crates' tests**
+
+Run: `cargo test -p musefs-db -p musefs-core -p musefs-cli`
+Expected: PASS (FUSE e2e stays `#[ignore]`d).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -u
+git commit -m "Make Track audio bounds unsigned; validate at row-read (#133)"
+```
+
+(`git add -u` is acceptable here: only tracked files change in this task.)
+
+---
+
+### Task 3: Flip art/binary-tag byte quantities to unsigned (TDD)
+
+**Files:**
+- Modify: `musefs-db/src/models.rs:109-114,136-153,179-183` (NewArt, Art, ArtMeta, BinaryTagRow)
+- Modify: `musefs-db/src/art.rs:97`, `musefs-db/src/bulk.rs:111`
+- Modify: `musefs-core/src/mapping.rs:43-62,75-81,212-…` (guard, inputs, test)
+- Modify: `musefs-core/src/scan.rs:469-470,555-556` (width/height writes)
+
+- [ ] **Step 1: Rewrite the skip-behavior test to pin the new error behavior**
+
+`musefs-core/src/mapping.rs:212` has
+`track_art_to_inputs_skips_negative_byte_len`, which pins the old
+skip-with-warn behavior. Rewrite it (keep the existing setup code that
+creates the db, track, and two art rows; replace name, the `UPDATE`, and the
+assertions):
+
+```rust
+    #[test]
+    fn track_art_to_inputs_errors_on_negative_byte_len() {
+        // ... existing setup: tempdir, Db::open, upsert_track -> tid,
+        //     upsert_art -> good, upsert_art -> bad, set_track_art ...
+        // (byte_len is derived from data, so corrupt it directly — a
+        // malformed external write to the contract column.)
+        db.conn
+            .execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
+            .unwrap();
+        let err = track_art_to_inputs(&db, tid);
+        assert!(
+            err.is_err(),
+            "negative byte_len must error at row-read, not be skipped: {err:?}"
+        );
+    }
+```
+
+Keep whatever zero-byte_len assertion the old test made for the `good` row in
+a separate, passing form if it still applies (byte_len == 0 remains valid and
+must still produce an input).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core errors_on_negative_byte_len`
+Expected: FAIL — the current guard skips the row, `track_art_to_inputs`
+returns `Ok` with one input.
+
+- [ ] **Step 3: Flip the field types**
+
+In `musefs-db/src/models.rs`:
+
+```rust
+pub struct NewArt {
+    pub mime: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub data: Vec<u8>,
+}
+```
+
+`Art`: `width`/`height` → `Option<u32>`, `byte_len` → `u64` (`id`, `sha256`,
+`mime`, `data` unchanged). `ArtMeta`: same three fields. `BinaryTagRow`:
+`byte_len` → `u64` (`rowid` stays i64).
+
+In `musefs-db/src/art.rs:97` and `musefs-db/src/bulk.rs:111` (the two
+`upsert_art` INSERTs — `byte_len` is computed, not a struct field):
+`a.data.len() as i64` → `a.data.len() as u64` (clippy-clean; stored via the
+fallible `ToSql for u64`).
+
+- [ ] **Step 4: Remove the dissolved guard and casts in mapping.rs**
+
+In `musefs-core/src/mapping.rs:43-62`, the `if meta.byte_len < 0 { … continue; }`
+block is now a dead comparison (`unused_comparisons` — warn-by-default rustc
+lint, denied in CI) and must go in this same task. Replace the guard plus the
+`ArtInput` push with:
+
+```rust
+        if let Some(meta) = db.get_art_meta(ta.art_id)? {
+            inputs.push(ArtInput {
+                art_id: ta.art_id,
+                mime: meta.mime,
+                description: ta.description,
+                picture_type: ta.picture_type as u32,
+                width: meta.width.unwrap_or(0),
+                height: meta.height.unwrap_or(0),
+                data_len: meta.byte_len,
+            });
+```
+
+(`picture_type as u32` survives until Task 4 flips that field; `width`/
+`height`/`data_len` casts vanish now.) Also `mapping.rs:79`:
+`len: row.byte_len as u64` → `len: row.byte_len`.
+
+- [ ] **Step 5: Fix remaining compile fallout**
+
+`cargo clippy --all-targets 2>&1 | grep -E '^error'`. Known sites:
+
+- `musefs-core/src/scan.rs:469-470,555-556`:
+  `width: (pic.width != 0).then_some(pic.width as i64)` →
+  `width: (pic.width != 0).then_some(pic.width)` (pic.width is u32; same for
+  height, both sites).
+- `musefs-core/src/mapping.rs:91`: `a.data_len as usize` →
+  `convert::usize_from(a.data_len)` (import `musefs_db::convert`).
+- Test fixtures constructing `NewArt`/`Art` with `Some(300)` etc. continue to
+  compile (integer literals infer u32); fix any explicit `i64` annotations.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test -p musefs-db -p musefs-core`
+Expected: PASS, including the rewritten Step 1 test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -u
+git commit -m "Make art/binary-tag byte quantities unsigned (#133)"
+```
+
+---
+
+### Task 4: Flip ordinals to u64 and picture_type to u32
+
+**Files:**
+- Modify: `musefs-db/src/models.rs:118-132,157-162,169-173,189-193` (Tag + Tag::new, TrackArt, BinaryTag, StructuralBlock)
+- Modify: `musefs-core/src/scan.rs:421-453,483,509-530,568` (ordinal counters)
+- Modify: `musefs-core/src/mapping.rs:58,101` (picture_type cast, test helper)
+- Modify: `musefs-format/src/mp3.rs:192` area (`apic_framing`)
+
+- [ ] **Step 1: Flip the field types**
+
+In `musefs-db/src/models.rs`: `Tag.ordinal`, `TrackArt.ordinal`,
+`BinaryTag.ordinal`, `StructuralBlock.ordinal` → `u64`;
+`TrackArt.picture_type` → `u32`; and:
+
+```rust
+impl Tag {
+    pub fn new(key: &str, value: &str, ordinal: u64) -> Tag {
+```
+
+- [ ] **Step 2: Fix the scan.rs ordinal counters**
+
+Four manual accumulators flip `HashMap<String, i64>` → `HashMap<String, u64>`
+(`scan.rs:421,442,509,530`; the `or_insert(0)`/`*ord += 1` bodies are
+type-inferred and need no edit). The two `.enumerate()` writes at
+`scan.rs:437,525` (`ordinal: ordinal as i64`) → `ordinal: ordinal as u64`,
+and at `scan.rs:483,568` likewise. `scan.rs:475,560`:
+`pic.picture_type as i64` → `pic.picture_type` (already u32).
+
+- [ ] **Step 3: Fix mapping.rs and mp3's APIC framing**
+
+`mapping.rs:58`: `picture_type: ta.picture_type as u32` →
+`picture_type: ta.picture_type` (cast vanishes). The test helper at
+`mapping.rs:101` (`fn tag(key, value, ordinal: i64)`) flips to `u64`.
+
+`musefs-format/src/mp3.rs:192` (`apic_framing`): `art.picture_type as u8` is
+a deliberate pre-existing one-byte truncation (ID3 APIC stores one byte;
+valid types are 0..=20). Keep it, made explicit:
+
+```rust
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "ID3 APIC type is one byte; valid picture types are 0..=20"
+    )]
+    d.push(art.picture_type as u8);
+```
+
+(Attach the attribute to the statement; if the builder style makes that
+awkward, hoist `let picture_type_byte = …;` with the attribute on the `let`.)
+
+- [ ] **Step 4: Fix remaining compile fallout**
+
+`cargo clippy --all-targets 2>&1 | grep -E '^error'`. Expected: `Tag::new`
+callers and struct literals with i64 ordinals across db/core/cli tests —
+integer literals (`0`, `1`) re-infer to u64 with no edit; explicit
+`as i64` fixture casts flip to `as u64` or drop.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p musefs-db -p musefs-core -p musefs-format -p musefs-cli`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git commit -m "Make ordinals u64 and picture_type u32 across db rows (#133)"
+```
+
+---
+
+### Task 5: Remaining musefs-db sites
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs:125-145,461`
+- Modify: `musefs-db/src/art.rs:62`, `musefs-db/src/tags.rs:116`
+
+- [ ] **Step 1: Restructure the migration loop (no cast at all)**
+
+`schema.rs:128/140` cast loop indices (`(i + 1) as i64`) for `user_version`
+targets. Restructure with a typed counter — pattern (adapt to the actual loop
+shape at those lines):
+
+```rust
+for (target, migration) in (1i64..).zip(MIGRATIONS) {
+```
+
+so `target` is born i64 and both casts disappear. `schema.rs:461` is a test:
+`MIGRATIONS.len() as i64` → `i64::try_from(MIGRATIONS.len()).unwrap()`.
+
+- [ ] **Step 2: Route blob offsets through the helper**
+
+`art.rs:62` and `tags.rs:116`: `blob.read_at_exact(buf, offset as usize)` →
+`blob.read_at_exact(buf, crate::convert::usize_from(offset))`.
+
+- [ ] **Step 3: Verify db is clippy-clean and tests pass**
+
+Run the shared-context clippy command grepped to `musefs-db/src`.
+Expected: no output. Run: `cargo test -p musefs-db` → PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "Clear remaining cast-lint sites in musefs-db (#133)"
+```
+
+---
+
+### Task 6: musefs-core src sweep
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs`, `facade.rs`, `ogg_index.rs`, `scan.rs`, `template.rs`
+
+- [ ] **Step 1: Route `u64 → usize` through the helper (mechanical)**
+
+Every `<expr> as usize` where the source is u64 becomes
+`usize_from(<expr>)` with `use musefs_db::convert::usize_from;`. Non-test
+sites:
+`reader.rs:83,363,373,376,431,528,701,702,760`, `facade.rs:178`
+(`(self.0.get() - 1) as usize` → `usize_from(self.0.get() - 1)`),
+`ogg_index.rs:76,169,214,215,224,421,545,563,579,595,610`,
+`scan.rs:240,253,255,262` (the read-window logic — e.g.
+`(window as u64).min(file_len) as usize` →
+`usize_from(u64::from(window).min(file_len))` if `window` is u32, or
+`usize_from((window as u64).min(file_len))` if it's usize — match the local
+type; `usize as u64` stays a plain cast).
+
+- [ ] **Step 2: Fix the Ogg sequence-renumber narrowing**
+
+`ogg_index.rs:198`:
+
+```rust
+let new_seq = (old_seq as i64 + seq_delta) as u32;
+```
+
+→
+
+```rust
+let new_seq = u32::try_from(i64::from(old_seq) + seq_delta)
+    .map_err(|_| CoreError::BackingChanged(path.display().to_string()))?;
+```
+
+Adapt the error to what's in scope at that site: the function already maps
+errors into `CoreError` (line 199); a sequence that leaves u32 range means
+the index no longer matches the backing pages — use the same error the
+surrounding bounds checks use (look 20 lines up for the established choice;
+`BackingChanged` is the semantic fit).
+
+- [ ] **Step 3: Fix the in-src test-module sites (test rule)**
+
+`reader.rs:493` (`vec![0xFFu8; audio_offset as usize]` — local is u64 after
+Task 2): `usize::try_from(audio_offset).unwrap()` or `usize_from`;
+`reader.rs:605,606,701,702` slicing by u64 locals: same;
+`reader.rs:656,660,1093` (`usize → u32` fixture lengths):
+`u32::try_from(x).unwrap()`;
+`reader.rs:812` (`u32 → u8`), `reader.rs:1082`, `scan.rs:1230`
+(`usize → u8` synthetic bytes like `(i % 250 + 1) as u8`): keep `as` only if
+masked/bounded **and** add no expect (lints aren't on yet) — preferred:
+`u8::try_from(i % 250 + 1).unwrap()`;
+`reader.rs:1100,1103` (`usize → i64`): `i64::try_from(x).unwrap()`;
+`reader.rs:1178` (`u64 → i64`): `i64::try_from(x).unwrap()`;
+`scan.rs:991,1134,1138,1245-1265` (`usize → u32` fixture chunk sizes):
+`u32::try_from(x).unwrap()`.
+
+- [ ] **Step 4: Verify core src is clippy-clean**
+
+Run the shared-context clippy command grepped to `musefs-core/src`.
+Expected: no output (test-module sites included).
+Run: `cargo test -p musefs-core` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "Apply cast convention across musefs-core (#133)"
+```
+
+---
+
+### Task 7: musefs-format — flac.rs, vorbiscomment.rs, wav.rs
+
+**Files:**
+- Modify: `musefs-format/src/flac.rs`, `vorbiscomment.rs`, `wav.rs`
+
+Patterns for all format tasks (7-10):
+
+- **`u64 → usize`** (slicing scanned buffers at parsed offsets):
+  `use musefs_db::convert::usize_from;` and wrap. These offsets were already
+  bounds-checked by the parser before slicing — the helper just makes the
+  pointer-width cast sanctioned.
+- **`usize → u32` writing a length field into synthesized metadata** (the
+  value derives from generated framing): `u32::try_from(x).map_err(|_|
+  FormatError::TooLarge)?` in fallible fns. The synthesized region is
+  attacker-influenced via db contents, so `TooLarge` (the existing variant
+  for "synthesized metadata exceeds the format's size limit") is the honest
+  error, matching the established `if frames_len > … return Err(TooLarge)`
+  style (mp3.rs:389, mp4.rs:727, wav.rs:248-area).
+- **`u64 → u32` for `art.data_len`** (flac.rs:205, ogg/mod.rs:301): same
+  `TooLarge` treatment — art comes from the untrusted db.
+- **lossless `u32 as u64`/`u8 as u32`**: `u64::from(x)` / `u32::from(x)`.
+- **Test modules**: `try_from(...).unwrap()`.
+
+- [ ] **Step 1: flac.rs (15 sites)**
+
+`151,197,199,499` (+test-mod `567-637`): `usize → u32` length fields → per
+the pattern (src sites `TooLarge`, test sites `.unwrap()`).
+`205`: `(art.data_len as u32)` →
+`u32::try_from(art.data_len).map_err(|_| FormatError::TooLarge)?` — this
+makes the picture-builder fn fallible if it isn't already; follow the
+existing `Result` plumbing of its caller (the FLAC synthesis fns all return
+`Result<_, FormatError>`).
+`262,283,451,954`: `u64 → usize` → `usize_from`.
+
+- [ ] **Step 2: vorbiscomment.rs (3 sites: 15,17,22)**
+
+`usize → u32` vorbis length prefixes (tag strings from the db; a >4GiB tag
+is malformed input): `u32::try_from(x).map_err(|_| FormatError::TooLarge)?`.
+
+- [ ] **Step 3: wav.rs (11 sites)**
+
+`45,206,248,651`: `u32 as u64` → `u64::from(x)`.
+`50,59`: `u64 → usize` → `usize_from`.
+`226` (`tag_len as u32`), `235` (`audio_length as u32`), `253`
+(`riff_size as u32`): note `riff_size` is explicitly guarded by
+`if riff_size > u32::MAX as u64 { return Err(FormatError::TooLarge) }` just
+above — replace guard+cast with a single
+`let riff_size = u32::try_from(riff_size).map_err(|_| FormatError::TooLarge)?;`
+(and the guard's `u32::MAX as u64` lossless cast disappears with it). For
+`226`/`235` add the same `try_from … TooLarge` (they are unguarded today —
+a >4GiB id3 chunk or data chunk cannot be represented in RIFF).
+`179,421,428,539,662,665`: `usize → u32` chunk lengths → same pattern (src)
+or `.unwrap()` (test mod).
+
+- [ ] **Step 4: Verify and commit**
+
+Run the clippy command grepped to
+`musefs-format/src/(flac|vorbiscomment|wav)`. Expected: no output.
+Run: `cargo test -p musefs-format flac wav vorbis` (three invocations or one
+plain `cargo test -p musefs-format`). Expected: PASS.
+
+```bash
+git add -u
+git commit -m "Apply cast convention to FLAC/WAV/VorbisComment synthesis (#133)"
+```
+
+---
+
+### Task 8: musefs-format — mp3.rs (22 sites)
+
+**Files:**
+- Modify: `musefs-format/src/mp3.rs`
+
+- [ ] **Step 1: Lossless widenings**
+
+`16-21` (`synchsafe_decode`): each `(b[n] & 0x7F) as u32` →
+`u32::from(b[n] & 0x7F)`. `537` same pattern. `650`
+(`(a << 8) | b as u64` fold): `u64::from(b)`.
+
+- [ ] **Step 2: `u64 → usize` → `usize_from`**
+
+Sites `348,366` (`bt.len as usize`, `data_len as usize` for frame headers)
+and test-mod `1343,1373,1707,1733,1760`. For the test-mod sites
+`usize::try_from(x).unwrap()` is equally fine — pick one style per file.
+
+- [ ] **Step 3: Narrowings**
+
+`192` was handled in Task 4 (APIC `#[expect]`). `392`
+(`syncsafe(frames_len as u32)`): the line above already guards
+`frames_len > SYNCHSAFE_MAX as u64` — replace the pair with
+
+```rust
+    let frames_len_ss = u32::try_from(frames_len)
+        .ok()
+        .filter(|&v| v <= SYNCHSAFE_MAX)
+        .ok_or(FormatError::TooLarge)?;
+    header.extend_from_slice(&syncsafe(frames_len_ss));
+```
+
+(keep the explanatory comment about hard error vs truncated file; note
+`SYNCHSAFE_MAX as u64` itself was a lossless cast that disappears).
+`145` (`usize → u32`): src-side length → `TooLarge` pattern.
+Test-mod `1332,1452,1481,1577,1610,1660,1681,1782-1803` (`usize → u32`) and
+`1826` (`u32 → u8`): `.try_from(...).unwrap()`.
+
+- [ ] **Step 4: Verify and commit**
+
+Clippy command grepped to `musefs-format/src/mp3`: no output.
+`cargo test -p musefs-format mp3`: PASS. Also
+`cargo test -p musefs-format --test proptest_mp3` if present (check
+`musefs-format/tests/` for the exact proptest name): PASS.
+
+```bash
+git add -u
+git commit -m "Apply cast convention to MP3/ID3 synthesis (#133)"
+```
+
+---
+
+### Task 9: musefs-format — mp4.rs (26 sites)
+
+**Files:**
+- Modify: `musefs-format/src/mp4.rs`
+
+- [ ] **Step 1: Lossless widenings**
+
+`66,105,726,825,1042…` etc. (`u32 as u64`): `u64::from(x)`. `781,782,2099,
+2103` (`u32 as i64`): `i64::from(x)`.
+
+- [ ] **Step 2: `u64 → usize`** (box-walking slices: `116,319,321,942,1010,
+1256,1678,1726,2264,2265`): `usize_from`.
+
+- [ ] **Step 3: Box-size narrowings (`u64 → u32`)**
+
+`604,608` (`---- ` atom), `680,685` (`covr`/`data` sizes), `731,733,737`
+(`udta`/`meta`/`ilst` — these three sit right after an existing
+`return Err(FormatError::TooLarge)` guard), `836` (`new_moov_size`):
+all become `u32::try_from(x).map_err(|_| FormatError::TooLarge)?`. Where a
+fn is currently infallible (`build_dash_atom`-style returning `Vec<u8>`),
+make it return `Result<Vec<u8>, FormatError>` and `?` at callers — every
+transitive caller already returns `Result<_, FormatError>`. Where the
+explicit guard makes the `try_from` infallible, you may delete the guard if
+and only if the `try_from` error carries the same semantics (it does:
+`TooLarge`); otherwise keep both.
+`530,872,916` (`usize → u32`): same `TooLarge` pattern.
+`785` (`i64 → u32`): inspect the site — it converts a parsed value; use
+`u32::try_from(x).map_err(|_| FormatError::Malformed)?` since it's file
+input, not synthesized size.
+
+- [ ] **Step 4: Test-module sites** (`1306-1321,2070-2071,2307,2365-2394`):
+`.unwrap()` / `From` per the test rule.
+
+- [ ] **Step 5: Verify and commit**
+
+Clippy grepped to `musefs-format/src/mp4`: no output.
+`cargo test -p musefs-format mp4`: PASS.
+
+```bash
+git add -u
+git commit -m "Apply cast convention to MP4 synthesis (#133)"
+```
+
+---
+
+### Task 10: musefs-format — ogg/ and fuzz_check.rs
+
+**Files:**
+- Modify: `musefs-format/src/ogg/mod.rs`, `ogg/page.rs`, `ogg/b64.rs`, `ogg/crc.rs`, `fuzz_check.rs`
+
+- [ ] **Step 1: ogg/mod.rs (30 sites)**
+
+- `u64 → usize` (page/window arithmetic: `390,452,562,623,753,799,838,839,
+  871-874,903,934,964,1003,1169,1317`): `usize_from`.
+- `usize → u32` vorbis/picture length fields (`293,295,378,391,660-677,
+  1284`): `TooLarge` pattern (src) / `.unwrap()` (test mod ≥1284 — check:
+  1284 is inside `mod tests`; verify with the file).
+- `301` (`art.data_len as u32`): `TooLarge` pattern (same as flac.rs:205).
+- `269` (`u32 as i64` ×2), `341,1042` (`u32 as u64`): `From`.
+
+- [ ] **Step 2: ogg/page.rs (5 sites)**
+
+`73` (`(payload_len % 255) as u8`):
+`u8::try_from(payload_len % 255).expect("x % 255 < 256")`.
+`116,330` (`chunk as u8`, `seg_count as u8` — both bounded ≤255 by the
+lacing construction): `u8::try_from(x).expect("lacing builds at most 255 segments per page")`.
+`570` (test, `u64 → usize` ×2): `usize::try_from(*offset).unwrap()` etc.
+
+- [ ] **Step 3: ogg/b64.rs (8 sites) + ogg/crc.rs (1 site)**
+
+b64.rs:`32` (`(out_offset - g0 * 4) as usize` — bounded by base64 group
+arithmetic): `usize_from`. `63` (`u64 → u8` — inspect: it extracts a byte
+index into the alphabet, bounded by `% 64`-style masking):
+`u8::try_from(...).expect("…mask bound…")` matching what the expression
+guarantees. `65,72,73,76` (test-mod slicing): `usize_from` or
+`.try_from(...).unwrap()`.
+
+crc.rs:`11` (`(i as u32) << 24` in a `const fn` — `try_from` is not const):
+restructure the loop variable:
+
+```rust
+const fn build_table() -> [u32; 256] {
+    let mut t = [0u32; 256];
+    let mut i = 0u32;
+    while i < 256 {
+        let mut crc = i << 24;
+        ...
+        t[i as usize] = crc;   // u32 -> usize: widening on 64-bit, clippy-clean
+        i += 1;
+    }
+    t
+}
+```
+
+- [ ] **Step 4: fuzz_check.rs (12 sites — all fixture builders)**
+
+`64-66` (`usize → u8`), `89-93,123,189,220-228,401` (`usize → u32`): these
+build minimal valid files for fuzz seeds/tests; values are literal-bounded →
+`u8::try_from(x).unwrap()` / `u32::try_from(x).unwrap()`.
+
+- [ ] **Step 5: Verify and commit**
+
+Clippy grepped to `musefs-format/src`: **no output at all** (format crate now
+fully clean). `cargo test -p musefs-format`: PASS (includes the
+feature-gated proptests via the self-dev-dependency).
+
+```bash
+git add -u
+git commit -m "Apply cast convention to Ogg synthesis and fixtures (#133)"
+```
+
+---
+
+### Task 11: musefs-fuse and musefs-latencyfs
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs:339,383`
+- Modify: `musefs-latencyfs/src/lib.rs` (10 sites + local guard)
+
+- [ ] **Step 1: fuse (2 sites)**
+
+`339`: `size as u64` → `u64::from(size)`.
+`383`: `.skip(offset as usize)` → `.skip(usize_from(offset))` with
+`use musefs_core::convert::usize_from;` (the Task 1 re-export; fuse depends
+only on core). Do **not** touch `lib.rs:112` (`attr.mtime_secs as u64`) —
+clippy does not flag it (see spec); adding an `#[expect]` there would error
+as unfulfilled.
+
+- [ ] **Step 2: latencyfs**
+
+latencyfs is standalone (no musefs deps — keep it that way). Add at the top
+of `musefs-latencyfs/src/lib.rs` (after the existing inner attributes/imports):
+
+```rust
+// latencyfs is 64-bit-only, like the rest of the workspace (musefs-db's
+// convert module declares the same bound for the dependent crates).
+const _: () = assert!(
+    std::mem::size_of::<usize>() == 8,
+    "musefs-latencyfs supports 64-bit targets only"
+);
+```
+
+Then per site:
+- `159` (`nsec as u32` in the `t` closure — i64 nanoseconds, OS-guaranteed
+  `0..=999_999_999`): `u32::try_from(nsec).unwrap_or(0)`.
+- `174-178` (`m.nlink() as u32`? — inspect; MetadataExt returns u64 for
+  `nlink`/`rdev`/`blksize`): `u32::try_from(x).unwrap_or(u32::MAX)` — this
+  is a latency-measurement harness translating OS metadata to FUSE wire
+  types; saturation is harmless and honest.
+- `296,358` (`offset as usize`, `size as usize`): local
+  `#[expect(clippy::cast_possible_truncation, reason = "64-bit-only (const assert at top of file); u64 -> usize is lossless")]`
+  on the smallest enclosing item, or a local `fn usize_from(v: u64) -> usize`
+  clone of the db helper — pick the helper if both sites can share it.
+- `417-419` (statfs `s.f_bfree as u64` etc. — inspect: statfs fields are
+  already u64 on linux; the flagged ones are the `as u32` trio at the end:
+  `f_bsize/f_namemax/f_frsize`): `u32::try_from(x).unwrap_or(u32::MAX)`.
+- `502` (`reply.written(n as u32)` where n: usize from `write_at`):
+  `u32::try_from(n).unwrap_or(u32::MAX)` (a single write can't exceed u32 in
+  practice; saturate rather than panic in the harness).
+
+- [ ] **Step 3: Verify and commit**
+
+Clippy grepped to `musefs-fuse/src|musefs-latencyfs/src`: no output.
+`cargo test -p musefs-fuse -p musefs-latencyfs`: PASS.
+
+```bash
+git add -u
+git commit -m "Apply cast convention to fuse adapter and latencyfs (#133)"
+```
+
+---
+
+### Task 12: Test/bench fixture sweep (~190 sites)
+
+**Files:**
+- Modify: `musefs-core/tests/`, `musefs-core/benches/`, `musefs-format/tests/`,
+  `musefs-cli/tests/`, `musefs-db` test modules, `musefs-fuse` tests — as
+  enumerated by clippy.
+
+- [ ] **Step 1: Enumerate what's left**
+
+Run the shared-context clippy command with grep
+`-E 'tests/|benches/'`. Everything remaining is fixture code.
+
+- [ ] **Step 2: Apply the test rule mechanically**
+
+- `len() as u32` / `usize → u32` header fields in fixture builders
+  (`musefs-core/tests/common/corpus.rs:234,241`, `common/mod.rs:136,190`,
+  `musefs-cli/tests/scan.rs:26-30`, `musefs-format/tests/*` …):
+  `u32::try_from(x).unwrap()`.
+- `usize → u8` synthetic byte streams (`musefs-cli/tests/scan.rs:7-9` …):
+  `u8::try_from(x).unwrap()` — or restructure the iterator to produce u8
+  (`(0u8..=200)`) where it reads better.
+- `usize → i64` / `u64 → i64` into db params: `i64::try_from(x).unwrap()` —
+  but first check whether Task 2-4's field flips already removed the i64
+  target (then the cast just drops).
+- `u32 as u64` lossless (`musefs-format/tests/wav_synthesize.rs:166`,
+  `mp3_synthesize.rs:29-32` …): `u64::from(x)`.
+- `u64 → usize` slicing: `usize::try_from(x).unwrap()` (tests prefer the
+  loud form over the helper).
+
+- [ ] **Step 3: Verify the whole workspace is clean**
+
+Run the shared-context clippy command with **no** grep filter.
+Expected: zero warnings.
+
+- [ ] **Step 4: Run everything**
+
+Run: `cargo test`
+Expected: PASS (workspace, FUSE e2e still ignored).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "Apply cast convention to test and bench fixtures (#133)"
+```
+
+---
+
+### Task 13: Flip the lints, document the convention
+
+**Files:**
+- Modify: `Cargo.toml` (workspace lints block)
+- Modify: `CLAUDE.md` (Conventions section)
+
+- [ ] **Step 1: Flip the four lints and replace the stale comment**
+
+In the root `Cargo.toml`, replace:
+
+```toml
+# Explicit `as` casts are deliberate throughout the byte/offset arithmetic
+# (audio bounds, chunk sizes, FUSE inode/size fields); flagging every one is noise.
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+cast_lossless = "allow"
+```
+
+with:
+
+```toml
+# Integer-conversion convention (docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md):
+# widenings use `From`; u64->usize goes through musefs_db::convert::usize_from
+# (64-bit-only, compile-time guarded); genuine narrowings use `try_from`
+# (`?` on input-dependent values, `.expect`/`.unwrap` on structurally bounded
+# ones and in tests); deliberate bit-truncation carries a per-site `#[expect]`.
+cast_possible_truncation = "warn"
+cast_sign_loss = "warn"
+cast_possible_wrap = "warn"
+cast_lossless = "warn"
+```
+
+- [ ] **Step 2: Add the convention to CLAUDE.md**
+
+In `CLAUDE.md` under `## Conventions`, append one bullet:
+
+```markdown
+- Integer conversions: the four clippy cast lints are deny-via-CI. Widenings
+  use `From`; `u64 -> usize` only via `musefs_db::convert::usize_from`
+  (the workspace is declared 64-bit-only; `usize as u64` is fine); genuine
+  narrowings use `try_from` (`?` for input-dependent values, `.expect` for
+  structurally bounded ones, `.unwrap` in tests); deliberate bit-truncation
+  keeps `as` under a reasoned `#[expect]`. Non-negative db row fields are
+  unsigned; rusqlite's checked conversions validate at the row boundary.
+```
+
+- [ ] **Step 3: Verify both CI clippy gates pass**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean exit 0.
+Run: `cargo clippy -p musefs-db --features mutants --all-targets -- -D warnings`
+Expected: clean exit 0 (the `mutants` feature adds `derive(Default)` paths).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml CLAUDE.md
+git commit -m "Enforce the integer cast convention via clippy lints (#133)"
+```
+
+---
+
+### Task 14: Full validation sweep
+
+No new code — the gates, in order (stop and fix on any failure; re-run the
+failed gate after fixing):
+
+- [ ] **Step 1: Format check**
+
+Run: `cargo fmt --all --check`
+Expected: exit 0 (check the exit status directly, not just output).
+If it fails: `cargo fmt --all`, re-check, and amend the fix into a new commit.
+
+- [ ] **Step 2: Workspace tests + proptests**
+
+Run: `cargo test`
+Run: `cargo test -p musefs-format`
+Run: `cargo test -p musefs-core --test proptest_read_fidelity`
+Expected: all PASS — the byte-identical serve-path invariant must hold.
+
+- [ ] **Step 3: Fuzz targets still build (out-of-workspace crate)**
+
+Run, for each of flac mp3 mp4 ogg wav ogg_page b64 vorbiscomment:
+`cargo +nightly fuzz build <target>`
+Expected: builds. (Format-layer signature changes — the new `Result` returns
+from Task 9 — only surface here and in CI's smoke job.)
+
+- [ ] **Step 4: In-diff mutation gate (CI parity)**
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff   # MUST succeed — an empty diff is a silent false pass
+cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Do NOT set TMPDIR. Expected: no missed mutants. Notes: the diff is large and
+the run will be long; `convert::usize_from` mutations are killed by the
+existing read-path tests plus Task 1's range test. If a mutant in a
+`try_from(...).map_err(...)` arm survives because no test exercises the
+overflow, prefer adding a small unit test for that arm over an exclude.
+
+- [ ] **Step 5: FUSE end-to-end (real mount, this machine has /dev/fuse)**
+
+Run: `cargo test -p musefs-fuse -- --ignored`
+Expected: PASS.
+
+- [ ] **Step 6: Final commit (if validation produced fixes)**
+
+```bash
+git add -u
+git commit -m "Validation fixes for the cast convention migration (#133)"
+```
+
+---
+
+## Execution notes
+
+- Tasks 2-4 change db model types; between tasks the tree always compiles
+  and tests pass, but the cast lints stay quiet until Task 13 — use the
+  shared-context clippy command as your per-task progress meter.
+- Tasks 7-10 (format files) are independent of each other and of Task 11;
+  they can be parallelized across subagents if desired. Tasks 1→2→3→4 are
+  strictly ordered; Task 5 needs 1; Task 6 needs 1-4; Task 12 needs all
+  prior; 13 needs 12; 14 needs 13.
+- If clippy reveals sites this plan's lists miss (lists were generated from
+  one pre-migration run), classify them by the Shared-context rules — the
+  convention covers every case; the lists are navigation aids, not the spec.

--- a/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
+++ b/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
@@ -7,7 +7,8 @@ integer conversions: ~300 bare `as` casts
 ## Problem
 
 `musefs-core` and `musefs-format` (and the rest of the workspace) contain
-hundreds of bare `as` integer casts and almost no `try_from`. `as` silently
+hundreds of bare `as` integer casts (the issue estimates ~300; the measured
+lint baseline below is 451) and almost no `try_from`. `as` silently
 truncates/wraps, which matters at every i64↔u64 boundary and on 32-bit
 targets. The workspace `Cargo.toml` currently blanket-allows the four clippy
 cast lints with a "casts are deliberate" comment — a stance, but not a
@@ -85,13 +86,22 @@ version goes into CLAUDE.md's Conventions section.
     (bookkeeping counter).
   - `Art`/`ArtMeta`/`BinaryTagRow`: `byte_len` → `u64`; `width`/`height` →
     `u32` (Option-ness unchanged).
-  - `Tag`/`TrackArt`/`BinaryTag`: `ordinal` → `u64` (write side becomes a
-    clippy-clean `usize as u64`); `picture_type` → `u8` (APIC type byte).
+  - `Tag`/`TrackArt`/`BinaryTag`/`StructuralBlock`: `ordinal` → `u64`;
+    `picture_type` → `u8` (APIC type byte). `Tag::new`'s `ordinal: i64`
+    parameter (`models.rs:125`) flips with it. Write-side mechanics: the
+    `.enumerate()` sites become clippy-clean `usize as u64`, but the four
+    manual ordinal accumulators in `scan.rs` (`HashMap<String, i64>` at
+    scan.rs:421, 442, 509, 530) flip their value type to `u64` along with
+    their `*ord += 1` increments.
 - **New `convert.rs`**: `pub fn usize_from(v: u64) -> usize` containing the
   workspace's only pointer-width `#[expect(clippy::cast_possible_truncation)]`
   (latencyfs, standalone, carries its own), adjacent to the 64-bit const
   guard. db hosts it because it is the workspace's base
   crate and needs it itself (`art.rs:62`, `tags.rs:116`).
+- One write site is not dissolved by any field flip: `art.rs:97` computes
+  `byte_len` from data (`a.data.len() as i64`; `NewArt` has no `byte_len`
+  field). It becomes `a.data.len() as u64` (clippy-clean) through the
+  fallible `ToSql for u64`. Same pattern at `bulk.rs:111`.
 
 ### `musefs-core`
 
@@ -100,6 +110,15 @@ version goes into CLAUDE.md's Conventions section.
 - The manual negative-bounds check at `reader.rs:154-156` dissolves into the
   type system; `track.audio_offset as u64` reads and `as i64` writes in
   `reader.rs`/`scan.rs`/`mapping.rs` disappear.
+- A **second** guard dissolves: the negative-`byte_len` skip-with-warn at
+  `mapping.rs:46-53`. Once `ArtMeta.byte_len` is `u64`, the `< 0` comparison
+  is dead (`unused_comparisons`, a warn-by-default rustc lint that fires
+  under CI's `-D warnings` immediately — the guard must be removed in the
+  same step as the field flip). See Behavioral changes.
+- Read-side fallout in `mapping.rs:58-61`: `ta.picture_type as u32` becomes
+  `u32::from(...)` (a new `cast_lossless` site once `picture_type` is `u8`);
+  the `width`/`height` `as u32` and `byte_len as u64` casts (also
+  `mapping.rs:79`) vanish outright.
 
 ### `musefs-format`
 
@@ -122,7 +141,8 @@ version goes into CLAUDE.md's Conventions section.
 - Standalone by design (no musefs deps) — stays that way. Its ~10 sites are
   handled locally: fuser attr-struct `u64 as u32` fields fed from test
   fixtures get `try_from(...).expect(...)` or a local `#[expect]` with
-  reason, plus its own one-line guard for its single `u64 → usize`.
+  reason, plus its own one-line guard for its two `u64 → usize` sites
+  (lib.rs:296, lib.rs:358).
 
 ### Workspace `Cargo.toml`
 
@@ -134,7 +154,11 @@ version goes into CLAUDE.md's Conventions section.
 
 Dependency order so the tree compiles at each step:
 
-1. db model type flips + `convert.rs`.
+1. db model type flips + `convert.rs`. Dissolving guards
+   (`reader.rs:154-156`, `mapping.rs:46-53`) are removed in the same step as
+   their field flips: dead `< 0` comparisons trip rustc's warn-by-default
+   `unused_comparisons` under `-D warnings`, independent of the cast-lint
+   flip in step 5.
 2. Consumers: core, fuse, cli — including tests/ and benches/ (the hidden
    `--all-targets` consumers).
 3. format parser-internal narrowings.
@@ -146,10 +170,19 @@ The ~190 test/bench fixture sites are mechanical
 
 ## Behavioral changes
 
-Exactly one intended: a corrupt row (negative offset/length/byte_len written
-by an external tool) now errors at row-read (`FromSqlError::OutOfRange`)
-instead of relying on the single hand-rolled check in `reader.rs`. Everything
-else — including the byte-identical serve-path invariant — must be unchanged.
+Exactly two intended, both the same class — a corrupt row (negative value in
+a contract column written by an external tool) now errors at row-read
+(`FromSqlError::OutOfRange`) instead of being handled ad hoc:
+
+1. Negative `audio_offset`/`audio_length`/`backing_size`: previously caught
+   by the hand-rolled check at `reader.rs:154-156`.
+2. Negative art `byte_len`: previously **skipped with a warning**
+   (`mapping.rs:46-53`, art row dropped, track still served); now the track
+   resolve errors. Stricter, and consistent with decision 3's
+   validate-at-the-boundary rationale.
+
+Everything else — including the byte-identical serve-path invariant — must
+be unchanged.
 
 ## Validation
 

--- a/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
+++ b/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
@@ -1,0 +1,174 @@
+# Integer cast convention (issue #133)
+
+**Date:** 2026-06-06
+**Issue:** [#133](https://github.com/Sohex/musefs/issues/133) — No convention for
+integer conversions: ~300 bare `as` casts
+
+## Problem
+
+`musefs-core` and `musefs-format` (and the rest of the workspace) contain
+hundreds of bare `as` integer casts and almost no `try_from`. `as` silently
+truncates/wraps, which matters at every i64↔u64 boundary and on 32-bit
+targets. The workspace `Cargo.toml` currently blanket-allows the four clippy
+cast lints with a "casts are deliberate" comment — a stance, but not a
+convention anything enforces per-site.
+
+Measured baseline (clippy with the four lints force-enabled, 64-bit host):
+**451 violations** — 409 cast warnings + 42 `cast_lossless` — of which ~190
+are in tests/benches fixture code. Dominant classes:
+
+| Class | Count | Disposition |
+| --- | --- | --- |
+| `u64 → usize` | 150 | sanctioned helper (64-bit guard) |
+| `usize → u32` | 117 | genuine narrowing; mostly test fixtures |
+| `usize → i64` | 50 | db writes — mostly dissolved by db type change |
+| `usize → u8` | 29 | test fixtures |
+| `u64 → u32` | 22 | narrowing; individual judgment |
+| `u64 → i64` / `i64 → u64`-family | 37 | db boundary — dissolved by db type change |
+| `u32/u64 → u8` byte extraction | 4 | restructure (`to_be_bytes`) or `#[expect]` |
+| `cast_lossless` (widening via `as`) | 42 | mechanical `From` fixes |
+
+## Decisions taken
+
+1. **64-bit only, declared.** musefs supports 64-bit targets only, enforced by
+   a compile-time guard (`const _: () = assert!(size_of::<usize>() == 8, ...)`).
+   This makes usize↔u64 lossless by construction.
+2. **Convention + lints + full migration.** All four cast lints flip from
+   `allow` to `warn` in `[workspace.lints.clippy]`; CI's `-D warnings` makes
+   them hard gates. All existing violations are migrated — the lints then
+   enforce the convention permanently.
+3. **Type-driven at the db boundary.** Non-negative quantities in
+   `musefs-db` row structs become unsigned; i64 is confined to the db layer.
+   Rationale: the SQLite store is the declared interface external tools
+   (beets/Picard) write to out-of-band, so row values are untrusted input.
+   Today a negative `audio_offset` wraps via `as u64` into a huge offset
+   (guarded only by one hand-rolled check at `musefs-core/src/reader.rs:154`).
+   rusqlite 0.40 already ships checked conversions — `FromSql for u64`
+   errors `OutOfRange` on negative values, `ToSql for u64` is fallible above
+   `i64::MAX` — so validation happens once at the row boundary through the
+   existing `rusqlite::Error → DbError → CoreError` chain. No new error
+   variants.
+
+## The convention
+
+Replaces the "casts are deliberate" comment block in `Cargo.toml`; a short
+version goes into CLAUDE.md's Conventions section.
+
+1. **Widening** (`u8/u16/u32` → wider): use `From` (`u64::from(x)`), never
+   `as`. Enforced by `cast_lossless`.
+2. **usize↔u64**: 64-bit-only is declared by the compile-time guard.
+   `usize as u64` is fine (clippy-clean on supported targets). `u64 → usize`
+   goes through the sanctioned helper `convert::usize_from(u64)` — the one
+   place a pointer-width truncation `#[expect]` lives.
+3. **Genuine narrowing** (`u64→u32`, `usize→u32`, `→u8`): prefer
+   restructuring (`to_be_bytes`/`from_be_bytes`, indexing); else `try_from` —
+   propagated with `?` where the value is input-dependent (parser/file data),
+   `.expect()` in tests and fixture builders where values are
+   literal-bounded.
+4. **i64 never crosses the db boundary upward** for non-negative quantities.
+   Row structs expose unsigned types; rusqlite does the checked conversion at
+   both ends.
+5. **Deliberate bit-truncation** keeps `as` with an inline
+   `#[expect(clippy::..., reason = "...")]` — expected to be rare once byte
+   extraction moves to `to_be_bytes`.
+
+## Component changes
+
+### `musefs-db`
+
+- **`models.rs` type flips** (SQLite schema, migrations, and the generated
+  Python `schema.py` are untouched — storage stays `INTEGER`; only Rust-side
+  types change):
+  - `Track`/`NewTrack`: `audio_offset`, `audio_length`, `backing_size` →
+    `u64`. **Stay i64:** `backing_mtime` (pre-1970 mtimes are legal),
+    `updated_at` (trigger-set timestamp), `id` (rowid), `content_version`
+    (bookkeeping counter).
+  - `Art`/`ArtMeta`/`BinaryTagRow`: `byte_len` → `u64`; `width`/`height` →
+    `u32` (Option-ness unchanged).
+  - `Tag`/`TrackArt`/`BinaryTag`: `ordinal` → `u64` (write side becomes a
+    clippy-clean `usize as u64`); `picture_type` → `u8` (APIC type byte).
+- **New `convert.rs`**: `pub fn usize_from(v: u64) -> usize` containing the
+  workspace's only pointer-width `#[expect(clippy::cast_possible_truncation)]`
+  (latencyfs, standalone, carries its own), adjacent to the 64-bit const
+  guard. db hosts it because it is the workspace's base
+  crate and needs it itself (`art.rs:62`, `tags.rs:116`).
+
+### `musefs-core`
+
+- Re-export the helper (`pub use musefs_db::convert;`) so `musefs-fuse`
+  (which depends only on core) can reach it without a new dependency edge.
+- The manual negative-bounds check at `reader.rs:154-156` dissolves into the
+  type system; `track.audio_offset as u64` reads and `as i64` writes in
+  `reader.rs`/`scan.rs`/`mapping.rs` disappear.
+
+### `musefs-format`
+
+- Parser-internal narrowings get individual judgment: already-bounds-checked
+  values keep a justified path (restructure or helper); input-dependent ones
+  get `try_from` + `?` into the existing per-format error.
+
+### `musefs-fuse`, `musefs-cli`
+
+- A handful of sites; use the re-exported helper / `try_from` per the
+  convention.
+- One special case: `attr.mtime_secs as u64` (`musefs-fuse/src/lib.rs:111`)
+  is a real sign-loss on a legitimately-negative value (pre-1970 mtime wraps
+  to a far-future date today). Fixing that display behavior is out of scope —
+  the site keeps `as` with an `#[expect(clippy::cast_sign_loss, reason)]`
+  documenting the pre-existing limitation.
+
+### `musefs-latencyfs`
+
+- Standalone by design (no musefs deps) — stays that way. Its ~10 sites are
+  handled locally: fuser attr-struct `u64 as u32` fields fed from test
+  fixtures get `try_from(...).expect(...)` or a local `#[expect]` with
+  reason, plus its own one-line guard for its single `u64 → usize`.
+
+### Workspace `Cargo.toml`
+
+- `cast_possible_truncation`, `cast_sign_loss`, `cast_possible_wrap`,
+  `cast_lossless` flip from `allow` to `warn`. Lands **last**, once the
+  workspace is warning-clean.
+
+## Migration order
+
+Dependency order so the tree compiles at each step:
+
+1. db model type flips + `convert.rs`.
+2. Consumers: core, fuse, cli — including tests/ and benches/ (the hidden
+   `--all-targets` consumers).
+3. format parser-internal narrowings.
+4. latencyfs local fixes.
+5. Lint flip in workspace `Cargo.toml` + convention comment + CLAUDE.md note.
+
+The ~190 test/bench fixture sites are mechanical
+(`u32::try_from(len).unwrap()` or typed literals).
+
+## Behavioral changes
+
+Exactly one intended: a corrupt row (negative offset/length/byte_len written
+by an external tool) now errors at row-read (`FromSqlError::OutOfRange`)
+instead of relying on the single hand-rolled check in `reader.rs`. Everything
+else — including the byte-identical serve-path invariant — must be unchanged.
+
+## Validation
+
+- `cargo clippy --all-targets -- -D warnings` clean, **and** the
+  `-p musefs-db --features mutants --all-targets` variant (both CI gates) —
+  the enforcement proof.
+- Full test suite + proptests (`cargo test`, `cargo test -p musefs-format`,
+  `cargo test -p musefs-core --test proptest_read_fidelity`).
+- `cargo +nightly fuzz build` for all targets — the fuzz crate is
+  out-of-workspace and otherwise only breaks in CI's smoke job.
+- In-diff mutation gate (`-j2`, output on `/tmp`, non-empty-diff sanity
+  check). Known risk: a large mechanical diff makes the run long;
+  `usize_from` is a mutation target whose kills come from existing read-path
+  tests.
+- `cargo fmt --all --check` before push.
+
+## Out of scope
+
+- SQLite schema or migration changes (none needed).
+- Python plugin / `schema.py` changes (schema unchanged).
+- Any behavioral change beyond the corrupt-row read error above.
+- 32-bit target support (explicitly declared unsupported instead).

--- a/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
+++ b/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
@@ -87,7 +87,11 @@ version goes into CLAUDE.md's Conventions section.
   - `Art`/`ArtMeta`/`BinaryTagRow`: `byte_len` → `u64`; `width`/`height` →
     `u32` (Option-ness unchanged).
   - `Tag`/`TrackArt`/`BinaryTag`/`StructuralBlock`: `ordinal` → `u64`;
-    `picture_type` → `u8` (APIC type byte). `Tag::new`'s `ordinal: i64`
+    `picture_type` → `u32` (FLAC's `METADATA_BLOCK_PICTURE` type field is
+    natively u32 and `ArtInput.picture_type` is already u32, so u32 keeps
+    scan-side ingestion lossless; the only narrower consumer is mp3's APIC
+    framing, which keeps its pre-existing deliberate one-byte truncation
+    under an `#[expect]`). `Tag::new`'s `ordinal: i64`
     parameter (`models.rs:125`) flips with it. Write-side mechanics: the
     `.enumerate()` sites become clippy-clean `usize as u64`, but the four
     manual ordinal accumulators in `scan.rs` (`HashMap<String, i64>` at
@@ -115,10 +119,9 @@ version goes into CLAUDE.md's Conventions section.
   is dead (`unused_comparisons`, a warn-by-default rustc lint that fires
   under CI's `-D warnings` immediately — the guard must be removed in the
   same step as the field flip). See Behavioral changes.
-- Read-side fallout in `mapping.rs:58-61`: `ta.picture_type as u32` becomes
-  `u32::from(...)` (a new `cast_lossless` site once `picture_type` is `u8`);
-  the `width`/`height` `as u32` and `byte_len as u64` casts (also
-  `mapping.rs:79`) vanish outright.
+- Read-side fallout in `mapping.rs:58-61`: the `ta.picture_type as u32`,
+  `width`/`height` `as u32`, and `byte_len as u64` casts (also
+  `mapping.rs:79`) all vanish outright.
 
 ### `musefs-format`
 
@@ -130,11 +133,11 @@ version goes into CLAUDE.md's Conventions section.
 
 - A handful of sites; use the re-exported helper / `try_from` per the
   convention.
-- One special case: `attr.mtime_secs as u64` (`musefs-fuse/src/lib.rs:111`)
-  is a real sign-loss on a legitimately-negative value (pre-1970 mtime wraps
-  to a far-future date today). Fixing that display behavior is out of scope —
-  the site keeps `as` with an `#[expect(clippy::cast_sign_loss, reason)]`
-  documenting the pre-existing limitation.
+- Note: `attr.mtime_secs as u64` (`musefs-fuse/src/lib.rs:112`) is guarded by
+  `if attr.mtime_secs > 0` and clippy's `cast_sign_loss` does not flag it, so
+  it needs no change (an `#[expect]` there would error as unfulfilled).
+  fuse's actual sites are `lib.rs:339` (lossless `u32 as u64`) and
+  `lib.rs:383` (`u64 → usize`).
 
 ### `musefs-latencyfs`
 

--- a/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
+++ b/docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md
@@ -99,8 +99,9 @@ version goes into CLAUDE.md's Conventions section.
     their `*ord += 1` increments.
 - **New `convert.rs`**: `pub fn usize_from(v: u64) -> usize` containing the
   workspace's only pointer-width `#[expect(clippy::cast_possible_truncation)]`
-  (latencyfs, standalone, carries its own), adjacent to the 64-bit const
-  guard. db hosts it because it is the workspace's base
+  for the db/core/fuse/cli stack (musefs-format carries its own crate-local
+  sibling — see below — and latencyfs, standalone, carries its own), adjacent
+  to the 64-bit const guard. db hosts it because it is the workspace's base
   crate and needs it itself (`art.rs:62`, `tags.rs:116`).
 - One write site is not dissolved by any field flip: `art.rs:97` computes
   `byte_len` from data (`a.data.len() as i64`; `NewArt` has no `byte_len`
@@ -128,15 +129,21 @@ version goes into CLAUDE.md's Conventions section.
 - Parser-internal narrowings get individual judgment: already-bounds-checked
   values keep a justified path (restructure or helper); input-dependent ones
   get `try_from` + `?` into the existing per-format error.
+- musefs-db is a DEV-dependency of musefs-format only (to avoid linking SQLite
+  into production format builds and the out-of-workspace fuzz targets), so
+  musefs-format carries its own crate-local `convert` sibling — a single
+  `usize_from` function with its own `#[expect(clippy::cast_possible_truncation)]`
+  and 64-bit guard — rather than re-exporting `musefs_db::convert`.
 
 ### `musefs-fuse`, `musefs-cli`
 
 - A handful of sites; use the re-exported helper / `try_from` per the
   convention.
 - Note: `attr.mtime_secs as u64` (`musefs-fuse/src/lib.rs:112`) is guarded by
-  `if attr.mtime_secs > 0` and clippy's `cast_sign_loss` does not flag it, so
-  it needs no change (an `#[expect]` there would error as unfulfilled).
-  fuse's actual sites are `lib.rs:339` (lossless `u32 as u64`) and
+  `if attr.mtime_secs > 0`, but clippy's `cast_sign_loss` flags it regardless
+  of the runtime guard. It was fixed with
+  `u64::try_from(...).expect("guarded by mtime_secs > 0")`.
+  fuse's other sites are `lib.rs:339` (lossless `u32 as u64`) and
   `lib.rs:383` (`u64 → usize`).
 
 ### `musefs-latencyfs`

--- a/musefs-cli/tests/scan.rs
+++ b/musefs-cli/tests/scan.rs
@@ -4,9 +4,9 @@ fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();
     out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
     let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
+    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
+    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
+    out.push(u8::try_from(len & 0xFF).unwrap());
     out.extend_from_slice(body);
     out
 }
@@ -23,11 +23,11 @@ fn streaminfo_body() -> Vec<u8> {
 fn vorbis_comment_body(comments: &[&str]) -> Vec<u8> {
     let vendor = "orig";
     let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
     out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
     for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
         out.extend_from_slice(c.as_bytes());
     }
     out

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
+use musefs_db::convert::usize_from;
 use musefs_db::{Db, Format};
 
 use crate::db_pool::DbPool;
@@ -84,7 +85,7 @@ fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
     meta.modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs() as i64)
+        .map_or(0, |d| d.as_secs().cast_signed())
 }
 
 fn validate_opened_backing(file: &std::fs::File, resolved: &ResolvedFile) -> Result<()> {
@@ -175,7 +176,7 @@ impl Fh {
 
     /// Sole site of the `-1`: handle → slab key.
     fn slab_key(self) -> usize {
-        (self.0.get() - 1) as usize
+        usize_from(self.0.get() - 1)
     }
 
     /// The raw wire value handed to the kernel.

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -15,6 +15,7 @@ mod tree;
 pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
 pub use facade::{Attr, Fh, Mode, MountConfig, Musefs};
+pub use musefs_db::convert;
 pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -281,4 +281,64 @@ mod tests {
             "negative byte_len must error at row-read, not be skipped"
         );
     }
+
+    #[test]
+    fn track_art_images_reads_stored_blob_bytes() {
+        use musefs_db::{NewArt, TrackArt};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art.db");
+        let db = Db::open(&path).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let first = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3, 4],
+            })
+            .unwrap();
+        let second = db
+            .upsert_art(&NewArt {
+                mime: "image/jpeg".into(),
+                width: None,
+                height: None,
+                data: vec![7, 8, 9],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[
+                TrackArt {
+                    art_id: first,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 0,
+                },
+                TrackArt {
+                    art_id: second,
+                    picture_type: 4,
+                    description: String::new(),
+                    ordinal: 1,
+                },
+            ],
+        )
+        .unwrap();
+
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        let images = super::track_art_images(&db, &inputs).unwrap();
+        assert_eq!(
+            images,
+            vec![vec![1, 2, 3, 4], vec![7, 8, 9]],
+            "must return each stored blob's exact bytes, in input order"
+        );
+    }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -40,25 +40,14 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
         // `track_art.art_id` is a foreign key into `art` (enforced, no ON DELETE),
         // so the row always exists; the `if let` is defensive, not a real branch.
         if let Some(meta) = db.get_art_meta(ta.art_id)? {
-            // A negative byte_len is a malformed external write to the contract
-            // column; skip the row rather than cast it to a huge u64 segment
-            // length (which would fail layout validation and break the track).
-            if meta.byte_len < 0 {
-                log::warn!(
-                    "skipping art {} on track {track_id}: negative byte_len {} (malformed DB write)",
-                    ta.art_id,
-                    meta.byte_len
-                );
-                continue;
-            }
             inputs.push(ArtInput {
                 art_id: ta.art_id,
                 mime: meta.mime,
                 description: ta.description,
                 picture_type: ta.picture_type as u32,
-                width: meta.width.unwrap_or(0) as u32,
-                height: meta.height.unwrap_or(0) as u32,
-                data_len: meta.byte_len as u64,
+                width: meta.width.unwrap_or(0),
+                height: meta.height.unwrap_or(0),
+                data_len: meta.byte_len,
             });
         }
     }
@@ -76,7 +65,7 @@ pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<
         .map(|row| BinaryTagInput {
             key: row.key,
             payload_id: row.rowid,
-            len: row.byte_len as u64,
+            len: row.byte_len,
         })
         .collect())
 }
@@ -88,7 +77,7 @@ pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<
 pub(crate) fn track_art_images<M>(db: &Db<M>, inputs: &[ArtInput]) -> Result<Vec<Vec<u8>>> {
     let mut out = Vec::with_capacity(inputs.len());
     for a in inputs {
-        out.push(db.read_art_chunk(a.art_id, 0, a.data_len as usize)?);
+        out.push(db.read_art_chunk(a.art_id, 0, musefs_db::convert::usize_from(a.data_len))?);
     }
     Ok(out)
 }
@@ -209,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn track_art_to_inputs_skips_negative_byte_len() {
+    fn track_art_to_inputs_errors_on_negative_byte_len() {
         use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("art.db");
@@ -240,9 +229,6 @@ mod tests {
                 data: vec![9, 9, 9, 9, 9],
             })
             .unwrap();
-        // A zero-byte_len row pins the guard's strict `<`: only *negative* is
-        // skipped, so byte_len == 0 must still be kept (distinguishes `< 0` from
-        // `<= 0`).
         let zero = db
             .upsert_art(&NewArt {
                 mime: "image/png".into(),
@@ -276,20 +262,23 @@ mod tests {
         )
         .unwrap();
 
-        // Simulate external malformed writes: byte_len is a stored column.
+        // byte_len == 0 is valid and must still be served (was the old
+        // strict-`<` pin; now pins that zero passes the u64 row-read).
         let raw = rusqlite::Connection::open(&path).unwrap();
-        raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
-            .unwrap();
         raw.execute("UPDATE art SET byte_len = 0 WHERE id = ?1", [zero])
             .unwrap();
-        drop(raw);
-
         let inputs = super::track_art_to_inputs(&db, tid).unwrap();
         let ids: Vec<i64> = inputs.iter().map(|a| a.art_id).collect();
-        assert_eq!(
-            ids,
-            vec![good, zero],
-            "negative byte_len is skipped; zero is kept (strict `<`)"
+        assert_eq!(ids, vec![good, bad, zero]);
+
+        // A negative byte_len is a malformed external write to the contract
+        // column: it now errors at row-read instead of being skipped.
+        raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
+            .unwrap();
+        drop(raw);
+        assert!(
+            super::track_art_to_inputs(&db, tid).is_err(),
+            "negative byte_len must error at row-read, not be skipped"
         );
     }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -44,7 +44,7 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
                 art_id: ta.art_id,
                 mime: meta.mime,
                 description: ta.description,
-                picture_type: ta.picture_type as u32,
+                picture_type: ta.picture_type,
                 width: meta.width.unwrap_or(0),
                 height: meta.height.unwrap_or(0),
                 data_len: meta.byte_len,
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
     use musefs_db::{BinaryTag, Db, Format, NewTrack};
 
-    fn tag(key: &str, value: &str, ordinal: i64) -> Tag {
+    fn tag(key: &str, value: &str, ordinal: u64) -> Tag {
         Tag::new(key, value, ordinal)
     }
 

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -8,7 +8,9 @@ use std::os::unix::fs::FileExt;
 
 use musefs_format::ogg::{patch_page_header_algebraic, verify_page_crc};
 
-use crate::error::{CoreError, Result};
+use musefs_db::convert::usize_from;
+
+use crate::error::Result;
 
 /// A one-entry memo of the most-recently-served page: `(page offset within the
 /// audio region, page total length, patched header bytes)`. Lives on the resolved
@@ -73,7 +75,7 @@ fn find_page_start(
     let scan_start = abs_target
         .saturating_sub(MAX_OGG_PAGE_BYTES)
         .max(audio_offset);
-    let window_len = (abs_target - scan_start) as usize;
+    let window_len = usize_from(abs_target - scan_start);
     let mut window = vec![0u8; window_len];
     read_counted(backing, &mut window, scan_start)?;
 
@@ -166,7 +168,7 @@ pub fn serve_ogg_window(
         }
         // One pread for the full header (27 + up to 255 seg-table bytes).
         // Clamped to the declared audio region end.
-        let read_len = MAX_OGG_HEADER_BYTES.min((audio_end - pos) as usize);
+        let read_len = MAX_OGG_HEADER_BYTES.min(usize_from(audio_end - pos));
         let mut hdr_buf = vec![0u8; read_len];
         read_counted(backing, &mut hdr_buf, pos)?;
         if hdr_buf.len() < 27 {
@@ -195,8 +197,9 @@ pub fn serve_ogg_window(
             h
         } else {
             let old_seq = u32::from_le_bytes(hdr_buf[18..22].try_into().unwrap());
-            let new_seq = (old_seq as i64 + seq_delta) as u32;
-            patch_page_header_algebraic(&hdr_buf[..header_len], new_seq).map_err(CoreError::from)?
+            let new_seq = u32::try_from(i64::from(old_seq) + seq_delta)
+                .map_err(|_| musefs_format::FormatError::Malformed)?;
+            patch_page_header_algebraic(&hdr_buf[..header_len], new_seq)?
         };
         if let Some(m) = memo {
             let total_len = (header_len + payload_len) as u64;
@@ -211,8 +214,8 @@ pub fn serve_ogg_window(
         let hs = rstart.max(page_rel);
         let he = rend.min(hdr_end);
         if hs < he {
-            let a = (hs - page_rel) as usize;
-            let b = (he - page_rel) as usize;
+            let a = usize_from(hs - page_rel);
+            let b = usize_from(he - page_rel);
             out.extend_from_slice(&patched_hdr[a..b]);
         }
 
@@ -221,7 +224,7 @@ pub fn serve_ogg_window(
         let pe = rend.min(page_end);
         if ps < pe {
             let within = ps - hdr_end;
-            let n = (pe - ps) as usize;
+            let n = usize_from(pe - ps);
             let start = out.len();
             out.resize(start + n, 0);
             read_counted(backing, &mut out[start..], pos + header_len as u64 + within)?;
@@ -385,7 +388,7 @@ mod tests {
         let mut comment = Vec::new();
         comment.push(0x84);
         let vc = b"\x06\x00\x00\x00musefs\x00\x00\x00\x00";
-        comment.extend_from_slice(&[0, 0, vc.len() as u8]);
+        comment.extend_from_slice(&[0, 0, u8::try_from(vc.len()).unwrap()]);
         comment.extend_from_slice(vc);
         let audio0 = vec![0xC1u8; 6000];
         let file = build_codec_file(0x3333, &[&p0, &comment], &[&audio0]);
@@ -418,7 +421,7 @@ mod tests {
     fn new_reference_region(path: &std::path::Path, ao: u64, alen: u64) -> Vec<u8> {
         use musefs_format::ogg::{parse_page, patch_page_header};
         let backing = std::fs::File::open(path).unwrap();
-        let mut full = vec![0u8; alen as usize];
+        let mut full = vec![0u8; usize_from(alen)];
         backing.read_exact_at(&mut full, ao).unwrap();
         let mut out = Vec::new();
         let mut pos = 0usize;
@@ -542,7 +545,7 @@ mod tests {
         // Exactly the whole header of page 0.
         assert_eq!(
             new_serve_range(&path, ao, alen, 0, hlen),
-            want[..hlen as usize]
+            want[..usize_from(hlen)]
         );
     }
 
@@ -560,7 +563,7 @@ mod tests {
         let end = hlen + 60;
         assert_eq!(
             new_serve_range(&path, ao, alen, start, end),
-            want[start as usize..end as usize]
+            want[usize_from(start)..usize_from(end)]
         );
     }
 
@@ -576,7 +579,7 @@ mod tests {
         let r = (hlen - 5)..(hlen + 20);
         assert_eq!(
             new_serve_range(&path, ao, alen, r.start, r.end),
-            want[r.start as usize..r.end as usize]
+            want[usize_from(r.start)..usize_from(r.end)]
         );
     }
 
@@ -592,7 +595,7 @@ mod tests {
         let r = (p0_end - 30)..(p0_end + 40);
         assert_eq!(
             new_serve_range(&path, ao, alen, r.start, r.end),
-            want[r.start as usize..r.end as usize]
+            want[usize_from(r.start)..usize_from(r.end)]
         );
     }
 
@@ -607,7 +610,7 @@ mod tests {
         // rend clamped to region end.
         assert_eq!(
             new_serve_range(&path, ao, alen, alen - 25, alen + 1000),
-            want[(alen - 25) as usize..]
+            want[usize_from(alen - 25)..]
         );
     }
 

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -115,7 +115,7 @@ impl HeaderCache {
         // on a cache hit, because the audio region may have shifted.
         crate::metrics::on_stat();
         let meta = std::fs::metadata(&track.backing_path)?;
-        if meta.len() != track.backing_size as u64 || mtime_secs(&meta) != track.backing_mtime {
+        if meta.len() != track.backing_size || mtime_secs(&meta) != track.backing_mtime {
             return Err(CoreError::BackingChanged(track.backing_path.clone()));
         }
 
@@ -151,11 +151,7 @@ impl HeaderCache {
                 // bound, or an audio region that runs past the end of the backing file,
                 // means the row no longer matches the file. Only synthesis splices at
                 // these bounds, so the check is scoped to this mode.
-                if track.audio_offset < 0
-                    || track.audio_length < 0
-                    || (track.audio_offset as u64).saturating_add(track.audio_length as u64)
-                        > meta.len()
-                {
+                if track.audio_offset.saturating_add(track.audio_length) > meta.len() {
                     return Err(CoreError::BackingChanged(track.backing_path.clone()));
                 }
 
@@ -177,10 +173,8 @@ impl HeaderCache {
                         // are not emitted twice.
                         let (structural, binary_tags): (Vec<MetadataBlock>, &[BinaryTagInput]) =
                             if rows.is_empty() {
-                                let front = read_front(
-                                    Path::new(&track.backing_path),
-                                    track.audio_offset as u64,
-                                )?;
+                                let front =
+                                    read_front(Path::new(&track.backing_path), track.audio_offset)?;
                                 (flac::read_metadata(&front)?.preserved, &[])
                             } else {
                                 let structural = rows
@@ -198,16 +192,16 @@ impl HeaderCache {
                             };
                         flac::synthesize_layout(
                             &structural,
-                            track.audio_offset as u64,
-                            track.audio_length as u64,
+                            track.audio_offset,
+                            track.audio_length,
                             &inputs,
                             binary_tags,
                             &art_inputs,
                         )?
                     }
                     Format::Mp3 => mp3::synthesize_layout(
-                        track.audio_offset as u64,
-                        track.audio_length as u64,
+                        track.audio_offset,
+                        track.audio_length,
                         &inputs,
                         &binary_tag_inputs,
                         &art_inputs,
@@ -247,21 +241,19 @@ impl HeaderCache {
                     Format::Wav => {
                         // Read only the front (RIFF header + fmt/fact); the data
                         // payload is served from the backing file at read time.
-                        let front =
-                            read_front(Path::new(&track.backing_path), track.audio_offset as u64)?;
+                        let front = read_front(Path::new(&track.backing_path), track.audio_offset)?;
                         let scan = wav::read_structure(&front)?;
                         wav::synthesize_layout(
                             &scan,
-                            track.audio_offset as u64,
-                            track.audio_length as u64,
+                            track.audio_offset,
+                            track.audio_length,
                             &inputs,
                             &binary_tag_inputs,
                             &art_inputs,
                         )?
                     }
                     Format::Opus | Format::Vorbis | Format::OggFlac => {
-                        let front =
-                            read_front(Path::new(&track.backing_path), track.audio_offset as u64)?;
+                        let front = read_front(Path::new(&track.backing_path), track.audio_offset)?;
                         let header = musefs_format::ogg::read_metadata(&front)?;
                         let art_images = crate::mapping::track_art_images(db, &art_inputs)?;
                         let arts: Vec<musefs_format::ogg::OggArt> = art_inputs
@@ -274,8 +266,8 @@ impl HeaderCache {
                             .collect();
                         musefs_format::ogg::synthesize_layout(
                             &header,
-                            track.audio_offset as u64,
-                            track.audio_length as u64,
+                            track.audio_offset,
+                            track.audio_length,
                             &inputs,
                             &arts,
                         )?
@@ -300,7 +292,7 @@ impl HeaderCache {
             total_len,
             content_version: track.content_version,
             backing_path: PathBuf::from(&track.backing_path),
-            backing_size: track.backing_size as u64,
+            backing_size: track.backing_size,
             backing_mtime_secs: track.backing_mtime,
             mtime_secs: mtime_secs_val,
             last_page: Mutex::new(None),
@@ -585,9 +577,9 @@ mod resolve_ogg_tests {
             .upsert_track(&NewTrack {
                 backing_path: path.to_string_lossy().into_owned(),
                 format: Format::Opus,
-                audio_offset: audio_offset as i64,
-                audio_length: audio_length as i64,
-                backing_size: meta.len() as i64,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap();
@@ -624,9 +616,9 @@ mod resolve_ogg_tests {
             .upsert_track(&NewTrack {
                 backing_path: path.to_string_lossy().into_owned(),
                 format: Format::Opus,
-                audio_offset: audio_offset as i64,
-                audio_length: audio_length as i64,
-                backing_size: meta.len() as i64,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap();
@@ -681,9 +673,9 @@ mod resolve_ogg_tests {
             .upsert_track(&NewTrack {
                 backing_path: path.to_string_lossy().into_owned(),
                 format: Format::Wav,
-                audio_offset: audio_offset as i64,
-                audio_length: audio_length as i64,
-                backing_size: meta.len() as i64,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap();
@@ -720,9 +712,9 @@ mod resolve_ogg_tests {
             .upsert_track(&NewTrack {
                 backing_path: path.to_string_lossy().into_owned(),
                 format: Format::Opus,
-                audio_offset: audio_offset as i64,
-                audio_length: audio_length as i64,
-                backing_size: meta.len() as i64,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap();
@@ -877,7 +869,7 @@ mod cache_bound_tests {
                 format: Format::Flac,
                 audio_offset,
                 audio_length,
-                backing_size: meta.len() as i64,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap();
@@ -905,7 +897,7 @@ mod cache_bound_tests {
                 format: Format::Flac,
                 audio_offset,
                 audio_length,
-                backing_size: meta.len() as i64,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap()
@@ -941,7 +933,7 @@ mod cache_bound_tests {
                 format: Format::Flac,
                 audio_offset,
                 audio_length,
-                backing_size: meta.len() as i64,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap()
@@ -973,7 +965,7 @@ mod cache_bound_tests {
                 format: Format::Flac,
                 audio_offset,
                 audio_length,
-                backing_size: meta.len() as i64,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap()
@@ -1008,8 +1000,8 @@ mod cache_bound_tests {
 
     fn track_with_bounds(
         path: &std::path::Path,
-        audio_offset: i64,
-        audio_length: i64,
+        audio_offset: u64,
+        audio_length: u64,
     ) -> (musefs_db::Db, i64) {
         use musefs_db::{Format, NewTrack};
         let db = musefs_db::Db::open_in_memory().unwrap();
@@ -1020,7 +1012,7 @@ mod cache_bound_tests {
                 format: Format::Flac,
                 audio_offset,
                 audio_length,
-                backing_size: meta.len() as i64,
+                backing_size: meta.len(),
                 backing_mtime: mtime_secs(&meta),
             })
             .unwrap();
@@ -1032,7 +1024,7 @@ mod cache_bound_tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("a.flac");
         let _ = write_flac_local(&path);
-        let len = std::fs::metadata(&path).unwrap().len() as i64;
+        let len = std::fs::metadata(&path).unwrap().len();
         let (db, id) = track_with_bounds(&path, len, 5);
         let cache = HeaderCache::new(Mode::Synthesis);
         assert!(matches!(
@@ -1075,7 +1067,7 @@ mod cache_bound_tests {
         assert_eq!(resolved.cache_bytes, inline_sum);
     }
 
-    fn write_flac_local(path: &std::path::Path) -> (i64, i64) {
+    fn write_flac_local(path: &std::path::Path) -> (u64, u64) {
         fn block(bt: u8, body: &[u8], last: bool) -> Vec<u8> {
             let mut v = vec![(if last { 0x80 } else { 0 }) | (bt & 0x7F)];
             let n = body.len();
@@ -1097,10 +1089,10 @@ mod cache_bound_tests {
         out.extend(block(0, &si, false));
         out.extend(block(4, &vc, true));
         let audio = [0xABu8; 256];
-        let audio_offset = out.len() as i64;
+        let audio_offset = out.len() as u64;
         out.extend_from_slice(&audio);
         std::fs::write(path, &out).unwrap();
-        (audio_offset, audio.len() as i64)
+        (audio_offset, audio.len() as u64)
     }
 
     #[test]
@@ -1172,9 +1164,9 @@ mod binary_tag_serve_tests {
             .upsert_track(&musefs_db::NewTrack {
                 backing_path: path.to_string_lossy().into_owned(),
                 format: musefs_db::Format::Mp3,
-                audio_offset: bounds.audio_offset as i64,
-                audio_length: bounds.audio_length as i64,
-                backing_size: meta.len() as i64,
+                audio_offset: bounds.audio_offset,
+                audio_length: bounds.audio_length,
+                backing_size: meta.len(),
                 backing_mtime: meta
                     .modified()
                     .unwrap()

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use musefs_db::convert::usize_from;
 use musefs_db::{Db, Format};
 use musefs_format::flac::{self, MetadataBlock};
 use musefs_format::{mp3, mp4, wav, BinaryTagInput, RegionLayout, Segment};
@@ -73,14 +74,14 @@ fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
     meta.modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs() as i64)
+        .map_or(0, |d| d.as_secs().cast_signed())
 }
 
 fn read_front(path: &Path, n: u64) -> std::io::Result<Vec<u8>> {
     use std::io::Read;
     crate::metrics::on_open();
     let mut f = std::fs::File::open(path)?;
-    let mut buf = vec![0u8; n as usize];
+    let mut buf = vec![0u8; usize_from(n)];
     f.read_exact(&mut buf)?;
     Ok(buf)
 }
@@ -352,7 +353,7 @@ fn read_segments_into<M>(
         return Ok(());
     }
     let end = offset.saturating_add(size).min(resolved.total_len);
-    out.reserve((end - offset) as usize);
+    out.reserve(usize_from(end - offset));
 
     let mut seg_start = 0u64;
     for seg in &resolved.layout.segments {
@@ -362,10 +363,10 @@ fn read_segments_into<M>(
         let ov_end = end.min(seg_end);
         if ov_start < ov_end {
             let within = ov_start - seg_start;
-            let n = (ov_end - ov_start) as usize;
+            let n = usize_from(ov_end - ov_start);
             match seg {
                 Segment::Inline(bytes) => {
-                    let w = within as usize;
+                    let w = usize_from(within);
                     out.extend_from_slice(&bytes[w..w + n]);
                 }
                 Segment::BackingAudio { offset: bo, .. } => {
@@ -420,7 +421,7 @@ fn read_segments_into<M>(
                         // Output base64 chars [offset+within, +n) of base64(image).
                         let w =
                             musefs_format::ogg::b64_window(*offset + within, n as u64, *art_total);
-                        let raw = db.read_art_chunk(*art_id, w.in_start, w.in_len as usize)?;
+                        let raw = db.read_art_chunk(*art_id, w.in_start, usize_from(w.in_len))?;
                         crate::metrics::on_art_chunk();
                         out.extend_from_slice(&musefs_format::ogg::encode_b64_slice(
                             &raw, w.skip, n,
@@ -482,7 +483,7 @@ mod ogg_serve_tests {
         let (a2, _) = lace_packet_pub(0x99, 4, false, 20, &vec![0xB2u8; 250]);
         audio.extend_from_slice(&a2);
         let audio_offset = 8u64;
-        let mut file_bytes = vec![0xFFu8; audio_offset as usize];
+        let mut file_bytes = vec![0xFFu8; usize_from(audio_offset)];
         file_bytes.extend_from_slice(&audio);
 
         let dir = tempfile::tempdir().unwrap();
@@ -517,7 +518,7 @@ mod ogg_serve_tests {
         // Read the whole virtual file; needs a Db only for ArtImage (unused here).
         let db = musefs_db::Db::open_in_memory().unwrap();
         let got = read_at(&resolved, &db, 0, total).unwrap();
-        assert_eq!(got.len(), total as usize);
+        assert_eq!(got.len(), usize_from(total));
         assert_eq!(&got[0..8], b"HDRBYTES");
 
         // The served audio region must have renumbered seqs (4 and 5) and identical
@@ -594,8 +595,8 @@ mod resolve_ogg_tests {
         // original audio pages, byte-identical (seq_delta==0 here since the original
         // OpusTags is also an empty-comment musefs-style header of equal page count).
         let header = musefs_format::ogg::read_header(&out).unwrap();
-        let synth_audio = &out[header.audio_offset as usize..];
-        assert_eq!(synth_audio, &original[audio_offset as usize..]);
+        let synth_audio = &out[usize_from(header.audio_offset)..];
+        assert_eq!(synth_audio, &original[usize_from(audio_offset)..]);
 
         // Tags were rewritten. `ogg::read_tags` now returns canonical lowercase
         // keys for known Vorbis fields (Tasks 1–6 changed the format layer).
@@ -645,11 +646,11 @@ mod resolve_ogg_tests {
         let mut body = Vec::new();
         for (id, payload) in [(&b"fmt "[..], &fmt[..]), (&b"data"[..], &data[..])] {
             body.extend_from_slice(id);
-            body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
             body.extend_from_slice(payload);
         }
         let mut bytes = b"RIFF".to_vec();
-        bytes.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+        bytes.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
         bytes.extend_from_slice(b"WAVE");
         bytes.extend_from_slice(&body);
 
@@ -690,8 +691,8 @@ mod resolve_ogg_tests {
         // to the original audio.
         let bounds = musefs_format::wav::locate_audio(&out).unwrap();
         assert_eq!(
-            &out[bounds.audio_offset as usize
-                ..(bounds.audio_offset + bounds.audio_length) as usize],
+            &out[usize_from(bounds.audio_offset)
+                ..usize_from(bounds.audio_offset + bounds.audio_length)],
             original_data.as_slice()
         );
 
@@ -749,7 +750,7 @@ mod ogg_art_serve_tests {
         let full_b64 = musefs_format::ogg::encode_b64_slice(
             &image,
             0,
-            musefs_format::ogg::b64_len(image.len() as u64) as usize,
+            usize_from(musefs_format::ogg::b64_len(image.len() as u64)),
         );
 
         let db = musefs_db::Db::open_in_memory().unwrap();
@@ -801,7 +802,9 @@ mod ogg_art_serve_tests {
 
     #[test]
     fn read_at_serves_raw_art_slice() {
-        let image: Vec<u8> = (0..300u32).map(|i| (i % 256) as u8).collect();
+        let image: Vec<u8> = (0..300u32)
+            .map(|i| u8::try_from(i % 256).unwrap())
+            .collect();
         let db = musefs_db::Db::open_in_memory().unwrap();
         let art_id = db
             .upsert_art(&musefs_db::NewArt {
@@ -1070,8 +1073,12 @@ mod cache_bound_tests {
     fn write_flac_local(path: &std::path::Path) -> (u64, u64) {
         fn block(bt: u8, body: &[u8], last: bool) -> Vec<u8> {
             let mut v = vec![(if last { 0x80 } else { 0 }) | (bt & 0x7F)];
-            let n = body.len();
-            v.extend_from_slice(&[(n >> 16) as u8, (n >> 8) as u8, n as u8]);
+            let n: u32 = u32::try_from(body.len()).unwrap();
+            v.extend_from_slice(&[
+                u8::try_from(n >> 16).unwrap(),
+                u8::try_from(n >> 8).unwrap(),
+                u8::try_from(n).unwrap(),
+            ]);
             v.extend_from_slice(body);
             v
         }
@@ -1082,7 +1089,7 @@ mod cache_bound_tests {
         si.extend_from_slice(&[0u8; 16]);
         let mut vc = Vec::new();
         let vendor = b"x";
-        vc.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        vc.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
         vc.extend_from_slice(vendor);
         vc.extend_from_slice(&0u32.to_le_bytes());
         let mut out = b"fLaC".to_vec();
@@ -1172,7 +1179,8 @@ mod binary_tag_serve_tests {
                     .unwrap()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
-                    .as_secs() as i64,
+                    .as_secs()
+                    .cast_signed(),
             })
             .unwrap();
         db.set_binary_tags(

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use musefs_db::convert::usize_from;
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedBinaryTag, EmbeddedPicture, Extent};
 
@@ -46,7 +47,7 @@ fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
     meta.modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs() as i64)
+        .map_or(0, |d| d.as_secs().cast_signed())
 }
 
 fn has_ext(path: &Path, ext: &str) -> bool {
@@ -237,7 +238,7 @@ fn probe_file(path: &Path, file_len: u64, window: usize) -> std::io::Result<Opti
     } else {
         None
     };
-    let mut want = (window as u64).min(file_len) as usize;
+    let mut want = usize_from((window as u64).min(file_len));
     let mut prefix = read_window(&file, want)?;
     for _ in 0..MAX_WIDEN_RETRIES {
         match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
@@ -250,16 +251,16 @@ fn probe_file(path: &Path, file_len: u64, window: usize) -> std::io::Result<Opti
                 }
                 // Grow to at least `up_to` (capped at the file), always making
                 // progress (`+1`), then retry.
-                want = (up_to.min(file_len) as usize)
+                want = usize_from(up_to.min(file_len))
                     .max(want + 1)
-                    .min(file_len as usize);
+                    .min(usize_from(file_len));
                 prefix = read_window(&file, want)?;
             }
         }
     }
     // Fallback: read the whole file once and use the full-buffer probe.
     if (prefix.len() as u64) < file_len {
-        prefix = read_window(&file, file_len as usize)?;
+        prefix = read_window(&file, usize_from(file_len))?;
     }
     Ok(probe_full(path, &prefix))
 }
@@ -988,7 +989,10 @@ mod scan_unit_tests {
     /// `probe_full` only locates audio + reads tags, never synthesizes.
     fn mp4_with_binary_freeform(mean: &str, name: &str, value: &[u8]) -> Vec<u8> {
         fn bx(kind: &[u8; 4], body: &[u8]) -> Vec<u8> {
-            let mut v = ((8 + body.len()) as u32).to_be_bytes().to_vec();
+            let mut v = u32::try_from(8 + body.len())
+                .unwrap()
+                .to_be_bytes()
+                .to_vec();
             v.extend_from_slice(kind);
             v.extend_from_slice(body);
             v
@@ -1131,11 +1135,11 @@ mod wav_probe_tests {
         let mut body = Vec::new();
         for (id, payload) in [(b"fmt ", &fmt), (b"data", &data)] {
             body.extend_from_slice(id);
-            body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
             body.extend_from_slice(payload);
         }
         let mut out = b"RIFF".to_vec();
-        out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
         out.extend_from_slice(b"WAVE");
         out.extend_from_slice(&body);
         out
@@ -1226,8 +1230,12 @@ mod hardening_tests {
 
     fn flac_block(bt: u8, body: &[u8], last: bool) -> Vec<u8> {
         let mut v = vec![(if last { 0x80 } else { 0 }) | (bt & 0x7F)];
-        let n = body.len();
-        v.extend_from_slice(&[(n >> 16) as u8, (n >> 8) as u8, n as u8]);
+        let n: u32 = u32::try_from(body.len()).unwrap();
+        v.extend_from_slice(&[
+            u8::try_from(n >> 16).unwrap(),
+            u8::try_from(n >> 8).unwrap(),
+            u8::try_from(n).unwrap(),
+        ]);
         v.extend_from_slice(body);
         v
     }
@@ -1242,11 +1250,11 @@ mod hardening_tests {
     fn vorbis_comment(entries: &[&str]) -> Vec<u8> {
         let mut vc = Vec::new();
         let vendor = b"x";
-        vc.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        vc.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
         vc.extend_from_slice(vendor);
-        vc.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        vc.extend_from_slice(&u32::try_from(entries.len()).unwrap().to_le_bytes());
         for e in entries {
-            vc.extend_from_slice(&(e.len() as u32).to_le_bytes());
+            vc.extend_from_slice(&u32::try_from(e.len()).unwrap().to_le_bytes());
             vc.extend_from_slice(e.as_bytes());
         }
         vc
@@ -1255,14 +1263,14 @@ mod hardening_tests {
         let mut b = Vec::new();
         b.extend_from_slice(&3u32.to_be_bytes());
         let mime = "image/png";
-        b.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
         b.extend_from_slice(mime.as_bytes());
         b.extend_from_slice(&0u32.to_be_bytes());
         b.extend_from_slice(&width.to_be_bytes());
         b.extend_from_slice(&height.to_be_bytes());
         b.extend_from_slice(&0u32.to_be_bytes());
         b.extend_from_slice(&0u32.to_be_bytes());
-        b.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
         b.extend_from_slice(data);
         b
     }
@@ -1674,7 +1682,7 @@ mod bounded_probe_tests {
             .get_track_by_path(&std::fs::canonicalize(&p).unwrap().to_string_lossy())
             .unwrap()
             .unwrap();
-        assert_eq!(track.audio_length as usize, b"DIFFERENT-AUDIO".len());
+        assert_eq!(usize_from(track.audio_length), b"DIFFERENT-AUDIO".len());
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -418,7 +418,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     })?;
 
     let mut tags = Vec::new();
-    let mut ordinals: HashMap<String, i64> = HashMap::new();
+    let mut ordinals: HashMap<String, u64> = HashMap::new();
     for (key, value) in probed.tags {
         let ord = ordinals.entry(key.clone()).or_insert(0);
         tags.push(Tag::new(&key, &value, *ord));
@@ -434,12 +434,12 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
         .map(|(ordinal, b)| musefs_db::BinaryTag {
             key: b.key,
             payload: b.payload,
-            ordinal: ordinal as i64,
+            ordinal: ordinal as u64,
         })
         .collect();
     db.set_binary_tags(track_id, &binary_tags)?;
 
-    let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
+    let mut sb_ordinals: HashMap<String, u64> = HashMap::new();
     let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
         .structural_blocks
         .into_iter()
@@ -472,7 +472,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
         })?;
         // Valid ID3/FLAC picture types are 0..=20; clamp anything out of range.
         let picture_type = if pic.picture_type <= 20 {
-            pic.picture_type as i64
+            pic.picture_type
         } else {
             0
         };
@@ -480,7 +480,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
             art_id,
             picture_type,
             description: pic.description,
-            ordinal: ordinal as i64,
+            ordinal: ordinal as u64,
         });
     }
     db.set_track_art(track_id, &track_arts)?;
@@ -506,7 +506,7 @@ fn ingest_bulk(
     })?;
 
     let mut tags = Vec::new();
-    let mut ordinals: HashMap<String, i64> = HashMap::new();
+    let mut ordinals: HashMap<String, u64> = HashMap::new();
     for (key, value) in &probed.tags {
         let ord = ordinals.entry(key.clone()).or_insert(0);
         tags.push(Tag::new(key, value, *ord));
@@ -522,12 +522,12 @@ fn ingest_bulk(
         .map(|(ordinal, b)| musefs_db::BinaryTag {
             key: b.key,
             payload: b.payload,
-            ordinal: ordinal as i64,
+            ordinal: ordinal as u64,
         })
         .collect();
     bw.set_binary_tags(track_id, &binary_tags)?;
 
-    let mut sb_ordinals: HashMap<String, i64> = HashMap::new();
+    let mut sb_ordinals: HashMap<String, u64> = HashMap::new();
     let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
         .structural_blocks
         .into_iter()
@@ -557,7 +557,7 @@ fn ingest_bulk(
             data: pic.data,
         })?;
         let picture_type = if pic.picture_type <= 20 {
-            pic.picture_type as i64
+            pic.picture_type
         } else {
             0
         };
@@ -565,7 +565,7 @@ fn ingest_bulk(
             art_id,
             picture_type,
             description: pic.description,
-            ordinal: ordinal as i64,
+            ordinal: ordinal as u64,
         });
     }
     bw.set_track_art(track_id, &track_arts)?;
@@ -1286,7 +1286,7 @@ mod hardening_tests {
         let db = musefs_db::Db::open_in_memory().unwrap();
         crate::scan_directory(&db, &path).unwrap();
         let track = db.list_tracks().unwrap().into_iter().next().unwrap();
-        let mut artists: Vec<(i64, String)> = db
+        let mut artists: Vec<(u64, String)> = db
             .get_tags(track.id)
             .unwrap()
             .into_iter()

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -466,8 +466,8 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     for (ordinal, pic) in accepted.enumerate() {
         let art_id = db.upsert_art(&NewArt {
             mime: pic.mime,
-            width: (pic.width != 0).then_some(pic.width as i64),
-            height: (pic.height != 0).then_some(pic.height as i64),
+            width: (pic.width != 0).then_some(pic.width),
+            height: (pic.height != 0).then_some(pic.height),
             data: pic.data,
         })?;
         // Valid ID3/FLAC picture types are 0..=20; clamp anything out of range.
@@ -552,8 +552,8 @@ fn ingest_bulk(
     for (ordinal, pic) in accepted.enumerate() {
         let art_id = bw.upsert_art(&NewArt {
             mime: pic.mime,
-            width: (pic.width != 0).then_some(pic.width as i64),
-            height: (pic.height != 0).then_some(pic.height as i64),
+            width: (pic.width != 0).then_some(pic.width),
+            height: (pic.height != 0).then_some(pic.height),
             data: pic.data,
         })?;
         let picture_type = if pic.picture_type <= 20 {

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1321,6 +1321,23 @@ mod hardening_tests {
     }
 
     #[test]
+    fn ingest_oracle_path_stores_nonzero_art_dimensions() {
+        // Drives the single-file `ingest` (not `ingest_bulk`) so the
+        // `(pic.width != 0).then_some(..)` dimension guards there are pinned.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art.flac");
+        write_flac(&path, &["ARTIST=A", "TITLE=T"], Some((10, 20)));
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        crate::scan_directory_full_oracle(&db, &path).unwrap();
+        let track = db.list_tracks().unwrap().into_iter().next().unwrap();
+        let ta = db.get_track_art(track.id).unwrap();
+        assert_eq!(ta.len(), 1);
+        let meta = db.get_art_meta(ta[0].art_id).unwrap().unwrap();
+        assert_eq!(meta.width, Some(10));
+        assert_eq!(meta.height, Some(20));
+    }
+
+    #[test]
     fn scan_directory_counts_scanned_and_skipped() {
         let dir = tempfile::tempdir().unwrap();
         write_flac(

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -411,9 +411,9 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     let track_id = db.upsert_track(&NewTrack {
         backing_path: abs_path.to_string(),
         format: probed.format,
-        audio_offset: probed.audio_offset as i64,
-        audio_length: probed.audio_length as i64,
-        backing_size: meta.len() as i64,
+        audio_offset: probed.audio_offset,
+        audio_length: probed.audio_length,
+        backing_size: meta.len(),
         backing_mtime: mtime_secs(meta),
     })?;
 
@@ -499,9 +499,9 @@ fn ingest_bulk(
     let track_id = bw.upsert_track(&NewTrack {
         backing_path: abs_path.to_string(),
         format: probed.format,
-        audio_offset: probed.audio_offset as i64,
-        audio_length: probed.audio_length as i64,
-        backing_size: meta_len as i64,
+        audio_offset: probed.audio_offset,
+        audio_length: probed.audio_length,
+        backing_size: meta_len,
         backing_mtime: meta_mtime,
     })?;
 
@@ -803,7 +803,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
 
     // Main-thread pre-dispatch skip pass: load existing (path -> size,mtime,id,format) once,
     // stat each candidate, keep only changed files. Workers stay DB-free.
-    let existing: HashMap<String, (i64, i64, i64, Format)> = db
+    let existing: HashMap<String, (u64, i64, i64, Format)> = db
         .list_tracks()?
         .into_iter()
         .map(|t| {
@@ -833,7 +833,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         let key = abs.to_string_lossy().into_owned();
         if let Some(&(size, mtime, id, format)) = existing.get(&key) {
             let needs_backfill = format == Format::Flac && !have_structural.contains(&id);
-            if size == meta.len() as i64 && mtime == mtime_secs(&meta) && !needs_backfill {
+            if size == meta.len() && mtime == mtime_secs(&meta) && !needs_backfill {
                 unchanged += 1;
                 continue;
             }
@@ -1639,8 +1639,8 @@ mod bounded_probe_tests {
             .get_track_by_path(&std::fs::canonicalize(&path).unwrap().to_string_lossy())
             .unwrap()
             .unwrap();
-        assert_eq!(track.audio_offset as u64, full.audio_offset);
-        assert_eq!(track.audio_length as u64, full.audio_length);
+        assert_eq!(track.audio_offset, full.audio_offset);
+        assert_eq!(track.audio_length, full.audio_length);
     }
 
     #[test]
@@ -1723,7 +1723,7 @@ mod bounded_probe_tests {
                 },
             )
             .unwrap();
-            let mut rows: Vec<(String, i64, i64)> = db
+            let mut rows: Vec<(String, u64, u64)> = db
                 .list_tracks()
                 .unwrap()
                 .into_iter()

--- a/musefs-core/tests/common/corpus.rs
+++ b/musefs-core/tests/common/corpus.rs
@@ -231,14 +231,14 @@ fn flac_bytes(comments: &[String], art: Option<&[u8]>, audio: &[u8]) -> Vec<u8> 
     if let Some(img) = art {
         let mut body = Vec::new();
         body.extend_from_slice(&3u32.to_be_bytes()); // picture type: front cover
-        body.extend_from_slice(&(b"image/png".len() as u32).to_be_bytes());
+        body.extend_from_slice(&u32::try_from(b"image/png".len()).unwrap().to_be_bytes());
         body.extend_from_slice(b"image/png");
         body.extend_from_slice(&0u32.to_be_bytes()); // description len
         body.extend_from_slice(&0u32.to_be_bytes()); // width
         body.extend_from_slice(&0u32.to_be_bytes()); // height
         body.extend_from_slice(&0u32.to_be_bytes()); // depth
         body.extend_from_slice(&0u32.to_be_bytes()); // colors
-        body.extend_from_slice(&(img.len() as u32).to_be_bytes());
+        body.extend_from_slice(&u32::try_from(img.len()).unwrap().to_be_bytes());
         body.extend_from_slice(img);
         out.extend_from_slice(&flac_block(6, &body, true));
     }

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -11,45 +11,45 @@ pub use musefs_format::fuzz_check::fixtures::{
 
 /// Write a simple FLAC (STREAMINFO + comment + audio) to `path`,
 /// returning (audio_offset, audio_length).
-pub fn write_flac(path: &Path, comments: &[&str], audio: &[u8]) -> (i64, i64) {
+pub fn write_flac(path: &Path, comments: &[&str], audio: &[u8]) -> (u64, u64) {
     let si = streaminfo_body();
     let vc = vorbis_comment_body("orig", comments);
     let bytes = make_flac(&[(0, si), (4, vc)], audio);
-    let audio_offset = (bytes.len() - audio.len()) as i64;
+    let audio_offset = (bytes.len() - audio.len()) as u64;
     std::fs::write(path, &bytes).unwrap();
-    (audio_offset, audio.len() as i64)
+    (audio_offset, audio.len() as u64)
 }
 
 /// Write a minimal MP3 (a 10-byte empty ID3v2.4 tag, then the given audio bytes)
 /// to `path`, returning (audio_offset, audio_length). The leading tag is
 /// arbitrary: MP3 synthesis regenerates the ID3v2 region entirely from the DB and
 /// never reads the backing front, so only the audio offset/length matter.
-pub fn write_mp3(path: &Path, audio: &[u8]) -> (i64, i64) {
+pub fn write_mp3(path: &Path, audio: &[u8]) -> (u64, u64) {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"ID3");
     bytes.extend_from_slice(&[0x04, 0x00, 0x00]); // version 2.4.0, no flags
     bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // synchsafe size 0
-    let audio_offset = bytes.len() as i64;
+    let audio_offset = bytes.len() as u64;
     bytes.extend_from_slice(audio);
     std::fs::write(path, &bytes).unwrap();
-    (audio_offset, audio.len() as i64)
+    (audio_offset, audio.len() as u64)
 }
 
 /// Write a minimal moov-first M4A (see `minimal_m4a`) to `path`, returning
 /// (audio_offset, audio_length) for the verbatim trailing `mdat` payload. M4A
 /// synthesis re-scans the file's structural boxes and serves the mdat payload
 /// verbatim, so the stored bounds need only satisfy the reader's size guard.
-pub fn write_m4a(path: &Path, audio: &[u8]) -> (i64, i64) {
+pub fn write_m4a(path: &Path, audio: &[u8]) -> (u64, u64) {
     let bytes = minimal_m4a(audio);
-    let audio_offset = (bytes.len() - audio.len()) as i64;
+    let audio_offset = (bytes.len() - audio.len()) as u64;
     std::fs::write(path, &bytes).unwrap();
-    (audio_offset, audio.len() as i64)
+    (audio_offset, audio.len() as u64)
 }
 
 /// Write a minimal valid PCM WAV (`fmt ` + `data`) to `path`, returning
 /// (audio_offset, audio_length) of the `data` payload. Tags are applied via the DB
 /// by the caller (mirrors how `write_flac` is paired with `replace_tags`).
-pub fn write_wav(path: &Path, audio: &[u8]) -> (i64, i64) {
+pub fn write_wav(path: &Path, audio: &[u8]) -> (u64, u64) {
     let mut fmt = Vec::new();
     fmt.extend_from_slice(&1u16.to_le_bytes()); // PCM
     fmt.extend_from_slice(&1u16.to_le_bytes()); // mono
@@ -69,9 +69,9 @@ pub fn write_wav(path: &Path, audio: &[u8]) -> (i64, i64) {
     bytes.extend_from_slice(b"WAVE");
     bytes.extend_from_slice(&body);
 
-    let audio_offset = (bytes.len() - audio.len()) as i64;
+    let audio_offset = (bytes.len() - audio.len()) as u64;
     std::fs::write(path, &bytes).unwrap();
-    (audio_offset, audio.len() as i64)
+    (audio_offset, audio.len() as u64)
 }
 
 /// Build a 32-bit-size box: [size][type][payload].
@@ -200,12 +200,12 @@ pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
 
 /// Write a moov-at-end M4A to `path`, returning (audio_offset, audio_length) of
 /// the verbatim `mdat` payload.
-pub fn write_m4a_moov_last(path: &Path, audio: &[u8]) -> (i64, i64) {
+pub fn write_m4a_moov_last(path: &Path, audio: &[u8]) -> (u64, u64) {
     let bytes = minimal_m4a_moov_last(audio);
     // ftyp: 8 header + 8 payload = 16; mdat header: 8 → payload at offset 24.
-    let audio_offset = (8 + b"M4A isom".len() + 8) as i64;
+    let audio_offset = (8 + b"M4A isom".len() + 8) as u64;
     std::fs::write(path, &bytes).unwrap();
-    (audio_offset, audio.len() as i64)
+    (audio_offset, audio.len() as u64)
 }
 
 /// Write a minimal valid Ogg **Opus** file (two header pages + one audio page
@@ -217,7 +217,7 @@ pub fn write_m4a_moov_last(path: &Path, audio: &[u8]) -> (i64, i64) {
 /// The synthesizer treats the audio packet body as opaque (renumbers pages,
 /// recomputes CRCs, never decodes), so arbitrary `audio` bytes are valid. The
 /// return is informational — `scan_directory` re-probes the file.
-pub fn write_ogg(path: &Path, audio: &[u8]) -> (i64, i64) {
+pub fn write_ogg(path: &Path, audio: &[u8]) -> (u64, u64) {
     use musefs_format::ogg::page_test_support::{
         build_header_pub, lace_packet_pub, vorbis_body_empty,
     };
@@ -232,7 +232,7 @@ pub fn write_ogg(path: &Path, audio: &[u8]) -> (i64, i64) {
     let (page, _) = lace_packet_pub(serial, header_pages, false, 960, audio);
     bytes.extend_from_slice(&page);
     std::fs::write(path, &bytes).unwrap();
-    (header_len as i64, (bytes.len() - header_len) as i64)
+    (header_len as u64, (bytes.len() - header_len) as u64)
 }
 
 /// A FLAC PICTURE block body (type 3 = front cover, image/png) carrying `data`.
@@ -264,7 +264,7 @@ pub fn write_opus_with_art(
     comments: &[&str],
     picture: &[u8],
     audio: &[u8],
-) -> (i64, i64) {
+) -> (u64, u64) {
     use base64::Engine as _;
     use musefs_format::ogg::page_test_support::{build_header_pub, lace_packet_pub};
     let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
@@ -282,7 +282,7 @@ pub fn write_opus_with_art(
     let (page, _) = lace_packet_pub(serial, header_pages, false, 960, audio);
     bytes.extend_from_slice(&page);
     std::fs::write(path, &bytes).unwrap();
-    (header_len as i64, (bytes.len() - header_len) as i64)
+    (header_len as u64, (bytes.len() - header_len) as u64)
 }
 
 /// Write an OggFLAC file (`0x7F "FLAC"` 1.0 mapping) whose header packets carry
@@ -295,7 +295,7 @@ pub fn write_oggflac_with_art(
     comments: &[&str],
     picture: &[u8],
     audio: &[u8],
-) -> (i64, i64) {
+) -> (u64, u64) {
     use musefs_format::ogg::page_test_support::{build_header_pub, lace_packet_pub};
     let mut pkt0 = vec![0x7F];
     pkt0.extend_from_slice(b"FLAC");
@@ -311,5 +311,5 @@ pub fn write_oggflac_with_art(
     let (page, _) = lace_packet_pub(serial, header_pages, false, 960, audio);
     bytes.extend_from_slice(&page);
     std::fs::write(path, &bytes).unwrap();
-    (header_len as i64, (bytes.len() - header_len) as i64)
+    (header_len as u64, (bytes.len() - header_len) as u64)
 }

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -61,11 +61,11 @@ pub fn write_wav(path: &Path, audio: &[u8]) -> (u64, u64) {
     let mut body = Vec::new();
     for (id, payload) in [(&b"fmt "[..], &fmt[..]), (&b"data"[..], audio)] {
         body.extend_from_slice(id);
-        body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
         body.extend_from_slice(payload);
     }
     let mut bytes = b"RIFF".to_vec();
-    bytes.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+    bytes.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
     bytes.extend_from_slice(b"WAVE");
     bytes.extend_from_slice(&body);
 
@@ -76,7 +76,10 @@ pub fn write_wav(path: &Path, audio: &[u8]) -> (u64, u64) {
 
 /// Build a 32-bit-size box: [size][type][payload].
 fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
-    let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();
+    let mut v = u32::try_from(8 + payload.len())
+        .unwrap()
+        .to_be_bytes()
+        .to_vec();
     v.extend_from_slice(kind);
     v.extend_from_slice(payload);
     v
@@ -133,7 +136,7 @@ pub fn minimal_m4a(mdat_payload: &[u8]) -> Vec<u8> {
     // that shrinks the `moov` patches the offset below zero and synthesis fails
     // (TooLarge). With the true offset, the patched value lands at the new payload
     // position. The first `stco` occurrence is the box type (it precedes `mdat`).
-    let mdat_payload_offset = (out.len() - mdat_payload.len()) as u32;
+    let mdat_payload_offset = u32::try_from(out.len() - mdat_payload.len()).unwrap();
     let stco = out
         .windows(4)
         .position(|w| w == b"stco")
@@ -187,7 +190,7 @@ pub fn minimal_m4a_moov_last(mdat_payload: &[u8]) -> Vec<u8> {
     // and could otherwise contain a false `stco` byte match.
     let moov_start = ftyp.len() + mdat.len();
     let mut out = [ftyp, mdat, moov].concat();
-    let mdat_payload_offset = (8 + b"M4A isom".len() + 8) as u32;
+    let mdat_payload_offset = u32::try_from(8 + b"M4A isom".len() + 8).unwrap();
     let stco_pos = moov_start
         + out[moov_start..]
             .windows(4)
@@ -243,14 +246,14 @@ pub fn write_ogg(path: &Path, audio: &[u8]) -> (u64, u64) {
 pub fn picture_block_body(data: &[u8]) -> Vec<u8> {
     let mut v = Vec::new();
     v.extend_from_slice(&3u32.to_be_bytes()); // picture type: front cover
-    v.extend_from_slice(&(b"image/png".len() as u32).to_be_bytes());
+    v.extend_from_slice(&u32::try_from(b"image/png".len()).unwrap().to_be_bytes());
     v.extend_from_slice(b"image/png");
     v.extend_from_slice(&0u32.to_be_bytes()); // empty description
     v.extend_from_slice(&1u32.to_be_bytes()); // width
     v.extend_from_slice(&1u32.to_be_bytes()); // height
     v.extend_from_slice(&0u32.to_be_bytes()); // depth
     v.extend_from_slice(&0u32.to_be_bytes()); // colors
-    v.extend_from_slice(&(data.len() as u32).to_be_bytes());
+    v.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
     v.extend_from_slice(data);
     v
 }

--- a/musefs-core/tests/external_contract.rs
+++ b/musefs-core/tests/external_contract.rs
@@ -3,13 +3,16 @@ use musefs_db::{Db, Format, NewTrack};
 use musefs_format::fuzz_check::fixtures;
 
 fn real_mtime(path: &std::path::Path) -> i64 {
-    std::fs::metadata(path)
-        .unwrap()
-        .modified()
-        .unwrap()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i64
+    i64::try_from(
+        std::fs::metadata(path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    )
+    .unwrap()
 }
 
 #[test]
@@ -37,7 +40,7 @@ fn scanner_owned_bounds_mutation_returns_controlled_error() {
     external
         .execute(
             "UPDATE tracks SET audio_length = audio_length + ?1 WHERE id = ?2",
-            rusqlite::params![bytes.len() as i64, id],
+            rusqlite::params![i64::try_from(bytes.len()).unwrap(), id],
         )
         .unwrap();
 

--- a/musefs-core/tests/external_contract.rs
+++ b/musefs-core/tests/external_contract.rs
@@ -26,9 +26,9 @@ fn scanner_owned_bounds_mutation_returns_controlled_error() {
         .upsert_track(&NewTrack {
             backing_path: audio_path.to_string_lossy().into_owned(),
             format: Format::Mp3,
-            audio_offset: bounds.audio_offset as i64,
-            audio_length: bounds.audio_length as i64,
-            backing_size: bytes.len() as i64,
+            audio_offset: bounds.audio_offset,
+            audio_length: bounds.audio_length,
+            backing_size: bytes.len() as u64,
             backing_mtime: real_mtime(&audio_path),
         })
         .unwrap();

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -191,14 +191,14 @@ fn serves_flac_with_embedded_art_through_the_facade() {
     fn picture_body(mime: &str, data: &[u8]) -> Vec<u8> {
         let mut b = Vec::new();
         b.extend_from_slice(&3u32.to_be_bytes()); // front cover
-        b.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
         b.extend_from_slice(mime.as_bytes());
         b.extend_from_slice(&0u32.to_be_bytes()); // description length
         b.extend_from_slice(&0u32.to_be_bytes()); // width
         b.extend_from_slice(&0u32.to_be_bytes()); // height
         b.extend_from_slice(&0u32.to_be_bytes()); // color depth
         b.extend_from_slice(&0u32.to_be_bytes()); // colors used
-        b.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
         b.extend_from_slice(data);
         b
     }

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -129,12 +129,14 @@ fn legacy_flac_without_structural_rows_serves_via_front_read_fallback() {
             audio_offset: scan.audio_offset,
             audio_length: scan.audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(
@@ -201,7 +203,8 @@ fn revalidate_backfills_structural_and_binary_rows_for_legacy_flac() {
 
 /// Read a binary tag's full payload from the DB via incremental blob I/O.
 fn read_binary_payload(db: &musefs_db::Db, rowid: i64, len: u64) -> Vec<u8> {
-    db.read_binary_tag_chunk(rowid, 0, len as usize).unwrap()
+    db.read_binary_tag_chunk(rowid, 0, usize::try_from(len).unwrap())
+        .unwrap()
 }
 
 /// Serve a scanned track's whole file via the synthesis read path.

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -126,9 +126,9 @@ fn legacy_flac_without_structural_rows_serves_via_front_read_fallback() {
         .upsert_track(&NewTrack {
             backing_path: path.to_string_lossy().into_owned(),
             format: Format::Flac,
-            audio_offset: scan.audio_offset as i64,
-            audio_length: scan.audio_length as i64,
-            backing_size: meta.len() as i64,
+            audio_offset: scan.audio_offset,
+            audio_length: scan.audio_length,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -200,7 +200,7 @@ fn revalidate_backfills_structural_and_binary_rows_for_legacy_flac() {
 }
 
 /// Read a binary tag's full payload from the DB via incremental blob I/O.
-fn read_binary_payload(db: &musefs_db::Db, rowid: i64, len: i64) -> Vec<u8> {
+fn read_binary_payload(db: &musefs_db::Db, rowid: i64, len: u64) -> Vec<u8> {
     db.read_binary_tag_chunk(rowid, 0, len as usize).unwrap()
 }
 

--- a/musefs-core/tests/interop_emit.rs
+++ b/musefs-core/tests/interop_emit.rs
@@ -148,8 +148,8 @@ fn emit(
     dst: &Path,
     bytes: &[u8],
     format: Format,
-    audio_offset: i64,
-    audio_length: i64,
+    audio_offset: u64,
+    audio_length: u64,
     arts: &[(&[u8], &str)],
 ) -> (u64, u64) {
     std::fs::write(src, bytes).unwrap();
@@ -160,7 +160,7 @@ fn emit(
             format,
             audio_offset,
             audio_length,
-            backing_size: std::fs::metadata(src).unwrap().len() as i64,
+            backing_size: std::fs::metadata(src).unwrap().len(),
             backing_mtime: real_mtime(src),
         })
         .unwrap();
@@ -210,8 +210,8 @@ fn emit_binary(
     dst: &Path,
     bytes: &[u8],
     format: Format,
-    audio_offset: i64,
-    audio_length: i64,
+    audio_offset: u64,
+    audio_length: u64,
     text: &[Tag],
     binary: &[BinaryTag],
 ) {
@@ -223,7 +223,7 @@ fn emit_binary(
             format,
             audio_offset,
             audio_length,
-            backing_size: std::fs::metadata(src).unwrap().len() as i64,
+            backing_size: std::fs::metadata(src).unwrap().len(),
             backing_mtime: real_mtime(src),
         })
         .unwrap();
@@ -251,8 +251,8 @@ fn emit_interop_fixtures() {
             &dir.join("out.flac"),
             &bytes,
             Format::Flac,
-            scan.audio_offset as i64,
-            scan.audio_length as i64,
+            scan.audio_offset,
+            scan.audio_length,
             &[],
         );
         manifest.push(ManifestRow {
@@ -278,8 +278,8 @@ fn emit_interop_fixtures() {
             &dir.join("out.mp3"),
             &bytes,
             Format::Mp3,
-            b.audio_offset as i64,
-            b.audio_length as i64,
+            b.audio_offset,
+            b.audio_length,
             &[],
         );
         manifest.push(ManifestRow {
@@ -306,8 +306,8 @@ fn emit_interop_fixtures() {
             &dir.join("out.m4a"),
             &bytes,
             Format::M4a,
-            scan.mdat_payload_offset as i64,
-            scan.mdat_payload_len as i64,
+            scan.mdat_payload_offset,
+            scan.mdat_payload_len,
             &[(COVR_JPEG, "image/jpeg"), (COVR_PNG, "image/png")],
         );
         manifest.push(ManifestRow {
@@ -333,8 +333,8 @@ fn emit_interop_fixtures() {
             &dir.join("out.ogg"),
             &bytes,
             Format::Opus,
-            scan.audio_offset as i64,
-            scan.audio_length as i64,
+            scan.audio_offset,
+            scan.audio_length,
             &[],
         );
         manifest.push(ManifestRow {
@@ -360,8 +360,8 @@ fn emit_interop_fixtures() {
             &dir.join("out.wav"),
             &bytes,
             Format::Wav,
-            b.audio_offset as i64,
-            b.audio_length as i64,
+            b.audio_offset,
+            b.audio_length,
             &[],
         );
         manifest.push(ManifestRow {
@@ -406,8 +406,8 @@ fn emit_interop_fixtures() {
             &dir.join("out_bin.mp3"),
             &bytes,
             Format::Mp3,
-            b.audio_offset as i64,
-            b.audio_length as i64,
+            b.audio_offset,
+            b.audio_length,
             &[
                 Tag::new("title", "Bin Title", 0),
                 Tag::new("artist", "Bin Artist", 0),
@@ -439,8 +439,8 @@ fn emit_interop_fixtures() {
             &dir.join("out_bin.m4a"),
             &bytes,
             Format::M4a,
-            scan.mdat_payload_offset as i64,
-            scan.mdat_payload_len as i64,
+            scan.mdat_payload_offset,
+            scan.mdat_payload_len,
             &[
                 Tag::new("title", "Bin Title", 0),
                 Tag::new("artist", "Bin Artist", 0),

--- a/musefs-core/tests/interop_emit.rs
+++ b/musefs-core/tests/interop_emit.rs
@@ -20,7 +20,10 @@ use std::path::Path;
 // requires `ftyp`, `mvhd`, exactly one `soun` trak whose `stbl` has `stco`,
 // and `udta/meta/ilst`.
 fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
-    let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();
+    let mut v = u32::try_from(8 + payload.len())
+        .unwrap()
+        .to_be_bytes()
+        .to_vec();
     v.extend_from_slice(kind);
     v.extend_from_slice(payload);
     v
@@ -102,13 +105,16 @@ const COVR_JPEG: &[u8] = b"\xFF\xD8\xFF\xE0interop-jpeg-cover";
 const COVR_PNG: &[u8] = b"\x89PNG\r\n\x1a\ninterop-png-cover";
 
 fn real_mtime(p: &Path) -> i64 {
-    std::fs::metadata(p)
-        .unwrap()
-        .modified()
-        .unwrap()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i64
+    i64::try_from(
+        std::fs::metadata(p)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    )
+    .unwrap()
 }
 
 #[derive(Debug)]

--- a/musefs-core/tests/interop_emit.rs
+++ b/musefs-core/tests/interop_emit.rs
@@ -188,7 +188,7 @@ fn emit(
                 art_id,
                 picture_type: 3,
                 description: String::new(),
-                ordinal: i as i64,
+                ordinal: i as u64,
             }
         })
         .collect();

--- a/musefs-core/tests/pipeline_backpressure.rs
+++ b/musefs-core/tests/pipeline_backpressure.rs
@@ -19,18 +19,22 @@ fn flac_with_art(data_len: usize) -> Vec<u8> {
     let mut body = Vec::new();
     body.extend_from_slice(&3u32.to_be_bytes()); // picture type (front cover)
     let mime = b"image/png";
-    body.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+    body.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
     body.extend_from_slice(mime);
     body.extend_from_slice(&0u32.to_be_bytes()); // description length
     body.extend_from_slice(&0u32.to_be_bytes()); // width
     body.extend_from_slice(&0u32.to_be_bytes()); // height
     body.extend_from_slice(&0u32.to_be_bytes()); // depth
     body.extend_from_slice(&0u32.to_be_bytes()); // colors
-    body.extend_from_slice(&(data_len as u32).to_be_bytes());
+    body.extend_from_slice(&u32::try_from(data_len).unwrap().to_be_bytes());
     body.extend(std::iter::repeat_n(0u8, data_len));
     v.push(0x86); // last-block flag (0x80) | PICTURE (0x06)
     let blen = body.len();
-    v.extend_from_slice(&[(blen >> 16) as u8, (blen >> 8) as u8, blen as u8]);
+    v.extend_from_slice(&[
+        u8::try_from((blen >> 16) & 0xFF).unwrap(),
+        u8::try_from((blen >> 8) & 0xFF).unwrap(),
+        u8::try_from(blen & 0xFF).unwrap(),
+    ]);
     v.extend_from_slice(&body);
     v.extend_from_slice(b"AUDIO");
     v

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -11,8 +11,8 @@ use musefs_db::Db;
 /// `(sha256, picture_type, description, ordinal)`.
 type NormalizedTrack = (
     String,
-    i64,
-    i64,
+    u64,
+    u64,
     Vec<(String, String, i64)>,
     Vec<(String, i64, String, i64)>,
 );

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -13,8 +13,8 @@ type NormalizedTrack = (
     String,
     u64,
     u64,
-    Vec<(String, String, i64)>,
-    Vec<(String, i64, String, i64)>,
+    Vec<(String, String, u64)>,
+    Vec<(String, u32, String, u64)>,
 );
 
 /// Normalize a DB to comparable rows: tracks by path, tags by (key,value,ordinal),

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -21,12 +21,14 @@ fn build(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -49,12 +51,14 @@ fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, 
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -93,12 +97,14 @@ fn build_wav(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -120,12 +126,14 @@ fn build_wav_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -162,7 +170,7 @@ proptest! {
         let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
         let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
         prop_assert_eq!(whole.len() as u64, resolved.total_len);
-        let served_audio = &whole[resolved.layout.header_len() as usize..];
+        let served_audio = &whole[usize::try_from(resolved.layout.header_len()).unwrap()..];
         prop_assert_eq!(served_audio, &original[..]);
     }
 
@@ -181,7 +189,7 @@ proptest! {
         let len = (b as u64) % (total - offset + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
         prop_assert_eq!(got.len() as u64, len);
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 
     #[test]
@@ -200,7 +208,7 @@ proptest! {
         let end = hlen + 1 + (after as u64 % (total - hlen)); // in (hlen, total]
         let whole = read_at(&resolved, &db, 0, total).unwrap();
         let got = read_at(&resolved, &db, start, end - start).unwrap();
-        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(start).unwrap()..usize::try_from(end).unwrap()]);
     }
 
     #[test]
@@ -236,7 +244,7 @@ proptest! {
         prop_assert_eq!(art_len, art.len() as u64);
         // The art blob is served verbatim at its segment offset.
         prop_assert_eq!(
-            &whole[art_off as usize..(art_off + art_len) as usize],
+            &whole[usize::try_from(art_off).unwrap()..usize::try_from(art_off + art_len).unwrap()],
             &art[..]
         );
         // A partial window *within the art span* matches the independently-read
@@ -246,7 +254,7 @@ proptest! {
         let offset = art_off + local_off;
         let len = (b as u64) % (art_len - local_off + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 
     #[test]
@@ -262,7 +270,7 @@ proptest! {
         // not the trailing bytes (a word-align pad may follow), so locate it.
         let bounds = musefs_format::wav::locate_audio(&whole).unwrap();
         prop_assert_eq!(
-            &whole[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+            &whole[usize::try_from(bounds.audio_offset).unwrap()..usize::try_from(bounds.audio_offset + bounds.audio_length).unwrap()],
             &original[..]
         );
     }
@@ -282,7 +290,7 @@ proptest! {
         let len = (b as u64) % (total - offset + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
         prop_assert_eq!(got.len() as u64, len);
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 
     #[test]
@@ -301,7 +309,7 @@ proptest! {
         let end = hlen + 1 + (after as u64 % (total - hlen));
         let whole = read_at(&resolved, &db, 0, total).unwrap();
         let got = read_at(&resolved, &db, start, end - start).unwrap();
-        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(start).unwrap()..usize::try_from(end).unwrap()]);
     }
 
     #[test]
@@ -334,14 +342,14 @@ proptest! {
         let art_len = art_len.expect("layout has an ArtImage segment");
         prop_assert_eq!(art_len, art.len() as u64);
         prop_assert_eq!(
-            &whole[art_off as usize..(art_off + art_len) as usize],
+            &whole[usize::try_from(art_off).unwrap()..usize::try_from(art_off + art_len).unwrap()],
             &art[..]
         );
         let local_off = (a as u64) % (art_len + 1);
         let offset = art_off + local_off;
         let len = (b as u64) % (art_len - local_off + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 }
 
@@ -358,12 +366,14 @@ fn build_mp3(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -383,12 +393,14 @@ fn build_mp3_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -428,7 +440,7 @@ proptest! {
         let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
         let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
         prop_assert_eq!(whole.len() as u64, resolved.total_len);
-        let served_audio = &whole[resolved.layout.header_len() as usize..];
+        let served_audio = &whole[usize::try_from(resolved.layout.header_len()).unwrap()..];
         prop_assert_eq!(served_audio, &original[..]);
     }
 
@@ -447,7 +459,7 @@ proptest! {
         let len = (b as u64) % (total - offset + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
         prop_assert_eq!(got.len() as u64, len);
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 
     #[test]
@@ -466,7 +478,7 @@ proptest! {
         let end = hlen + 1 + (after as u64 % (total - hlen)); // in (hlen, total]
         let whole = read_at(&resolved, &db, 0, total).unwrap();
         let got = read_at(&resolved, &db, start, end - start).unwrap();
-        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(start).unwrap()..usize::try_from(end).unwrap()]);
     }
 
     #[test]
@@ -500,14 +512,14 @@ proptest! {
         let art_len = art_len.expect("layout has an ArtImage segment");
         prop_assert_eq!(art_len, art.len() as u64);
         prop_assert_eq!(
-            &whole[art_off as usize..(art_off + art_len) as usize],
+            &whole[usize::try_from(art_off).unwrap()..usize::try_from(art_off + art_len).unwrap()],
             &art[..]
         );
         let local_off = (a as u64) % (art_len + 1);
         let offset = art_off + local_off;
         let len = (b as u64) % (art_len - local_off + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 
     #[test]
@@ -543,7 +555,7 @@ proptest! {
         );
         let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
         prop_assert_eq!(whole.len() as u64, resolved.total_len);
-        let served_audio = &whole[resolved.layout.header_len() as usize..];
+        let served_audio = &whole[usize::try_from(resolved.layout.header_len()).unwrap()..];
         prop_assert_eq!(served_audio, &original[..]);
     }
 }
@@ -561,12 +573,14 @@ fn build_m4a(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -586,12 +600,14 @@ fn build_m4a_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -632,7 +648,7 @@ proptest! {
         let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
         let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
         prop_assert_eq!(whole.len() as u64, resolved.total_len);
-        let served_audio = &whole[resolved.layout.header_len() as usize..];
+        let served_audio = &whole[usize::try_from(resolved.layout.header_len()).unwrap()..];
         prop_assert_eq!(served_audio, &original[..]);
     }
 
@@ -651,7 +667,7 @@ proptest! {
         let len = (b as u64) % (total - offset + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
         prop_assert_eq!(got.len() as u64, len);
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 
     #[test]
@@ -670,7 +686,7 @@ proptest! {
         let end = hlen + 1 + (after as u64 % (total - hlen)); // in (hlen, total]
         let whole = read_at(&resolved, &db, 0, total).unwrap();
         let got = read_at(&resolved, &db, start, end - start).unwrap();
-        prop_assert_eq!(&got[..], &whole[start as usize..end as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(start).unwrap()..usize::try_from(end).unwrap()]);
     }
 
     #[test]
@@ -704,13 +720,13 @@ proptest! {
         let art_len = art_len.expect("layout has an ArtImage segment");
         prop_assert_eq!(art_len, art.len() as u64);
         prop_assert_eq!(
-            &whole[art_off as usize..(art_off + art_len) as usize],
+            &whole[usize::try_from(art_off).unwrap()..usize::try_from(art_off + art_len).unwrap()],
             &art[..]
         );
         let local_off = (a as u64) % (art_len + 1);
         let offset = art_off + local_off;
         let len = (b as u64) % (art_len - local_off + 1);
         let got = read_at(&resolved, &db, offset, len).unwrap();
-        prop_assert_eq!(&got[..], &whole[offset as usize..(offset + len) as usize]);
+        prop_assert_eq!(&got[..], &whole[usize::try_from(offset).unwrap()..usize::try_from(offset + len).unwrap()]);
     }
 }

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -20,7 +20,7 @@ fn build(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
             format: Format::Flac,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -48,7 +48,7 @@ fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, 
             format: Format::Flac,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -92,7 +92,7 @@ fn build_wav(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             format: Format::Wav,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -119,7 +119,7 @@ fn build_wav_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             format: Format::Wav,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -357,7 +357,7 @@ fn build_mp3(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             format: Format::Mp3,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -382,7 +382,7 @@ fn build_mp3_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             format: Format::Mp3,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -560,7 +560,7 @@ fn build_m4a(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             format: Format::M4a,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -585,7 +585,7 @@ fn build_m4a_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             format: Format::M4a,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -17,12 +17,14 @@ fn setup() -> (tempfile::TempDir, Db, i64) {
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", "Real", 0)])
@@ -39,7 +41,7 @@ fn reading_whole_file_matches_total_len_and_splices_audio() {
     let whole = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
     assert_eq!(whole.len() as u64, resolved.total_len);
 
-    let audio_part = &whole[resolved.layout.header_len() as usize..];
+    let audio_part = &whole[usize::try_from(resolved.layout.header_len()).unwrap()..];
     let expected: Vec<u8> = (0..200u32).map(|i| (i % 251) as u8).collect();
     assert_eq!(audio_part, &expected[..]);
 
@@ -67,8 +69,12 @@ fn random_offset_and_size_match_the_whole_read() {
         (50, 0),
     ] {
         let got = read_at(&resolved, &db, off, size).unwrap();
-        let end = (off + size).min(resolved.total_len) as usize;
-        assert_eq!(got, &whole[off as usize..end], "off={off} size={size}");
+        let end = usize::try_from((off + size).min(resolved.total_len)).unwrap();
+        assert_eq!(
+            got,
+            &whole[usize::try_from(off).unwrap()..end],
+            "off={off} size={size}"
+        );
     }
 }
 
@@ -176,5 +182,5 @@ fn read_at_reserves_only_the_served_window() {
     // an over-reserve would inflate every worker's resident memory.
     let got = read_at(&resolved, &db, resolved.total_len - 7, 50).unwrap();
     assert_eq!(got.len(), 7);
-    assert!(got.capacity() < resolved.total_len as usize);
+    assert!(got.capacity() < usize::try_from(resolved.total_len).unwrap());
 }

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -16,7 +16,7 @@ fn setup() -> (tempfile::TempDir, Db, i64) {
             format: Format::Flac,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()

--- a/musefs-core/tests/reader.rs
+++ b/musefs-core/tests/reader.rs
@@ -18,12 +18,14 @@ fn setup() -> (tempfile::TempDir, Db, i64) {
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: meta
-                .modified()
-                .unwrap()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
+            backing_mtime: i64::try_from(
+                meta.modified()
+                    .unwrap()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            )
+            .unwrap(),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", "Real Title", 0)])
@@ -63,12 +65,14 @@ fn resolve_errors_when_audio_bounds_overrun_the_file() {
     let (dir, db, _id) = setup();
     let flac = dir.path().join("song.flac");
     let meta = std::fs::metadata(&flac).unwrap();
-    let mtime = meta
-        .modified()
-        .unwrap()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i64;
+    let mtime = i64::try_from(
+        meta.modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    )
+    .unwrap();
     // Re-upsert the same path with an audio_length that runs past EOF (the offset
     // is valid, but offset + length exceeds the file size).
     let id = db

--- a/musefs-core/tests/reader.rs
+++ b/musefs-core/tests/reader.rs
@@ -17,7 +17,7 @@ fn setup() -> (tempfile::TempDir, Db, i64) {
             format: Format::Flac,
             audio_offset,
             audio_length,
-            backing_size: meta.len() as i64,
+            backing_size: meta.len(),
             backing_mtime: meta
                 .modified()
                 .unwrap()
@@ -76,8 +76,8 @@ fn resolve_errors_when_audio_bounds_overrun_the_file() {
             backing_path: flac.to_string_lossy().into_owned(),
             format: Format::Flac,
             audio_offset: 0,
-            audio_length: meta.len() as i64 + 1,
-            backing_size: meta.len() as i64,
+            audio_length: meta.len() + 1,
+            backing_size: meta.len(),
             backing_mtime: mtime,
         })
         .unwrap();

--- a/musefs-core/tests/scan.rs
+++ b/musefs-core/tests/scan.rs
@@ -111,8 +111,8 @@ fn scans_mp3_files_seeding_tracks_and_tags() {
     assert_eq!(tracks.len(), 1);
     let t = &tracks[0];
     assert_eq!(t.format, Format::Mp3);
-    assert_eq!(t.audio_offset as u64, audio_offset);
-    assert_eq!(t.audio_length, audio_len as i64);
+    assert_eq!(t.audio_offset, audio_offset);
+    assert_eq!(t.audio_length, audio_len);
 
     let tags = db.get_tags(t.id).unwrap();
     assert!(tags

--- a/musefs-core/tests/scan.rs
+++ b/musefs-core/tests/scan.rs
@@ -255,14 +255,14 @@ fn flac_with_picture(comments: &[&str], img: &[u8]) -> Vec<u8> {
     fn picture_body(pic_type: u32, mime: &str, data: &[u8]) -> Vec<u8> {
         let mut b = Vec::new();
         b.extend_from_slice(&pic_type.to_be_bytes());
-        b.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
         b.extend_from_slice(mime.as_bytes());
         b.extend_from_slice(&0u32.to_be_bytes()); // empty description
         b.extend_from_slice(&0u32.to_be_bytes()); // width
         b.extend_from_slice(&0u32.to_be_bytes()); // height
         b.extend_from_slice(&0u32.to_be_bytes()); // depth
         b.extend_from_slice(&0u32.to_be_bytes()); // colors
-        b.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
         b.extend_from_slice(data);
         b
     }
@@ -316,14 +316,14 @@ fn flac_with_pictures(comments: &[&str], pics: &[(u32, &[u8])]) -> Vec<u8> {
     fn picture_body(pic_type: u32, mime: &str, data: &[u8]) -> Vec<u8> {
         let mut b = Vec::new();
         b.extend_from_slice(&pic_type.to_be_bytes());
-        b.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
         b.extend_from_slice(mime.as_bytes());
         b.extend_from_slice(&0u32.to_be_bytes()); // description
         b.extend_from_slice(&0u32.to_be_bytes()); // width
         b.extend_from_slice(&0u32.to_be_bytes()); // height
         b.extend_from_slice(&0u32.to_be_bytes()); // depth
         b.extend_from_slice(&0u32.to_be_bytes()); // colors
-        b.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        b.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
         b.extend_from_slice(data);
         b
     }

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -31,19 +31,23 @@ fn flac_with_big_art(data_len: usize, audio: &[u8]) -> Vec<u8> {
     let mut body = Vec::new();
     body.extend_from_slice(&3u32.to_be_bytes()); // picture type (front cover)
     let mime = b"image/png";
-    body.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+    body.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
     body.extend_from_slice(mime);
     body.extend_from_slice(&0u32.to_be_bytes()); // description length
     body.extend_from_slice(&0u32.to_be_bytes()); // width
     body.extend_from_slice(&0u32.to_be_bytes()); // height
     body.extend_from_slice(&0u32.to_be_bytes()); // depth
     body.extend_from_slice(&0u32.to_be_bytes()); // colors
-    body.extend_from_slice(&(data_len as u32).to_be_bytes());
+    body.extend_from_slice(&u32::try_from(data_len).unwrap().to_be_bytes());
     // Distinct, position-sensitive bytes so a misparse is observable.
-    body.extend((0..data_len).map(|i| (i % 251) as u8));
+    body.extend((0u8..=200).cycle().take(data_len));
     v.push(0x86); // last-block flag (0x80) | PICTURE (0x06)
     let blen = body.len();
-    v.extend_from_slice(&[(blen >> 16) as u8, (blen >> 8) as u8, blen as u8]);
+    v.extend_from_slice(&[
+        u8::try_from((blen >> 16) & 0xFF).unwrap(),
+        u8::try_from((blen >> 8) & 0xFF).unwrap(),
+        u8::try_from(blen & 0xFF).unwrap(),
+    ]);
     v.extend_from_slice(&body);
     v.extend_from_slice(audio);
     v

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -50,7 +50,7 @@ fn flac_with_big_art(data_len: usize, audio: &[u8]) -> Vec<u8> {
 }
 
 /// Normalize a DB to comparable `(path, audio_offset, audio_length)` rows.
-fn rows(db: &Db) -> Vec<(String, i64, i64)> {
+fn rows(db: &Db) -> Vec<(String, u64, u64)> {
     let mut r: Vec<_> = db
         .list_tracks()
         .unwrap()

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -7,7 +7,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-rusqlite = { version = "0.40", features = ["bundled", "blob"] }
+# fallible_uint enables the checked FromSql/ToSql impls for u64/usize, which
+# validate non-negative row columns at the boundary (the cast-convention spec).
+rusqlite = { version = "0.40", features = ["bundled", "blob", "fallible_uint"] }
 sha2 = "0.11"
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -77,7 +77,7 @@ impl<M> Db<M> {
     /// than silently zero-filling.
     pub fn read_art_chunk_into(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()> {
         let blob = self.conn.blob_open("main", "art", "data", art_id, true)?;
-        blob.read_at_exact(buf, offset as usize)?;
+        blob.read_at_exact(buf, crate::convert::usize_from(offset))?;
         Ok(())
     }
 

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -96,9 +96,9 @@ impl<M> Db<M> {
         let rows = stmt.query_map(params![track_id], |r| {
             Ok(TrackArt {
                 art_id: r.get(0)?,
-                picture_type: r.get(1)?,
+                picture_type: r.get::<_, i32>(1)? as u32,
                 description: r.get(2)?,
-                ordinal: r.get(3)?,
+                ordinal: r.get::<_, i64>(3)? as u64,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
@@ -137,9 +137,9 @@ impl Db<ReadWrite> {
                 stmt.execute(params![
                     track_id,
                     it.art_id,
-                    it.picture_type,
+                    it.picture_type as i32,
                     it.description,
-                    it.ordinal
+                    it.ordinal as i64
                 ])?;
             }
         }

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -22,15 +22,24 @@ impl<M> Db<M> {
         )?;
         let mut rows = stmt.query(params![id])?;
         match rows.next()? {
-            Some(r) => Ok(Some(Art {
-                id: r.get(0)?,
-                sha256: r.get(1)?,
-                mime: r.get(2)?,
-                width: r.get(3)?,
-                height: r.get(4)?,
-                byte_len: r.get(5)?,
-                data: r.get(6)?,
-            })),
+            Some(r) => {
+                let byte_len: i64 = r.get(5)?;
+                if byte_len < 0 {
+                    return Err(rusqlite::Error::InvalidParameterName(format!(
+                        "negative byte_len {byte_len} for art id {id}"
+                    ))
+                    .into());
+                }
+                Ok(Some(Art {
+                    id: r.get(0)?,
+                    sha256: r.get(1)?,
+                    mime: r.get(2)?,
+                    width: r.get::<_, Option<i64>>(3)?.map(|v| v as u32),
+                    height: r.get::<_, Option<i64>>(4)?.map(|v| v as u32),
+                    byte_len: byte_len as u64,
+                    data: r.get(6)?,
+                }))
+            }
             None => Ok(None),
         }
     }
@@ -43,12 +52,21 @@ impl<M> Db<M> {
             .prepare("SELECT mime, width, height, byte_len FROM art WHERE id = ?1")?;
         let mut rows = stmt.query(params![id])?;
         match rows.next()? {
-            Some(r) => Ok(Some(ArtMeta {
-                mime: r.get(0)?,
-                width: r.get(1)?,
-                height: r.get(2)?,
-                byte_len: r.get(3)?,
-            })),
+            Some(r) => {
+                let byte_len: i64 = r.get(3)?;
+                if byte_len < 0 {
+                    return Err(rusqlite::Error::InvalidParameterName(format!(
+                        "negative byte_len {byte_len} for art id {id}"
+                    ))
+                    .into());
+                }
+                Ok(Some(ArtMeta {
+                    mime: r.get(0)?,
+                    width: r.get::<_, Option<i64>>(1)?.map(|v| v as u32),
+                    height: r.get::<_, Option<i64>>(2)?.map(|v| v as u32),
+                    byte_len: byte_len as u64,
+                }))
+            }
             None => Ok(None),
         }
     }

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -22,24 +22,15 @@ impl<M> Db<M> {
         )?;
         let mut rows = stmt.query(params![id])?;
         match rows.next()? {
-            Some(r) => {
-                let byte_len: i64 = r.get(5)?;
-                if byte_len < 0 {
-                    return Err(rusqlite::Error::InvalidParameterName(format!(
-                        "negative byte_len {byte_len} for art id {id}"
-                    ))
-                    .into());
-                }
-                Ok(Some(Art {
-                    id: r.get(0)?,
-                    sha256: r.get(1)?,
-                    mime: r.get(2)?,
-                    width: r.get::<_, Option<i64>>(3)?.map(|v| v as u32),
-                    height: r.get::<_, Option<i64>>(4)?.map(|v| v as u32),
-                    byte_len: byte_len as u64,
-                    data: r.get(6)?,
-                }))
-            }
+            Some(r) => Ok(Some(Art {
+                id: r.get(0)?,
+                sha256: r.get(1)?,
+                mime: r.get(2)?,
+                width: r.get(3)?,
+                height: r.get(4)?,
+                byte_len: r.get(5)?,
+                data: r.get(6)?,
+            })),
             None => Ok(None),
         }
     }
@@ -52,21 +43,12 @@ impl<M> Db<M> {
             .prepare("SELECT mime, width, height, byte_len FROM art WHERE id = ?1")?;
         let mut rows = stmt.query(params![id])?;
         match rows.next()? {
-            Some(r) => {
-                let byte_len: i64 = r.get(3)?;
-                if byte_len < 0 {
-                    return Err(rusqlite::Error::InvalidParameterName(format!(
-                        "negative byte_len {byte_len} for art id {id}"
-                    ))
-                    .into());
-                }
-                Ok(Some(ArtMeta {
-                    mime: r.get(0)?,
-                    width: r.get::<_, Option<i64>>(1)?.map(|v| v as u32),
-                    height: r.get::<_, Option<i64>>(2)?.map(|v| v as u32),
-                    byte_len: byte_len as u64,
-                }))
-            }
+            Some(r) => Ok(Some(ArtMeta {
+                mime: r.get(0)?,
+                width: r.get(1)?,
+                height: r.get(2)?,
+                byte_len: r.get(3)?,
+            })),
             None => Ok(None),
         }
     }
@@ -96,9 +78,9 @@ impl<M> Db<M> {
         let rows = stmt.query_map(params![track_id], |r| {
             Ok(TrackArt {
                 art_id: r.get(0)?,
-                picture_type: r.get::<_, i32>(1)? as u32,
+                picture_type: r.get(1)?,
                 description: r.get(2)?,
-                ordinal: r.get::<_, i64>(3)? as u64,
+                ordinal: r.get(3)?,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
@@ -112,7 +94,7 @@ impl Db<ReadWrite> {
             "INSERT INTO art (sha256, mime, width, height, byte_len, data)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT(sha256) DO NOTHING",
-            params![sha, a.mime, a.width, a.height, a.data.len() as i64, a.data],
+            params![sha, a.mime, a.width, a.height, a.data.len() as u64, a.data],
         )?;
         let id =
             self.conn
@@ -137,9 +119,9 @@ impl Db<ReadWrite> {
                 stmt.execute(params![
                     track_id,
                     it.art_id,
-                    it.picture_type as i32,
+                    it.picture_type,
                     it.description,
-                    it.ordinal as i64
+                    it.ordinal
                 ])?;
             }
         }

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -46,7 +46,7 @@ impl BulkWriter<'_> {
                 audio_length=excluded.audio_length, backing_size=excluded.backing_size,
                 backing_mtime=excluded.backing_mtime,
                 updated_at=CAST(strftime('%s','now') AS INTEGER)",
-            params![t.backing_path, t.format.as_str(), t.audio_offset as i64, t.audio_length as i64, t.backing_size as i64, t.backing_mtime],
+            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime],
         )?;
         Ok(self.tx.query_row(
             "SELECT id FROM tracks WHERE backing_path = ?1",
@@ -64,7 +64,7 @@ impl BulkWriter<'_> {
             "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
         )?;
         for t in tags {
-            stmt.execute(params![track_id, t.key, t.value, t.ordinal as i64])?;
+            stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
         }
         Ok(())
     }
@@ -79,7 +79,7 @@ impl BulkWriter<'_> {
              VALUES (?1, ?2, '', ?3, ?4)",
         )?;
         for t in tags {
-            stmt.execute(params![track_id, t.key, t.payload, t.ordinal as i64])?;
+            stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
         }
         Ok(())
     }
@@ -98,7 +98,7 @@ impl BulkWriter<'_> {
              VALUES (?1, ?2, ?3, ?4)",
         )?;
         for b in blocks {
-            stmt.execute(params![track_id, b.kind, b.ordinal as i64, b.body])?;
+            stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
         }
         Ok(())
     }
@@ -108,7 +108,7 @@ impl BulkWriter<'_> {
         self.tx.execute(
             "INSERT INTO art (sha256, mime, width, height, byte_len, data)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6) ON CONFLICT(sha256) DO NOTHING",
-            params![sha, a.mime, a.width, a.height, a.data.len() as i64, a.data],
+            params![sha, a.mime, a.width, a.height, a.data.len() as u64, a.data],
         )?;
         Ok(self
             .tx
@@ -130,9 +130,9 @@ impl BulkWriter<'_> {
             stmt.execute(params![
                 track_id,
                 it.art_id,
-                it.picture_type as i32,
+                it.picture_type,
                 it.description,
-                it.ordinal as i64
+                it.ordinal
             ])?;
         }
         Ok(())

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -46,7 +46,7 @@ impl BulkWriter<'_> {
                 audio_length=excluded.audio_length, backing_size=excluded.backing_size,
                 backing_mtime=excluded.backing_mtime,
                 updated_at=CAST(strftime('%s','now') AS INTEGER)",
-            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime],
+            params![t.backing_path, t.format.as_str(), t.audio_offset as i64, t.audio_length as i64, t.backing_size as i64, t.backing_mtime],
         )?;
         Ok(self.tx.query_row(
             "SELECT id FROM tracks WHERE backing_path = ?1",

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -64,7 +64,7 @@ impl BulkWriter<'_> {
             "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
         )?;
         for t in tags {
-            stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+            stmt.execute(params![track_id, t.key, t.value, t.ordinal as i64])?;
         }
         Ok(())
     }
@@ -79,7 +79,7 @@ impl BulkWriter<'_> {
              VALUES (?1, ?2, '', ?3, ?4)",
         )?;
         for t in tags {
-            stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
+            stmt.execute(params![track_id, t.key, t.payload, t.ordinal as i64])?;
         }
         Ok(())
     }
@@ -98,7 +98,7 @@ impl BulkWriter<'_> {
              VALUES (?1, ?2, ?3, ?4)",
         )?;
         for b in blocks {
-            stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
+            stmt.execute(params![track_id, b.kind, b.ordinal as i64, b.body])?;
         }
         Ok(())
     }
@@ -130,9 +130,9 @@ impl BulkWriter<'_> {
             stmt.execute(params![
                 track_id,
                 it.art_id,
-                it.picture_type,
+                it.picture_type as i32,
                 it.description,
-                it.ordinal
+                it.ordinal as i64
             ])?;
         }
         Ok(())

--- a/musefs-db/src/convert.rs
+++ b/musefs-db/src/convert.rs
@@ -1,0 +1,32 @@
+//! Sanctioned integer conversions, justified by the 64-bit-only guard below.
+
+// musefs supports 64-bit targets only; this is the compile-time declaration
+// of that boundary. It makes u64 <-> usize conversions lossless by
+// construction everywhere in the workspace.
+const _: () = assert!(
+    std::mem::size_of::<usize>() == 8,
+    "musefs supports 64-bit targets only"
+);
+
+/// The workspace's only sanctioned `u64 -> usize` cast (see the guard above).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "u64 -> usize is lossless on 64-bit targets; guarded by the const assert above"
+)]
+#[inline]
+#[must_use]
+pub fn usize_from(v: u64) -> usize {
+    v as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::usize_from;
+
+    #[test]
+    fn usize_from_is_lossless_across_the_range() {
+        assert_eq!(usize_from(0), 0);
+        assert_eq!(usize_from(u64::from(u32::MAX) + 1), 4_294_967_296);
+        assert_eq!(usize_from(u64::MAX), usize::MAX);
+    }
+}

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -1,5 +1,6 @@
 mod art;
 mod bulk;
+pub mod convert;
 mod error;
 mod models;
 mod schema;

--- a/musefs-db/src/models.rs
+++ b/musefs-db/src/models.rs
@@ -87,9 +87,9 @@ pub struct Track {
     pub id: i64,
     pub backing_path: String,
     pub format: Format,
-    pub audio_offset: i64,
-    pub audio_length: i64,
-    pub backing_size: i64,
+    pub audio_offset: u64,
+    pub audio_length: u64,
+    pub backing_size: u64,
     pub backing_mtime: i64,
     pub content_version: i64,
     pub updated_at: i64,
@@ -99,9 +99,9 @@ pub struct Track {
 pub struct NewTrack {
     pub backing_path: String,
     pub format: Format,
-    pub audio_offset: i64,
-    pub audio_length: i64,
-    pub backing_size: i64,
+    pub audio_offset: u64,
+    pub audio_length: u64,
+    pub backing_size: u64,
     pub backing_mtime: i64,
 }
 

--- a/musefs-db/src/models.rs
+++ b/musefs-db/src/models.rs
@@ -108,8 +108,8 @@ pub struct NewTrack {
 #[derive(Debug, Clone)]
 pub struct NewArt {
     pub mime: String,
-    pub width: Option<i64>,
-    pub height: Option<i64>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
     pub data: Vec<u8>,
 }
 
@@ -137,9 +137,9 @@ pub struct Art {
     pub id: i64,
     pub sha256: String,
     pub mime: String,
-    pub width: Option<i64>,
-    pub height: Option<i64>,
-    pub byte_len: i64,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub byte_len: u64,
     pub data: Vec<u8>,
 }
 
@@ -147,9 +147,9 @@ pub struct Art {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArtMeta {
     pub mime: String,
-    pub width: Option<i64>,
-    pub height: Option<i64>,
-    pub byte_len: i64,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub byte_len: u64,
 }
 
 #[cfg_attr(feature = "mutants", derive(Default))]
@@ -179,7 +179,7 @@ pub struct BinaryTag {
 pub struct BinaryTagRow {
     pub rowid: i64,
     pub key: String,
-    pub byte_len: i64,
+    pub byte_len: u64,
 }
 
 /// A read-only structural metadata block derived from the backing file

--- a/musefs-db/src/models.rs
+++ b/musefs-db/src/models.rs
@@ -118,11 +118,11 @@ pub struct NewArt {
 pub struct Tag {
     pub key: String,
     pub value: String,
-    pub ordinal: i64,
+    pub ordinal: u64,
 }
 
 impl Tag {
-    pub fn new(key: &str, value: &str, ordinal: i64) -> Tag {
+    pub fn new(key: &str, value: &str, ordinal: u64) -> Tag {
         Tag {
             key: key.to_string(),
             value: value.to_string(),
@@ -156,9 +156,9 @@ pub struct ArtMeta {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrackArt {
     pub art_id: i64,
-    pub picture_type: i64,
+    pub picture_type: u32,
     pub description: String,
-    pub ordinal: i64,
+    pub ordinal: u64,
 }
 
 /// A binary tag payload to write (e.g. an opaque ID3 `PRIV` frame body). `key` is
@@ -169,7 +169,7 @@ pub struct TrackArt {
 pub struct BinaryTag {
     pub key: String,
     pub payload: Vec<u8>,
-    pub ordinal: i64,
+    pub ordinal: u64,
 }
 
 /// A binary tag row read back for synthesis: the streaming handle (`rowid`), the
@@ -188,6 +188,6 @@ pub struct BinaryTagRow {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructuralBlock {
     pub kind: String,
-    pub ordinal: i64,
+    pub ordinal: u64,
     pub body: Vec<u8>,
 }

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -125,7 +125,7 @@ END;
 const MIGRATIONS: &[&str] = &[MIGRATION_V1, MIGRATION_V2, MIGRATION_V3];
 
 pub fn migrate(conn: &mut Connection) -> Result<()> {
-    let latest = MIGRATIONS.len() as i64;
+    let latest = i64::try_from(MIGRATIONS.len()).expect("MIGRATIONS count must fit i64");
     // Fast path: already at the latest version, no transaction needed.
     if conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))? >= latest {
         return Ok(());
@@ -136,8 +136,7 @@ pub fn migrate(conn: &mut Connection) -> Result<()> {
     // sees the updated version and skips re-applying the migration.
     let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
     let current: i64 = tx.pragma_query_value(None, "user_version", |r| r.get(0))?;
-    for (i, sql) in MIGRATIONS.iter().enumerate() {
-        let target = (i + 1) as i64;
+    for (target, sql) in (1i64..).zip(MIGRATIONS) {
         if current < target {
             tx.execute_batch(sql)?;
             tx.pragma_update(None, "user_version", target)?;
@@ -458,7 +457,10 @@ mod schema_py_tests {
 
         assert_eq!(dump_master(&rendered), dump_master(&migrated));
         assert_eq!(user_version(&rendered), user_version(&migrated));
-        assert_eq!(user_version(&rendered), MIGRATIONS.len() as i64);
+        assert_eq!(
+            user_version(&rendered),
+            i64::try_from(MIGRATIONS.len()).unwrap()
+        );
     }
 
     /// NOT #[ignore]d on purpose: the compare path must run under plain

--- a/musefs-db/src/structural.rs
+++ b/musefs-db/src/structural.rs
@@ -24,7 +24,7 @@ impl<M> Db<M> {
         let rows = stmt.query_map(params![track_id], |r| {
             Ok(StructuralBlock {
                 kind: r.get(0)?,
-                ordinal: r.get::<_, i64>(1)? as u64,
+                ordinal: r.get(1)?,
                 body: r.get(2)?,
             })
         })?;
@@ -46,7 +46,7 @@ impl Db<ReadWrite> {
                  VALUES (?1, ?2, ?3, ?4)",
             )?;
             for b in blocks {
-                stmt.execute(params![track_id, b.kind, b.ordinal as i64, b.body])?;
+                stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
             }
         }
         tx.commit()?;

--- a/musefs-db/src/structural.rs
+++ b/musefs-db/src/structural.rs
@@ -24,7 +24,7 @@ impl<M> Db<M> {
         let rows = stmt.query_map(params![track_id], |r| {
             Ok(StructuralBlock {
                 kind: r.get(0)?,
-                ordinal: r.get(1)?,
+                ordinal: r.get::<_, i64>(1)? as u64,
                 body: r.get(2)?,
             })
         })?;
@@ -46,7 +46,7 @@ impl Db<ReadWrite> {
                  VALUES (?1, ?2, ?3, ?4)",
             )?;
             for b in blocks {
-                stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
+                stmt.execute(params![track_id, b.kind, b.ordinal as i64, b.body])?;
             }
         }
         tx.commit()?;

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -111,7 +111,7 @@ impl<M> Db<M> {
         let blob = self
             .conn
             .blob_open("main", "tags", "value_blob", payload_id, true)?;
-        blob.read_at_exact(buf, offset as usize)?;
+        blob.read_at_exact(buf, crate::convert::usize_from(offset))?;
         Ok(())
     }
 

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -82,8 +82,6 @@ impl<M> Db<M> {
         Ok(out)
     }
 
-    /// Binary tag rows for a track: streaming handle (rowid), key, and payload
-    /// length. Ordered by (key, ordinal) to match `get_binary_tags`/synthesis order.
     pub fn get_binary_tags(&self, track_id: i64) -> Result<Vec<BinaryTagRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT rowid, key, length(value_blob) FROM tags \
@@ -93,7 +91,7 @@ impl<M> Db<M> {
             Ok(BinaryTagRow {
                 rowid: r.get(0)?,
                 key: r.get(1)?,
-                byte_len: r.get(2)?,
+                byte_len: r.get::<_, i64>(2)? as u64,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -12,7 +12,7 @@ impl<M> Db<M> {
             Ok(Tag {
                 key: r.get(0)?,
                 value: r.get(1)?,
-                ordinal: r.get(2)?,
+                ordinal: r.get::<_, i64>(2)? as u64,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
@@ -44,7 +44,7 @@ impl<M> Db<M> {
                     Tag {
                         key: r.get(1)?,
                         value: r.get(2)?,
-                        ordinal: r.get(3)?,
+                        ordinal: r.get::<_, i64>(3)? as u64,
                     },
                 ))
             })?;
@@ -70,7 +70,7 @@ impl<M> Db<M> {
                 Tag {
                     key: r.get(1)?,
                     value: r.get(2)?,
-                    ordinal: r.get(3)?,
+                    ordinal: r.get::<_, i64>(3)? as u64,
                 },
             ))
         })?;
@@ -141,7 +141,7 @@ impl Db<ReadWrite> {
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
             )?;
             for t in tags {
-                stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+                stmt.execute(params![track_id, t.key, t.value, t.ordinal as i64])?;
             }
         }
         tx.commit()?;
@@ -162,7 +162,7 @@ impl Db<ReadWrite> {
                  VALUES (?1, ?2, '', ?3, ?4)",
             )?;
             for t in tags {
-                stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
+                stmt.execute(params![track_id, t.key, t.payload, t.ordinal as i64])?;
             }
         }
         tx.commit()?;

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -12,7 +12,7 @@ impl<M> Db<M> {
             Ok(Tag {
                 key: r.get(0)?,
                 value: r.get(1)?,
-                ordinal: r.get::<_, i64>(2)? as u64,
+                ordinal: r.get(2)?,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
@@ -44,7 +44,7 @@ impl<M> Db<M> {
                     Tag {
                         key: r.get(1)?,
                         value: r.get(2)?,
-                        ordinal: r.get::<_, i64>(3)? as u64,
+                        ordinal: r.get(3)?,
                     },
                 ))
             })?;
@@ -70,7 +70,7 @@ impl<M> Db<M> {
                 Tag {
                     key: r.get(1)?,
                     value: r.get(2)?,
-                    ordinal: r.get::<_, i64>(3)? as u64,
+                    ordinal: r.get(3)?,
                 },
             ))
         })?;
@@ -82,6 +82,8 @@ impl<M> Db<M> {
         Ok(out)
     }
 
+    /// Binary tag rows for a track: streaming handle (rowid), key, and payload
+    /// length. Ordered by (key, ordinal) to match `get_binary_tags`/synthesis order.
     pub fn get_binary_tags(&self, track_id: i64) -> Result<Vec<BinaryTagRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT rowid, key, length(value_blob) FROM tags \
@@ -91,7 +93,7 @@ impl<M> Db<M> {
             Ok(BinaryTagRow {
                 rowid: r.get(0)?,
                 key: r.get(1)?,
-                byte_len: r.get::<_, i64>(2)? as u64,
+                byte_len: r.get(2)?,
             })
         })?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
@@ -141,7 +143,7 @@ impl Db<ReadWrite> {
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
             )?;
             for t in tags {
-                stmt.execute(params![track_id, t.key, t.value, t.ordinal as i64])?;
+                stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
             }
         }
         tx.commit()?;
@@ -162,7 +164,7 @@ impl Db<ReadWrite> {
                  VALUES (?1, ?2, '', ?3, ?4)",
             )?;
             for t in tags {
-                stmt.execute(params![track_id, t.key, t.payload, t.ordinal as i64])?;
+                stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
             }
         }
         tx.commit()?;

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -20,13 +20,23 @@ fn parse_format_col(fmt: &str) -> rusqlite::Result<Format> {
 fn row_to_track(r: &Row) -> rusqlite::Result<Track> {
     let fmt: String = r.get("format")?;
     let format = parse_format_col(&fmt)?;
+    let audio_offset_i: i64 = r.get("audio_offset")?;
+    let audio_length_i: i64 = r.get("audio_length")?;
+    let backing_size_i: i64 = r.get("backing_size")?;
+    if audio_offset_i < 0 || audio_length_i < 0 || backing_size_i < 0 {
+        return Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Integer,
+            "negative audio bounds or backing size".into(),
+        ));
+    }
     Ok(Track {
         id: r.get("id")?,
         backing_path: r.get("backing_path")?,
         format,
-        audio_offset: r.get("audio_offset")?,
-        audio_length: r.get("audio_length")?,
-        backing_size: r.get("backing_size")?,
+        audio_offset: audio_offset_i as u64,
+        audio_length: audio_length_i as u64,
+        backing_size: backing_size_i as u64,
         backing_mtime: r.get("backing_mtime")?,
         content_version: r.get("content_version")?,
         updated_at: r.get("updated_at")?,
@@ -184,9 +194,9 @@ impl Db<ReadWrite> {
             params![
                 t.backing_path,
                 t.format.as_str(),
-                t.audio_offset,
-                t.audio_length,
-                t.backing_size,
+                t.audio_offset as i64,
+                t.audio_length as i64,
+                t.backing_size as i64,
                 t.backing_mtime,
             ],
         )?;
@@ -227,6 +237,34 @@ impl Db<ReadWrite> {
         self.conn
             .execute("DELETE FROM track_changes WHERE seq <= ?1", [seq])?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod negative_audio_bounds_tests {
+    use crate::{Db, Format, NewTrack};
+
+    #[test]
+    fn negative_audio_bounds_error_at_row_read() {
+        let db = Db::open_in_memory().unwrap();
+        let id = db
+            .upsert_track(&NewTrack {
+                backing_path: "/x.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 1,
+                backing_size: 1,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        // Simulate a malformed external write to a contract column.
+        db.conn
+            .execute("UPDATE tracks SET audio_offset = -1 WHERE id = ?1", [id])
+            .unwrap();
+        assert!(
+            db.get_track(id).is_err(),
+            "negative audio_offset must fail row-read, not wrap"
+        );
     }
 }
 

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -20,23 +20,13 @@ fn parse_format_col(fmt: &str) -> rusqlite::Result<Format> {
 fn row_to_track(r: &Row) -> rusqlite::Result<Track> {
     let fmt: String = r.get("format")?;
     let format = parse_format_col(&fmt)?;
-    let audio_offset_i: i64 = r.get("audio_offset")?;
-    let audio_length_i: i64 = r.get("audio_length")?;
-    let backing_size_i: i64 = r.get("backing_size")?;
-    if audio_offset_i < 0 || audio_length_i < 0 || backing_size_i < 0 {
-        return Err(rusqlite::Error::FromSqlConversionFailure(
-            0,
-            rusqlite::types::Type::Integer,
-            "negative audio bounds or backing size".into(),
-        ));
-    }
     Ok(Track {
         id: r.get("id")?,
         backing_path: r.get("backing_path")?,
         format,
-        audio_offset: audio_offset_i as u64,
-        audio_length: audio_length_i as u64,
-        backing_size: backing_size_i as u64,
+        audio_offset: r.get("audio_offset")?,
+        audio_length: r.get("audio_length")?,
+        backing_size: r.get("backing_size")?,
         backing_mtime: r.get("backing_mtime")?,
         content_version: r.get("content_version")?,
         updated_at: r.get("updated_at")?,
@@ -194,9 +184,9 @@ impl Db<ReadWrite> {
             params![
                 t.backing_path,
                 t.format.as_str(),
-                t.audio_offset as i64,
-                t.audio_length as i64,
-                t.backing_size as i64,
+                t.audio_offset,
+                t.audio_length,
+                t.backing_size,
                 t.backing_mtime,
             ],
         )?;

--- a/musefs-format/src/convert.rs
+++ b/musefs-format/src/convert.rs
@@ -1,0 +1,22 @@
+//! Sanctioned integer conversions, justified by the 64-bit-only guard below.
+//! A deliberate sibling of `musefs_db::convert`: the format crate is pure byte
+//! surgery and does not link the SQLite store for one helper.
+
+// musefs supports 64-bit targets only; this is the compile-time declaration
+// of that boundary. It makes u64 <-> usize conversions lossless by
+// construction.
+const _: () = assert!(
+    std::mem::size_of::<usize>() == 8,
+    "musefs supports 64-bit targets only"
+);
+
+/// This crate's only sanctioned `u64 -> usize` cast (see the guard above).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "u64 -> usize is lossless on 64-bit targets; guarded by the const assert above"
+)]
+#[inline]
+#[must_use]
+pub(crate) fn usize_from(v: u64) -> usize {
+    v as usize
+}

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -145,10 +145,22 @@ use crate::layout::{RegionLayout, Segment};
 /// Inclusive maximum body length of a FLAC metadata block (24-bit length field).
 pub(crate) const MAX_BLOCK_BODY: u64 = 0x00FF_FFFF;
 
-pub(crate) fn push_block_header(out: &mut Vec<u8>, block_type: u8, body_len: usize, is_last: bool) {
+pub(crate) fn push_block_header(
+    out: &mut Vec<u8>,
+    block_type: u8,
+    body_len: usize,
+    is_last: bool,
+) -> Result<()> {
+    // A FLAC block length is a 24-bit field; refuse anything larger rather
+    // than emit a truncated length.
+    let len = u32::try_from(body_len)
+        .ok()
+        .filter(|&v| u64::from(v) <= MAX_BLOCK_BODY)
+        .ok_or(FormatError::TooLarge)?;
     let first = (if is_last { 0x80 } else { 0 }) | (block_type & 0x7F);
     out.push(first);
-    out.extend_from_slice(&(body_len as u32).to_be_bytes()[1..]);
+    out.extend_from_slice(&len.to_be_bytes()[1..]);
+    Ok(())
 }
 
 /// Map a stored structural-block `kind` string back to its FLAC block type.
@@ -191,19 +203,31 @@ pub fn split_preserved(
     (structural, binary)
 }
 
-fn picture_body_framing(art: &ArtInput) -> Vec<u8> {
+fn picture_body_framing(art: &ArtInput) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(&art.picture_type.to_be_bytes());
-    out.extend_from_slice(&(art.mime.len() as u32).to_be_bytes());
+    out.extend_from_slice(
+        &u32::try_from(art.mime.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    );
     out.extend_from_slice(art.mime.as_bytes());
-    out.extend_from_slice(&(art.description.len() as u32).to_be_bytes());
+    out.extend_from_slice(
+        &u32::try_from(art.description.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    );
     out.extend_from_slice(art.description.as_bytes());
     out.extend_from_slice(&art.width.to_be_bytes());
     out.extend_from_slice(&art.height.to_be_bytes());
     out.extend_from_slice(&0u32.to_be_bytes()); // color depth (unknown)
     out.extend_from_slice(&0u32.to_be_bytes()); // number of colors (non-indexed)
-    out.extend_from_slice(&(art.data_len as u32).to_be_bytes()); // picture data length
-    out
+    out.extend_from_slice(
+        &u32::try_from(art.data_len)
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    ); // picture data length
+    Ok(out)
 }
 
 /// Build the ordered segment layout for a synthesized FLAC file:
@@ -237,16 +261,16 @@ pub fn synthesize_layout(
     let mut idx = 0usize;
 
     for blk in &ordered {
-        push_block_header(&mut buf, blk.block_type, blk.body.len(), idx == last_index);
+        push_block_header(&mut buf, blk.block_type, blk.body.len(), idx == last_index)?;
         buf.extend_from_slice(&blk.body);
         idx += 1;
     }
 
-    let vc = crate::vorbiscomment::build(tags);
+    let vc = crate::vorbiscomment::build(tags)?;
     if vc.len() as u64 > MAX_BLOCK_BODY {
         return Err(FormatError::TooLarge);
     }
-    push_block_header(&mut buf, BLOCK_VORBIS_COMMENT, vc.len(), idx == last_index);
+    push_block_header(&mut buf, BLOCK_VORBIS_COMMENT, vc.len(), idx == last_index)?;
     buf.extend_from_slice(&vc);
     idx += 1;
 
@@ -259,7 +283,12 @@ pub fn synthesize_layout(
         if bt.len > MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
         }
-        push_block_header(&mut buf, block_type, bt.len as usize, idx == last_index);
+        push_block_header(
+            &mut buf,
+            block_type,
+            crate::convert::usize_from(bt.len),
+            idx == last_index,
+        )?;
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::BinaryTag {
             payload_id: bt.payload_id,
@@ -272,7 +301,7 @@ pub fn synthesize_layout(
         if art.data_len == 0 {
             continue;
         }
-        let framing = picture_body_framing(art);
+        let framing = picture_body_framing(art)?;
         let body_len = framing.len() as u64 + art.data_len;
         if body_len > MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
@@ -280,9 +309,9 @@ pub fn synthesize_layout(
         push_block_header(
             &mut buf,
             BLOCK_PICTURE,
-            body_len as usize,
+            crate::convert::usize_from(body_len),
             idx == last_index,
-        );
+        )?;
         buf.extend_from_slice(&framing);
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::ArtImage {
@@ -437,7 +466,7 @@ mod tests {
     /// body) + `audio` bytes. Returns (full_bytes, audio_offset).
     fn flac_with_streaminfo(audio: &[u8]) -> (Vec<u8>, u64) {
         let mut v = b"fLaC".to_vec();
-        push_block_header(&mut v, BLOCK_STREAMINFO, 34, true);
+        push_block_header(&mut v, BLOCK_STREAMINFO, 34, true).unwrap();
         v.extend(std::iter::repeat_n(0u8, 34));
         let audio_offset = v.len() as u64;
         v.extend_from_slice(audio);
@@ -448,7 +477,7 @@ mod tests {
     fn read_metadata_bounded_complete_when_prefix_covers_blocks() {
         let (full, audio_offset) = flac_with_streaminfo(b"AUDIOAUDIO");
         // Prefix that includes all metadata but not all audio.
-        let prefix = &full[..audio_offset as usize + 2];
+        let prefix = &full[..crate::convert::usize_from(audio_offset) + 2];
         match read_metadata_bounded(prefix).unwrap() {
             Extent::Complete(meta) => assert_eq!(meta.audio_offset, audio_offset),
             other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
@@ -481,11 +510,11 @@ mod tests {
     fn push_block_header_emits_24bit_length_big_endian() {
         // pins :101 (`>>16` -> `<<16`): high byte 0x12 must land in out[1].
         let mut out = Vec::new();
-        push_block_header(&mut out, BLOCK_PICTURE, 0x12_3456, false);
+        push_block_header(&mut out, BLOCK_PICTURE, 0x12_3456, false).unwrap();
         assert_eq!(out, vec![BLOCK_PICTURE, 0x12, 0x34, 0x56]);
         // :99 is equivalent, but exercise the is_last/0x80 path anyway.
         let mut last = Vec::new();
-        push_block_header(&mut last, BLOCK_VORBIS_COMMENT, 0, true);
+        push_block_header(&mut last, BLOCK_VORBIS_COMMENT, 0, true).unwrap();
         assert_eq!(last, vec![0x80 | BLOCK_VORBIS_COMMENT, 0x00, 0x00, 0x00]);
     }
 
@@ -496,7 +525,7 @@ mod tests {
     fn raw_block(block_type: u8, body: &[u8], last: bool, len_override: Option<usize>) -> Vec<u8> {
         let n = len_override.unwrap_or(body.len());
         let mut v = vec![(if last { 0x80 } else { 0 }) | (block_type & 0x7F)];
-        v.extend_from_slice(&(n as u32).to_be_bytes()[1..]);
+        v.extend_from_slice(&u32::try_from(n).unwrap().to_be_bytes()[1..]);
         v.extend_from_slice(body);
         v
     }
@@ -564,11 +593,11 @@ mod tests {
     /// comment as u32-LE length + bytes.
     fn vc_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
         let mut v = Vec::new();
-        v.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        v.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
         v.extend_from_slice(vendor.as_bytes());
-        v.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+        v.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
         for c in comments {
-            v.extend_from_slice(&(c.len() as u32).to_le_bytes());
+            v.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
             v.extend_from_slice(c.as_bytes());
         }
         v
@@ -626,15 +655,15 @@ mod tests {
     fn picture_body(ptype: u32, mime: &str, desc: &str, w: u32, h: u32, data: &[u8]) -> Vec<u8> {
         let mut v = Vec::new();
         v.extend_from_slice(&ptype.to_be_bytes());
-        v.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        v.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
         v.extend_from_slice(mime.as_bytes());
-        v.extend_from_slice(&(desc.len() as u32).to_be_bytes());
+        v.extend_from_slice(&u32::try_from(desc.len()).unwrap().to_be_bytes());
         v.extend_from_slice(desc.as_bytes());
         v.extend_from_slice(&w.to_be_bytes());
         v.extend_from_slice(&h.to_be_bytes());
         v.extend_from_slice(&0u32.to_be_bytes()); // depth
         v.extend_from_slice(&0u32.to_be_bytes()); // colors
-        v.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        v.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
         v.extend_from_slice(data);
         v
     }
@@ -931,7 +960,7 @@ mod tests {
         // Derive the exact framing length from production rather than hardcoding it
         // (it is independent of the data_len *value* — that field is always 4 bytes).
         // This keeps the boundary correct regardless of the framing's field count.
-        let framing_len = picture_body_framing(&mk(0)).len() as u64;
+        let framing_len = picture_body_framing(&mk(0)).unwrap().len() as u64;
         let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
                                                   // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
                                                   // (data_len is only a count; no large allocation occurs.)
@@ -950,8 +979,10 @@ mod tests {
         // value so the body lands exactly on the limit; one more byte errors.
         // Mirrors the PICTURE/binary-tag boundary tests: the `>` accepts the
         // inclusive limit while the `>=` mutant rejects it.
-        let overhead = crate::vorbiscomment::build(&[TagInput::new("title", "")]).len() as u64;
-        let at_limit = "x".repeat((MAX_BLOCK_BODY - overhead) as usize);
+        let overhead = crate::vorbiscomment::build(&[TagInput::new("title", "")])
+            .unwrap()
+            .len() as u64;
+        let at_limit = "x".repeat(crate::convert::usize_from(MAX_BLOCK_BODY - overhead));
         let tags = [TagInput::new("title", at_limit.as_str())];
         assert!(synthesize_layout(&[], 0, 0, &tags, &[], &[]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.

--- a/musefs-format/src/fuzz_check.rs
+++ b/musefs-format/src/fuzz_check.rs
@@ -374,6 +374,24 @@ mod fixtures_tests {
     }
 
     #[test]
+    fn flac_block_encodes_24bit_length_big_endian() {
+        // Pin all three length bytes of the 24-bit block-length field. The body is
+        // sized so each byte is distinct and non-zero (0x030201 = 197_121), which
+        // distinguishes `>> 16`/`>> 8` from `<< 16`/`<< 8` (a left shift would zero
+        // the high/mid bytes). The header is 4 bytes: type|last, then 3 length bytes.
+        let len = 0x03_02_01usize;
+        let body = vec![0xABu8; len];
+        let block = fixtures::flac_block(4, &body, false);
+        assert_eq!(block[0], 4, "block type, last-flag clear");
+        assert_eq!(
+            &block[1..4],
+            &[0x03, 0x02, 0x01],
+            "24-bit big-endian length"
+        );
+        assert_eq!(block.len(), 4 + len);
+    }
+
+    #[test]
     fn m4a_fixture_parses() {
         let f = fixtures::m4a(&[9u8; 16]);
         let b = crate::mp4::locate_audio(&f).unwrap();

--- a/musefs-format/src/fuzz_check.rs
+++ b/musefs-format/src/fuzz_check.rs
@@ -61,9 +61,9 @@ pub mod fixtures {
         let first = (if is_last { 0x80 } else { 0 }) | (block_type & 0x7F);
         out.push(first);
         let len = body.len();
-        out.push(((len >> 16) & 0xFF) as u8);
-        out.push(((len >> 8) & 0xFF) as u8);
-        out.push((len & 0xFF) as u8);
+        out.push(u8::try_from((len >> 16) & 0xFF).expect("masked to 0xFF"));
+        out.push(u8::try_from((len >> 8) & 0xFF).expect("masked to 0xFF"));
+        out.push(u8::try_from(len & 0xFF).expect("masked to 0xFF"));
         out.extend_from_slice(body);
         out
     }
@@ -86,11 +86,11 @@ pub mod fixtures {
     /// Minimal VORBIS_COMMENT body with the given already-formatted `KEY=value` comments.
     pub fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
         let mut out = Vec::new();
-        out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
         out.extend_from_slice(vendor.as_bytes());
-        out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
         for c in comments {
-            out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+            out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
             out.extend_from_slice(c.as_bytes());
         }
         out
@@ -120,7 +120,10 @@ pub mod fixtures {
     }
 
     fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
-        let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();
+        let mut v = u32::try_from(8 + payload.len())
+            .unwrap()
+            .to_be_bytes()
+            .to_vec();
         v.extend_from_slice(kind);
         v.extend_from_slice(payload);
         v
@@ -186,7 +189,7 @@ pub mod fixtures {
         // that shrinks the `moov` patches the offset below zero and synthesis fails
         // (TooLarge). With the true offset, the patched value lands at the new payload
         // position. The first `stco` occurrence is the box type (it precedes `mdat`).
-        let mdat_payload_offset = (out.len() - mdat_payload.len()) as u32;
+        let mdat_payload_offset = u32::try_from(out.len() - mdat_payload.len()).unwrap();
         let stco = out
             .windows(4)
             .position(|w| w == b"stco")
@@ -217,15 +220,15 @@ pub mod fixtures {
 
         // Chunk helpers: 4-byte id + LE 32-bit size + payload.
         let mut fmt_chunk = b"fmt ".to_vec();
-        fmt_chunk.extend_from_slice(&(fmt.len() as u32).to_le_bytes());
+        fmt_chunk.extend_from_slice(&u32::try_from(fmt.len()).unwrap().to_le_bytes());
         fmt_chunk.extend_from_slice(&fmt);
 
         let mut data_chunk = b"data".to_vec();
-        data_chunk.extend_from_slice(&(data_payload.len() as u32).to_le_bytes());
+        data_chunk.extend_from_slice(&u32::try_from(data_payload.len()).unwrap().to_le_bytes());
         data_chunk.extend_from_slice(&data_payload);
 
         // RIFF size = 4 ("WAVE") + fmt_chunk.len() + data_chunk.len()
-        let riff_size = (4 + fmt_chunk.len() + data_chunk.len()) as u32;
+        let riff_size = u32::try_from(4 + fmt_chunk.len() + data_chunk.len()).unwrap();
         let mut out = Vec::with_capacity(12 + fmt_chunk.len() + data_chunk.len());
         out.extend_from_slice(b"RIFF");
         out.extend_from_slice(&riff_size.to_le_bytes());
@@ -398,7 +401,7 @@ mod fixtures_tests {
         // value (out.len() - payload.len()) and where it is written (stco + 12).
         let payload = b"AUDIOAUDIO";
         let f = fixtures::m4a(payload);
-        let expected = (f.len() - payload.len()) as u32;
+        let expected = u32::try_from(f.len() - payload.len()).unwrap();
         let stco = f
             .windows(4)
             .position(|w| w == b"stco")

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -1,3 +1,4 @@
+mod convert;
 mod error;
 pub mod flac;
 mod input;

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -189,6 +189,10 @@ fn apic_framing(art: &ArtInput) -> Vec<u8> {
     let mut d = vec![ENC_UTF8];
     d.extend_from_slice(art.mime.as_bytes());
     d.push(0x00);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "ID3 APIC type is one byte; valid picture types are 0..=20"
+    )]
     d.push(art.picture_type as u8);
     d.extend_from_slice(art.description.as_bytes());
     d.push(0x00);

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -134,14 +134,14 @@ fn syncsafe(n: u32) -> [u8; 4] {
 }
 
 /// Inclusive maximum of a 28-bit ID3v2.4 syncsafe size field.
-const SYNCHSAFE_MAX: usize = 0x0FFF_FFFF;
+const SYNCHSAFE_MAX: u32 = 0x0FFF_FFFF;
 
 fn push_frame_header(out: &mut Vec<u8>, id: &[u8; 4], data_len: usize) -> Result<()> {
     // ID3v2.4 frame sizes are a 28-bit syncsafe field; guard so an oversized frame
     // is a hard error rather than a silently-truncated (corrupt) tag.
     let data_len_u32 = u32::try_from(data_len)
         .ok()
-        .filter(|&v| v as usize <= SYNCHSAFE_MAX)
+        .filter(|&v| v <= SYNCHSAFE_MAX)
         .ok_or(FormatError::TooLarge)?;
     out.extend_from_slice(id);
     out.extend_from_slice(&syncsafe(data_len_u32));
@@ -394,7 +394,7 @@ pub fn build_id3v2_segments(
     // large pictures summing past the limit) is a hard error, not a truncated file.
     let frames_len_ss = u32::try_from(frames_len)
         .ok()
-        .filter(|&v| v as usize <= SYNCHSAFE_MAX)
+        .filter(|&v| v <= SYNCHSAFE_MAX)
         .ok_or(FormatError::TooLarge)?;
     header.extend_from_slice(&syncsafe(frames_len_ss));
     segments.insert(0, Segment::Inline(header));

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1,3 +1,4 @@
+use crate::convert::usize_from;
 use crate::error::{FormatError, Result};
 use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
@@ -14,10 +15,10 @@ pub struct Mp3Bounds {
 }
 
 fn synchsafe_decode(b: &[u8]) -> u32 {
-    ((b[0] & 0x7F) as u32) << 21
-        | ((b[1] & 0x7F) as u32) << 14
-        | ((b[2] & 0x7F) as u32) << 7
-        | (b[3] & 0x7F) as u32
+    u32::from(b[0] & 0x7F) << 21
+        | u32::from(b[1] & 0x7F) << 14
+        | u32::from(b[2] & 0x7F) << 7
+        | u32::from(b[3] & 0x7F)
 }
 
 /// Locate the audio region: skip a leading ID3v2 tag (if present) and a trailing
@@ -138,11 +139,12 @@ const SYNCHSAFE_MAX: usize = 0x0FFF_FFFF;
 fn push_frame_header(out: &mut Vec<u8>, id: &[u8; 4], data_len: usize) -> Result<()> {
     // ID3v2.4 frame sizes are a 28-bit syncsafe field; guard so an oversized frame
     // is a hard error rather than a silently-truncated (corrupt) tag.
-    if data_len > SYNCHSAFE_MAX {
-        return Err(FormatError::TooLarge);
-    }
+    let data_len_u32 = u32::try_from(data_len)
+        .ok()
+        .filter(|&v| v as usize <= SYNCHSAFE_MAX)
+        .ok_or(FormatError::TooLarge)?;
     out.extend_from_slice(id);
-    out.extend_from_slice(&syncsafe(data_len as u32));
+    out.extend_from_slice(&syncsafe(data_len_u32));
     out.extend_from_slice(&[0x00, 0x00]); // frame flags
     Ok(())
 }
@@ -349,7 +351,7 @@ pub fn build_id3v2_segments(
         let Ok(id): std::result::Result<[u8; 4], _> = bt.key.as_bytes().try_into() else {
             continue;
         };
-        push_frame_header(&mut buf, &id, bt.len as usize)?;
+        push_frame_header(&mut buf, &id, usize_from(bt.len))?;
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::BinaryTag {
             payload_id: bt.payload_id,
@@ -367,7 +369,7 @@ pub fn build_id3v2_segments(
         }
         let framing = apic_framing(art);
         let data_len = framing.len() as u64 + art.data_len;
-        push_frame_header(&mut buf, b"APIC", data_len as usize)?;
+        push_frame_header(&mut buf, b"APIC", usize_from(data_len))?;
         buf.extend_from_slice(&framing);
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::ArtImage {
@@ -390,10 +392,11 @@ pub fn build_id3v2_segments(
     // The total tag size is a 28-bit syncsafe field. Ingestion caps each art well
     // under this, but guard at the format boundary so an oversized tag (e.g. many
     // large pictures summing past the limit) is a hard error, not a truncated file.
-    if frames_len > SYNCHSAFE_MAX as u64 {
-        return Err(FormatError::TooLarge);
-    }
-    header.extend_from_slice(&syncsafe(frames_len as u32));
+    let frames_len_ss = u32::try_from(frames_len)
+        .ok()
+        .filter(|&v| v as usize <= SYNCHSAFE_MAX)
+        .ok_or(FormatError::TooLarge)?;
+    header.extend_from_slice(&syncsafe(frames_len_ss));
     segments.insert(0, Segment::Inline(header));
 
     Ok((segments, 10 + frames_len))
@@ -538,7 +541,7 @@ pub fn read_pictures(data: &[u8]) -> Vec<EmbeddedPicture> {
     tag.pictures()
         .map(|p| EmbeddedPicture {
             mime: p.mime_type.clone(),
-            picture_type: u8::from(p.picture_type) as u32,
+            picture_type: u8::from(p.picture_type).into(),
             description: p.description.clone(),
             width: 0,
             height: 0,
@@ -651,7 +654,7 @@ fn classify_binary_frame(
                     let c = counter
                         .iter()
                         .take(8)
-                        .fold(0u64, |a, &b| (a << 8) | b as u64);
+                        .fold(0u64, |a, &b| (a << 8) | u64::from(b));
                     if c > 0 {
                         promoted.push(("playcount".to_string(), c.to_string()));
                     }
@@ -1333,7 +1336,7 @@ mod tests {
     /// then `audio`. Returns (full, audio_offset).
     fn mp3_with_id3v2(body_len: usize, audio: &[u8]) -> (Vec<u8>, u64) {
         let mut v = b"ID3\x04\x00\x00".to_vec(); // version 2.4, no flags
-        v.extend_from_slice(&syncsafe(body_len as u32));
+        v.extend_from_slice(&syncsafe(u32::try_from(body_len).unwrap()));
         v.extend(std::iter::repeat_n(0u8, body_len)); // tag body
         let audio_offset = v.len() as u64;
         v.extend_from_slice(&[0xFF, 0xFB]); // MPEG frame sync
@@ -1344,7 +1347,7 @@ mod tests {
     #[test]
     fn locate_audio_bounded_complete_with_no_id3v1() {
         let (full, audio_offset) = mp3_with_id3v2(8, b"frames");
-        let prefix = &full[..audio_offset as usize + 2]; // covers tag + sync
+        let prefix = &full[..usize_from(audio_offset) + 2]; // covers tag + sync
         let file_len = full.len() as u64;
         match locate_audio_bounded(prefix, file_len, None).unwrap() {
             Extent::Complete(b) => {
@@ -1374,7 +1377,7 @@ mod tests {
         full.extend(std::iter::repeat_n(0u8, 125)); // 128-byte tag total
         let file_len = full.len() as u64;
         let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
-        let prefix = &full[..audio_offset as usize + 2];
+        let prefix = &full[..usize_from(audio_offset) + 2];
         match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
             Extent::Complete(b) => {
                 assert_eq!(b.audio_offset, audio_offset);
@@ -1453,7 +1456,7 @@ mod tests {
         let body = 6usize;
         let mut full = b"ID3\x04\x00".to_vec();
         full.push(0x10); // flags: footer present
-        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend_from_slice(&syncsafe(u32::try_from(body).unwrap()));
         full.extend(std::iter::repeat_n(0u8, body)); // tag body
         full.extend(std::iter::repeat_n(0u8, 10)); // footer region
         let expected_offset = full.len() as u64; // 10 + 6 + 10 = 26
@@ -1482,7 +1485,7 @@ mod tests {
     fn locate_audio_bounded_tag_len_equals_file_len_is_notmp3_not_malformed() {
         let body = 8usize;
         let mut full = b"ID3\x04\x00\x00".to_vec();
-        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend_from_slice(&syncsafe(u32::try_from(body).unwrap()));
         full.extend(std::iter::repeat_n(0u8, body)); // file ends exactly at tag end
         let file_len = full.len() as u64; // == tag_len == audio_offset (18)
         match locate_audio_bounded(&full, file_len, None) {
@@ -1578,7 +1581,7 @@ mod tests {
     fn locate_audio_bounded_sync_one_byte_past_eof_is_notmp3() {
         let body = 4usize;
         let mut full = b"ID3\x04\x00\x00".to_vec();
-        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend_from_slice(&syncsafe(u32::try_from(body).unwrap()));
         full.extend(std::iter::repeat_n(0u8, body)); // tag end at offset 14
         let audio_offset = full.len() as u64; // 14
         full.push(0xFF); // a single sync byte present (so prefix has audio_offset+1)
@@ -1611,7 +1614,7 @@ mod tests {
         // unbounded reject `audio_offset + 1 >= len` (accepts when +2 <= len).
         let body = 4usize;
         let mut full = b"ID3\x04\x00\x00".to_vec();
-        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend_from_slice(&syncsafe(u32::try_from(body).unwrap()));
         full.extend(std::iter::repeat_n(0u8, body)); // tag end at offset 14
         let audio_offset = full.len() as u64; // 14
         full.push(0xFF); // frame sync pair, and nothing after
@@ -1661,7 +1664,7 @@ mod tests {
     fn locate_audio_bounded_rejects_bad_second_sync_byte_after_id3() {
         let body = 4usize;
         let mut full = b"ID3\x04\x00\x00".to_vec();
-        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend_from_slice(&syncsafe(u32::try_from(body).unwrap()));
         full.extend(std::iter::repeat_n(0u8, body)); // audio_offset = 14
         full.extend_from_slice(&[0xFF, 0x00]); // byte14=0xFF good, byte15=0x00 bad
         full.extend_from_slice(b"tail");
@@ -1682,7 +1685,7 @@ mod tests {
     fn locate_audio_bounded_needmore_for_sync_past_prefix() {
         let body = 4usize;
         let mut full = b"ID3\x04\x00\x00".to_vec();
-        full.extend_from_slice(&syncsafe(body as u32));
+        full.extend_from_slice(&syncsafe(u32::try_from(body).unwrap()));
         full.extend(std::iter::repeat_n(0u8, body)); // audio_offset = 14
         full.extend_from_slice(&[0xFF, 0xFB]); // sync at 14..16
         full.extend_from_slice(b"more audio bytes here");
@@ -1708,7 +1711,7 @@ mod tests {
         let file_len = full.len() as u64;
         assert!(file_len >= audio_offset + 128); // both conditions true
         let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
-        let prefix = &full[..audio_offset as usize + 2];
+        let prefix = &full[..usize_from(audio_offset) + 2];
         match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
             Extent::Complete(b) => {
                 assert_eq!(b.audio_offset, audio_offset);
@@ -1734,7 +1737,7 @@ mod tests {
         assert!(file_len >= audio_offset + 128); // first operand TRUE
         let tail: [u8; 128] = full[full.len() - 128..].try_into().unwrap();
         assert_ne!(&tail[0..3], b"TAG"); // second operand FALSE
-        let prefix = &full[..audio_offset as usize + 2];
+        let prefix = &full[..usize_from(audio_offset) + 2];
         match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
             Extent::Complete(b) => {
                 assert_eq!(b.audio_offset, audio_offset);
@@ -1761,7 +1764,7 @@ mod tests {
                                                 // looks at tail[0..3]); file_len is the real gate here.
         let mut tail = [0u8; 128];
         tail[0..3].copy_from_slice(b"TAG");
-        let prefix = &full[..audio_offset as usize + 2];
+        let prefix = &full[..usize_from(audio_offset) + 2];
         match locate_audio_bounded(prefix, file_len, Some(&tail)).unwrap() {
             Extent::Complete(b) => {
                 assert_eq!(b.audio_offset, audio_offset);
@@ -1783,10 +1786,10 @@ mod tests {
         let mut out = Vec::new();
         out.extend_from_slice(b"ID3");
         out.extend_from_slice(&[0x04, 0x00, 0x00]); // v2.4.0, no flags
-        out.extend_from_slice(&ss(total_body as u32));
+        out.extend_from_slice(&ss(u32::try_from(total_body).unwrap()));
         for (id, body) in frames {
             out.extend_from_slice(*id);
-            out.extend_from_slice(&ss(body.len() as u32));
+            out.extend_from_slice(&ss(u32::try_from(body.len()).unwrap()));
             out.extend_from_slice(&[0x00, 0x00]); // frame flags
             out.extend_from_slice(body);
         }
@@ -1801,10 +1804,10 @@ mod tests {
         let mut out = Vec::new();
         out.extend_from_slice(b"ID3");
         out.extend_from_slice(&[0x03, 0x00, 0x00]); // v2.3.0, no flags
-        out.extend_from_slice(&ss(total_body as u32)); // tag size is synchsafe in every version
+        out.extend_from_slice(&ss(u32::try_from(total_body).unwrap())); // tag size is synchsafe in every version
         for (id, body) in frames {
             out.extend_from_slice(*id);
-            out.extend_from_slice(&(body.len() as u32).to_be_bytes()); // v2.3: plain u32 frame size
+            out.extend_from_slice(&(u32::try_from(body.len()).unwrap()).to_be_bytes()); // v2.3: plain u32 frame size
             out.extend_from_slice(&[0x00, 0x00]); // frame flags
             out.extend_from_slice(body);
         }
@@ -1827,7 +1830,9 @@ mod tests {
         // synchsafe misdecode (the `== 3` branch flipped) truncates it. Both frames
         // must survive byte-exact.
         let filler = vec![0xAAu8; 8];
-        let body: Vec<u8> = (0..200u32).map(|i| (i % 250 + 1) as u8).collect();
+        let body: Vec<u8> = (0..200u32)
+            .map(|i| u8::try_from(i % 250 + 1).unwrap())
+            .collect();
         let tag = build_v23_tag(&[(b"GEOB", &filler), (b"PRIV", &body)]);
         let (opaque, _promoted) = super::read_binary_tags(&tag);
         let geob = opaque

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -3,6 +3,7 @@
 //! whose `mdat` audio payload is served verbatim. Strict: anything outside the
 //! supported shape (single audio track, one `mdat`, non-fragmented) is rejected.
 
+use crate::convert::usize_from;
 use crate::error::{FormatError, Result};
 use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
 use crate::layout::{RegionLayout, Segment};
@@ -63,7 +64,7 @@ pub struct BoxHeader {
 /// largesize). `remaining` is the byte count from this box's start to EOF, used
 /// to resolve a `size == 0` ("extends to end") box.
 pub fn box_header(hdr: &[u8], remaining: u64) -> Result<BoxHeader> {
-    let size32 = be_u32(hdr, 0)? as u64;
+    let size32 = u64::from(be_u32(hdr, 0)?);
     let kind: [u8; 4] = hdr
         .get(4..8)
         .ok_or(FormatError::Malformed)?
@@ -102,7 +103,7 @@ pub enum Mp4ScanError {
 }
 
 fn read_box(buf: &[u8], pos: usize) -> Result<BoxRef> {
-    let size32 = be_u32(buf, pos)? as u64;
+    let size32 = u64::from(be_u32(buf, pos)?);
     let kind: [u8; 4] = buf
         .get(pos + 4..pos + 8)
         .ok_or(FormatError::Malformed)?
@@ -113,7 +114,7 @@ fn read_box(buf: &[u8], pos: usize) -> Result<BoxRef> {
         0 => (8usize, (buf.len() - pos) as u64),
         n => (8usize, n),
     };
-    let total = total as usize;
+    let total = usize_from(total);
     let Some(end) = pos.checked_add(total) else {
         return Err(FormatError::Malformed);
     };
@@ -316,9 +317,9 @@ pub fn read_structure_from<R: Read + Seek>(
     let moov_len = usize::try_from(moov_h.total_len).map_err(|_| FormatError::Malformed)?;
     let ftyp_bytes = region(r, ftyp_s, ftyp_len)?;
     let moov_bytes = region(r, moov_s, moov_len)?;
-    let mdat_header = region(r, mdat_s, mdat_h.header_len as usize)?;
+    let mdat_header = region(r, mdat_s, usize_from(mdat_h.header_len))?;
 
-    validate_moov(&moov_bytes[moov_h.header_len as usize..])?;
+    validate_moov(&moov_bytes[usize_from(moov_h.header_len)..])?;
 
     Ok(Mp4Scan {
         ftyp: ftyp_bytes,
@@ -526,25 +527,26 @@ pub fn read_binary_tags(buf: &[u8]) -> Vec<EmbeddedBinaryTag> {
     out
 }
 
-fn boxed(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
-    let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();
+fn boxed(kind: &[u8; 4], payload: &[u8]) -> Result<Vec<u8>> {
+    let size = u32::try_from(8 + payload.len()).map_err(|_| FormatError::TooLarge)?;
+    let mut v = size.to_be_bytes().to_vec();
     v.extend_from_slice(kind);
     v.extend_from_slice(payload);
-    v
+    Ok(v)
 }
 
-fn text_atom(kind: &[u8; 4], values: &[&str]) -> Vec<u8> {
+fn text_atom(kind: &[u8; 4], values: &[&str]) -> Result<Vec<u8>> {
     let mut inner = Vec::new();
     for v in values {
         let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
         data.extend_from_slice(&0u32.to_be_bytes()); // locale
         data.extend_from_slice(v.as_bytes());
-        inner.extend(boxed(b"data", &data));
+        inner.extend(boxed(b"data", &data)?);
     }
     boxed(kind, &inner)
 }
 
-fn number_atom(kind: &[u8; 4], n: u16, width: usize) -> Vec<u8> {
+fn number_atom(kind: &[u8; 4], n: u16, width: usize) -> Result<Vec<u8>> {
     debug_assert!(
         width >= 4,
         "number_atom width must hold the 4-byte reserved+value prefix"
@@ -555,26 +557,26 @@ fn number_atom(kind: &[u8; 4], n: u16, width: usize) -> Vec<u8> {
     body.extend_from_slice(&n.to_be_bytes());
     body.resize(width, 0);
     data.extend_from_slice(&body);
-    boxed(kind, &boxed(b"data", &data))
+    boxed(kind, &boxed(b"data", &data)?)
 }
 
 /// Emit a `----` freeform atom: a `mean` and `name` sub-box (each with a 4-byte
 /// FullBox prefix) followed by one UTF-8 `data` sub-box per value. Note that the
 /// scan path (`read_freeform`) only recovers the first value on read-back, so
 /// multi-value freeform tags round-trip only their first value.
-fn freeform_atom(mean: &str, name: &str, values: &[&str]) -> Vec<u8> {
+fn freeform_atom(mean: &str, name: &str, values: &[&str]) -> Result<Vec<u8>> {
     let mut inner = Vec::new();
     let mut mean_body = 0u32.to_be_bytes().to_vec(); // version/flags
     mean_body.extend_from_slice(mean.as_bytes());
-    inner.extend(boxed(b"mean", &mean_body));
+    inner.extend(boxed(b"mean", &mean_body)?);
     let mut name_body = 0u32.to_be_bytes().to_vec();
     name_body.extend_from_slice(name.as_bytes());
-    inner.extend(boxed(b"name", &name_body));
+    inner.extend(boxed(b"name", &name_body)?);
     for v in values {
         let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
         data.extend_from_slice(&0u32.to_be_bytes()); // locale
         data.extend_from_slice(v.as_bytes());
-        inner.extend(boxed(b"data", &data));
+        inner.extend(boxed(b"data", &data)?);
     }
     boxed(b"----", &inner)
 }
@@ -590,26 +592,33 @@ fn parse_freeform_key(key: &str) -> Option<(&str, &str)> {
 /// `[---- size][----][mean box][name box][data size][data][type 0][locale 0]`.
 /// Mirrors `freeform_atom` but emits type code 0 (binary) and no value bytes — the
 /// value is served from the DB as a `Segment::BinaryTag`.
-fn freeform_binary_prefix(mean: &str, name: &str, payload_len: u64) -> Vec<u8> {
+fn freeform_binary_prefix(mean: &str, name: &str, payload_len: u64) -> Result<Vec<u8>> {
     let mut mean_body = 0u32.to_be_bytes().to_vec(); // version/flags
     mean_body.extend_from_slice(mean.as_bytes());
-    let mean_box = boxed(b"mean", &mean_body);
+    let mean_box = boxed(b"mean", &mean_body)?;
     let mut name_body = 0u32.to_be_bytes().to_vec();
     name_body.extend_from_slice(name.as_bytes());
-    let name_box = boxed(b"name", &name_body);
+    let name_box = boxed(b"name", &name_body)?;
 
     let data_size = 8 + 8 + payload_len; // data header + type + locale + payload
     let inner_len = mean_box.len() as u64 + name_box.len() as u64 + data_size;
 
-    let mut out = ((8 + inner_len) as u32).to_be_bytes().to_vec();
+    let mut out = u32::try_from(8 + inner_len)
+        .map_err(|_| FormatError::TooLarge)?
+        .to_be_bytes()
+        .to_vec();
     out.extend_from_slice(b"----");
     out.extend_from_slice(&mean_box);
     out.extend_from_slice(&name_box);
-    out.extend_from_slice(&(data_size as u32).to_be_bytes());
+    out.extend_from_slice(
+        &u32::try_from(data_size)
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    );
     out.extend_from_slice(b"data");
     out.extend_from_slice(&0u32.to_be_bytes()); // type 0 = binary/implicit
     out.extend_from_slice(&0u32.to_be_bytes()); // locale
-    out
+    Ok(out)
 }
 
 /// Build the `udta` box as an ordered segment list: `Segment::Inline` for all box
@@ -639,16 +648,18 @@ fn build_udta(
     let mut ilst_inline: Vec<u8> = Vec::new();
     for (key, values) in &groups {
         match crate::tagmap::key_to_mp4(key) {
-            Some(crate::tagmap::Mp4Slot::Text(atom)) => ilst_inline.extend(text_atom(atom, values)),
+            Some(crate::tagmap::Mp4Slot::Text(atom)) => {
+                ilst_inline.extend(text_atom(atom, values)?);
+            }
             Some(crate::tagmap::Mp4Slot::Number(atom, width)) => {
                 if let Ok(n) = values.first().copied().unwrap_or("").parse::<u16>() {
-                    ilst_inline.extend(number_atom(atom, n, width));
+                    ilst_inline.extend(number_atom(atom, n, width)?);
                 }
             }
             Some(crate::tagmap::Mp4Slot::Freeform(mean, name)) => {
-                ilst_inline.extend(freeform_atom(mean, name, values));
+                ilst_inline.extend(freeform_atom(mean, name, values)?);
             }
-            None => ilst_inline.extend(freeform_atom("com.apple.iTunes", key, values)),
+            None => ilst_inline.extend(freeform_atom("com.apple.iTunes", key, values)?),
         }
     }
 
@@ -664,7 +675,7 @@ fn build_udta(
             // Not a `----:<mean>:<name>` key; skip defensively (no double-store path).
             continue;
         };
-        ilst_inline.extend_from_slice(&freeform_binary_prefix(mean, name, bt.len));
+        ilst_inline.extend_from_slice(&freeform_binary_prefix(mean, name, bt.len)?);
         ilst_segments.push(Segment::Inline(std::mem::take(&mut ilst_inline)));
         ilst_segments.push(Segment::BinaryTag {
             payload_id: bt.payload_id,
@@ -677,12 +688,20 @@ fn build_udta(
         // One covr atom; each art is its own `data` child (the iTunes
         // convention for multiple artworks).
         let covr_size: u64 = 8 + arts.iter().map(|a| 16 + a.data_len).sum::<u64>();
-        ilst_inline.extend_from_slice(&(covr_size as u32).to_be_bytes());
+        ilst_inline.extend_from_slice(
+            &u32::try_from(covr_size)
+                .map_err(|_| FormatError::TooLarge)?
+                .to_be_bytes(),
+        );
         ilst_inline.extend_from_slice(b"covr");
         for a in arts {
             let type_code: u32 = if a.mime == "image/png" { 14 } else { 13 };
             let data_size = 8 + 8 + a.data_len; // data header + type + locale + image
-            ilst_inline.extend_from_slice(&(data_size as u32).to_be_bytes());
+            ilst_inline.extend_from_slice(
+                &u32::try_from(data_size)
+                    .map_err(|_| FormatError::TooLarge)?
+                    .to_be_bytes(),
+            );
             ilst_inline.extend_from_slice(b"data");
             ilst_inline.extend_from_slice(&type_code.to_be_bytes());
             ilst_inline.extend_from_slice(&0u32.to_be_bytes()); // locale; image streams next
@@ -709,7 +728,7 @@ fn build_udta(
     hdlr_body.extend_from_slice(b"mdir");
     hdlr_body.extend_from_slice(b"appl");
     hdlr_body.extend_from_slice(&[0u8; 9]);
-    let hdlr = boxed(b"hdlr", &hdlr_body);
+    let hdlr = boxed(b"hdlr", &hdlr_body)?;
 
     // Box sizes. Each enclosing box adds its 8-byte header to the inline content of
     // its child and carries `streamed_total` through unchanged (the streamed bytes
@@ -720,21 +739,21 @@ fn build_udta(
     let udta_inline_len = 8 + meta_inline_len; // [meta hdr][meta inline]
     let udta_size = 8 + udta_inline_len + streamed_total;
 
-    // MP4 box sizes are 32-bit. udta encloses all inner boxes, so guarding it bounds
-    // them all; refuse oversized metadata at the format boundary rather than emit a
-    // silently-truncated (corrupt) size field.
-    if udta_size > u32::MAX as u64 {
-        return Err(FormatError::TooLarge);
-    }
+    // MP4 box sizes are 32-bit. udta encloses all inner boxes, so converting it
+    // first bounds them all; refuse oversized metadata at the format boundary
+    // rather than emit a silently-truncated (corrupt) size field.
+    let udta_size = u32::try_from(udta_size).map_err(|_| FormatError::TooLarge)?;
+    let meta_size = u32::try_from(meta_size).map_err(|_| FormatError::TooLarge)?;
+    let ilst_size = u32::try_from(ilst_size).map_err(|_| FormatError::TooLarge)?;
 
     // Leading framing: everything up to the start of ilst content.
-    let mut header = (udta_size as u32).to_be_bytes().to_vec();
+    let mut header = udta_size.to_be_bytes().to_vec();
     header.extend_from_slice(b"udta");
-    header.extend_from_slice(&(meta_size as u32).to_be_bytes());
+    header.extend_from_slice(&meta_size.to_be_bytes());
     header.extend_from_slice(b"meta");
     header.extend_from_slice(&0u32.to_be_bytes()); // meta FullBox version/flags
     header.extend_from_slice(&hdlr);
-    header.extend_from_slice(&(ilst_size as u32).to_be_bytes());
+    header.extend_from_slice(&ilst_size.to_be_bytes());
     header.extend_from_slice(b"ilst");
 
     // Merge the header into the first ilst inline segment (always Inline when present,
@@ -778,17 +797,15 @@ fn patch_chunk_offsets(kept: &mut [u8], delta: i64) -> Result<()> {
             return Err(FormatError::Malformed);
         }
         if entry == 4 {
-            let v = be_u32(kept, pos)? as i64 + delta;
-            if v < 0 || v > u32::MAX as i64 {
-                return Err(FormatError::TooLarge);
-            }
-            kept[pos..pos + 4].copy_from_slice(&(v as u32).to_be_bytes());
+            let v = i64::from(be_u32(kept, pos)?) + delta;
+            let new_val = u32::try_from(v).map_err(|_| FormatError::TooLarge)?;
+            kept[pos..pos + 4].copy_from_slice(&new_val.to_be_bytes());
         } else {
-            let v = be_u64(kept, pos)? as i64 + delta;
+            let v = be_u64(kept, pos)?.cast_signed() + delta;
             if v < 0 {
                 return Err(FormatError::Malformed);
             }
-            kept[pos..pos + 8].copy_from_slice(&(v as u64).to_be_bytes());
+            kept[pos..pos + 8].copy_from_slice(&v.cast_unsigned().to_be_bytes());
         }
     }
     Ok(())
@@ -822,18 +839,22 @@ pub fn synthesize_layout(
 
     let new_moov_size = 8 + kept.len() as u64 + udta_total;
     // MP4 box sizes are 32-bit; mirror build_udta's guard.
-    if new_moov_size > u32::MAX as u64 {
+    if new_moov_size > u64::from(u32::MAX) {
         return Err(FormatError::TooLarge);
     }
     let new_mdat_payload_pos =
         scan.ftyp.len() as u64 + new_moov_size + scan.mdat_header.len() as u64;
-    let delta = new_mdat_payload_pos as i64 - scan.mdat_payload_offset as i64;
+    let delta = new_mdat_payload_pos.cast_signed() - scan.mdat_payload_offset.cast_signed();
 
     patch_chunk_offsets(&mut kept, delta)?;
 
     let mut head = Vec::new();
     head.extend_from_slice(&scan.ftyp);
-    head.extend_from_slice(&(new_moov_size as u32).to_be_bytes());
+    head.extend_from_slice(
+        &u32::try_from(new_moov_size)
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    );
     head.extend_from_slice(b"moov");
     head.extend_from_slice(&kept);
 
@@ -869,7 +890,10 @@ mod tests {
 
     /// Build a 32-bit-size box: [size][type][payload].
     fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
-        let mut v = ((8 + payload.len()) as u32).to_be_bytes().to_vec();
+        let mut v = u32::try_from(8 + payload.len())
+            .unwrap()
+            .to_be_bytes()
+            .to_vec();
         v.extend_from_slice(kind);
         v.extend_from_slice(payload);
         v
@@ -913,7 +937,7 @@ mod tests {
     /// an stco) and mdat. `mdat_payload` is the verbatim audio.
     fn mk_mp4(moov_first: bool, mdat_payload: &[u8], stco_entries: &[u32]) -> Vec<u8> {
         let mut stco = vec![0u8; 4];
-        stco.extend_from_slice(&(stco_entries.len() as u32).to_be_bytes());
+        stco.extend_from_slice(&u32::try_from(stco_entries.len()).unwrap().to_be_bytes());
         for e in stco_entries {
             stco.extend_from_slice(&e.to_be_bytes());
         }
@@ -939,7 +963,7 @@ mod tests {
             let buf = mk_mp4(moov_first, b"AUDIODATA", &[0]);
             let b = locate_audio(&buf).unwrap();
             assert_eq!(b.audio_length, 9);
-            assert_eq!(&buf[b.audio_offset as usize..][..9], b"AUDIODATA");
+            assert_eq!(&buf[usize_from(b.audio_offset)..][..9], b"AUDIODATA");
         }
     }
 
@@ -1007,7 +1031,7 @@ mod tests {
         assert_eq!(&s.moov[4..8], b"moov");
         assert_eq!(&s.mdat_header[4..8], b"mdat");
         assert_eq!(s.mdat_payload_len, 9);
-        assert_eq!(&buf[s.mdat_payload_offset as usize..][..9], b"AUDIODATA");
+        assert_eq!(&buf[usize_from(s.mdat_payload_offset)..][..9], b"AUDIODATA");
     }
 
     fn data_atom(type_code: u32, value: &[u8]) -> Vec<u8> {
@@ -1169,7 +1193,7 @@ mod tests {
             picture_type: 3,
             width: 0,
             height: 0,
-            data_len: u32::MAX as u64 + 1,
+            data_len: u64::from(u32::MAX) + 1,
         };
         assert!(matches!(
             build_udta(&[TagInput::new("title", "T")], &[], &[art]),
@@ -1253,7 +1277,7 @@ mod tests {
             match seg {
                 Segment::Inline(b) => out.extend_from_slice(b),
                 Segment::BinaryTag { len, .. } | Segment::ArtImage { len, .. } => {
-                    out.resize(out.len() + *len as usize, 0);
+                    out.resize(out.len() + usize_from(*len), 0);
                 }
                 other => panic!("unexpected segment in udta: {other:?}"),
             }
@@ -1307,7 +1331,10 @@ mod tests {
         let delta = new_mdat - scan.mdat_payload_offset;
         assert_eq!(
             first_stco(&head),
-            vec![42 + delta as u32, 100 + delta as u32]
+            vec![
+                42 + u32::try_from(delta).unwrap(),
+                100 + u32::try_from(delta).unwrap()
+            ]
         );
         // The new file head re-parses as a valid moov of the declared size.
         let moov = find_moov_in_head(&head);
@@ -1318,7 +1345,7 @@ mod tests {
     /// box instead of an `stco`. moov-first, since that's all this exercises.
     fn mk_mp4_co64(mdat_payload: &[u8], co64_entries: &[u64]) -> Vec<u8> {
         let mut co64 = vec![0u8; 4];
-        co64.extend_from_slice(&(co64_entries.len() as u32).to_be_bytes());
+        co64.extend_from_slice(&u32::try_from(co64_entries.len()).unwrap().to_be_bytes());
         for e in co64_entries {
             co64.extend_from_slice(&e.to_be_bytes());
         }
@@ -1576,9 +1603,9 @@ mod tests {
         let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
         data.extend_from_slice(&0u32.to_be_bytes()); // locale
         data.extend_from_slice(b"abc-123");
-        let mut inner = boxed(b"mean", &mean_body);
-        inner.extend(boxed(b"name", &name_body));
-        inner.extend(boxed(b"data", &data));
+        let mut inner = boxed(b"mean", &mean_body).unwrap();
+        inner.extend(boxed(b"name", &name_body).unwrap());
+        inner.extend(boxed(b"data", &data).unwrap());
 
         let (key, value) = read_freeform(&inner).unwrap();
         assert_eq!(key, "musicbrainz_albumid"); // folded via vocabulary
@@ -1594,9 +1621,9 @@ mod tests {
         let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
         data.extend_from_slice(&0u32.to_be_bytes()); // locale
         data.extend_from_slice(b"hello");
-        let mut inner = boxed(b"mean", &mean_body);
-        inner.extend(boxed(b"name", &name_body));
-        inner.extend(boxed(b"data", &data));
+        let mut inner = boxed(b"mean", &mean_body).unwrap();
+        inner.extend(boxed(b"name", &name_body).unwrap());
+        inner.extend(boxed(b"data", &data).unwrap());
 
         let (key, value) = read_freeform(&inner).unwrap();
         assert_eq!(key, "My Custom Field"); // not in vocabulary -> verbatim name
@@ -1610,8 +1637,8 @@ mod tests {
         let mut data = 0u32.to_be_bytes().to_vec(); // type 0 = binary, not text
         data.extend_from_slice(&0u32.to_be_bytes()); // locale
         data.extend_from_slice(&[0xff, 0x00, 0x01]);
-        let mut inner = boxed(b"name", &name_body);
-        inner.extend(boxed(b"data", &data));
+        let mut inner = boxed(b"name", &name_body).unwrap();
+        inner.extend(boxed(b"data", &data).unwrap());
 
         assert!(read_freeform(&inner).is_none()); // binary-typed data is skipped
     }
@@ -1628,7 +1655,7 @@ mod tests {
         let udta = materialize_udta(&segs);
         // build_udta returns a full `udta` box; read_tags expects a buffer containing
         // moov/udta/meta/ilst, so wrap udta in a minimal moov for the round trip.
-        let moov = boxed(b"moov", &udta);
+        let moov = boxed(b"moov", &udta).unwrap();
 
         let tags = read_tags(&moov);
         for expected in [
@@ -1675,7 +1702,7 @@ mod tests {
         }
         let normal = mk_mp4(true, &[0xABu8; 64], &[0]); // [ftyp][moov][mdat]
         let scan = read_structure(&normal).unwrap();
-        let payload_start = scan.mdat_payload_offset as usize;
+        let payload_start = usize_from(scan.mdat_payload_offset);
         let mdat_box_start = payload_start - scan.mdat_header.len(); // normal 8-byte header
         let payload = normal[payload_start..].to_vec();
         let mut buf = normal[..mdat_box_start].to_vec(); // ftyp + moov
@@ -1723,7 +1750,7 @@ mod tests {
         // `remaining` to `file_len + pos`, wrongly accepting the overrun (returns Ok).
         let mut buf = mk_mp4(true, b"AUDIO", &[0]); // [ftyp][moov][mdat], mdat last
         let scan = read_structure(&buf).unwrap();
-        let mdat_start = (scan.mdat_payload_offset - scan.mdat_header.len() as u64) as usize;
+        let mdat_start = usize_from(scan.mdat_payload_offset - scan.mdat_header.len() as u64);
         let real = u32::from_be_bytes(buf[mdat_start..mdat_start + 4].try_into().unwrap());
         buf[mdat_start..mdat_start + 4].copy_from_slice(&(real + 100).to_be_bytes());
         let mut cur = std::io::Cursor::new(buf.clone());
@@ -1770,8 +1797,8 @@ mod tests {
         let name_body = 0u32.to_be_bytes().to_vec(); // exactly 4 bytes
         let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
         data.extend_from_slice(&0u32.to_be_bytes()); // locale -> dp.len() == 8
-        let mut inner = boxed(b"name", &name_body);
-        inner.extend(boxed(b"data", &data));
+        let mut inner = boxed(b"name", &name_body).unwrap();
+        inner.extend(boxed(b"data", &data).unwrap());
         let (key, value) = read_freeform(&inner).unwrap();
         assert_eq!(key, ""); // empty name, not in vocabulary -> verbatim ""
         assert_eq!(value, "");
@@ -1785,8 +1812,8 @@ mod tests {
         let name_body = vec![0u8, 0, 0]; // 3 bytes
         let mut data = 1u32.to_be_bytes().to_vec();
         data.extend_from_slice(&0u32.to_be_bytes());
-        let mut inner = boxed(b"name", &name_body);
-        inner.extend(boxed(b"data", &data));
+        let mut inner = boxed(b"name", &name_body).unwrap();
+        inner.extend(boxed(b"data", &data).unwrap());
         assert!(read_freeform(&inner).is_none());
     }
 
@@ -1801,9 +1828,9 @@ mod tests {
         let mut data = 1u32.to_be_bytes().to_vec();
         data.extend_from_slice(&0u32.to_be_bytes());
         data.extend_from_slice(b"abc-123");
-        let mut inner = boxed(b"mean", &mean_body);
-        inner.extend(boxed(b"name", &name_body));
-        inner.extend(boxed(b"data", &data));
+        let mut inner = boxed(b"mean", &mean_body).unwrap();
+        inner.extend(boxed(b"name", &name_body).unwrap());
+        inner.extend(boxed(b"data", &data).unwrap());
         let (key, value) = read_freeform(&inner).unwrap();
         assert_eq!(key, "MusicBrainz Album Id"); // empty mean -> not folded
         assert_eq!(value, "abc-123");
@@ -2067,8 +2094,8 @@ mod tests {
         let Segment::Inline(h0) = &segs0[0] else {
             panic!("inline head")
         };
-        let overhead = u32::from_be_bytes(h0[0..4].try_into().unwrap()) as u64;
-        let max_len = u32::MAX as u64 - overhead;
+        let overhead = u64::from(u32::from_be_bytes(h0[0..4].try_into().unwrap()));
+        let max_len = u64::from(u32::MAX) - overhead;
 
         let (segs_max, streamed) =
             build_udta(&[TagInput::new("title", "T")], &[], &[art(max_len)]).unwrap();
@@ -2096,11 +2123,11 @@ mod tests {
         assert!(patch_chunk_offsets(&mut k, 0).is_ok()); // v == 0
 
         let mut k = soun_trak();
-        assert!(patch_chunk_offsets(&mut k, u32::MAX as i64).is_ok()); // v == u32::MAX
+        assert!(patch_chunk_offsets(&mut k, i64::from(u32::MAX)).is_ok()); // v == u32::MAX
 
         let mut k = soun_trak();
         assert!(matches!(
-            patch_chunk_offsets(&mut k, u32::MAX as i64 + 1), // v == u32::MAX + 1
+            patch_chunk_offsets(&mut k, i64::from(u32::MAX) + 1), // v == u32::MAX + 1
             Err(FormatError::TooLarge)
         ));
 
@@ -2152,20 +2179,20 @@ mod tests {
         let mut data_body = type_code.to_be_bytes().to_vec();
         data_body.extend_from_slice(&0u32.to_be_bytes()); // locale
         data_body.extend_from_slice(value);
-        let mut inner = boxed(b"mean", &mean_body);
-        inner.extend(boxed(b"name", &name_body));
-        inner.extend(boxed(b"data", &data_body));
-        boxed(b"----", &inner)
+        let mut inner = boxed(b"mean", &mean_body).unwrap();
+        inner.extend(boxed(b"name", &name_body).unwrap());
+        inner.extend(boxed(b"data", &data_body).unwrap());
+        boxed(b"----", &inner).unwrap()
     }
 
     /// Wrap an `ilst` body in the moov/udta/meta/ilst boxes `ilst_region` expects.
     fn moov_with_ilst(ilst_body: &[u8]) -> Vec<u8> {
-        let ilst = boxed(b"ilst", ilst_body);
+        let ilst = boxed(b"ilst", ilst_body).unwrap();
         let mut meta = 0u32.to_be_bytes().to_vec(); // FullBox version/flags
-        meta.extend(boxed(b"hdlr", &[0u8; 25]));
+        meta.extend(boxed(b"hdlr", &[0u8; 25]).unwrap());
         meta.extend_from_slice(&ilst);
-        let udta = boxed(b"udta", &boxed(b"meta", &meta));
-        boxed(b"moov", &udta)
+        let udta = boxed(b"udta", &boxed(b"meta", &meta).unwrap()).unwrap();
+        boxed(b"moov", &udta).unwrap()
     }
 
     #[test]
@@ -2194,14 +2221,18 @@ mod tests {
             let mut b = 0u32.to_be_bytes().to_vec();
             b.extend_from_slice(b"com.serato.dj");
             b
-        });
-        short_inner.extend(boxed(b"name", &{
-            let mut b = 0u32.to_be_bytes().to_vec();
-            b.extend_from_slice(b"short");
-            b
-        }));
-        short_inner.extend(boxed(b"data", &[0u8; 5])); // 5 < 8: truncated header
-        let short = boxed(b"----", &short_inner);
+        })
+        .unwrap();
+        short_inner.extend(
+            boxed(b"name", &{
+                let mut b = 0u32.to_be_bytes().to_vec();
+                b.extend_from_slice(b"short");
+                b
+            })
+            .unwrap(),
+        );
+        short_inner.extend(boxed(b"data", &[0u8; 5]).unwrap()); // 5 < 8: truncated header
+        let short = boxed(b"----", &short_inner).unwrap();
 
         // A `data` box of exactly 8 bytes (binary type 0, no value) is well-formed
         // with an empty payload — it must be emitted, not skipped.
@@ -2261,8 +2292,8 @@ mod tests {
                 Segment::Inline(b) => served.extend_from_slice(b),
                 Segment::BinaryTag { .. } => served.extend_from_slice(&payload),
                 Segment::BackingAudio { offset, len } => {
-                    let s = *offset as usize;
-                    served.extend_from_slice(&buf[s..s + *len as usize]);
+                    let s = usize_from(*offset);
+                    served.extend_from_slice(&buf[s..s + usize_from(*len)]);
                 }
                 other => panic!("unexpected segment: {other:?}"),
             }
@@ -2304,7 +2335,7 @@ mod tests {
         let layout1 = synthesize_layout(&scan, &tags, &[], &[art(1)]).unwrap();
         let head_len = inline_head(&layout1).len();
         let overhead = (head_len as u64) - (scan.ftyp.len() as u64);
-        let max_len = u32::MAX as u64 - overhead;
+        let max_len = u64::from(u32::MAX) - overhead;
 
         assert!(max_len > 0, "overhead {overhead} must be < u32::MAX");
         // Boundary accepted
@@ -2362,7 +2393,7 @@ mod tests {
         buf.extend_from_slice(&moov_size.to_be_bytes());
         buf.extend_from_slice(b"moov");
         assert_eq!(buf.len(), 40);
-        let file_len = 32 + moov_size as u64;
+        let file_len = 32 + u64::from(moov_size);
         let mut cur = Cursor::new(buf);
         match read_structure_from(&mut cur, file_len).unwrap_err() {
             Mp4ScanError::MetadataTooLarge {
@@ -2371,7 +2402,7 @@ mod tests {
                 cap,
             } => {
                 assert_eq!(box_kind, "moov");
-                assert_eq!(size, moov_size as u64);
+                assert_eq!(size, u64::from(moov_size));
                 assert_eq!(cap, 256 * 1024 * 1024);
             }
             other => panic!("expected MetadataTooLarge, got {other:?}"),
@@ -2391,7 +2422,7 @@ mod tests {
         buf.extend_from_slice(&[0u8; 8]);
         buf.extend_from_slice(&cap.to_be_bytes());
         buf.extend_from_slice(b"moov");
-        let file_len = 32 + cap as u64;
+        let file_len = 32 + u64::from(cap);
         let mut cur = Cursor::new(buf);
         let err = read_structure_from(&mut cur, file_len).unwrap_err();
         assert!(

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -838,10 +838,9 @@ pub fn synthesize_layout(
     let udta_total: u64 = udta_segments.iter().map(Segment::len).sum();
 
     let new_moov_size = 8 + kept.len() as u64 + udta_total;
-    // MP4 box sizes are 32-bit; mirror build_udta's guard.
-    if new_moov_size > u64::from(u32::MAX) {
-        return Err(FormatError::TooLarge);
-    }
+    // MP4 box sizes are 32-bit; mirror build_udta's bound. The try_from below
+    // (writing the size field) is the enforcing check.
+    let new_moov_size_u32 = u32::try_from(new_moov_size).map_err(|_| FormatError::TooLarge)?;
     let new_mdat_payload_pos =
         scan.ftyp.len() as u64 + new_moov_size + scan.mdat_header.len() as u64;
     let delta = new_mdat_payload_pos.cast_signed() - scan.mdat_payload_offset.cast_signed();
@@ -850,11 +849,7 @@ pub fn synthesize_layout(
 
     let mut head = Vec::new();
     head.extend_from_slice(&scan.ftyp);
-    head.extend_from_slice(
-        &u32::try_from(new_moov_size)
-            .map_err(|_| FormatError::TooLarge)?
-            .to_be_bytes(),
-    );
+    head.extend_from_slice(&new_moov_size_u32.to_be_bytes());
     head.extend_from_slice(b"moov");
     head.extend_from_slice(&kept);
 

--- a/musefs-format/src/ogg/b64.rs
+++ b/musefs-format/src/ogg/b64.rs
@@ -29,7 +29,7 @@ pub fn b64_window(out_offset: u64, take: u64, img_total: u64) -> B64Window {
     B64Window {
         in_start,
         in_len: in_end.saturating_sub(in_start),
-        skip: (out_offset - g0 * 4) as usize,
+        skip: crate::convert::usize_from(out_offset - g0 * 4),
     }
 }
 
@@ -60,20 +60,23 @@ mod tests {
     fn any_window_matches_substring_of_full_encode() {
         // Cover image lengths that hit every length-mod-3 case and various windows.
         for &img_total in &[0u64, 1, 2, 3, 4, 5, 6, 7, 100, 257, 1024] {
-            let img: Vec<u8> = (0..img_total).map(|i| (i * 7 + 3) as u8).collect();
+            let img: Vec<u8> = (0..img_total)
+                .map(|i| u8::try_from((i * 7 + 3) % 256).unwrap())
+                .collect();
             let full = full_b64(&img);
-            assert_eq!(b64_len(img_total) as usize, full.len());
+            assert_eq!(crate::convert::usize_from(b64_len(img_total)), full.len());
             if full.is_empty() {
                 continue;
             }
             for o in 0..full.len() as u64 {
                 for take in 1..=(full.len() as u64 - o) {
                     let w = b64_window(o, take, img_total);
-                    let raw = &img[w.in_start as usize..(w.in_start + w.in_len) as usize];
-                    let got = encode_b64_slice(raw, w.skip, take as usize);
+                    let raw = &img[crate::convert::usize_from(w.in_start)
+                        ..crate::convert::usize_from(w.in_start + w.in_len)];
+                    let got = encode_b64_slice(raw, w.skip, crate::convert::usize_from(take));
                     assert_eq!(
                         got,
-                        &full[o as usize..(o + take) as usize],
+                        &full[crate::convert::usize_from(o)..crate::convert::usize_from(o + take)],
                         "img_total={img_total} o={o} take={take}"
                     );
                 }

--- a/musefs-format/src/ogg/crc.rs
+++ b/musefs-format/src/ogg/crc.rs
@@ -6,9 +6,9 @@ const POLY: u32 = 0x04c1_1db7;
 
 const fn build_table() -> [u32; 256] {
     let mut t = [0u32; 256];
-    let mut i = 0usize;
+    let mut i = 0u32;
     while i < 256 {
-        let mut crc = (i as u32) << 24;
+        let mut crc = i << 24;
         let mut j = 0;
         while j < 8 {
             crc = if crc & 0x8000_0000 != 0 {
@@ -18,7 +18,7 @@ const fn build_table() -> [u32; 256] {
             };
             j += 1;
         }
-        t[i] = crc;
+        t[i as usize] = crc;
         i += 1;
     }
     t

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -610,6 +610,50 @@ mod tests {
         assert_eq!(len, scan.audio_length);
     }
 
+    #[test]
+    fn synthesize_emits_nonzero_seq_delta_when_header_page_count_changes() {
+        // seq_delta = synthesized_page_count - original_header_pages. When the
+        // original header spanned a different number of pages than the regenerated
+        // one, the delta is non-zero — pins the subtraction at the OggAudio segment.
+        let mut data = opus_headers();
+        let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 80]);
+        data.extend_from_slice(&audio);
+        let scan = locate_audio(&data).unwrap();
+        let mut header =
+            read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
+
+        // Synthesis re-lays the Opus header into a known page count; record it.
+        let baseline =
+            synthesize_layout(&header, scan.audio_offset, scan.audio_length, &[], &[]).unwrap();
+        let synth_pages = baseline
+            .segments()
+            .iter()
+            .filter(|s| matches!(s, Segment::Inline(_)))
+            .count();
+        assert!(synth_pages >= 1);
+
+        // Pretend the ORIGINAL header spanned three extra pages, so the served audio
+        // pages must be renumbered downward by exactly three.
+        let original_pages = u32::try_from(synth_pages).unwrap() + 3;
+        header.header_pages = original_pages;
+        let layout =
+            synthesize_layout(&header, scan.audio_offset, scan.audio_length, &[], &[]).unwrap();
+        let delta = layout
+            .segments()
+            .iter()
+            .find_map(|s| match s {
+                Segment::OggAudio { seq_delta, .. } => Some(*seq_delta),
+                _ => None,
+            })
+            .expect("expected an OggAudio segment");
+        assert_eq!(
+            delta,
+            i64::try_from(synth_pages).unwrap() - i64::from(original_pages),
+            "seq_delta must be synthesized pages minus original header pages"
+        );
+        assert_eq!(delta, -3);
+    }
+
     fn vorbis_headers_with(setup: &[u8]) -> Vec<u8> {
         // Minimal-but-shaped Vorbis ID header (30 bytes from 0x01"vorbis").
         let mut id = b"\x01vorbis".to_vec();
@@ -1121,6 +1165,41 @@ mod tests {
         assert!(
             result.is_err(),
             "expected Err when key + b64(prefix) + b64(data) overflows u32"
+        );
+    }
+
+    #[test]
+    fn art_value_at_u32_max_boundary_is_accepted_by_build_packets() {
+        // Pin the exact `value_len > u32::MAX` boundary: with mime "image/png" and
+        // an empty description, key(23) + b64(prefix=42)=56 + b64(data_len) lands on
+        // u32::MAX EXACTLY when data_len == 3_221_225_412. A correct `>` admits it
+        // (the downstream u32 length field still fits); `>=`/`==` or a `*`-mutated
+        // sum would wrongly reject it. The declared 3 GiB image is never
+        // materialized (image bytes are empty), so the build is cheap.
+        let meta = crate::input::ArtInput {
+            art_id: 0,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            data_len: 3_221_225_412,
+            picture_type: 3,
+            width: 0,
+            height: 0,
+        };
+        let art = OggArt {
+            meta: &meta,
+            image: &[],
+        };
+        let header = OggHeader {
+            codec: Codec::Vorbis,
+            serial: 0,
+            packets: vec![vec![], vec![], vec![]],
+            header_pages: 1,
+            audio_offset: 0,
+        };
+        let accepted = build_packets_with_art(&header, &[], &[art]).is_ok();
+        assert!(
+            accepted,
+            "value_len exactly u32::MAX must be accepted by build_packets_with_art"
         );
     }
 

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -1404,6 +1404,20 @@ mod tests {
 }
 
 #[cfg(test)]
+mod page_test_support_tests {
+    /// Pins the fixture's contract: a parseable VorbisComment with zero
+    /// comments. Consumers (musefs-core's ogg tests) splice it into OpusTags
+    /// packets, but only format-local tests can kill mutations of it — the
+    /// mutation gate runs each crate's own suite.
+    #[test]
+    fn vorbis_body_empty_is_a_parseable_empty_comment() {
+        let body = super::page_test_support::vorbis_body_empty();
+        let parsed = crate::vorbiscomment::parse(&body).unwrap();
+        assert!(parsed.is_empty());
+    }
+}
+
+#[cfg(test)]
 mod bounded_tests {
     use super::*;
     use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -266,7 +266,7 @@ pub fn synthesize_layout(
         segments.extend(segs);
         seq += used;
     }
-    let seq_delta = seq as i64 - header.header_pages as i64;
+    let seq_delta = i64::from(seq) - i64::from(header.header_pages);
     segments.push(Segment::OggAudio {
         offset: audio_offset,
         len: audio_length,
@@ -281,7 +281,7 @@ pub fn synthesize_layout(
 /// This makes `base64(prefix ++ image) == base64(prefix) ++ base64(image)`, so the
 /// image's base64 is an independent substring that can be served incrementally.
 /// The declared data-length field is the true image length (`art.data_len`).
-fn picture_prefix(art: &crate::input::ArtInput) -> Vec<u8> {
+fn picture_prefix(art: &crate::input::ArtInput) -> Result<Vec<u8>> {
     // Unpadded prefix length = 4(type)+4(mimelen)+mime +4(desclen)+desc
     //   +4(w)+4(h)+4(depth)+4(colors)+4(datalen) = 32 + mime + desc.
     let base = 32 + art.mime.len() + art.description.len();
@@ -290,16 +290,28 @@ fn picture_prefix(art: &crate::input::ArtInput) -> Vec<u8> {
 
     let mut out = Vec::new();
     out.extend_from_slice(&art.picture_type.to_be_bytes());
-    out.extend_from_slice(&(art.mime.len() as u32).to_be_bytes());
+    out.extend_from_slice(
+        &u32::try_from(art.mime.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    );
     out.extend_from_slice(art.mime.as_bytes());
-    out.extend_from_slice(&(description.len() as u32).to_be_bytes());
+    out.extend_from_slice(
+        &u32::try_from(description.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    );
     out.extend_from_slice(description.as_bytes());
     out.extend_from_slice(&art.width.to_be_bytes());
     out.extend_from_slice(&art.height.to_be_bytes());
     out.extend_from_slice(&0u32.to_be_bytes()); // depth
     out.extend_from_slice(&0u32.to_be_bytes()); // colors
-    out.extend_from_slice(&(art.data_len as u32).to_be_bytes()); // image data length
-    out
+    out.extend_from_slice(
+        &u32::try_from(art.data_len)
+            .map_err(|_| FormatError::TooLarge)?
+            .to_be_bytes(),
+    ); // image data length
+    Ok(out)
 }
 
 use crate::ogg::page::PayloadChunk;
@@ -333,12 +345,12 @@ fn build_packets_with_art(
             // value includes the key, base64 of the picture prefix, and base64 of
             // the image; any one of these alone may fit in u32 but the sum may not.
             for a in arts {
-                let prefix = picture_prefix(a.meta);
+                let prefix = picture_prefix(a.meta)?;
                 let b64_prefix_len = b64_len(prefix.len() as u64);
                 let value_len = METADATA_BLOCK_PICTURE_KEY.len() as u64
                     + b64_prefix_len
                     + b64_len(a.meta.data_len);
-                if value_len > u32::MAX as u64 {
+                if value_len > u64::from(u32::MAX) {
                     return Err(FormatError::TooLarge);
                 }
             }
@@ -383,7 +395,7 @@ fn comment_packet_chunks(
     head.extend_from_slice(&leading);
 
     for art in arts {
-        let prefix = picture_prefix(art.meta);
+        let prefix = picture_prefix(art.meta)?;
         let b64_prefix = b64_encode(&prefix);
         let value_len = METADATA_BLOCK_PICTURE_KEY.len()
             + b64_prefix.len()
@@ -447,7 +459,7 @@ fn oggflac_packets_with_art(
     }
     block_packets.push(vec![PayloadChunk::Bytes(comment)]);
     for art in arts {
-        let prefix = picture_prefix(art.meta);
+        let prefix = picture_prefix(art.meta)?;
         let body_len = prefix.len() as u64 + art.meta.data_len;
         if body_len > crate::flac::MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
@@ -564,7 +576,7 @@ mod tests {
             &data
         })
         .unwrap();
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let layout = synthesize_layout(
             &header,
@@ -625,7 +637,7 @@ mod tests {
 
         let scan = locate_audio(&data).unwrap();
         assert_eq!(scan.codec, Codec::Vorbis);
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
         // The original setup packet (3rd header packet) must be carried through.
         assert_eq!(header.packets[2], setup);
 
@@ -662,7 +674,7 @@ mod tests {
         let mut pic = Vec::new();
         pic.extend_from_slice(&3u32.to_be_bytes());
         let mime = b"image/png";
-        pic.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+        pic.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
         pic.extend_from_slice(mime);
         pic.extend_from_slice(&0u32.to_be_bytes()); // desc len
         pic.extend_from_slice(&1u32.to_be_bytes()); // width
@@ -670,16 +682,20 @@ mod tests {
         pic.extend_from_slice(&0u32.to_be_bytes()); // depth
         pic.extend_from_slice(&0u32.to_be_bytes()); // colors
         let img = b"PNG";
-        pic.extend_from_slice(&(img.len() as u32).to_be_bytes());
+        pic.extend_from_slice(&u32::try_from(img.len()).unwrap().to_be_bytes());
         pic.extend_from_slice(img);
         let b64 = base64::engine::general_purpose::STANDARD.encode(&pic);
 
         let mut body = Vec::new();
-        body.extend_from_slice(&(crate::vorbiscomment::VENDOR.len() as u32).to_le_bytes());
+        body.extend_from_slice(
+            &u32::try_from(crate::vorbiscomment::VENDOR.len())
+                .unwrap()
+                .to_le_bytes(),
+        );
         body.extend_from_slice(crate::vorbiscomment::VENDOR.as_bytes());
         body.extend_from_slice(&1u32.to_le_bytes()); // one comment
         let comment = format!("METADATA_BLOCK_PICTURE={b64}");
-        body.extend_from_slice(&(comment.len() as u32).to_le_bytes());
+        body.extend_from_slice(&u32::try_from(comment.len()).unwrap().to_le_bytes());
         body.extend_from_slice(comment.as_bytes());
 
         let mut tags_pkt = b"OpusTags".to_vec();
@@ -755,7 +771,7 @@ mod tests {
 
         let scan = locate_audio(&data).unwrap();
         assert_eq!(scan.codec, Codec::OggFlac);
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let layout = synthesize_layout(
             &header,
@@ -801,7 +817,7 @@ mod tests {
         let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 80]);
         data.extend_from_slice(&audio);
         let scan = locate_audio(&data).unwrap();
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let image: Vec<u8> = (0..5000u32).map(|i| (i % 251) as u8).collect();
         let meta = crate::input::ArtInput {
@@ -840,8 +856,13 @@ mod tests {
                 } => {
                     assert!(*base64);
                     let w = b64_window(*offset, *len, *art_total);
-                    let raw = &image[w.in_start as usize..(w.in_start + w.in_len) as usize];
-                    bytes.extend_from_slice(&encode_b64_slice(raw, w.skip, *len as usize));
+                    let raw = &image[crate::convert::usize_from(w.in_start)
+                        ..crate::convert::usize_from(w.in_start + w.in_len)];
+                    bytes.extend_from_slice(&encode_b64_slice(
+                        raw,
+                        w.skip,
+                        crate::convert::usize_from(*len),
+                    ));
                 }
                 Segment::OggAudio { .. } => break, // header region ends here
                 other => panic!("unexpected {other:?}"),
@@ -873,10 +894,18 @@ mod tests {
                     let img = images.iter().find(|(id, _)| id == art_id).expect("image").1;
                     if *base64 {
                         let w = b64_window(*offset, *len, *art_total);
-                        let raw = &img[w.in_start as usize..(w.in_start + w.in_len) as usize];
-                        bytes.extend_from_slice(&encode_b64_slice(raw, w.skip, *len as usize));
+                        let raw = &img[crate::convert::usize_from(w.in_start)
+                            ..crate::convert::usize_from(w.in_start + w.in_len)];
+                        bytes.extend_from_slice(&encode_b64_slice(
+                            raw,
+                            w.skip,
+                            crate::convert::usize_from(*len),
+                        ));
                     } else {
-                        bytes.extend_from_slice(&img[*offset as usize..(*offset + *len) as usize]);
+                        bytes.extend_from_slice(
+                            &img[crate::convert::usize_from(*offset)
+                                ..crate::convert::usize_from(*offset + *len)],
+                        );
                     }
                 }
                 Segment::OggAudio { .. } => break,
@@ -905,7 +934,7 @@ mod tests {
         let (audio, _) = crate::ogg::page::lace_packet(55, 99, false, 1024, &[0u8; 64]);
         data.extend_from_slice(&audio);
         let scan = locate_audio(&data).unwrap();
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let image: Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
         let meta = art_input(11, "image/png", image.len());
@@ -936,7 +965,7 @@ mod tests {
         let (audio, _) = crate::ogg::page::lace_packet(77, 3, false, 4096, &[0u8; 64]);
         data.extend_from_slice(&audio);
         let scan = locate_audio(&data).unwrap();
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let image: Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
         let meta = art_input(22, "image/png", image.len());
@@ -966,7 +995,7 @@ mod tests {
         let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 64]);
         data.extend_from_slice(&audio);
         let scan = locate_audio(&data).unwrap();
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let img_a: Vec<u8> = (0..3000u32).map(|i| (i % 251) as u8).collect();
         let img_b: Vec<u8> = (0..1500u32).map(|i| ((i * 3) % 251) as u8).collect();
@@ -1005,7 +1034,7 @@ mod tests {
         let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 64]);
         data.extend_from_slice(&audio);
         let scan = locate_audio(&data).unwrap();
-        let header = read_metadata(&data[..scan.audio_offset as usize]).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         let img: Vec<u8> = (0..2000u32).map(|i| (i % 251) as u8).collect();
         let empty: Vec<u8> = Vec::new();
@@ -1044,7 +1073,7 @@ mod tests {
             art_id: 0,
             mime: "image/jpeg".to_string(),
             description: String::new(),
-            data_len: u32::MAX as u64,
+            data_len: u64::from(u32::MAX),
             picture_type: 3,
             width: 0,
             height: 0,
@@ -1106,7 +1135,7 @@ mod tests {
             height: 1,
             data_len: 12345,
         };
-        let p = picture_prefix(&art);
+        let p = picture_prefix(&art).unwrap();
         assert_eq!(p.len() % 3, 0);
         // datalen is the last 4 bytes (big-endian) and equals the true image length.
         let dl = u32::from_be_bytes(p[p.len() - 4..].try_into().unwrap());
@@ -1172,7 +1201,9 @@ mod tests {
         let overhead = crate::vorbiscomment::build(&[crate::input::TagInput::new("title", "")])
             .unwrap()
             .len() as u64;
-        let at_limit = "x".repeat((crate::flac::MAX_BLOCK_BODY - overhead) as usize);
+        let at_limit = "x".repeat(crate::convert::usize_from(
+            crate::flac::MAX_BLOCK_BODY - overhead,
+        ));
         let tags = [crate::input::TagInput::new("title", at_limit.as_str())];
         assert!(oggflac_packets_with_art(&header, &tags, &[]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
@@ -1207,7 +1238,7 @@ mod tests {
             height: 0,
             data_len,
         };
-        let framing_len = picture_prefix(&mk(0)).len() as u64;
+        let framing_len = picture_prefix(&mk(0)).unwrap().len() as u64;
         let at_limit = mk(crate::flac::MAX_BLOCK_BODY - framing_len);
         let arts = [OggArt {
             meta: &at_limit,
@@ -1281,13 +1312,13 @@ mod tests {
             height: 1,
             data_len: 100,
         };
-        let prefix = picture_prefix(&art);
+        let prefix = picture_prefix(&art).unwrap();
         assert_eq!(prefix.len() % 3, 0);
         // Declared description length lives at offset 8 + mime.len() (after
         // type[4] + mimelen[4] + mime). pad = declared - desc.len() must be 0..=2.
         let off = 8 + art.mime.len();
         let declared = u32::from_be_bytes(prefix[off..off + 4].try_into().unwrap());
-        let pad = declared - art.description.len() as u32;
+        let pad = declared - u32::try_from(art.description.len()).unwrap();
         assert!(pad <= 2, "pad must be 0..=2, got {pad}");
         assert_eq!(pad, 0, "base % 3 == 0 implies pad 0");
     }
@@ -1320,7 +1351,7 @@ mod bounded_tests {
     fn read_metadata_bounded_complete_when_prefix_covers_header() {
         let (full, audio_offset) = opus_stream();
         let file_len = full.len() as u64;
-        let prefix = &full[..audio_offset as usize]; // exactly the header region
+        let prefix = &full[..crate::convert::usize_from(audio_offset)]; // exactly the header region
         match read_metadata_bounded(prefix, file_len).unwrap() {
             Extent::Complete(h) => assert_eq!(h.audio_offset, audio_offset),
             other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -345,12 +345,12 @@ fn build_packets_with_art(
             if header.codec == Codec::Opus {
                 Ok(vec![
                     vec![PayloadChunk::Bytes(header.packets[0].clone())],
-                    comment_packet_chunks(b"OpusTags", tags, arts, false),
+                    comment_packet_chunks(b"OpusTags", tags, arts, false)?,
                 ])
             } else {
                 Ok(vec![
                     vec![PayloadChunk::Bytes(header.packets[0].clone())],
-                    comment_packet_chunks(b"\x03vorbis", tags, arts, true),
+                    comment_packet_chunks(b"\x03vorbis", tags, arts, true)?,
                     vec![PayloadChunk::Bytes(header.packets[2].clone())],
                 ])
             }
@@ -369,13 +369,13 @@ fn comment_packet_chunks(
     tags: &[TagInput],
     arts: &[OggArt],
     framing_bit: bool,
-) -> Vec<PayloadChunk> {
-    let text_body = crate::vorbiscomment::build(tags); // vendor + count(text) + text comments
+) -> Result<Vec<PayloadChunk>> {
+    let text_body = crate::vorbiscomment::build(tags)?; // vendor + count(text) + text comments
     let vendor_len = u32::from_le_bytes(text_body[0..4].try_into().unwrap()) as usize;
     let count_pos = 4 + vendor_len;
     let text_count = u32::from_le_bytes(text_body[count_pos..count_pos + 4].try_into().unwrap());
     let mut leading = text_body.clone();
-    let new_count = text_count + arts.len() as u32;
+    let new_count = text_count + u32::try_from(arts.len()).map_err(|_| FormatError::TooLarge)?;
     leading[count_pos..count_pos + 4].copy_from_slice(&new_count.to_le_bytes());
 
     let mut chunks: Vec<PayloadChunk> = Vec::new();
@@ -387,8 +387,12 @@ fn comment_packet_chunks(
         let b64_prefix = b64_encode(&prefix);
         let value_len = METADATA_BLOCK_PICTURE_KEY.len()
             + b64_prefix.len()
-            + b64_len(art.meta.data_len) as usize;
-        head.extend_from_slice(&(value_len as u32).to_le_bytes());
+            + crate::convert::usize_from(b64_len(art.meta.data_len));
+        head.extend_from_slice(
+            &u32::try_from(value_len)
+                .map_err(|_| FormatError::TooLarge)?
+                .to_le_bytes(),
+        );
         head.extend_from_slice(METADATA_BLOCK_PICTURE_KEY);
         head.extend_from_slice(&b64_prefix);
         chunks.push(PayloadChunk::Bytes(std::mem::take(&mut head)));
@@ -405,7 +409,7 @@ fn comment_packet_chunks(
     if !head.is_empty() {
         chunks.push(PayloadChunk::Bytes(head));
     }
-    chunks
+    Ok(chunks)
 }
 
 /// OggFLAC header packets with art: the text comment packet (no art) plus one
@@ -426,12 +430,12 @@ fn oggflac_packets_with_art(
         }
     }
 
-    let vc = crate::vorbiscomment::build(tags);
+    let vc = crate::vorbiscomment::build(tags)?;
     if vc.len() as u64 > crate::flac::MAX_BLOCK_BODY {
         return Err(FormatError::TooLarge);
     }
     let mut comment = Vec::new();
-    crate::flac::push_block_header(&mut comment, 4, vc.len(), false);
+    crate::flac::push_block_header(&mut comment, 4, vc.len(), false)?;
     comment.extend_from_slice(&vc);
 
     let following_count = structural.len() + 1 + arts.len();
@@ -449,7 +453,7 @@ fn oggflac_packets_with_art(
             return Err(FormatError::TooLarge);
         }
         let mut blk = Vec::new();
-        crate::flac::push_block_header(&mut blk, 6, body_len as usize, false);
+        crate::flac::push_block_header(&mut blk, 6, crate::convert::usize_from(body_len), false)?;
         blk.extend_from_slice(&prefix);
         block_packets.push(vec![
             PayloadChunk::Bytes(blk),
@@ -490,7 +494,7 @@ pub mod page_test_support {
 
     /// An empty VorbisComment body (vendor + zero comments), for fixtures.
     pub fn vorbis_body_empty() -> Vec<u8> {
-        crate::vorbiscomment::build(&[])
+        crate::vorbiscomment::build(&[]).unwrap()
     }
 }
 
@@ -538,7 +542,8 @@ mod tests {
     #[test]
     fn read_tags_opus() {
         // Build an OpusTags packet with one real comment via the shared builder.
-        let body = crate::vorbiscomment::build(&[crate::input::TagInput::new("title", "Sun")]);
+        let body =
+            crate::vorbiscomment::build(&[crate::input::TagInput::new("title", "Sun")]).unwrap();
         let mut tags_pkt = b"OpusTags".to_vec();
         tags_pkt.extend_from_slice(&body);
         let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
@@ -605,7 +610,7 @@ mod tests {
         id.push(0xB8); // blocksizes
         id.push(0x01); // framing bit
         let mut comment = b"\x03vorbis".to_vec();
-        comment.extend_from_slice(&crate::vorbiscomment::build(&[]));
+        comment.extend_from_slice(&crate::vorbiscomment::build(&[]).unwrap());
         comment.push(0x01);
         let (bytes, _) = crate::ogg::page::build_header(55, &[&id, &comment, setup]);
         bytes
@@ -694,7 +699,7 @@ mod tests {
         // STREAMINFO block (type 0): 4-byte header + 34-byte body (zeros are fine
         // for our framing test).
         let mut streaminfo = Vec::new();
-        crate::flac::push_block_header(&mut streaminfo, 0, 34, false);
+        crate::flac::push_block_header(&mut streaminfo, 0, 34, false).unwrap();
         streaminfo.extend(std::iter::repeat_n(0u8, 34));
 
         // Mapping header packet: 0x7F "FLAC" v1.0 count "fLaC" STREAMINFO.
@@ -708,13 +713,13 @@ mod tests {
 
         // A SEEKTABLE block (type 3, structural — must be preserved).
         let mut seektable = Vec::new();
-        crate::flac::push_block_header(&mut seektable, 3, 18, false);
+        crate::flac::push_block_header(&mut seektable, 3, 18, false).unwrap();
         seektable.extend(std::iter::repeat_n(0xEEu8, 18));
 
         // An existing VORBIS_COMMENT (type 4, last) to be replaced.
         let mut old_vc = Vec::new();
-        let body = crate::vorbiscomment::build(&[crate::input::TagInput::new("x", "old")]);
-        crate::flac::push_block_header(&mut old_vc, 4, body.len(), true);
+        let body = crate::vorbiscomment::build(&[crate::input::TagInput::new("x", "old")]).unwrap();
+        crate::flac::push_block_header(&mut old_vc, 4, body.len(), true).unwrap();
         old_vc.extend_from_slice(&body);
 
         let (bytes, _) = crate::ogg::page::build_header(77, &[&mapping, &seektable, &old_vc]);
@@ -1164,8 +1169,9 @@ mod tests {
             header_pages: 1,
             audio_offset: 0,
         };
-        let overhead =
-            crate::vorbiscomment::build(&[crate::input::TagInput::new("title", "")]).len() as u64;
+        let overhead = crate::vorbiscomment::build(&[crate::input::TagInput::new("title", "")])
+            .unwrap()
+            .len() as u64;
         let at_limit = "x".repeat((crate::flac::MAX_BLOCK_BODY - overhead) as usize);
         let tags = [crate::input::TagInput::new("title", at_limit.as_str())];
         assert!(oggflac_packets_with_art(&header, &tags, &[]).is_ok());

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -70,7 +70,7 @@ pub fn parse_page(buf: &[u8], pos: usize) -> Result<PageHeader> {
 /// 0, which is required to signal the packet's end.
 pub(crate) fn lacing_values(payload_len: usize) -> Vec<u8> {
     let mut v = vec![255u8; payload_len / 255];
-    v.push((payload_len % 255) as u8);
+    v.push(u8::try_from(payload_len % 255).expect("x % 255 < 256"));
     v
 }
 
@@ -113,7 +113,7 @@ pub fn lace_packet(
         out.extend_from_slice(&serial.to_le_bytes());
         out.extend_from_slice(&seq.to_le_bytes());
         out.extend_from_slice(&0u32.to_le_bytes()); // CRC placeholder
-        out.push(chunk as u8);
+        out.push(u8::try_from(chunk).expect("chunk is .min(255) so fits in u8"));
         out.extend_from_slice(table);
         out.extend_from_slice(&packet[payload_pos..payload_pos + page_payload]);
 
@@ -327,7 +327,7 @@ pub(crate) fn lace_chunks_to_segments(
         page.extend_from_slice(&serial.to_le_bytes());
         page.extend_from_slice(&seq.to_le_bytes());
         page.extend_from_slice(&0u32.to_le_bytes()); // CRC placeholder
-        page.push(seg_count as u8);
+        page.push(u8::try_from(seg_count).expect("seg_count is .min(255) so fits in u8"));
         page.extend_from_slice(table);
         copy_payload(&mut page, chunks, payload_pos, page_payload);
         let crc = crc32(&page);
@@ -567,7 +567,10 @@ mod tests {
                     ..
                 } => {
                     assert!(*base64);
-                    v.extend_from_slice(&art_out[*offset as usize..(*offset + *len) as usize]);
+                    v.extend_from_slice(
+                        &art_out[usize::try_from(*offset).unwrap()
+                            ..usize::try_from(*offset + *len).unwrap()],
+                    );
                 }
                 other => panic!("unexpected segment {other:?}"),
             }

--- a/musefs-format/src/vorbiscomment.rs
+++ b/musefs-format/src/vorbiscomment.rs
@@ -10,19 +10,31 @@ pub(crate) const VENDOR: &str = "musefs";
 /// Build a VorbisComment body: vendor string then count then `KEY=value` comments.
 /// Lengths are 32-bit little-endian. Known canonical keys are mapped to their
 /// Vorbis field name via the vocabulary; unknown keys are upper-cased.
-pub(crate) fn build(tags: &[TagInput]) -> Vec<u8> {
+pub(crate) fn build(tags: &[TagInput]) -> Result<Vec<u8>> {
     let mut out = Vec::new();
-    out.extend_from_slice(&(VENDOR.len() as u32).to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(VENDOR.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_le_bytes(),
+    );
     out.extend_from_slice(VENDOR.as_bytes());
-    out.extend_from_slice(&(tags.len() as u32).to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(tags.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_le_bytes(),
+    );
     for t in tags {
         let field = crate::tagmap::key_to_vorbis(&t.key)
             .map_or_else(|| t.key.to_ascii_uppercase(), str::to_string);
         let comment = format!("{field}={}", t.value);
-        out.extend_from_slice(&(comment.len() as u32).to_le_bytes());
+        out.extend_from_slice(
+            &u32::try_from(comment.len())
+                .map_err(|_| FormatError::TooLarge)?
+                .to_le_bytes(),
+        );
         out.extend_from_slice(comment.as_bytes());
     }
-    out
+    Ok(out)
 }
 
 fn read_u32_le(data: &[u8], pos: usize) -> Result<u32> {
@@ -76,7 +88,7 @@ mod tests {
             TagInput::new("artist", "Boards of Canada"),
             TagInput::new("title", "Roygbiv"),
         ];
-        let body = build(&tags);
+        let body = build(&tags).unwrap();
         let parsed = parse(&body).unwrap();
         assert_eq!(
             parsed,
@@ -102,7 +114,7 @@ mod tests {
             TagInput::new("albumartist", "VA"),
             TagInput::new("custom_thing", "x"),
         ];
-        let body = build(&tags);
+        let body = build(&tags).unwrap();
         let parsed = parse(&body).unwrap();
         // build upper-cases unknown keys; parse folds known fields to canonical,
         // keeps unknown verbatim.

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -41,13 +41,17 @@ fn walk_chunks(buf: &[u8]) -> Vec<([u8; 4], usize, u64)> {
     while pos + 8 <= buf.len() {
         let mut id = [0u8; 4];
         id.copy_from_slice(&buf[pos..pos + 4]);
-        let size =
-            u32::from_le_bytes([buf[pos + 4], buf[pos + 5], buf[pos + 6], buf[pos + 7]]) as u64;
+        let size = u64::from(u32::from_le_bytes([
+            buf[pos + 4],
+            buf[pos + 5],
+            buf[pos + 6],
+            buf[pos + 7],
+        ]));
         let payload_offset = pos + 8;
         out.push((id, payload_offset, size));
         let advance = 8u64 + size + (size & 1); // word-align: pad odd payloads
         match (pos as u64).checked_add(advance) {
-            Some(next) if next <= buf.len() as u64 => pos = next as usize,
+            Some(next) if next <= buf.len() as u64 => pos = crate::convert::usize_from(next),
             _ => break,
         }
     }
@@ -56,7 +60,7 @@ fn walk_chunks(buf: &[u8]) -> Vec<([u8; 4], usize, u64)> {
 
 /// Borrow a chunk's payload bytes if they fit fully in `buf`.
 fn chunk_slice(buf: &[u8], offset: usize, len: u64) -> Option<&[u8]> {
-    let end = offset.checked_add(len as usize)?;
+    let end = offset.checked_add(crate::convert::usize_from(len))?;
     buf.get(offset..end)
 }
 
@@ -141,7 +145,7 @@ fn info_fourcc(key: &str) -> Option<&'static [u8; 4]> {
 /// Build the `LIST`/`INFO` chunk payload (`"INFO"` + subchunks) from the first
 /// value of each mappable tag key, in first-seen order. Returns `None` when no
 /// tag maps to an INFO field (so the chunk is omitted entirely).
-fn build_info_payload(tags: &[TagInput]) -> Option<Vec<u8>> {
+fn build_info_payload(tags: &[TagInput]) -> Result<Option<Vec<u8>>> {
     let mut entries: Vec<(&'static [u8; 4], &str)> = Vec::new();
     let mut used: Vec<&str> = Vec::new();
     for t in tags {
@@ -154,16 +158,16 @@ fn build_info_payload(tags: &[TagInput]) -> Option<Vec<u8>> {
         }
     }
     if entries.is_empty() {
-        return None;
+        return Ok(None);
     }
     let mut payload = Vec::new();
     payload.extend_from_slice(b"INFO");
     for (cc, value) in entries {
         let mut v = value.as_bytes().to_vec();
         v.push(0x00); // INFO values are NUL-terminated
-        append_chunk(&mut payload, cc, &v);
+        append_chunk(&mut payload, cc, &v)?;
     }
-    Some(payload)
+    Ok(Some(payload))
 }
 
 /// 8-byte RIFF chunk header: fourcc + LE u32 size.
@@ -175,19 +179,22 @@ fn chunk_header(id: &[u8; 4], len: u32) -> [u8; 8] {
 }
 
 /// Append a chunk (`fourcc + LE size + payload + word-align pad`) to `out`.
-fn append_chunk(out: &mut Vec<u8>, id: &[u8; 4], payload: &[u8]) {
-    out.extend_from_slice(&chunk_header(id, payload.len() as u32));
+fn append_chunk(out: &mut Vec<u8>, id: &[u8; 4], payload: &[u8]) -> Result<()> {
+    let len = u32::try_from(payload.len()).map_err(|_| FormatError::TooLarge)?;
+    out.extend_from_slice(&chunk_header(id, len));
     out.extend_from_slice(payload);
     if payload.len() % 2 == 1 {
         out.push(0x00);
     }
+    Ok(())
 }
 
 /// Push a fully-inline chunk (`fourcc + LE size + payload + word-align pad`).
-fn push_inline_chunk(segments: &mut Vec<Segment>, id: &[u8; 4], payload: &[u8]) {
+fn push_inline_chunk(segments: &mut Vec<Segment>, id: &[u8; 4], payload: &[u8]) -> Result<()> {
     let mut chunk = Vec::with_capacity(8 + payload.len() + 1);
-    append_chunk(&mut chunk, id, payload);
+    append_chunk(&mut chunk, id, payload)?;
     segments.push(Segment::Inline(chunk));
+    Ok(())
 }
 
 /// Build the synthesized WAV region: a fresh `RIFF`/`WAVE` front carrying the
@@ -203,18 +210,16 @@ pub fn synthesize_layout(
     binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<RegionLayout> {
-    if audio_length > u32::MAX as u64 {
-        return Err(FormatError::TooLarge); // RF64 territory; out of scope
-    }
+    let audio_length_u32 = u32::try_from(audio_length).map_err(|_| FormatError::TooLarge)?; // RF64 territory; out of scope
 
     let mut segments: Vec<Segment> = Vec::new();
 
-    push_inline_chunk(&mut segments, b"fmt ", &scan.fmt);
+    push_inline_chunk(&mut segments, b"fmt ", &scan.fmt)?;
     if let Some(fact) = &scan.fact {
-        push_inline_chunk(&mut segments, b"fact", fact);
+        push_inline_chunk(&mut segments, b"fact", fact)?;
     }
-    if let Some(info) = build_info_payload(tags) {
-        push_inline_chunk(&mut segments, b"LIST", &info);
+    if let Some(info) = build_info_payload(tags)? {
+        push_inline_chunk(&mut segments, b"LIST", &info)?;
     }
 
     // Embedded `id3 ` chunk: 8-byte chunk header + the ID3v2 tag segments, padded.
@@ -222,9 +227,8 @@ pub fn synthesize_layout(
     // an empty `ArtImage { len: 0 }` would fail `RegionLayout::validate` and brick
     // the track — so WAV inherits that handling by delegating to it.
     let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, binary_tags, arts)?;
-    segments.push(Segment::Inline(
-        chunk_header(b"id3 ", tag_len as u32).to_vec(),
-    ));
+    let tag_len_u32 = u32::try_from(tag_len).map_err(|_| FormatError::TooLarge)?;
+    segments.push(Segment::Inline(chunk_header(b"id3 ", tag_len_u32).to_vec()));
     segments.extend(tag_segments);
     if tag_len % 2 == 1 {
         segments.push(Segment::Inline(vec![0x00]));
@@ -232,7 +236,7 @@ pub fn synthesize_layout(
 
     // `data` chunk: header + the original payload (BackingAudio) + word-align pad.
     segments.push(Segment::Inline(
-        chunk_header(b"data", audio_length as u32).to_vec(),
+        chunk_header(b"data", audio_length_u32).to_vec(),
     ));
     segments.push(Segment::BackingAudio {
         offset: audio_offset,
@@ -244,13 +248,10 @@ pub fn synthesize_layout(
 
     // RIFF size = (everything after the 8-byte "RIFF"+size prefix) = body + "WAVE".
     let body_len: u64 = segments.iter().map(Segment::len).sum();
-    let riff_size = body_len + 4;
-    if riff_size > u32::MAX as u64 {
-        return Err(FormatError::TooLarge);
-    }
+    let riff_size = u32::try_from(body_len + 4).map_err(|_| FormatError::TooLarge)?;
     let mut header = Vec::with_capacity(12);
     header.extend_from_slice(b"RIFF");
-    header.extend_from_slice(&(riff_size as u32).to_le_bytes());
+    header.extend_from_slice(&riff_size.to_le_bytes());
     header.extend_from_slice(b"WAVE");
     segments.insert(0, Segment::Inline(header));
 
@@ -418,14 +419,14 @@ mod tests {
         let mut body = Vec::new();
         for (id, payload) in chunks {
             body.extend_from_slice(*id);
-            body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+            body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
             body.extend_from_slice(payload);
             if payload.len() % 2 == 1 {
                 body.push(0x00);
             }
         }
         let mut out = b"RIFF".to_vec();
-        out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
         out.extend_from_slice(b"WAVE");
         out.extend_from_slice(&body);
         out
@@ -490,6 +491,7 @@ mod tests {
         ];
         for (key, cc) in cases {
             let payload = build_info_payload(&[TagInput::new(key, "X")])
+                .unwrap()
                 .unwrap_or_else(|| panic!("INFO payload for {key}"));
             assert!(
                 payload.windows(4).any(|w| w == &cc[..]),
@@ -505,11 +507,15 @@ mod tests {
         // Value "a"  -> v.len()=2 (even, NO pad). Kills `% → /` (2/2==1 pads) and
         //               `== → !=` (2%2=0 != 1 pads).
         // Value "ab" -> v.len()=3 (odd, padded). Kills `% → +` (3+2 != 1, no pad).
-        let even = build_info_payload(&[TagInput::new("title", "a")]).unwrap();
+        let even = build_info_payload(&[TagInput::new("title", "a")])
+            .unwrap()
+            .unwrap();
         // "INFO"(4) + "INAM"(4) + len(4) + "a\0"(2) = 14, no pad.
         assert_eq!(even.len(), 14);
 
-        let odd = build_info_payload(&[TagInput::new("title", "ab")]).unwrap();
+        let odd = build_info_payload(&[TagInput::new("title", "ab")])
+            .unwrap()
+            .unwrap();
         // "INFO"(4) + "INAM"(4) + len(4) + "ab\0"(3) + pad(1) = 16.
         assert_eq!(odd.len(), 16);
     }
@@ -519,13 +525,13 @@ mod tests {
         // :168 `payload.len() % 2 == 1`.
         // Even payload (len 2): NO pad. Kills `% → /` (2/2==1 pads).
         let mut segs = Vec::new();
-        push_inline_chunk(&mut segs, b"test", &[0xAA, 0xBB]);
+        push_inline_chunk(&mut segs, b"test", &[0xAA, 0xBB]).unwrap();
         assert_eq!(segs.len(), 1);
         assert_eq!(segs[0].len(), 10); // "test"(4) + len(4) + payload(2)
 
         // Odd payload (len 3): padded. Kills `% → +` (3+2 != 1, no pad).
         let mut segs2 = Vec::new();
-        push_inline_chunk(&mut segs2, b"test", &[0xAA, 0xBB, 0xCC]);
+        push_inline_chunk(&mut segs2, b"test", &[0xAA, 0xBB, 0xCC]).unwrap();
         assert_eq!(segs2[0].len(), 12); // 4 + 4 + 3 + pad(1)
     }
 
@@ -536,7 +542,7 @@ mod tests {
             let mut v = val.as_bytes().to_vec();
             v.push(0x00);
             p.extend_from_slice(*cc);
-            p.extend_from_slice(&(v.len() as u32).to_le_bytes());
+            p.extend_from_slice(&u32::try_from(v.len()).unwrap().to_le_bytes());
             p.extend_from_slice(&v);
             if v.len() % 2 == 1 {
                 p.push(0x00);
@@ -635,20 +641,18 @@ mod tests {
 
     #[test]
     fn synthesize_rejects_riff_size_overflow() {
-        // :227 `> → ==`. `BackingAudio` is virtual (no real allocation), so we can
-        // pass `audio_length == u32::MAX`: it PASSES the :186 guard (`> u32::MAX` is
-        // false) but makes `riff_size > u32::MAX`. Original `>` → TooLarge; the `==`
-        // mutant (`riff_size == u32::MAX`) is false (riff_size is strictly greater),
-        // so it wrongly proceeds and returns Ok with a truncated size.
+        // `BackingAudio` is virtual (no real allocation), so we can pass
+        // `audio_length == u32::MAX`: it passes the audio_length u32 check but makes
+        // `riff_size > u32::MAX` once the other chunks are added.
         //
-        // NOTE — this must use exactly u32::MAX, not the existing
-        // `rejects_audio_over_32bit` test's `u32::MAX + 1`: that larger value is
-        // caught by the :186 guard first and never reaches :227.
+        // NOTE — this must use exactly u32::MAX, not `u32::MAX + 1`: the larger
+        // value is caught by the audio_length conversion first and never reaches
+        // the riff_size check.
         let scan = WavScan {
             fmt: fmt_pcm(),
             fact: None,
         };
-        let res = synthesize_layout(&scan, 0, u32::MAX as u64, &[], &[], &[]);
+        let res = synthesize_layout(&scan, 0, u64::from(u32::MAX), &[], &[], &[]);
         assert_eq!(res, Err(FormatError::TooLarge));
     }
 
@@ -659,10 +663,10 @@ mod tests {
         body.extend_from_slice(&16u32.to_le_bytes());
         body.extend(std::iter::repeat_n(0u8, 16));
         body.extend_from_slice(b"data");
-        body.extend_from_slice(&(audio.len() as u32).to_le_bytes());
+        body.extend_from_slice(&u32::try_from(audio.len()).unwrap().to_le_bytes());
         body.extend_from_slice(audio);
         let mut v = b"RIFF".to_vec();
-        v.extend_from_slice(&((4 + body.len()) as u32).to_le_bytes());
+        v.extend_from_slice(&u32::try_from(4 + body.len()).unwrap().to_le_bytes());
         v.extend_from_slice(b"WAVE");
         v.extend_from_slice(&body);
         v

--- a/musefs-format/tests/common/mod.rs
+++ b/musefs-format/tests/common/mod.rs
@@ -25,8 +25,8 @@ pub fn resolve_layout(
                 out.extend_from_slice(img);
             }
             Segment::BackingAudio { offset, len } => {
-                let o = *offset as usize;
-                let l = *len as usize;
+                let o = usize::try_from(*offset).unwrap();
+                let l = usize::try_from(*len).unwrap();
                 out.extend_from_slice(&backing[o..o + l]);
             }
             Segment::OggAudio { .. } => unreachable!("no Ogg audio in this fixture"),

--- a/musefs-format/tests/flac_pictures.rs
+++ b/musefs-format/tests/flac_pictures.rs
@@ -4,15 +4,15 @@ use musefs_format::fuzz_check::fixtures::{flac_block, streaminfo_body};
 fn picture_body(pic_type: u32, mime: &str, desc: &str, w: u32, h: u32, data: &[u8]) -> Vec<u8> {
     let mut b = Vec::new();
     b.extend_from_slice(&pic_type.to_be_bytes());
-    b.extend_from_slice(&(mime.len() as u32).to_be_bytes());
+    b.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
     b.extend_from_slice(mime.as_bytes());
-    b.extend_from_slice(&(desc.len() as u32).to_be_bytes());
+    b.extend_from_slice(&u32::try_from(desc.len()).unwrap().to_be_bytes());
     b.extend_from_slice(desc.as_bytes());
     b.extend_from_slice(&w.to_be_bytes());
     b.extend_from_slice(&h.to_be_bytes());
     b.extend_from_slice(&0u32.to_be_bytes()); // color depth
     b.extend_from_slice(&0u32.to_be_bytes()); // colors used
-    b.extend_from_slice(&(data.len() as u32).to_be_bytes());
+    b.extend_from_slice(&u32::try_from(data.len()).unwrap().to_be_bytes());
     b.extend_from_slice(data);
     b
 }

--- a/musefs-format/tests/mp3_synthesize.rs
+++ b/musefs-format/tests/mp3_synthesize.rs
@@ -26,10 +26,10 @@ fn assemble(layout: &RegionLayout, audio: &[u8], arts: &[(i64, &[u8])]) -> Vec<u
 
 /// Decode the 28-bit syncsafe ID3v2 tag-size field from the 10-byte header.
 fn header_size_field(bytes: &[u8]) -> u64 {
-    ((bytes[6] as u64) << 21)
-        | ((bytes[7] as u64) << 14)
-        | ((bytes[8] as u64) << 7)
-        | (bytes[9] as u64)
+    (u64::from(bytes[6]) << 21)
+        | (u64::from(bytes[7]) << 14)
+        | (u64::from(bytes[8]) << 7)
+        | u64::from(bytes[9])
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn synthesize_errors_when_frames_sum_past_the_tag_limit() {
         art_id: id,
         mime: "image/jpeg".to_string(),
         description: String::new(),
-        picture_type: id as u32,
+        picture_type: u32::try_from(id).unwrap(),
         width: 0,
         height: 0,
         data_len: 0x0800_0000, // 128 MiB each; two sum past the 256 MiB tag limit

--- a/musefs-format/tests/mp4_oracle.rs
+++ b/musefs-format/tests/mp4_oracle.rs
@@ -12,7 +12,9 @@ fn materialize(layout: &RegionLayout, backing: &[u8]) -> Vec<u8> {
         match seg {
             Segment::Inline(b) => out.extend_from_slice(b),
             Segment::BackingAudio { offset, len } => {
-                out.extend_from_slice(&backing[*offset as usize..(*offset + *len) as usize]);
+                let s = usize::try_from(*offset).unwrap();
+                let e = usize::try_from(*offset + *len).unwrap();
+                out.extend_from_slice(&backing[s..e]);
             }
             Segment::ArtImage { .. } => unreachable!("no art in this fixture"),
             Segment::OggAudio { .. } => unreachable!("no Ogg audio in this fixture"),
@@ -25,7 +27,9 @@ fn materialize(layout: &RegionLayout, backing: &[u8]) -> Vec<u8> {
 
 fn samples(bytes: &[u8]) -> Vec<Vec<u8>> {
     // `::mp4` is the external oracle crate; `mp4` (no leading `::`) is our own module.
-    let mut r = ::mp4::Mp4Reader::read_header(Cursor::new(bytes), bytes.len() as u64).unwrap();
+    let mut r =
+        ::mp4::Mp4Reader::read_header(Cursor::new(bytes), u64::try_from(bytes.len()).unwrap())
+            .unwrap();
     let track_id = *r.tracks().keys().next().unwrap();
     let count = r.sample_count(track_id).unwrap();
     (1..=count)

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -106,7 +106,7 @@ proptest! {
             backing_mtime: 0,
         }).unwrap();
         let db_tags: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
-            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as i64 }
+            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as u64 }
         }).collect();
         db.set_binary_tags(tid, &db_tags).unwrap();
         let rows = db.get_binary_tags(tid).unwrap();

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -111,7 +111,7 @@ proptest! {
         db.set_binary_tags(tid, &db_tags).unwrap();
         let rows = db.get_binary_tags(tid).unwrap();
         let binary_tag_inputs: Vec<BinaryTagInput> = rows.iter().map(|r| {
-            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len as u64 }
+            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len }
         }).collect();
 
         // Step 3: Build promoted text tags.

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -106,7 +106,7 @@ proptest! {
             backing_mtime: 0,
         }).unwrap();
         let db_tags: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
-            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as u64 }
+            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: u64::try_from(i).unwrap() }
         }).collect();
         db.set_binary_tags(tid, &db_tags).unwrap();
         let rows = db.get_binary_tags(tid).unwrap();
@@ -126,7 +126,7 @@ proptest! {
         // Step 5: Materialize — inline bytes + substituted BinaryTag payloads.
         let mut materialized = Vec::new();
         let payload_map: std::collections::HashMap<i64, Vec<u8>> = rows.iter().map(|r| {
-            let blob = db.read_binary_tag_chunk(r.rowid, 0, r.byte_len as usize).unwrap();
+            let blob = db.read_binary_tag_chunk(r.rowid, 0, usize::try_from(r.byte_len).unwrap()).unwrap();
             (r.rowid, blob)
         }).collect();
         for seg in &segments {

--- a/musefs-format/tests/proptest_mp4.rs
+++ b/musefs-format/tests/proptest_mp4.rs
@@ -21,7 +21,7 @@ proptest! {
             .iter()
             .enumerate()
             .map(|(i, (kind, len))| ArtInput {
-                art_id: i as i64 + 1,
+                art_id: i64::try_from(i).unwrap() + 1,
                 mime: if *kind == 1 { "image/jpeg".into() } else { "image/png".into() },
                 description: String::new(),
                 picture_type: 3,
@@ -53,7 +53,7 @@ proptest! {
         let mut inputs: Vec<BinaryTagInput> = Vec::new();
         let mut map: HashMap<i64, Vec<u8>> = HashMap::new();
         for (i, (name, bytes)) in bins.iter().enumerate() {
-            let id = i as i64 + 1;
+            let id = i64::try_from(i).unwrap() + 1;
             inputs.push(BinaryTagInput {
                 key: format!("----:com.apple.iTunes:{name}"),
                 payload_id: id,
@@ -79,8 +79,8 @@ proptest! {
                         out.extend_from_slice(map.get(payload_id).unwrap());
                     }
                     Segment::BackingAudio { offset, len } => {
-                        let s = *offset as usize;
-                        out.extend_from_slice(&original[s..s + *len as usize]);
+                        let s = usize::try_from(*offset).unwrap();
+                        out.extend_from_slice(&original[s..s + usize::try_from(*len).unwrap()]);
                     }
                     other => panic!("unexpected segment: {other:?}"),
                 }

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -46,7 +46,7 @@ fn fmt_pcm_16bit_mono() -> Vec<u8> {
 fn wav_with_id3(id3: &[u8], audio: &[u8]) -> Vec<u8> {
     fn chunk(id: &[u8; 4], body: &[u8]) -> Vec<u8> {
         let mut c = id.to_vec();
-        c.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        c.extend_from_slice(&u32::try_from(body.len()).unwrap().to_le_bytes());
         c.extend_from_slice(body);
         if body.len() % 2 == 1 {
             c.push(0); // RIFF word-alignment pad
@@ -60,7 +60,7 @@ fn wav_with_id3(id3: &[u8], audio: &[u8]) -> Vec<u8> {
     body.extend(chunk(b"data", audio));
     let mut out = Vec::new();
     out.extend_from_slice(b"RIFF");
-    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(body.len()).unwrap().to_le_bytes());
     out.extend_from_slice(&body);
     out
 }
@@ -79,8 +79,8 @@ fn materialize_wav(
                 out.extend_from_slice(map.get(payload_id).unwrap());
             }
             Segment::BackingAudio { offset, len } => {
-                let s = *offset as usize;
-                out.extend_from_slice(&audio[s..s + *len as usize]);
+                let s = usize::try_from(*offset).unwrap();
+                out.extend_from_slice(&audio[s..s + usize::try_from(*len).unwrap()]);
             }
             Segment::ArtImage { .. } => panic!("no art in this fixture"),
             other => panic!("unexpected segment in WAV layout: {other:?}"),
@@ -158,7 +158,7 @@ proptest! {
             audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime: 0,
         }).unwrap();
         let rows: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
-            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as u64 }
+            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: u64::try_from(i).unwrap() }
         }).collect();
         db.set_binary_tags(tid, &rows).unwrap();
         let stored = db.get_binary_tags(tid).unwrap();
@@ -167,7 +167,7 @@ proptest! {
         }).collect();
         let mut map: HashMap<i64, Vec<u8>> = HashMap::new();
         for r in &stored {
-            map.insert(r.rowid, db.read_binary_tag_chunk(r.rowid, 0, r.byte_len as usize).unwrap());
+            map.insert(r.rowid, db.read_binary_tag_chunk(r.rowid, 0, usize::try_from(r.byte_len).unwrap()).unwrap());
         }
 
         // Promoted text tags drive POPM/UFID regeneration.

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -158,7 +158,7 @@ proptest! {
             audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime: 0,
         }).unwrap();
         let rows: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
-            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as i64 }
+            musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: i as u64 }
         }).collect();
         db.set_binary_tags(tid, &rows).unwrap();
         let stored = db.get_binary_tags(tid).unwrap();

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -163,7 +163,7 @@ proptest! {
         db.set_binary_tags(tid, &rows).unwrap();
         let stored = db.get_binary_tags(tid).unwrap();
         let inputs: Vec<BinaryTagInput> = stored.iter().map(|r| {
-            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len as u64 }
+            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len }
         }).collect();
         let mut map: HashMap<i64, Vec<u8>> = HashMap::new();
         for r in &stored {

--- a/musefs-format/tests/read_metadata.rs
+++ b/musefs-format/tests/read_metadata.rs
@@ -10,7 +10,7 @@ fn read_metadata_on_front_bytes_recovers_preserved_and_offset() {
     let file = make_flac(&[(0, si.clone()), (4, vc)], &audio);
 
     let scan = locate_audio(&file).unwrap();
-    let front = &file[..scan.audio_offset as usize];
+    let front = &file[..usize::try_from(scan.audio_offset).unwrap()];
 
     let meta = read_metadata(front).unwrap();
     assert_eq!(meta.audio_offset, scan.audio_offset);

--- a/musefs-format/tests/roundtrip.rs
+++ b/musefs-format/tests/roundtrip.rs
@@ -67,7 +67,10 @@ fn full_roundtrip_preserved_blocks_multivalue_tags_and_two_pictures() {
     let assembled = resolve_layout(&layout, &file, &art_map, &HashMap::new());
 
     assert_eq!(assembled.len() as u64, layout.total_len());
-    assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
+    assert_eq!(
+        &assembled[usize::try_from(layout.header_len()).unwrap()..],
+        &audio[..]
+    );
 
     let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC");
 

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -61,7 +61,10 @@ fn art_becomes_an_artimage_segment_and_lengths_are_exact() {
     art_map.insert(42i64, image.clone());
     let assembled = resolve_layout(&layout, &file, &art_map, &HashMap::new());
     assert_eq!(assembled.len() as u64, layout.total_len());
-    assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
+    assert_eq!(
+        &assembled[usize::try_from(layout.header_len()).unwrap()..],
+        &audio[..]
+    );
 }
 
 #[test]
@@ -144,7 +147,10 @@ fn zero_byte_art_is_skipped_so_the_track_still_serves() {
     let art_map = HashMap::new();
     let assembled = resolve_layout(&layout, &file, &art_map, &HashMap::new());
     assert_eq!(assembled.len() as u64, layout.total_len());
-    assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
+    assert_eq!(
+        &assembled[usize::try_from(layout.header_len()).unwrap()..],
+        &audio[..]
+    );
 
     // metaflac sees a valid FLAC with zero pictures.
     let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");

--- a/musefs-format/tests/synthesize_tags.rs
+++ b/musefs-format/tests/synthesize_tags.rs
@@ -39,7 +39,10 @@ fn measured_lengths_match_assembled_bytes() {
         layout.header_len(),
         assembled.len() as u64 - audio.len() as u64
     );
-    assert_eq!(&assembled[layout.header_len() as usize..], &audio[..]);
+    assert_eq!(
+        &assembled[usize::try_from(layout.header_len()).unwrap()..],
+        &audio[..]
+    );
 }
 
 #[test]

--- a/musefs-format/tests/wav_locate.rs
+++ b/musefs-format/tests/wav_locate.rs
@@ -18,7 +18,7 @@ pub fn build_wav(chunks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
     let mut body = Vec::new();
     for (id, payload) in chunks {
         body.extend_from_slice(*id);
-        body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
         body.extend_from_slice(payload);
         if payload.len() % 2 == 1 {
             body.push(0x00);
@@ -26,7 +26,7 @@ pub fn build_wav(chunks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
     }
     let mut out = Vec::new();
     out.extend_from_slice(b"RIFF");
-    out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
     out.extend_from_slice(b"WAVE");
     out.extend_from_slice(&body);
     out
@@ -39,7 +39,8 @@ fn locate_finds_data_bounds() {
     let bounds = locate_audio(&wav).unwrap();
     assert_eq!(bounds.audio_length, 10);
     assert_eq!(
-        &wav[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+        &wav[usize::try_from(bounds.audio_offset).unwrap()
+            ..usize::try_from(bounds.audio_offset + bounds.audio_length).unwrap()],
         data.as_slice()
     );
 }
@@ -80,7 +81,7 @@ fn read_structure_works_on_front_only_buffer() {
     // walk must still surface `fmt ` even though `data`'s payload is absent.
     let wav = build_wav(&[(b"fmt ", fmt_pcm_16bit_mono()), (b"data", vec![0u8; 100])]);
     let bounds = locate_audio(&wav).unwrap();
-    let front = &wav[..bounds.audio_offset as usize];
+    let front = &wav[..usize::try_from(bounds.audio_offset).unwrap()];
     let scan = read_structure(front).unwrap();
     assert_eq!(scan.fmt, fmt_pcm_16bit_mono());
     assert_eq!(scan.fact, None);

--- a/musefs-format/tests/wav_read_tags.rs
+++ b/musefs-format/tests/wav_read_tags.rs
@@ -17,7 +17,7 @@ fn build_wav(chunks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
     let mut body = Vec::new();
     for (id, payload) in chunks {
         body.extend_from_slice(*id);
-        body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
         body.extend_from_slice(payload);
         if payload.len() % 2 == 1 {
             body.push(0x00);
@@ -25,7 +25,7 @@ fn build_wav(chunks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
     }
     let mut out = Vec::new();
     out.extend_from_slice(b"RIFF");
-    out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
     out.extend_from_slice(b"WAVE");
     out.extend_from_slice(&body);
     out
@@ -38,7 +38,7 @@ fn info_payload(pairs: &[(&[u8; 4], &str)]) -> Vec<u8> {
         let mut v = val.as_bytes().to_vec();
         v.push(0x00);
         p.extend_from_slice(*cc);
-        p.extend_from_slice(&(v.len() as u32).to_le_bytes());
+        p.extend_from_slice(&u32::try_from(v.len()).unwrap().to_le_bytes());
         p.extend_from_slice(&v);
         if v.len() % 2 == 1 {
             p.push(0x00);

--- a/musefs-format/tests/wav_synthesize.rs
+++ b/musefs-format/tests/wav_synthesize.rs
@@ -163,7 +163,7 @@ fn rejects_audio_over_32bit() {
         fmt: fmt_pcm_16bit_mono(),
         fact: None,
     };
-    let res = synthesize_layout(&scan, 0, (u32::MAX as u64) + 1, &[], &[], &[]);
+    let res = synthesize_layout(&scan, 0, u64::from(u32::MAX) + 1, &[], &[], &[]);
     assert_eq!(res, Err(musefs_format::FormatError::TooLarge));
 }
 
@@ -219,7 +219,8 @@ fn skips_zero_byte_art() {
     let bytes = assemble(&layout, &audio, &[]);
     let bounds = musefs_format::wav::locate_audio(&bytes).unwrap();
     assert_eq!(
-        &bytes[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+        &bytes[usize::try_from(bounds.audio_offset).unwrap()
+            ..usize::try_from(bounds.audio_offset + bounds.audio_length).unwrap()],
         &audio[..]
     );
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -16,6 +16,7 @@ use fuser::{
     INodeNo, InitFlags, KernelConfig, LockOwner, Notifier, OpenFlags, ReplyAttr, ReplyData,
     ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, Request, Session,
 };
+use musefs_core::convert::usize_from;
 use musefs_core::Attr;
 use musefs_core::CoreError;
 use musefs_core::Fh;
@@ -108,7 +109,7 @@ fn reply_errno(op: &str, ino: u64, err: &CoreError) -> fuser::Errno {
 /// back to `fallback_mtime` so tools don't see a 1970 timestamp.
 pub fn to_file_attr(attr: &Attr, uid: u32, gid: u32, fallback_mtime: SystemTime) -> FileAttr {
     let mtime = if attr.mtime_secs > 0 {
-        SystemTime::UNIX_EPOCH + Duration::from_secs(attr.mtime_secs as u64)
+        SystemTime::UNIX_EPOCH + Duration::from_secs(u64::try_from(attr.mtime_secs).unwrap_or(0))
     } else {
         fallback_mtime
     };
@@ -336,7 +337,7 @@ impl Filesystem for MusefsFs {
                     ino.0,
                     NonZeroU64::new(fh.0).map(Fh::from),
                     offset,
-                    size as u64,
+                    u64::from(size),
                     &mut buf,
                 ) {
                     Ok(()) => reply.data(&buf),
@@ -380,7 +381,7 @@ impl Filesystem for MusefsFs {
             listing.push((child, kind, name));
         }
 
-        for (i, (child, kind, name)) in listing.into_iter().enumerate().skip(offset as usize) {
+        for (i, (child, kind, name)) in listing.into_iter().enumerate().skip(usize_from(offset)) {
             // The offset stored is the index of the *next* entry to return.
             if reply.add(INodeNo(child), (i + 1) as u64, kind, &name) {
                 break;

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -109,7 +109,10 @@ fn reply_errno(op: &str, ino: u64, err: &CoreError) -> fuser::Errno {
 /// back to `fallback_mtime` so tools don't see a 1970 timestamp.
 pub fn to_file_attr(attr: &Attr, uid: u32, gid: u32, fallback_mtime: SystemTime) -> FileAttr {
     let mtime = if attr.mtime_secs > 0 {
-        SystemTime::UNIX_EPOCH + Duration::from_secs(u64::try_from(attr.mtime_secs).unwrap_or(0))
+        SystemTime::UNIX_EPOCH
+            + Duration::from_secs(
+                u64::try_from(attr.mtime_secs).expect("guarded by mtime_secs > 0"),
+            )
     } else {
         fallback_mtime
     };

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -9,9 +9,9 @@ fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();
     out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
     let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
+    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
+    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
+    out.push(u8::try_from(len & 0xFF).unwrap());
     out.extend_from_slice(body);
     out
 }
@@ -27,11 +27,11 @@ fn streaminfo_body() -> Vec<u8> {
 
 fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
     let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
     out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
     for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
         out.extend_from_slice(c.as_bytes());
     }
     out

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -8,9 +8,9 @@ fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();
     out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
     let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
+    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
+    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
+    out.push(u8::try_from(len & 0xFF).unwrap());
     out.extend_from_slice(body);
     out
 }
@@ -26,11 +26,11 @@ fn streaminfo_body() -> Vec<u8> {
 
 fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
     let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
     out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
     for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
         out.extend_from_slice(c.as_bytes());
     }
     out
@@ -110,7 +110,7 @@ fn make_wav(artist: &str, title: &str, audio: &[u8]) -> Vec<u8> {
         let mut v = val.as_bytes().to_vec();
         v.push(0x00);
         info.extend_from_slice(cc);
-        info.extend_from_slice(&(v.len() as u32).to_le_bytes());
+        info.extend_from_slice(&u32::try_from(v.len()).unwrap().to_le_bytes());
         info.extend_from_slice(&v);
         if v.len() % 2 == 1 {
             info.push(0x00);
@@ -124,14 +124,14 @@ fn make_wav(artist: &str, title: &str, audio: &[u8]) -> Vec<u8> {
         (&b"data"[..], audio),
     ] {
         body.extend_from_slice(id);
-        body.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        body.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
         body.extend_from_slice(payload);
         if payload.len() % 2 == 1 {
             body.push(0x00);
         }
     }
     let mut out = b"RIFF".to_vec();
-    out.extend_from_slice(&((body.len() + 4) as u32).to_le_bytes());
+    out.extend_from_slice(&u32::try_from(body.len() + 4).unwrap().to_le_bytes());
     out.extend_from_slice(b"WAVE");
     out.extend_from_slice(&body);
     out
@@ -162,7 +162,8 @@ fn end_to_end_read_through_mount_wav() {
     assert_eq!(&bytes[8..12], b"WAVE");
     let bounds = musefs_format::wav::locate_audio(&bytes).unwrap();
     assert_eq!(
-        &bytes[bounds.audio_offset as usize..(bounds.audio_offset + bounds.audio_length) as usize],
+        &bytes[usize::try_from(bounds.audio_offset).unwrap()
+            ..usize::try_from(bounds.audio_offset + bounds.audio_length).unwrap()],
         audio.as_slice()
     );
 

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -20,6 +20,23 @@ use fuser::{
     Session, TimeOrNow, WriteFlags,
 };
 
+// latencyfs is 64-bit-only, like the rest of the workspace (musefs-db's
+// convert module declares the same bound for the dependent crates).
+const _: () = assert!(
+    std::mem::size_of::<usize>() == 8,
+    "musefs-latencyfs supports 64-bit targets only"
+);
+
+/// The crate's only sanctioned `u64 -> usize` cast (see the guard above).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "u64 -> usize is lossless on 64-bit targets; guarded by the const assert above"
+)]
+#[inline]
+fn usize_from(v: u64) -> usize {
+    v as usize
+}
+
 const TTL: Duration = Duration::from_secs(1);
 
 fn ms(n: u64) -> Duration {
@@ -156,7 +173,11 @@ fn attr_from_meta(ino: u64, m: &std::fs::Metadata) -> FileAttr {
     };
     let t = |secs: i64, nsec: i64| {
         if secs >= 0 {
-            SystemTime::UNIX_EPOCH + Duration::new(secs as u64, nsec as u32)
+            SystemTime::UNIX_EPOCH
+                + Duration::new(
+                    u64::try_from(secs).unwrap_or(0),
+                    u32::try_from(nsec).unwrap_or(0),
+                )
         } else {
             SystemTime::UNIX_EPOCH
         }
@@ -171,11 +192,11 @@ fn attr_from_meta(ino: u64, m: &std::fs::Metadata) -> FileAttr {
         crtime: SystemTime::UNIX_EPOCH,
         kind,
         perm: (m.mode() & 0o7777) as u16,
-        nlink: m.nlink() as u32,
+        nlink: u32::try_from(m.nlink()).unwrap_or(u32::MAX),
         uid: m.uid(),
         gid: m.gid(),
-        rdev: m.rdev() as u32,
-        blksize: m.blksize() as u32,
+        rdev: u32::try_from(m.rdev()).unwrap_or(u32::MAX),
+        blksize: u32::try_from(m.blksize()).unwrap_or(u32::MAX),
         flags: 0,
     }
 }
@@ -293,7 +314,7 @@ impl fuser::Filesystem for PassthroughFs {
             let cino = self.inodes.lock().unwrap().intern(p);
             entries.push((cino, kind, ent.file_name()));
         }
-        for (i, (cino, kind, name)) in entries.into_iter().enumerate().skip(offset as usize) {
+        for (i, (cino, kind, name)) in entries.into_iter().enumerate().skip(usize_from(offset)) {
             if reply.add(INodeNo(cino), (i + 1) as u64, kind, &name) {
                 break;
             }
@@ -355,7 +376,7 @@ impl fuser::Filesystem for PassthroughFs {
         let Some(file) = guard.get(&fh.0) else {
             return reply.error(fuser::Errno::EBADF);
         };
-        let mut buf = vec![0u8; size as usize];
+        let mut buf = vec![0u8; usize_from(u64::from(size))];
         match file.read_at(&mut buf, offset) {
             Ok(n) => reply.data(&buf[..n]),
             Err(e) => {
@@ -414,9 +435,9 @@ impl fuser::Filesystem for PassthroughFs {
                         s.f_bavail as u64,
                         s.f_files as u64,
                         s.f_ffree as u64,
-                        s.f_bsize as u32,
-                        s.f_namemax as u32,
-                        s.f_frsize as u32,
+                        u32::try_from(s.f_bsize as u64).unwrap_or(u32::MAX),
+                        u32::try_from(s.f_namemax as u64).unwrap_or(u32::MAX),
+                        u32::try_from(s.f_frsize as u64).unwrap_or(u32::MAX),
                     );
                 }
             }
@@ -499,7 +520,7 @@ impl fuser::Filesystem for PassthroughFs {
             return reply.error(fuser::Errno::EBADF);
         };
         match file.write_at(data, offset) {
-            Ok(n) => reply.written(n as u32),
+            Ok(n) => reply.written(u32::try_from(n).unwrap_or(u32::MAX)),
             Err(e) => {
                 reply.error(fuser::Errno::from_i32(
                     e.raw_os_error().unwrap_or(libc::EIO),


### PR DESCRIPTION
Closes #133.

Replaces the blanket `allow` on the four clippy cast lints with an enforced convention: all ~451 pre-existing violations are migrated, the lints are flipped to `warn`, and CI's `-D warnings` makes them hard gates from here on.

## The convention

- **Widenings** use `From`, never `as` (enforced by `cast_lossless`).
- **u64 ↔ usize**: the workspace is declared 64-bit-only by compile-time guards; `u64 → usize` goes only through sanctioned `usize_from` helpers (`musefs_db::convert`, re-exported by core for fuse/cli; crate-local siblings in musefs-format and standalone latencyfs) — the only places a pointer-width `#[expect]` lives.
- **Genuine narrowings** use `try_from`: `?` (→ `FormatError::TooLarge`) where the value is input-dependent, `.expect("<invariant>")` where structurally bounded, `.unwrap()` in tests/fixtures.
- **i64 never crosses the db boundary upward**: non-negative row fields (`audio_offset`, `audio_length`, `backing_size`, `byte_len`, ordinals, `picture_type`, art `width`/`height`) are now unsigned; rusqlite's checked conversions (feature `fallible_uint`) validate once at the row boundary.

Spec: `docs/superpowers/specs/2026-06-06-integer-cast-convention-design.md` · Plan: `docs/superpowers/plans/2026-06-06-integer-cast-convention.md`

## Behavioral changes

The SQLite store is the declared interface external tools (beets/Picard) write to, so row values are untrusted:

1. A negative `audio_offset`/`audio_length`/`backing_size` now errors at row-read (`FromSqlError::OutOfRange`) instead of being caught by a hand-rolled reader guard.
2. A negative art `byte_len` now errors at row-read instead of being skipped with a warning (the track resolve errors).
3. Length fields that previously truncated silently now refuse with `TooLarge` — notably a >16 MiB structural block from the db would have had its 24-bit FLAC length field truncated; `push_block_header` is now fallible with the bound enforced centrally.

Everything else — including the byte-identical serve-path invariant — is unchanged (pinned by the proptests). One fixture nit: `scan_counters`' synthetic byte pattern changed period (251→201); the test only requires distinct position-sensitive bytes, so the invariant is unaffected.

## Deviations from the spec discovered in execution (spec amended in-tree)

- musefs-db is only a *dev*-dependency of musefs-format, so the format crate carries its own crate-local `convert` sibling rather than linking SQLite into format/fuzz builds.
- The guarded `mtime_secs as u64` cast in musefs-fuse *is* flagged by `cast_sign_loss` (clippy doesn't see runtime guards); fixed with a reasoned `.expect`.

## Validation

- `cargo clippy --all-targets -- -D warnings` and the `-p musefs-db --features mutants` variant: clean (the enforcement proof)
- `cargo test`: 681 passed · format proptests: 326 · `proptest_read_fidelity`: 17 (byte-identical invariant)
- `cargo +nightly fuzz build`: all 8 targets
- FUSE e2e (`-- --ignored`, real mounts): 9 passed
- In-diff mutation gate (365 hunks, `-j2`): **in progress** — result will be posted as a follow-up comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced workspace integer-conversion conventions and tightened cast linting; added sanctioned u64→usize helpers with a 64‑bit guard.
  * Migrated many metadata and DB fields to unsigned types and replaced unchecked casts with checked conversions.

* **Bug Fixes**
  * Malformed or negative DB numeric values now fail at read time instead of silently wrapping/truncating.
  * Parsing, slicing, and size/length handling hardened to prevent truncation, overflow, and related misreads.

* **Documentation**
  * Added design, migration plan, and CI guidance for the new conversion and mutation-testing conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->