### PR TITLE
DbPool: pool-owned connections — drop closes them from any thread

### DIFF
--- a/docs/superpowers/plans/2026-06-07-dbpool-owned-connections.md
+++ b/docs/superpowers/plans/2026-06-07-dbpool-owned-connections.md
@@ -1,0 +1,313 @@
+# DbPool Pool-Owned Connections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `DbPool::drop` close every per-thread SQLite read connection from whatever thread drops the pool, by inverting ownership: the pool owns its connections in a `ThreadId`-keyed map instead of a global `thread_local!`.
+
+**Architecture:** Rewrite the `PerThread` variant of `musefs_core::DbPool` (`musefs-core/src/db_pool.rs`) to hold `conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>`. The manual `Drop` impl, the `thread_local! PER_PATH` map, the `NEXT_POOL_ID` counter, and the `id` field are all deleted — the compiler-generated drop of `conns` closes every connection. Public API (`new`/`with`/`with_poll`) is unchanged; the only consumer is `musefs-core/src/facade.rs` and it needs no edits.
+
+**Tech Stack:** Rust, `parking_lot` (`Mutex`, `ReentrantMutex` — already a dependency), `rusqlite` via `musefs-db`. Tests use `/proc/self/fd` readlink (Linux-only, like the rest of the suite).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md` — read it before starting. Key invariants: the map guard is NEVER held while the caller's closure runs (would reintroduce the nested-`with` deadlock PR #144 fixed); the inner `ReentrantMutex` is uncontended but load-bearing for `Send + Sync` (`Db` is `Send + !Sync`); contention-free per-thread WAL reads and `with_poll`'s `data_version` semantics are unchanged.
+
+**Branch:** `main` is protected. Create a working branch first: `git checkout -b dbpool-owned-connections` (or execute in a worktree per superpowers:using-git-worktrees).
+
+---
+
+### Task 1: Failing tests — pool drop closes connections
+
+The two new tests encode the bug: today, `DbPool::drop` only clears the dropping thread's `thread_local!` entry, so both tests FAIL against the current implementation. They must be written and seen red before the rewrite.
+
+**Files:**
+- Modify: `musefs-core/src/db_pool.rs` (tests module only, currently lines 124–230)
+
+- [ ] **Step 1: Add the fd-counting helper and the two failing tests**
+
+Add inside `mod tests` in `musefs-core/src/db_pool.rs` (after the existing imports `use super::*; use musefs_db::Db;`):
+
+```rust
+    /// Count this process's open fds whose target path starts with `db_path`.
+    /// Prefix match deliberately: a WAL reader holds up to three fds
+    /// (`db`, `db-wal`, `db-shm`).
+    fn db_fd_count(db_path: &std::path::Path) -> usize {
+        let prefix = db_path.to_str().unwrap();
+        std::fs::read_dir("/proc/self/fd")
+            .unwrap()
+            .filter_map(|e| std::fs::read_link(e.unwrap().path()).ok())
+            .filter(|target| target.to_string_lossy().starts_with(prefix))
+            .count()
+    }
+
+    #[test]
+    fn drop_closes_connections_opened_by_live_threads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.db");
+        Db::open(&path).unwrap(); // create + migrate (writer, sets WAL)
+        let baseline = db_fd_count(&path);
+
+        let pool = Arc::new(DbPool::new(Db::open(&path).unwrap()).unwrap());
+        // 2 workers + the main thread; workers park here until main has asserted.
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let pool = Arc::clone(&pool);
+            let barrier = Arc::clone(&barrier);
+            let done = done_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                pool.with(|db| Ok(db.data_version()?)).unwrap();
+                drop(pool); // this thread's Arc clone; main's is then the last
+                done.send(()).unwrap();
+                barrier.wait();
+            }));
+        }
+        // Count exactly two done-signals; don't drain-until-Err — the workers
+        // still hold their sender clones while parked at the barrier.
+        drop(done_tx);
+        for _ in 0..2 {
+            done_rx.recv().unwrap();
+        }
+
+        // Both workers are done using the pool but still alive (parked at, or
+        // headed to, the barrier — they cannot pass it until main waits too).
+        drop(pool);
+        assert_eq!(
+            db_fd_count(&path),
+            baseline,
+            "pool drop must close all threads' connections while those threads are alive"
+        );
+
+        barrier.wait();
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn drop_on_foreign_thread_closes_all_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.db");
+        Db::open(&path).unwrap();
+        let baseline = db_fd_count(&path);
+
+        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
+        pool.with(|db| Ok(db.data_version()?)).unwrap(); // opens this thread's connection
+
+        // DbPool is Send: drop it on a thread that never opened a connection.
+        std::thread::spawn(move || drop(pool)).join().unwrap();
+
+        assert_eq!(
+            db_fd_count(&path),
+            baseline,
+            "drop on a foreign thread must still close every connection"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the new tests and verify they FAIL**
+
+Run: `cargo test -p musefs-core db_pool`
+
+Expected: the two new tests FAIL on their `assert_eq!` (fd count above baseline — the current TLS design leaks the workers'/main's connections), every pre-existing `db_pool` test still PASSES. If a new test passes here, STOP — the test is not observing the leak (most likely the readlink prefix doesn't match; check `db_fd_count` against a hand-opened `Db`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/src/db_pool.rs
+git commit -m "test: pin DbPool drop-closes-connections contract (#127)"
+```
+
+(The pre-commit hook runs fmt/clippy on the diff; failing-but-compiling tests are expected to commit cleanly. If the hook rejects committing red tests for some reason, fold this commit into Task 2's instead — do not skip hooks.)
+
+---
+
+### Task 2: Rewrite DbPool internals — pool-owned connection map
+
+**Files:**
+- Modify: `musefs-core/src/db_pool.rs` (everything above `mod tests`, currently lines 1–122, plus one test literal at ~lines 189–202)
+
+- [ ] **Step 1: Replace the non-test body of the file**
+
+Replace everything above `#[cfg(test)] mod tests` in `musefs-core/src/db_pool.rs` with:
+
+```rust
+//! Hands a read connection to whichever thread needs one.
+//!
+//! - File-backed DB → each thread lazily opens its own read-only connection
+//!   (WAL makes concurrent readers contention-free; the worker pool is bounded,
+//!   so the connection count is bounded).
+//! - In-memory DB (tests) cannot be reopened by path, so a single connection is
+//!   shared behind a mutex.
+//!
+//! The pool owns every connection it opens, keyed by the opening thread, so
+//! dropping the pool closes all of them — from any thread (#127). A thread
+//! that dies while the pool lives leaves its connection in the map until the
+//! pool is dropped; that bound is the pool's lifetime, not the thread's.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread::ThreadId;
+
+use parking_lot::{Mutex, ReentrantMutex};
+
+use musefs_db::{Db, ReadOnly};
+
+use crate::error::{CoreError, Result};
+
+/// `with` and `with_poll` may nest freely, on any variant: per-thread reads
+/// hand out `Arc` clones of this thread's own connection, and every mutex a
+/// caller's closure can re-enter is reentrant.
+///
+/// The `poll`/`conns` asymmetry is deliberate. `poll` is a bare
+/// `ReentrantMutex` because the pool owns it directly and `with_poll` takes
+/// no other lock. `conns` values are `Arc`-wrapped so `with` can clone a
+/// handle and release the map guard *before* running the caller's closure —
+/// holding the (non-reentrant) map guard across it would deadlock nested
+/// `with`. The inner `ReentrantMutex` is never contended (only its owning
+/// thread locks it) but is load-bearing for the type system: `Db` is
+/// `Send + !Sync`, so the mutex wrapper is what keeps the map field, and
+/// therefore `DbPool`, `Send + Sync`.
+pub enum DbPool {
+    PerThread {
+        path: PathBuf,
+        poll: ReentrantMutex<Db<ReadOnly>>,
+        conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>,
+    },
+    Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
+}
+
+impl DbPool {
+    /// Build a pool from the DB used to construct the mount. File-backed DBs
+    /// become per-thread pools (the passed connection becomes the poll
+    /// connection — workers open their own); in-memory DBs are wrapped in a
+    /// shared mutex.
+    pub fn new(db: Db) -> Result<DbPool> {
+        let db = db.into_read_only();
+        match db.path() {
+            Some(p) => Ok(DbPool::PerThread {
+                path: p.to_path_buf(),
+                poll: ReentrantMutex::new(db),
+                conns: Mutex::new(HashMap::new()),
+            }),
+            None => Ok(DbPool::Shared(Arc::new(ReentrantMutex::new(db)))),
+        }
+    }
+
+    /// Run `f` with the persistent poll connection.
+    ///
+    /// For `PerThread` pools, `PRAGMA data_version` is connection-relative: a fresh
+    /// thread-local connection starts at 0, so it can't detect changes that happened
+    /// before it opened. The poll connection is the original writer Db, kept alive
+    /// precisely so it can observe incremental changes from other connections.
+    /// For `Shared` pools (in-memory), the single shared connection serves both roles.
+    pub fn with_poll<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
+        match self {
+            DbPool::PerThread { poll, .. } => f(&poll.lock()),
+            DbPool::Shared(m) => f(&m.lock()),
+        }
+    }
+
+    /// Run `f` with this thread's read connection, opening it on first use.
+    pub fn with<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
+        match self {
+            DbPool::PerThread { path, conns, .. } => {
+                let conn = {
+                    let mut map = conns.lock();
+                    match map.entry(std::thread::current().id()) {
+                        Entry::Occupied(e) => Arc::clone(e.get()),
+                        Entry::Vacant(e) => {
+                            let db =
+                                Db::open_readonly(path).map_err(|source| CoreError::DbOpen {
+                                    path: path.clone(),
+                                    source,
+                                })?;
+                            Arc::clone(e.insert(Arc::new(ReentrantMutex::new(db))))
+                        }
+                    }
+                    // map guard dropped here, before f runs — see the type docs
+                };
+                f(&conn.lock())
+            }
+            DbPool::Shared(m) => f(&m.lock()),
+        }
+    }
+}
+```
+
+Deleted relative to the old file: the `Drop` impl, `NEXT_POOL_ID`, the `id` field, `thread_local! PER_PATH`, the `PerPathMap` alias, the "lifetime contract (#127, accepted by design)" doc block, and the now-unused imports (`std::cell::RefCell`, `std::rc::Rc`, `std::sync::atomic::{AtomicU64, Ordering}`).
+
+- [ ] **Step 2: Adapt the hand-constructed `PerThread` literal in the error test**
+
+In `mod tests`, `with_open_failure_includes_path_in_error` builds the variant directly. Replace:
+
+```rust
+        let pool = DbPool::PerThread {
+            id: u64::MAX,
+            path: bad.clone(),
+            poll: ReentrantMutex::new(Db::open_in_memory().unwrap().into_read_only()),
+        };
+```
+
+with:
+
+```rust
+        let pool = DbPool::PerThread {
+            path: bad.clone(),
+            poll: ReentrantMutex::new(Db::open_in_memory().unwrap().into_read_only()),
+            conns: Mutex::new(HashMap::new()),
+        };
+```
+
+- [ ] **Step 3: Run the db_pool tests — all green, including Task 1's two**
+
+Run: `cargo test -p musefs-core db_pool`
+
+Expected: all tests PASS — the eight pre-existing ones (reentrancy, nesting, two-pools-same-path, poll, error-path) plus `drop_closes_connections_opened_by_live_threads` and `drop_on_foreign_thread_closes_all_connections`.
+
+- [ ] **Step 4: Run the full workspace suite**
+
+Run: `cargo test`
+
+Expected: PASS across all crates (the FUSE e2e tests stay `#[ignore]`d). The only consumer (`facade.rs`) uses `with`/`with_poll` only, so nothing else should need edits — a failure elsewhere means the rewrite changed observable behavior; stop and investigate rather than patching the caller.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/db_pool.rs
+git commit -m "fix: DbPool owns its connections; drop closes them from any thread (#127)"
+```
+
+---
+
+### Task 3: Verification gates (CI parity)
+
+**Files:** none (verification only; fixes, if any, amend nothing — new commits)
+
+- [ ] **Step 1: Format and lint exactly as CI does**
+
+Run: `cargo fmt --all --check && cargo clippy --all-targets`
+
+Expected: both exit 0. If fmt rejects, run `cargo fmt --all`, re-run the check, and commit the formatting as part of a new commit. (clippy `--all-targets` matters: benches and integration-test dirs hold API consumers a plain `cargo build` misses.)
+
+- [ ] **Step 2: In-diff mutation gate**
+
+Run (verbatim from CLAUDE.md — `/tmp` here is RAM-backed tmpfs and some mutants are allocation bombs, hence the cgroup + on-disk TMPDIR; don't pipe through tail/grep):
+
+```bash
+git diff "$(git merge-base main HEAD)...HEAD" -- '*.rs' > mutants.diff
+grep -q '^@@ ' mutants.diff
+mkdir -p ~/.cache/musefs-mutants-tmp
+TMPDIR="$HOME/.cache/musefs-mutants-tmp" systemd-run --user --scope --collect \
+    -p MemoryMax=10G -p MemorySwapMax=0 \
+    cargo mutants --in-diff mutants.diff -j2 --exclude 'musefs-latencyfs/**' --output /tmp/mutants-out/in-diff
+```
+
+Expected: `grep` exits 0 (non-empty diff — an empty diff is a silent false pass), and `cargo mutants` reports 0 missed. Surviving mutants in `with`'s map handling mean a coverage gap — add a targeted test rather than excluding, unless the mutant is genuinely unobservable (then a documented `exclude_re` in `.cargo/mutants.toml`, per the established convention).
+
+- [ ] **Step 3: Confirm the working tree is clean and the branch is pushable**
+
+Run: `git status`
+
+Expected: clean. Hand off per superpowers:finishing-a-development-branch (PR should reference "Closes #127" — the issue is open, reopened 2026-06-07).

--- a/docs/superpowers/plans/2026-06-07-dbpool-owned-connections.md
+++ b/docs/superpowers/plans/2026-06-07-dbpool-owned-connections.md
@@ -110,14 +110,12 @@ Run: `cargo test -p musefs-core db_pool`
 
 Expected: the two new tests FAIL on their `assert_eq!` (fd count above baseline — the current TLS design leaks the workers'/main's connections), every pre-existing `db_pool` test still PASSES. If a new test passes here, STOP — the test is not observing the leak (most likely the readlink prefix doesn't match; check `db_fd_count` against a hand-opened `Db`).
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Do NOT commit yet**
 
-```bash
-git add musefs-core/src/db_pool.rs
-git commit -m "test: pin DbPool drop-closes-connections contract (#127)"
-```
-
-(The pre-commit hook runs fmt/clippy on the diff; failing-but-compiling tests are expected to commit cleanly. If the hook rejects committing red tests for some reason, fold this commit into Task 2's instead — do not skip hooks.)
+The pre-commit hook (`.githooks/pre-commit`) runs `cargo test --workspace`, so
+a commit with deliberately-red tests is guaranteed to be rejected. Never
+bypass it with `--no-verify`. The red state was verified in Step 2; these
+tests are committed together with the implementation in Task 2 Step 5.
 
 ---
 
@@ -272,7 +270,10 @@ Run: `cargo test`
 
 Expected: PASS across all crates (the FUSE e2e tests stay `#[ignore]`d). The only consumer (`facade.rs`) uses `with`/`with_poll` only, so nothing else should need edits — a failure elsewhere means the rewrite changed observable behavior; stop and investigate rather than patching the caller.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Commit (tests from Task 1 + implementation together)**
+
+This is the first commit of the branch — it carries Task 1's tests too, since
+the pre-commit hook's workspace test run forbids committing them red.
 
 ```bash
 git add musefs-core/src/db_pool.rs

--- a/docs/superpowers/plans/2026-06-07-dbpool-owned-connections.md
+++ b/docs/superpowers/plans/2026-06-07-dbpool-owned-connections.md
@@ -158,9 +158,9 @@ use crate::error::{CoreError, Result};
 /// hand out `Arc` clones of this thread's own connection, and every mutex a
 /// caller's closure can re-enter is reentrant.
 ///
-/// The `poll`/`conns` asymmetry is deliberate. `poll` is a bare
-/// `ReentrantMutex` because the pool owns it directly and `with_poll` takes
-/// no other lock. `conns` values are `Arc`-wrapped so `with` can clone a
+/// The `poll`/`conns` asymmetry is deliberate. `poll` is uniquely owned (the
+/// `Box` only keeps the variant small) because `with_poll` locks it in place
+/// and takes no other lock. `conns` values are `Arc`-wrapped so `with` can clone a
 /// handle and release the map guard *before* running the caller's closure —
 /// holding the (non-reentrant) map guard across it would deadlock nested
 /// `with`. The inner `ReentrantMutex` is never contended (only its owning
@@ -170,7 +170,7 @@ use crate::error::{CoreError, Result};
 pub enum DbPool {
     PerThread {
         path: PathBuf,
-        poll: ReentrantMutex<Db<ReadOnly>>,
+        poll: Box<ReentrantMutex<Db<ReadOnly>>>,
         conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>,
     },
     Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
@@ -186,7 +186,7 @@ impl DbPool {
         match db.path() {
             Some(p) => Ok(DbPool::PerThread {
                 path: p.to_path_buf(),
-                poll: ReentrantMutex::new(db),
+                poll: Box::new(ReentrantMutex::new(db)),
                 conns: Mutex::new(HashMap::new()),
             }),
             None => Ok(DbPool::Shared(Arc::new(ReentrantMutex::new(db)))),
@@ -253,7 +253,9 @@ with:
 ```rust
         let pool = DbPool::PerThread {
             path: bad.clone(),
-            poll: ReentrantMutex::new(Db::open_in_memory().unwrap().into_read_only()),
+            poll: Box::new(ReentrantMutex::new(
+                Db::open_in_memory().unwrap().into_read_only(),
+            )),
             conns: Mutex::new(HashMap::new()),
         };
 ```

--- a/docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md
+++ b/docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md
@@ -1,0 +1,128 @@
+# DbPool: pool-owned connections (reopened #127)
+
+**Date:** 2026-06-07
+**Issue:** #127 (reopened) — `DbPool::drop` leaves other threads' connections;
+the TLS-based design is unreachable from the type that owns the lifetime
+**Status:** Approved
+
+## Problem
+
+PR #144 fixed the nested-`with` deadlock half of #127 and accepted the `Drop`
+half by design: `DbPool::drop` clears only the dropping thread's entry in the
+global `thread_local! PER_PATH` map, so connections opened by other threads
+(one fd + SQLite page cache each) persist until those threads exit. The
+documented rationale was that cross-thread cleanup is unreachable because
+`Rc<Db>` is `!Send`.
+
+That acceptance is reversed. The unreachability is self-imposed by the `Rc`
+choice, and the hole is wider than the original issue stated: `DbPool` is
+`Send + Sync` — it must be, because `Arc<Musefs>` is moved into
+`threadpool::ThreadPool::execute` closures throughout the FUSE adapter
+(`musefs-fuse/src/lib.rs`) — so a pool can be dropped on a thread that never
+opened a connection, in which case the `Drop` impl removes nothing at all.
+Connection lifetime is owned by thread-local storage; the type that is
+supposed to govern that lifetime cannot reach it. The "lifetime contract"
+doc block patches a type-system hole with prose.
+
+For the current `musefs` binary the leak is bounded (a mount's worker pool
+lives exactly as long as the mount), but `musefs-core` is a library: an
+embedder that creates and drops pools on long-lived shared threads strands a
+connection per pool per thread, unboundedly.
+
+### Alternatives rejected
+
+- **Make `DbPool` `!Send`** (reviewer suggestion): fails to compile the
+  serving architecture (`Arc<Musefs>` requires `Musefs: Send + Sync`), and
+  even where viable it only prevents the cross-thread-drop variant — drop on
+  the origin thread still strands every other thread's connection.
+- **Global `DashMap<(ThreadId, PathBuf), Weak>` registry** (reviewer
+  suggestion): with `Weak` entries the strong refs still live in TLS and
+  remain unreachable, so it doesn't close the hole; with strong entries it
+  converges to the chosen design but with global state, composite keys
+  (`PathBuf` alone breaks two-pools-same-path), a `Drop` that must scan the
+  registry, and a new dependency to optimize a lock that has no contention.
+- **No caching, open per `with` call**: a SQLite open per FUSE operation is
+  what the pool exists to avoid.
+
+## Design
+
+Invert ownership: the pool owns its connections; threads have affinity to
+one. The global TLS map is deleted.
+
+```rust
+pub enum DbPool {
+    PerThread {
+        path: PathBuf,
+        poll: ReentrantMutex<Db<ReadOnly>>,
+        conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>,
+    },
+    Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
+}
+```
+
+Deleted outright: the manual `Drop` impl, `NEXT_POOL_ID`, the `id` field, the
+`thread_local! PER_PATH` map, the `PerPathMap` alias, and the
+"lifetime contract (#127, accepted by design)" doc block. The
+compiler-generated drop of `conns` closes every connection, from whatever
+thread drops the pool — `Arc<ReentrantMutex<Db>>` is `Send`, so this is sound
+by construction. Two-pools-same-path keying falls out for free: each pool has
+its own map, so no composite key is needed.
+
+The inner `ReentrantMutex` is never contended — only its owning thread ever
+locks it — but it is load-bearing for the type system: `Arc<Db>` is not
+`Send` (`Db` is not `Sync`), so the mutex wrapper is what keeps the map
+field, and therefore `DbPool`, `Send + Sync`. It is reentrant (not a plain
+`Mutex`) so nested `with` on the same thread keeps working. This earns a
+comment in the code.
+
+### `with` flow
+
+1. Lock `conns`; `entry(thread::current().id())` — on vacancy,
+   `Db::open_readonly(path)` and insert (open failure maps to
+   `CoreError::DbOpen` carrying the path, unchanged).
+2. Clone the `Arc`; **drop the map guard**.
+3. Lock the connection's `ReentrantMutex`; run `f`.
+
+The map lock is never held while `f` runs, so nesting cannot deadlock on it;
+lock order is strictly map→conn, and conn locks are single-thread by
+construction, so no cross-order deadlock exists. The one-time open happens
+under the map lock — that briefly blocks other threads' first access, once
+per thread per pool; not worth a double-checked dance.
+
+`with_poll`, the `Shared` variant, and `data_version` semantics are
+untouched. Warm per-thread page caches and contention-free WAL reads (#94)
+are preserved. Per-call cost drops slightly: one `ThreadId` hash under an
+uncontended `parking_lot::Mutex` replaces a `PathBuf` clone plus two
+`(PathBuf, u64)` hashes in TLS.
+
+### Inverted residual (documented, no machinery)
+
+The leak bound flips: a thread that dies while the pool lives leaves its
+connection in the map until pool drop, instead of a dropped pool leaking
+until threads die. This is the strictly better bound — FUSE workers live
+exactly as long as the mount, and an embedder's pool drop now reclaims
+everything. One sentence in the module doc.
+
+## Tests
+
+- Existing tests adapt mechanically: the `PerThread` literal in
+  `with_open_failure_includes_path_in_error` loses `id`, gains an empty
+  `conns`.
+- **New: drop closes other threads' connections.** Worker threads each run
+  `with`, then park on a barrier — still alive — when the pool is dropped;
+  assert the process's open-fd count for the DB path (readlink over
+  `/proc/self/fd`, Linux-only like the rest of the suite) returns to
+  baseline. (Note: `std::thread::scope` can't express this — scoped closures
+  borrow the pool for the whole scope — so plain threads with a done-signal
+  before the drop, joined at the end.)
+- **New: cross-thread drop.** Create and use the pool on one thread, move it
+  into another thread and drop it there; assert all DB fds are closed. This
+  pins the `Send` hole as a regression test.
+- Existing reentrancy tests (`reentrant_with_does_not_panic`,
+  `nested_with_poll_on_per_thread_pool`, and the `Shared`-variant nesting
+  tests) continue to cover nesting.
+
+## Verification
+
+Workspace tests, `cargo clippy --all-targets`, `cargo fmt --all --check`,
+and the in-diff mutation gate (CI parity invocation per CLAUDE.md).

--- a/docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md
+++ b/docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md
@@ -53,7 +53,7 @@ one. The global TLS map is deleted.
 pub enum DbPool {
     PerThread {
         path: PathBuf,
-        poll: ReentrantMutex<Db<ReadOnly>>,
+        poll: Box<ReentrantMutex<Db<ReadOnly>>>,
         conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>,
     },
     Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
@@ -76,10 +76,11 @@ field, and therefore `DbPool`, `Send + Sync`. It is reentrant (not a plain
 comment in the code.
 
 The `poll`/`conns` asymmetry is deliberate and also earns a comment: `poll`
-stays a bare `ReentrantMutex` field because the pool owns it directly and
-`with_poll` takes no other lock, while `conns` values are `Arc`-wrapped
-precisely so `with` can clone a handle and **release the map guard before
-running `f`**. "Tidying" the asymmetry away — holding the map guard across
+stays a uniquely owned `Box<ReentrantMutex>` field (boxed only to keep the
+variant small for `clippy::large_enum_variant`) because the pool owns it
+directly and `with_poll` takes no other lock, while `conns` values are
+`Arc`-wrapped precisely so `with` can clone a handle and **release the map
+guard before running `f`**. "Tidying" the asymmetry away — holding the map guard across
 `f` instead — would reintroduce the nested-`with` deadlock PR #144 fixed
 (the map `Mutex` is not reentrant).
 

--- a/docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md
+++ b/docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md
@@ -75,6 +75,14 @@ field, and therefore `DbPool`, `Send + Sync`. It is reentrant (not a plain
 `Mutex`) so nested `with` on the same thread keeps working. This earns a
 comment in the code.
 
+The `poll`/`conns` asymmetry is deliberate and also earns a comment: `poll`
+stays a bare `ReentrantMutex` field because the pool owns it directly and
+`with_poll` takes no other lock, while `conns` values are `Arc`-wrapped
+precisely so `with` can clone a handle and **release the map guard before
+running `f`**. "Tidying" the asymmetry away — holding the map guard across
+`f` instead — would reintroduce the nested-`with` deadlock PR #144 fixed
+(the map `Mutex` is not reentrant).
+
 ### `with` flow
 
 1. Lock `conns`; `entry(thread::current().id())` — on vacancy,
@@ -85,9 +93,14 @@ comment in the code.
 
 The map lock is never held while `f` runs, so nesting cannot deadlock on it;
 lock order is strictly map→conn, and conn locks are single-thread by
-construction, so no cross-order deadlock exists. The one-time open happens
-under the map lock — that briefly blocks other threads' first access, once
-per thread per pool; not worth a double-checked dance.
+construction, so no cross-order deadlock exists. The `poll` lock participates
+safely too (`with_poll` inside `with` and vice versa): `poll` is never
+acquired while the map lock is held, the map lock is never held while
+acquiring any other lock, and conn locks are only ever taken by their owning
+thread — so any wait chain through `poll` terminates; no cycle is possible.
+The one-time open happens under the map lock — that briefly blocks other
+threads' first access, once per thread per pool; not worth a double-checked
+dance.
 
 `with_poll`, the `Shared` variant, and `data_version` semantics are
 untouched. Warm per-thread page caches and contention-free WAL reads (#94)
@@ -109,12 +122,16 @@ everything. One sentence in the module doc.
   `with_open_failure_includes_path_in_error` loses `id`, gains an empty
   `conns`.
 - **New: drop closes other threads' connections.** Worker threads each run
-  `with`, then park on a barrier — still alive — when the pool is dropped;
-  assert the process's open-fd count for the DB path (readlink over
-  `/proc/self/fd`, Linux-only like the rest of the suite) returns to
-  baseline. (Note: `std::thread::scope` can't express this — scoped closures
-  borrow the pool for the whole scope — so plain threads with a done-signal
-  before the drop, joined at the end.)
+  `with`, then park on a barrier — still alive — when the pool is dropped.
+  Fd accounting: readlink every entry of `/proc/self/fd` and **prefix-match**
+  against the DB path, since a WAL reader holds up to three fds (`db`,
+  `db-wal`, `db-shm`); baseline is the count taken **before the pool is
+  created**, and the assertion (count back to baseline) runs **while the
+  workers are still parked** — only then is the barrier released and the
+  threads joined, so thread exit can't be what closed the fds. (Note:
+  `std::thread::scope` can't express this — scoped closures borrow the pool
+  for the whole scope — so plain threads with a done-signal before the drop,
+  joined at the end.)
 - **New: cross-thread drop.** Create and use the pool on one thread, move it
   into another thread and drop it there; assert all DB fds are closed. This
   pins the `Send` hole as a regression test.

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -47,8 +47,9 @@ pub enum DbPool {
 
 impl DbPool {
     /// Build a pool from the DB used to construct the mount. File-backed DBs
-    /// become per-thread pools (the passed connection is dropped — workers open
-    /// their own); in-memory DBs are wrapped in a shared mutex.
+    /// become per-thread pools (the passed connection becomes the poll
+    /// connection — workers open their own); in-memory DBs are wrapped in a
+    /// shared mutex.
     pub fn new(db: Db) -> Result<DbPool> {
         let db = db.into_read_only();
         match db.path() {

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -1,67 +1,48 @@
 //! Hands a read connection to whichever thread needs one.
 //!
-//! - File-backed DB → each thread lazily opens its own read-only connection
-//!   (WAL makes concurrent readers contention-free; the worker pool is bounded,
-//!   so the connection count is bounded).
+//! - File-backed DB → the pool owns one read-only connection per thread in an
+//!   internal map. Each thread lazily opens its own connection, and dropping
+//!   the pool drops the map and closes every connection it owns.
 //! - In-memory DB (tests) cannot be reopened by path, so a single connection is
 //!   shared behind a mutex.
 //!
-//! Each thread opens a read connection per unique database path, so
-//! multiple mounts (or test DBs) on the same thread don't collide.
+//! Dropping the pool closes every connection it owns, from whatever thread
+//! drops it (#127). A thread that dies while the pool lives leaves its
+//! connection in the map until the pool is dropped; that bound is the pool's
+//! lifetime, not the thread's. Each pool has its own map, so multiple mounts
+//! (or test DBs) on the same thread don't collide.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::path::PathBuf;
-use std::rc::Rc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::thread::ThreadId;
 
-use parking_lot::ReentrantMutex;
+use parking_lot::{Mutex, ReentrantMutex};
 
 use musefs_db::{Db, ReadOnly};
 
 use crate::error::{CoreError, Result};
 
-static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
-
 /// `with` and `with_poll` may nest freely, on any variant: `PerThread` reads
-/// hand out thread-local `Rc` clones, and both mutexes are reentrant.
+/// hand out cloned `Arc`s from the pool-owned map, and the connection locks
+/// are reentrant.
 ///
-/// Lifetime contract (#127, accepted by design): `PerThread` read connections
-/// are owned by the threads that opened them and live until those threads
-/// exit. Dropping the pool clears only the dropping thread's connection, so a
-/// caller that creates and drops many pools on long-lived shared threads
-/// strands connections (one fd + SQLite cache each) until those threads exit.
-/// Fine for musefs — a mount's worker pool lives exactly as long as the mount;
-/// closing the gap would need a cross-thread registry, deliberately not built
-/// (`Rc<Db>` is `!Send`, so another thread's entry is unreachable anyway).
+/// The `poll`/`conns` asymmetry is deliberate. `poll` is uniquely owned (the
+/// `Box` only keeps the variant small) because `with_poll` locks it in place
+/// and takes no other lock. `conns` values are `Arc`-wrapped so `with` can
+/// clone a handle and release the map guard *before* running the caller's
+/// closure — holding the (non-reentrant) map guard across it would deadlock
+/// nested `with`. The inner `ReentrantMutex` is never contended (only its
+/// owning thread locks it) but is load-bearing for the type system: `Db` is
+/// `Send + !Sync`, so the mutex wrapper is what keeps the map field, and
+/// therefore `DbPool`, `Send + Sync`.
 pub enum DbPool {
     PerThread {
-        id: u64,
         path: PathBuf,
-        poll: ReentrantMutex<Db<ReadOnly>>,
+        poll: Box<ReentrantMutex<Db<ReadOnly>>>,
+        conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>,
     },
     Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
-}
-
-/// Clears only the *dropping thread's* thread-local connection for this pool —
-/// see the lifetime contract on [`DbPool`].
-impl Drop for DbPool {
-    fn drop(&mut self) {
-        if let DbPool::PerThread { id, path, .. } = self {
-            let id = *id;
-            let path = path.clone();
-            PER_PATH.with(|cell| {
-                cell.borrow_mut().remove(&(path, id));
-            });
-        }
-    }
-}
-
-type PerPathMap = HashMap<(PathBuf, u64), Rc<Db<ReadOnly>>>;
-
-thread_local! {
-    static PER_PATH: RefCell<PerPathMap> = RefCell::new(HashMap::new());
 }
 
 impl DbPool {
@@ -72,9 +53,9 @@ impl DbPool {
         let db = db.into_read_only();
         match db.path() {
             Some(p) => Ok(DbPool::PerThread {
-                id: NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed),
                 path: p.to_path_buf(),
-                poll: ReentrantMutex::new(db),
+                poll: Box::new(ReentrantMutex::new(db)),
+                conns: Mutex::new(HashMap::new()),
             }),
             None => Ok(DbPool::Shared(Arc::new(ReentrantMutex::new(db)))),
         }
@@ -97,22 +78,25 @@ impl DbPool {
     /// Run `f` with a read connection.
     pub fn with<R>(&self, f: impl FnOnce(&Db<ReadOnly>) -> Result<R>) -> Result<R> {
         match self {
-            DbPool::PerThread { id, path, .. } => PER_PATH.with(|cell| {
+            DbPool::PerThread { path, conns, .. } => {
+                let tid = std::thread::current().id();
                 let db = {
-                    let mut map = cell.borrow_mut();
-                    if let std::collections::hash_map::Entry::Vacant(e) =
-                        map.entry((path.clone(), *id))
-                    {
-                        let db = Db::open_readonly(path).map_err(|source| CoreError::DbOpen {
-                            path: path.clone(),
-                            source,
-                        })?;
-                        e.insert(Rc::new(db));
+                    let mut map = conns.lock();
+                    match map.entry(tid) {
+                        Entry::Occupied(entry) => Arc::clone(entry.get()),
+                        Entry::Vacant(entry) => {
+                            let db =
+                                Db::open_readonly(path).map_err(|source| CoreError::DbOpen {
+                                    path: path.clone(),
+                                    source,
+                                })?;
+                            Arc::clone(entry.insert(Arc::new(ReentrantMutex::new(db))))
+                        }
                     }
-                    Rc::clone(map.get(&(path.clone(), *id)).unwrap())
                 };
-                f(&db)
-            }),
+                let guard = db.lock();
+                f(&guard)
+            }
             DbPool::Shared(m) => {
                 let db = m.lock();
                 f(&db)
@@ -125,6 +109,83 @@ impl DbPool {
 mod tests {
     use super::*;
     use musefs_db::Db;
+
+    /// Count this process's open fds whose target path starts with `db_path`.
+    /// Prefix match deliberately: a WAL reader holds up to three fds
+    /// (`db`, `db-wal`, `db-shm`).
+    fn db_fd_count(db_path: &std::path::Path) -> usize {
+        let prefix = db_path.to_str().unwrap();
+        std::fs::read_dir("/proc/self/fd")
+            .unwrap()
+            .filter_map(|e| std::fs::read_link(e.unwrap().path()).ok())
+            .filter(|target| target.to_string_lossy().starts_with(prefix))
+            .count()
+    }
+
+    #[test]
+    fn drop_closes_connections_opened_by_live_threads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("d.db");
+        Db::open(&path).unwrap(); // create + migrate (writer, sets WAL)
+        let baseline = db_fd_count(&path);
+
+        let pool = Arc::new(DbPool::new(Db::open(&path).unwrap()).unwrap());
+        // 2 workers + the main thread; workers park here until main has asserted.
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let pool = Arc::clone(&pool);
+            let barrier = Arc::clone(&barrier);
+            let done = done_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                pool.with(|db| Ok(db.data_version()?)).unwrap();
+                drop(pool); // this thread's Arc clone; main's is then the last
+                done.send(()).unwrap();
+                barrier.wait();
+            }));
+        }
+        // Count exactly two done-signals; don't drain-until-Err — the workers
+        // still hold their sender clones while parked at the barrier.
+        drop(done_tx);
+        for _ in 0..2 {
+            done_rx.recv().unwrap();
+        }
+
+        // Both workers are done using the pool but still alive (parked at, or
+        // headed to, the barrier — they cannot pass it until main waits too).
+        drop(pool);
+        assert_eq!(
+            db_fd_count(&path),
+            baseline,
+            "pool drop must close all threads' connections while those threads are alive"
+        );
+
+        barrier.wait();
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn drop_on_foreign_thread_closes_all_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.db");
+        Db::open(&path).unwrap();
+        let baseline = db_fd_count(&path);
+
+        let pool = DbPool::new(Db::open(&path).unwrap()).unwrap();
+        pool.with(|db| Ok(db.data_version()?)).unwrap(); // opens this thread's connection
+
+        // DbPool is Send: drop it on a thread that never opened a connection.
+        std::thread::spawn(move || drop(pool)).join().unwrap();
+
+        assert_eq!(
+            db_fd_count(&path),
+            baseline,
+            "drop on a foreign thread must still close every connection"
+        );
+    }
 
     #[test]
     fn shared_pool_for_in_memory_db() {
@@ -190,9 +251,11 @@ mod tests {
     fn with_open_failure_includes_path_in_error() {
         let bad = std::path::PathBuf::from("/nonexistent-musefs-dir/does-not-exist.db");
         let pool = DbPool::PerThread {
-            id: u64::MAX,
             path: bad.clone(),
-            poll: ReentrantMutex::new(Db::open_in_memory().unwrap().into_read_only()),
+            poll: Box::new(ReentrantMutex::new(
+                Db::open_in_memory().unwrap().into_read_only(),
+            )),
+            conns: Mutex::new(HashMap::new()),
         };
         let msg = pool.with(|_db| Ok(())).unwrap_err().to_string();
         assert!(


### PR DESCRIPTION
Closes #127 (reopened).

#144 accepted the `Drop` half of #127 by design; this reverses that. `DbPool` is necessarily `Send + Sync` (`Arc<Musefs>` moves into worker-pool closures), so a pool dropped on a foreign thread cleaned up nothing at all, and even an origin-thread drop stranded every other thread's connection in the global `thread_local!` map — connection lifetime was owned by TLS that the owning type couldn't reach.

Ownership is inverted: `PerThread` now holds
`conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>`. The manual
`Drop` impl, the pool-id counter, and the TLS map are deleted — the
compiler-generated drop closes every connection from whatever thread drops the
pool. `with` clones this thread's `Arc` and releases the map guard before
running the closure, so nesting stays deadlock-free (lock order map→conn; the
inner reentrant mutex is uncontended but keeps the map field `Send + Sync`,
since `Db` is `Send + !Sync`). `poll` is boxed (`large_enum_variant`) and
uniquely owned, so nothing can keep it alive past the pool. The residual
inverts: a thread that dies while the pool lives parks its connection until
pool drop — bounded by the pool's lifetime instead of the thread's.

New tests pin the contract by counting `/proc/self/fd` entries (prefix-matched
for WAL sidecars): pool drop closes connections opened by still-live threads,
and a foreign-thread drop closes everything.

Verification: workspace tests (698 passed), clippy `--all-targets`, fmt, and
the in-diff mutation gate (1 mutant, unviable — a generic return can't be
defaulted; 0 missed).

Spec: docs/superpowers/specs/2026-06-07-dbpool-owned-connections-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized pool-owned connection tracking so the pool now closes connections it owns instead of relying on per-thread teardown; public APIs remain unchanged.

* **Documentation**
  * Added an implementation plan and detailed design spec describing the new pool-owned connection model and lifecycle.

* **Tests**
  * Added regression tests to verify connections are closed reliably when a pool is dropped (including cross-thread scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->