### PR TITLE
StructureOnly: serve reads via kernel FUSE passthrough (#112)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -610,11 +610,11 @@ threshold (p>0.05, "No change in performance detected").
 
 - **Before** = `main` @ `0881b31`: every read round-trips kernel → daemon → positioned read → copy back.
 - **After** = `issue-112-passthrough`: backing fd registered at open (FUSE passthrough, kernel 6.9+); the kernel serves reads directly from the backing inode, bypassing the daemon entirely.
-- Harness: 512 MiB single-track FLAC StructureOnly mount, `dd bs=1M` sequential read, 3 runs each, fresh mount per run, RAM-cached backing file (isolates FUSE-path overhead). Both binaries mounted via `sudo` (passthrough requires `CAP_SYS_ADMIN` for `FUSE_DEV_IOC_BACKING_OPEN`).
+- Harness: 512 MiB single-track FLAC StructureOnly mount, `dd bs=1M` sequential read, fresh mount per binary with 3 runs inside it, RAM-cached backing file (isolates FUSE-path overhead). Both binaries mounted via `sudo` (passthrough requires `CAP_SYS_ADMIN` for `FUSE_DEV_IOC_BACKING_OPEN`).
 
 | | run 1 | run 2 | run 3 | median |
 |---|---|---|---|---|
 | Before (daemon reads) | 2.7 GB/s | 2.8 GB/s | 2.8 GB/s | 2.8 GB/s |
 | After (passthrough) | 9.3 GB/s | 9.3 GB/s | 9.4 GB/s | 9.3 GB/s |
 
-Passthrough is **~3.3× faster** on this RAM-cached sequential-read workload; the before path copies 512 MiB twice (daemon read buffer → kernel reply), while the after path copies it zero times.
+Passthrough is **~3.3× faster** on this RAM-cached sequential-read workload: the before path round-trips every ~128 KiB chunk through the daemon (wakeup + positioned read into the reply buffer + copy back through `/dev/fuse`), while the after path reads straight from the backing inode's page cache like a native file.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -601,3 +601,20 @@ No workload shows a regression outside noise. `seek_read` formats trend 2–6%
 faster (cache lookup path no longer behind a Mutex). `sequential_read/ogg`
 (+3.8%) and `cold_first_read/flac` (+1.9%) are within Criterion's noise
 threshold (p>0.05, "No change in performance detected").
+
+---
+
+## Issue #112 — StructureOnly kernel passthrough
+
+*Measured 2026-06-06.*
+
+- **Before** = `main` @ `0881b31`: every read round-trips kernel → daemon → positioned read → copy back.
+- **After** = `issue-112-passthrough`: backing fd registered at open (FUSE passthrough, kernel 6.9+); the kernel serves reads directly from the backing inode, bypassing the daemon entirely.
+- Harness: 512 MiB single-track FLAC StructureOnly mount, `dd bs=1M` sequential read, 3 runs each, fresh mount per run, RAM-cached backing file (isolates FUSE-path overhead). Both binaries mounted via `sudo` (passthrough requires `CAP_SYS_ADMIN` for `FUSE_DEV_IOC_BACKING_OPEN`).
+
+| | run 1 | run 2 | run 3 | median |
+|---|---|---|---|---|
+| Before (daemon reads) | 2.7 GB/s | 2.8 GB/s | 2.8 GB/s | 2.8 GB/s |
+| After (passthrough) | 9.3 GB/s | 9.3 GB/s | 9.4 GB/s | 9.3 GB/s |
+
+Passthrough is **~3.3× faster** on this RAM-cached sequential-read workload; the before path copies 512 MiB twice (daemon read buffer → kernel reply), while the after path copies it zero times.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,12 @@ Two mount **modes** (`musefs_core::Mode`):
   payload.
 - `StructureOnly` — a single whole-file `BackingAudio` segment; the original bytes
   are served verbatim under the templated tree. Stored audio bounds are not
-  validated in this mode because the whole file is served.
+  validated in this mode because the whole file is served. On kernels with FUSE
+  passthrough (6.9+) **and a daemon holding CAP_SYS_ADMIN** (kernel-gated; run as
+  root or `setcap cap_sys_admin=ep` the binary) reads are served by the kernel
+  directly from the backing fd registered at open (silent fallback to daemon
+  reads elsewhere, pre-announced at mount time when the capability is absent);
+  freshness is open-time-only for such handles — plain POSIX fd semantics.
 
 ## SQLite store is the contract
 

--- a/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
+++ b/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
@@ -301,7 +301,7 @@ Replace the body of `fn open` (`musefs-fuse/src/lib.rs:283-290`) with:
 In `fn release` (`musefs-fuse/src/lib.rs:292-307`), replace the `if let` body:
 
 ```rust
-        // Cheap (two map removes); no need to offload to the pool.
+        // Cheap (a backing-map remove + a slab remove); no need to offload to the pool.
         if let Some(fh) = NonZeroU64::new(fh.0) {
             // Dropping the BackingId fires the backing-close ioctl. Absent for
             // plain (non-passthrough) handles — remove is then a no-op.
@@ -432,7 +432,7 @@ fn mount_one_track(
     let flac = make_flac(&["ARTIST=Alpha", "TITLE=Track"], &audio);
     std::fs::write(backing.path().join("a.flac"), &flac).unwrap();
 
-    // On-disk DB so musefs_db uses the PerThread pool (mirrors tests/mount.rs).
+    // On-disk DB so musefs_db uses the PerThread pool (mirrors tests/concurrency.rs).
     let db_path = backing.path().join("m.db");
     let db = musefs_db::Db::open(&db_path).unwrap();
     scan_directory(&db, backing.path()).unwrap();

--- a/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
+++ b/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
@@ -1,0 +1,710 @@
+# StructureOnly FUSE Passthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** StructureOnly reads served by the kernel directly from the backing fd (FUSE passthrough, kernel 6.9+), with silent fallback to the daemon read path everywhere passthrough is unavailable.
+
+**Architecture:** Core gains one accessor (`Musefs::passthrough_fd`) exposing the already-opened-and-validated backing `File` of a handle, `Some` only in `StructureOnly` mode. The FUSE layer advertises `FUSE_PASSTHROUGH` at init, registers the fd at `open` (`reply.open_backing` → `BackingId` → `opened_passthrough`), holds the `BackingId` in an `fh → BackingId` map until `release`, and falls back to the existing `opened` reply on any failure (sticky-disabled after the first).
+
+**Tech Stack:** Rust; fuser 0.17 (already a dependency — `BackingId`, `opened_passthrough`, `set_max_stack_depth`); no new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md` — read it before starting. Binding decisions: silent fallback, no CLI flag, POSIX open-time-validation freshness, insert-before-reply ordering, `FOPEN_KEEP_CACHE` stripped on passthrough replies, init must call **both** `add_capabilities(FUSE_PASSTHROUGH)` and `set_max_stack_depth(2)`.
+
+**Conventions that apply (from CLAUDE.md):** Serena tools for code reads/edits; integer-conversion convention (no bare `as`); each crate's `error.rs` owns its errors (no new errors needed here); commit per task; don't push.
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `musefs-core/src/facade.rs` | Add `PassthroughFd` wrapper + `Musefs::passthrough_fd`; unit test |
+| `musefs-core/src/lib.rs` | Re-export `PassthroughFd` |
+| `musefs-fuse/src/lib.rs` | `init` capability handshake; `MusefsFs` fields; `open`/`release` wiring |
+| `musefs-fuse/tests/passthrough.rs` | New metrics-gated e2e test (passthrough + synthesis control) |
+| `musefs-core/src/metrics.rs` | Module-doc note: passthrough reads are invisible to serve counters |
+| `CLAUDE.md` | StructureOnly mode bullet: passthrough + freshness semantics |
+| `BENCHMARKS.md` | Before/after StructureOnly sequential-read throughput |
+
+---
+
+### Task 1: Core `passthrough_fd` accessor
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (struct after `Handle` ~line 63, method in `impl Musefs` after `open_handle` ~line 1040, test in the existing `mod tests`)
+- Modify: `musefs-core/src/lib.rs:17` (re-export)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `musefs-core/src/facade.rs` (it models `open_handle_reresolves_after_content_version_bump`, which is the fixture pattern to mirror):
+
+```rust
+#[test]
+fn passthrough_fd_exposes_backing_only_in_structure_only() {
+    use crate::scan::scan_directory;
+    use id3::TagLike;
+    use std::collections::BTreeMap;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let mut tag = id3::Tag::new();
+        tag.set_artist("Pix");
+        tag.set_title("Song");
+        let mut bytes = Vec::new();
+        tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+        bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+        std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+    }
+    let db_path = dir.path().join("m.db");
+    {
+        let db = musefs_db::Db::open(&db_path).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+    }
+    let cfg = |mode| MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode,
+        poll_interval: std::time::Duration::ZERO,
+    };
+
+    // StructureOnly: exposed, and the fd refers to the backing inode.
+    let fs = Musefs::open(
+        musefs_db::Db::open(&db_path).unwrap(),
+        cfg(Mode::StructureOnly),
+    )
+    .unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let fh = fs.open_handle(file_inode).unwrap();
+    let pfd = fs
+        .passthrough_fd(fh)
+        .expect("StructureOnly exposes the backing fd");
+    let fd_meta = std::fs::File::from(pfd.as_fd().try_clone_to_owned().unwrap())
+        .metadata()
+        .unwrap();
+    let backing_meta = std::fs::metadata(dir.path().join("a.mp3")).unwrap();
+    assert_eq!(
+        (fd_meta.dev(), fd_meta.ino()),
+        (backing_meta.dev(), backing_meta.ino()),
+        "passthrough fd must be the backing file"
+    );
+
+    // A released handle no longer resolves.
+    fs.release_handle(fh);
+    assert!(fs.passthrough_fd(fh).is_none());
+
+    // Synthesis: never exposed, even for a live handle.
+    let fs = Musefs::open(
+        musefs_db::Db::open(&db_path).unwrap(),
+        cfg(Mode::Synthesis),
+    )
+    .unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let fh = fs.open_handle(file_inode).unwrap();
+    assert!(fs.passthrough_fd(fh).is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core passthrough_fd_exposes`
+Expected: FAIL to compile — `no method named passthrough_fd`
+
+- [ ] **Step 3: Write the implementation**
+
+In `musefs-core/src/facade.rs`, insert after the `Handle` struct (after ~line 63):
+
+```rust
+/// An owned view of an open handle's backing fd, for FUSE passthrough
+/// registration. Holds its own `Arc<Handle>`, so the fd outlives a concurrent
+/// slab removal while the registration ioctl is in flight.
+pub struct PassthroughFd(Arc<Handle>);
+
+impl std::os::fd::AsFd for PassthroughFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        self.0.file.as_fd()
+    }
+}
+```
+
+(`use std::os::fd::AsFd;` is needed in scope for `self.0.file.as_fd()` — add it to the imports at the top of `facade.rs`.)
+
+In `impl Musefs`, insert after `release_handle` (~line 1046):
+
+```rust
+/// The backing fd behind `fh`, for kernel passthrough registration. `Some`
+/// only in StructureOnly mode, where the served bytes ARE the backing file;
+/// in Synthesis mode the bytes are spliced, so no single fd represents
+/// them. `None` also for a stale or released handle.
+pub fn passthrough_fd(&self, fh: Fh) -> Option<PassthroughFd> {
+    if self.config.mode != Mode::StructureOnly {
+        return None;
+    }
+    let handle = self.handles.get(fh.slab_key())?;
+    Some(PassthroughFd(Arc::clone(&handle)))
+}
+```
+
+(`self.handles.get` returns a `sharded_slab::Entry` that derefs to `Arc<Handle>`; if `Arc::clone(&handle)` fails to infer through the guard, use `Arc::clone(&*handle)`.)
+
+In `musefs-core/src/lib.rs`, extend line 17:
+
+```rust
+pub use facade::{Attr, Fh, Mode, MountConfig, Musefs, PassthroughFd};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core passthrough_fd_exposes`
+Expected: PASS
+
+- [ ] **Step 5: Run the crate's full test suite (no regressions)**
+
+Run: `cargo test -p musefs-core`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/src/lib.rs
+git commit -m "core: expose a handle's backing fd for passthrough (StructureOnly only) (#112)"
+```
+
+---
+
+### Task 2: FUSE init advertises FUSE_PASSTHROUGH
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs:239-253` (the `init` method of `impl Filesystem for MusefsFs`)
+
+No unit test is possible — `KernelConfig` cannot be constructed outside fuser. The e2e test in Task 4 is the verification; this task is gated on compile + clippy.
+
+- [ ] **Step 1: Add the two init calls**
+
+In `init`, after the existing `FUSE_PARALLEL_DIROPS` line (`musefs-fuse/src/lib.rs:252`), add:
+
+```rust
+        // Passthrough needs BOTH calls: fuser only copies max_stack_depth into
+        // the init reply when the FUSE_PASSTHROUGH bit was negotiated, and a
+        // depth of 0 disables passthrough outright. Depth 2 (fuser's own
+        // example value) additionally lets backing files live on a stacked fs
+        // (e.g. a music library on overlayfs). On kernels without support the
+        // bit is simply not acked and open_backing later fails -> fallback.
+        let _ = config.add_capabilities(InitFlags::FUSE_PASSTHROUGH);
+        let _ = config.set_max_stack_depth(2);
+```
+
+- [ ] **Step 2: Verify it compiles clean**
+
+Run: `cargo clippy -p musefs-fuse --all-targets`
+Expected: no errors, no new warnings
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-fuse/src/lib.rs
+git commit -m "fuse: advertise FUSE_PASSTHROUGH + stack depth at init (#112)"
+```
+
+---
+
+### Task 3: FUSE open/release passthrough wiring
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` — `MusefsFs` struct (~line 156), `MusefsFs::new` (~line 173), `open` (~line 283), `release` (~line 292), fuser import list (~line 14)
+
+Like Task 2, this is only observable through a real mount; Task 4's e2e test is the verification. Gate on compile + clippy + the existing (non-ignored) suite.
+
+- [ ] **Step 1: Add the fuser import**
+
+Add `BackingId` to the existing `use fuser::{...}` list (`musefs-fuse/src/lib.rs:14-18`). Add `use std::collections::HashMap;` to the std imports.
+
+- [ ] **Step 2: Add the two fields to `MusefsFs`**
+
+After the `poll_pending` field (~line 165):
+
+```rust
+    /// Kernel-registered backing fds for live passthrough handles, keyed by
+    /// the wire fh. The entry is inserted BEFORE the open reply is sent — the
+    /// kernel cannot release an fh it has not yet seen — so every live
+    /// passthrough handle has an entry. `release` removes it; dropping the
+    /// `BackingId` fires the backing-close ioctl.
+    backing: Arc<Mutex<HashMap<u64, BackingId>>>,
+    /// Sticky disable: flipped on the first `open_backing` failure (kernel
+    /// without passthrough support), so later opens skip the doomed ioctl.
+    passthrough_disabled: Arc<AtomicBool>,
+```
+
+In `MusefsFs::new` (~line 173), add to the struct literal:
+
+```rust
+            backing: Arc::new(Mutex::new(HashMap::new())),
+            passthrough_disabled: Arc::new(AtomicBool::new(false)),
+```
+
+- [ ] **Step 3: Rewrite `open`**
+
+Replace the body of `fn open` (`musefs-fuse/src/lib.rs:283-290`) with:
+
+```rust
+    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        let core = Arc::clone(&self.core);
+        let flags = open_flags(self.config.keep_cache);
+        let backing = Arc::clone(&self.backing);
+        let passthrough_disabled = Arc::clone(&self.passthrough_disabled);
+        self.pool.execute(move || {
+            let fh = match core.open_handle(ino.0) {
+                Ok(fh) => fh,
+                Err(e) => return reply.error(reply_errno("open", ino.0, &e)),
+            };
+            if !passthrough_disabled.load(Ordering::Relaxed) {
+                if let Some(pfd) = core.passthrough_fd(fh) {
+                    match reply.open_backing(&pfd) {
+                        Ok(id) => {
+                            // Insert before the reply (see the `backing` field
+                            // doc). FOPEN_KEEP_CACHE is dropped: page-cache
+                            // ownership belongs to the backing inode here.
+                            // Poisoning recovery: the lock guards single map
+                            // ops; a panic mid-insert leaves nothing torn.
+                            let mut map = backing
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let id = map.entry(fh.get()).or_insert(id);
+                            return reply.opened_passthrough(
+                                FileHandle(fh.get()),
+                                FopenFlags::empty(),
+                                id,
+                            );
+                        }
+                        Err(e) => {
+                            // Sticky: the failure modes (kernel < 6.9, ioctl
+                            // unsupported) are static per mount.
+                            passthrough_disabled.store(true, Ordering::Relaxed);
+                            log::info!(
+                                "FUSE passthrough unavailable; serving reads through the daemon: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+            reply.opened(FileHandle(fh.get()), flags);
+        });
+    }
+```
+
+- [ ] **Step 4: Extend `release`**
+
+In `fn release` (`musefs-fuse/src/lib.rs:292-307`), replace the `if let` body:
+
+```rust
+        // Cheap (two map removes); no need to offload to the pool.
+        if let Some(fh) = NonZeroU64::new(fh.0) {
+            // Dropping the BackingId fires the backing-close ioctl. Absent for
+            // plain (non-passthrough) handles — remove is then a no-op.
+            self.backing
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&fh.get());
+            self.core.release_handle(Fh::from(fh));
+        }
+        reply.ok();
+```
+
+- [ ] **Step 5: Verify compile + existing suite**
+
+Run: `cargo clippy -p musefs-fuse --all-targets && cargo test -p musefs-fuse`
+Expected: clean clippy; all non-ignored tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-fuse/src/lib.rs
+git commit -m "fuse: register StructureOnly backing fds for kernel passthrough (#112)"
+```
+
+---
+
+### Task 4: End-to-end passthrough test
+
+**Files:**
+- Create: `musefs-fuse/tests/passthrough.rs`
+
+Two `#[ignore]`d tests in one metrics-gated binary: the passthrough assertion, and a Synthesis control that proves the pread counter observable is live (guarding the zero-assert against vacuity). Metrics counters are process-global, so the run command pins `--test-threads=1` and each test calls `reset()`.
+
+- [ ] **Step 1: Write the test file**
+
+```rust
+#![cfg(feature = "metrics")]
+//! StructureOnly passthrough: after `open`, the kernel must serve reads
+//! directly from the registered backing fd — byte-identical content with ZERO
+//! daemon preads. The Synthesis control test proves the pread counter
+//! observable is live (a broken counter would make the zero-assert vacuous).
+//!
+//! Run with:
+//!   cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1
+
+use std::collections::BTreeMap;
+use std::io::Read;
+
+use musefs_core::{metrics, scan_directory, Mode, MountConfig, Musefs};
+
+// ---------------------------------------------------------------------------
+// Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)
+// ---------------------------------------------------------------------------
+
+fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
+    let len = body.len();
+    out.push(((len >> 16) & 0xFF) as u8);
+    out.push(((len >> 8) & 0xFF) as u8);
+    out.push((len & 0xFF) as u8);
+    out.extend_from_slice(body);
+    out
+}
+
+fn streaminfo_body() -> Vec<u8> {
+    let mut b = vec![
+        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
+        0x00, 0x00, 0x00,
+    ];
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(vendor.as_bytes());
+    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    for c in comments {
+        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(c.as_bytes());
+    }
+    out
+}
+
+fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
+    out.extend_from_slice(audio);
+    out
+}
+
+fn config(mode: Mode) -> MountConfig {
+    MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode,
+        poll_interval: std::time::Duration::ZERO,
+    }
+}
+
+/// FUSE passthrough landed in mainline 6.9.
+fn kernel_supports_passthrough() -> bool {
+    let rel = std::fs::read_to_string("/proc/sys/kernel/osrelease").unwrap_or_default();
+    let mut parts = rel.trim().split(|c: char| !c.is_ascii_digit());
+    let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (major, minor) >= (6, 9)
+}
+
+/// Scan one ~2 MiB FLAC into a fresh on-disk DB and mount it. Returns the
+/// backing bytes, the virtual path, the session, and the two TempDir guards.
+fn mount_one_track(
+    mode: Mode,
+) -> (
+    Vec<u8>,
+    std::path::PathBuf,
+    fuser::BackgroundSession,
+    tempfile::TempDir,
+    std::path::PathBuf,
+) {
+    let backing = tempfile::tempdir().unwrap();
+    let audio = vec![0xABu8; 2 * 1024 * 1024];
+    let flac = make_flac(&["ARTIST=Alpha", "TITLE=Track"], &audio);
+    std::fs::write(backing.path().join("a.flac"), &flac).unwrap();
+
+    // On-disk DB so musefs_db uses the PerThread pool (mirrors tests/mount.rs).
+    let db_path = backing.path().join("m.db");
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+
+    let fs = Musefs::open(db, config(mode)).unwrap();
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-passthrough-test").unwrap();
+    let mnt = mountpoint.keep(); // keep mount alive for the test's duration
+    let virt = mnt.join("Alpha").join("Track.flac");
+    (flac, virt, session, backing, mnt)
+}
+
+#[test]
+#[ignore = "real mount; needs /dev/fuse + kernel >= 6.9 — run with: cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1"]
+fn structure_only_reads_are_kernel_passthrough() {
+    if !kernel_supports_passthrough() {
+        eprintln!("kernel < 6.9: no FUSE passthrough; skipping");
+        return;
+    }
+    let (backing_bytes, virt, session, _backing, _mnt) = mount_one_track(Mode::StructureOnly);
+
+    // Sequencing matters: FUSE `open` fires here (on_open and warmup counters
+    // land), THEN reset, THEN read — so the pread assertion has a clean
+    // baseline and covers exactly the reads of this fd.
+    let mut f = std::fs::File::open(&virt).expect("open through mount");
+    metrics::reset();
+    let mut served = Vec::new();
+    f.read_to_end(&mut served).expect("read through mount");
+
+    assert_eq!(
+        served, backing_bytes,
+        "StructureOnly must serve backing bytes verbatim"
+    );
+    let snap = metrics::snapshot();
+    assert_eq!(
+        snap.preads, 0,
+        "daemon served {} preads — kernel passthrough did not engage",
+        snap.preads
+    );
+
+    // Close + unmount exercise the BackingId release path (release drops the
+    // map entry; session drop tears down the channel) — must not hang or error.
+    drop(f);
+    drop(session);
+}
+
+#[test]
+#[ignore = "real mount; needs /dev/fuse — run with: cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1"]
+fn synthesis_reads_still_go_through_the_daemon() {
+    let (_backing_bytes, virt, session, _backing, _mnt) = mount_one_track(Mode::Synthesis);
+
+    let mut f = std::fs::File::open(&virt).expect("open through mount");
+    metrics::reset();
+    let mut served = Vec::new();
+    f.read_to_end(&mut served).expect("read through mount");
+
+    // Synthesis splices a fresh header; the read MUST hit the daemon. This
+    // proves the pread counter observable is live, so the passthrough test's
+    // zero-assert cannot pass vacuously.
+    let snap = metrics::snapshot();
+    assert!(
+        snap.preads > 0,
+        "expected daemon preads on a Synthesis mount; the metrics observable is broken"
+    );
+    drop(f);
+    drop(session);
+}
+```
+
+- [ ] **Step 2: Run the new tests (they must FAIL only if Tasks 1–3 are broken)**
+
+Run: `cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1`
+Expected: both PASS (kernel here is 7.0). If `structure_only_reads_are_kernel_passthrough` fails on the pread assert, passthrough did not engage — debug Tasks 2/3 (most likely the init handshake) before proceeding; do not weaken the assert.
+
+- [ ] **Step 3: Run the full ignored e2e suite (no regressions)**
+
+Run: `cargo test -p musefs-fuse --features metrics -- --ignored --nocapture --test-threads=1`
+Expected: all PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-fuse/tests/passthrough.rs
+git commit -m "fuse: e2e test for StructureOnly kernel passthrough (#112)"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs:17-25` (the `Mode` doc comments)
+- Modify: `musefs-core/src/metrics.rs:1-19` (module doc)
+- Modify: `CLAUDE.md` (the `StructureOnly` mode bullet)
+
+- [ ] **Step 1: `Mode::StructureOnly` doc comment**
+
+Replace the `StructureOnly` variant doc in `musefs-core/src/facade.rs`:
+
+```rust
+    /// Pure passthrough: serve the original backing file bytes unchanged.
+    /// Where the kernel supports FUSE passthrough (6.9+), reads are served
+    /// directly from the backing fd registered at open — open-time validation
+    /// only: a handle held across a backing-file replacement keeps serving
+    /// the inode it opened (plain POSIX fd semantics); new opens re-resolve.
+    StructureOnly,
+```
+
+- [ ] **Step 2: metrics.rs module-doc note**
+
+Append to the "Counting scope" paragraph in `musefs-core/src/metrics.rs` (after the `on_scan_open`/`on_scan_read` sentence):
+
+```rust
+//! Counters measure *daemon* work, not user traffic: StructureOnly reads
+//! served via kernel passthrough never reach userspace and are invisible to
+//! `on_pread` — by design (the passthrough e2e test asserts exactly this).
+```
+
+- [ ] **Step 3: CLAUDE.md mode bullet**
+
+In CLAUDE.md's "Two mount **modes**" section, extend the `StructureOnly` bullet:
+
+```markdown
+- `StructureOnly` — a single whole-file `BackingAudio` segment; the original bytes
+  are served verbatim under the templated tree. Stored audio bounds are not
+  validated in this mode because the whole file is served. On kernels with FUSE
+  passthrough (6.9+) reads are served by the kernel directly from the backing fd
+  registered at open (silent fallback to daemon reads elsewhere); freshness is
+  open-time-only for such handles — plain POSIX fd semantics.
+```
+
+- [ ] **Step 4: Verify build (doc comments compile)**
+
+Run: `cargo clippy --all-targets`
+Expected: clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/src/metrics.rs CLAUDE.md
+git commit -m "docs: StructureOnly passthrough semantics (#112)"
+```
+
+---
+
+### Task 6: Benchmark and BENCHMARKS.md entry
+
+**Files:**
+- Modify: `BENCHMARKS.md` (new section)
+
+Before = `main` (daemon-served reads), After = this branch (kernel passthrough). Same machine, same fixture, release builds. The backing file is RAM-cached either way (17 GiB RAM vs a 512 MiB file), so the measurement isolates FUSE-path overhead — which is the thing the issue is about.
+
+- [ ] **Step 1: Generate the fixture (one 512 MiB FLAC)**
+
+```bash
+mkdir -p /tmp/pt-bench/backing /tmp/pt-bench/mnt
+python3 - <<'EOF'
+import struct
+def block(btype, body, last=False):
+    h = bytes([ (0x80 if last else 0) | btype ]) + len(body).to_bytes(3, 'big')
+    return h + body
+streaminfo = bytes([0x10,0,0x10,0,0,0,0,0,0,0,0x0A,0xC4,0x42,0xF0,0,0,0,0]) + bytes(16)
+def vc(vendor, comments):
+    out = struct.pack('<I', len(vendor)) + vendor.encode()
+    out += struct.pack('<I', len(comments))
+    for c in comments:
+        out += struct.pack('<I', len(c)) + c.encode()
+    return out
+with open('/tmp/pt-bench/backing/big.flac', 'wb') as f:
+    f.write(b'fLaC')
+    f.write(block(0, streaminfo))
+    f.write(block(4, vc('orig', ['ARTIST=Alpha', 'TITLE=Big']), last=True))
+    f.write(bytes([0xAB]) * (512 * 1024 * 1024))
+EOF
+```
+
+- [ ] **Step 2: Build both binaries**
+
+```bash
+cargo build --release   # branch ("after") -> target/release/musefs
+git worktree add /tmp/pt-bench/main-tree main
+(cd /tmp/pt-bench/main-tree && cargo build --release)   # "before"
+```
+
+- [ ] **Step 3: Measure (3 runs each, fresh mount per run)**
+
+For each binary `BIN` in `target/release/musefs` (after) and `/tmp/pt-bench/main-tree/target/release/musefs` (before):
+
+```bash
+"$BIN" scan /tmp/pt-bench/backing --db /tmp/pt-bench/m.db
+"$BIN" mount /tmp/pt-bench/mnt --db /tmp/pt-bench/m.db --mode structure-only &
+MOUNT_PID=$!; sleep 1
+for i in 1 2 3; do
+  dd if=/tmp/pt-bench/mnt/Alpha/Big.flac of=/dev/null bs=1M 2>&1 | tail -1
+done
+fusermount3 -u /tmp/pt-bench/mnt; wait $MOUNT_PID
+```
+
+Record the dd-reported MB/s for each run. (First run includes page-cache warmup of the backing file; report all three, call out the median.)
+
+- [ ] **Step 4: Record in BENCHMARKS.md and clean up**
+
+Append a section following the existing format (Before/After bullets, exact commands, measured date):
+
+```markdown
+## Issue #112 — StructureOnly kernel passthrough
+
+*Measured YYYY-MM-DD.*
+
+- **Before** = `main` @ `<sha>`: every read round-trips kernel -> daemon -> positioned read -> copy back.
+- **After** = `issue-112-passthrough`: backing fd registered at open (FUSE passthrough, kernel 6.9+); the kernel serves reads directly.
+- Harness: 512 MiB single-track StructureOnly mount, `dd bs=1M` sequential read, 3 runs each, fresh mount per run, RAM-cached backing file (isolates FUSE-path overhead).
+
+| | run 1 | run 2 | run 3 | median |
+|---|---|---|---|---|
+| Before (daemon reads) | _MB/s_ | _MB/s_ | _MB/s_ | _MB/s_ |
+| After (passthrough) | _MB/s_ | _MB/s_ | _MB/s_ | _MB/s_ |
+```
+
+(The `_MB/s_` cells are filled with the measured numbers from Step 3 — do not commit placeholders.)
+
+Clean up: `git worktree remove /tmp/pt-bench/main-tree && rm -rf /tmp/pt-bench`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add BENCHMARKS.md
+git commit -m "bench: StructureOnly passthrough before/after throughput (#112)"
+```
+
+---
+
+### Task 7: Final validation
+
+- [ ] **Step 1: Format + lint + full workspace tests**
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets
+cargo test
+```
+Expected: all clean/PASS. (`cargo fmt --all --check` must exit 0 — CI has a fmt gate; check the exit status directly, don't pipe.)
+
+- [ ] **Step 2: FUSE e2e suite once more**
+
+```bash
+cargo test -p musefs-fuse --features metrics -- --ignored --nocapture --test-threads=1
+```
+Expected: all PASS
+
+- [ ] **Step 3: In-diff mutation gate (CI parity)**
+
+Run exactly as documented in CLAUDE.md (memory-capped cgroup, TMPDIR on real disk, sanity-check the diff first):
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+mkdir -p ~/.cache/musefs-mutants-tmp
+TMPDIR="$HOME/.cache/musefs-mutants-tmp" systemd-run --user --scope --collect \
+    -p MemoryMax=10G -p MemorySwapMax=0 \
+    cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+Expected: exit 0, no missed mutants. Note: the FUSE handler bodies (`open`/`release`/`init`) are only exercised by `#[ignore]`d tests, which cargo-mutants does not run — mutants there may survive. Survivors confined to those handlers are acceptable with a note in the PR; survivors in `facade.rs` are not (the unit test must catch them — strengthen it instead).
+
+- [ ] **Step 4: Wrap up**
+
+Use superpowers:finishing-a-development-branch to choose merge/PR handling. PR title: `StructureOnly: serve reads via kernel FUSE passthrough (#112)`.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec coverage: init handshake (Task 2), accessor + mode gating (Task 1), open/release lifecycle with insert-before-reply and KEEP_CACHE strip (Task 3), silent fallback + sticky disable (Task 3), e2e with metrics sequencing + kernel skip + synthesis control (Task 4), docs (Task 5), benchmark (Task 6), mutation gate (Task 7). Freshness semantics need no code — documented in Task 5.
+- Type consistency: `passthrough_fd(fh: Fh) -> Option<PassthroughFd>` used identically in Tasks 1 and 3; map keyed by `fh.get()` (wire value) in both `open` and `release`.
+- No placeholders: benchmark table cells are explicitly filled at measurement time (Step 4 says so); every code step shows complete code.

--- a/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
+++ b/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
@@ -328,6 +328,79 @@ git commit -m "fuse: register StructureOnly backing fds for kernel passthrough (
 
 ---
 
+### Task 3b: Mount-time CAP_SYS_ADMIN probe (added after discovery)
+
+**Why (discovered in Task 4):** the kernel gates `FUSE_DEV_IOC_BACKING_OPEN`
+behind `CAP_SYS_ADMIN`; unprivileged daemons get EPERM on every registration.
+Decision: pre-set the sticky disable at mount time for a StructureOnly mount
+that definitively lacks the capability, logging one info line so the operator
+learns at mount, not first open.
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (tiny `Musefs::mode()` accessor)
+- Modify: `musefs-fuse/src/lib.rs` (probe helper + `MusefsFs::new` wiring; parser unit test)
+
+- [ ] **Step 1: Core accessor** — in `impl Musefs` next to `passthrough_fd`:
+
+```rust
+/// The mount's serving mode (how file contents are produced).
+pub fn mode(&self) -> Mode {
+    self.config.mode
+}
+```
+
+- [ ] **Step 2: Probe helper in musefs-fuse** — a pure parser plus a thin reader, near `open_flags`:
+
+```rust
+/// True only when /proc/self/status definitively shows CAP_SYS_ADMIN (bit 21)
+/// absent from CapEff. Unreadable/unparseable -> false (stay neutral; the
+/// first open's ioctl attempt decides instead).
+fn definitely_lacks_cap_sys_admin() -> bool {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| cap_eff_has_sys_admin(&s))
+        .is_some_and(|has| !has)
+}
+
+/// Parse the `CapEff:` line; None when absent or malformed.
+fn cap_eff_has_sys_admin(status: &str) -> Option<bool> {
+    const CAP_SYS_ADMIN_BIT: u32 = 21;
+    let hex = status
+        .lines()
+        .find_map(|l| l.strip_prefix("CapEff:"))?
+        .trim();
+    let mask = u64::from_str_radix(hex, 16).ok()?;
+    Some(mask & (1 << CAP_SYS_ADMIN_BIT) != 0)
+}
+```
+
+Unit tests (in the existing tests module of lib.rs): root mask (`0000003fffffffff` → Some(true)), unprivileged (`0000000000000000` → Some(false)), missing line → None, garbage hex → None.
+
+- [ ] **Step 3: Wire into `MusefsFs::new`** — initialize the sticky flag from the probe:
+
+```rust
+        let passthrough_disabled =
+            core.mode() == musefs_core::Mode::StructureOnly && definitely_lacks_cap_sys_admin();
+        if passthrough_disabled {
+            log::info!(
+                "StructureOnly mount without CAP_SYS_ADMIN: kernel passthrough unavailable; reads will be served by the daemon"
+            );
+        }
+```
+
+and `passthrough_disabled: Arc::new(AtomicBool::new(passthrough_disabled)),` in the struct literal. (`core` is the `Musefs` parameter, before it moves into the `Arc`.)
+
+- [ ] **Step 4: Verify** — `cargo test -p musefs-fuse` (parser tests pass), `cargo clippy --all-targets`, `cargo fmt --all --check`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/facade.rs musefs-fuse/src/lib.rs
+git commit -m "fuse: pre-disable passthrough at mount when CAP_SYS_ADMIN is absent (#112)"
+```
+
+---
+
 ### Task 4: End-to-end passthrough test
 
 **Files:**
@@ -445,11 +518,26 @@ fn mount_one_track(
     (flac, virt, session, backing, mnt)
 }
 
+/// The backing-open ioctl is CAP_SYS_ADMIN-gated; without it passthrough
+/// falls back to daemon reads and the zero-pread assert cannot hold.
+fn have_cap_sys_admin() -> bool {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    status
+        .lines()
+        .find_map(|l| l.strip_prefix("CapEff:"))
+        .and_then(|hex| u64::from_str_radix(hex.trim(), 16).ok())
+        .is_some_and(|mask| mask & (1 << 21) != 0)
+}
+
 #[test]
-#[ignore = "real mount; needs /dev/fuse + kernel >= 6.9 — run with: cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1"]
+#[ignore = "real mount; needs /dev/fuse + kernel >= 6.9 + CAP_SYS_ADMIN — build as user, run test binary via sudo"]
 fn structure_only_reads_are_kernel_passthrough() {
     if !kernel_supports_passthrough() {
         eprintln!("kernel < 6.9: no FUSE passthrough; skipping");
+        return;
+    }
+    if !have_cap_sys_admin() {
+        eprintln!("no CAP_SYS_ADMIN: backing-open ioctl would EPERM; skipping (run via sudo)");
         return;
     }
     let (backing_bytes, virt, session, _backing, _mnt) = mount_one_track(Mode::StructureOnly);
@@ -504,8 +592,16 @@ fn synthesis_reads_still_go_through_the_daemon() {
 
 - [ ] **Step 2: Run the new tests (they must FAIL only if Tasks 1–3 are broken)**
 
-Run: `cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1`
-Expected: both PASS (kernel here is 7.0). If `structure_only_reads_are_kernel_passthrough` fails on the pread assert, passthrough did not engage — debug Tasks 2/3 (most likely the init handshake) before proceeding; do not weaken the assert.
+Unprivileged run (structure_only must SKIP with the capability message, synthesis must PASS):
+`cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1`
+
+Privileged run (both must PASS — build as user, run the binary via sudo):
+```bash
+BIN=$(cargo test -p musefs-fuse --features metrics --test passthrough --no-run 2>&1 \
+      | grep -o 'target/debug/deps/passthrough-[a-f0-9]*' | head -1)
+sudo -n "$BIN" --ignored --nocapture --test-threads=1
+```
+If `structure_only_reads_are_kernel_passthrough` fails on the pread assert under sudo, passthrough did not engage — debug Tasks 2/3 (most likely the init handshake) before proceeding; do not weaken the assert.
 
 - [ ] **Step 3: Run the full ignored e2e suite (no regressions)**
 
@@ -534,10 +630,12 @@ Replace the `StructureOnly` variant doc in `musefs-core/src/facade.rs`:
 
 ```rust
     /// Pure passthrough: serve the original backing file bytes unchanged.
-    /// Where the kernel supports FUSE passthrough (6.9+), reads are served
-    /// directly from the backing fd registered at open — open-time validation
-    /// only: a handle held across a backing-file replacement keeps serving
-    /// the inode it opened (plain POSIX fd semantics); new opens re-resolve.
+    /// Where the kernel supports FUSE passthrough (6.9+) and the daemon holds
+    /// CAP_SYS_ADMIN (the kernel gates backing-fd registration), reads are
+    /// served directly from the backing fd registered at open — open-time
+    /// validation only: a handle held across a backing-file replacement keeps
+    /// serving the inode it opened (plain POSIX fd semantics); new opens
+    /// re-resolve. Without the capability, reads fall back to the daemon.
     StructureOnly,
 ```
 
@@ -559,9 +657,11 @@ In CLAUDE.md's "Two mount **modes**" section, extend the `StructureOnly` bullet:
 - `StructureOnly` — a single whole-file `BackingAudio` segment; the original bytes
   are served verbatim under the templated tree. Stored audio bounds are not
   validated in this mode because the whole file is served. On kernels with FUSE
-  passthrough (6.9+) reads are served by the kernel directly from the backing fd
-  registered at open (silent fallback to daemon reads elsewhere); freshness is
-  open-time-only for such handles — plain POSIX fd semantics.
+  passthrough (6.9+) **and a daemon holding CAP_SYS_ADMIN** (kernel-gated; run as
+  root or `setcap cap_sys_admin=ep` the binary) reads are served by the kernel
+  directly from the backing fd registered at open (silent fallback to daemon
+  reads elsewhere, pre-announced at mount time when the capability is absent);
+  freshness is open-time-only for such handles — plain POSIX fd semantics.
 ```
 
 - [ ] **Step 4: Verify build (doc comments compile)**
@@ -623,7 +723,9 @@ For each binary `BIN` in `target/release/musefs` (after) and `/tmp/pt-bench/main
 
 ```bash
 "$BIN" scan /tmp/pt-bench/backing --db /tmp/pt-bench/m.db
-"$BIN" mount /tmp/pt-bench/mnt --db /tmp/pt-bench/m.db --mode structure-only &
+# sudo: the backing-open ioctl is CAP_SYS_ADMIN-gated; without it the "after"
+# measurement would silently benchmark the fallback path.
+sudo -n "$BIN" mount /tmp/pt-bench/mnt --db /tmp/pt-bench/m.db --mode structure-only &
 MOUNT_PID=$!; sleep 1
 for i in 1 2 3; do
   dd if=/tmp/pt-bench/mnt/Alpha/Big.flac of=/dev/null bs=1M 2>&1 | tail -1

--- a/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
+++ b/docs/superpowers/plans/2026-06-06-issue-112-structureonly-passthrough.md
@@ -727,10 +727,12 @@ For each binary `BIN` in `target/release/musefs` (after) and `/tmp/pt-bench/main
 # measurement would silently benchmark the fallback path.
 sudo -n "$BIN" mount /tmp/pt-bench/mnt --db /tmp/pt-bench/m.db --mode structure-only &
 MOUNT_PID=$!; sleep 1
+# sudo dd too: a root-mounted FUSE fs without allow_other is readable only by
+# root. Run BOTH binaries this way so before/after measure the same setup.
 for i in 1 2 3; do
-  dd if=/tmp/pt-bench/mnt/Alpha/Big.flac of=/dev/null bs=1M 2>&1 | tail -1
+  sudo -n dd if=/tmp/pt-bench/mnt/Alpha/Big.flac of=/dev/null bs=1M 2>&1 | tail -1
 done
-fusermount3 -u /tmp/pt-bench/mnt; wait $MOUNT_PID
+sudo -n umount /tmp/pt-bench/mnt; wait $MOUNT_PID
 ```
 
 Record the dd-reported MB/s for each run. (First run includes page-cache warmup of the backing file; report all three, call out the median.)

--- a/docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md
@@ -1,0 +1,139 @@
+# Issue #112: Native FUSE Passthrough for StructureOnly Reads
+
+## Problem
+
+In `StructureOnly` mode every read is served verbatim from the backing file,
+yet each one still round-trips through the FUSE daemon: kernel → userspace
+`read` handler → worker pool → positioned read against the backing fd → copy
+back to the kernel. musefs adds no byte-level transformation in this mode —
+only the virtual tree — so that per-read overhead is pure cost.
+
+Mainline kernels (6.9+) support FUSE passthrough: the daemon registers a
+backing fd at open time and the kernel serves subsequent reads (and mmap)
+directly from it. fuser 0.17 — the version already in use — exposes the full
+API: `KernelConfig::set_max_stack_depth`, `ReplyOpen::open_backing` →
+`BackingId` (the `FUSE_DEV_IOC_BACKING_OPEN` ioctl), and
+`ReplyOpen::opened_passthrough`.
+
+## Goals
+
+- StructureOnly reads served by the kernel at near-native throughput, with no
+  userspace round-trip after open.
+- Lookup, readdir, getattr, and poll-refresh behavior unchanged.
+- Strict best-effort: every passthrough failure degrades to the existing
+  daemon-served read path, never to a user-visible error.
+- No new dependencies, no new CLI surface.
+
+## Non-Goals
+
+- No passthrough in `Synthesis` mode — the served bytes there are spliced, so
+  there is no backing fd that represents the virtual file.
+- No CLI flag. Passthrough is an internal optimization of StructureOnly mode;
+  a flag can be added later if a real need appears.
+- No `BackingId` reuse cache across concurrent opens of the same track.
+  Per-open registration is one cheap ioctl; dedup can be layered on later
+  without design change.
+- No write support. The mount is `MountOption::RO`; passthrough cannot open a
+  write hole.
+
+## Chosen Approach
+
+Core exposes a per-handle passthrough fd; the FUSE layer owns the `BackingId`
+lifecycle. (Rejected: passing the mode into `FuseConfig` and re-opening the
+path in the FUSE layer — it duplicates mode knowledge across layers and the
+re-opened fd would not be the one `open_handle` validated.)
+
+### Core (`musefs-core/src/facade.rs`)
+
+One new method on `Musefs`: `passthrough_fd(fh)`, returning `Some` only when
+the mount mode is `StructureOnly`. It hands back a borrowable view of the
+backing `File` that `open_handle` already opened and validated — likely a
+small public wrapper around the `Arc<Handle>` implementing `AsFd`, so no
+lifetime entanglement with the handle map (exact shape settled at plan time).
+
+No other core changes. `open_handle`, `read_into`, and `release_handle` are
+untouched; in `Synthesis` mode the feature is completely inert.
+
+### FUSE (`musefs-fuse/src/lib.rs`)
+
+- `init`: request `set_max_stack_depth(1)` best-effort, alongside the existing
+  capability requests. This advertises `FUSE_PASSTHROUGH` to the kernel.
+- `open`: after `core.open_handle(ino)` succeeds, ask
+  `core.passthrough_fd(fh)`. If `Some`, try `reply.open_backing(fd)`; on
+  success reply `opened_passthrough(fh, flags, &backing_id)` and stash the
+  `BackingId` in a new `fh → BackingId` map on `MusefsFs`. Otherwise reply
+  plain `opened` as today.
+- `release`: remove the map entry — dropping the `BackingId` fires the
+  backing-close ioctl — then `core.release_handle` as today.
+- `read`: unchanged. The kernel never sends reads for passthrough handles;
+  non-passthrough handles (Synthesis mounts, fallback opens) keep the existing
+  path.
+
+Resulting read path in StructureOnly: kernel serves reads and mmap directly
+from the registered backing fd.
+
+## Error Handling and Fallback
+
+- `set_max_stack_depth` result is discarded like the existing capability
+  requests; an old kernel just means the flag is not advertised.
+- `open_backing` failure (kernel < 6.9 did not ack `FUSE_PASSTHROUGH`, ioctl
+  error, fd problem): log once at info level and reply with plain `opened` —
+  the handle works exactly as today. The first failure flips an `AtomicBool`
+  on `MusefsFs` and subsequent opens skip the attempt, so a long-running mount
+  on an old kernel does not pay a doomed ioctl per open.
+- `open_handle` failure: unchanged — the error is replied before passthrough
+  is considered.
+- `BackingId` drop safety: fuser's `Drop` impl holds only a `Weak` to the
+  channel, so a `BackingId` dropped after session teardown is a no-op;
+  unmount ordering is safe.
+
+Deliberate non-handling: if the first failure was transient rather than
+"kernel lacks support", the sticky disable means the mount never retries.
+The failure modes are overwhelmingly static per kernel, and the cost of being
+wrong is reverting to today's behavior.
+
+## Freshness, Caching, and Metrics
+
+- **Refresh / `content_version`:** open-time validation only. `open_handle`
+  still resolves the layout and validates backing size+mtime; once a
+  passthrough handle is open it serves the original inode like a plain POSIX
+  fd, across backing-file replacement or DB edits. New opens always
+  re-resolve and pick up changes. In StructureOnly the bytes are verbatim, so
+  a stale handle serves the file it opened — never corrupted splice output.
+  Documented on `Mode::StructureOnly` and in CLAUDE.md's mode description.
+- **`--keep-cache` / `inval_inode`:** for passthrough handles, page-cache
+  ownership moves to the backing inode, so the `poll_refresh_notify` →
+  `inval_inode` flow is irrelevant but harmless for them (it targets the FUSE
+  inode's cache, which passthrough reads do not populate). No changes; a
+  comment notes why.
+- **Metrics:** `metrics::on_open` still counts opens. Per-read counters
+  (`on_pread` etc.) will not see passthrough reads — they measure daemon
+  work, not user traffic, which is now true by design. Noted in the
+  `metrics.rs` module docs. This is also the observable the e2e test asserts
+  on.
+- **`poll_refresh` cadence:** unchanged — it is driven by lookup, readdir,
+  and getattr, which all still arrive.
+
+## Testing
+
+- **Core unit tests** (`facade.rs`): `passthrough_fd` returns `Some` for an
+  open handle under `StructureOnly` and `None` under `Synthesis`; the exposed
+  fd refers to the same inode as the backing file (compare fstat dev/ino).
+- **FUSE e2e** (new `#[ignore]`d test alongside
+  `end_to_end_read_through_mount`): mount StructureOnly on a kernel ≥ 6.9,
+  read a file through the mount, assert (a) bytes identical to the backing
+  file, and (b) — gated on the `metrics` feature, which musefs-fuse already
+  forwards to core — the serve-path pread counter delta is zero, proving the
+  kernel served the reads without calling the daemon. Exercise
+  open → read → close → unmount to cover the `BackingId` release path. The
+  test skips (not fails) when the kernel predates passthrough, mirroring the
+  silent-fallback contract.
+- **Regression:** existing Synthesis e2e tests guard that passthrough stays
+  inert outside StructureOnly; no changes to them.
+- **Mutation gate:** standard in-diff `cargo mutants` run per CI parity.
+- **Benchmark:** before/after StructureOnly sequential-read throughput
+  through a real mount, recorded in `BENCHMARKS.md` at landing time.
+
+Known limitation: the old-kernel fallback path cannot be exercised on the
+development machine (kernel 7.0). Unit-level coverage of the sticky-disable
+flag plus e2e coverage of the modern path is the practical ceiling.

--- a/docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md
@@ -18,7 +18,12 @@ API: `KernelConfig::set_max_stack_depth`, `ReplyOpen::open_backing` →
 ## Goals
 
 - StructureOnly reads served by the kernel at near-native throughput, with no
-  userspace round-trip after open.
+  userspace round-trip after open. **Scope discovered during implementation:**
+  the kernel gates backing-fd registration (`FUSE_DEV_IOC_BACKING_OPEN`)
+  behind `CAP_SYS_ADMIN` — a security restriction kept since the 6.9 merge —
+  so passthrough engages only for a privileged daemon (root, or
+  `setcap cap_sys_admin=ep` on the binary). Unprivileged mounts take the
+  silent fallback below; the optimization is opt-in-by-privilege.
 - Lookup, readdir, getattr, and poll-refresh behavior unchanged.
 - Strict best-effort: every passthrough failure degrades to the existing
   daemon-served read path, never to a user-visible error.
@@ -102,6 +107,13 @@ from the registered backing fd.
   the handle works exactly as today. The first failure flips an `AtomicBool`
   on `MusefsFs` and subsequent opens skip the attempt, so a long-running mount
   on an old kernel does not pay a doomed ioctl per open.
+- Missing `CAP_SYS_ADMIN` (the common unprivileged-mount case): a mount-time
+  probe parses `CapEff` from `/proc/self/status` (bit 21); when a
+  StructureOnly mount definitively lacks the capability, the sticky disable
+  is pre-set and one info-level line is logged at mount time — the operator
+  learns immediately instead of at first open, and no doomed ioctl is ever
+  issued. If `/proc` is unreadable or the line unparseable, the probe stays
+  neutral and the first open's attempt decides, as above.
 - `open_handle` failure: unchanged — the error is replied before passthrough
   is considered.
 - `BackingId` drop safety: fuser's `Drop` impl holds only a `Weak` to the
@@ -153,7 +165,9 @@ wrong is reverting to today's behavior.
   `metrics::reset()`, then read, then assert the preads delta against that
   clean baseline. Exercise open → read → close → unmount to cover the
   `BackingId` release path. The test skips (not fails) when the kernel
-  predates passthrough, mirroring the silent-fallback contract.
+  predates passthrough OR the process lacks `CAP_SYS_ADMIN`, mirroring the
+  silent-fallback contract; locally it runs under `sudo` (build as the user,
+  run the test binary privileged).
 - **Regression:** existing Synthesis e2e tests guard that passthrough stays
   inert outside StructureOnly; no changes to them.
 - **Mutation gate:** standard in-diff `cargo mutants` run per CI parity.

--- a/docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-112-structureonly-passthrough-design.md
@@ -46,25 +46,45 @@ re-opened fd would not be the one `open_handle` validated.)
 ### Core (`musefs-core/src/facade.rs`)
 
 One new method on `Musefs`: `passthrough_fd(fh)`, returning `Some` only when
-the mount mode is `StructureOnly`. It hands back a borrowable view of the
-backing `File` that `open_handle` already opened and validated — likely a
-small public wrapper around the `Arc<Handle>` implementing `AsFd`, so no
-lifetime entanglement with the handle map (exact shape settled at plan time).
+the mount mode is `StructureOnly` (gate on the existing `self.config.mode`).
+It hands back an owned wrapper around the `Arc<Handle>` implementing `AsFd`,
+exposing the backing `File` that `open_handle` already opened and validated —
+no lifetime entanglement with the handle slab.
 
 No other core changes. `open_handle`, `read_into`, and `release_handle` are
 untouched; in `Synthesis` mode the feature is completely inert.
 
 ### FUSE (`musefs-fuse/src/lib.rs`)
 
-- `init`: request `set_max_stack_depth(1)` best-effort, alongside the existing
-  capability requests. This advertises `FUSE_PASSTHROUGH` to the kernel.
+- `init`: request `add_capabilities(InitFlags::FUSE_PASSTHROUGH)` **and**
+  `set_max_stack_depth(2)`, both best-effort, alongside the existing
+  per-bit capability requests. Both calls are required: fuser only copies
+  `max_stack_depth` into the init reply when the `FUSE_PASSTHROUGH`
+  capability bit was negotiated (fuser `ll/request.rs`), and the stack depth
+  must be ≥ 1 or passthrough is disabled. Depth 2 (matching fuser's own
+  passthrough example) lets backing files live on a stacked fs themselves
+  (e.g. a music library on overlayfs); the cost is nil and the failure mode
+  at depth 1 would be a silent fallback the user never sees.
 - `open`: after `core.open_handle(ino)` succeeds, ask
   `core.passthrough_fd(fh)`. If `Some`, try `reply.open_backing(fd)`; on
-  success reply `opened_passthrough(fh, flags, &backing_id)` and stash the
-  `BackingId` in a new `fh → BackingId` map on `MusefsFs`. Otherwise reply
-  plain `opened` as today.
+  success, insert the `BackingId` into the `fh → BackingId` map **before**
+  sending `opened_passthrough(fh, flags, &backing_id)` — the kernel cannot
+  send `release` for an fh before it receives the open reply, so
+  insert-before-reply makes the map entry's existence an invariant for every
+  live passthrough handle (no orphan-leak window). Otherwise reply plain
+  `opened` as today. The open handler runs inside `pool.execute`, which
+  captures only what it is given — the map and the sticky-disable flag are
+  therefore `Arc`-shared state cloned into the closure (the map as
+  `Arc<Mutex<HashMap<u64, BackingId>>>`), exactly like `core` and
+  `poll_pending` already are.
+- Open flags for passthrough replies: strip `FOPEN_KEEP_CACHE`. Page-cache
+  ownership for a passthrough handle belongs to the backing inode, so the
+  flag is meaningless there; plain (fallback and Synthesis) opens keep
+  today's flags unchanged.
 - `release`: remove the map entry — dropping the `BackingId` fires the
-  backing-close ioctl — then `core.release_handle` as today.
+  backing-close ioctl — then `core.release_handle` as today. (`release` runs
+  synchronously on the dispatch thread; a map remove is cheap enough, same
+  rationale as the existing `release_handle` comment.)
 - `read`: unchanged. The kernel never sends reads for passthrough handles;
   non-passthrough handles (Synthesis mounts, fallback opens) keep the existing
   path.
@@ -74,8 +94,9 @@ from the registered backing fd.
 
 ## Error Handling and Fallback
 
-- `set_max_stack_depth` result is discarded like the existing capability
-  requests; an old kernel just means the flag is not advertised.
+- The `add_capabilities(FUSE_PASSTHROUGH)` and `set_max_stack_depth` results
+  are discarded like the existing capability requests; an old kernel just
+  means the flag is not advertised.
 - `open_backing` failure (kernel < 6.9 did not ack `FUSE_PASSTHROUGH`, ioctl
   error, fd problem): log once at info level and reply with plain `opened` —
   the handle works exactly as today. The first failure flips an `AtomicBool`
@@ -102,7 +123,8 @@ wrong is reverting to today's behavior.
   a stale handle serves the file it opened — never corrupted splice output.
   Documented on `Mode::StructureOnly` and in CLAUDE.md's mode description.
 - **`--keep-cache` / `inval_inode`:** for passthrough handles, page-cache
-  ownership moves to the backing inode, so the `poll_refresh_notify` →
+  ownership moves to the backing inode (and `FOPEN_KEEP_CACHE` is stripped
+  from their open replies, per above), so the `poll_refresh_notify` →
   `inval_inode` flow is irrelevant but harmless for them (it targets the FUSE
   inode's cache, which passthrough reads do not populate). No changes; a
   comment notes why.
@@ -123,11 +145,15 @@ wrong is reverting to today's behavior.
   `end_to_end_read_through_mount`): mount StructureOnly on a kernel ≥ 6.9,
   read a file through the mount, assert (a) bytes identical to the backing
   file, and (b) — gated on the `metrics` feature, which musefs-fuse already
-  forwards to core — the serve-path pread counter delta is zero, proving the
-  kernel served the reads without calling the daemon. Exercise
-  open → read → close → unmount to cover the `BackingId` release path. The
-  test skips (not fails) when the kernel predates passthrough, mirroring the
-  silent-fallback contract.
+  forwards to core (the existing metrics-gated `concurrency.rs` test is the
+  template) — the serve-path pread counter (`PREADS`) delta is zero, proving
+  the kernel served the reads without calling the daemon. Counter sequencing
+  matters because `on_open`/`on_stat` fire during open and other counters
+  during mount warmup: open the file through the mount first, then
+  `metrics::reset()`, then read, then assert the preads delta against that
+  clean baseline. Exercise open → read → close → unmount to cover the
+  `BackingId` release path. The test skips (not fails) when the kernel
+  predates passthrough, mirroring the silent-fallback contract.
 - **Regression:** existing Synthesis e2e tests guard that passthrough stays
   inert outside StructureOnly; no changes to them.
 - **Mutation gate:** standard in-diff `cargo mutants` run per CI parity.

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -63,6 +63,17 @@ struct Handle {
     file: std::fs::File,
 }
 
+/// An owned view of an open handle's backing fd, for FUSE passthrough
+/// registration. Holds its own `Arc<Handle>`, so the fd outlives a concurrent
+/// slab removal while the registration ioctl is in flight.
+pub struct PassthroughFd(Arc<Handle>);
+
+impl std::os::fd::AsFd for PassthroughFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        self.0.file.as_fd()
+    }
+}
+
 /// A cached file size/attr entry: validated at `content_version`.
 #[derive(Clone, Copy)]
 struct SizeEntry {
@@ -1044,6 +1055,18 @@ impl Musefs {
     pub fn release_handle(&self, fh: Fh) {
         self.handles.remove(fh.slab_key());
     }
+
+    /// The backing fd behind `fh`, for kernel passthrough registration. `Some`
+    /// only in StructureOnly mode, where the served bytes ARE the backing file;
+    /// in Synthesis mode the bytes are spliced, so no single fd represents
+    /// them. `None` also for a stale or released handle.
+    pub fn passthrough_fd(&self, fh: Fh) -> Option<PassthroughFd> {
+        if self.config.mode != Mode::StructureOnly {
+            return None;
+        }
+        let handle = self.handles.get(fh.slab_key())?;
+        Some(PassthroughFd(Arc::clone(&*handle)))
+    }
 }
 
 #[cfg(test)]
@@ -1422,5 +1445,71 @@ mod tests {
         assert!(!fs.poll_due(), "inside the retry backoff window");
         fs.expire_refresh_backoff_for_test();
         assert!(fs.poll_due(), "past the retry backoff window");
+    }
+
+    #[test]
+    fn passthrough_fd_exposes_backing_only_in_structure_only() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+        use std::collections::BTreeMap;
+        use std::os::fd::AsFd;
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = |mode| MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode,
+            poll_interval: std::time::Duration::ZERO,
+        };
+
+        // StructureOnly: exposed, and the fd refers to the backing inode.
+        let fs = Musefs::open(
+            musefs_db::Db::open(&db_path).unwrap(),
+            cfg(Mode::StructureOnly),
+        )
+        .unwrap();
+        let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+        let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+        let fh = fs.open_handle(file_inode).unwrap();
+        let pfd = fs
+            .passthrough_fd(fh)
+            .expect("StructureOnly exposes the backing fd");
+        let fd_meta = std::fs::File::from(pfd.as_fd().try_clone_to_owned().unwrap())
+            .metadata()
+            .unwrap();
+        let backing_meta = std::fs::metadata(dir.path().join("a.mp3")).unwrap();
+        assert_eq!(
+            (fd_meta.dev(), fd_meta.ino()),
+            (backing_meta.dev(), backing_meta.ino()),
+            "passthrough fd must be the backing file"
+        );
+
+        // A released handle no longer resolves.
+        fs.release_handle(fh);
+        assert!(fs.passthrough_fd(fh).is_none());
+
+        // Synthesis: never exposed, even for a live handle.
+        let fs =
+            Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg(Mode::Synthesis)).unwrap();
+        let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+        let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+        let fh = fs.open_handle(file_inode).unwrap();
+        assert!(fs.passthrough_fd(fh).is_none());
     }
 }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -21,6 +21,12 @@ pub enum Mode {
     /// Splice a freshly synthesized metadata region in front of the backing audio.
     Synthesis,
     /// Pure passthrough: serve the original backing file bytes unchanged.
+    /// Where the kernel supports FUSE passthrough (6.9+) and the daemon holds
+    /// CAP_SYS_ADMIN (the kernel gates backing-fd registration), reads are
+    /// served directly from the backing fd registered at open — open-time
+    /// validation only: a handle held across a backing-file replacement keeps
+    /// serving the inode it opened (plain POSIX fd semantics); new opens
+    /// re-resolve. Without the capability, reads fall back to the daemon.
     StructureOnly,
 }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1067,6 +1067,11 @@ impl Musefs {
         let handle = self.handles.get(fh.slab_key())?;
         Some(PassthroughFd(Arc::clone(&*handle)))
     }
