### PR TITLE
Index rendered child lookups (#114)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -392,6 +392,36 @@ cargo test -p musefs-core --release --test bench_refresh \
 
 ---
 
+## Issue #114 — Rendered Child Lookup Root Fan-Out
+
+*Measured 2026-06-06 (same machine as implementation run; release build; ignored harness).*
+
+Harness:
+
+```bash
+cargo test -p musefs-core --release --test bench_refresh \
+  bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture
+```
+
+The corpus uses `CorpusParams::single(Format::Flac, n, 1)`, so `$artist/$album/$title`
+creates `n` top-level artist directories. The timed update retags one track with
+only `COMMENT`, moving it to fallback `Unknown/Unknown/...`; this exercises an
+absent rendered-name lookup at root in `deepest_existing_ancestor`.
+
+| library size (top-level artists) | refresh-root-fanout-1 wall (ms) |
+|---------------------------------:|--------------------------------:|
+| 100 | 0 |
+| 1000 | 0 |
+| 5000 | 1 |
+| 20000 | 1 |
+
+The rendered-name child index turns the root lookup into an indexed miss, so the
+tree-side lookup no longer scans unrelated artists. Overall wall time may still
+include SQLite changelog reads, changed-track rendering, and test harness setup,
+but the root sibling scan from issue #114 is removed.
+
+---
+
 ## Phase 6 PR 2 — Scan pair (#67, #68)
 
 *Measured 2026-06-04 (same box, lightly loaded · tempfs · `ci` tier).*

--- a/docs/superpowers/plans/2026-06-06-issue-114-rendered-child-index.md
+++ b/docs/superpowers/plans/2026-06-06-issue-114-rendered-child-index.md
@@ -1,0 +1,575 @@
+# Issue #114 Rendered Child Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove sibling fan-out scans from rendered-name navigation in incremental tree refresh.
+
+**Architecture:** Add `VirtualTree::rendered_children`, a secondary parent/rendered-name/disambiguated-name index maintained beside `children`. Keep public lookup/readdir behavior on disambiguated names, preserve current same-rendered iteration order, and make `children_by_rendered` an indexed lookup used by `deepest_existing_ancestor`.
+
+**Tech Stack:** Rust 2021, `im::{HashMap as ImHashMap, OrdMap}`, Cargo tests, existing `bench_refresh` ignored timing harness.
+
+---
+
+## File Structure
+
+- Modify `musefs-core/src/tree.rs`: add the rendered-name child index, index-maintenance helpers, indexed lookup helper, and focused unit tests.
+- Modify `musefs-core/tests/bench_refresh.rs`: add an ignored root fan-out refresh benchmark using many top-level artists.
+- Modify `BENCHMARKS.md`: record benchmark command and results after running the ignored benchmark.
+
+No new module is needed. The index is an internal invariant of `VirtualTree`, so it belongs in `tree.rs` with the existing tree maps and mutation primitives.
+
+## Task 1: Add Focused Tree Tests
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs`
+
+- [ ] **Step 1: Add rendered lookup regression tests**
+
+In `musefs-core/src/tree.rs`, inside the existing `#[cfg(test)] mod tests`, replace the current `child_by_rendered_finds_disambiguated_node` test with this stronger version and add the four new tests immediately after it:
+
+```rust
+    #[test]
+    fn child_by_rendered_finds_disambiguated_node() {
+        let t = VirtualTree::build(&[(10, "D/song.flac".into()), (20, "D/song.flac".into())]);
+        let d = t.lookup(VirtualTree::ROOT, "D").unwrap();
+        let base = t.lookup(d, "song.flac").unwrap();
+        let suffixed = t.lookup(d, "song (2).flac").unwrap();
+
+        assert_eq!(t.children_by_rendered(d, "song.flac"), vec![base, suffixed]);
+        assert_eq!(t.children_by_rendered_examined_for_test(d, "song.flac"), 2);
+    }
+
+    #[test]
+    fn deepest_existing_ancestor_preserves_dir_vs_file_order() {
+        let t = VirtualTree::build(&[(1, "X".into()), (2, "X/a.flac".into())]);
+        let file = t.lookup(VirtualTree::ROOT, "X").unwrap();
+        let dir = t.lookup(VirtualTree::ROOT, "X (2)").unwrap();
+
+        assert_eq!(t.children_by_rendered(VirtualTree::ROOT, "X"), vec![file, dir]);
+        assert_eq!(
+            t.deepest_existing_ancestor("X/new.flac"),
+            (dir, 1),
+            "same-rendered file must not hide the matching directory"
+        );
+    }
+
+    #[test]
+    fn children_by_rendered_updates_when_collision_member_removed() {
+        let mut alloc = InodeAllocator::new();
+        let mut t = VirtualTree::build_with(
+            &[(10, "D/song.flac".into()), (20, "D/song.flac".into())],
+            &mut alloc,
+        );
+        let d = t.lookup(VirtualTree::ROOT, "D").unwrap();
+        let survivor = t.lookup(d, "song (2).flac").unwrap();
+
+        t.remove_track(10, &mut alloc);
+
+        assert_eq!(t.children_by_rendered(d, "song.flac"), vec![survivor]);
+        assert_eq!(t.children_by_rendered_examined_for_test(d, "song.flac"), 1);
+    }
+
+    #[test]
+    fn children_by_rendered_updates_when_empty_dir_pruned() {
+        let mut alloc = InodeAllocator::new();
+        let mut t = VirtualTree::build_with(
+            &[
+                (10, "A/B/x.flac".into()),
+                (20, "A/C/y.flac".into()),
+            ],
+            &mut alloc,
+        );
+        let a = t.lookup(VirtualTree::ROOT, "A").unwrap();
+        assert_eq!(t.children_by_rendered_examined_for_test(a, "B"), 1);
+
+        t.remove_track(10, &mut alloc);
+
+        assert!(t.children_by_rendered(a, "B").is_empty());
+        assert_eq!(t.children_by_rendered_examined_for_test(a, "B"), 0);
+        assert_eq!(t.children_by_rendered_examined_for_test(a, "C"), 1);
+    }
+
+    #[test]
+    fn deepest_existing_ancestor_miss_does_not_scan_root_fanout() {
+        let entries: Vec<(i64, String)> = (0..1024)
+            .map(|i| {
+                (
+                    i64::from(i),
+                    format!("Artist {i:04}/Album {i:04}/Track.flac"),
+                )
+            })
+            .collect();
+        let t = VirtualTree::build(&entries);
+
+        assert_eq!(
+            t.deepest_existing_ancestor("Unknown/Unknown/new.flac"),
+            (VirtualTree::ROOT, 0)
+        );
+        assert_eq!(
+            t.children_by_rendered_examined_for_test(VirtualTree::ROOT, "Unknown"),
+            0,
+            "rendered-name miss should examine no same-rendered candidates"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail for the expected reason**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core --lib rendered -- --nocapture
+```
+
+Expected: FAIL at compile time with errors like:
+
+```text
+no method named `children_by_rendered_examined_for_test` found for struct `VirtualTree`
+```
+
+Do not implement the helper in this task. The failing test pins the next task's public test surface.
+
+- [ ] **Step 3: Leave the failing tests uncommitted**
+
+Run:
+
+```bash
+rtk git status --short
+```
+
+Expected: `musefs-core/src/tree.rs` is modified. Do not commit yet; Task 2 will commit tests and implementation together after the focused tests pass.
+
+## Task 2: Add And Maintain `rendered_children`
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs`
+
+- [ ] **Step 1: Add the `rendered_children` field and root initialization**
+
+In `VirtualTree`, add the secondary index field:
+
+```rust
+pub struct VirtualTree {
+    nodes: ImHashMap<u64, Node>,
+    children: ImHashMap<u64, OrdMap<String, u64>>,
+    rendered_children: ImHashMap<u64, OrdMap<String, OrdMap<String, u64>>>,
+    track_to_inode: ImHashMap<i64, u64>,
+}
+```
+
+In `VirtualTree::build_with`, initialize it and add an empty root entry:
+
+```rust
+let mut tree = VirtualTree {
+    nodes: ImHashMap::new(),
+    children: ImHashMap::new(),
+    rendered_children: ImHashMap::new(),
+    track_to_inode: ImHashMap::new(),
+};
+```
+
+After `tree.children.insert(Self::ROOT, OrdMap::new());`, add:
+
+```rust
+tree.rendered_children.insert(Self::ROOT, OrdMap::new());
+```
+
+- [ ] **Step 2: Add index maintenance helpers**
+
+In `impl VirtualTree`, place these helpers near `lookup`/`children_by_rendered` so all child-index operations are local:
+
+```rust
+    fn insert_rendered_child(&mut self, parent: u64, rendered: &str, name: &str, inode: u64) {
+        self.rendered_children
+            .entry(parent)
+            .or_insert_with(OrdMap::new)
+            .entry(rendered.to_string())
+            .or_insert_with(OrdMap::new)
+            .insert(name.to_string(), inode);
+    }
+
+    fn remove_rendered_child(&mut self, parent: u64, rendered: &str, name: &str) {
+        let Some(by_rendered) = self.rendered_children.get_mut(&parent) else {
+            return;
+        };
+        let remove_bucket = match by_rendered.get_mut(rendered) {
+            Some(same_rendered) => {
+                same_rendered.remove(name);
+                same_rendered.is_empty()
+            }
+            None => false,
+        };
+        if remove_bucket {
+            by_rendered.remove(rendered);
+        }
+    }
+```
+
+Do not replace these helpers with ad hoc updates at each call site.
+
+- [ ] **Step 3: Update insert paths**
+
+In `insert_file`, after:
+
+```rust
+self.children.get_mut(&dir).unwrap().insert(name, inode);
+```
+
+change the insertion to preserve a clone for both maps:
+
+```rust
+self.children.get_mut(&dir).unwrap().insert(name.clone(), inode);
+self.insert_rendered_child(dir, raw_name, &name, inode);
+```
+
+In `ensure_dir`, after inserting the child into `children`, add the rendered index update. The end of the method should look like this:
+
+```rust
+self.children.insert(inode, OrdMap::new());
+self.rendered_children.insert(inode, OrdMap::new());
+self.children
+    .get_mut(&parent)
+    .unwrap()
+    .insert(unique.clone(), inode);
+self.insert_rendered_child(parent, name, &unique, inode);
+(inode, full)
+```
+
+Preserve the existing early return:
+
+```rust
+if let Some(&existing) = self.children[&parent].get(name) {
+    if self.is_dir(existing) {
+        return (existing, join_path(parent_path, name));
+    }
+}
+```
+
+Do not replace that check with a rendered-bucket search.
+
+- [ ] **Step 4: Update removal and pruning**
+
+In `remove_track`, read both names before deleting the node:
+
+```rust
+let ino = self.track_to_inode.remove(&track_id)?;
+let parent = self.nodes.get(&ino)?.parent;
+let names = self
+    .nodes
+    .get(&ino)
+    .map(|n| (n.name.clone(), n.rendered_name.clone()));
+self.nodes.remove(&ino);
+if let Some((name, rendered)) = names {
+    if let Some(kids) = self.children.get_mut(&parent) {
+        kids.remove(&name);
+    }
+    self.remove_rendered_child(parent, &rendered, &name);
+}
+Some(self.prune_empty_dirs_upward(parent))
+```
+
+In `prune_empty_dirs_upward`, remove the pruned directory from both child maps and remove the directory's own empty rendered map. The loop body after `let names = ...;` should become:
+
+```rust
+self.children.remove(&dir);
+self.rendered_children.remove(&dir);
+self.nodes.remove(&dir);
+if let Some((name, rendered)) = &names {
+    if let Some(kids) = self.children.get_mut(&parent) {
+        kids.remove(name);
+    }
+    self.remove_rendered_child(parent, rendered, name);
+}
+last_pruned = names;
+dir = parent;
+```
+
+- [ ] **Step 5: Replace `children_by_rendered` with indexed lookup and add test helper**
+
+Replace the existing `children_by_rendered` method with these methods:
+
+```rust
+    fn children_by_rendered_with_examined(&self, dir: u64, rendered: &str) -> (Vec<u64>, usize) {
+        match self
+            .rendered_children
+            .get(&dir)
+            .and_then(|kids| kids.get(rendered))
+        {
+            None => (Vec::new(), 0),
+            Some(same_rendered) => {
+                let children: Vec<u64> = same_rendered.values().copied().collect();
+                let examined = same_rendered.len();
+                (children, examined)
+            }
+        }
+    }
+
+    /// Inodes of `dir`'s direct children whose pre-disambiguation name is `rendered`.
+    pub fn children_by_rendered(&self, dir: u64, rendered: &str) -> Vec<u64> {
+        self.children_by_rendered_with_examined(dir, rendered).0
+    }
+
+    #[cfg(test)]
+    fn children_by_rendered_examined_for_test(&self, dir: u64, rendered: &str) -> usize {
+        self.children_by_rendered_with_examined(dir, rendered).1
+    }
+```
+
+This keeps `deepest_existing_ancestor` unchanged; it should continue to call `children_by_rendered`.
+
+- [ ] **Step 6: Run focused tree tests**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core --lib rendered -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run all tree unit tests**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core --lib tree -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+rtk git add musefs-core/src/tree.rs
+rtk git commit -m "fix(core): index rendered child lookups"
+```
+
+## Task 3: Verify Incremental Tree Equivalence
+
+**Files:**
+- No new source edits expected. Fix `musefs-core/src/tree.rs` only if these tests expose an index-maintenance bug.
+
+- [ ] **Step 1: Run incremental refresh tests**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core --test incremental_refresh -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run core tests**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit any fixes required by equivalence tests**
+
+If Step 1 or Step 2 required a code fix, commit it:
+
+```bash
+rtk git add musefs-core/src/tree.rs
+rtk git commit -m "fix(core): maintain rendered child index during refresh"
+```
+
+If no files changed, do not create an empty commit.
+
+## Task 4: Add Root Fan-Out Benchmark
+
+**Files:**
+- Modify: `musefs-core/tests/bench_refresh.rs`
+
+- [ ] **Step 1: Add the ignored benchmark**
+
+In `musefs-core/tests/bench_refresh.rs`, add this test after `bench_refresh_one_across_library_sizes`:
+
+```rust
+#[test]
+#[ignore = "issue #114 timing harness; run with --ignored --nocapture"]
+fn bench_refresh_root_fanout_one_across_library_sizes() {
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    println!("\n{}", RunReport::header());
+    for n in [100usize, 1000, 5000, 20000] {
+        // Many albums with one track each produce many top-level artists under
+        // `$artist/$album/$title`, exercising `deepest_existing_ancestor` at
+        // root fan-out when the changed track moves to fallback `Unknown`.
+        let tmp = tempfile::tempdir().unwrap();
+        let params = CorpusParams::single(Format::Flac, n, 1);
+        let target = prepare_format(&params, tmp.path(), params.format_mix[0]);
+
+        let db = Db::open(&target.db_path).unwrap();
+        scan_directory(&db, &target.corpus_dir).unwrap();
+        let fs = Musefs::open(db, config()).unwrap();
+
+        let one_ms = time_refresh(&target.db_path, &fs, 1);
+        println!(
+            "{}",
+            RunReport {
+                label: format!("refresh-root-fanout-1@{n}"),
+                format: "flac".into(),
+                tier: tier.clone(),
+                storage: "tempfs".into(),
+                wall_ms: one_ms,
+                opens: 0,
+                preads: 0,
+                fsyncs: None,
+                bytes_read: 0,
+                peak_rss_kib: None,
+            }
+            .row()
+        );
+    }
+    println!();
+}
+```
+
+- [ ] **Step 2: Run just the benchmark test in release mode**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core --release --test bench_refresh bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture
+```
+
+Expected: PASS and print four `refresh-root-fanout-1@N` rows.
+
+- [ ] **Step 3: Commit the benchmark**
+
+```bash
+rtk git add musefs-core/tests/bench_refresh.rs
+rtk git commit -m "bench(core): add root fanout refresh sweep"
+```
+
+## Task 5: Record Benchmark Evidence
+
+**Files:**
+- Modify: `BENCHMARKS.md`
+
+- [ ] **Step 1: Capture benchmark output and generate markdown rows**
+
+Run the benchmark once more and capture its output:
+
+```bash
+rtk cargo test -p musefs-core --release --test bench_refresh bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture | rtk tee /tmp/musefs-issue114-root-fanout.txt
+```
+
+Generate the markdown table body:
+
+```bash
+rtk awk '$1 ~ /^refresh-root-fanout-1@/ { split($1, a, "@"); printf "| %s | %s |\n", a[2], $5 }' /tmp/musefs-issue114-root-fanout.txt
+```
+
+Expected: four rows, one each for `100`, `1000`, `5000`, and `20000`, with numeric millisecond values in the second column.
+
+- [ ] **Step 2: Add the benchmark results section**
+
+In `BENCHMARKS.md`, in the refresh benchmark area near the existing "Phase 6 PR 1 — Refresh O(changed) (#69)" section, add this section. Under the table header, paste the four numeric rows generated in Step 1.
+
+```markdown
+---
+
+## Issue #114 — Rendered Child Lookup Root Fan-Out
+
+*Measured 2026-06-06 (same machine as implementation run; release build; ignored harness).*
+
+Harness:
+
+```bash
+cargo test -p musefs-core --release --test bench_refresh \
+  bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture
+```
+
+The corpus uses `CorpusParams::single(Format::Flac, n, 1)`, so `$artist/$album/$title`
+creates `n` top-level artist directories. The timed update retags one track with
+only `COMMENT`, moving it to fallback `Unknown/Unknown/...`; this exercises an
+absent rendered-name lookup at root in `deepest_existing_ancestor`.
+
+| library size (top-level artists) | refresh-root-fanout-1 wall (ms) |
+|---------------------------------:|--------------------------------:|
+
+The rendered-name child index turns the root lookup into an indexed miss, so the
+tree-side lookup no longer scans unrelated artists. Overall wall time may still
+include SQLite changelog reads, changed-track rendering, and test harness setup,
+but the root sibling scan from issue #114 is removed.
+```
+
+The committed section must contain four table body rows. Each second-column cell must be only a number.
+
+- [ ] **Step 3: Verify the table cells are numeric**
+
+Run:
+
+```bash
+rtk awk '/^## Issue #114/{in_section=1} in_section && /^## / && $0 !~ /^## Issue #114/{in_section=0} in_section && /^\| [0-9]+[[:space:]]+\|/ { rows++; if ($4 !~ /^[0-9]+$/) bad=1 } END { if (rows != 4 || bad) exit 1 }' BENCHMARKS.md
+```
+
+Expected: exit 0. If it exits 1, fix the table so it has four body rows and numeric wall-time cells.
+
+- [ ] **Step 4: Commit the benchmark results**
+
+```bash
+rtk git add BENCHMARKS.md
+rtk git commit -m "docs: record issue 114 refresh benchmark"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+- No source edits expected. Fix only regressions discovered by verification.
+
+- [ ] **Step 1: Run formatting check**
+
+Run:
+
+```bash
+rtk cargo fmt --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run core tests**
+
+Run:
+
+```bash
+rtk cargo test -p musefs-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run workspace tests**
+
+Run:
+
+```bash
+rtk cargo test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run clippy**
+
+Run:
+
+```bash
+rtk cargo clippy --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+rtk git status --short
+rtk git log --oneline -6
+```
+
+Expected: clean worktree, with commits for tests, implementation, benchmark, and benchmark documentation.

--- a/docs/superpowers/plans/2026-06-06-issue-114-rendered-child-index.md
+++ b/docs/superpowers/plans/2026-06-06-issue-114-rendered-child-index.md
@@ -40,7 +40,7 @@ In `musefs-core/src/tree.rs`, inside the existing `#[cfg(test)] mod tests`, repl
     }
 
     #[test]
