### PR TITLE
Eliminate unsafe code and deny it workspace-wide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,13 @@ this on every push/PR and uploads to Codecov (`CODECOV_TOKEN` repo secret).
 - **Lint policy.** `clippy::pedantic` minus a few intentional/noisy groups,
   defined in the root `Cargo.toml` under `[workspace.lints]`. The hook and
   CI deny all warnings.
+- **Unsafe code.** `unsafe_code = "deny"` is set for the workspace members in
+  the root `Cargo.toml` (`[workspace.lints.rust]`); the standalone `fuzz/`
+  crate is outside the workspace and is not covered. A genuinely-necessary
+  `unsafe` is opted in per-site with `#[expect(unsafe_code, reason = "...")]`
+  — never a bare `unsafe` block and never by relaxing the workspace lint, so
+  every `unsafe` is greppable and review-visible. Prefer a safe crate (e.g.
+  `rustix` for syscalls) over hand-rolled FFI.
 - **Layering.** Keep `musefs-fuse`, `musefs-cli`, and the `musefs` binary
   thin; cross-cutting logic belongs in `musefs-core`
   (see [ARCHITECTURE.md](ARCHITECTURE.md#crate-layout)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "musefs-db",
  "musefs-format",
  "ogg",
+ "rustix",
  "sha2",
  "tempfile",
  "threadpool",
@@ -966,6 +967,7 @@ dependencies = [
  "fuser",
  "libc",
  "rusqlite",
+ "rustix",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/Sohex/musefs"
 
+[workspace.lints.rust]
+# unsafe is denied by default everywhere; a genuinely-necessary unsafe must be
+# opted in per-site with `#[expect(unsafe_code, reason = "...")]` so it stays
+# greppable and review-visible. Never relax this workspace lint for a one-off.
+unsafe_code = "deny"
+
 # Curated clippy policy: pedantic on, minus the groups that are intentional or
 # stylistic in this codebase. Inherited by each crate via `[lints] workspace = true`.
 [workspace.lints.clippy]

--- a/docs/superpowers/plans/2026-06-08-eliminate-unsafe-code.md
+++ b/docs/superpowers/plans/2026-06-08-eliminate-unsafe-code.md
@@ -1,0 +1,559 @@
+# Eliminate `unsafe` Code Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove every `unsafe` block from the workspace by replacing libc FFI with safe `rustix` calls and replacing one test's `std::env::set_var` with an in-process metrics setter, then enforce `unsafe_code = "deny"` workspace-wide.
+
+**Architecture:** Five `unsafe` sites (all thin libc FFI) are swapped to `rustix` (already in the dep tree via `tempfile`). The one `set_var` test is reworked to call a new `musefs_core::metrics::set_fault_pread` hook that pre-seeds the existing per-pread fault `OnceLock`, leaving the documented `MUSEFS_FAULT_*_US` env-var benchmark interface untouched. A workspace `[workspace.lints.rust] unsafe_code = "deny"` lint is added **last** (after all sites are clean) so every intermediate commit stays green; future `unsafe` requires a visible per-site `#[expect(unsafe_code, reason = "...")]`.
+
+**Tech Stack:** Rust (edition 2021), `rustix` 1.x (`process` + `fs` features), `fuser` 0.17, `libc` (kept for safe errno/`statvfs`-free constants only).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-08-eliminate-unsafe-code-design.md`
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+| ---- | ------ | -------------- |
+| `musefs-fuse/Cargo.toml` | Modify | Add `rustix` dep (`process` feature) |
+| `musefs-fuse/src/lib.rs:188-190` | Modify | getuid/getgid → rustix |
+| `musefs-latencyfs/Cargo.toml` | Modify | Add `rustix` dep (`process` + `fs` features) |
+| `musefs-latencyfs/src/lib.rs:232-234` | Modify | getuid/getgid → rustix |
+| `musefs-latencyfs/src/lib.rs:416-449` | Modify | `statfs` MaybeUninit/`libc::statvfs` → `rustix::fs::statvfs` |
+| `musefs-latencyfs/tests/passthrough.rs:107-117` | Modify | test `libc::statvfs` → `rustix::fs::statvfs` |
+| `musefs-core/src/metrics.rs:26-78` | Modify | Lift per-pread fault cell to module scope; add `set_fault_pread` |
+| `musefs-core/tests/fault_injection.rs` | Create | TDD test for `set_fault_pread` (its own metrics-gated binary) |
+| `musefs-fuse/tests/concurrency.rs:118-127` | Modify | `set_var` → `set_fault_pread` |
+| `Cargo.toml` (root) | Modify | Add `[workspace.lints.rust] unsafe_code = "deny"` |
+| `CONTRIBUTING.md` (Code conventions) | Modify | Document the unsafe policy + opt-in convention |
+
+**Note on commit ordering:** the `unsafe_code = "deny"` lint is the **final** task. Every prior commit must already pass the pre-commit hook (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`), which it does because removing `unsafe` and adding `rustix` introduces no warnings on its own.
+
+---
+
+## Task 1: `musefs-fuse` getuid/getgid → rustix
+
+**Files:**
+- Modify: `musefs-fuse/Cargo.toml`
+- Modify: `musefs-fuse/src/lib.rs:188-190`
+
+This is a behavior-preserving FFI swap. There is no clean unit test for it (the
+uid/gid are read from the live process at mount-construction time), so the safety
+net is: it compiles, and the existing `musefs-fuse` test suite stays green.
+
+- [ ] **Step 1: Add the `rustix` dependency**
+
+In `musefs-fuse/Cargo.toml`, under `[dependencies]`, add the `rustix` line (keep
+the existing `libc = "0.2"` line — it is still used for safe errno constants like
+`libc::EIO`):
+
+```toml
+[dependencies]
+fuser = "0.17"
+libc = "0.2"
+log = "0.4"
+musefs-core = { path = "../musefs-core", version = "0.2.0" }
+rustix = { version = "1", features = ["process"] }
+threadpool = "1"
+```
+
+Leave `default-features` on (do not pass `default-features = false`) — rustix's
+default `std` is what provides the safe API and the non-Linux backends.
+
+- [ ] **Step 2: Replace the getuid/getgid unsafe block**
+
+In `musefs-fuse/src/lib.rs`, the current `MusefsFs` construction (lines 188-190)
+reads:
+
+```rust
+            // SAFETY: getuid/getgid are always-successful libc calls.
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+```
+
+Replace those three lines with:
+
+```rust
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
+```
+
+`as_raw()` returns `RawUid`/`RawGid` (= `u32`), matching the `uid: u32` / `gid: u32`
+fields.
+
+- [ ] **Step 3: Verify it compiles and existing tests pass**
+
+Run: `cargo test -p musefs-fuse`
+Expected: PASS (all existing tests; e.g. `to_file_attr` unit tests are unaffected).
+
+- [ ] **Step 4: Verify clippy is clean**
+
+Run: `cargo clippy -p musefs-fuse --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-fuse/Cargo.toml musefs-fuse/src/lib.rs
+git commit -m "musefs-fuse: getuid/getgid via rustix (drop unsafe)"
+```
+
+---
+
+## Task 2: `musefs-latencyfs` getuid/getgid + statvfs → rustix
+
+**Files:**
+- Modify: `musefs-latencyfs/Cargo.toml`
+- Modify: `musefs-latencyfs/src/lib.rs:232-234` (getuid/getgid)
+- Modify: `musefs-latencyfs/src/lib.rs:416-449` (`statfs`)
+- Modify: `musefs-latencyfs/tests/passthrough.rs:107-117` (test statvfs)
+
+Behavior-preserving FFI swaps. The `statfs` path is exercised by the ignored
+`mkdir_rmdir_and_statfs_through_the_mount` e2e test (real mount; needs `/dev/fuse`).
+
+- [ ] **Step 1: Add the `rustix` dependency**
+
+In `musefs-latencyfs/Cargo.toml`, under `[dependencies]`, add the `rustix` line
+(keep `libc = "0.2"` — still used for errno constants):
+
+```toml
+[dependencies]
+fuser = "0.17"
+libc = "0.2"
+rustix = { version = "1", features = ["process", "fs"] }
+tempfile = "3"
+```
+
+- [ ] **Step 2: Replace the getuid/getgid unsafe block**
+
+In `musefs-latencyfs/src/lib.rs`, the `PassthroughFs::new` body (lines 232-234)
+reads:
+
+```rust
+            // SAFETY: getuid/getgid never fail.
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+```
+
+Replace those three lines with:
+
+```rust
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
+```
+
+- [ ] **Step 3: Replace the `statfs` MaybeUninit/`libc::statvfs` block**
+
+In `musefs-latencyfs/src/lib.rs`, the `statfs` method (lines 416-449) currently
+reads:
+
+```rust
+    fn statfs(&self, _req: &Request, ino: INodeNo, reply: ReplyStatfs) {
+        nap(self.lat.stat);
+        // Pass through real statvfs of the inode's path; fall back to benign values.
+        if let Some(p) = self.ipath(ino.0) {
+            // Use the raw OS path bytes (not `to_string_lossy`, which would
+            // mangle non-UTF-8 names into U+FFFD and statvfs a different path).
+            if let Ok(cstr) =
+                std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(p.as_os_str()))
+            {
+                let mut s = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+                // SAFETY: cstr is a valid NUL-terminated path; s is a valid out-param.
+                if unsafe { libc::statvfs(cstr.as_ptr(), s.as_mut_ptr()) } == 0 {
+                    // SAFETY: statvfs returned 0, so it fully initialized `s`.
+                    let s = unsafe { s.assume_init() };
+                    // statvfs field types vary by platform: the count fields are
+                    // u64 on Linux/FreeBSD (so `as u64` is unnecessary) but u32 on
+                    // macOS (so it's a lossless widening). Allow both lints rather
+                    // than branch per-OS (rust-lang/rust-clippy#17166).
+                    #[allow(clippy::unnecessary_cast, clippy::cast_lossless)]
+                    return reply.statfs(
+                        s.f_blocks as u64,
+                        s.f_bfree as u64,
+                        s.f_bavail as u64,
+                        s.f_files as u64,
+                        s.f_ffree as u64,
+                        u32::try_from(s.f_bsize as u64).unwrap_or(u32::MAX),
+                        u32::try_from(s.f_namemax as u64).unwrap_or(u32::MAX),
+                        u32::try_from(s.f_frsize as u64).unwrap_or(u32::MAX),
+                    );
+                }
+            }
+        }
+        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
+    }
+```
+
+Replace the entire method body with:
+
+```rust
+    fn statfs(&self, _req: &Request, ino: INodeNo, reply: ReplyStatfs) {
+        nap(self.lat.stat);
+        // Pass through real statvfs of the inode's path; fall back to benign values.
+        if let Some(p) = self.ipath(ino.0) {
+            // rustix accepts the path directly (no CString needed) and returns a
+            // safe StatVfs with all-u64 fields, so no per-platform casts.
+            if let Ok(s) = rustix::fs::statvfs(&p) {
+                return reply.statfs(
+                    s.f_blocks,
+                    s.f_bfree,
+                    s.f_bavail,
+                    s.f_files,
+                    s.f_ffree,
+                    u32::try_from(s.f_bsize).unwrap_or(u32::MAX),
+                    u32::try_from(s.f_namemax).unwrap_or(u32::MAX),
+                    u32::try_from(s.f_frsize).unwrap_or(u32::MAX),
+                );
+            }
+        }
+        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
+    }
+```
+
+`rustix::fs::statvfs` returns all fields as `u64`: the first five `reply.statfs`
+arguments take `u64` directly (no cast), and the three `u32` arguments use
+`u32::try_from(...).unwrap_or(u32::MAX)` — genuine narrowings per the project's
+cast convention. The `#[allow(clippy::unnecessary_cast, clippy::cast_lossless)]`
+and the `CString`/`MaybeUninit` machinery are gone.
+
+- [ ] **Step 4: Replace the statvfs unsafe in the passthrough test**
+
+In `musefs-latencyfs/tests/passthrough.rs`, the tail of
+`mkdir_rmdir_and_statfs_through_the_mount` (lines 107-117) reads:
+
+```rust
+    // statfs returns real, non-empty filesystem stats for the mount (not the
+    // benign all-zero fallback), exercising the passthrough statvfs path.
+    let cpath = std::ffi::CString::new(mp.to_str().unwrap()).unwrap();
+    let mut s: libc::statvfs = unsafe { std::mem::zeroed() };
+    // SAFETY: cpath is a valid NUL-terminated path; s is a valid out-param.
+    assert_eq!(unsafe { libc::statvfs(cpath.as_ptr(), &raw mut s) }, 0);
+    assert!(s.f_blocks > 0, "statfs should report real block counts");
+```
+
+Replace those lines with:
+
+```rust
+    // statfs returns real, non-empty filesystem stats for the mount (not the
+    // benign all-zero fallback), exercising the passthrough statvfs path.
+    let s = rustix::fs::statvfs(mp).unwrap();
+    assert!(s.f_blocks > 0, "statfs should report real block counts");
+```
+
+- [ ] **Step 5: Verify it compiles and the (non-ignored) tests pass**
+
+Run: `cargo test -p musefs-latencyfs`
+Expected: PASS. (The real-mount `mkdir_rmdir_and_statfs_through_the_mount` test
+is `#[ignore]` and will not run here; this step proves compilation.)
+
+- [ ] **Step 6: (Best-effort) run the ignored e2e test if `/dev/fuse` is available**
+
+Run: `cargo test -p musefs-latencyfs -- --ignored --test-threads=1`
+Expected: PASS if `/dev/fuse` + libfuse present; otherwise the mount-dependent
+test errors at mount and may be skipped — not a blocker for this task, but run it
+if the environment supports FUSE since it is the only real exercise of the new
+`statfs` path.
+
+- [ ] **Step 7: Verify clippy is clean**
+
+Run: `cargo clippy -p musefs-latencyfs --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-latencyfs/Cargo.toml musefs-latencyfs/src/lib.rs musefs-latencyfs/tests/passthrough.rs
+git commit -m "musefs-latencyfs: getuid/getgid + statvfs via rustix (drop unsafe)"
+```
+
+---
+
+## Task 3: `musefs-core` metrics — add `set_fault_pread` setter
+
+**Files:**
+- Modify: `musefs-core/src/metrics.rs:26-78`
+- Create: `musefs-core/tests/fault_injection.rs`
+
+This adds a programmatic, env-free way to seed the per-pread fault duration, so
+the concurrency test (Task 4) no longer needs `std::env::set_var`. The
+`MUSEFS_FAULT_*_US` env-var path is preserved as the fallback. This task is
+genuine TDD: write the test first, watch it fail, implement, watch it pass.
+
+- [ ] **Step 1: Write the failing test (its own metrics-gated binary)**
+
+Create `musefs-core/tests/fault_injection.rs`:
+
+```rust
+//! Verifies the programmatic per-pread fault setter. Its own single-test binary:
+//! the per-pread fault cell is a process-global OnceLock, so a dedicated binary
+//! guarantees `set_fault_pread` runs before any `on_pread` reads/seeds the cell.
+#![cfg(feature = "metrics")]
+
+use std::time::{Duration, Instant};
+
+#[test]
+fn set_fault_pread_injects_latency_without_env() {
+    musefs_core::metrics::set_fault_pread(Some(Duration::from_millis(20)));
+    let t = Instant::now();
+    musefs_core::metrics::on_pread(0);
+    assert!(
+        t.elapsed() >= Duration::from_millis(15),
+        "on_pread should sleep for the programmatically-set fault duration"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile**
+
+Run: `cargo test -p musefs-core --features metrics --test fault_injection`
+Expected: FAIL — compile error, `set_fault_pread` not found in `musefs_core::metrics`.
+
+- [ ] **Step 3: Lift the per-pread fault cell to module scope and add the setter**
+
+In `musefs-core/src/metrics.rs`, inside `#[cfg(feature = "metrics")] mod imp`,
+the statics block (lines 32-40) currently ends at `SCAN_BYTES_READ`. Add a
+module-scope fault cell after it:
+
+```rust
+    static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
+    static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
+    static PREAD_FAULT: OnceLock<Option<Duration>> = OnceLock::new();
+```
+
+Then change `on_pread` (currently lines 68-73):
+
+```rust
+    pub fn on_pread(bytes: u64) {
+        PREADS.fetch_add(1, Ordering::Relaxed);
+        PREAD_BYTES.fetch_add(bytes, Ordering::Relaxed);
+        static C: OnceLock<Option<Duration>> = OnceLock::new();
+        fault("MUSEFS_FAULT_PREAD_US", &C);
+    }
+```
+
+to use the module-scope cell, and add the setter immediately after it:
+
+```rust
+    pub fn on_pread(bytes: u64) {
+        PREADS.fetch_add(1, Ordering::Relaxed);
+        PREAD_BYTES.fetch_add(bytes, Ordering::Relaxed);
+        fault("MUSEFS_FAULT_PREAD_US", &PREAD_FAULT);
+    }
+
+    /// Pre-seed the per-pread fault duration in-process, bypassing the
+    /// `MUSEFS_FAULT_PREAD_US` env var (which stays as the benchmark fallback).
+    ///
+    /// Must be called before the first `on_pread`: the cell is a process-global
+    /// `OnceLock`, so this is a no-op once the cell has been read or seeded.
+    /// Intended for a single-test binary where that ordering is guaranteed.
+    pub fn set_fault_pread(d: Option<Duration>) {
+        let _ = PREAD_FAULT.set(d);
+    }
+```
+
+Leave `on_open` and `on_stat` with their existing function-local `static C`
+cells — only the pread cell needs a setter (YAGNI).
+
+- [ ] **Step 4: Add the no-op stub to the non-metrics module**
+
+So the symbol exists regardless of feature, in `musefs-core/src/metrics.rs`
+inside `#[cfg(not(feature = "metrics"))] mod imp` (the stub block; `on_pread`
+is the line `pub fn on_pread(_bytes: u64) {}`), add after it:
+
+```rust
+    pub fn on_pread(_bytes: u64) {}
+
+    pub fn set_fault_pread(_d: Option<std::time::Duration>) {}
+```
+
+(This keeps `metrics::set_fault_pread` callable in non-metrics builds as a no-op,
+matching how the other hooks are stubbed.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core --features metrics --test fault_injection`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the whole crate still builds both ways and is clippy-clean**
+
+Run: `cargo clippy -p musefs-core --all-targets -- -D warnings`
+Then: `cargo clippy -p musefs-core --all-targets --features metrics -- -D warnings`
+Expected: no warnings in either.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/metrics.rs musefs-core/tests/fault_injection.rs
+git commit -m "musefs-core: add metrics::set_fault_pread (env-free fault seeding)"
+```
+
+---
+
+## Task 4: `musefs-fuse` concurrency test — drop `set_var`
+
+**Files:**
+- Modify: `musefs-fuse/tests/concurrency.rs:118-127`
+
+Swap the environment mutation for the new programmatic setter. This is the last
+remaining `unsafe` site.
+
+- [ ] **Step 1: Replace the `set_var` call and update the comment**
+
+In `musefs-fuse/tests/concurrency.rs`, the test opening (lines 118-127) currently
+reads:
+
+```rust
+fn slow_read_does_not_block_stat() {
+    // 50 ms per backing pread call. The big file is >2 MiB; the kernel sends
+    // ~128 KiB chunks, so there are ~16 FUSE read calls → ~800ms total.
+    // The fault duration is parsed once into a process-global OnceLock on the
+    // first on_pread. This is its own integration-test binary with a single test,
+    // so no earlier on_pread can have initialized it — setting the env var here,
+    // before any read, is guaranteed to be observed.
+    unsafe { std::env::set_var("MUSEFS_FAULT_PREAD_US", "50000") };
+```
+
+Replace the comment + `set_var` line with:
+
+```rust
+fn slow_read_does_not_block_stat() {
+    // 50 ms per backing pread call. The big file is >2 MiB; the kernel sends
+    // ~128 KiB chunks, so there are ~16 FUSE read calls → ~800ms total.
+    // The fault duration seeds a process-global OnceLock read on the first
+    // on_pread. This is its own integration-test binary with a single test, so
+    // no earlier on_pread can have seeded it — setting it here, before any read,
+    // is guaranteed to be observed.
+    musefs_core::metrics::set_fault_pread(Some(std::time::Duration::from_micros(50_000)));
+```
+
+(`musefs_core` is already imported in this file via
+`use musefs_core::{scan_directory, Mode, MountConfig, Musefs};`; the fully-qualified
+`musefs_core::metrics::set_fault_pread` call needs no new `use`.)
+
+- [ ] **Step 2: Verify the test binary compiles under the metrics feature**
+
+Run: `cargo test -p musefs-fuse --features metrics --test concurrency`
+Expected: compiles; the single test reports as `ignored` (it is `#[ignore]` —
+real mount needed). Compilation success is the goal here.
+
+- [ ] **Step 3: (Best-effort) run the ignored concurrency test if FUSE is available**
+
+Run: `cargo test -p musefs-fuse --features metrics --test concurrency -- --ignored --nocapture --test-threads=1`
+Expected: PASS if `/dev/fuse` + libfuse present (a slow read must not block the
+unrelated stat) — confirms the setter actually injects latency end-to-end. Skip
+if the environment lacks FUSE; not a blocker for this task.
+
+- [ ] **Step 4: Verify clippy is clean under the metrics feature**
+
+Run: `cargo clippy -p musefs-fuse --all-targets --features metrics -- -D warnings`
+Expected: no warnings. (The standard clippy gate omits `--features metrics`, so
+this file is otherwise never linted — run it explicitly.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-fuse/tests/concurrency.rs
+git commit -m "musefs-fuse: drive concurrency test via set_fault_pread (drop set_var)"
+```
+
+---
+
+## Task 5: Enforce `unsafe_code = "deny"` workspace-wide + document it
+
+**Files:**
+- Modify: `Cargo.toml` (root)
+- Modify: `CONTRIBUTING.md` (Code conventions section)
+
+All five `unsafe` sites are now gone; add the lint that prevents regression, then
+document the policy. This is the capstone and must be the final commit.
+
+- [ ] **Step 1: Add the workspace rust-lint table**
+
+In the root `Cargo.toml`, add a new `[workspace.lints.rust]` section immediately
+before the existing `[workspace.lints.clippy]` section:
+
+```toml
+[workspace.lints.rust]
+# unsafe is denied by default everywhere; a genuinely-necessary unsafe must be
+# opted in per-site with `#[expect(unsafe_code, reason = "...")]` so it stays
+# greppable and review-visible. Never relax this workspace lint for a one-off.
+unsafe_code = "deny"
+
+# Curated clippy policy: pedantic on, minus the groups that are intentional or
+# stylistic in this codebase. Inherited by each crate via `[lints] workspace = true`.
+[workspace.lints.clippy]
+```
+
+(Every crate already declares `[lints] workspace = true`, so this applies to all
+seven workspace members at once. `fuzz/` is excluded from the workspace and is
+unaffected.)
+
+- [ ] **Step 2: Verify the whole workspace is clean under the new lint**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: no warnings, no `unsafe_code` errors.
+
+Then verify the metrics-gated targets (which the default `--all-targets` run does
+not compile) are also clean:
+
+Run: `cargo clippy --all-targets --features metrics -- -D warnings`
+Expected: no warnings, no `unsafe_code` errors — proves the concurrency test
+(site 5) and the fault-injection test compile under `deny`.
+
+- [ ] **Step 3: Run the full workspace test suite**
+
+Run: `cargo test --workspace`
+Expected: PASS (this is what the pre-commit hook will also run).
+
+- [ ] **Step 4: Document the policy in CONTRIBUTING.md**
+
+In `CONTRIBUTING.md`, under `## Code conventions`, add a new bullet immediately
+after the existing `**Lint policy.**` bullet (which ends "The hook and CI deny
+all warnings."):
+
+```markdown
+- **Unsafe code.** `unsafe_code = "deny"` is set workspace-wide in the root
+  `Cargo.toml` (`[workspace.lints.rust]`). A genuinely-necessary `unsafe` is
+  opted in per-site with `#[expect(unsafe_code, reason = "…")]` — never a bare
+  `unsafe` block and never by relaxing the workspace lint — so every `unsafe`
+  is greppable and shows up in review. Prefer a safe crate (e.g. `rustix` for
+  syscalls) over hand-rolled FFI.
+```
+
+- [ ] **Step 5: Final full verification before commit**
+
+Run: `cargo fmt --all --check`
+Expected: clean (no diff).
+
+Run: `grep -rn "unsafe" --include="*.rs" musefs-*/src musefs-*/tests musefs/src 2>/dev/null | grep -v "// " | grep "unsafe {"`
+Expected: no output — confirms no `unsafe {` blocks remain in workspace src/tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml CONTRIBUTING.md
+git commit -m "workspace: deny unsafe_code and document the opt-in policy"
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Spec coverage:** Task 1 covers fuse getuid/getgid; Task 2 covers latencyfs
+  getuid/getgid, latencyfs `statfs`, and the latencyfs passthrough test; Task 3
+  adds the metrics setter; Task 4 removes the `set_var`; Task 5 adds the lint and
+  the CONTRIBUTING.md note. All five spec sites + enforcement + docs are covered.
+- **rustix facts (verified against rustix 1.1.4 in the dep tree):**
+  `rustix::process::getuid()/getgid()` exist; `.as_raw()` returns `u32`;
+  `rustix::fs::statvfs<P: Arg>(path)` accepts `&PathBuf`; `StatVfs` fields
+  (`f_blocks`, `f_bfree`, `f_bavail`, `f_files`, `f_ffree`, `f_bsize`,
+  `f_namemax`, `f_frsize`) are all `u64`; `fuser`'s `ReplyStatfs::statfs` takes
+  `(u64, u64, u64, u64, u64, u32, u32, u32)`.
+- **Green-commit discipline:** the `deny` lint lands only in Task 5, after every
+  `unsafe` is removed, so the pre-commit hook passes on every commit.
+- **Metrics OnceLock constraint:** `set_fault_pread` is a no-op once the cell is
+  read/seeded; both callers (the new `fault_injection.rs` test and the
+  `concurrency.rs` test) are single-test, metrics-gated binaries where the
+  set-before-first-`on_pread` ordering holds.

--- a/docs/superpowers/plans/2026-06-08-eliminate-unsafe-code.md
+++ b/docs/superpowers/plans/2026-06-08-eliminate-unsafe-code.md
@@ -21,7 +21,7 @@
 | `musefs-latencyfs/Cargo.toml` | Modify | Add `rustix` dep (`process` + `fs` features) |
 | `musefs-latencyfs/src/lib.rs:232-234` | Modify | getuid/getgid → rustix |
 | `musefs-latencyfs/src/lib.rs:416-449` | Modify | `statfs` MaybeUninit/`libc::statvfs` → `rustix::fs::statvfs` |
-| `musefs-latencyfs/tests/passthrough.rs:107-117` | Modify | test `libc::statvfs` → `rustix::fs::statvfs` |
+| `musefs-latencyfs/tests/passthrough.rs:106-112` | Modify | test `libc::statvfs` → `rustix::fs::statvfs` |
 | `musefs-core/src/metrics.rs:26-78` | Modify | Lift per-pread fault cell to module scope; add `set_fault_pread` |
 | `musefs-core/tests/fault_injection.rs` | Create | TDD test for `set_fault_pread` (its own metrics-gated binary) |
 | `musefs-fuse/tests/concurrency.rs:118-127` | Modify | `set_var` → `set_fault_pread` |
@@ -107,7 +107,7 @@ git commit -m "musefs-fuse: getuid/getgid via rustix (drop unsafe)"
 - Modify: `musefs-latencyfs/Cargo.toml`
 - Modify: `musefs-latencyfs/src/lib.rs:232-234` (getuid/getgid)
 - Modify: `musefs-latencyfs/src/lib.rs:416-449` (`statfs`)
-- Modify: `musefs-latencyfs/tests/passthrough.rs:107-117` (test statvfs)
+- Modify: `musefs-latencyfs/tests/passthrough.rs:106-112` (test statvfs)
 
 Behavior-preserving FFI swaps. The `statfs` path is exercised by the ignored
 `mkdir_rmdir_and_statfs_through_the_mount` e2e test (real mount; needs `/dev/fuse`).
@@ -220,7 +220,7 @@ and the `CString`/`MaybeUninit` machinery are gone.
 - [ ] **Step 4: Replace the statvfs unsafe in the passthrough test**
 
 In `musefs-latencyfs/tests/passthrough.rs`, the tail of
-`mkdir_rmdir_and_statfs_through_the_mount` (lines 107-117) reads:
+`mkdir_rmdir_and_statfs_through_the_mount` (lines 106-112) reads:
 
 ```rust
     // statfs returns real, non-empty filesystem stats for the mount (not the
@@ -425,11 +425,12 @@ fn slow_read_does_not_block_stat() {
     // on_pread. This is its own integration-test binary with a single test, so
     // no earlier on_pread can have seeded it — setting it here, before any read,
     // is guaranteed to be observed.
-    musefs_core::metrics::set_fault_pread(Some(std::time::Duration::from_micros(50_000)));
+    musefs_core::metrics::set_fault_pread(Some(Duration::from_micros(50_000)));
 ```
 
 (`musefs_core` is already imported in this file via
-`use musefs_core::{scan_directory, Mode, MountConfig, Musefs};`; the fully-qualified
+`use musefs_core::{scan_directory, Mode, MountConfig, Musefs};`, and `Duration`
+via `use std::time::{Duration, Instant};` — the
 `musefs_core::metrics::set_fault_pread` call needs no new `use`.)
 
 - [ ] **Step 2: Verify the test binary compiles under the metrics feature**

--- a/docs/superpowers/specs/2026-06-08-eliminate-unsafe-code-design.md
+++ b/docs/superpowers/specs/2026-06-08-eliminate-unsafe-code-design.md
@@ -1,0 +1,201 @@
+# Eliminate `unsafe` code and enforce it workspace-wide
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+
+## Goal
+
+Remove every `unsafe` block from the workspace `src` and test code, replacing
+the underlying libc FFI with safe `rustix` calls, and add a workspace-level lint
+so that `unsafe` is denied by default everywhere. `unsafe` remains *permitted*
+when genuinely necessary, but only via a visible, greppable per-site opt-in — it
+can never be introduced silently.
+
+## Background
+
+A sweep of the workspace (`fuzz/` is excluded and out of scope — it is not a
+workspace member) finds exactly five `unsafe` sites, all thin libc FFI:
+
+| # | Location | Current code |
+|---|----------|--------------|
+| 1 | `musefs-fuse/src/lib.rs:189-190` | `unsafe { libc::getuid() }` / `getgid()` |
+| 2 | `musefs-latencyfs/src/lib.rs:233-234` | `unsafe { libc::getuid() }` / `getgid()` |
+| 3 | `musefs-latencyfs/src/lib.rs:425-429` | `MaybeUninit::<libc::statvfs>` + `unsafe libc::statvfs` + `assume_init` |
+| 4 | `musefs-latencyfs/tests/passthrough.rs:109-111` | `mem::zeroed()` + `unsafe libc::statvfs` |
+| 5 | `musefs-fuse/tests/concurrency.rs:127` | `unsafe { std::env::set_var("MUSEFS_FAULT_PREAD_US", "50000") }` |
+
+Notes:
+
+- `rustix 1.1.4` is **already** in the dependency tree (pulled by `tempfile`),
+  so making it a direct dependency adds essentially zero compile cost.
+- `libc` stays a dependency: it is still used for *safe* errno constants
+  (`libc::EIO`, `libc::ENOENT`, …) in both crates. Only the `unsafe` FFI calls
+  are removed, not the constant references.
+- Site 5 compiles today only because the whole test file is
+  `#![cfg(feature = "metrics")]` and the lint pass does not enable that feature,
+  so the block is currently invisible. The `unsafe` was written defensively for
+  edition 2024, where `std::env::set_var` is genuinely `unsafe`.
+
+## Approach
+
+### Crate choice: `rustix`
+
+`rustix` covers all three distinct operations (`getuid`, `getgid`, `statvfs`)
+with one already-compiled, soundness-audited crate. On Linux it uses raw
+syscalls (no libc indirection); on FreeBSD/macOS it uses the libc backend
+(matching the project's existing cross-platform support). Its `StatVfs` struct
+normalises every field to `u64`, which additionally lets us delete the
+per-platform cast workaround at site 3.
+
+Alternatives considered and rejected:
+
+- **nix** (also already in the tree): safe wrappers, but its `Statvfs` keeps
+  platform-varying field types, so the cast cruft at site 3 would remain.
+- **uzers/users**: purpose-built for uid/gid only — cannot do `statvfs`, would
+  require a second new dependency or leave site 3 unsafe.
+
+### Changes
+
+**Dependencies**
+
+- `musefs-fuse/Cargo.toml`: add `rustix = { version = "1", features = ["process"] }`
+- `musefs-latencyfs/Cargo.toml`: add `rustix = { version = "1", features = ["process", "fs"] }`
+
+**Site 1 & 2 — getuid/getgid**
+
+Replace the `unsafe` block with:
+
+```rust
+uid: rustix::process::getuid().as_raw(),
+gid: rustix::process::getgid().as_raw(),
+```
+
+`as_raw()` returns `RawUid`/`RawGid` (= `c_uint` = `u32`), which drops directly
+into the existing `uid: u32` / `gid: u32` fields. The `// SAFETY:` comments are
+removed.
+
+**Site 3 — latencyfs `statfs`**
+
+Replace the `MaybeUninit` / `assume_init` dance with:
+
+```rust
+if let Ok(s) = rustix::fs::statvfs(p) {
+    return reply.statfs(
+        s.f_blocks,
+        s.f_bfree,
+        s.f_bavail,
+        s.f_files,
+        s.f_ffree,
+        u32::try_from(s.f_bsize).unwrap_or(u32::MAX),
+        u32::try_from(s.f_namemax).unwrap_or(u32::MAX),
+        u32::try_from(s.f_frsize).unwrap_or(u32::MAX),
+    );
+}
+```
+
+`rustix::fs::statvfs` takes a path directly (no `CString` construction needed),
+so the manual `CString::new(OsStrExt::as_bytes(...))` step is also removed.
+Because every `StatVfs` field is `u64`, the `#[allow(clippy::unnecessary_cast,
+clippy::cast_lossless)]` attribute and its explanatory comment are deleted; the
+`u32::try_from(...).unwrap_or(u32::MAX)` narrowings for the three `u32` reply
+fields stay (they are genuine narrowings per the project's cast convention).
+
+**Site 4 — latencyfs passthrough test**
+
+Replace the `mem::zeroed` + `unsafe statvfs` with:
+
+```rust
+let s = rustix::fs::statvfs(mp).unwrap();
+assert!(s.f_blocks > 0, "statfs should report real block counts");
+```
+
+The `CString` construction is no longer needed.
+
+**Site 5 — fuse concurrency test + metrics setter**
+
+The `MUSEFS_FAULT_OPEN_US` / `MUSEFS_FAULT_STAT_US` / `MUSEFS_FAULT_PREAD_US`
+environment variables are a **documented benchmark interface** (see
+`BENCHMARKS.md` and the SP0 measurement spec) and must keep working. The
+benchmark harness sets them via the shell, so no Rust `set_var` is involved
+there — only the one test mutates the environment from Rust.
+
+In `musefs-core/src/metrics.rs` (inside the existing `#[cfg(feature =
+"metrics")]` module):
+
+1. Lift the three currently-function-local
+   `static C: OnceLock<Option<Duration>>` cells (in `on_open`, `on_stat`,
+   `on_pread`) to module scope (e.g. `OPEN_FAULT`, `STAT_FAULT`, `PREAD_FAULT`).
+   `fault()` already takes the cell by reference, so its body is unchanged.
+2. Add a public test/bench hook that pre-seeds a cell before its first read:
+
+   ```rust
+   /// Pre-seed the per-pread fault duration in-process, bypassing the
+   /// `MUSEFS_FAULT_PREAD_US` env var. No-op if the cell was already read.
+   pub fn set_fault_pread(d: Option<Duration>) {
+       let _ = PREAD_FAULT.set(d);
+   }
+   ```
+
+   (Only `set_fault_pread` is required by the current test; the open/stat
+   setters are not added until a caller needs them — YAGNI.)
+
+The `fault()` helper still falls back to `std::env::var` via `get_or_init` when
+the cell was not pre-seeded, so the benchmark env-var path is unchanged.
+
+The concurrency test replaces line 127 with:
+
+```rust
+musefs_core::metrics::set_fault_pread(Some(Duration::from_micros(50_000)));
+```
+
+This is deterministic (no env race), needs no environment mutation, and removes
+the only Rust-side `set_var`.
+
+### Enforcement
+
+Add to the root `Cargo.toml`:
+
+```toml
+[workspace.lints.rust]
+unsafe_code = "deny"
+```
+
+Every crate already inherits via `[lints] workspace = true`, so this applies
+workspace-wide at once. `deny` (not `forbid`) is chosen deliberately: a future,
+genuinely-necessary `unsafe` can be opted in per-site with a visible
+`#[expect(unsafe_code, reason = "...")]`, which is greppable, shows up in review,
+and (because it is `#[expect]`, not `#[allow]`) errors if the `unsafe` is later
+removed but the annotation left behind. `forbid` would block even a justified
+one-off until the whole-workspace lint were relaxed.
+
+`fuzz/` is outside the workspace and is unaffected.
+
+## Out of scope
+
+- Migrating the workspace to edition 2024. (Noted only because edition 2024 is
+  what makes `set_var` `unsafe`; this change happens to make that future
+  migration cleaner, but the migration itself is a separate task.)
+- Replacing `libc` errno *constants* with `rustix::io::Errno` — unnecessary
+  churn; the constants are safe.
+
+## Testing
+
+- `cargo build` and `cargo test` (full workspace) stay green.
+- `cargo clippy --all-targets` passes with the new `unsafe_code = "deny"` lint —
+  this is the proof that no `unsafe` remains in any compiled target.
+- `cargo clippy --all-targets --features metrics -p musefs-fuse` (the feature
+  that gates the concurrency test) passes — confirms site 5's replacement
+  compiles under the lint, which it does not today.
+- The ignored real-mount concurrency test
+  (`cargo test -p musefs-fuse --features metrics -- --ignored ...`) still
+  demonstrates that a slow read does not block an unrelated stat, now driven by
+  `set_fault_pread` instead of an env var.
+- Cross-lint for FreeBSD via `--target x86_64-unknown-freebsd` per the project's
+  existing CI parity check (rustix's `process`/`fs` modules are available there).
+
+## Documentation
+
+No user-facing docs change (the env-var benchmark interface is unchanged). If a
+contributor-facing note on the `unsafe_code = "deny"` policy and the
+`#[expect(unsafe_code, reason = "...")]` opt-in convention fits CONTRIBUTING.md's
+conventions section, add it there.

--- a/docs/superpowers/specs/2026-06-08-eliminate-unsafe-code-design.md
+++ b/docs/superpowers/specs/2026-06-08-eliminate-unsafe-code-design.md
@@ -61,6 +61,10 @@ Alternatives considered and rejected:
 - `musefs-fuse/Cargo.toml`: add `rustix = { version = "1", features = ["process"] }`
 - `musefs-latencyfs/Cargo.toml`: add `rustix = { version = "1", features = ["process", "fs"] }`
 
+`default-features` is left **on** — rustix's default `std` (and the libc-auxv
+backend it selects on non-Linux) is what provides the safe API and the
+FreeBSD/macOS backends. Do not pass `default-features = false`.
+
 **Site 1 & 2 — getuid/getgid**
 
 Replace the `unsafe` block with:
@@ -142,6 +146,13 @@ In `musefs-core/src/metrics.rs` (inside the existing `#[cfg(feature =
 The `fault()` helper still falls back to `std::env::var` via `get_or_init` when
 the cell was not pre-seeded, so the benchmark env-var path is unchanged.
 
+Note the cells are now module-scope statics (process-global): a value seeded or
+read once persists for the life of the process. This is fine here because the
+concurrency test is its own single-test `#![cfg(feature = "metrics")]` binary,
+so `set_fault_pread` always runs before any `on_pread` and no other test in the
+same binary contends for the cell. The plan should add a short comment at the
+setter documenting this single-binary / set-before-first-read constraint.
+
 The concurrency test replaces line 127 with:
 
 ```rust
@@ -195,7 +206,9 @@ one-off until the whole-workspace lint were relaxed.
 
 ## Documentation
 
-No user-facing docs change (the env-var benchmark interface is unchanged). If a
-contributor-facing note on the `unsafe_code = "deny"` policy and the
-`#[expect(unsafe_code, reason = "...")]` opt-in convention fits CONTRIBUTING.md's
-conventions section, add it there.
+No user-facing docs change (the env-var benchmark interface is unchanged). Add a
+short note to CONTRIBUTING.md's conventions section recording the policy: the
+workspace denies `unsafe_code`; a genuinely-necessary `unsafe` is opted in
+per-site with `#[expect(unsafe_code, reason = "...")]` (never a bare `unsafe`
+block and never relaxing the workspace lint), so every `unsafe` is greppable and
+review-visible.

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -38,6 +38,7 @@ mod imp {
     static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
     static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
     static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
+    static PREAD_FAULT: OnceLock<Option<Duration>> = OnceLock::new();
 
     /// Sleep for the duration named by `var` (microseconds), parsed once.
     fn fault(var: &'static str, cell: &OnceLock<Option<Duration>>) {
@@ -68,8 +69,15 @@ mod imp {
     pub fn on_pread(bytes: u64) {
         PREADS.fetch_add(1, Ordering::Relaxed);
         PREAD_BYTES.fetch_add(bytes, Ordering::Relaxed);
-        static C: OnceLock<Option<Duration>> = OnceLock::new();
-        fault("MUSEFS_FAULT_PREAD_US", &C);
+        fault("MUSEFS_FAULT_PREAD_US", &PREAD_FAULT);
+    }
+
+    pub fn set_fault_pread(d: Option<Duration>) {
+        let first_set = PREAD_FAULT.set(d).is_ok();
+        debug_assert!(
+            first_set,
+            "set_fault_pread must run before the first on_pread"
+        );
     }
 
     pub fn on_art_chunk() {
@@ -152,6 +160,8 @@ mod imp {
     pub fn on_stat() {}
     #[inline(always)]
     pub fn on_pread(_bytes: u64) {}
+    #[inline(always)]
+    pub fn set_fault_pread(_d: Option<std::time::Duration>) {}
     #[inline(always)]
     pub fn on_art_chunk() {}
     #[inline(always)]

--- a/musefs-core/tests/fault_injection.rs
+++ b/musefs-core/tests/fault_injection.rs
@@ -1,0 +1,17 @@
+//! Verifies the programmatic per-pread fault setter. Its own single-test binary:
+//! the per-pread fault cell is a process-global OnceLock, so a dedicated binary
+//! guarantees `set_fault_pread` runs before any `on_pread` reads/seeds the cell.
+#![cfg(feature = "metrics")]
+
+use std::time::{Duration, Instant};
+
+#[test]
+fn set_fault_pread_injects_latency_without_env() {
+    musefs_core::metrics::set_fault_pread(Some(Duration::from_millis(20)));
+    let t = Instant::now();
+    musefs_core::metrics::on_pread(0);
+    assert!(
+        t.elapsed() >= Duration::from_millis(15),
+        "on_pread should sleep for the programmatically-set fault duration"
+    );
+}

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -13,6 +13,7 @@ metrics = ["musefs-core/metrics"]
 fuser = "0.17"
 libc = "0.2"
 log = "0.4"
+rustix = { version = "1", features = ["process"] }
 musefs-core = { path = "../musefs-core", version = "0.2.0" }
 threadpool = "1"
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -185,9 +185,8 @@ impl MusefsFs {
             // class of work; foreground reads are bounded only by client
             // concurrency, so a wide parallel read storm can still queue jobs.
             pool: ThreadPool::new(workers),
-            // SAFETY: getuid/getgid are always-successful libc calls.
-            uid: unsafe { libc::getuid() },
-            gid: unsafe { libc::getgid() },
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
             mount_time: SystemTime::now(),
             config,
             notifier: Arc::new(OnceLock::new()),

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -19,9 +19,9 @@ fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();
     out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
     let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
+    out.push(u8::try_from((len >> 16) & 0xFF).expect("FLAC block length high byte fits in u8"));
+    out.push(u8::try_from((len >> 8) & 0xFF).expect("FLAC block length middle byte fits in u8"));
+    out.push(u8::try_from(len & 0xFF).expect("FLAC block length low byte fits in u8"));
     out.extend_from_slice(body);
     out
 }
@@ -37,11 +37,23 @@ fn streaminfo_body() -> Vec<u8> {
 
 fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
     let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(vendor.len())
+            .expect("vendor length fits in u32")
+            .to_le_bytes(),
+    );
     out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(comments.len())
+            .expect("comment count fits in u32")
+            .to_le_bytes(),
+    );
     for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(
+            &u32::try_from(c.len())
+                .expect("comment length fits in u32")
+                .to_le_bytes(),
+        );
         out.extend_from_slice(c.as_bytes());
     }
     out
@@ -120,11 +132,11 @@ fn setup_two_track_mount() -> (
 fn slow_read_does_not_block_stat() {
     // 50 ms per backing pread call. The big file is >2 MiB; the kernel sends
     // ~128 KiB chunks, so there are ~16 FUSE read calls → ~800ms total.
-    // The fault duration is parsed once into a process-global OnceLock on the
-    // first on_pread. This is its own integration-test binary with a single test,
-    // so no earlier on_pread can have initialized it — setting the env var here,
-    // before any read, is guaranteed to be observed.
-    unsafe { std::env::set_var("MUSEFS_FAULT_PREAD_US", "50000") };
+    // The fault duration seeds a process-global OnceLock read on the first
+    // on_pread. This is its own integration-test binary with a single test, so
+    // no earlier on_pread can have seeded it — setting it here, before any read,
+    // is guaranteed to be observed.
+    musefs_core::metrics::set_fault_pread(Some(Duration::from_millis(50)));
 
     let (_mnt, big, other, _session, _backing) = setup_two_track_mount();
 

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -20,9 +20,9 @@ fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
     let mut out = Vec::new();
     out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
     let len = body.len();
-    out.push(((len >> 16) & 0xFF) as u8);
-    out.push(((len >> 8) & 0xFF) as u8);
-    out.push((len & 0xFF) as u8);
+    out.push(u8::try_from((len >> 16) & 0xFF).expect("FLAC block length high byte fits in u8"));
+    out.push(u8::try_from((len >> 8) & 0xFF).expect("FLAC block length middle byte fits in u8"));
+    out.push(u8::try_from(len & 0xFF).expect("FLAC block length low byte fits in u8"));
     out.extend_from_slice(body);
     out
 }
@@ -38,11 +38,23 @@ fn streaminfo_body() -> Vec<u8> {
 
 fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
     let mut out = Vec::new();
-    out.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(vendor.len())
+            .expect("vendor length fits in u32")
+            .to_le_bytes(),
+    );
     out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&(comments.len() as u32).to_le_bytes());
+    out.extend_from_slice(
+        &u32::try_from(comments.len())
+            .expect("comment count fits in u32")
+            .to_le_bytes(),
+    );
     for c in comments {
-        out.extend_from_slice(&(c.len() as u32).to_le_bytes());
+        out.extend_from_slice(
+            &u32::try_from(c.len())
+                .expect("comment length fits in u32")
+                .to_le_bytes(),
+        );
         out.extend_from_slice(c.as_bytes());
     }
     out

--- a/musefs-latencyfs/Cargo.toml
+++ b/musefs-latencyfs/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 fuser = "0.17"
 libc = "0.2"
+rustix = { version = "1", features = ["process", "fs"] }
 tempfile = "3"
 
 [dev-dependencies]

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -229,9 +229,8 @@ impl PassthroughFs {
             next_fh: AtomicU64::new(1),
             lat,
             fsyncs,
-            // SAFETY: getuid/getgid never fail.
-            uid: unsafe { libc::getuid() },
-            gid: unsafe { libc::getgid() },
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
         }
     }
     fn ipath(&self, ino: u64) -> Option<PathBuf> {
@@ -417,32 +416,17 @@ impl fuser::Filesystem for PassthroughFs {
         nap(self.lat.stat);
         // Pass through real statvfs of the inode's path; fall back to benign values.
         if let Some(p) = self.ipath(ino.0) {
-            // Use the raw OS path bytes (not `to_string_lossy`, which would
-            // mangle non-UTF-8 names into U+FFFD and statvfs a different path).
-            if let Ok(cstr) =
-                std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(p.as_os_str()))
-            {
-                let mut s = std::mem::MaybeUninit::<libc::statvfs>::uninit();
-                // SAFETY: cstr is a valid NUL-terminated path; s is a valid out-param.
-                if unsafe { libc::statvfs(cstr.as_ptr(), s.as_mut_ptr()) } == 0 {
-                    // SAFETY: statvfs returned 0, so it fully initialized `s`.
-                    let s = unsafe { s.assume_init() };
-                    // statvfs field types vary by platform: the count fields are
-                    // u64 on Linux/FreeBSD (so `as u64` is unnecessary) but u32 on
-                    // macOS (so it's a lossless widening). Allow both lints rather
-                    // than branch per-OS (rust-lang/rust-clippy#17166).
-                    #[allow(clippy::unnecessary_cast, clippy::cast_lossless)]
-                    return reply.statfs(
-                        s.f_blocks as u64,
-                        s.f_bfree as u64,
-                        s.f_bavail as u64,
-                        s.f_files as u64,
-                        s.f_ffree as u64,
-                        u32::try_from(s.f_bsize as u64).unwrap_or(u32::MAX),
-                        u32::try_from(s.f_namemax as u64).unwrap_or(u32::MAX),
-                        u32::try_from(s.f_frsize as u64).unwrap_or(u32::MAX),
-                    );
-                }
+            if let Ok(s) = rustix::fs::statvfs(&p) {
+                return reply.statfs(
+                    s.f_blocks,
+                    s.f_bfree,
+                    s.f_bavail,
+                    s.f_files,
+                    s.f_ffree,
+                    u32::try_from(s.f_bsize).unwrap_or(u32::MAX),
+                    u32::try_from(s.f_namemax).unwrap_or(u32::MAX),
+                    u32::try_from(s.f_frsize).unwrap_or(u32::MAX),
+                );
             }
         }
         reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);

--- a/musefs-latencyfs/tests/passthrough.rs
+++ b/musefs-latencyfs/tests/passthrough.rs
@@ -105,9 +105,6 @@ fn mkdir_rmdir_and_statfs_through_the_mount() {
 
     // statfs returns real, non-empty filesystem stats for the mount (not the
     // benign all-zero fallback), exercising the passthrough statvfs path.
-    let cpath = std::ffi::CString::new(mp.to_str().unwrap()).unwrap();
-    let mut s: libc::statvfs = unsafe { std::mem::zeroed() };
-    // SAFETY: cpath is a valid NUL-terminated path; s is a valid out-param.
-    assert_eq!(unsafe { libc::statvfs(cpath.as_ptr(), &raw mut s) }, 0);
+    let s = rustix::fs::statvfs(mp).unwrap();
     assert!(s.f_blocks > 0, "statfs should report real block counts");
 }


### PR DESCRIPTION
Removes every `unsafe` block from the workspace, replacing the underlying libc FFI with safe `rustix` calls, and adds a workspace lint denying `unsafe_code` everywhere. `unsafe` remains *permitted* when genuinely necessary, but only via a visible, greppable per-site `#[expect(unsafe_code, reason = "...")]` — it can never be introduced silently.

A sweep found exactly five `unsafe` sites, all thin libc FFI:

| Site | Change |
| ---- | ------ |
| `musefs-fuse` / `musefs-latencyfs` getuid/getgid | `unsafe { libc::getuid()/getgid() }` → `rustix::process::getuid()/getgid().as_raw()` |
| `musefs-latencyfs` `statfs` | `MaybeUninit`/`CString`/`assume_init` dance → `rustix::fs::statvfs(&p)`; `StatVfs` is all `u64`, so the per-platform cast workaround is gone |
| `musefs-latencyfs` passthrough test | `mem::zeroed` + unsafe `statvfs` → `rustix::fs::statvfs(mp)` |
| `musefs-fuse` concurrency test | `unsafe { env::set_var(...) }` → new `metrics::set_fault_pread` programmatic setter (env-var benchmark interface unchanged) |

### Notes

- `rustix` was already in the dependency tree (via `tempfile`), so making it a direct dep of `musefs-fuse` / `musefs-latencyfs` adds essentially zero compile cost.
- `libc` stays a dependency — it's still used for *safe* errno constants (`libc::EIO`, …); only the `unsafe` FFI is removed.
- The concurrency test no longer mutates the environment. `metrics::set_fault_pread` pre-seeds the per-pread fault `OnceLock` in-process (guarded by a `debug_assert!` enforcing set-before-first-read), with a new TDD test in `musefs-core/tests/fault_injection.rs`. The `MUSEFS_FAULT_*` env-var benchmark interface is untouched.
- Enforcement: `[workspace.lints.rust] unsafe_code = "deny"`, inherited by every crate. `deny` (not `forbid`) so a future justified `unsafe` can opt in per-site without relaxing the workspace lint. `fuzz/` is outside the workspace and unaffected.
- The metrics-gated `musefs-fuse` test files are now linted under `--features metrics` (a verification step the spec mandates), so their integer casts adopt the project's `try_from` convention.

Design spec and implementation plan are included under `docs/superpowers/`.

### Verification

- No `unsafe` blocks remain anywhere in the workspace.
- `cargo clippy --all-targets` and `cargo clippy --all-targets --features metrics -p musefs-fuse` both clean under the new lint.
- `cargo test --workspace`: 708 passed, 22 ignored.
- `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added direct API for programmatic fault injection in latency testing

* **Chores**
  * Configured workspace-level safety enforcement standards
  * Updated code patterns for consistency with safety guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->