+
+    /// The mount's serving mode (how file contents are produced).
+    pub fn mode(&self) -> Mode {
+        self.config.mode
+    }
 }
 
 #[cfg(test)]

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -14,7 +14,7 @@ mod tree;
 
 pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
-pub use facade::{Attr, Fh, Mode, MountConfig, Musefs};
+pub use facade::{Attr, Fh, Mode, MountConfig, Musefs, PassthroughFd};
 pub use musefs_db::convert;
 pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
 pub use scan::scan_directory_full_oracle;

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -17,6 +17,9 @@
 //! `on_scan_open`/`on_scan_read` count backing-file opens and positioned
 //! reads on the *scan* path (distinct from the serve path); `on_scan_read`
 //! also accumulates bytes read, analogous to `on_pread`.
+//! Counters measure *daemon* work, not user traffic: StructureOnly reads
+//! served via kernel passthrough never reach userspace and are invisible to
+//! `on_pread` — by design (the passthrough e2e test asserts exactly this).
 
 pub use imp::*;
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -3,6 +3,7 @@
 //! offloaded onto a bounded worker pool and answered via the `Send` reply
 //! objects, so a slow backing read cannot stall metadata operations.
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -12,9 +13,9 @@ use std::time::{Duration, SystemTime};
 use threadpool::ThreadPool;
 
 use fuser::{
-    BackgroundSession, Config, FileAttr, FileHandle, FileType, Filesystem, FopenFlags, Generation,
-    INodeNo, InitFlags, KernelConfig, LockOwner, Notifier, OpenFlags, ReplyAttr, ReplyData,
-    ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, Request, Session,
+    BackgroundSession, BackingId, Config, FileAttr, FileHandle, FileType, Filesystem, FopenFlags,
+    Generation, INodeNo, InitFlags, KernelConfig, LockOwner, Notifier, OpenFlags, ReplyAttr,
+    ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, Request, Session,
 };
 use musefs_core::convert::usize_from;
 use musefs_core::Attr;