-    fn deepest_existing_ancestor_preserves_dir_vs_file_order() {
+    fn deepest_existing_ancestor_preserves_rendered_dir_vs_file_order() {
         let t = VirtualTree::build(&[(1, "X".into()), (2, "X/a.flac".into())]);
         let file = t.lookup(VirtualTree::ROOT, "X").unwrap();
         let dir = t.lookup(VirtualTree::ROOT, "X (2)").unwrap();
@@ -90,7 +90,7 @@ In `musefs-core/src/tree.rs`, inside the existing `#[cfg(test)] mod tests`, repl
     }
 
     #[test]
-    fn deepest_existing_ancestor_miss_does_not_scan_root_fanout() {
+    fn deepest_existing_ancestor_rendered_miss_does_not_scan_root_fanout() {
         let entries: Vec<(i64, String)> = (0..1024)
             .map(|i| {
                 (
@@ -314,6 +314,14 @@ Replace the existing `children_by_rendered` method with these methods:
         self.children_by_rendered_with_examined(dir, rendered).1
     }
 ```
+
+`children_by_rendered_with_examined` must treat `examined` as the number of
+direct child entries inspected by the lookup, not merely the number of returned
+matches. With the rendered index, an absent rendered-name bucket inspects `0`
+child entries and a present bucket inspects `same_rendered.len()` child entries.
+If this helper were ever implemented by scanning `children[dir]`, it would need
+to count every sibling visited, so the root fan-out miss test would report the
+full fan-out and fail.
 
 This keeps `deepest_existing_ancestor` unchanged; it should continue to call `children_by_rendered`.
 

--- a/docs/superpowers/specs/2026-06-06-issue-114-rendered-child-index-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-114-rendered-child-index-design.md
@@ -1,0 +1,222 @@
+# Issue #114: Rendered-Name Child Index
+
+## Problem
+
+Issue #114 identifies the remaining fan-out-proportional step in incremental
+tree refresh. `VirtualTree::deepest_existing_ancestor` navigates a rendered path
+by calling `children_by_rendered` at each directory level. Today
+`children_by_rendered` scans every disambiguated child under that directory and
+filters by `Node.rendered_name`.
+
+For a moved or added track under a template such as `$artist/$album/$title`, a
+single-track change can therefore scan every top-level artist at the root before
+finding the matching rendered directory. The rest of the #69 refresh path is
+collision-gated and O(changed); this sibling scan is the remaining cost that
+scales with directory fan-out even when rendered names do not collide.
+
+## Goals
+
+- Make rendered-name child lookup independent of unrelated sibling fan-out.
+- Preserve the existing virtual tree semantics: public lookup and readdir remain
+  keyed by disambiguated names, while internal refresh navigation uses rendered
+  names.
+- Keep the change local to `musefs-core/src/tree.rs` and the existing refresh
+  benchmark/test surfaces.
+- Provide both focused tree-level regression coverage and end-to-end benchmark
+  evidence.
+
+## Non-Goals
+
+- Do not change template rendering, collision disambiguation, inode allocation,
+  or FUSE behavior.
+- Do not address the separate residual O(N) work in `rebuild_incremental`
+  (`list_render_keys` and full snapshot reconstruction).
+- Do not introduce a new runtime fallback path for index inconsistency; the
+  index is maintained as an internal tree invariant and covered by tests.
+
+## Chosen Approach
+
+Add a secondary rendered-name child index to `VirtualTree`:
+
+```rust
+children: parent -> disambiguated_name -> inode
+rendered_children: parent -> rendered_name -> ordered child inodes
+```
+
+The existing `children` map remains the public directory map for mounted paths,
+because mounted paths use post-disambiguation names. The new index is only for
+internal operations that need to navigate by pre-disambiguation rendered names,
+especially `deepest_existing_ancestor`.
+
+`children_by_rendered(dir, rendered)` becomes an indexed lookup. In the common
+no-collision case, it returns a one-element set without scanning siblings. When
+several direct children share a rendered name, the lookup scans only that
+rendered-name bucket, which is the actual ambiguity the current algorithm already
+has to resolve.
+
+## Data Structure
+
+Use an immutable map shape consistent with the current tree representation:
+
+```rust
+rendered_children: ImHashMap<u64, OrdMap<String, OrdSet<u64>>>
+```
+
+`OrdSet<u64>` gives deterministic iteration for tests and preserves derived
+`PartialEq`/`Eq` as a strong equivalence oracle. The field should be part of the
+`VirtualTree` struct, so existing `self == other` equivalence also validates the
+secondary index.
+
+The name `rendered_children` avoids colliding with the existing
+`children_by_rendered` method name. The method can keep its public test-facing
+API and return a `Vec<u64>` collected from the indexed set.
+
+## Maintenance Rules
+
+All updates to the secondary index happen at the same boundary as updates to
+`nodes` and `children`.
+
+On root initialization:
+- Insert an empty `children` entry for `VirtualTree::ROOT`.
+- Insert an empty `rendered_children` entry for `VirtualTree::ROOT`.
+
+On inserting a file:
+- Insert the node into `nodes`.
+- Insert the disambiguated name into `children[parent]`.
+- Insert the inode into `rendered_children[parent][raw_file_name]`.
+
+On ensuring a new directory:
+- If an existing child with the raw rendered name is already a directory, return
+  it as today. No index update is needed.
+- Otherwise insert the new directory node and empty child maps.
+- Insert its disambiguated name into `children[parent]`.
+- Insert its inode into `rendered_children[parent][raw_dir_name]`.
+
+On removing a file:
+- Read the node's parent, disambiguated name, and rendered name before deleting
+  it.
+- Remove the track from `track_to_inode`.
+- Remove the node from `nodes`.
+- Remove the disambiguated name from `children[parent]`.
+- Remove the inode from `rendered_children[parent][rendered_name]`; remove the
+  bucket if it becomes empty.
+
+On pruning an empty directory:
+- Read the directory node's parent, disambiguated name, and rendered name before
+  deleting it.
+- Remove the directory's own empty `children` and `rendered_children` entries.
+- Remove the directory node from `nodes`.
+- Remove the disambiguated child link from `children[parent]`.
+- Remove the inode from `rendered_children[parent][rendered_name]`; remove the
+  bucket if it becomes empty.
+
+`rebuild_subtree` already removes and reinserts tracks through these primitives,
+so it should maintain the index without special-case code.
+
+## Algorithm Changes
+
+`children_by_rendered` changes from a sibling scan to an indexed lookup:
+
+```rust
+fn children_by_rendered(&self, dir: u64, rendered: &str) -> Vec<u64> {
+    self.rendered_children
+        .get(&dir)
+        .and_then(|kids| kids.get(rendered))
+        .map(|set| set.iter().copied().collect())
+        .unwrap_or_default()
+}
+```
+
+`deepest_existing_ancestor` keeps its current behavior:
+
+- Split the rendered path into components.
+- Walk directory components only, excluding the final file component.
+- At each level, ask for children whose `rendered_name` matches the component.
+- Pick the first child that is a directory.
+- Stop at the first missing rendered directory.
+
+The complexity changes from O(number of siblings at each walked level) to
+O(size of the matching rendered-name bucket at each walked level). For normal
+non-colliding library layouts this is O(path depth), independent of root artist
+count or album fan-out.
+
+## Edge Cases
+
+- Multiple files with the same rendered file name remain in the same rendered
+  bucket and continue to disambiguate through `children`.
+- A file and a directory with the same rendered name remain in the same rendered
+  bucket; `deepest_existing_ancestor` filters the bucket for a directory.
+- Removing one member of a rendered-name collision bucket leaves the remaining
+  members indexed.
+- Removing the final member of a rendered-name bucket removes that bucket.
+- Pruning an empty directory removes its own child-map entries and the parent
+  rendered-name index entry.
+- A full rebuild and an equivalent incremental rebuild compare equal, including
+  the secondary index.
+
+## Testing
+
+Focused tree tests in `musefs-core/src/tree.rs`:
+
+- Keep or extend `child_by_rendered_finds_disambiguated_node` to assert that
+  multiple same-rendered children are returned from the indexed path.
+- Add a file-vs-directory rendered-name collision test proving
+  `deepest_existing_ancestor` still finds the directory when another bucket
+  member is a file.
+- Add a removal test proving that deleting one same-rendered file leaves the
+  other bucket member reachable through `children_by_rendered`.
+- Add a prune test proving that removing the only file under a directory deletes
+  that directory from its parent's rendered-name bucket.
+- Add a root fan-out regression test that builds many top-level rendered
+  directories and resolves a path under a late entry. The functional assertion
+  confirms the correct ancestor; test-only observability can assert that lookup
+  visits only the matching rendered-name bucket rather than every root sibling.
+
+Existing equivalence tests and the incremental-refresh property oracle should
+remain green. Because `VirtualTree::equiv` delegates to derived equality, adding
+the new field strengthens those tests automatically.
+
+## Benchmark Evidence
+
+Extend `musefs-core/tests/bench_refresh.rs` with an ignored benchmark for the
+root fan-out case described in issue #114.
+
+The current sweep uses `CorpusParams::single(Format::Flac, 1, n)`, producing one
+artist and one album with many sibling tracks. The new benchmark should instead
+use `CorpusParams::single(Format::Flac, n, 1)`, producing many top-level artists
+under `$artist/$album/$title`.
+
+The benchmark should:
+
+- Build independent corpora at sizes such as 100, 1000, 5000, and 20000.
+- Open `Musefs` with the existing benchmark config.
+- Retag one track to remove its artist/album/title tags, so the rendered path
+  moves to the fallback `Unknown/Unknown/...` root entry. Before this issue is
+  fixed, looking for absent rendered root `Unknown` scans every existing artist;
+  after the fix, it is one indexed miss.
+- Print rows such as `refresh-root-fanout-1@5000`.
+- Record the implementation results in `BENCHMARKS.md`.
+
+The benchmark is evidence, not a normal CI gate. The focused tree tests provide
+the deterministic regression coverage.
+
+## Verification Plan
+
+Implementation should run at least:
+
+```bash
+cargo test -p musefs-core --lib tree
+cargo test -p musefs-core --test incremental_refresh
+cargo test -p musefs-core --test bench_refresh bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture
+```
+
+Then run the broader core/workspace checks selected by the implementation plan,
+including clippy if the Rust diff is non-trivial.
+
+## Open Questions Resolved
+
+- Success evidence will include both focused tree tests and an end-to-end refresh
+  benchmark.
+- The chosen approach is a full rendered-name child index, not a directory-only
+  shortcut or refresh-path memoization.
+- The scope is limited to #114; broader O(N) refresh work remains out of scope.

--- a/docs/superpowers/specs/2026-06-06-issue-114-rendered-child-index-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-114-rendered-child-index-design.md
@@ -29,8 +29,9 @@ scales with directory fan-out even when rendered names do not collide.
 
 - Do not change template rendering, collision disambiguation, inode allocation,
   or FUSE behavior.
-- Do not address the separate residual O(N) work in `rebuild_incremental`
-  (`list_render_keys` and full snapshot reconstruction).
+- Do not address refresh costs outside rendered-name child lookup. The current
+  changelog path already renders only changed/added tracks and mutates the
+  render-state snapshot in place.
 - Do not introduce a new runtime fallback path for index inconsistency; the
   index is maintained as an internal tree invariant and covered by tests.
 
@@ -40,7 +41,7 @@ Add a secondary rendered-name child index to `VirtualTree`:
 
 ```rust
 children: parent -> disambiguated_name -> inode
-rendered_children: parent -> rendered_name -> ordered child inodes
+rendered_children: parent -> rendered_name -> disambiguated_name -> inode
 ```
 
 The existing `children` map remains the public directory map for mounted paths,
@@ -59,17 +60,22 @@ has to resolve.
 Use an immutable map shape consistent with the current tree representation:
 
 ```rust
-rendered_children: ImHashMap<u64, OrdMap<String, OrdSet<u64>>>
+rendered_children: ImHashMap<u64, OrdMap<String, OrdMap<String, u64>>>
 ```
 
-`OrdSet<u64>` gives deterministic iteration for tests and preserves derived
-`PartialEq`/`Eq` as a strong equivalence oracle. The field should be part of the
-`VirtualTree` struct, so existing `self == other` equivalence also validates the
-secondary index.
+The inner `OrdMap<String, u64>` is keyed by the child's disambiguated name. This
+preserves the current `children_by_rendered` iteration order, because today's
+implementation scans `children[parent]` in disambiguated-name order and filters
+by `Node.rendered_name`. Preserving that order matters because
+`deepest_existing_ancestor` picks the first same-rendered child that is a
+directory.
+
+The field should be part of the `VirtualTree` struct, so existing `self == other`
+equivalence also validates the secondary index.
 
 The name `rendered_children` avoids colliding with the existing
 `children_by_rendered` method name. The method can keep its public test-facing
-API and return a `Vec<u64>` collected from the indexed set.
+API and return a `Vec<u64>` collected from the inner map's values.
 
 ## Maintenance Rules
 
@@ -83,14 +89,18 @@ On root initialization:
 On inserting a file:
 - Insert the node into `nodes`.
 - Insert the disambiguated name into `children[parent]`.
-- Insert the inode into `rendered_children[parent][raw_file_name]`.
+- Insert the inode into
+  `rendered_children[parent][raw_file_name][disambiguated_file_name]`.
 
 On ensuring a new directory:
-- If an existing child with the raw rendered name is already a directory, return
-  it as today. No index update is needed.
+- Preserve current semantics: first check `children[parent].get(raw_dir_name)`.
+  If the base public key is occupied by a directory, return it. Do not search the
+  rendered-name bucket for some other same-rendered directory, because that would
+  change collision/disambiguation behavior.
 - Otherwise insert the new directory node and empty child maps.
 - Insert its disambiguated name into `children[parent]`.
-- Insert its inode into `rendered_children[parent][raw_dir_name]`.
+- Insert its inode into
+  `rendered_children[parent][raw_dir_name][disambiguated_dir_name]`.
 
 On removing a file:
 - Read the node's parent, disambiguated name, and rendered name before deleting
@@ -98,8 +108,9 @@ On removing a file:
 - Remove the track from `track_to_inode`.
 - Remove the node from `nodes`.
 - Remove the disambiguated name from `children[parent]`.
-- Remove the inode from `rendered_children[parent][rendered_name]`; remove the
-  bucket if it becomes empty.
+- Remove the disambiguated name from
+  `rendered_children[parent][rendered_name]`; remove the rendered-name bucket if
+  it becomes empty.
 
 On pruning an empty directory:
 - Read the directory node's parent, disambiguated name, and rendered name before
@@ -107,8 +118,9 @@ On pruning an empty directory:
 - Remove the directory's own empty `children` and `rendered_children` entries.
 - Remove the directory node from `nodes`.
 - Remove the disambiguated child link from `children[parent]`.
-- Remove the inode from `rendered_children[parent][rendered_name]`; remove the
-  bucket if it becomes empty.
+- Remove the disambiguated child link from
+  `rendered_children[parent][rendered_name]`; remove the rendered-name bucket if
+  it becomes empty.
 
 `rebuild_subtree` already removes and reinserts tracks through these primitives,
 so it should maintain the index without special-case code.
@@ -122,7 +134,7 @@ fn children_by_rendered(&self, dir: u64, rendered: &str) -> Vec<u64> {
     self.rendered_children
         .get(&dir)
         .and_then(|kids| kids.get(rendered))
-        .map(|set| set.iter().copied().collect())
+        .map(|same_rendered| same_rendered.values().copied().collect())
         .unwrap_or_default()
 }
 ```
@@ -168,9 +180,14 @@ Focused tree tests in `musefs-core/src/tree.rs`:
 - Add a prune test proving that removing the only file under a directory deletes
   that directory from its parent's rendered-name bucket.
 - Add a root fan-out regression test that builds many top-level rendered
-  directories and resolves a path under a late entry. The functional assertion
-  confirms the correct ancestor; test-only observability can assert that lookup
-  visits only the matching rendered-name bucket rather than every root sibling.
+  directories and resolves a path under an absent rendered root such as
+  `Unknown/Unknown/new.flac`.
+- Make test-only lookup observability mandatory. Implement `children_by_rendered`
+  through a small helper that returns both the matching children and the number
+  of same-rendered candidates examined. In non-test builds the count is ignored;
+  in tests, the root fan-out miss asserts the count is `0`, proving the lookup
+  did not scan unrelated root siblings. Collision tests can assert the count is
+  the rendered bucket size.
 
 Existing equivalence tests and the incremental-refresh property oracle should
 remain green. Because `VirtualTree::equiv` delegates to derived equality, adding
@@ -207,7 +224,7 @@ Implementation should run at least:
 ```bash
 cargo test -p musefs-core --lib tree
 cargo test -p musefs-core --test incremental_refresh
-cargo test -p musefs-core --test bench_refresh bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture
+cargo test -p musefs-core --release --test bench_refresh bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture
 ```
 
 Then run the broader core/workspace checks selected by the implementation plan,

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -78,6 +78,7 @@ pub struct Node {
 pub struct VirtualTree {
     nodes: ImHashMap<u64, Node>,
     children: ImHashMap<u64, OrdMap<String, u64>>,
+    rendered_children: ImHashMap<u64, OrdMap<String, OrdMap<String, u64>>>,
     track_to_inode: ImHashMap<i64, u64>,
 }
 
@@ -94,6 +95,7 @@ impl VirtualTree {
         let mut tree = VirtualTree {
             nodes: ImHashMap::new(),
             children: ImHashMap::new(),
+            rendered_children: ImHashMap::new(),
             track_to_inode: ImHashMap::new(),
         };
         tree.nodes.insert(
@@ -106,6 +108,7 @@ impl VirtualTree {
             },
         );
         tree.children.insert(Self::ROOT, OrdMap::new());
+        tree.rendered_children.insert(Self::ROOT, OrdMap::new());
         for (track_id, path) in entries {
             tree.insert_file(*track_id, path, alloc);
         }
@@ -181,7 +184,11 @@ impl VirtualTree {
                 kind: NodeKind::File { track_id },
             },
         );
-        self.children.get_mut(&dir).unwrap().insert(name, inode);
+        self.children
+            .get_mut(&dir)
+            .unwrap()
+            .insert(name.clone(), inode);
+        self.insert_rendered_child(dir, raw_name, &name, inode);
     }
 
     fn ensure_dir(
@@ -209,10 +216,12 @@ impl VirtualTree {
             },
         );
         self.children.insert(inode, OrdMap::new());
+        self.rendered_children.insert(inode, OrdMap::new());
         self.children
             .get_mut(&parent)
             .unwrap()
-            .insert(unique, inode);
+            .insert(unique.clone(), inode);
+        self.insert_rendered_child(parent, name, &unique, inode);
         (inode, full)
     }
 
@@ -280,18 +289,53 @@ impl VirtualTree {
     }
 
     /// Inodes of `dir`'s direct children whose pre-disambiguation name is `rendered`.
+    fn children_by_rendered_with_examined(&self, dir: u64, rendered: &str) -> (Vec<u64>, usize) {
+        match self
+            .rendered_children
+            .get(&dir)
+            .and_then(|kids| kids.get(rendered))
+        {
+            None => (Vec::new(), 0),
+            Some(same_rendered) => {
+                let children: Vec<u64> = same_rendered.values().copied().collect();
+                let examined = same_rendered.len();
+                (children, examined)
+            }
+        }
+    }
+
+    /// Inodes of `dir`'s direct children whose pre-disambiguation name is `rendered`.
     pub fn children_by_rendered(&self, dir: u64, rendered: &str) -> Vec<u64> {
-        match self.children.get(&dir) {
-            None => Vec::new(),
-            Some(kids) => kids
-                .values()
-                .copied()
-                .filter(|&c| {
-                    self.nodes
-                        .get(&c)
-                        .is_some_and(|n| n.rendered_name == rendered)
-                })
-                .collect(),
+        self.children_by_rendered_with_examined(dir, rendered).0
+    }
+
+    #[cfg(test)]
+    fn children_by_rendered_examined_for_test(&self, dir: u64, rendered: &str) -> usize {
+        self.children_by_rendered_with_examined(dir, rendered).1
+    }
+
+    fn insert_rendered_child(&mut self, parent: u64, rendered: &str, name: &str, inode: u64) {
+        self.rendered_children
+            .entry(parent)
+            .or_default()
+            .entry(rendered.to_string())
+            .or_default()
+            .insert(name.to_string(), inode);
+    }
+
+    fn remove_rendered_child(&mut self, parent: u64, rendered: &str, name: &str) {
+        let Some(by_rendered) = self.rendered_children.get_mut(&parent) else {
+            return;
+        };
+        let remove_bucket = match by_rendered.get_mut(rendered) {
+            Some(same_rendered) => {
+                same_rendered.remove(name);
+                same_rendered.is_empty()
+            }
+            None => false,
+        };
+        if remove_bucket {
+            by_rendered.remove(rendered);
         }
     }
 
@@ -347,10 +391,16 @@ impl VirtualTree {
     ) -> Option<(u64, Option<(String, String)>)> {
         let ino = self.track_to_inode.remove(&track_id)?;
         let parent = self.nodes.get(&ino)?.parent;
-        let name = self.nodes.get(&ino).map(|n| n.name.clone());
+        let names = self
+            .nodes
+            .get(&ino)
+            .map(|n| (n.name.clone(), n.rendered_name.clone()));
         self.nodes.remove(&ino);
-        if let (Some(name), Some(kids)) = (name, self.children.get_mut(&parent)) {
-            kids.remove(&name);
+        if let Some((name, rendered)) = names {
+            if let Some(kids) = self.children.get_mut(&parent) {
+                kids.remove(&name);
+            }
+            self.remove_rendered_child(parent, &rendered, &name);
         }
         Some(self.prune_empty_dirs_upward(parent))
     }
@@ -637,9 +687,13 @@ impl VirtualTree {
                 .get(&dir)
                 .map(|n| (n.name.clone(), n.rendered_name.clone()));
             self.children.remove(&dir);
+            self.rendered_children.remove(&dir);
             self.nodes.remove(&dir);
-            if let (Some((name, _)), Some(kids)) = (&names, self.children.get_mut(&parent)) {
-                kids.remove(name);
+            if let Some((name, rendered)) = &names {
+                if let Some(kids) = self.children.get_mut(&parent) {
+                    kids.remove(name);
+                }
+                self.remove_rendered_child(parent, rendered, name);
             }
             last_pruned = names;
             dir = parent;
@@ -876,8 +930,84 @@ mod tests {
     fn child_by_rendered_finds_disambiguated_node() {
         let t = VirtualTree::build(&[(10, "D/song.flac".into()), (20, "D/song.flac".into())]);
         let d = t.lookup(VirtualTree::ROOT, "D").unwrap();
-        let by_rendered: Vec<u64> = t.children_by_rendered(d, "song.flac");
-        assert_eq!(by_rendered.len(), 2);
+        let base = t.lookup(d, "song.flac").unwrap();
+        let suffixed = t.lookup(d, "song (2).flac").unwrap();
+
+        assert_eq!(t.children_by_rendered(d, "song.flac"), vec![suffixed, base]);
+        assert_eq!(t.children_by_rendered_examined_for_test(d, "song.flac"), 2);
+    }
+
+    #[test]
+    fn deepest_existing_ancestor_preserves_rendered_dir_vs_file_order() {
+        let t = VirtualTree::build(&[(1, "X".into()), (2, "X/a.flac".into())]);
+        let file = t.lookup(VirtualTree::ROOT, "X").unwrap();
+        let dir = t.lookup(VirtualTree::ROOT, "X (2)").unwrap();
+
+        assert_eq!(
+            t.children_by_rendered(VirtualTree::ROOT, "X"),
+            vec![file, dir]
+        );
+        assert_eq!(
+            t.deepest_existing_ancestor("X/new.flac"),
+            (dir, 1),
+            "same-rendered file must not hide the matching directory"
+        );
+    }
+
+    #[test]
+    fn children_by_rendered_updates_when_collision_member_removed() {
+        let mut alloc = InodeAllocator::new();
+        let mut t = VirtualTree::build_with(
+            &[(10, "D/song.flac".into()), (20, "D/song.flac".into())],
+            &mut alloc,
+        );
+        let d = t.lookup(VirtualTree::ROOT, "D").unwrap();
+        let survivor = t.lookup(d, "song (2).flac").unwrap();
+
+        t.remove_track(10, &mut alloc);
+
+        assert_eq!(t.children_by_rendered(d, "song.flac"), vec![survivor]);
+        assert_eq!(t.children_by_rendered_examined_for_test(d, "song.flac"), 1);
+    }
+
+    #[test]
+    fn children_by_rendered_updates_when_empty_dir_pruned() {
+        let mut alloc = InodeAllocator::new();
+        let mut t = VirtualTree::build_with(
+            &[(10, "A/B/x.flac".into()), (20, "A/C/y.flac".into())],
+            &mut alloc,
+        );
+        let a = t.lookup(VirtualTree::ROOT, "A").unwrap();
+        assert_eq!(t.children_by_rendered_examined_for_test(a, "B"), 1);
+
+        t.remove_track(10, &mut alloc);
+
+        assert!(t.children_by_rendered(a, "B").is_empty());
+        assert_eq!(t.children_by_rendered_examined_for_test(a, "B"), 0);
+        assert_eq!(t.children_by_rendered_examined_for_test(a, "C"), 1);
+    }
+
+    #[test]
+    fn deepest_existing_ancestor_rendered_miss_does_not_scan_root_fanout() {
+        let entries: Vec<(i64, String)> = (0..1024)
+            .map(|i| {
+                (
+                    i64::from(i),
+                    format!("Artist {i:04}/Album {i:04}/Track.flac"),
+                )
+            })
+            .collect();
+        let t = VirtualTree::build(&entries);
+
+        assert_eq!(
+            t.deepest_existing_ancestor("Unknown/Unknown/new.flac"),
+            (VirtualTree::ROOT, 0)
+        );
+        assert_eq!(
+            t.children_by_rendered_examined_for_test(VirtualTree::ROOT, "Unknown"),
+            0,
+            "rendered-name miss should examine no same-rendered candidates"
+        );
     }
 
     #[test]

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -136,3 +136,41 @@ fn bench_refresh_one_across_library_sizes() {
     }
     println!();
 }
+
+#[test]
+#[ignore = "issue #114 timing harness; run with --ignored --nocapture"]
+fn bench_refresh_root_fanout_one_across_library_sizes() {
+    let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    println!("\n{}", RunReport::header());
+    for n in [100usize, 1000, 5000, 20000] {
+        // Many albums with one track each produce many top-level artists under
+        // `$artist/$album/$title`, exercising `deepest_existing_ancestor` at
+        // root fan-out when the changed track moves to fallback `Unknown`.
+        let tmp = tempfile::tempdir().unwrap();
+        let params = CorpusParams::single(Format::Flac, n, 1);
+        let target = prepare_format(&params, tmp.path(), params.format_mix[0]);
+
+        let db = Db::open(&target.db_path).unwrap();
+        scan_directory(&db, &target.corpus_dir).unwrap();
+        let fs = Musefs::open(db, config()).unwrap();
+
+        let one_ms = time_refresh(&target.db_path, &fs, 1);
+        println!(
+            "{}",
+            RunReport {
+                label: format!("refresh-root-fanout-1@{n}"),
+                format: "flac".into(),
+                tier: tier.clone(),
+                storage: "tempfs".into(),
+                wall_ms: one_ms,
+                opens: 0,
+                preads: 0,
+                fsyncs: None,
+                bytes_read: 0,
+                peak_rss_kib: None,
+            }
+            .row()
+        );
+    }
+    println!();
+}


### PR DESCRIPTION
Closes #114.

## Summary
- Add `VirtualTree::rendered_children`, a parent → rendered-name → disambiguated-name → inode index maintained beside `children` through every mutation path (`insert_file`, `ensure_dir`, `remove_track`, `prune_empty_dirs_upward`), so rendered-name navigation in incremental refresh no longer scans all siblings.
- `children_by_rendered` becomes an indexed lookup with identical membership and iteration order (inner map keyed by disambiguated name, matching the old scan order); `deepest_existing_ancestor` is unchanged and now resolves a root rendered-name miss without touching unrelated children.
- New unit tests cover collision insert/remove, empty-dir prune, dir-vs-file same-rendered ordering, and a 1024-artist root-fanout miss that asserts zero examined candidates via a `cfg(test)` examined-count helper.
- New ignored benchmark `bench_refresh_root_fanout_one_across_library_sizes` plus recorded results in BENCHMARKS.md: one-track refresh at root fan-out stays flat at 0/0/1/1 ms across 100/1k/5k/20k top-level artists.

## Test Plan
- [x] `cargo test -p musefs-core` (263 passed)
- [x] `cargo test` workspace (691 passed)
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all --check`
- [x] In-diff mutation gate: 38 mutants, 37 caught, 1 unviable, 0 missed
- [x] `cargo test -p musefs-core --release --test bench_refresh bench_refresh_root_fanout_one_across_library_sizes -- --ignored --nocapture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented an indexing optimization to improve performance when navigating library hierarchies.

* **Documentation**
  * Added comprehensive design documentation and implementation plan for the optimization.
  * Added benchmark results demonstrating performance gains across various library sizes.

* **Tests**
  * Added performance benchmark test to measure optimization effectiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->