### PR TITLE
Case-insensitive filename support (Plan B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ All tuning flags have sensible defaults; adjust them to your backing store:
 | `--max-readahead-kib` | `512` | Kernel read-ahead window. Larger hides HDD/NFS latency during sequential playback (clamped to the kernel maximum). |
 | `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. |
 | `--keep-cache` | disabled | Keep the kernel page cache across opens. External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
+| `--case-insensitive <true|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files are disambiguated with a ` (2)` suffix. Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
 
 ## Supported formats
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All tuning flags have sensible defaults; adjust them to your backing store:
 | `--max-readahead-kib` | `512` | Kernel read-ahead window. Larger hides HDD/NFS latency during sequential playback (clamped to the kernel maximum). |
 | `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. |
 | `--keep-cache` | disabled | Keep the kernel page cache across opens. External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
-| `--case-insensitive <true|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files are disambiguated with a ` (2)` suffix. Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
+| `--case-insensitive <true\|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files get a numeric suffix (e.g. `Song (2)`). Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
 
 ## Supported formats
 

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -74,6 +74,12 @@ pub struct MountArgs {
     /// changes.
     #[arg(long)]
     pub keep_cache: bool,
+    /// Compare filenames case-insensitively: case-variant directories merge and
+    /// case-variant files are disambiguated. Defaults to true on macOS (whose
+    /// volumes are usually case-insensitive), false on Linux/FreeBSD. Override
+    /// with `--case-insensitive false` (e.g. a case-sensitive APFS volume).
+    #[arg(long, default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set)]
+    pub case_insensitive: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -147,6 +153,7 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         default_fallback: args.default_fallback.clone(),
         mode: args.mode.into(),
         poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
+        case_insensitive: args.case_insensitive,
     };
     let fuse_config = musefs_fuse::FuseConfig {
         ttl: std::time::Duration::from_millis(args.attr_ttl_ms),
@@ -248,11 +255,44 @@ mod tests {
         assert_eq!(config.default_fallback, "Unknown");
         assert_eq!(config.mode, musefs_core::Mode::Synthesis);
         assert!(!fuse_config.keep_cache);
+        assert_eq!(config.case_insensitive, cfg!(target_os = "macos"));
         // ms → Duration.
         assert_eq!(config.poll_interval, std::time::Duration::from_millis(250));
         assert_eq!(fuse_config.ttl, std::time::Duration::from_millis(750));
         // KiB → bytes.
         assert_eq!(fuse_config.max_readahead, 64 * 1024);
         assert_eq!(fuse_config.max_background, 32);
+    }
+
+    #[test]
+    fn case_insensitive_defaults_to_os() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "mount", "/mnt", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (config, _) = parse_mount_config(&args);
+        assert_eq!(config.case_insensitive, cfg!(target_os = "macos"));
+    }
+
+    #[test]
+    fn case_insensitive_is_overridable() {
+        use clap::Parser;
+        for (val, want) in [("true", true), ("false", false)] {
+            let cli = Cli::try_parse_from([
+                "musefs",
+                "mount",
+                "/mnt",
+                "--db",
+                "/tmp/x.db",
+                "--case-insensitive",
+                val,
+            ])
+            .unwrap();
+            let Command::Mount(args) = cli.command else {
+                panic!("expected Mount");
+            };
+            assert_eq!(args.case_insensitive, want);
+        }
     }
 }

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -129,6 +129,7 @@ fn parse_mount_config_defaults_are_sensible() {
         max_readahead_kib: 512,
         max_background: 64,
         keep_cache: false,
+        case_insensitive: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
@@ -155,6 +156,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         max_readahead_kib: 256,
         max_background: 32,
         keep_cache: true,
+        case_insensitive: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
@@ -177,6 +179,7 @@ fn parse_mount_config_saturating_readahead() {
         max_readahead_kib: u32::MAX,
         max_background: 64,
         keep_cache: false,
+        case_insensitive: false,
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -16,6 +16,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -40,6 +40,9 @@ pub struct MountConfig {
     /// Minimum time between `data_version` polls; a metadata-op storm within this
     /// window skips the poll entirely. `Duration::ZERO` disables debouncing.
     pub poll_interval: std::time::Duration,
+    /// Compare filenames case-insensitively (dirs merge, files disambiguate).
+    /// Set by the CLI (`--case-insensitive`), default true on macOS.
+    pub case_insensitive: bool,
 }
 
 /// Attributes the FUSE layer maps onto `fuser::FileAttr`.
@@ -321,7 +324,10 @@ impl Musefs {
         alloc: &mut InodeAllocator,
     ) -> Result<(VirtualTree, HashMap<i64, TrackRenderState>)> {
         let (entries, snapshot) = Self::render_entries(db, template, config)?;
-        Ok((VirtualTree::build_with(&entries, alloc), snapshot))
+        Ok((
+            VirtualTree::build_with_ci(&entries, alloc, config.case_insensitive),
+            snapshot,
+        ))
     }
 
     /// Rebuild the tree from the current DB contents (used after external edits).
@@ -356,7 +362,7 @@ impl Musefs {
             .pool
             .with(|db| Self::render_entries(db, &self.template, &self.config))?;
         let mut alloc = crate::lock::lock_or_flag(&self.inodes, &self.needs_rebuild, "inodes");
-        let tree = VirtualTree::build_with(&entries, &mut alloc);
+        let tree = VirtualTree::build_with_ci(&entries, &mut alloc, self.config.case_insensitive);
         alloc.prune_retired(&tree);
         drop(alloc);
         self.tree.store(Arc::new(tree));
@@ -409,6 +415,14 @@ impl Musefs {
             return Err(CoreError::BackingChanged(
                 "forced refresh failure".to_string(),
             ));
+        }
+        // Case-insensitive trees use full rebuilds: the incremental path
+        // navigates by exact rendered name, which a folded (merged) tree can
+        // mismatch. `Ok(None)` routes the caller to `rebuild_full`, which builds a
+        // correct folded tree via `build_with_ci`. (The O(changed) optimization
+        // stays case-sensitive-only.)
+        if self.config.case_insensitive {
+            return Ok(None);
         }
         let last_seq = self.last_seq.load(Ordering::Acquire);
 
@@ -504,7 +518,11 @@ impl Musefs {
                     let mut entries: Vec<(i64, String)> =
                         snap.iter().map(|(&id, s)| (id, s.path.clone())).collect();
                     entries.sort_by_key(|(id, _)| *id);
-                    let reference = VirtualTree::build_with(&entries, &mut ref_alloc);
+                    let reference = VirtualTree::build_with_ci(
+                        &entries,
+                        &mut ref_alloc,
+                        self.config.case_insensitive,
+                    );
                     debug_assert!(
                         tree.equiv(&reference),
                         "incremental tree diverged from build_with"
@@ -519,7 +537,7 @@ impl Musefs {
                 let mut entries: Vec<(i64, String)> =
                     snap.iter().map(|(&id, s)| (id, s.path.clone())).collect();
                 entries.sort_by_key(|(id, _)| *id);
-                VirtualTree::build_with(&entries, &mut alloc)
+                VirtualTree::build_with_ci(&entries, &mut alloc, self.config.case_insensitive)
             }
         };
         alloc.prune_retired(&tree);
@@ -1156,6 +1174,7 @@ mod tests {
             default_fallback: "Unknown".to_string(),
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1247,6 +1266,7 @@ mod tests {
             default_fallback: "Unknown".to_string(),
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1337,6 +1357,7 @@ mod tests {
             default_fallback: "Unknown".to_string(),
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
         };
 
         let (entries, snapshot) =
@@ -1375,6 +1396,7 @@ mod tests {
             default_fallback: "Unknown".to_string(),
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1421,6 +1443,7 @@ mod tests {
             default_fallback: "Unknown".to_string(),
             mode: Mode::Synthesis,
             poll_interval: interval,
+            case_insensitive: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
         (dir, fs)
@@ -1487,6 +1510,7 @@ mod tests {
             default_fallback: "Unknown".to_string(),
             mode,
             poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
         };
 
         // StructureOnly: exposed, and the fd refers to the backing inode.

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -416,14 +416,6 @@ impl Musefs {
                 "forced refresh failure".to_string(),
             ));
         }
-        // Case-insensitive trees use full rebuilds: the incremental path
-        // navigates by exact rendered name, which a folded (merged) tree can
-        // mismatch. `Ok(None)` routes the caller to `rebuild_full`, which builds a
-        // correct folded tree via `build_with_ci`. (The O(changed) optimization
-        // stays case-sensitive-only.)
-        if self.config.case_insensitive {
-            return Ok(None);
-        }
         let last_seq = self.last_seq.load(Ordering::Acquire);
 
         // Phase 1 (DB, no VFS locks): changelog + live render keys.
@@ -654,6 +646,16 @@ impl Musefs {
         }
         // The guard clears `refreshing` on every exit path (incl. panic).
         let _guard = RefreshGuard(&self.refreshing);
+
+        // A folded tree can't use the incremental path (it navigates by exact
+        // rendered name, which a merged/folded tree mismatches), so always
+        // full-rebuild. This is intentional — NOT a changelog gap — so route
+        // through force_full_rebuild to keep the gap counter and the "changelog
+        // gap" diagnostics meaningful (the O(changed) fast path stays
+        // case-sensitive-only).
+        if self.config.case_insensitive {
+            return self.force_full_rebuild(&mut on_changed);
+        }
 
         let old_tree = self.tree.load_full();
         match self.rebuild_incremental() {

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1,5 +1,12 @@
 use im::{HashMap as ImHashMap, OrdMap};
 
+/// Case-fold a name for case-insensitive comparison. Unicode-aware lowercasing;
+/// ASCII is the floor. Applied identically to every comparison (collision,
+/// disambiguation, lookup) - never compare a folded value against an unfolded one.
+fn fold(name: &str) -> String {
+    name.to_lowercase()
+}
+
 /// Why an incremental tree mutation could not complete; the caller falls back to
 /// a full rebuild. Carries diagnostics instead of `()` (#95).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,7 +86,16 @@ pub struct VirtualTree {
     nodes: ImHashMap<u64, Node>,
     children: ImHashMap<u64, OrdMap<String, u64>>,
     rendered_children: ImHashMap<u64, OrdMap<String, OrdMap<String, u64>>>,
+    /// `parent -> fold(name) -> inode`, populated ONLY when `case_insensitive`.
+    /// Build-only (folding always full-rebuilds, so a published tree is never
+    /// mutated). Gives O(1) folded lookup and collision checks. Part of structural
+    /// equality; built deterministically, so fresh and re-rendered folded trees
+    /// compare equal.
+    folded_children: ImHashMap<u64, ImHashMap<String, u64>>,
     track_to_inode: ImHashMap<i64, u64>,
+    /// When true, names are compared case-insensitively (dirs merge, files
+    /// disambiguate). Defaults to false (exact matching, identical to Linux).
+    case_insensitive: bool,
 }
 
 impl VirtualTree {
@@ -89,14 +105,27 @@ impl VirtualTree {
         VirtualTree::build_with(entries, &mut InodeAllocator::new())
     }
 
-    /// Build the tree assigning inodes via `alloc` (keyed by rendered path), so
-    /// inodes are stable across rebuilds that reuse the same allocator.
+    /// Case-sensitive build (the default everywhere except a folded mount).
+    /// Inodes are assigned via `alloc` (keyed by rendered path), stable across
+    /// rebuilds that reuse the same allocator.
     pub fn build_with(entries: &[(i64, String)], alloc: &mut InodeAllocator) -> VirtualTree {
+        VirtualTree::build_with_ci(entries, alloc, false)
+    }
+
+    /// Build with explicit case-folding. With `case_insensitive`, names fold:
+    /// case-variant directories merge, case-variant files disambiguate.
+    pub fn build_with_ci(
+        entries: &[(i64, String)],
+        alloc: &mut InodeAllocator,
+        case_insensitive: bool,
+    ) -> VirtualTree {
         let mut tree = VirtualTree {
             nodes: ImHashMap::new(),
             children: ImHashMap::new(),
             rendered_children: ImHashMap::new(),
+            folded_children: ImHashMap::new(),
             track_to_inode: ImHashMap::new(),
+            case_insensitive,
         };
         tree.nodes.insert(
             Self::ROOT,
@@ -137,9 +166,15 @@ impl VirtualTree {
     }
 
     pub fn lookup(&self, parent: u64, name: &str) -> Option<u64> {
-        self.children
-            .get(&parent)
-            .and_then(|c| c.get(name).copied())
+        if self.case_insensitive {
+            self.folded_children
+                .get(&parent)
+                .and_then(|b| b.get(&fold(name)).copied())
+        } else {
+            self.children
+                .get(&parent)
+                .and_then(|c| c.get(name).copied())
+        }
     }
 
     pub fn is_dir(&self, inode: u64) -> bool {
@@ -189,6 +224,7 @@ impl VirtualTree {
             .unwrap()
             .insert(name.clone(), inode);
         self.insert_rendered_child(dir, raw_name, &name, inode);
+        self.insert_folded_child(dir, &name, inode);
     }
 
     fn ensure_dir(
@@ -198,10 +234,13 @@ impl VirtualTree {
         name: &str,
         alloc: &mut InodeAllocator,
     ) -> (u64, String) {
-        if let Some(&existing) = self.children[&parent].get(name) {
-            if self.is_dir(existing) {
-                return (existing, join_path(parent_path, name));
-            }
+        if let Some(existing) = self.dir_child_named(parent, name) {
+            let stored = self
+                .node(existing)
+                .expect("dir_child_named node")
+                .name
+                .clone();
+            return (existing, join_path(parent_path, &stored));
         }
         let unique = self.disambiguate(parent, name);
         let full = join_path(parent_path, &unique);
@@ -222,22 +261,60 @@ impl VirtualTree {
             .unwrap()
             .insert(unique.clone(), inode);
         self.insert_rendered_child(parent, name, &unique, inode);
+        self.insert_folded_child(parent, &unique, inode);
         (inode, full)
     }
 
     /// Return `name` if free in `dir`, else append ` (k)` before the extension.
+    /// Freeness is case-folded when the tree is case-insensitive.
     fn disambiguate(&self, dir: u64, name: &str) -> String {
-        let existing = &self.children[&dir];
-        if !existing.contains_key(name) {
+        if !self.taken(dir, name) {
             return name.to_string();
         }
         for k in 2u32.. {
             let candidate = suffix_candidate(name, k);
-            if !existing.contains_key(&candidate) {
+            if !self.taken(dir, &candidate) {
                 return candidate;
             }
         }
         unreachable!("an unoccupied candidate rank always exists")
+    }
+
+    /// Mirror a child insertion into the folded index (no-op unless folding).
+    fn insert_folded_child(&mut self, parent: u64, name: &str, inode: u64) {
+        if !self.case_insensitive {
+            return;
+        }
+        self.folded_children
+            .entry(parent)
+            .or_default()
+            .insert(fold(name), inode);
+    }
+
+    /// True if `name` is already taken in `dir` (folded when case-insensitive).
+    fn taken(&self, dir: u64, name: &str) -> bool {
+        if self.case_insensitive {
+            self.folded_children
+                .get(&dir)
+                .is_some_and(|b| b.contains_key(&fold(name)))
+        } else {
+            self.children
+                .get(&dir)
+                .is_some_and(|c| c.contains_key(name))
+        }
+    }
+
+    /// An existing *directory* child of `dir` matching `name` (folded when
+    /// case-insensitive), for merge reuse. `None` if absent or a non-dir.
+    fn dir_child_named(&self, dir: u64, name: &str) -> Option<u64> {
+        let ino = if self.case_insensitive {
+            self.folded_children
+                .get(&dir)
+                .and_then(|b| b.get(&fold(name)).copied())
+        } else {
+            self.children.get(&dir).and_then(|c| c.get(name).copied())
+        }?;
+        self.is_dir(ino).then_some(ino)
     }
 
     /// Cheap rename-relevance gate for the child of `dir` whose current key is
@@ -924,6 +1001,54 @@ mod tests {
         assert!(t.lookup(d, "song.flac").is_some());
         assert!(t.lookup(d, "song (2).flac").is_some());
         assert!(t.lookup(d, "song (3).flac").is_some());
+    }
+
+    #[test]
+    fn case_insensitive_merges_directories() {
+        // Two artist dirs differing only by case collapse into one; both titles
+        // live under the first-seen casing.
+        let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), true);
+        let foo = tree.lookup(VirtualTree::ROOT, "Foo").expect("Foo dir");
+        // Case-insensitive lookup resolves any casing to the same inode.
+        assert_eq!(tree.lookup(VirtualTree::ROOT, "foo"), Some(foo));
+        assert_eq!(tree.lookup(VirtualTree::ROOT, "FOO"), Some(foo));
+        // Exactly one child of root (the merged dir), with both files under it.
+        assert_eq!(tree.children(VirtualTree::ROOT).unwrap().len(), 1);
+        assert!(tree.lookup(foo, "A").is_some());
+        assert!(tree.lookup(foo, "B").is_some());
+        assert_eq!(tree.children(foo).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn case_insensitive_disambiguates_leaf_files() {
+        // Two files in the same dir whose names differ only by case must NOT
+        // collide: the second is disambiguated.
+        let entries = vec![
+            (1i64, "Dir/Song".to_string()),
+            (2i64, "Dir/song".to_string()),
+        ];
+        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), true);
+        let dir = tree.lookup(VirtualTree::ROOT, "Dir").expect("Dir");
+        let names: Vec<String> = tree.children(dir).unwrap().keys().cloned().collect();
+        // First-seen "Song" keeps its name; "song" becomes "song (2)".
+        assert!(names.contains(&"Song".to_string()));
+        assert!(names.contains(&"song (2)".to_string()));
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn case_sensitive_keeps_both_dirs_separate() {
+        // Control: with folding OFF, "Foo" and "foo" are distinct dirs and a
+        // differently-cased query misses.
+        let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), false);
+        assert_eq!(tree.children(VirtualTree::ROOT).unwrap().len(), 2);
+        assert_ne!(
+            tree.lookup(VirtualTree::ROOT, "Foo"),
+            tree.lookup(VirtualTree::ROOT, "foo")
+        );
+        assert_eq!(tree.lookup(VirtualTree::ROOT, "FOO"), None);
     }
 
     #[test]

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -87,10 +87,12 @@ pub struct VirtualTree {
     children: ImHashMap<u64, OrdMap<String, u64>>,
     rendered_children: ImHashMap<u64, OrdMap<String, OrdMap<String, u64>>>,
     /// `parent -> fold(name) -> inode`, populated ONLY when `case_insensitive`.
-    /// Build-only (folding always full-rebuilds, so a published tree is never
-    /// mutated). Gives O(1) folded lookup and collision checks. Part of structural
-    /// equality; built deterministically, so fresh and re-rendered folded trees
-    /// compare equal.
+    /// Kept in sync with `children` on every insert AND removal, so a folded
+    /// `lookup` never resolves a stale inode even if the tree is mutated in place
+    /// (production folded mounts only ever full-rebuild, but the public
+    /// `build_with_ci` + mutators must stay consistent). Gives O(1) folded lookup
+    /// and collision checks. Part of structural equality; built deterministically,
+    /// so fresh and re-rendered folded trees compare equal.
     folded_children: ImHashMap<u64, ImHashMap<String, u64>>,
     track_to_inode: ImHashMap<i64, u64>,
     /// When true, names are compared case-insensitively (dirs merge, files
@@ -291,6 +293,20 @@ impl VirtualTree {
             .insert(fold(name), inode);
     }
 
+    /// Mirror a child removal out of the folded index, dropping an emptied parent
+    /// bucket so lookups never resolve a stale inode (no-op unless folding).
+    fn remove_folded_child(&mut self, parent: u64, name: &str) {
+        if !self.case_insensitive {
+            return;
+        }
+        if let Some(bucket) = self.folded_children.get_mut(&parent) {
+            bucket.remove(&fold(name));
+            if bucket.is_empty() {
+                self.folded_children.remove(&parent);
+            }
+        }
+    }
+
     /// True if `name` is already taken in `dir` (folded when case-insensitive).
     fn taken(&self, dir: u64, name: &str) -> bool {
         if self.case_insensitive {
@@ -478,6 +494,7 @@ impl VirtualTree {
                 kids.remove(&name);
             }
             self.remove_rendered_child(parent, &rendered, &name);
+            self.remove_folded_child(parent, &name);
         }
         Some(self.prune_empty_dirs_upward(parent))
     }
@@ -765,12 +782,14 @@ impl VirtualTree {
                 .map(|n| (n.name.clone(), n.rendered_name.clone()));
             self.children.remove(&dir);
             self.rendered_children.remove(&dir);
+            self.folded_children.remove(&dir);
             self.nodes.remove(&dir);
             if let Some((name, rendered)) = &names {
                 if let Some(kids) = self.children.get_mut(&parent) {
                     kids.remove(name);
                 }
                 self.remove_rendered_child(parent, rendered, name);
+                self.remove_folded_child(parent, name);
             }
             last_pruned = names;
             dir = parent;
@@ -1049,6 +1068,26 @@ mod tests {
             tree.lookup(VirtualTree::ROOT, "foo")
         );
         assert_eq!(tree.lookup(VirtualTree::ROOT, "FOO"), None);
+    }
+
+    #[test]
+    fn case_insensitive_removal_keeps_folded_lookup_consistent() {
+        // A folded tree mutated in place must not resolve a removed name via the
+        // folded index (the index is maintained on removal, not just insert).
+        let entries = vec![
+            (1i64, "Dir/Song".to_string()),
+            (2i64, "Dir/Other".to_string()),
+        ];
+        let mut tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), true);
+        let dir = tree.lookup(VirtualTree::ROOT, "dir").expect("dir");
+        assert!(tree.lookup(dir, "song").is_some());
+
+        tree.remove_track(1, &mut InodeAllocator::new());
+
+        // The removed file no longer resolves (any casing); the sibling still does.
+        assert_eq!(tree.lookup(dir, "song"), None);
+        assert_eq!(tree.lookup(dir, "Song"), None);
+        assert!(tree.lookup(dir, "other").is_some());
     }
 
     #[test]

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -190,6 +190,7 @@ fn bench_read_under_latency() {
         default_fallback: "Unknown".to_string(),
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     };
     fn first_inode(fs: &Musefs, dir: u64) -> Option<u64> {
         for (_, ino, is_dir) in fs.readdir(dir).unwrap() {

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -15,6 +15,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: Mode::Synthesis,
         poll_interval: Duration::ZERO, // no debounce: each poll actually polls
+        case_insensitive: false,
     }
 }
 

--- a/musefs-core/tests/binary_tag_tree.rs
+++ b/musefs-core/tests/binary_tag_tree.rs
@@ -10,6 +10,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -11,6 +11,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -49,6 +49,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-core/tests/incremental_refresh.rs
+++ b/musefs-core/tests/incremental_refresh.rs
@@ -22,6 +22,14 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".into(),
         mode: Mode::Synthesis,
         poll_interval: Duration::ZERO,
+        case_insensitive: false,
+    }
+}
+
+fn config_ci() -> MountConfig {
+    MountConfig {
+        case_insensitive: true,
+        ..config()
     }
 }
 
@@ -82,6 +90,76 @@ fn incremental_refresh_matches_full_rebuild_over_edits() {
         tree_fingerprint(&fs).keys().collect::<Vec<_>>(),
         tree_fingerprint(&reference).keys().collect::<Vec<_>>(),
         "incremental and full-rebuild paths must match"
+    );
+}
+
+#[test]
+fn case_insensitive_refresh_merges_and_matches_full_rebuild() {
+    let target = small_corpus(2);
+    let db_path = target.db_path.clone();
+    let corpus = target.corpus_dir.clone();
+
+    let db = Db::open(&db_path).unwrap();
+    scan_directory(&db, &corpus).unwrap();
+
+    // Make the two tracks' artists differ only by case (same album so they share
+    // a parent): under folding the artist dir must MERGE.
+    let writer = Db::open(&db_path).unwrap();
+    let ids: Vec<i64> = writer.list_tracks().unwrap().iter().map(|t| t.id).collect();
+    writer
+        .replace_tags(
+            ids[0],
+            &[
+                Tag::new("ARTIST", "Foo", 0),
+                Tag::new("ALBUM", "Al", 0),
+                Tag::new("TITLE", "One", 0),
+            ],
+        )
+        .unwrap();
+    writer
+        .replace_tags(
+            ids[1],
+            &[
+                Tag::new("ARTIST", "foo", 0),
+                Tag::new("ALBUM", "Al", 0),
+                Tag::new("TITLE", "Two", 0),
+            ],
+        )
+        .unwrap();
+
+    let fs = Musefs::open(Db::open(&db_path).unwrap(), config_ci()).unwrap();
+
+    // Exactly one top-level artist directory (the merged "Foo"/"foo").
+    let fp = tree_fingerprint(&fs);
+    let top_dirs: std::collections::BTreeSet<String> = fp
+        .keys()
+        .map(|p| p.split('/').next().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        top_dirs.len(),
+        1,
+        "case-variant artists must merge into one dir"
+    );
+
+    // An external edit is still picked up - incremental is bypassed, so this goes
+    // through a full folded rebuild - and the result matches a fresh folded build.
+    writer
+        .replace_tags(
+            ids[1],
+            &[
+                Tag::new("ARTIST", "foo", 0),
+                Tag::new("ALBUM", "Al", 0),
+                Tag::new("TITLE", "Renamed", 0),
+            ],
+        )
+        .unwrap();
+    fs.poll_refresh().unwrap();
+
+    let reference = Musefs::open(Db::open(&db_path).unwrap(), config_ci()).unwrap();
+    assert_eq!(
+        tree_fingerprint(&fs).keys().collect::<Vec<_>>(),
+        tree_fingerprint(&reference).keys().collect::<Vec<_>>(),
+        "case-insensitive refresh (full rebuild) must match a fresh folded build"
     );
 }
 

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -21,6 +21,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -588,6 +588,7 @@ mod tests {
             mode: Mode::Synthesis,
             // Zero interval => poll_due() is always true, isolating the gate.
             poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
         };
         let core =
             Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -63,6 +63,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -55,6 +55,7 @@ fn mount_config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -52,6 +52,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -62,6 +62,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -64,6 +64,7 @@ fn config(mode: Mode) -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -22,6 +22,7 @@ fn config() -> MountConfig {
         default_fallback: "Unknown".to_string(),
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
     }
 }
 


### PR DESCRIPTION
Implements Plan B from `docs/superpowers/plans/` — case-insensitive filename
handling for case-insensitive volumes (macOS), the runtime axis deferred from
the FreeBSD/macOS groundwork in #166.

On a case-insensitive volume the virtual tree folds case: case-variant
**directories merge** into one (first-seen casing wins) and case-variant
**files are disambiguated** (` (2)` suffix), and lookups match regardless of
case. **Linux/FreeBSD behavior is byte-for-byte unchanged and pays zero
overhead** (the folded index is only populated when folding is on).

## What's in this PR

- **`tree.rs`** — a `case_insensitive` flag plus a build-only `folded_children`
  index (`parent -> fold(name) -> inode`, populated only when folding).
  `build_with` delegates to a new `build_with_ci`; `lookup`, `disambiguate` (via
  a `taken` helper), and `ensure_dir` (merge via `dir_child_named`, keeping the
  first-seen stored name) fold when enabled. The index is maintained at the two
  insert sites; `collision_gate` and the incremental machinery are untouched.
- **`facade.rs`** — `MountConfig.case_insensitive`, plumbed through `build_full`
  and `rebuild_full`. **The incremental refresh path is bypassed when folding**:
  `rebuild_incremental` returns its existing `Ok(None)`, routing the caller to a
  full folded rebuild. The incremental path navigates by *exact* rendered name,
  which a merged/folded tree can mismatch — bypassing it keeps `apply_changes`
  correct by construction (the O(changed) optimization stays case-sensitive-only;
  a refresh-latency cost on macOS, which is best-effort).
- **CLI** — `--case-insensitive <true|false>`, defaulting to `true` on macOS and
  `false` on Linux/FreeBSD, overridable (e.g. a case-sensitive APFS volume).

## Design notes
- **Build-only folded index:** because folding always full-rebuilds, a published
  folded tree is never mutated in place, so there is no remove-side maintenance
  to keep consistent. The case-sensitive path never populates the index.
- **Directories merge / leaf files disambiguate** mirrors a native
  case-insensitive filesystem and is the minimal generalization of the existing
  exact-name behavior.
- **Folding** is `str::to_lowercase()` (Unicode lowercasing; ASCII floor). Full
  Apple HFS+/APFS normalization is out of scope.

## Validation
- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`,
  `cargo test --workspace`: green.
- New tests: folded merge / leaf-disambiguate / case-sensitive control (tree);
  CLI default-to-OS + override; and a facade acceptance test that a
  case-insensitive mount merges case-variant artists and still reflects an
  external edit after a refresh (exercising the bypass → full-rebuild path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --case-insensitive <true|false> CLI option to control filename case-sensitivity. Defaults to true on macOS, false on Linux/FreeBSD. When enabled, names that differ only by case merge into single directories/files and mounts perform full rebuilds rather than incremental refreshes.

* **Tests**
  * Test coverage updated to exercise case-insensitive mounting and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->