### PR TITLE
Bump workspace to Rust edition 2024

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -88,23 +88,27 @@ exclude_re = [
     # cadence mutation persists the identical track set. The win is fewer commits
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
-    'musefs-core/src/scan\.rs:711:29:',
-    'musefs-core/src/scan\.rs:713:32:',
-    'musefs-core/src/scan\.rs:713:47:',
-    'musefs-core/src/scan\.rs:713:62:',
-    'musefs-core/src/scan\.rs:721:37:',
-    'musefs-core/src/scan\.rs:723:40:',
-    'musefs-core/src/scan\.rs:723:55:',
-    'musefs-core/src/scan\.rs:723:70:',
+    # NB: line:col here (and for revalidate below) — `replace += with` and
+    # `>=`/`||` repeat in run_pipeline (e.g. the killable `*scanned += 1` at
+    # 691), so these cannot be safely description-anchored. Re-verify these
+    # coordinates after any change that reformats scan.rs.
+    'musefs-core/src/scan\.rs:713:29:',
+    'musefs-core/src/scan\.rs:715:32:',
+    'musefs-core/src/scan\.rs:715:47:',
+    'musefs-core/src/scan\.rs:715:62:',
+    'musefs-core/src/scan\.rs:723:37:',
+    'musefs-core/src/scan\.rs:725:40:',
+    'musefs-core/src/scan\.rs:725:55:',
+    'musefs-core/src/scan\.rs:725:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
     # from a deterministic test. With skip_failed identically 0, the `failed =
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
-    'musefs-core/src/scan\.rs:827:25:',
-    'musefs-core/src/scan\.rs:831:25:',
-    'musefs-core/src/scan\.rs:867:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:829:25:',
+    'musefs-core/src/scan\.rs:833:25:',
+    'musefs-core/src/scan\.rs:869:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are
@@ -141,13 +145,13 @@ exclude_re = [
     # eprintln on stderr. The fallback's build_with is itself directly tested; this
     # injection point exists only to drive that branch, with nothing observable to
     # assert in this config.
-    'musefs-core/src/facade\.rs:777:9: replace Musefs::force_apply_failure_for_test with \(\)',
+    'replace Musefs::force_apply_failure_for_test with \(\)',
     # apply_changes path-stable guard `&self.path_of(ino) == new_path` -> false: a
     # `changed` id whose rendered path is unchanged would be treated as a move
     # (remove + re-insert at the same path) instead of a no-op. Re-interning the same
     # path yields the same inode and rebuild_subtree re-canonicalizes the parent, so
     # the resulting tree is identical — a pure short-circuit optimization.
-    'musefs-core/src/tree\.rs:489:30: replace match guard .* with false in VirtualTree::apply_changes',
+    'replace match guard .* with false in VirtualTree::apply_changes',
     # (The add-side/remove-side dirty-propagation walks formerly inline in
     # apply_changes now live in dirty_min_flip_ancestors; their equivalent and
     # hang-class mutants are covered by the description-anchored
@@ -163,7 +167,7 @@ exclude_re = [
     # ancestor_in's loop terminator `cur == Self::ROOT` -> `!=`: the walk never breaks
     # at root (root.parent == root), so a node with no ancestor in the set loops
     # forever instead of returning false.
-    'musefs-core/src/tree\.rs:615:20: replace == with != in VirtualTree::ancestor_in',
+    'replace == with != in VirtualTree::ancestor_in',
 
     # SP4 storage-aware serving — equivalent mutant in serve_ogg_window's last-page
     # memo. `total_len = header_len + payload_len` only sets the memoized page's

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -231,11 +231,14 @@ exclude_re = [
     # equals the bound at the exact nanosecond it is sampled — a measure-zero
     # boundary no deterministic test can construct: the `*_for_test` hooks backdate
     # the stamp by exactly the bound, but time advances before the comparison runs,
-    # so elapsed() is already strictly greater under both operators. (The mirrored
-    # gates in poll_refresh_notify have the same property.) The `<`->`>`/`==`
-    # variants ARE caught and stay in scope; anchored on operator+function since
-    # both `<` in poll_due are this class.
+    # so elapsed() is already strictly greater under both operators. The same
+    # measure-zero class applies to the mirrored gates in `poll_refresh_notify`
+    # (both `<` gates there) — covered by the sibling entry below; it surfaced
+    # once the edition-2024 let-chain reformat pulled the refresh_retry_backoff
+    # gate into a diff. The `<`->`>`/`==` variants ARE caught and stay in scope;
+    # anchored on operator+function since both `<` in each fn are this class.
     'musefs-core/src/facade\.rs:\d+:\d+: replace < with <= in Musefs::poll_due',
+    'replace < with <= in Musefs::poll_refresh_notify',
 
     # CACHE_ESTIMATED_ITEMS const arithmetic — equivalent mutant. This is the
     # `estimated_items_capacity` hint passed to Cache::with_weighter; it sizes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ behavior, the docs under [`docs/`](docs/).
 
 ## Getting set up
 
-You need stable Rust (edition 2021) with `rustfmt` and `clippy`. To mount or run
+You need stable Rust (edition 2024) with `rustfmt` and `clippy`. To mount or run
 the FUSE end-to-end tests you need a FUSE-capable OS: Linux with `/dev/fuse` and
 libfuse (`libfuse3-dev` / `libfuse3` plus `pkg-config`), or FreeBSD with
 `/dev/fuse` and the `fusefs` kernel module (no libfuse — see [FreeBSD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["fuzz"]
 
 [workspace.package]
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/Sohex/musefs"
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ splice at stale offsets). Run `musefs scan --revalidate` to re-probe it.
 
 ## Requirements
 
-- Rust (2021 edition) and Cargo to build/install.
+- Rust (2024 edition) and Cargo to build/install.
 - A supported OS with FUSE to mount — Linux (`/dev/fuse` + libfuse) or FreeBSD
   (`/dev/fuse` + the `fusefs` kernel module; no libfuse). macOS (FUSE-T) is
   best-effort. See [Platform support](#platform-support) for details.

--- a/docs/superpowers/plans/2026-06-08-edition-2024-bump.md
+++ b/docs/superpowers/plans/2026-06-08-edition-2024-bump.md
@@ -1,0 +1,475 @@
+# Edition 2024 Bump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the musefs Cargo workspace from Rust edition 2021 to edition 2024 with zero behavioral change, keeping every gate green.
+
+**Architecture:** Three forced changes only — rename the now-reserved `gen` keyword, flip the edition declaration, and route the (now-`unsafe`-in-2024) test env mutations through one audited helper. Sequenced into individually-green commits, then a survey deliverable seeds a later ergonomics PR.
+
+**Tech Stack:** Rust edition 2024 (requires rustc ≥ 1.85; CI/local run 1.96), Cargo workspace (`[workspace.package] edition` inherited via `edition.workspace = true`), `cargo fix --edition`, clippy `-D warnings`, `deny(unsafe_code)` workspace lint with per-site `#[expect(unsafe_code, reason = …)]`.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-08-edition-2024-bump-design.md`
+
+**Why the commit order matters (read before starting):**
+- The `gen` rename is edition-independent — it compiles green on edition 2021, so it lands **first**, on its own.
+- The env helper wraps `std::env::set_var`/`remove_var` in `unsafe { … }`. On edition 2021 those calls are *safe*, so the block would trip `unused_unsafe` under `-D warnings`. On edition 2024 they're *unsafe*, so the block is required. The helper is therefore only green **together with** the edition flip — they share one commit.
+- `cargo fix --edition` must run **while still on edition 2021** (it migrates current→next). Run it after the `gen` rename so it has nothing to rename to `r#gen`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+| --- | --- | --- |
+| `musefs-core/src/facade.rs` | Modify | Rename `Handle::gen` field + 5 use sites → `generation` |
+| `musefs-core/src/tree.rs` | Modify | Rename 3 test-loop `gen` vars + `{gen}` interpolations → `generation` |
+| `Cargo.toml` | Modify | `[workspace.package] edition = "2024"` |
+| `fuzz/Cargo.toml` | Modify | `edition = "2024"` (crate is excluded from the workspace) |
+| `musefs-core/tests/common_corpus_smoke.rs` | Modify | Add `set_env`/`remove_env` helpers; route all 15 env mutations through them |
+| `CONTRIBUTING.md` | Modify | "edition 2021" → "edition 2024" |
+| `README.md` | Modify | "Rust (2021 edition)" → "Rust (2024 edition)" |
+| `docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md` | Create | PR 2 improvement-candidate inventory (let-chains etc.) |
+
+---
+
+## Task 1: Rename the `gen` reserved keyword
+
+`gen` becomes a reserved keyword in edition 2024. Rename every identifier use to `generation` (edition-independent — this compiles on 2021).
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (field decl `:71`, uses `:971`, `:981`, `:1010`, `:1067`, `:1075`)
+- Modify: `musefs-core/src/tree.rs` (loops at `:903`, `:923`, `:943` and their `{gen}` interpolations)
+
+- [ ] **Step 1: Rename the `Handle::gen` field and its uses in `facade.rs`**
+
+Apply these exact replacements (use Serena `replace_content` / `replace_symbol_body`):
+
+Field declaration (`Handle` struct, ~line 71):
+```rust
+// before
+    gen: AtomicU64,
+// after
+    generation: AtomicU64,
+```
+
+Read fast-path, the generation check (~line 971):
+```rust
+// before
+                    if h.gen.load(Ordering::Acquire) != cur {
+// after
+                    if h.generation.load(Ordering::Acquire) != cur {
+```
+
+Re-stamp after re-resolve (~line 981):
+```rust
+// before
+                        h.gen.store(cur, Ordering::Release);
+// after
+                        h.generation.store(cur, Ordering::Release);
+```
+
+Stale-layout re-stamp (~lines 1010–1011):
+```rust
+// before
+                    h.gen
+                        .store(self.refresh_gen.load(Ordering::Acquire), Ordering::Release);
+// after
+                    h.generation
+                        .store(self.refresh_gen.load(Ordering::Acquire), Ordering::Release);
+```
+
+`open_handle` local + field init (~lines 1067 and 1075):
+```rust
+// before
+        let gen = self.refresh_gen.load(Ordering::Acquire);
+// after
+        let generation = self.refresh_gen.load(Ordering::Acquire);
+```
+```rust
+// before
+            gen: AtomicU64::new(gen),
+// after
+            generation: AtomicU64::new(generation),
+```
+
+Note: prose comments in `facade.rs` that mention "gen"/"generation" (e.g. lines ~58, ~62, ~976, ~1062–1065) are documentation, not identifiers — leave them unchanged.
+
+- [ ] **Step 2: Rename the `gen` test-loop variables and interpolations in `tree.rs`**
+
+Three `#[test]` loops use `gen` as the loop variable and interpolate it into `format!` strings. Rename each.
+
+`prune_retired_bounds_map_under_churn` (~lines 903–913):
+```rust
+// before
+        for gen in 0..100 {
+            let entries = vec![(1, format!("Gen{gen}/a.flac"))];
+            let tree = VirtualTree::build_with(&entries, &mut alloc);
+            alloc.prune_retired(&tree);
+            assert!(
+                alloc.paths.len() <= 2 * tree.nodes.len(),
+                "gen {gen}: map {} exceeds 2x live {}",
+// after
+        for generation in 0..100 {
+            let entries = vec![(1, format!("Gen{generation}/a.flac"))];
+            let tree = VirtualTree::build_with(&entries, &mut alloc);
+            alloc.prune_retired(&tree);
+            assert!(
+                alloc.paths.len() <= 2 * tree.nodes.len(),
+                "gen {generation}: map {} exceeds 2x live {}",
+```
+
+`prune_retired_keeps_live_inodes_stable` (~lines 923–927):
+```rust
+// before
+        for gen in 0..10 {
+            let entries = vec![
+                (1, "Keep/song.flac".to_string()),
+                (2, format!("Gen{gen}/x.flac")),
+// after
+        for generation in 0..10 {
+            let entries = vec![
+                (1, "Keep/song.flac".to_string()),
+                (2, format!("Gen{generation}/x.flac")),
+```
+
+`pruned_path_reborn_gets_fresh_inode_never_recycled` (~lines 943–944):
+```rust
+// before
+        for gen in 0..10 {
+            let t = VirtualTree::build_with(&[(1, format!("Gen{gen}/x.flac"))], &mut alloc);
+// after
+        for generation in 0..10 {
+            let t = VirtualTree::build_with(&[(1, format!("Gen{generation}/x.flac"))], &mut alloc);
+```
+
+- [ ] **Step 3: Sweep for any remaining bare `gen` identifier**
+
+Run:
+```bash
+grep -rnw gen musefs-core/src/facade.rs musefs-core/src/tree.rs
+```
+Expected: every remaining hit is inside a comment or string-literal prose (e.g. `"gen {generation}:"`, `// … gen …`). There must be **no** hit that is a code identifier (`gen:`, `h.gen`, `for gen`, `{gen}`). If any identifier hit remains, fix it.
+
+Then confirm none survive workspace-wide:
+```bash
+grep -rnw gen --include='*.rs' musefs-db musefs-format musefs-core musefs-fuse musefs-cli musefs musefs-latencyfs
+```
+Expected: only comment/string prose, no identifiers. Two hits in `musefs-format/src/mp4.rs` (~lines 1212, 1219) are the `©gen` iTunes atom named in comments — `©` is a non-word char so `\bgen` matches; these are expected prose, not identifiers, and stay. (`refresh_gen` correctly does **not** match — `_` is a word char — so its uses are untouched.)
+
+- [ ] **Step 4: Run the commit gate (still edition 2021 — must stay green)**
+
+Mirror what the pre-commit hook enforces, so there's no surprise at Step 5:
+```bash
+cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test
+```
+Expected: PASS. The rename is purely mechanical; all existing tests pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/src/tree.rs
+git commit -m "$(cat <<'EOF'
+Rename `gen` identifier to `generation` (reserved in edition 2024)
+
+`gen` becomes a reserved keyword in Rust edition 2024. Rename the
+`Handle` generation-counter field and the `tree.rs` test-loop variables
+ahead of the edition bump. Pure rename, no behavioral change.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Run `cargo fix --edition` for residual idioms (still on 2021)
+
+Catch any compiler-driven migration fixups (e.g. `+ use<>` precise-capture bounds, never-type fallback, `if let` tail-temporary scopes) before flipping the edition. Reconnaissance shows the only `-> impl` return (`musefs-format/tests/proptest_flac.rs:6`) captures no lifetimes, so this likely produces **no** changes — the step exists to prove that.
+
+**Files:** none expected; whatever `cargo fix` touches.
+
+- [ ] **Step 1: Confirm a clean tree**
+
+Run:
+```bash
+git status --porcelain
+```
+Expected: empty (Task 1 committed). `cargo fix` refuses to run on a dirty tree without `--allow-dirty`.
+
+- [ ] **Step 2: Run the edition migration fixer**
+
+Run (include `--all-features` so the migration pass also covers the `metrics`/`fuzzing`/`mutants` gated code, not just the default surface):
+```bash
+cargo fix --edition --workspace --all-targets --all-features
+```
+Expected: completes with "Migrating … to 2024" and reports 0 fixes (or only trivial, correct ones).
+
+- [ ] **Step 3: Review the diff — keep correct fixes, revert cosmetic churn**
+
+Run:
+```bash
+git diff
+```
+- Keep any genuinely-needed `+ use<>` bound or compiler-forced change.
+- Revert any purely-cosmetic reformatting so the migration diff stays minimal:
+  ```bash
+  git checkout -- <file>   # for each cosmetic-only file
+  ```
+
+- [ ] **Step 4: Verify still green on edition 2021**
+
+Run:
+```bash
+cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit only if `cargo fix` produced real changes**
+
+If `git status --porcelain` is empty, **skip this commit** and proceed to Task 3. Otherwise:
+```bash
+git add -p   # stage only the kept migration fixes
+git commit -m "$(cat <<'EOF'
+Apply cargo fix --edition residual fixups for edition 2024
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Flip the edition + add the env helper + docs (one atomic green-on-2024 commit)
+
+The edition flip and the env helper are mutually dependent for greenness (see "Why the commit order matters"), so they land together.
+
+**Files:**
+- Modify: `Cargo.toml`, `fuzz/Cargo.toml`
+- Modify: `musefs-core/tests/common_corpus_smoke.rs`
+- Modify: `CONTRIBUTING.md`, `README.md`
+
+- [ ] **Step 1: Flip the workspace edition**
+
+In `Cargo.toml`, under `[workspace.package]`:
+```toml
+# before
+edition = "2021"
+# after
+edition = "2024"
+```
+
+- [ ] **Step 2: Flip the fuzz crate edition**
+
+In `fuzz/Cargo.toml`, under `[package]`:
+```toml
+# before
+edition = "2021"
+# after
+edition = "2024"
+```
+
+- [ ] **Step 3: Add the audited env helpers to `common_corpus_smoke.rs`**
+
+Insert these two functions immediately after the `ENV_LOCK` static (~line 15). The helper lives **in this test file**, not in shared `tests/common/` — the mutation sites and `ENV_LOCK` are file-private here, and shared placement would spread `#[expect(unsafe_code)]` into ~25 test binaries (risking an unfulfilled-expect failure under `-D warnings`).
+
+```rust
+/// Set a process-global env var. `std::env::set_var` became `unsafe` in
+/// edition 2024 (mutating the environment is unsound with concurrent readers).
+/// This concentrates that single `unsafe` in one audited place; soundness rests
+/// on the existing `ENV_LOCK` discipline — every env-touching test holds the
+/// lock for the full read-modify span, so no other test thread touches the
+/// environment concurrently.
+fn set_env(key: &str, val: impl AsRef<std::ffi::OsStr>) {
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation, serialized by ENV_LOCK; std marked env mutation unsafe in edition 2024"
+    )]
+    unsafe {
+        std::env::set_var(key, val);
+    }
+}
+
+/// Remove a process-global env var. See [`set_env`] for the safety argument.
+fn remove_env(key: &str) {
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation, serialized by ENV_LOCK; std marked env mutation unsafe in edition 2024"
+    )]
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+```
+
+- [ ] **Step 4: Route all 15 env mutations through the helpers**
+
+In `common_corpus_smoke.rs`, replace every occurrence — 6 `set_var` + 9 `remove_var` = 15 calls (the doc comment at the top of the file also names `set_var`/`remove_var`; leave that prose alone):
+- `std::env::set_var(K, V)` → `set_env(K, V)`
+- `std::env::remove_var(K)` → `remove_env(K)`
+
+Representative example (`env_overrides_apply_over_tier`, ~lines 39–45):
+```rust
+// before
+    std::env::set_var("MUSEFS_BENCH_TIER", "ci");
+    std::env::set_var("MUSEFS_BENCH_ALBUMS", "3");
+    std::env::set_var("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
+    let p = CorpusParams::from_env();
+    std::env::remove_var("MUSEFS_BENCH_ALBUMS");
+    std::env::remove_var("MUSEFS_BENCH_TRACKS_PER_ALBUM");
+    std::env::remove_var("MUSEFS_BENCH_TIER");
+// after
+    set_env("MUSEFS_BENCH_TIER", "ci");
+    set_env("MUSEFS_BENCH_ALBUMS", "3");
+    set_env("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
+    let p = CorpusParams::from_env();
+    remove_env("MUSEFS_BENCH_ALBUMS");
+    remove_env("MUSEFS_BENCH_TRACKS_PER_ALBUM");
+    remove_env("MUSEFS_BENCH_TIER");
+```
+
+The site that passes a `&Path` value (`set_var("MUSEFS_BENCH_DIR", scratch.path())`) is covered by the `impl AsRef<OsStr>` value parameter — it becomes `set_env("MUSEFS_BENCH_DIR", scratch.path())`.
+
+Confirm none remain:
+```bash
+grep -n 'std::env::set_var\|std::env::remove_var' musefs-core/tests/common_corpus_smoke.rs
+```
+Expected: no output.
+
+- [ ] **Step 5: Verify the workspace compiles on edition 2024**
+
+Run:
+```bash
+cargo build --workspace
+```
+Expected: PASS. (Before Step 3/4 it would fail with "call to unsafe function `set_var` is unsafe"; the helper resolves every site.)
+
+- [ ] **Step 6: Update the two live docs**
+
+`CONTRIBUTING.md` (~line 9):
+```
+// before
+You need stable Rust (edition 2021) with `rustfmt` and `clippy`. To mount or run
+// after
+You need stable Rust (edition 2024) with `rustfmt` and `clippy`. To mount or run
+```
+
+`README.md` (~line 154):
+```
+// before
+- Rust (2021 edition) and Cargo to build/install.
+// after
+- Rust (2024 edition) and Cargo to build/install.
+```
+
+- [ ] **Step 7: Run the full verification gate**
+
+Run each; all must pass:
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
+cargo build --no-default-features
+cargo test
+cargo test --doc
+cargo clippy --all-targets --target x86_64-unknown-freebsd -- -D warnings
+cargo +nightly fuzz build
+```
+Expected: PASS for every command. (`--all-features` exercises the `metrics`/`fuzzing`/`mutants` gated code under the new edition; the FreeBSD cross-clippy is the project's only non-Linux lint gate; `cargo +nightly fuzz build` confirms the independently-bumped fuzz crate.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml fuzz/Cargo.toml musefs-core/tests/common_corpus_smoke.rs CONTRIBUTING.md README.md
+git commit -m "$(cat <<'EOF'
+Bump workspace to Rust edition 2024
+
+Flip the workspace and fuzz-crate edition to 2024. std marks
+env::set_var/remove_var unsafe in 2024, so route the bench smoke test's
+15 env mutations through a single audited set_env/remove_env helper with
+one #[expect(unsafe_code)], guarded by the existing ENV_LOCK — keeping
+the workspace deny(unsafe_code) intact everywhere else.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Produce the PR 2 improvement-candidate inventory
+
+The "quick look" deliverable: a notes file cataloging edition-2024-enabled cleanups (primarily let-chains), **without applying any**. This seeds PR 2's own brainstorm and is superseded by that spec.
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md`
+
+- [ ] **Step 1: Survey nested `if let` ladders (let-chain candidates)**
+
+Let-chains (`if let Some(x) = a && cond && let Ok(y) = b`) compile on stable only under edition 2024. Find collapse candidates — adjacent/nested `if let` and `if let` immediately followed by an `if` on the bound value:
+```bash
+grep -rnA2 'if let' --include='*.rs' \
+  musefs-db musefs-format musefs-core musefs-fuse musefs-cli musefs musefs-latencyfs \
+  | grep -B1 -E 'if let|&&|^\s*if ' | head -120
+```
+For each real nested ladder, note `file:line`, the current shape, and the collapsed let-chain form. Skip `if let … else` chains and matches where collapsing would change control flow (e.g. distinct `else` arms).
+
+- [ ] **Step 2: Note any other edition-2024 ergonomics seen in passing**
+
+Record (if any surfaced during Tasks 1–3): `+ use<>` precise-capture simplifications, or never-type (`!` → `()`) ergonomics. If none, say so explicitly.
+
+- [ ] **Step 3: Write the notes file**
+
+Create `docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md` with this structure, populated from the real findings above:
+
+```markdown
+# Edition 2024 — improvement candidates (PR 2 seed)
+
+**Date:** 2026-06-08
+**Status:** Inventory only — nothing applied. Input to PR 2's brainstorm.
+**Context:** Produced during the edition 2024 bump (PR 1,
+`docs/superpowers/plans/2026-06-08-edition-2024-bump.md`).
+
+## Let-chain collapse candidates
+
+For each: file:line, current nested shape, proposed let-chain form, and a
+one-line note on why it's safe (no control-flow/`else` change).
+
+- `path/to/file.rs:NN` — <current> → <collapsed>. <safety note>
+- … (one bullet per real candidate found)
+
+(If the survey found none worth collapsing, state that plainly.)
+
+## Other ergonomics
+
+- <`use<>` / never-type notes, or "none observed">
+
+## Explicitly out of scope for PR 2
+- Anything requiring behavioral change or new tests beyond a mechanical rewrite.
+```
+
+This is a documentation file — write it directly; it is not a code placeholder.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md
+git commit -m "$(cat <<'EOF'
+Add edition-2024 improvement-candidate inventory (PR 2 seed)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review notes (verification of this plan against the spec)
+
+- **Spec §1 (edition declaration):** Task 3 Steps 1–2. ✓
+- **Spec §2 (`gen` keyword + textual sweep):** Task 1 Steps 1–3. ✓
+- **Spec §3 (env helper, in-file, one `#[expect]`):** Task 3 Steps 3–4. ✓
+- **Spec §4 (cargo fix sequencing, before flip):** Task 2; ordering enforced by Task 1 → Task 2 → Task 3. ✓
+- **Spec §5 (docs):** Task 3 Step 6. ✓
+- **Spec Verification (all gates incl. `--doc`, `--all-features`, `--no-default-features`, FreeBSD, fuzz):** Task 3 Step 7. ✓
+- **Spec deliverable (PR 2 inventory notes file):** Task 4. ✓
+- **Type/name consistency:** `generation` used uniformly across facade.rs/tree.rs; `set_env`/`remove_env` defined in Task 3 Step 3 and used in Step 4. ✓

--- a/docs/superpowers/specs/2026-06-08-edition-2024-bump-design.md
+++ b/docs/superpowers/specs/2026-06-08-edition-2024-bump-design.md
@@ -1,0 +1,171 @@
+# Edition 2024 bump — design
+
+**Date:** 2026-06-08
+**Status:** Approved, ready for implementation planning
+**Scope:** PR 1 of a two-PR sequence. This PR performs the mechanical migration
+to Rust edition 2024. A follow-up PR 2 (separately brainstormed) applies the
+ergonomic cleanups the edition unlocks; PR 1 only *inventories* them.
+
+## Goal
+
+Move the musefs workspace from edition 2021 to edition 2024 with no behavioral
+change, keeping every gate green (the pre-commit hook runs the full workspace
+suite, so the bump commit must be green). Produce a written inventory of
+edition-2024-enabled improvements to seed PR 2.
+
+## Background / why this is small
+
+Reconnaissance shows the migration is nearly mechanical:
+
+- **No `unsafe`, no `static mut`, no `extern` blocks.** The headline 2024
+  footgun-removals (`unsafe extern`, `#[unsafe(...)]` attributes,
+  `unsafe_op_in_unsafe_fn`, `&` to `static mut`) do not apply — consistent with
+  the no-unsafe posture established in #168.
+- **One `-> impl` return** across the codebase → negligible RPIT
+  lifetime-capture (`+ use<>`) migration risk.
+- **No `rust-version`/MSRV commitment**; CI runs on default `stable` (1.96
+  locally), well past the 1.85 that edition 2024 requires. The bump is
+  mechanically safe.
+
+Only two code-touching issues exist, both required for the edition to compile.
+
+## What changes
+
+### 1. Edition declaration (2 files)
+
+- `Cargo.toml` → `[workspace.package] edition = "2024"`. All 7 workspace crates
+  (`musefs-db`, `musefs-format`, `musefs-core`, `musefs-fuse`, `musefs-cli`,
+  `musefs`, `musefs-latencyfs`) inherit via `edition.workspace = true`.
+- `fuzz/Cargo.toml` → `edition = "2024"`. The `fuzz` crate is excluded from the
+  workspace, so it is bumped independently.
+
+### 2. Forced fixup A — the `gen` reserved keyword
+
+`gen` becomes a reserved keyword in edition 2024. It is used as an identifier in
+~12 sites:
+
+- `musefs-core/src/facade.rs`: a `gen: AtomicU64` field on the facade handle
+  struct plus local bindings reading/writing it.
+- `musefs-core/src/tree.rs`: `for gen in 0..N` test loop variables and
+  format-string interpolations of `gen`.
+
+**Decision:** rename the identifiers to readable names (e.g. `gen` →
+`generation`) rather than papering over them with `r#gen` raw-identifier cruft.
+The struct field rename goes through `find_referencing_symbols` to update every
+use; the test loop variables are local renames. Pure rename — no behavioral
+change.
+
+**Catch the interpolations:** `find_referencing_symbols` will not see `gen`
+inside `format!("Gen{gen}…")` interpolations or doc comments in `tree.rs`
+(≈ lines 903–944), and those break the build silently if missed. After the
+symbolic rename, run a textual sweep (`grep -rnw gen`) over the touched files
+to confirm zero remaining bare-`gen` identifier occurrences.
+
+### 3. Forced fixup B — `std::env::set_var` / `remove_var` become `unsafe`
+
+Edition 2024 marks `std::env::set_var` and `std::env::remove_var` as `unsafe fn`
+(process-global mutation is unsound in the presence of concurrent readers). The
+workspace **denies `unsafe_code`**, including in tests (`--all-targets`).
+
+The 15 call sites (6 `set_var` + 9 `remove_var`) live in
+`musefs-core/tests/common_corpus_smoke.rs`, which
+deliberately mutates the `MUSEFS_BENCH_*` environment to exercise the
+config-from-env path in `tests/common/corpus.rs`. Those env vars are the bench
+harness's established shell-driven config protocol (read across `corpus.rs`,
+`bench_ingest.rs`, `bench_refresh.rs`, and the `read_throughput` bench), so
+redesigning the smoke test to avoid process-env mutation is out of scope for an
+edition bump.
+
+**Decision:** concentrate the now-`unsafe` calls into a single audited test
+helper rather than scattering `unsafe` across 15 sites.
+
+- Add the helper **in `common_corpus_smoke.rs` itself**, not in the shared
+  `tests/common/` module. The 15 mutation sites and the env-lock `static` are
+  already file-private to the smoke test, and `tests/common/corpus.rs` only
+  *reads* env. Putting the helper (and its `#[expect(unsafe_code)]`) in shared
+  `common/` would spread the attribute into the ~25 test binaries that include
+  the module and risk an unfulfilled-`expect` failure under `-D warnings` in
+  binaries that never call it.
+- The helper — e.g. `set_env(key, val)` and `remove_env(key)` — wraps the
+  `unsafe { std::env::set_var(...) }` / `remove_var` in **one** place under a
+  single, scope-minimal `#[expect(unsafe_code, reason = "test-only env
+  mutation, serialized by the env lock; std marked env mutation unsafe in
+  edition 2024")]` on the `unsafe` block.
+- The safety precondition (no concurrent env access) is already met: every
+  env-touching test acquires `ENV_LOCK` first. The helper documents this.
+- Replace the 15 `std::env::set_var`/`remove_var` call sites with calls to the
+  helper.
+
+This is exactly the per-site opt-in the workspace lint comment prescribes for
+"a genuinely-necessary unsafe", keeps the `deny` lint meaningful everywhere
+else, and is the only `unsafe` reintroduced.
+
+### 4. Catch-all migration pass
+
+**Sequencing:** apply the `gen` rename (fixup A) and the env helper (fixup B)
+**before** running `cargo fix --edition`. If `cargo fix` runs first against the
+raw env calls, it auto-inserts 15 separate `unsafe { … }` blocks that the
+`deny(unsafe_code)` lint then rejects — wasted churn. Hand-fix A and B, then run
+`cargo fix --edition` to catch anything residual.
+
+Run `cargo fix --edition`, then review its output by hand:
+
+- Keep any genuinely-needed `+ use<>` precise-capture bound on the single
+  `-> impl` return.
+- Watch for never-type fallback (`!` → `()`) and `if let` tail-temporary-scope
+  changes flagged by the migration; address only what the compiler reports.
+- **Revert purely-cosmetic churn** so the final diff stays mechanical and
+  reviewable (declaration + `gen` rename + env helper + any real compiler-forced
+  fix, nothing else).
+
+### 5. Docs
+
+Update the two live docs that name the edition; leave historical
+specs/plans under `docs/superpowers/` untouched (frozen records):
+
+- `CONTRIBUTING.md:9` — "edition 2021" → "edition 2024".
+- `README.md:154` — "Rust (2021 edition)" → "Rust (2024 edition)".
+
+## Verification
+
+All must be green (pre-commit hook runs the full workspace suite):
+
+- `cargo build`
+- `cargo test` (full workspace)
+- `cargo test --doc` (doctests — run explicitly; do not assume the pre-commit
+  invocation covers them)
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo clippy --all-targets --all-features -- -D warnings` (covers the
+  non-default feature-gated code: `metrics` in core/fuse, `fuzzing` in format,
+  `mutants` in db — the edition change applies to gated code too)
+- `cargo build --no-default-features` (the other end of the feature surface)
+- `cargo fmt --all --check`
+- FreeBSD cross-clippy: `cargo clippy --all-targets --target x86_64-unknown-freebsd`
+  (the project's only non-Linux lint gate)
+- `cargo +nightly fuzz build` (confirm the independently-bumped fuzz crate
+  still builds)
+
+FUSE e2e (`--ignored`, sudo-gated) is unaffected by an edition bump and is not
+required to change.
+
+## Deliverable for PR 2 — improvement-candidate inventory
+
+During/after the migration, write a notes file to
+`docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md` cataloging
+the edition-2024-enabled cleanups, **without applying any of them**:
+
+- **Let-chains** (the primary win — `if let … && let … && cond`, stable only
+  under edition 2024). Survey the ~103 `if let` sites for nested ladders that
+  collapse; list concrete file:line candidates with a one-line before/after
+  sketch.
+- Any `+ use<>` precise-capture simplifications or never-type ergonomics noticed
+  in passing.
+
+This notes file is the input to PR 2's own brainstorm/spec and is superseded by
+that spec.
+
+## Out of scope
+
+- Applying any ergonomic cleanup (let-chains etc.) — that is PR 2.
+- Redesigning the bench `MUSEFS_BENCH_*` env config protocol.
+- Any `rust-version`/MSRV policy addition.

--- a/docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md
+++ b/docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md
@@ -1,0 +1,85 @@
+# Edition 2024 — improvement candidates (PR 2 seed)
+
+**Date:** 2026-06-08
+**Status:** Inventory only — nothing applied. Input to PR 2's brainstorm.
+**Context:** Produced during the edition 2024 bump (PR 1,
+`docs/superpowers/plans/2026-06-08-edition-2024-bump.md`).
+
+## Headline finding
+
+**The bump itself already applied every mechanically-beneficial let-chain
+collapse.** Under edition 2024, `clippy::collapsible_if` (a default-`warn`
+lint, escalated to error by the `-D warnings` gate) suggests merging a nested
+`if let P = e { if c { … } }` into `if let P = e && c { … }`. Because the
+workspace clippy gate denies warnings, those collapses were *forced* during the
+bump commit (`ba8f744`) — 9 sites across 5 files, not optional cleanup:
+
+| File | Line | Collapsed chain |
+| --- | --- | --- |
+| `musefs-format/src/mp3.rs` | 113, 651 | `if let Some(tail) = tail && … && &tail[0..3] == b"TAG"` (bool chain); POPM `if let Some(nul) … && let Some((&rating, counter)) …` |
+| `musefs-core/src/facade.rs` | 747, 758, 780, 785 | refresh-diff `inode_of_track` guards merged into the surrounding conditions (`&& let` at 748/758/781/786) |
+| `musefs-fuse/src/lib.rs` | 226 | `… && let Err(inval_err) = n.inval_inode(…)` |
+| `musefs-fuse/src/platform/passthrough.rs` | 59 | `… && let Some(pfd) = core.passthrough_fd(fh)` |
+| `musefs-latencyfs/src/lib.rs` | 419, 585 | `… && let Ok(s) = statvfs(&p)`; `… && let Err(e) = OpenOptions::new()…` |
+
+So the "quick look for what edition 2024 improves" that motivated this work was,
+for let-chains, **answered by the migration itself**. PR 2's residual scope is
+small — possibly empty.
+
+## Residual let-chain candidates
+
+Of the 69 remaining `if let` sites in `src/` (non-test), the nested ones that
+clippy did *not* collapse were each checked. None is a clean, behavior-
+preserving let-chain win:
+
+- **Intervening `let` binding** (can't appear mid-chain in a 2024 let-chain).
+  Example `musefs-core/src/scan.rs:837`:
+  ```rust
+  if let Some(&(size, mtime, id, format)) = existing.get(&key) {
+      let needs_backfill = format == Format::Flac && !have_structural.contains(&id);
+      if size == meta.len() && mtime == mtime_secs(&meta) && !needs_backfill { … }
+  }
+  ```
+  `needs_backfill` is derived from the destructured fields and reused in the
+  inner test; a let-chain cannot bind it, so collapsing would require inlining
+  the expression twice. Not a win.
+
+- **Inner `if` has an `else`** → collapsing changes semantics (the `else` would
+  also catch the outer `None`). Example `musefs-format/src/ogg/mod.rs:483`:
+  ```rust
+  if let Some(PayloadChunk::Bytes(b)) = bp.first_mut() {
+      if i + 1 == n { b[0] |= 0x80; } else { b[0] &= 0x7F; }
+  }
+  ```
+  A `&& i + 1 == n { … } else { … }` chain would run the `else` when
+  `bp.first_mut()` is `None`. Incorrect — leave as-is.
+
+- **`else if let` fallback chains** (e.g. `musefs-format/src/mp3.rs:575–579`,
+  the comment/lyrics/text fallback) are disjunctive alternatives, not nested
+  conjunctions — let-chains do not apply.
+
+- **`match` arms with guards** (e.g. `musefs-core/src/refresh_diff.rs:49,76`,
+  `musefs-core/src/tree.rs:633`, `musefs-format/src/tagmap.rs:176,184,200`) are
+  already the idiomatic form; rewriting them as `if let … &&` guards would be a
+  regression in clarity, not an improvement.
+
+## Other edition-2024 ergonomics
+
+- **Precise capturing (`+ use<>`):** the workspace has exactly one `-> impl`
+  return (`musefs-format/tests/proptest_flac.rs:6`), which captures no
+  lifetimes; `cargo fix --edition` produced no `use<>` bounds. Nothing to adopt.
+- **Never-type fallback / `let_and_return`:** one `let_and_return` in
+  `musefs-db/src/tracks.rs` was force-fixed by clippy during the bump (the 2024
+  tail-expression temporary-scope change made the transform drop-order-safe).
+  No further opportunities observed.
+- **`gen` blocks / generators:** still unstable; not available on stable.
+
+## Recommendation for PR 2
+
+PR 2 may not be worth opening as a code change. The let-chain value the edition
+unlocked was auto-applied under the clippy gate during PR 1, and the residual
+candidates are either semantically unsafe to collapse, blocked by intervening
+bindings, or already idiomatic. If PR 2 proceeds, it should be a deliberate
+*readability* pass (a human deciding a specific `else if let` ladder or match
+reads better restructured), not a mechanical sweep — and each change weighed
+individually, since none is gate-forced.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "musefs-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::thread;
 
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use musefs_core::{scan_directory, Mode, MountConfig, Musefs, VirtualTree};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use musefs_core::{Mode, MountConfig, Musefs, VirtualTree, scan_directory};
 
 #[path = "../tests/common/mod.rs"]
 mod common;
-use common::corpus::{bench_formats, format_token, generate, CorpusParams, Format};
+use common::corpus::{CorpusParams, Format, bench_formats, format_token, generate};
 
 fn config() -> MountConfig {
     MountConfig {

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -43,8 +43,8 @@ impl ByteBudget {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     const WAIT: Duration = Duration::from_millis(100);

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -12,7 +12,7 @@
 //! lifetime, not the thread's. Each pool has its own map, so multiple mounts
 //! (or test DBs) on the same thread don't collide.
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{HashMap, hash_map::Entry};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::ThreadId;

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -10,8 +10,8 @@ use musefs_db::{Db, Format};
 use crate::db_pool::DbPool;
 use crate::error::{CoreError, Result};
 use crate::mapping::tags_to_fields;
-use crate::reader::{read_at_into, read_at_with_file_into, HeaderCache, ResolvedFile};
-use crate::refresh_diff::{partition_changelog, ChangeSet, TrackRenderState};
+use crate::reader::{HeaderCache, ResolvedFile, read_at_into, read_at_with_file_into};
+use crate::refresh_diff::{ChangeSet, TrackRenderState, partition_changelog};
 use crate::template::Template;
 use crate::tree::{InodeAllocator, NodeKind, VirtualTree};
 
@@ -577,10 +577,9 @@ impl Musefs {
         }
         if let Some(last_failed) =
             *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
+            && last_failed.elapsed() < self.refresh_retry_backoff
         {
-            if last_failed.elapsed() < self.refresh_retry_backoff {
-                return false;
-            }
+            return false;
         }
         true
     }
@@ -624,10 +623,9 @@ impl Musefs {
         }
         if let Some(last_failed) =
             *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
+            && last_failed.elapsed() < self.refresh_retry_backoff
         {
-            if last_failed.elapsed() < self.refresh_retry_backoff {
-                return Ok(false);
-            }
+            return Ok(false);
         }
         let version = self.pool.with_poll(|db| Ok(db.data_version()?))?;
         if version == self.last_data_version.load(Ordering::Acquire) {
@@ -744,12 +742,12 @@ impl Musefs {
         on_changed: &mut impl FnMut(u64),
     ) {
         for (tid, ns) in new {
-            if let Some(os) = old.get(tid) {
-                if os.content_version != ns.content_version && os.path == ns.path {
-                    if let Some(ino) = new_tree.inode_of_track(*tid) {
-                        on_changed(ino);
-                    }
-                }
+            if let Some(os) = old.get(tid)
+                && os.content_version != ns.content_version
+                && os.path == ns.path
+                && let Some(ino) = new_tree.inode_of_track(*tid)
+            {
+                on_changed(ino);
             }
         }
         for (tid, os) in old {
@@ -757,10 +755,8 @@ impl Musefs {
                 None => true,
                 Some(ns) => ns.path != os.path,
             };
-            if moved_or_gone {
-                if let Some(ino) = old_tree.inode_of_track(*tid) {
-                    on_changed(ino);
-                }
+            if moved_or_gone && let Some(ino) = old_tree.inode_of_track(*tid) {
+                on_changed(ino);
             }
         }
     }
@@ -780,15 +776,16 @@ impl Musefs {
             let (Some(os), Some(ns)) = (displaced.get(&id), new_states.get(&id)) else {
                 continue;
             };
-            if os.content_version != ns.content_version && os.path == ns.path {
-                if let Some(ino) = new_tree.inode_of_track(id) {
-                    on_changed(ino);
-                }
+            if os.content_version != ns.content_version
+                && os.path == ns.path
+                && let Some(ino) = new_tree.inode_of_track(id)
+            {
+                on_changed(ino);
             }
-            if ns.path != os.path {
-                if let Some(ino) = old_tree.inode_of_track(id) {
-                    on_changed(ino);
-                }
+            if ns.path != os.path
+                && let Some(ino) = old_tree.inode_of_track(id)
+            {
+                on_changed(ino);
             }
         }
         for &id in &change.removed {
@@ -889,7 +886,7 @@ impl Musefs {
                             is_dir: true,
                             size: 0,
                             mtime_secs: 0,
-                        })
+                        });
                     }
                     NodeKind::File { track_id } => *track_id,
                 },
@@ -903,14 +900,14 @@ impl Musefs {
             // `.map(|e| *e)` copies the SizeEntry (Copy) so the shard Ref drops
             // before the miss-path insert below — same key → same shard, and
             // holding the Ref across the re-lock would deadlock.
-            if let Some(e) = self.size_cache.get(&track_id).map(|e| *e) {
-                if e.content_version == track.content_version {
-                    // Hit: no backing stat, no synthesis. NOTE: a backing file
-                    // changed in place without a rescan would leave mtime/size
-                    // stale until the next scan bumps content_version — acceptable
-                    // for a read-only mount (reads still validate at open()).
-                    return Ok((e.total_len, e.mtime_secs));
-                }
+            if let Some(e) = self.size_cache.get(&track_id).map(|e| *e)
+                && e.content_version == track.content_version
+            {
+                // Hit: no backing stat, no synthesis. NOTE: a backing file
+                // changed in place without a rescan would leave mtime/size
+                // stale until the next scan bumps content_version — acceptable
+                // for a read-only mount (reads still validate at open()).
+                return Ok((e.total_len, e.mtime_secs));
             }
             // Miss: full resolve (validates via stat, builds + caches the layout).
             let resolved = self.cache.resolve(db, track_id)?;

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -68,7 +68,7 @@ pub struct Attr {
 struct Handle {
     track_id: i64,
     resolved: arc_swap::ArcSwap<ResolvedFile>,
-    gen: AtomicU64,
+    generation: AtomicU64,
     file: std::fs::File,
 }
 
@@ -968,7 +968,7 @@ impl Musefs {
                 for _attempt in 0..4 {
                     out.clear();
                     let cur = self.refresh_gen.load(Ordering::Acquire);
-                    if h.gen.load(Ordering::Acquire) != cur {
+                    if h.generation.load(Ordering::Acquire) != cur {
                         // A refresh changed something; re-resolve (cheap content_version
                         // cache hit when this track is unchanged) and re-stamp.
                         let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
@@ -978,7 +978,7 @@ impl Musefs {
                             continue;
                         }
                         h.resolved.store(fresh);
-                        h.gen.store(cur, Ordering::Release);
+                        h.generation.store(cur, Ordering::Release);
                     }
                     let resolved = h.resolved.load();
                     let r: &ResolvedFile = &resolved;
@@ -1007,7 +1007,7 @@ impl Musefs {
                     // Stale layout: force a re-resolve next iteration against the live version.
                     let fresh = self.pool.with(|db| self.cache.resolve(db, h.track_id))?;
                     h.resolved.store(fresh);
-                    h.gen
+                    h.generation
                         .store(self.refresh_gen.load(Ordering::Acquire), Ordering::Release);
                 }
                 // Pathological constant re-tagging raced every attempt; surface a
@@ -1064,7 +1064,7 @@ impl Musefs {
         // would make the first read skip re-resolution and serve stale bytes. With
         // the pre-resolve gen, a racing refresh leaves gen behind refresh_gen, so
         // the next read re-resolves.
-        let gen = self.refresh_gen.load(Ordering::Acquire);
+        let generation = self.refresh_gen.load(Ordering::Acquire);
         let resolved = self.pool.with(|db| self.cache.resolve(db, track_id))?;
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
@@ -1072,7 +1072,7 @@ impl Musefs {
         fh_from_key(self.handles.insert(Arc::new(Handle {
             track_id,
             resolved: arc_swap::ArcSwap::from(resolved),
-            gen: AtomicU64::new(gen),
+            generation: AtomicU64::new(generation),
             file,
         })))
     }

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -16,11 +16,11 @@ pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
 pub use facade::{Attr, Fh, Mode, MountConfig, Musefs, PassthroughFd};
 pub use musefs_db::convert;
-pub use reader::{read_at, read_at_with_file, HeaderCache, ResolvedFile};
+pub use reader::{HeaderCache, ResolvedFile, read_at, read_at_with_file};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{
-    revalidate, revalidate_with, scan_directory, scan_directory_with, RevalidateStats, ScanOptions,
-    ScanStats,
+    RevalidateStats, ScanOptions, ScanStats, revalidate, revalidate_with, scan_directory,
+    scan_directory_with,
 };
 pub use template::Template;
 pub use tree::{Node, NodeKind, VirtualTree};

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -25,8 +25,8 @@ pub use imp::*;
 
 #[cfg(feature = "metrics")]
 mod imp {
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::OnceLock;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::Duration;
 
     static OPENS: AtomicU64 = AtomicU64::new(0);

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -6,9 +6,9 @@ use std::sync::Mutex;
 use musefs_db::convert::usize_from;
 use musefs_db::{Db, Format};
 use musefs_format::flac::{self, MetadataBlock};
-use musefs_format::{mp3, mp4, wav, BinaryTagInput, RegionLayout, Segment};
-use quick_cache::sync::Cache;
+use musefs_format::{BinaryTagInput, RegionLayout, Segment, mp3, mp4, wav};
 use quick_cache::Weighter;
+use quick_cache::sync::Cache;
 
 use crate::error::{CoreError, Result};
 use crate::facade::Mode;
@@ -120,10 +120,10 @@ impl HeaderCache {
             return Err(CoreError::BackingChanged(track.backing_path.clone()));
         }
 
-        if let Some(hit) = self.cache.get(&track_id) {
-            if hit.content_version == track.content_version {
-                return Ok(hit);
-            }
+        if let Some(hit) = self.cache.get(&track_id)
+            && hit.content_version == track.content_version
+        {
+            return Ok(hit);
         }
         let resolved = self.build(db, &track, &meta)?;
         self.cache.insert(track_id, resolved.clone());
@@ -472,8 +472,8 @@ pub fn read_at_with_file<M>(
 #[cfg(test)]
 mod ogg_serve_tests {
     use super::*;
-    use musefs_format::ogg::page_test_support::lace_packet_pub;
     use musefs_format::Segment;
+    use musefs_format::ogg::page_test_support::lace_packet_pub;
     use std::io::Write;
 
     #[test]
@@ -530,9 +530,11 @@ mod ogg_serve_tests {
         let h1 = musefs_format::ogg::parse_page(served_audio, p1_off).unwrap();
         assert_eq!(h1.seq, 5);
         // Payload bytes unchanged.
-        assert!(served_audio[h0.header_len..h0.total_len()]
-            .iter()
-            .all(|&b| b == 0xA1));
+        assert!(
+            served_audio[h0.header_len..h0.total_len()]
+                .iter()
+                .all(|&b| b == 0xA1)
+        );
         assert!(
             served_audio[p1_off + h1.header_len..p1_off + h1.total_len()]
                 .iter()
@@ -601,9 +603,10 @@ mod resolve_ogg_tests {
         // Tags were rewritten. `ogg::read_tags` now returns canonical lowercase
         // keys for known Vorbis fields (Tasks 1–6 changed the format layer).
         let tags = musefs_format::ogg::read_tags(&out).unwrap();
-        assert!(tags
-            .iter()
-            .any(|(k, v)| k == "title" && v == "Telephasic Workshop"));
+        assert!(
+            tags.iter()
+                .any(|(k, v)| k == "title" && v == "Telephasic Workshop")
+        );
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use musefs_db::convert::usize_from;
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
-use musefs_format::{flac, mp3, mp4, ogg, wav, EmbeddedBinaryTag, EmbeddedPicture, Extent};
+use musefs_format::{EmbeddedBinaryTag, EmbeddedPicture, Extent, flac, mp3, mp4, ogg, wav};
 
 use crate::byte_budget::ByteBudget;
 use crate::error::Result;
@@ -605,8 +605,8 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
 /// single writer (this thread) in batched transactions. Per-file errors are
 /// counted, not fatal.
 fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<ScanStats> {
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     let jobs = effective_jobs(opts.jobs);
     let window = opts.window;
@@ -626,38 +626,40 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         let budget = Arc::clone(&budget);
         let skipped = Arc::clone(&skipped);
         let failed = Arc::clone(&failed);
-        workers.push(std::thread::spawn(move || loop {
-            let next = { work.lock().unwrap().next() };
-            let Some(path) = next else { break };
-            let Ok(meta) = std::fs::metadata(&path) else {
-                failed.fetch_add(1, Ordering::Relaxed);
-                continue;
-            };
-            match probe_file(&path, meta.len(), window) {
-                Ok(Some(probed)) => {
-                    let Ok(abs) = std::fs::canonicalize(&path) else {
-                        failed.fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    };
-                    let weight = payload_weight(&probed);
-                    budget.acquire(weight); // backpressure on in-flight art bytes
-                    let unit = Unit {
-                        abs_path: abs.to_string_lossy().into_owned(),
-                        meta_len: meta.len(),
-                        meta_mtime: mtime_secs(&meta),
-                        probed,
-                        weight,
-                    };
-                    if tx.send(unit).is_err() {
-                        budget.release(weight);
-                        break;
-                    }
-                }
-                Ok(None) => {
-                    skipped.fetch_add(1, Ordering::Relaxed);
-                }
-                Err(_) => {
+        workers.push(std::thread::spawn(move || {
+            loop {
+                let next = { work.lock().unwrap().next() };
+                let Some(path) = next else { break };
+                let Ok(meta) = std::fs::metadata(&path) else {
                     failed.fetch_add(1, Ordering::Relaxed);
+                    continue;
+                };
+                match probe_file(&path, meta.len(), window) {
+                    Ok(Some(probed)) => {
+                        let Ok(abs) = std::fs::canonicalize(&path) else {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            continue;
+                        };
+                        let weight = payload_weight(&probed);
+                        budget.acquire(weight); // backpressure on in-flight art bytes
+                        let unit = Unit {
+                            abs_path: abs.to_string_lossy().into_owned(),
+                            meta_len: meta.len(),
+                            meta_mtime: mtime_secs(&meta),
+                            probed,
+                            weight,
+                        };
+                        if tx.send(unit).is_err() {
+                            budget.release(weight);
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        skipped.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(_) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }
         }));
@@ -851,11 +853,11 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         if !Path::new(&track.backing_path).starts_with(&canon_root) {
             continue;
         }
-        if let Err(e) = std::fs::metadata(&track.backing_path) {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                db.delete_track(track.id)?;
-                pruned += 1;
-            }
+        if let Err(e) = std::fs::metadata(&track.backing_path)
+            && e.kind() == std::io::ErrorKind::NotFound
+        {
+            db.delete_track(track.id)?;
+            pruned += 1;
         }
     }
     db.gc_orphan_art()?;

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -900,13 +900,13 @@ mod tests {
     #[test]
     fn prune_retired_bounds_map_under_churn() {
         let mut alloc = InodeAllocator::new();
-        for gen in 0..100 {
-            let entries = vec![(1, format!("Gen{gen}/a.flac"))];
+        for generation in 0..100 {
+            let entries = vec![(1, format!("Gen{generation}/a.flac"))];
             let tree = VirtualTree::build_with(&entries, &mut alloc);
             alloc.prune_retired(&tree);
             assert!(
                 alloc.paths.len() <= 2 * tree.nodes.len(),
-                "gen {gen}: map {} exceeds 2x live {}",
+                "gen {generation}: map {} exceeds 2x live {}",
                 alloc.paths.len(),
                 tree.nodes.len()
             );
@@ -920,10 +920,10 @@ mod tests {
         let keep_dir = tree.lookup(VirtualTree::ROOT, "Keep").unwrap();
         let keep_file = tree.lookup(keep_dir, "song.flac").unwrap();
         let mut last = tree;
-        for gen in 0..10 {
+        for generation in 0..10 {
             let entries = vec![
                 (1, "Keep/song.flac".to_string()),
-                (2, format!("Gen{gen}/x.flac")),
+                (2, format!("Gen{generation}/x.flac")),
             ];
             last = VirtualTree::build_with(&entries, &mut alloc);
             alloc.prune_retired(&last);
@@ -940,8 +940,8 @@ mod tests {
         let gone_dir = t1.lookup(VirtualTree::ROOT, "Gone").unwrap();
         let gone_file = t1.lookup(gone_dir, "x.flac").unwrap();
         // Churn well past the threshold so a prune drops the retired entries.
-        for gen in 0..10 {
-            let t = VirtualTree::build_with(&[(1, format!("Gen{gen}/x.flac"))], &mut alloc);
+        for generation in 0..10 {
+            let t = VirtualTree::build_with(&[(1, format!("Gen{generation}/x.flac"))], &mut alloc);
             alloc.prune_retired(&t);
         }
         assert!(

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -674,10 +674,10 @@ impl VirtualTree {
         // (2) Structural mutation. A pruned dir chain is rename-relevant for the
         // surviving parent only on a rendered-name collision (gated like step 1).
         for &id in removed.iter().chain(moved_out.iter()) {
-            if let Some((surv, Some((name, rendered)))) = self.remove_track(id, alloc) {
-                if self.collision_gate(surv, &name, &rendered) {
-                    dirty.insert(surv);
-                }
+            if let Some((surv, Some((name, rendered)))) = self.remove_track(id, alloc)
+                && self.collision_gate(surv, &name, &rendered)
+            {
+                dirty.insert(surv);
             }
         }
         // Insert in ascending id order: two pending ids landing on the same fresh

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -3,12 +3,12 @@ mod common;
 use std::time::Instant;
 
 use common::corpus::{
-    bench_base_dir, bench_formats, format_token, prepare, prepare_format, CorpusParams, Target,
+    CorpusParams, Target, bench_base_dir, bench_formats, format_token, prepare, prepare_format,
 };
-use common::report::{peak_rss_kib, RunReport};
+use common::report::{RunReport, peak_rss_kib};
 use musefs_core::{
-    metrics, revalidate_with, scan_directory_with, Mode, MountConfig, Musefs, ScanOptions,
-    VirtualTree,
+    Mode, MountConfig, Musefs, ScanOptions, VirtualTree, metrics, revalidate_with,
+    scan_directory_with,
 };
 use musefs_db::Db;
 

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -3,9 +3,9 @@ mod common;
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
-use common::corpus::{prepare, prepare_format, CorpusParams, Format};
+use common::corpus::{CorpusParams, Format, prepare, prepare_format};
 use common::report::RunReport;
-use musefs_core::{scan_directory, Mode, MountConfig, Musefs};
+use musefs_core::{Mode, MountConfig, Musefs, scan_directory};
 use musefs_db::Db;
 
 fn config() -> MountConfig {

--- a/musefs-core/tests/binary_tag_tree.rs
+++ b/musefs-core/tests/binary_tag_tree.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::{make_flac, streaminfo_body, vorbis_comment_body};
-use musefs_core::{scan_directory, MountConfig, Musefs, VirtualTree};
+use musefs_core::{MountConfig, Musefs, VirtualTree, scan_directory};
 use std::collections::BTreeMap;
 
 fn config() -> MountConfig {

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -228,8 +228,8 @@ pub fn write_ogg(path: &Path, audio: &[u8]) -> (u64, u64) {
     let mut tags = b"OpusTags".to_vec();
     tags.extend_from_slice(&vorbis_body_empty());
     let serial = 0x6d75_7366; // "musf"
-                              // build_header returns (bytes, header_page_count); the audio page continues
-                              // the sequence at that count.
+    // build_header returns (bytes, header_page_count); the audio page continues
+    // the sequence at that count.
     let (mut bytes, header_pages) = build_header_pub(serial, &[&head, &tags]);
     let header_len = bytes.len();
     let (page, _) = lace_packet_pub(serial, header_pages, false, 960, audio);

--- a/musefs-core/tests/common/report.rs
+++ b/musefs-core/tests/common/report.rs
@@ -4,7 +4,7 @@
 /// place so the two can never drift out of alignment. (`format!` needs a string
 /// literal, so this is a macro rather than a `const`.)
 macro_rules! report_fmt {
-    ($($arg:expr),* $(,)?) => {
+    ($($arg:expr_2021),* $(,)?) => {
         format!("{:<10} {:<10} {:<14} {:<10} {:>10} {:>10} {:>10} {:>10} {:>14} {:>12}", $($arg),*)
     };
 }

--- a/musefs-core/tests/common_corpus_smoke.rs
+++ b/musefs-core/tests/common_corpus_smoke.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use common::corpus::{prepare, CorpusParams, Format, Tier};
-use common::report::{peak_rss_kib, RunReport};
+use common::corpus::{CorpusParams, Format, Tier, prepare};
+use common::report::{RunReport, peak_rss_kib};
 use common::write_m4a_moov_last;
 use common::write_ogg;
 use musefs_core::scan_directory;
@@ -13,6 +13,33 @@ use musefs_db::Db;
 /// recovers from poisoning (`PoisonError::into_inner`) so that a panic in one
 /// locked test doesn't cascade into spurious `.lock()` failures in the others.
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Set a process-global env var. `std::env::set_var` became `unsafe` in
+/// edition 2024 (mutating the environment is unsound with concurrent readers).
+/// This concentrates that single `unsafe` in one audited place; soundness rests
+/// on the existing `ENV_LOCK` discipline — every env-touching test holds the
+/// lock for the full read-modify span, so no other test thread touches the
+/// environment concurrently.
+fn set_env(key: &str, val: impl AsRef<std::ffi::OsStr>) {
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation, serialized by ENV_LOCK; std marked env mutation unsafe in edition 2024"
+    )]
+    unsafe {
+        std::env::set_var(key, val);
+    }
+}
+
+/// Remove a process-global env var. See [`set_env`] for the safety argument.
+fn remove_env(key: &str) {
+    #[expect(
+        unsafe_code,
+        reason = "test-only env mutation, serialized by ENV_LOCK; std marked env mutation unsafe in edition 2024"
+    )]
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
 
 #[test]
 fn tier_presets_have_expected_shape() {
@@ -36,13 +63,13 @@ fn env_overrides_apply_over_tier() {
     let _g = ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    std::env::set_var("MUSEFS_BENCH_TIER", "ci");
-    std::env::set_var("MUSEFS_BENCH_ALBUMS", "3");
-    std::env::set_var("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
+    set_env("MUSEFS_BENCH_TIER", "ci");
+    set_env("MUSEFS_BENCH_ALBUMS", "3");
+    set_env("MUSEFS_BENCH_TRACKS_PER_ALBUM", "4");
     let p = CorpusParams::from_env();
-    std::env::remove_var("MUSEFS_BENCH_ALBUMS");
-    std::env::remove_var("MUSEFS_BENCH_TRACKS_PER_ALBUM");
-    std::env::remove_var("MUSEFS_BENCH_TIER");
+    remove_env("MUSEFS_BENCH_ALBUMS");
+    remove_env("MUSEFS_BENCH_TRACKS_PER_ALBUM");
+    remove_env("MUSEFS_BENCH_TIER");
     assert_eq!(p.albums, 3);
     assert_eq!(p.tracks_per_album, 4);
     assert_eq!(p.track_count(), 12);
@@ -88,10 +115,10 @@ fn prepare_generates_when_no_library_set() {
     let _g = ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    std::env::remove_var("MUSEFS_BENCH_LIBRARY");
-    std::env::remove_var("MUSEFS_BENCH_DB");
+    remove_env("MUSEFS_BENCH_LIBRARY");
+    remove_env("MUSEFS_BENCH_DB");
     let scratch = tempfile::tempdir().unwrap();
-    std::env::set_var("MUSEFS_BENCH_DIR", scratch.path());
+    set_env("MUSEFS_BENCH_DIR", scratch.path());
     let p = CorpusParams {
         albums: 1,
         tracks_per_album: 2,
@@ -101,7 +128,7 @@ fn prepare_generates_when_no_library_set() {
         seed: 3,
     };
     let t = prepare(&p);
-    std::env::remove_var("MUSEFS_BENCH_DIR");
+    remove_env("MUSEFS_BENCH_DIR");
     assert!(t.corpus_dir.exists());
     assert!(!t.is_real_library);
     // DB path is separate from the corpus dir.
@@ -185,7 +212,7 @@ fn bench_formats_defaults_to_all_when_unset() {
     let _g = ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
+    remove_env("MUSEFS_BENCH_FORMAT_MIX");
     assert_eq!(
         common::corpus::bench_formats(),
         common::corpus::ALL_FORMATS.to_vec()
@@ -197,11 +224,11 @@ fn bench_formats_filters_and_never_empty() {
     let _g = ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "ogg,wav");
+    set_env("MUSEFS_BENCH_FORMAT_MIX", "ogg,wav");
     let filtered = common::corpus::bench_formats();
-    std::env::set_var("MUSEFS_BENCH_FORMAT_MIX", "garbagetoken");
+    set_env("MUSEFS_BENCH_FORMAT_MIX", "garbagetoken");
     let fallback = common::corpus::bench_formats();
-    std::env::remove_var("MUSEFS_BENCH_FORMAT_MIX");
+    remove_env("MUSEFS_BENCH_FORMAT_MIX");
     assert_eq!(filtered, vec![Format::Ogg, Format::Wav]);
     assert_eq!(
         fallback,
@@ -250,7 +277,7 @@ fn bench_base_dir_defaults_to_held_tempdir() {
     let _g = ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    std::env::remove_var("MUSEFS_BENCH_DIR");
+    remove_env("MUSEFS_BENCH_DIR");
     let (base, scratch) = common::corpus::bench_base_dir();
     assert!(base.exists(), "base dir exists");
     assert!(

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -1,7 +1,7 @@
 mod common;
 use common::make_flac;
 use common::{streaminfo_body, vorbis_comment_body};
-use musefs_core::{scan_directory, CoreError, MountConfig, Musefs, VirtualTree};
+use musefs_core::{CoreError, MountConfig, Musefs, VirtualTree, scan_directory};
 use std::collections::BTreeMap;
 
 fn config() -> MountConfig {

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -781,6 +781,79 @@ fn poll_refresh_notify_reports_changed_track_inode() {
 }
 
 #[test]
+fn poll_refresh_notify_reports_changed_inode_on_full_rebuild_fallback() {
+    use musefs_db::Tag;
+    let dir = tempfile::tempdir().unwrap();
+    // Two backing files -> two tracks: Alice/Song and Bob/Tune.
+    for (name, artist, title) in [("a.flac", "Alice", "Song"), ("b.flac", "Bob", "Tune")] {
+        let bytes = make_flac(
+            &[
+                (0, streaminfo_body()),
+                (
+                    4,
+                    vorbis_comment_body(
+                        "v",
+                        &[&format!("ARTIST={artist}"), &format!("TITLE={title}")],
+                    ),
+                ),
+            ],
+            &[0xAB; 64],
+        );
+        std::fs::write(dir.path().join(name), &bytes).unwrap();
+    }
+    let db_path = dir.path().join("m.db");
+    {
+        let db = musefs_db::Db::open(&db_path).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+    }
+    let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), config()).unwrap();
+
+    let alice = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let alice_song = fs.lookup(alice, "Song.flac").unwrap();
+
+    let alice_id = musefs_db::Db::open(&db_path)
+        .unwrap()
+        .list_tracks()
+        .unwrap()
+        .into_iter()
+        .find(|t| t.backing_path.ends_with("a.flac"))
+        .unwrap()
+        .id;
+
+    // Path-stable retag: content_version bumps, inode/path stay put.
+    {
+        let db2 = musefs_db::Db::open(&db_path).unwrap();
+        db2.replace_tags(
+            alice_id,
+            &[
+                Tag::new("artist", "Alice", 0),
+                Tag::new("title", "Song", 0),
+                Tag::new("album", "New", 0),
+            ],
+        )
+        .unwrap();
+    }
+
+    // Force the changelog-gap full-rebuild path so the notifier is
+    // `notify_changed` (the full-rebuild routine) rather than the incremental
+    // `notify_changed_delta` the sibling test exercises — covering the
+    // full-rebuild change-detection (content_version-rose + path-stable). The
+    // rebuild reuses the same inode for a path-stable track.
+    {
+        let writer = musefs_db::Db::open(&db_path).unwrap();
+        let max_seq = writer.changelog_since(0).unwrap().max_seq;
+        writer.delete_changelog_through_for_test(max_seq).unwrap();
+    }
+    let mut changed = Vec::new();
+    assert!(fs.poll_refresh_notify(|ino| changed.push(ino)).unwrap());
+    assert_eq!(
+        changed,
+        vec![alice_song],
+        "full-rebuild path must invalidate exactly the changed track's stable inode"
+    );
+}
+
+#[test]
 fn poll_refresh_notify_reports_old_inode_for_path_changing_retag() {
     use musefs_db::Tag;
     let dir = tempfile::tempdir().unwrap();

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::{make_flac, streaminfo_body, vorbis_comment_body};
-use musefs_core::{scan_directory, MountConfig, Musefs, VirtualTree};
+use musefs_core::{MountConfig, Musefs, VirtualTree, scan_directory};
 use std::collections::BTreeMap;
 
 // Block types: STREAMINFO=0, APPLICATION=2, SEEKTABLE=3, VORBIS_COMMENT=4, CUESHEET=5.
@@ -154,12 +154,13 @@ fn legacy_flac_without_structural_rows_serves_via_front_read_fallback() {
 
     // The legacy path carries every preserved block inline, including APPLICATION.
     let tag = metaflac::Tag::read_from(&mut std::io::Cursor::new(&served)).expect("valid FLAC");
-    assert!(tag
-        .blocks()
-        .any(|b| matches!(b, metaflac::Block::Application(_))));
+    assert!(
+        tag.blocks()
+            .any(|b| matches!(b, metaflac::Block::Application(_)))
+    );
 }
 
-use musefs_core::{read_at, revalidate, HeaderCache, Mode};
+use musefs_core::{HeaderCache, Mode, read_at, revalidate};
 use proptest::prelude::*;
 
 #[test]

--- a/musefs-core/tests/incremental_refresh.rs
+++ b/musefs-core/tests/incremental_refresh.rs
@@ -3,10 +3,10 @@ mod common;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use musefs_core::{scan_directory, Mode, MountConfig, Musefs};
+use musefs_core::{Mode, MountConfig, Musefs, scan_directory};
 use musefs_db::{Db, Tag};
 
-use common::corpus::{prepare, CorpusParams, Format, Target};
+use common::corpus::{CorpusParams, Format, Target, prepare};
 use proptest::prelude::*;
 
 /// A small single-album FLAC corpus with `n` tracks. The returned `Target` owns

--- a/musefs-core/tests/interop_emit.rs
+++ b/musefs-core/tests/interop_emit.rs
@@ -1,8 +1,8 @@
 mod common;
-use musefs_core::{read_at, HeaderCache, Mode};
+use musefs_core::{HeaderCache, Mode, read_at};
 use musefs_db::{BinaryTag, Db, Format, NewArt, NewTrack, Tag, TrackArt};
-use musefs_format::fuzz_check::fixtures;
 use musefs_format::Segment;
+use musefs_format::fuzz_check::fixtures;
 use std::io::Write;
 use std::path::Path;
 

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -5,7 +5,7 @@ use common::{
     make_flac, picture_block_body, streaminfo_body, vorbis_comment_body, write_ogg,
     write_oggflac_with_art, write_opus_with_art,
 };
-use musefs_core::{metrics, scan_directory, MountConfig, Musefs, VirtualTree};
+use musefs_core::{MountConfig, Musefs, VirtualTree, metrics, scan_directory};
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 
@@ -448,7 +448,7 @@ fn scan_still_reads_id3v1_tail_for_mp3() {
     let _guard = METRICS_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    use common::corpus::{prepare_format, CorpusParams, Format as CFormat};
+    use common::corpus::{CorpusParams, Format as CFormat, prepare_format};
     let tmp = tempfile::tempdir().unwrap();
     let params = CorpusParams::single(CFormat::Mp3, 1, 1);
     let target = prepare_format(&params, tmp.path(), params.format_mix[0]);

--- a/musefs-core/tests/pipeline_backpressure.rs
+++ b/musefs-core/tests/pipeline_backpressure.rs
@@ -3,7 +3,7 @@
 //! blocking in `budget.acquire` (called before `send`) must never strand the
 //! writer parked on `recv`. Pre-fix this deadlocked on art-bearing libraries.
 
-use musefs_core::{scan_directory_with, ScanOptions};
+use musefs_core::{ScanOptions, scan_directory_with};
 use musefs_db::Db;
 
 /// A minimal FLAC carrying a PICTURE block of `data_len` image bytes (so the

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::corpus::{bench_formats, format_token, generate, CorpusParams};
+use common::corpus::{CorpusParams, bench_formats, format_token, generate};
 use musefs_db::Db;
 
 /// One comparable track row: `(backing_path, audio_offset, audio_length, tags,

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -3,7 +3,7 @@ use common::write_flac;
 use common::write_m4a;
 use common::write_mp3;
 use common::write_wav;
-use musefs_core::{read_at, HeaderCache, Mode};
+use musefs_core::{HeaderCache, Mode, read_at};
 use musefs_db::{BinaryTag, Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_format::Segment;
 use proptest::prelude::*;

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::write_flac;
-use musefs_core::{read_at, read_at_with_file, HeaderCache, Mode};
+use musefs_core::{HeaderCache, Mode, read_at, read_at_with_file};
 use musefs_db::{Db, Format, NewTrack, Tag};
 
 fn setup() -> (tempfile::TempDir, Db, i64) {
@@ -83,17 +83,21 @@ fn reading_past_eof_returns_empty() {
     let (_dir, db, id) = setup();
     let cache = HeaderCache::new(Mode::Synthesis);
     let resolved = cache.resolve(&db, id).unwrap();
-    assert!(read_at(&resolved, &db, resolved.total_len, 100)
-        .unwrap()
-        .is_empty());
-    assert!(read_at(&resolved, &db, resolved.total_len + 5, 100)
-        .unwrap()
-        .is_empty());
+    assert!(
+        read_at(&resolved, &db, resolved.total_len, 100)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        read_at(&resolved, &db, resolved.total_len + 5, 100)
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
 fn read_at_streams_art_image_segments() {
-    use musefs_core::{read_at, ResolvedFile};
+    use musefs_core::{ResolvedFile, read_at};
     use musefs_format::{RegionLayout, Segment};
 
     let db = Db::open_in_memory().unwrap();
@@ -145,9 +149,11 @@ fn out_of_range_read_short_circuits_before_opening_the_backing_file() {
     // backing file; deleting it makes any open attempt an error.
     std::fs::remove_file(&resolved.backing_path).unwrap();
 
-    assert!(read_at(&resolved, &db, resolved.total_len, 100)
-        .unwrap()
-        .is_empty());
+    assert!(
+        read_at(&resolved, &db, resolved.total_len, 100)
+            .unwrap()
+            .is_empty()
+    );
     assert!(read_at(&resolved, &db, 10, 0).unwrap().is_empty());
 }
 
@@ -165,9 +171,11 @@ fn read_at_with_file_out_of_range_and_zero_size_return_empty() {
         (resolved.total_len, 1),
         (10, 0),
     ] {
-        assert!(read_at_with_file(&resolved, &db, &file, off, size)
-            .unwrap()
-            .is_empty());
+        assert!(
+            read_at_with_file(&resolved, &db, &file, off, size)
+                .unwrap()
+                .is_empty()
+        );
     }
 }
 

--- a/musefs-core/tests/reader.rs
+++ b/musefs-core/tests/reader.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::write_flac;
-use musefs_core::{read_at, HeaderCache, Mode};
+use musefs_core::{HeaderCache, Mode, read_at};
 use musefs_db::{Db, Format, NewTrack, Tag};
 
 fn setup() -> (tempfile::TempDir, Db, i64) {
@@ -134,11 +134,11 @@ fn resolve_includes_art_image_segments() {
 
     let cache = HeaderCache::new(Mode::Synthesis);
     let resolved = cache.resolve(&db, id).unwrap();
-    assert!(resolved
-        .layout
-        .segments
-        .iter()
-        .any(|s| matches!(s, Segment::ArtImage { art_id: a, len } if *a == art_id && *len == 80)));
+    assert!(
+        resolved.layout.segments.iter().any(
+            |s| matches!(s, Segment::ArtImage { art_id: a, len } if *a == art_id && *len == 80)
+        )
+    );
 }
 
 #[test]

--- a/musefs-core/tests/scan.rs
+++ b/musefs-core/tests/scan.rs
@@ -115,12 +115,14 @@ fn scans_mp3_files_seeding_tracks_and_tags() {
     assert_eq!(t.audio_length, audio_len);
 
     let tags = db.get_tags(t.id).unwrap();
-    assert!(tags
-        .iter()
-        .any(|tag| tag.key == "artist" && tag.value == "Bob"));
-    assert!(tags
-        .iter()
-        .any(|tag| tag.key == "title" && tag.value == "Track"));
+    assert!(
+        tags.iter()
+            .any(|tag| tag.key == "artist" && tag.value == "Bob")
+    );
+    assert!(
+        tags.iter()
+            .any(|tag| tag.key == "title" && tag.value == "Track")
+    );
 }
 
 #[test]
@@ -139,9 +141,10 @@ fn scans_m4a_files_seeding_tracks() {
     assert_eq!(tracks[0].format, Format::M4a);
 
     let tags = db.get_tags(tracks[0].id).unwrap();
-    assert!(tags
-        .iter()
-        .any(|t| t.key == "title" && t.value == "Orig M4A"));
+    assert!(
+        tags.iter()
+            .any(|t| t.key == "title" && t.value == "Orig M4A")
+    );
 }
 
 #[test]

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -5,8 +5,8 @@
 //! fallback, and the revalidate skip-pass counters.
 
 use musefs_core::{
-    revalidate, revalidate_with, scan_directory, scan_directory_full_oracle, scan_directory_with,
-    ScanOptions,
+    ScanOptions, revalidate, revalidate_with, scan_directory, scan_directory_full_oracle,
+    scan_directory_with,
 };
 use musefs_db::Db;
 
@@ -306,7 +306,9 @@ fn revalidate_failed_carries_scan_failure() {
     // still opens despite mode 000, permissions aren't enforced for us, so this
     // test can't exercise the probe_file failure path. Skip rather than fail.
     if std::fs::File::open(&denied).is_ok() {
-        eprintln!("skipping revalidate_failed_carries_scan_failure: file permissions not enforced (running as root?)");
+        eprintln!(
+            "skipping revalidate_failed_carries_scan_failure: file permissions not enforced (running as root?)"
+        );
         std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o644)).unwrap();
         return;
     }

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -1,7 +1,7 @@
 use crate::art::sha256_hex;
 use crate::models::{BinaryTag, NewArt, NewTrack, StructuralBlock, Tag, TrackArt};
 use crate::{Db, ReadWrite, Result};
-use rusqlite::{params, Transaction};
+use rusqlite::{Transaction, params};
 
 impl Db<ReadWrite> {
     /// Apply the bulk-write pragmas to an open connection. WAL is left untouched
@@ -146,8 +146,8 @@ impl BulkWriter<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::{Format, NewArt, NewTrack, Tag, TrackArt};
     use crate::Db;
+    use crate::models::{Format, NewArt, NewTrack, Tag, TrackArt};
 
     #[test]
     fn bulk_writer_persists_a_batch_in_one_commit() {

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -1,6 +1,6 @@
 use crate::models::{Format, NewTrack, Track};
 use crate::{Db, ReadWrite, Result};
-use rusqlite::{params, Row};
+use rusqlite::{Row, params};
 
 const TRACK_COLS: &str = "id, backing_path, format, audio_offset, audio_length, \
                           backing_size, backing_mtime, content_version, updated_at";
@@ -128,10 +128,8 @@ impl<M> Db<M> {
             let mut stmt = tx.prepare(
                 "SELECT DISTINCT track_id FROM track_changes WHERE seq > ?1 ORDER BY track_id",
             )?;
-            let ids = stmt
-                .query_map([last_seq], |r| r.get(0))?
-                .collect::<rusqlite::Result<Vec<i64>>>()?;
-            ids
+            stmt.query_map([last_seq], |r| r.get(0))?
+                .collect::<rusqlite::Result<Vec<i64>>>()?
         };
         tx.commit()?;
         Ok(ChangelogRead {

--- a/musefs-db/tests/tags.rs
+++ b/musefs-db/tests/tags.rs
@@ -119,7 +119,8 @@ fn read_binary_tag_chunk_into_matches_vec_variant_and_errors_on_short_read() {
     assert_eq!(buf, expected);
 
     let mut over = vec![0u8; 128];
-    assert!(db
-        .read_binary_tag_chunk_into(payload_id, 3, &mut over)
-        .is_err());
+    assert!(
+        db.read_binary_tag_chunk_into(payload_id, 3, &mut over)
+            .is_err()
+    );
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -903,7 +903,7 @@ mod tests {
 
     #[test]
     fn split_preserved_classifies_structural_and_binary() {
-        use super::{split_preserved, structural_block_type, MetadataBlock};
+        use super::{MetadataBlock, split_preserved, structural_block_type};
         // STREAMINFO(0), APPLICATION(2), SEEKTABLE(3), CUESHEET(5) in arbitrary order.
         let blocks = vec![
             MetadataBlock {
@@ -962,8 +962,8 @@ mod tests {
         // This keeps the boundary correct regardless of the framing's field count.
         let framing_len = picture_body_framing(&mk(0)).unwrap().len() as u64;
         let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
-                                                  // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
-                                                  // (data_len is only a count; no large allocation occurs.)
+        // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
+        // (data_len is only a count; no large allocation occurs.)
         assert!(synthesize_layout(&[], 0, 0, &[], &[], &[mk(at_limit)]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
         assert_eq!(

--- a/musefs-format/src/fuzz_check.rs
+++ b/musefs-format/src/fuzz_check.rs
@@ -261,7 +261,7 @@ pub mod fixtures {
         out.push(0x04); // major version 4
         out.push(0x00); // revision 0
         out.push(0x00); // flags
-                        // Syncsafe size = 0 (no frames).
+        // Syncsafe size = 0 (no frames).
         out.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
         // MPEG frame sync: 0xFF + 0xFB (MPEG1, Layer III, 128kbps, 44100Hz, stereo).
         // Followed by 2 bytes to satisfy the `audio_offset + 1 < len` check.

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -110,10 +110,11 @@ pub fn locate_audio_bounded(
     }
 
     let mut audio_end = file_len;
-    if let Some(tail) = tail {
-        if file_len >= audio_offset as u64 + 128 && &tail[0..3] == b"TAG" {
-            audio_end -= 128;
-        }
+    if let Some(tail) = tail
+        && file_len >= audio_offset as u64 + 128
+        && &tail[0..3] == b"TAG"
+    {
+        audio_end -= 128;
     }
 
     Ok(Extent::Complete(Mp3Bounds {
@@ -648,16 +649,16 @@ fn classify_binary_frame(
     match id {
         b"POPM" => {
             // <owner>\0<rating:u8>[<counter: big-endian>]
-            if let Some(nul) = body.iter().position(|&b| b == 0) {
-                if let Some((&rating, counter)) = body[nul + 1..].split_first() {
-                    promoted.push(("rating".to_string(), rating.to_string()));
-                    let c = counter
-                        .iter()
-                        .take(8)
-                        .fold(0u64, |a, &b| (a << 8) | u64::from(b));
-                    if c > 0 {
-                        promoted.push(("playcount".to_string(), c.to_string()));
-                    }
+            if let Some(nul) = body.iter().position(|&b| b == 0)
+                && let Some((&rating, counter)) = body[nul + 1..].split_first()
+            {
+                promoted.push(("rating".to_string(), rating.to_string()));
+                let c = counter
+                    .iter()
+                    .take(8)
+                    .fold(0u64, |a, &b| (a << 8) | u64::from(b));
+                if c > 0 {
+                    promoted.push(("playcount".to_string(), c.to_string()));
                 }
             }
         }
@@ -705,7 +706,7 @@ mod tests {
         bytes.push(0x03); // major version 2.3
         bytes.push(0x00); // revision
         bytes.push(0x00); // flags: no extended header, no unsync
-                          // synchsafe body = 10 (covers exactly one 10-byte frame header)
+        // synchsafe body = 10 (covers exactly one 10-byte frame header)
         bytes.extend_from_slice(&[0x00, 0x00, 0x00, 0x0A]);
         // Frame header: id "TIT2", size 0xFFFF_FFFF (big-endian, plain 32-bit)
         bytes.extend_from_slice(b"TIT2");
@@ -1219,7 +1220,7 @@ mod tests {
         let mut f_mid = b"TT2".to_vec();
         f_mid.extend_from_slice(&[0x00, 0x01, 0x00]); // 24-bit size = 256
         assert!(!id3v2_alloc_safe(&id3v2(0x02, 0x00, 6, &f_mid))); // pins the mid byte
-                                                                   // size bytes [0x01,0x00,0x00] = 65536 -> reject; pins the high byte.
+        // size bytes [0x01,0x00,0x00] = 65536 -> reject; pins the high byte.
         let mut f_hi = b"TT2".to_vec();
         f_hi.extend_from_slice(&[0x01, 0x00, 0x00]);
         assert!(!id3v2_alloc_safe(&id3v2(0x02, 0x00, 6, &f_hi)));
@@ -1557,8 +1558,8 @@ mod tests {
     #[test]
     fn locate_audio_bounded_short_prefix_small_file_proceeds() {
         let data = [0xFF, 0xFB, 0x90, 0x00, 0x00]; // len 5, file_len 8 -> but prefix==file here
-                                                   // Make file_len 8 with the same 5-byte prefix window; the sync pair (2 bytes)
-                                                   // is inside the prefix, so it resolves without needing more.
+        // Make file_len 8 with the same 5-byte prefix window; the sync pair (2 bytes)
+        // is inside the prefix, so it resolves without needing more.
         let file_len = 8u64;
         match locate_audio_bounded(&data, file_len, None).unwrap() {
             Extent::Complete(b) => {
@@ -1585,7 +1586,7 @@ mod tests {
         full.extend(std::iter::repeat_n(0u8, body)); // tag end at offset 14
         let audio_offset = full.len() as u64; // 14
         full.push(0xFF); // a single sync byte present (so prefix has audio_offset+1)
-                         // file_len = audio_offset + 1, so audio_offset + 2 == file_len + 1 (just past).
+        // file_len = audio_offset + 1, so audio_offset + 2 == file_len + 1 (just past).
         let file_len = audio_offset + 1; // 15
         match locate_audio_bounded(&full, file_len, None) {
             Err(FormatError::NotMp3) => {}
@@ -1620,7 +1621,7 @@ mod tests {
         full.push(0xFF); // frame sync pair, and nothing after
         full.push(0xFB);
         let file_len = full.len() as u64; // 16 == audio_offset + 2
-                                          // kills mp3 L96 `>`->`>=`: equal-fit audio must be accepted, not rejected.
+        // kills mp3 L96 `>`->`>=`: equal-fit audio must be accepted, not rejected.
         match locate_audio_bounded(&full, file_len, None).unwrap() {
             Extent::Complete(b) => {
                 assert_eq!(b.audio_offset, audio_offset);
@@ -1760,8 +1761,8 @@ mod tests {
         full.extend_from_slice(b"TAGxx"); // tail-ish marker, but file stays short
         let file_len = full.len() as u64;
         assert!(file_len < audio_offset + 128); // first operand FALSE
-                                                // Build a 128-byte tail buffer that starts with "TAG" (the function only
-                                                // looks at tail[0..3]); file_len is the real gate here.
+        // Build a 128-byte tail buffer that starts with "TAG" (the function only
+        // looks at tail[0..3]); file_len is the real gate here.
         let mut tail = [0u8; 128];
         tail[0..3].copy_from_slice(b"TAG");
         let prefix = &full[..usize_from(audio_offset) + 2];

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -1774,7 +1774,7 @@ mod tests {
             read_structure_from(&mut cur, buf.len() as u64).is_err()
         };
         assert!(dup(bx(b"ftyp", b"M4A isom")), "duplicate ftyp must reject"); // ftyp |= line
-                                                                              // duplicate moov: reuse the moov from a fresh fixture so it is structurally valid.
+        // duplicate moov: reuse the moov from a fresh fixture so it is structurally valid.
         let extra_moov = {
             let other = mk_mp4(true, b"AUDIO", &[0]);
             let s = read_structure(&other).unwrap();
@@ -2203,9 +2203,11 @@ mod tests {
         assert_eq!(tags[0].payload, serato);
 
         // The text `----` is the text path's job, never opaque.
-        assert!(read_binary_tags(&moov)
-            .iter()
-            .all(|t| t.key != "----:com.apple.iTunes:MOOD"));
+        assert!(
+            read_binary_tags(&moov)
+                .iter()
+                .all(|t| t.key != "----:com.apple.iTunes:MOOD")
+        );
     }
 
     #[test]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -2,9 +2,9 @@ mod b64;
 mod crc;
 mod page;
 
-pub use b64::{b64_len, b64_window, encode_b64_slice, B64Window};
+pub use b64::{B64Window, b64_len, b64_window, encode_b64_slice};
 pub use page::{
-    parse_page, patch_page_header, patch_page_header_algebraic, verify_page_crc, PageHeader,
+    PageHeader, parse_page, patch_page_header, patch_page_header_algebraic, verify_page_crc,
 };
 
 use crate::error::{FormatError, Result};
@@ -1468,7 +1468,7 @@ mod bounded_tests {
         // read_header errors. The guard `(prefix.len() as u64) < file_len` is FALSE,
         // so the function must fall to the `Err(e)` arm and return Err — never grow.
         let bad: &[u8] = b"not an ogg stream at all"; // capture pattern != "OggS"
-                                                      // Confirm the premise: read_header genuinely errors on this buffer.
+        // Confirm the premise: read_header genuinely errors on this buffer.
         assert!(read_header(bad).is_err());
         let len = bad.len() as u64;
         // kills ogg L226 guard `< file_len` -> `true`: under `true` this returns
@@ -1486,7 +1486,7 @@ mod bounded_tests {
         // does not mask, and file_len = 10_000_000 > L*2 so `.min` does not clamp.
         // Correct up_to = L*2 = 200_000. `+`->100_002, `/`->50_000 all differ.
         let buf = vec![0u8; 100_000]; // all zeros: capture pattern != "OggS" -> errors
-                                      // Confirm the premise: read_header genuinely errors on this buffer.
+        // Confirm the premise: read_header genuinely errors on this buffer.
         assert!(read_header(&buf).is_err());
         let file_len = 10_000_000u64;
         match read_metadata_bounded(&buf, file_len).unwrap() {

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -1,4 +1,4 @@
-use super::crc::{crc32, crc_shift_zeros};
+use super::crc::{crc_shift_zeros, crc32};
 use crate::error::{FormatError, Result};
 
 pub const CAPTURE: &[u8; 4] = b"OggS";
@@ -640,9 +640,11 @@ mod tests {
             .sum();
         assert_eq!(art_served, art_out.len() as u64);
         // No OggArtSlice may be zero-length (kills emit_segments:337 < -> <=).
-        assert!(segments
-            .iter()
-            .all(|s| !matches!(s, Segment::OggArtSlice { len: 0, .. })));
+        assert!(
+            segments
+                .iter()
+                .all(|s| !matches!(s, Segment::OggArtSlice { len: 0, .. }))
+        );
     }
 
     #[test]
@@ -651,7 +653,7 @@ mod tests {
         // via patch_page_header and confirm header_type (incl. EOS) is unchanged.
         let (mut page, _) = lace_packet(0xEE, 3, false, 9, &[0x11u8; 120]);
         page[5] |= FLAG_EOS; // header_type byte
-                             // Recompute the CRC over the EOS-modified page (CRC field zeroed first).
+        // Recompute the CRC over the EOS-modified page (CRC field zeroed first).
         let mut z = page.clone();
         z[22..26].copy_from_slice(&0u32.to_le_bytes());
         let crc = crc32(&z);
@@ -673,7 +675,7 @@ mod tests {
         let p = hand_page();
         assert_eq!(parse_page(&p[..26], 0), Err(FormatError::Malformed));
         assert!(parse_page(&p[..27], 0).is_err()); // header present but table missing
-                                                   // Header present, segment table truncated (kills :47).
+        // Header present, segment table truncated (kills :47).
         assert_eq!(parse_page(&p[..28], 0), Err(FormatError::Malformed));
         // Exactly full header+table+payload parses.
         assert!(parse_page(&p, 0).is_ok());
@@ -774,7 +776,7 @@ mod tests {
         let mut hdr = vec![0u8; 27];
         hdr[..4].copy_from_slice(b"OggS");
         hdr[18..22].copy_from_slice(&7u32.to_le_bytes()); // old_seq
-                                                          // byte 26 (seg_count) == 0 → header_len 27, payload_len 0.
+        // byte 26 (seg_count) == 0 → header_len 27, payload_len 0.
         let out = patch_page_header_algebraic(&hdr, 9).unwrap();
         assert_eq!(out.len(), 27);
         assert_eq!(u32::from_le_bytes(out[18..22].try_into().unwrap()), 9);

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -594,10 +594,11 @@ mod tests {
     fn inline_offset_of(layout: &RegionLayout, fourcc: &[u8; 4]) -> u64 {
         let mut off = 0u64;
         for s in &layout.segments {
-            if let Segment::Inline(b) = s {
-                if b.len() >= 4 && &b[0..4] == fourcc {
-                    return off;
-                }
+            if let Segment::Inline(b) = s
+                && b.len() >= 4
+                && &b[0..4] == fourcc
+            {
+                return off;
             }
             off += s.len();
         }

--- a/musefs-format/tests/locate.rs
+++ b/musefs-format/tests/locate.rs
@@ -1,7 +1,7 @@
 mod common;
 use common::{make_flac, streaminfo_body, vorbis_comment_body};
-use musefs_format::flac::locate_audio;
 use musefs_format::FormatError;
+use musefs_format::flac::locate_audio;
 
 #[test]
 fn locates_audio_after_metadata_and_preserves_streaminfo() {

--- a/musefs-format/tests/mp3_locate.rs
+++ b/musefs-format/tests/mp3_locate.rs
@@ -1,5 +1,5 @@
-use musefs_format::mp3::locate_audio;
 use musefs_format::FormatError;
+use musefs_format::mp3::locate_audio;
 
 /// A 10-byte ID3v2.4 header declaring `body_len` bytes of tag body (no footer).
 fn id3v2_header(body_len: u32) -> Vec<u8> {

--- a/musefs-format/tests/mp3_synthesize.rs
+++ b/musefs-format/tests/mp3_synthesize.rs
@@ -73,10 +73,12 @@ fn synthesizes_apic_with_streamed_image_bytes() {
     let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &arts).unwrap();
 
     // The image is a streamed segment, not materialized inline.
-    assert!(layout
-        .segments
-        .iter()
-        .any(|s| matches!(s, Segment::ArtImage { art_id: 7, len } if *len == 200)));
+    assert!(
+        layout
+            .segments
+            .iter()
+            .any(|s| matches!(s, Segment::ArtImage { art_id: 7, len } if *len == 200))
+    );
 
     let bytes = assemble(&layout, &audio, &[(7, &art_bytes)]);
     assert_eq!(bytes.len() as u64, layout.total_len());

--- a/musefs-format/tests/mp4_oracle.rs
+++ b/musefs-format/tests/mp4_oracle.rs
@@ -3,7 +3,7 @@
 //! samples read through OUR patched chunk offsets are byte-identical to the
 //! originals — proving the offset surgery.
 
-use musefs_format::{mp4, ArtInput, RegionLayout, Segment, TagInput};
+use musefs_format::{ArtInput, RegionLayout, Segment, TagInput, mp4};
 use std::io::Cursor;
 
 fn materialize(layout: &RegionLayout, backing: &[u8]) -> Vec<u8> {

--- a/musefs-format/tests/proptest_flac.rs
+++ b/musefs-format/tests/proptest_flac.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{flac, ArtInput, Segment, TagInput};
+use musefs_format::{ArtInput, Segment, TagInput, flac};
 use proptest::prelude::*;
 
 fn tags_strategy() -> impl Strategy<Value = Vec<(String, String)>> {

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{mp3, ArtInput, BinaryTagInput, Segment, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, Segment, TagInput, mp3};
 use proptest::prelude::*;
 
 proptest! {

--- a/musefs-format/tests/proptest_mp4.rs
+++ b/musefs-format/tests/proptest_mp4.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{mp4, ArtInput, BinaryTagInput, RegionLayout, Segment, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, RegionLayout, Segment, TagInput, mp4};
 use proptest::prelude::*;
 
 proptest! {

--- a/musefs-format/tests/proptest_ogg.rs
+++ b/musefs-format/tests/proptest_ogg.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{ogg, TagInput};
+use musefs_format::{TagInput, ogg};
 use proptest::prelude::*;
 
 proptest! {

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{wav, ArtInput, BinaryTagInput, RegionLayout, Segment, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, RegionLayout, Segment, TagInput, wav};
 use proptest::prelude::*;
 
 proptest! {

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -138,10 +138,12 @@ fn zero_byte_art_is_skipped_so_the_track_still_serves() {
     .unwrap();
 
     // No ArtImage segment was emitted.
-    assert!(!layout
-        .segments
-        .iter()
-        .any(|s| matches!(s, Segment::ArtImage { .. })));
+    assert!(
+        !layout
+            .segments
+            .iter()
+            .any(|s| matches!(s, Segment::ArtImage { .. }))
+    );
 
     // The track still round-trips: header + verbatim audio (no art bytes needed).
     let art_map = HashMap::new();

--- a/musefs-format/tests/wav_locate.rs
+++ b/musefs-format/tests/wav_locate.rs
@@ -1,5 +1,5 @@
-use musefs_format::wav::{locate_audio, read_structure};
 use musefs_format::FormatError;
+use musefs_format::wav::{locate_audio, read_structure};
 
 /// A 16-byte PCM `fmt ` payload: mono, 44.1 kHz, 16-bit.
 pub fn fmt_pcm_16bit_mono() -> Vec<u8> {

--- a/musefs-format/tests/wav_synthesize.rs
+++ b/musefs-format/tests/wav_synthesize.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use id3::TagLike;
-use musefs_format::wav::{synthesize_layout, WavScan};
+use musefs_format::wav::{WavScan, synthesize_layout};
 use musefs_format::{ArtInput, RegionLayout, Segment, TagInput};
 
 fn fmt_pcm_16bit_mono() -> Vec<u8> {
@@ -91,10 +91,12 @@ fn embeds_full_fidelity_id3_tag_with_art() {
 
     let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
     // Art is a streamed segment, never materialized inline.
-    assert!(layout
-        .segments
-        .iter()
-        .any(|s| matches!(s, Segment::ArtImage { art_id: 9, len } if *len == 120)));
+    assert!(
+        layout
+            .segments
+            .iter()
+            .any(|s| matches!(s, Segment::ArtImage { art_id: 9, len } if *len == 120))
+    );
 
     let bytes = assemble(&layout, &audio, &[(9, &art_bytes)]);
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -16,11 +16,11 @@ use fuser::{
     INodeNo, InitFlags, KernelConfig, LockOwner, Notifier, OpenFlags, ReplyAttr, ReplyData,
     ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, Request, Session,
 };
-use musefs_core::convert::usize_from;
 use musefs_core::Attr;
 use musefs_core::CoreError;
 use musefs_core::Fh;
 use musefs_core::Musefs;
+use musefs_core::convert::usize_from;
 use std::num::NonZeroU64;
 
 mod platform;
@@ -222,10 +222,10 @@ impl MusefsFs {
             self.pool.execute(move || {
                 let _guard = PollPendingGuard(&pending);
                 if let Err(e) = core.poll_refresh_notify(|ino| {
-                    if let Some(n) = notifier.get() {
-                        if let Err(inval_err) = n.inval_inode(INodeNo(ino), 0, 0) {
-                            log::warn!("inval_inode({ino}) failed: {inval_err}");
-                        }
+                    if let Some(n) = notifier.get()
+                        && let Err(inval_err) = n.inval_inode(INodeNo(ino), 0, 0)
+                    {
+                        log::warn!("inval_inode({ino}) failed: {inval_err}");
                     }
                 }) {
                     log::warn!("poll_refresh_notify failed: {e}");

--- a/musefs-fuse/src/platform/passthrough.rs
+++ b/musefs-fuse/src/platform/passthrough.rs
@@ -55,27 +55,23 @@ mod imp {
         reply: ReplyOpen,
         plain_flags: FopenFlags,
     ) {
-        if !pt.disabled.load(Ordering::Relaxed) {
-            if let Some(pfd) = core.passthrough_fd(fh) {
-                match reply.open_backing(&pfd) {
-                    Ok(id) => {
-                        // Insert before the reply: the kernel cannot release an
-                        // fh it has not yet seen. FOPEN_KEEP_CACHE is dropped -
-                        // page-cache ownership belongs to the backing inode here.
-                        let mut map = pt.backing.lock().unwrap_or_else(PoisonError::into_inner);
-                        let id = map.entry(fh.get()).insert_entry(id).into_mut();
-                        return reply.opened_passthrough(
-                            FileHandle(fh.get()),
-                            FopenFlags::empty(),
-                            id,
-                        );
-                    }
-                    Err(e) => {
-                        pt.disabled.store(true, Ordering::Relaxed);
-                        log::info!(
-                            "FUSE passthrough unavailable; serving reads through the daemon: {e}"
-                        );
-                    }
+        if !pt.disabled.load(Ordering::Relaxed)
+            && let Some(pfd) = core.passthrough_fd(fh)
+        {
+            match reply.open_backing(&pfd) {
+                Ok(id) => {
+                    // Insert before the reply: the kernel cannot release an
+                    // fh it has not yet seen. FOPEN_KEEP_CACHE is dropped -
+                    // page-cache ownership belongs to the backing inode here.
+                    let mut map = pt.backing.lock().unwrap_or_else(PoisonError::into_inner);
+                    let id = map.entry(fh.get()).insert_entry(id).into_mut();
+                    return reply.opened_passthrough(FileHandle(fh.get()), FopenFlags::empty(), id);
+                }
+                Err(e) => {
+                    pt.disabled.store(true, Ordering::Relaxed);
+                    log::info!(
+                        "FUSE passthrough unavailable; serving reads through the daemon: {e}"
+                    );
                 }
             }
         }
@@ -182,4 +178,4 @@ mod imp {
     pub fn request_capabilities(_config: &mut KernelConfig) {}
 }
 
-pub use imp::{reply_open, request_capabilities, PassthroughState};
+pub use imp::{PassthroughState, reply_open, request_capabilities};

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use fuser::BackgroundSession;
-use musefs_core::{scan_directory, Mode, MountConfig, Musefs};
+use musefs_core::{Mode, MountConfig, Musefs, scan_directory};
 
 // ---------------------------------------------------------------------------
 // Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use musefs_core::{scan_directory, MountConfig, Musefs};
+use musefs_core::{MountConfig, Musefs, scan_directory};
 
 // --- minimal proven FLAC fixture (mirrors musefs-fuse/tests/mount.rs) ---
 
@@ -129,11 +129,11 @@ fn keep_cache_mount_reflects_retag_after_refresh() {
             let _ = std::fs::metadata(&song);
             std::thread::sleep(Duration::from_millis(50));
             // re-read and check whether the size changed
-            if let Ok(b) = std::fs::read(&song) {
-                if b.len() != original_size {
-                    result = Some(b);
-                    break;
-                }
+            if let Ok(b) = std::fs::read(&song)
+                && b.len() != original_size
+            {
+                result = Some(b);
+                break;
             }
         }
         // Final read regardless — we'll assert on the content below

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use musefs_core::{scan_directory, MountConfig, Musefs};
+use musefs_core::{MountConfig, Musefs, scan_directory};
 
 // --- minimal proven FLAC fixture (mirrors musefs-core/tests/common) ---
 

--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use musefs_core::{scan_directory, MountConfig, Musefs};
+use musefs_core::{MountConfig, Musefs, scan_directory};
 
 /// Encode a tiny tagged fixture with ffmpeg. `args` are the codec-specific ffmpeg
 /// args (codec + container). Returns false (skip) if ffmpeg/codec is unavailable.
@@ -158,11 +158,7 @@ fn make_fixture_with_cover(
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
     let ok = cmd.status().is_ok_and(|s| s.success()) && out.exists();
-    if ok {
-        Some((out, png.to_vec()))
-    } else {
-        None
-    }
+    if ok { Some((out, png.to_vec())) } else { None }
 }
 
 #[test]

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -10,7 +10,7 @@
 use std::collections::BTreeMap;
 use std::io::Read;
 
-use musefs_core::{metrics, scan_directory, Mode, MountConfig, Musefs};
+use musefs_core::{Mode, MountConfig, Musefs, metrics, scan_directory};
 
 // ---------------------------------------------------------------------------
 // Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use musefs_core::{scan_directory, MountConfig, Musefs};
+use musefs_core::{MountConfig, Musefs, scan_directory};
 use sha2::{Digest, Sha256};
 
 #[derive(Clone, Copy)]

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -300,7 +300,7 @@ impl fuser::Filesystem for PassthroughFs {
             Err(e) => {
                 return reply.error(fuser::Errno::from_i32(
                     e.raw_os_error().unwrap_or(libc::EIO),
-                ))
+                ));
             }
         };
         for ent in rd.flatten() {
@@ -345,7 +345,7 @@ impl fuser::Filesystem for PassthroughFs {
                 Err(e) => {
                     return reply.error(fuser::Errno::from_i32(
                         e.raw_os_error().unwrap_or(libc::EIO),
-                    ))
+                    ));
                 }
             },
         };
@@ -415,19 +415,19 @@ impl fuser::Filesystem for PassthroughFs {
     fn statfs(&self, _req: &Request, ino: INodeNo, reply: ReplyStatfs) {
         nap(self.lat.stat);
         // Pass through real statvfs of the inode's path; fall back to benign values.
-        if let Some(p) = self.ipath(ino.0) {
-            if let Ok(s) = rustix::fs::statvfs(&p) {
-                return reply.statfs(
-                    s.f_blocks,
-                    s.f_bfree,
-                    s.f_bavail,
-                    s.f_files,
-                    s.f_ffree,
-                    u32::try_from(s.f_bsize).unwrap_or(u32::MAX),
-                    u32::try_from(s.f_namemax).unwrap_or(u32::MAX),
-                    u32::try_from(s.f_frsize).unwrap_or(u32::MAX),
-                );
-            }
+        if let Some(p) = self.ipath(ino.0)
+            && let Ok(s) = rustix::fs::statvfs(&p)
+        {
+            return reply.statfs(
+                s.f_blocks,
+                s.f_bfree,
+                s.f_bavail,
+                s.f_files,
+                s.f_ffree,
+                u32::try_from(s.f_bsize).unwrap_or(u32::MAX),
+                u32::try_from(s.f_namemax).unwrap_or(u32::MAX),
+                u32::try_from(s.f_frsize).unwrap_or(u32::MAX),
+            );
         }
         reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
     }
@@ -464,7 +464,7 @@ impl fuser::Filesystem for PassthroughFs {
             Err(e) => {
                 return reply.error(fuser::Errno::from_i32(
                     e.raw_os_error().unwrap_or(libc::EIO),
-                ))
+                ));
             }
         };
         let m = match file.metadata() {
@@ -472,7 +472,7 @@ impl fuser::Filesystem for PassthroughFs {
             Err(e) => {
                 return reply.error(fuser::Errno::from_i32(
                     e.raw_os_error().unwrap_or(libc::EIO),
-                ))
+                ));
             }
         };
         let ino = self.inodes.lock().unwrap().intern(child);
@@ -581,16 +581,15 @@ impl fuser::Filesystem for PassthroughFs {
         // The only attr SQLite needs: truncate/extend the WAL. Propagate any
         // failure rather than replying ok with the stale (un-truncated) size,
         // which would lie to the kernel and desync the WAL on disk.
-        if let Some(sz) = size {
-            if let Err(e) = OpenOptions::new()
+        if let Some(sz) = size
+            && let Err(e) = OpenOptions::new()
                 .write(true)
                 .open(&p)
                 .and_then(|f| f.set_len(sz))
-            {
-                return reply.error(fuser::Errno::from_i32(
-                    e.raw_os_error().unwrap_or(libc::EIO),
-                ));
-            }
+        {
+            return reply.error(fuser::Errno::from_i32(
+                e.raw_os_error().unwrap_or(libc::EIO),
+            ));
         }
         match std::fs::symlink_metadata(&p) {
             Ok(m) => reply.attr(&TTL, &attr_from_meta(ino.0, &m)),

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use musefs_cli::{run, Cli};
+use musefs_cli::{Cli, run};
 
 fn main() {
     // The library crates report serve-path failures through the `log` facade;


### PR DESCRIPTION
## What

Migrates the musefs workspace from Rust edition 2021 to **edition 2024**. No behavioral change — the served-bytes invariant and all logic are untouched.

Spec & plan: `docs/superpowers/specs/2026-06-08-edition-2024-bump-design.md`, `docs/superpowers/plans/2026-06-08-edition-2024-bump.md`.

## Commits

1. **Rename `gen` → `generation`** — `gen` is a reserved keyword in 2024 (the `Handle` generation-counter field + test-loop vars). Pure rename, edition-independent.
2. **Bump to edition 2024** — flip the workspace + fuzz-crate edition. `std` marks `env::set_var`/`remove_var` `unsafe` in 2024, so the bench smoke test's 15 env mutations route through one audited `set_env`/`remove_env` helper with a single `#[expect(unsafe_code)]`, guarded by the existing env lock — keeping `deny(unsafe_code)` intact everywhere else.
3. **Re-anchor `.cargo/mutants.toml`** — see below.
4. **Improvement-candidate inventory** — survey deliverable (no code change).

## Why this touches ~60 files

The bump is mechanically forced to be wider than just the edition flip, because the project's gates enforce it:

- **rustfmt style-edition 2024** (no `rustfmt.toml`, so style follows the package edition) reorders imports / reformats closures — required to pass the `cargo fmt --check` gate.
- **clippy `collapsible_if`** force-collapses 9 nested `if let` ladders into let-chains, and one `let_and_return` (enabled by 2024's tail-expression temporary-scope change) — reverting any of these fails the `-D warnings` gate.

None of it is optional cleanup; it's the blast radius of an edition bump under `fmt --check` + `clippy -D warnings` with no style pin.

## mutants.toml re-anchoring

The scan.rs reformatting shifted line numbers, drifting several `file:line:col`-anchored `exclude_re` entries off their target mutants. Fixed by re-pointing the scan.rs flush-cadence/revalidate anchors (they can't be description-anchored — `replace += with` repeats in those functions, e.g. the killable `*scanned += 1`) and converting the now-unambiguous facade/tree entries to durable description-anchored regexes. Verified with `cargo mutants --list` that the documented-equivalent mutants are excluded and every killable sibling remains in scope. (Three facade/tree anchors were already stale at the parent commit — fixed here as a bonus.)

## Verification

All green locally: `cargo build`, full `cargo test` (incl. doctests), `clippy --all-targets` and `--all-features` (`-D warnings`), `build --no-default-features`, FreeBSD cross-clippy (`--target x86_64-unknown-freebsd`), and `cargo +nightly fuzz build`. Pre-commit hook (fmt + clippy + full suite + ruff) passed on every commit.

## Follow-up

The improvement inventory (`docs/superpowers/specs/2026-06-08-edition-2024-improvements-notes.md`) concludes a dedicated PR 2 is likely unnecessary: the edition's let-chain value was auto-applied by the forced clippy pass, and residual `if let` sites are either un-chainable (intervening bindings), unsafe to collapse (inner `else`), or already-idiomatic match guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped workspace to Rust edition 2024 and updated toolchain requirement; broad codebase modernizations and refactors applied.
  * Updated logging initialization to default to warn on startup.
  * Adjusted mutation-testing exclusions.

* **Documentation**
  * Added migration plan, design/spec, and improvements-inventory for the edition-2024 bump; updated README/CONTRIBUTING.

* **Tests**
  * Improved test env handling and reformatted many tests for readability; preserved test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->