@@ -166,6 +167,15 @@ pub struct MusefsFs {
     /// Single-flight gate for `fire_poll_refresh`: at most one poll task is
     /// queued/running at a time, so a metadata-op storm can't flood the pool (#89).
     poll_pending: Arc<AtomicBool>,
+    /// Kernel-registered backing fds for live passthrough handles, keyed by
+    /// the wire fh. The entry is inserted BEFORE the open reply is sent — the
+    /// kernel cannot release an fh it has not yet seen — so every live
+    /// passthrough handle has an entry. `release` removes it; dropping the
+    /// `BackingId` fires the backing-close ioctl.
+    backing: Arc<Mutex<HashMap<u64, BackingId>>>,
+    /// Sticky disable: flipped on the first `open_backing` failure (kernel
+    /// without passthrough support), so later opens skip the doomed ioctl.
+    passthrough_disabled: Arc<AtomicBool>,
 }
 
 impl MusefsFs {
@@ -186,6 +196,8 @@ impl MusefsFs {
             config,
             notifier: Arc::new(OnceLock::new()),
             poll_pending: Arc::new(AtomicBool::new(false)),
+            backing: Arc::new(Mutex::new(HashMap::new())),
+            passthrough_disabled: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -292,9 +304,44 @@ impl Filesystem for MusefsFs {
     fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         let core = Arc::clone(&self.core);
         let flags = open_flags(self.config.keep_cache);
-        self.pool.execute(move || match core.open_handle(ino.0) {
-            Ok(fh) => reply.opened(FileHandle(fh.get()), flags),
-            Err(e) => reply.error(reply_errno("open", ino.0, &e)),
+        let backing = Arc::clone(&self.backing);
+        let passthrough_disabled = Arc::clone(&self.passthrough_disabled);
+        self.pool.execute(move || {
+            let fh = match core.open_handle(ino.0) {
+                Ok(fh) => fh,
+                Err(e) => return reply.error(reply_errno("open", ino.0, &e)),
+            };
+            if !passthrough_disabled.load(Ordering::Relaxed) {
+                if let Some(pfd) = core.passthrough_fd(fh) {
+                    match reply.open_backing(&pfd) {
+                        Ok(id) => {
+                            // Insert before the reply (see the `backing` field
+                            // doc). FOPEN_KEEP_CACHE is dropped: page-cache
+                            // ownership belongs to the backing inode here.
+                            // Poisoning recovery: the lock guards single map
+                            // ops; a panic mid-insert leaves nothing torn.
+                            let mut map = backing
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let id = map.entry(fh.get()).or_insert(id);
+                            return reply.opened_passthrough(
+                                FileHandle(fh.get()),
+                                FopenFlags::empty(),
+                                id,
+                            );
+                        }
+                        Err(e) => {
+                            // Sticky: the failure modes (kernel < 6.9, ioctl
+                            // unsupported) are static per mount.
+                            passthrough_disabled.store(true, Ordering::Relaxed);
+                            log::info!(
+                                "FUSE passthrough unavailable; serving reads through the daemon: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+            reply.opened(FileHandle(fh.get()), flags);
         });
     }
 
@@ -308,8 +355,14 @@ impl Filesystem for MusefsFs {
         _flush: bool,
         reply: ReplyEmpty,
     ) {
-        // Cheap (a map remove); no need to offload to the pool.
+        // Cheap (a backing-map remove + a slab remove); no need to offload to the pool.
         if let Some(fh) = NonZeroU64::new(fh.0) {
+            // Dropping the BackingId fires the backing-close ioctl. Absent for
+            // plain (non-passthrough) handles — remove is then a no-op.
+            self.backing
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&fh.get());
             self.core.release_handle(Fh::from(fh));
         }
         reply.ok();

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -323,7 +323,7 @@ impl Filesystem for MusefsFs {
                             let mut map = backing
                                 .lock()
                                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-                            let id = map.entry(fh.get()).or_insert(id);
+                            let id = map.entry(fh.get()).insert_entry(id).into_mut();
                             return reply.opened_passthrough(
                                 FileHandle(fh.get()),
                                 FopenFlags::empty(),

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -250,6 +250,14 @@ impl Filesystem for MusefsFs {
         // default; PARALLEL_DIROPS may be unsupported on older kernels (ignored).
         let _ = config.add_capabilities(InitFlags::FUSE_ASYNC_READ);
         let _ = config.add_capabilities(InitFlags::FUSE_PARALLEL_DIROPS);
+        // Passthrough needs BOTH calls: fuser only copies max_stack_depth into
+        // the init reply when the FUSE_PASSTHROUGH bit was negotiated, and a
+        // depth of 0 disables passthrough outright. Depth 2 (fuser's own
+        // example value) additionally lets backing files live on a stacked fs
+        // (e.g. a music library on overlayfs). On kernels without support the
+        // bit is simply not acked and open_backing later fails -> fallback.
+        let _ = config.add_capabilities(InitFlags::FUSE_PASSTHROUGH);
+        let _ = config.set_max_stack_depth(2);
         Ok(())
     }
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -252,8 +252,8 @@ impl Filesystem for MusefsFs {
         let _ = config.add_capabilities(InitFlags::FUSE_PARALLEL_DIROPS);
         // Passthrough needs BOTH calls: fuser only copies max_stack_depth into
         // the init reply when the FUSE_PASSTHROUGH bit was negotiated, and a
-        // depth of 0 disables passthrough outright. Depth 2 (fuser's own
-        // example value) additionally lets backing files live on a stacked fs
+        // depth of 0 disables passthrough outright. Depth 2 (the kernel's
+        // hard maximum) additionally lets backing files live on a stacked fs
         // (e.g. a music library on overlayfs). On kernels without support the
         // bit is simply not acked and open_backing later fails -> fallback.
         let _ = config.add_capabilities(InitFlags::FUSE_PASSTHROUGH);

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -73,6 +73,27 @@ fn open_flags(keep_cache: bool) -> FopenFlags {
     }
 }
 
+/// True only when /proc/self/status definitively shows CAP_SYS_ADMIN (bit 21)
+/// absent from CapEff. Unreadable/unparseable -> false (stay neutral; the
+/// first open's ioctl attempt decides instead).
+fn definitely_lacks_cap_sys_admin() -> bool {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| cap_eff_has_sys_admin(&s))
+        .is_some_and(|has| !has)
+}
+
+/// Parse the `CapEff:` line; None when absent or malformed.
+fn cap_eff_has_sys_admin(status: &str) -> Option<bool> {
+    const CAP_SYS_ADMIN_BIT: u32 = 21;
+    let hex = status
+        .lines()
+        .find_map(|l| l.strip_prefix("CapEff:"))?
+        .trim();
+    let mask = u64::from_str_radix(hex, 16).ok()?;
+    Some(mask & (1 << CAP_SYS_ADMIN_BIT) != 0)
+}
+
 /// Map a core error onto a POSIX errno for the FUSE reply. `Io` errors carry the
 /// underlying errno when present; everything structural collapses to `EIO`.
 pub fn errno(err: &CoreError) -> fuser::Errno {
@@ -182,6 +203,13 @@ impl MusefsFs {
     pub fn new(core: Musefs, config: FuseConfig) -> MusefsFs {
         // Work is I/O-bound (especially on NFS), so oversize the pool vs CPUs.
         let workers = std::thread::available_parallelism().map_or(4, std::num::NonZero::get) * 2;
+        let passthrough_disabled =
+            core.mode() == musefs_core::Mode::StructureOnly && definitely_lacks_cap_sys_admin();
+        if passthrough_disabled {
+            log::info!(
+                "StructureOnly mount without CAP_SYS_ADMIN: kernel passthrough unavailable; reads will be served by the daemon"
+            );
+        }
         MusefsFs {
             core: Arc::new(core),
             // `ThreadPool`'s queue is unbounded. `max_background` (set in `init`)
@@ -197,7 +225,7 @@ impl MusefsFs {
             notifier: Arc::new(OnceLock::new()),
             poll_pending: Arc::new(AtomicBool::new(false)),
             backing: Arc::new(Mutex::new(HashMap::new())),
-            passthrough_disabled: Arc::new(AtomicBool::new(false)),
+            passthrough_disabled: Arc::new(AtomicBool::new(passthrough_disabled)),
         }
     }
 
@@ -649,6 +677,33 @@ mod tests {
         }
         assert_eq!(fs.pool.queued_count(), queued, "no task should be queued");
         assert_eq!(fs.pool.active_count(), active, "no task should be started");
+    }
+
+    #[test]
+    fn cap_eff_parser_root_mask_has_sys_admin() {
+        // Bit 21 is set in the root effective capability mask.
+        assert_eq!(
+            cap_eff_has_sys_admin("CapPrm:\t0000003fffffffff\nCapEff:\t0000003fffffffff\n"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn cap_eff_parser_zero_mask_lacks_sys_admin() {
+        assert_eq!(
+            cap_eff_has_sys_admin("CapEff:\t0000000000000000\n"),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn cap_eff_parser_missing_line_returns_none() {
+        assert_eq!(cap_eff_has_sys_admin("Name:\tfoo\nUid:\t1000\n"), None);
+    }
+
+    #[test]
+    fn cap_eff_parser_garbage_hex_returns_none() {
+        assert_eq!(cap_eff_has_sys_admin("CapEff:\tnothex\n"), None);
     }
 
     #[test]

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -1,0 +1,177 @@
+#![cfg(feature = "metrics")]
+//! StructureOnly passthrough: after `open`, the kernel must serve reads
+//! directly from the registered backing fd — byte-identical content with ZERO
+//! daemon preads. The Synthesis control test proves the pread counter
+//! observable is live (a broken counter would make the zero-assert vacuous).
+//!
+//! Run with:
+//!   cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1
+
+use std::collections::BTreeMap;
+use std::io::Read;
+
+use musefs_core::{metrics, scan_directory, Mode, MountConfig, Musefs};
+
+// ---------------------------------------------------------------------------
+// Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)
+// ---------------------------------------------------------------------------
+
+fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
+    let len = body.len();
+    out.push(((len >> 16) & 0xFF) as u8);
+    out.push(((len >> 8) & 0xFF) as u8);
+    out.push((len & 0xFF) as u8);
+    out.extend_from_slice(body);
+    out
+}
+
+fn streaminfo_body() -> Vec<u8> {
+    let mut b = vec![
+        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
+        0x00, 0x00, 0x00,
+    ];
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(vendor.as_bytes());
+    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    for c in comments {
+        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(c.as_bytes());
+    }
+    out
+}
+
+fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
+    out.extend_from_slice(audio);
+    out
+}
+
+fn config(mode: Mode) -> MountConfig {
+    MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode,
+        poll_interval: std::time::Duration::ZERO,
+    }
+}
+
+/// FUSE passthrough landed in mainline 6.9.
+fn kernel_supports_passthrough() -> bool {
+    let rel = std::fs::read_to_string("/proc/sys/kernel/osrelease").unwrap_or_default();
+    let mut parts = rel.trim().split(|c: char| !c.is_ascii_digit());
+    let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (major, minor) >= (6, 9)
+}
+
+/// Scan one ~2 MiB FLAC into a fresh on-disk DB and mount it. Returns the
+/// backing bytes, the virtual path, the session, and the two TempDir guards.
+fn mount_one_track(
+    mode: Mode,
+) -> (
+    Vec<u8>,
+    std::path::PathBuf,
+    fuser::BackgroundSession,
+    tempfile::TempDir,
+    std::path::PathBuf,
+) {
+    let backing = tempfile::tempdir().unwrap();
+    let audio = vec![0xABu8; 2 * 1024 * 1024];
+    let flac = make_flac(&["ARTIST=Alpha", "TITLE=Track"], &audio);
+    std::fs::write(backing.path().join("a.flac"), &flac).unwrap();
+
+    // On-disk DB so musefs_db uses the PerThread pool (mirrors tests/concurrency.rs).
+    let db_path = backing.path().join("m.db");
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+
+    let fs = Musefs::open(db, config(mode)).unwrap();
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-passthrough-test").unwrap();
+    let mnt = mountpoint.keep(); // keep mount alive for the test's duration
+    let virt = mnt.join("Alpha").join("Track.flac");
+    (flac, virt, session, backing, mnt)
+}
+
+/// The backing-open ioctl is CAP_SYS_ADMIN-gated; without it passthrough
+/// falls back to daemon reads and the zero-pread assert cannot hold.
+fn have_cap_sys_admin() -> bool {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    status
+        .lines()
+        .find_map(|l| l.strip_prefix("CapEff:"))
+        .and_then(|hex| u64::from_str_radix(hex.trim(), 16).ok())
+        .is_some_and(|mask| mask & (1 << 21) != 0)
+}
+
+#[test]
+#[ignore = "real mount; needs /dev/fuse + kernel >= 6.9 + CAP_SYS_ADMIN — build as user, run test binary via sudo"]
+fn structure_only_reads_are_kernel_passthrough() {
+    if !kernel_supports_passthrough() {
+        eprintln!("kernel < 6.9: no FUSE passthrough; skipping");
+        return;
+    }
+    if !have_cap_sys_admin() {
+        eprintln!("no CAP_SYS_ADMIN: backing-open ioctl would EPERM; skipping (run via sudo)");
+        return;
+    }
+    let (backing_bytes, virt, session, _backing, _mnt) = mount_one_track(Mode::StructureOnly);
+
+    // Sequencing matters: FUSE `open` fires here (on_open and warmup counters
+    // land), THEN reset, THEN read — so the pread assertion has a clean
+    // baseline and covers exactly the reads of this fd.
+    let mut f = std::fs::File::open(&virt).expect("open through mount");
+    metrics::reset();
+    let mut served = Vec::new();
+    f.read_to_end(&mut served).expect("read through mount");
+
+    assert_eq!(
+        served, backing_bytes,
+        "StructureOnly must serve backing bytes verbatim"
+    );
+    let snap = metrics::snapshot();
+    assert_eq!(
+        snap.preads, 0,
+        "daemon served {} preads — kernel passthrough did not engage",
+        snap.preads
+    );
+
+    // Close + unmount exercise the BackingId release path (release drops the
+    // map entry; session drop tears down the channel) — must not hang or error.
+    drop(f);
+    drop(session);
+}
+
+#[test]
+#[ignore = "real mount; needs /dev/fuse — run with: cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1"]
+fn synthesis_reads_still_go_through_the_daemon() {
+    let (_backing_bytes, virt, session, _backing, _mnt) = mount_one_track(Mode::Synthesis);
+
+    let mut f = std::fs::File::open(&virt).expect("open through mount");
+    metrics::reset();
+    let mut served = Vec::new();
+    f.read_to_end(&mut served).expect("read through mount");
+
+    // Synthesis splices a fresh header; the read MUST hit the daemon. This
+    // proves the pread counter observable is live, so the passthrough test's
+    // zero-assert cannot pass vacuously.
+    let snap = metrics::snapshot();
+    assert!(
+        snap.preads > 0,
+        "expected daemon preads on a Synthesis mount; the metrics observable is broken"
+    );
+    drop(f);
+    drop(session);
+}

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -77,7 +77,8 @@ fn kernel_supports_passthrough() -> bool {
 }
 
 /// Scan one ~2 MiB FLAC into a fresh on-disk DB and mount it. Returns the
-/// backing bytes, the virtual path, the session, and the two TempDir guards.
+/// backing bytes, the virtual path, the session, the backing TempDir guard,
+/// and the (deliberately leaked, mirrors concurrency.rs) mountpoint path.
 fn mount_one_track(
     mode: Mode,
 ) -> (
@@ -107,6 +108,8 @@ fn mount_one_track(
 
 /// The backing-open ioctl is CAP_SYS_ADMIN-gated; without it passthrough
 /// falls back to daemon reads and the zero-pread assert cannot hold.
+/// Mirrors the daemon's private `cap_eff_has_sys_admin` (src/lib.rs) — keep
+/// the two predicates in sync.
 fn have_cap_sys_admin() -> bool {
     let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
     status
@@ -149,7 +152,8 @@ fn structure_only_reads_are_kernel_passthrough() {
     );
 
     // Close + unmount exercise the BackingId release path (release drops the
-    // map entry; session drop tears down the channel) — must not hang or error.
+    // map entry; session drop tears down the channel) — a regression there
+    // manifests as a hang here.
     drop(f);
     drop(session);
 }


### PR DESCRIPTION
Closes #112.

## Summary
- In `StructureOnly` mode, `open` now registers the validated backing fd with the kernel (fuser 0.17 `open_backing` → `BackingId` → `opened_passthrough`); the kernel serves all subsequent reads and mmap directly from the backing inode — zero daemon round-trips after open. **~3.3× sequential-read throughput** (2.8 → 9.3 GB/s median, recorded in BENCHMARKS.md).
- Strictly best-effort with silent fallback: `init` advertises `FUSE_PASSTHROUGH` + stack depth 2; any `open_backing` failure logs once at info and sticky-disables further attempts; `Synthesis` mode is completely untouched (`passthrough_fd` returns `None`).
- **Kernel gate discovered during implementation:** `FUSE_DEV_IOC_BACKING_OPEN` requires `CAP_SYS_ADMIN` (restriction kept since the 6.9 merge), so passthrough engages only for a privileged daemon (root or `setcap cap_sys_admin=ep`). A mount-time `CapEff` probe pre-disables and logs once for unprivileged StructureOnly mounts, so the operator learns at mount time and no doomed ioctl is paid per open. Spec/plan were amended accordingly.
- Freshness semantics for passthrough handles are plain POSIX fd semantics: full validation at open (`validate_opened_backing`), and a handle held across a backing-file replacement keeps serving the inode it opened; new opens re-resolve. Documented on `Mode::StructureOnly`, in `metrics.rs` (passthrough reads are invisible to serve counters by design), and in CLAUDE.md.
- `BackingId` lifecycle: inserted into an `fh → BackingId` map *before* the open reply (the kernel can't release an fh it hasn't seen, so a live passthrough handle always has an entry), dropped at `release` (fires the backing-close ioctl), `Weak`-guarded at unmount. `FOPEN_KEEP_CACHE` is stripped on passthrough replies — page-cache ownership belongs to the backing inode.

## Test plan
- [x] New core unit test: `passthrough_fd` exposes the backing fd (same dev/ino) only in StructureOnly, `None` after release and in Synthesis
- [x] New CapEff parser unit tests (root/zero/missing/garbage)
- [x] New e2e `musefs-fuse/tests/passthrough.rs` (metrics-gated, `#[ignore]`d): byte-identical content with **zero daemon preads** through a real StructureOnly mount (run via sudo; skips without kernel ≥ 6.9 or CAP_SYS_ADMIN), plus a Synthesis control asserting `preads > 0` so the zero-assert can't pass vacuously — both verified locally under sudo
- [x] Full e2e suite (`--ignored`, 12 tests) passes; workspace `cargo test` 696 passed; clippy + fmt clean
- [x] In-diff mutation gate: 5 mutants — 2 caught, 3 unviable, 0 missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled kernel-level FUSE passthrough for StructureOnly mode on kernel 6.9+, delivering ~3.3× throughput improvement (2.8 GB/s → 9.3 GB/s)
  * Added capability-based security gating with transparent fallback

* **Documentation**
  * Added design specification and implementation plan for passthrough support
  * Published benchmarks documenting performance gains
  * Updated StructureOnly mode semantics documentation

* **Tests**
  * Added integration tests validating passthrough behavior and fallback mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->