### PR TITLE
Expand path-template engine: fallback chains, conditional sections, path fields

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,6 +150,16 @@ for plugin authors, including a generated copy of the schema
 (`musefs_common/schema.py`, regenerated from `schema.rs` by a drift-guarded
 test — see [CONTRIBUTING](CONTRIBUTING.md)).
 
+External tools can also offload path layout entirely: a plugin evaluates its own
+(arbitrarily complex) path logic, writes the resulting relative path into a
+custom text tag — e.g. `INSERT INTO tags (track_id, key, value, ordinal) VALUES
+(?, 'beets_path', 'Pink Floyd/Animals/01 Pigs', 0)` — and the user mounts with
+`--template '$!{beets_path}'`. Because the field map is just the (lowercased) tag
+keys, any number of such tags (`beets_path`, `lidarr_path`, …) can back
+different concurrent mounts. The path field keeps embedded `/` as directory
+separators but sanitizes each segment and drops empty/`.`/`..` segments, so a
+misbehaving writer cannot inject traversal or empty components into the tree.
+
 Connections are mode-typed (`Db<ReadWrite>` / `Db<ReadOnly>`), opened in WAL
 mode with a busy timeout. The serve path uses a `DbPool` whose per-thread
 variant hands each reader thread its own connection — WAL reads never contend.
@@ -190,10 +200,14 @@ bytes.
 
 `VirtualTree::build` (`musefs-core/src/tree.rs`) materializes an inode → node
 mapping from rendered paths. Paths come from beets-style templates
-(`template.rs`): `$field` / `${field}` substitutions over the track's tag
-fields, each resolving through per-field fallbacks and then a global
-`default_fallback`; rendered values are sanitized to a single path component
-('/' and control characters become '_'). Path collisions are resolved
+(`template.rs`): `$field` / `${field}` substitutions (with `${a|b}` fallback
+chains) over the track's tag fields, each resolving through per-field fallbacks
+and then a global `default_fallback`; `[...]` conditional sections suppress
+their literals when every field they reference is empty. Plain values are
+sanitized to a single path component ('/' and control characters become '_'),
+while a `$!{field}` path field keeps '/' as directory separators (sanitizing
+each segment and dropping empty/`.`/`..` segments) so a precomputed multi-level
+path expands into real directories. Path collisions are resolved
 deterministically by appending ` (k)` before the extension
 (`disambiguate`). `mapping.rs` bridges DB tag rows to the format layer's
 inputs and to template fields — ordering and multi-value semantics live

--- a/README.md
+++ b/README.md
@@ -63,13 +63,24 @@ musefs mount /path/to/mountpoint --db library.db \
 ```
 
 `mount` blocks until the filesystem is unmounted (`fusermount -u`, or
-Ctrl-C). Paths come from a beets-style template: `$field` or `${field}`
-substitutes a tag field (e.g. `$artist`, `$album`, `$title`, `$tracknumber`,
-`$date`, `$genre` — any tag key in the store works, matched
-case-insensitively); anything else is literal. A missing field renders as
-the `--default-fallback` value (default `Unknown`). Name collisions get a
-deterministic `(2)`, `(3)`, … suffix. The default template is
-`$artist/$title`.
+Ctrl-C). Paths come from a beets-style template (matched case-insensitively;
+any tag key in the store works):
+
+- `$field` / `${field}` — substitute a tag field (e.g. `$artist`, `$album`,
+  `$title`, `$tracknumber`, `$date`, `$genre`).
+- `${albumartist|artist}` — **fallback chain**: the first present field wins,
+  before the `--default-fallback` value (default `Unknown`) is used.
+- `[ … ]` — **conditional section**: the bracketed text is emitted only when at
+  least one field inside it is present. So `$album[ - CD $disc]` yields
+  `Album - CD 2`, or just `Album` on a single-disc release. Write `$[` / `$]`
+  for literal brackets.
+- `$!{field}` — **path field**: the value's `/` are kept as directory
+  separators (each segment sanitized; empty/`.`/`..` dropped). Lets an external
+  tool precompute a whole relative path into one tag and mount it as
+  `--template '$!{beets_path}'`.
+
+Anything else is literal. Name collisions get a deterministic `(2)`, `(3)`, …
+suffix. The default template is `$artist/$title`.
 
 Two modes:
 

--- a/docs/superpowers/plans/2026-06-08-path-template-expansion.md
+++ b/docs/superpowers/plans/2026-06-08-path-template-expansion.md
@@ -31,7 +31,7 @@ fn owned(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
 }
 ```
 
-- [ ] **Step 1: Add fallback-chain tests**
+- [x] **Step 1: Add fallback-chain tests**
 
 Append to `musefs-core/tests/template.rs`:
 
@@ -68,7 +68,7 @@ fn field_names_are_case_insensitive() {
 }
 ```
 
-- [ ] **Step 2: Add conditional-section tests**
+- [x] **Step 2: Add conditional-section tests**
 
 Append:
 
@@ -137,7 +137,7 @@ fn empty_section_emits_nothing() {
 }
 ```
 
-- [ ] **Step 3: Add path-field tests**
+- [x] **Step 3: Add path-field tests**
 
 Append:
 
@@ -179,7 +179,7 @@ fn path_field_sanitizes_control_chars_within_segments() {
 }
 ```
 
-- [ ] **Step 4: Add escaping and parser-edge-case tests**
+- [x] **Step 4: Add escaping and parser-edge-case tests**
 
 Append:
 
@@ -220,12 +220,12 @@ fn empty_braced_field_is_absent() {
 }
 ```
 
-- [ ] **Step 5: Run the new tests to verify they fail**
+- [x] **Step 5: Run the new tests to verify they fail**
 
 Run: `cargo test -p musefs-core --test template`
 Expected: compile error / FAIL — the new syntax (`${a|b}`, `[...]`, `$!{}`, `$[`) isn't implemented yet (e.g. `${albumartist|artist}` resolves the literal name `"albumartist|artist"` to `Unknown`, sections render their brackets literally, `$!{p}` flattens slashes).
 
-- [ ] **Step 6: Replace the `Part` enum and `Template` struct doc**
+- [x] **Step 6: Replace the `Part` enum and `Template` struct doc**
 
 In `musefs-core/src/template.rs`, replace the struct/enum block (the current `pub struct Template { parts: Vec<Part> }` and `enum Part { Literal(String), Field(String) }`, lines ~3–15) with:
 
@@ -251,7 +251,7 @@ enum Part {
 }
 ```
 
-- [ ] **Step 7: Replace the imports and `impl Template` block**
+- [x] **Step 7: Replace the imports and `impl Template` block**
 
 Replace the top-of-file `use std::collections::BTreeMap;` with:
 
@@ -300,7 +300,7 @@ impl Template {
 }
 ```
 
-- [ ] **Step 8: Replace the free functions (parse + render helpers + sanitizers)**
+- [x] **Step 8: Replace the free functions (parse + render helpers + sanitizers)**
 
 Replace the existing free functions at the bottom of the file (`sanitize_into` and `is_field_char`) with the full set below:
 
@@ -526,17 +526,17 @@ fn is_field_char(c: char) -> bool {
 }
 ```
 
-- [ ] **Step 9: Run the full template test file to verify all pass**
+- [x] **Step 9: Run the full template test file to verify all pass**
 
 Run: `cargo test -p musefs-core --test template`
 Expected: PASS — all new cases plus the original 5 (`substitutes_dollar_and_braced_fields_and_appends_ext`, `missing_field_uses_per_field_fallback_then_default`, `sanitizes_path_illegal_characters_in_values`, `lone_dollar_stays_literal`, `unterminated_brace_consumes_rest_as_field_name`).
 
-- [ ] **Step 10: Lint and format**
+- [x] **Step 10: Lint and format**
 
 Run: `cargo fmt && cargo clippy -p musefs-core --all-targets -- -D warnings`
 Expected: no warnings, no diff from fmt.
 
-- [ ] **Step 11: Commit**
+- [x] **Step 11: Commit**
 
 ```bash
 git add musefs-core/src/template.rs musefs-core/tests/template.rs
@@ -560,7 +560,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 `proptest` is already a `musefs-core` dev-dependency (`musefs-core/Cargo.toml`). There is no template fuzz target (the `fuzz/` crate only covers the format layer); this proptest is the invariant gate.
 
-- [ ] **Step 1: Add the proptest import**
+- [x] **Step 1: Add the proptest import**
 
 At the top of `musefs-core/tests/template.rs`, below the existing `use` lines, add:
 
@@ -568,7 +568,7 @@ At the top of `musefs-core/tests/template.rs`, below the existing `use` lines, a
 use proptest::prelude::*;
 ```
 
-- [ ] **Step 2: Add the invariant property test**
+- [x] **Step 2: Add the invariant property test**
 
 Append to `musefs-core/tests/template.rs`:
 
@@ -609,12 +609,12 @@ fn path_field_neutralizes_traversal_values() {
 }
 ```
 
-- [ ] **Step 3: Run the tests**
+- [x] **Step 3: Run the tests**
 
 Run: `cargo test -p musefs-core --test template`
 Expected: PASS (proptest runs its default 256 cases; the explicit traversal test passes). Note `....//` sanitizes to the component `....` (not `.` or `..`), which is a legal filename — the assertion only forbids empty/`.`/`..`.
 
-- [ ] **Step 4: Lint, format, commit**
+- [x] **Step 4: Lint, format, commit**
 
 ```bash
 cargo fmt && cargo clippy -p musefs-core --all-targets -- -D warnings
@@ -633,7 +633,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - Modify: `ARCHITECTURE.md` (Virtual tree paragraph ~lines 192–200; external-writer contract ~after line 151)
 - Modify: `musefs-cli/src/lib.rs` (doc-comment on the `template` arg, line 49)
 
-- [ ] **Step 1: Update the README template description**
+- [x] **Step 1: Update the README template description**
 
 In `README.md`, replace the paragraph that currently reads:
 
@@ -672,7 +672,7 @@ Anything else is literal. Name collisions get a deterministic `(2)`, `(3)`, …
 suffix. The default template is `$artist/$title`.
 ```
 
-- [ ] **Step 2: Update the ARCHITECTURE Virtual tree paragraph**
+- [x] **Step 2: Update the ARCHITECTURE Virtual tree paragraph**
 
 In `ARCHITECTURE.md`, replace the sentence in the **Virtual tree** section that currently reads:
 
@@ -698,7 +698,7 @@ each segment and dropping empty/`.`/`..` segments) so a precomputed multi-level
 path expands into real directories.
 ```
 
-- [ ] **Step 3: Document the computed-path tag workflow**
+- [x] **Step 3: Document the computed-path tag workflow**
 
 In `ARCHITECTURE.md`, in **The external-writer contract** section, insert this paragraph immediately before the line that begins `Connections are mode-typed`:
 
@@ -715,7 +715,7 @@ misbehaving writer cannot inject traversal or empty components into the tree.
 
 ```
 
-- [ ] **Step 4: Update the CLI doc-comment**
+- [x] **Step 4: Update the CLI doc-comment**
 
 In `musefs-cli/src/lib.rs`, replace the doc-comment line:
 
@@ -731,12 +731,12 @@ with:
     /// brackets), and $!{field} path fields that keep '/' as separators.
 ```
 
-- [ ] **Step 5: Verify docs build cleanly and CLI still parses**
+- [x] **Step 5: Verify docs build cleanly and CLI still parses**
 
 Run: `cargo build -p musefs-cli && cargo test -p musefs-cli`
 Expected: PASS (the doc-comment change is a comment; the `default-fallback`/`template` default-value tests at `musefs-cli/src/lib.rs:254-255` are unaffected).
 
-- [ ] **Step 6: Format and commit**
+- [x] **Step 6: Format and commit**
 
 ```bash
 cargo fmt
@@ -750,7 +750,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ## Final verification
 
-- [ ] **Run the full workspace suite (mirrors the pre-commit gate):**
+- [x] **Run the full workspace suite (mirrors the pre-commit gate):**
 
 Run: `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test`
 Expected: all green.

--- a/docs/superpowers/plans/2026-06-08-path-template-expansion.md
+++ b/docs/superpowers/plans/2026-06-08-path-template-expansion.md
@@ -1,0 +1,769 @@
+# Expanded Path-Template Engine — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend musefs's path-template engine with inline fallback chains (`${a|b}`), foobar2000-style conditional sections (`[...]`), a slash-preserving path field (`$!{field}`) for plugin-computed paths, and `$[`/`$]` bracket escapes — keeping `parse` infallible and `render`'s public signature unchanged.
+
+**Architecture:** All engine logic lives in `musefs-core/src/template.rs`. The `Part` enum becomes recursive (`Literal`, `Field { names, raw }`, `Section`). `parse` becomes a recursive descent over a `Peekable<Chars>`; `render` delegates to a recursive `render_parts(..., in_section)` that returns `(text, any_present)`, applying `default_fallback` only at the top level and suppressing a section when none of its referenced fields are present. A new `sanitize_path` splits raw values on `/`, sanitizes each segment, and drops empty/`.`/`..` segments. The rendered string already feeds `VirtualTree::build` (`tree.rs`), which splits on `/` into the inode tree — so multi-segment path-field output becomes real directories with no tree-layer change. The single call site (`render_one` in `facade.rs`) and `MountConfig` are untouched.
+
+**Tech Stack:** Rust (workspace edition 2024). Tests in `musefs-core/tests/template.rs` (integration tests against the public `Template`); property test via `proptest` (already a `musefs-core` dev-dependency). Docs in `README.md`, `ARCHITECTURE.md`, and the CLI doc-comment in `musefs-cli/src/lib.rs`.
+
+**Reference:** Design spec at `docs/superpowers/specs/2026-06-08-path-template-expansion-design.md`. Work is on branch `path-template-expansion`.
+
+**Pre-commit note:** The pre-commit hook runs `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and the **full workspace test suite**, then ruff. Every commit must be green. Run `cargo fmt` before each commit. The `fuzz/` crate is out-of-workspace and unaffected (no template fuzz target exists).
+
+---
+
+## Task 1: Rewrite the template engine
+
+**Files:**
+- Modify: `musefs-core/src/template.rs` (full rewrite of the `Part` enum, `parse`, `render`, and helpers)
+- Test: `musefs-core/tests/template.rs` (keep the existing 5 tests; add the new cases below)
+
+The existing tests use these helpers already present at the top of `musefs-core/tests/template.rs`:
+
+```rust
+fn fields<'a>(pairs: &[(&str, &'a str)]) -> BTreeMap<String, &'a str> {
+    pairs.iter().map(|&(k, v)| (k.to_string(), v)).collect()
+}
+fn owned(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+}
+```
+
+- [ ] **Step 1: Add fallback-chain tests**
+
+Append to `musefs-core/tests/template.rs`:
+
+```rust
+#[test]
+fn fallback_chain_uses_first_present_candidate() {
+    let f = fields(&[("artist", "Beck"), ("title", "Loser")]);
+    let path = Template::parse("${albumartist|artist}/$title")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Beck/Loser.flac");
+}
+
+#[test]
+fn fallback_chain_skips_empty_value() {
+    let f = fields(&[("albumartist", ""), ("artist", "Beck"), ("title", "Loser")]);
+    let path = Template::parse("${albumartist|artist}/$title")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Beck/Loser.flac");
+}
+
+#[test]
+fn fallback_chain_all_empty_falls_to_default_at_top_level() {
+    let f = fields(&[("title", "Loser")]);
+    let path = Template::parse("${albumartist|artist}/$title")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Unknown/Loser.flac");
+}
+
+#[test]
+fn field_names_are_case_insensitive() {
+    let f = fields(&[("albumartist", "VA")]);
+    let path = Template::parse("$AlbumArtist").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "VA.flac");
+}
+```
+
+- [ ] **Step 2: Add conditional-section tests**
+
+Append:
+
+```rust
+#[test]
+fn section_suppressed_when_field_absent() {
+    let f = fields(&[("album", "LP")]);
+    let path = Template::parse("$album[ - CD $disc]")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP.flac");
+}
+
+#[test]
+fn section_emitted_when_field_present() {
+    let f = fields(&[("album", "LP"), ("disc", "2")]);
+    let path = Template::parse("$album[ - CD $disc]")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP - CD 2.flac");
+}
+
+#[test]
+fn nested_section_outer_kept_inner_dropped() {
+    let f = fields(&[("artist", "AC"), ("album", "LP"), ("title", "Song")]);
+    let path = Template::parse("$artist[/[$date - ]$album]/$title")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "AC/LP/Song.flac");
+}
+
+#[test]
+fn nested_section_inner_present_renders_prefix() {
+    let f = fields(&[("artist", "AC"), ("date", "1999"), ("album", "LP"), ("title", "Song")]);
+    let path = Template::parse("$artist[/[$date - ]$album]/$title")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "AC/1999 - LP/Song.flac");
+}
+
+#[test]
+fn section_all_referenced_fields_empty_is_suppressed() {
+    let f = fields(&[("album", "LP")]);
+    let path = Template::parse("$album[ $[$date$]]")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP.flac");
+}
+
+#[test]
+fn escaped_brackets_render_literally_inside_kept_section() {
+    let f = fields(&[("album", "LP"), ("date", "1999")]);
+    let path = Template::parse("$album[ $[$date$]]")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP [1999].flac");
+}
+
+#[test]
+fn empty_field_inside_kept_section_renders_blank_not_default() {
+    let f = fields(&[("album", "LP")]);
+    let path = Template::parse("[$album$disc]")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP.flac");
+}
+
+#[test]
+fn empty_section_emits_nothing() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$title[]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Song.flac");
+}
+```
+
+- [ ] **Step 3: Add path-field tests**
+
+Append:
+
+```rust
+#[test]
+fn path_field_keeps_slashes_as_separators() {
+    let f = fields(&[("p", "Pink Floyd/Animals/01 Pigs")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Pink Floyd/Animals/01 Pigs.flac");
+}
+
+#[test]
+fn path_field_drops_empty_and_dot_segments() {
+    let f = fields(&[("p", "a//../b/./c")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "a/b/c.flac");
+}
+
+#[test]
+fn path_field_all_segments_dropped_falls_to_default() {
+    let f = fields(&[("p", "..")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Unknown.flac");
+}
+
+#[test]
+fn path_field_fallback_chain() {
+    let f = fields(&[("lidarr_path", "Artist/Album/Song")]);
+    let path = Template::parse("$!{beets_path|lidarr_path}")
+        .render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Artist/Album/Song.flac");
+}
+
+#[test]
+fn path_field_sanitizes_control_chars_within_segments() {
+    let f = fields(&[("p", "a\u{0001}b/c")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "a_b/c.flac");
+}
+```
+
+- [ ] **Step 4: Add escaping and parser-edge-case tests**
+
+Append:
+
+```rust
+#[test]
+fn escaped_brackets_at_top_level_render_literally() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$[$title$]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "[Song].flac");
+}
+
+#[test]
+fn stray_closing_bracket_is_literal() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$title]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Song].flac");
+}
+
+#[test]
+fn unterminated_section_runs_to_end_of_input() {
+    let f = fields(&[("album", "LP"), ("disc", "2")]);
+    let path = Template::parse("$album[ CD $disc").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP CD 2.flac");
+}
+
+#[test]
+fn dollar_bang_without_brace_stays_literal() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$!x/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "$!x/Song.flac");
+}
+
+#[test]
+fn empty_braced_field_is_absent() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("${}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Unknown/Song.flac");
+}
+```
+
+- [ ] **Step 5: Run the new tests to verify they fail**
+
+Run: `cargo test -p musefs-core --test template`
+Expected: compile error / FAIL — the new syntax (`${a|b}`, `[...]`, `$!{}`, `$[`) isn't implemented yet (e.g. `${albumartist|artist}` resolves the literal name `"albumartist|artist"` to `Unknown`, sections render their brackets literally, `$!{p}` flattens slashes).
+
+- [ ] **Step 6: Replace the `Part` enum and `Template` struct doc**
+
+In `musefs-core/src/template.rs`, replace the struct/enum block (the current `pub struct Template { parts: Vec<Part> }` and `enum Part { Literal(String), Field(String) }`, lines ~3–15) with:
+
+```rust
+/// A parsed path template: literal runs, `$field` / `${field}` substitutions
+/// (with optional `${a|b}` fallback chains and `$!{field}` slash-preserving path
+/// fields), and `[...]` conditional sections. Parse once per mount; `render`
+/// then costs one output `String` per call, with no re-parse.
+#[derive(Debug, Clone)]
+pub struct Template {
+    parts: Vec<Part>,
+}
+
+#[derive(Debug, Clone)]
+enum Part {
+    Literal(String),
+    /// `names` is the `|`-separated fallback chain (length 1 for a plain field);
+    /// `raw` marks a `$!{…}` path field whose '/' are kept as separators.
+    Field { names: Vec<String>, raw: bool },
+    /// A `[...]` conditional section: emitted only if at least one field
+    /// referenced within it (transitively) is present.
+    Section(Vec<Part>),
+}
+```
+
+- [ ] **Step 7: Replace the imports and `impl Template` block**
+
+Replace the top-of-file `use std::collections::BTreeMap;` with:
+
+```rust
+use std::collections::BTreeMap;
+use std::iter::Peekable;
+use std::str::Chars;
+```
+
+Replace the entire `impl Template { ... }` block (current `parse` and `render`) with:
+
+```rust
+impl Template {
+    /// Parse a beets-style template. Infallible.
+    ///
+    /// - `$field` / `${field}` substitute a tag field; `${a|b|c}` is a fallback
+    ///   chain (first present wins). Names are matched case-insensitively.
+    /// - `$!{field}` is a path field: the value's '/' are kept as directory
+    ///   separators (each segment sanitized; empty / `.` / `..` dropped).
+    /// - `[...]` is a conditional section, suppressed when every field it
+    ///   references is empty. `$[` and `$]` emit literal brackets.
+    /// - A `$` not followed by a recognized form stays literal; an unterminated
+    ///   `${`/`$!{` consumes the rest as the name; an unterminated `[` runs to
+    ///   end of input.
+    pub fn parse(template: &str) -> Template {
+        let mut chars = template.chars().peekable();
+        let parts = parse_parts(&mut chars, false);
+        Template { parts }
+    }
+
+    /// Render one track's path. Outside a section a missing field resolves
+    /// through `fallbacks` then `default_fallback`; inside a section a missing
+    /// field renders blank and drives suppression. The extension follows a '.'.
+    pub fn render(
+        &self,
+        fields: &BTreeMap<String, &str>,
+        fallbacks: &BTreeMap<String, String>,
+        default_fallback: &str,
+        ext: &str,
+    ) -> String {
+        let (mut out, _) = render_parts(&self.parts, fields, fallbacks, default_fallback, false);
+        out.push('.');
+        out.push_str(ext);
+        out
+    }
+}
+```
+
+- [ ] **Step 8: Replace the free functions (parse + render helpers + sanitizers)**
+
+Replace the existing free functions at the bottom of the file (`sanitize_into` and `is_field_char`) with the full set below:
+
+```rust
+/// Parse parts until a closing `]` (when `in_section`) or end of input.
+fn parse_parts(chars: &mut Peekable<Chars>, in_section: bool) -> Vec<Part> {
+    let mut parts = Vec::new();
+    let mut literal = String::new();
+    while let Some(&c) = chars.peek() {
+        match c {
+            ']' if in_section => {
+                chars.next(); // consume the closing ']'
+                break;
+            }
+            '[' => {
+                chars.next();
+                push_literal(&mut parts, &mut literal);
+                let inner = parse_parts(chars, true);
+                parts.push(Part::Section(inner));
+            }
+            '$' => {
+                chars.next(); // consume '$'
+                match chars.peek() {
+                    Some('[') => {
+                        chars.next();
+                        literal.push('[');
+                    }
+                    Some(']') => {
+                        chars.next();
+                        literal.push(']');
+                    }
+                    Some('{') => {
+                        chars.next();
+                        let names = parse_braced_names(chars);
+                        push_literal(&mut parts, &mut literal);
+                        parts.push(Part::Field { names, raw: false });
+                    }
+                    Some('!') => {
+                        chars.next(); // consume '!'
+                        if chars.peek() == Some(&'{') {
+                            chars.next(); // consume '{'
+                            let names = parse_braced_names(chars);
+                            push_literal(&mut parts, &mut literal);
+                            parts.push(Part::Field { names, raw: true });
+                        } else {
+                            literal.push('$');
+                            literal.push('!');
+                        }
+                    }
+                    Some(&nc) if is_field_char(nc) => {
+                        let name = parse_unbraced_name(chars);
+                        push_literal(&mut parts, &mut literal);
+                        parts.push(Part::Field {
+                            names: vec![name],
+                            raw: false,
+                        });
+                    }
+                    _ => literal.push('$'),
+                }
+            }
+            _ => {
+                literal.push(c);
+                chars.next();
+            }
+        }
+    }
+    push_literal(&mut parts, &mut literal);
+    parts
+}
+
+fn push_literal(parts: &mut Vec<Part>, literal: &mut String) {
+    if !literal.is_empty() {
+        parts.push(Part::Literal(std::mem::take(literal)));
+    }
+}
+
+/// Consume up to the next `}` (or end of input) and split on `|` into the
+/// candidate name list, lowercased for case-insensitive lookup.
+fn parse_braced_names(chars: &mut Peekable<Chars>) -> Vec<String> {
+    let mut content = String::new();
+    for nc in chars.by_ref() {
+        if nc == '}' {
+            break;
+        }
+        content.push(nc);
+    }
+    content.split('|').map(|s| s.to_ascii_lowercase()).collect()
+}
+
+fn parse_unbraced_name(chars: &mut Peekable<Chars>) -> String {
+    let mut name = String::new();
+    while let Some(&nc) = chars.peek() {
+        if is_field_char(nc) {
+            name.push(nc);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    name.to_ascii_lowercase()
+}
+
+/// Render `parts`, returning the text and whether at least one referenced field
+/// was present. `in_section` gates `default_fallback`: it is substituted only at
+/// the top level (outside any `[...]`).
+fn render_parts(
+    parts: &[Part],
+    fields: &BTreeMap<String, &str>,
+    fallbacks: &BTreeMap<String, String>,
+    default_fallback: &str,
+    in_section: bool,
+) -> (String, bool) {
+    let mut out = String::new();
+    let mut any_present = false;
+    for part in parts {
+        match part {
+            Part::Literal(lit) => out.push_str(lit),
+            Part::Field { names, raw: false } => {
+                if let Some(value) = resolve_plain(names, fields, fallbacks) {
+                    sanitize_into(&mut out, value);
+                    any_present = true;
+                } else if !in_section {
+                    sanitize_into(&mut out, default_fallback);
+                }
+            }
+            Part::Field { names, raw: true } => {
+                if let Some(path) = resolve_path(names, fields, fallbacks) {
+                    out.push_str(&path);
+                    any_present = true;
+                } else if !in_section {
+                    sanitize_into(&mut out, default_fallback);
+                }
+            }
+            Part::Section(inner) => {
+                let (text, present) =
+                    render_parts(inner, fields, fallbacks, default_fallback, true);
+                if present {
+                    out.push_str(&text);
+                    any_present = true;
+                }
+            }
+        }
+    }
+    (out, any_present)
+}
+
+/// First candidate with a non-empty value, checked against `fields` then
+/// `fallbacks`.
+fn resolve_plain<'a>(
+    names: &[String],
+    fields: &BTreeMap<String, &'a str>,
+    fallbacks: &'a BTreeMap<String, String>,
+) -> Option<&'a str> {
+    for name in names {
+        if let Some(v) = fields.get(name).copied().filter(|v| !v.is_empty()) {
+            return Some(v);
+        }
+        if let Some(v) = fallbacks
+            .get(name)
+            .map(String::as_str)
+            .filter(|v| !v.is_empty())
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// First candidate that yields at least one surviving path segment, returned as
+/// the sanitized multi-segment path.
+fn resolve_path(
+    names: &[String],
+    fields: &BTreeMap<String, &str>,
+    fallbacks: &BTreeMap<String, String>,
+) -> Option<String> {
+    for name in names {
+        let value = fields
+            .get(name)
+            .copied()
+            .or_else(|| fallbacks.get(name).map(String::as_str));
+        if let Some(value) = value {
+            let path = sanitize_path(value);
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Append `value` with '/' and control characters replaced by '_' so it stays a
+/// single path component. The template's own '/' separators are literals, not
+/// passed through here.
+fn sanitize_into(out: &mut String, value: &str) {
+    for c in value.chars() {
+        if c == '/' || (c as u32) < 0x20 {
+            out.push('_');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Split `value` on '/', drop empty / `.` / `..` segments, sanitize each
+/// surviving segment, and rejoin with '/'. Guarantees no empty, `.`, `..`, or
+/// leading/trailing-slash components reach the virtual tree.
+fn sanitize_path(value: &str) -> String {
+    let mut out = String::new();
+    for segment in value.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('/');
+        }
+        sanitize_into(&mut out, segment);
+    }
+    out
+}
+
+fn is_field_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+```
+
+- [ ] **Step 9: Run the full template test file to verify all pass**
+
+Run: `cargo test -p musefs-core --test template`
+Expected: PASS — all new cases plus the original 5 (`substitutes_dollar_and_braced_fields_and_appends_ext`, `missing_field_uses_per_field_fallback_then_default`, `sanitizes_path_illegal_characters_in_values`, `lone_dollar_stays_literal`, `unterminated_brace_consumes_rest_as_field_name`).
+
+- [ ] **Step 10: Lint and format**
+
+Run: `cargo fmt && cargo clippy -p musefs-core --all-targets -- -D warnings`
+Expected: no warnings, no diff from fmt.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add musefs-core/src/template.rs musefs-core/tests/template.rs
+git commit -m "feat(template): fallback chains, conditional sections, path fields
+
+Recursive Part model (Literal / Field{names,raw} / Section). Adds
+\${a|b} fallback chains, [...] conditional sections (foobar2000
+all-empty suppression), \$!{field} slash-preserving path fields, and
+\$[/\$] bracket escapes. Field names are now matched case-insensitively.
+render's public signature is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Path-traversal safety invariant (property test)
+
+**Files:**
+- Test: `musefs-core/tests/template.rs` (add a `proptest!` block)
+
+`proptest` is already a `musefs-core` dev-dependency (`musefs-core/Cargo.toml`). There is no template fuzz target (the `fuzz/` crate only covers the format layer); this proptest is the invariant gate.
+
+- [ ] **Step 1: Add the proptest import**
+
+At the top of `musefs-core/tests/template.rs`, below the existing `use` lines, add:
+
+```rust
+use proptest::prelude::*;
+```
+
+- [ ] **Step 2: Add the invariant property test**
+
+Append to `musefs-core/tests/template.rs`:
+
+```rust
+proptest! {
+    // render must never panic, and a path field must never emit an empty,
+    // '.', or '..' component (no traversal / no absolute path into the tree).
+    #[test]
+    fn render_never_panics_and_path_fields_stay_safe(tmpl in ".{0,64}", value in ".{0,64}") {
+        let f = fields(&[("p", value.as_str())]);
+
+        // arbitrary templates must not panic
+        let _ = Template::parse(&tmpl).render(&f, &BTreeMap::new(), "Unknown", "flac");
+
+        // a path field over an adversarial value yields only safe components
+        let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let body = rendered.strip_suffix(".flac").expect("ext appended");
+        for component in body.split('/') {
+            prop_assert!(!component.is_empty());
+            prop_assert_ne!(component, ".");
+            prop_assert_ne!(component, "..");
+        }
+    }
+}
+
+#[test]
+fn path_field_neutralizes_traversal_values() {
+    for value in ["../../etc/passwd", "/abs/path", "a/../../b", "....//", "/", "..", "."] {
+        let f = fields(&[("p", value)]);
+        let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let body = rendered.strip_suffix(".flac").unwrap();
+        for component in body.split('/') {
+            assert!(!component.is_empty(), "empty component from {value:?}");
+            assert_ne!(component, ".", "'.' component from {value:?}");
+            assert_ne!(component, "..", "'..' component from {value:?}");
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo test -p musefs-core --test template`
+Expected: PASS (proptest runs its default 256 cases; the explicit traversal test passes). Note `....//` sanitizes to the component `....` (not `.` or `..`), which is a legal filename — the assertion only forbids empty/`.`/`..`.
+
+- [ ] **Step 4: Lint, format, commit**
+
+```bash
+cargo fmt && cargo clippy -p musefs-core --all-targets -- -D warnings
+git add musefs-core/tests/template.rs
+git commit -m "test(template): proptest path-traversal safety invariant
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Documentation
+
+**Files:**
+- Modify: `README.md` (template paragraph, ~lines 66–72)
+- Modify: `ARCHITECTURE.md` (Virtual tree paragraph ~lines 192–200; external-writer contract ~after line 151)
+- Modify: `musefs-cli/src/lib.rs` (doc-comment on the `template` arg, line 49)
+
+- [ ] **Step 1: Update the README template description**
+
+In `README.md`, replace the paragraph that currently reads:
+
+```markdown
+`mount` blocks until the filesystem is unmounted (`fusermount -u`, or
+Ctrl-C). Paths come from a beets-style template: `$field` or `${field}`
+substitutes a tag field (e.g. `$artist`, `$album`, `$title`, `$tracknumber`,
+`$date`, `$genre` — any tag key in the store works, matched
+case-insensitively); anything else is literal. A missing field renders as
+the `--default-fallback` value (default `Unknown`). Name collisions get a
+deterministic `(2)`, `(3)`, … suffix. The default template is
+`$artist/$title`.
+```
+
+with:
+
+```markdown
+`mount` blocks until the filesystem is unmounted (`fusermount -u`, or
+Ctrl-C). Paths come from a beets-style template (matched case-insensitively;
+any tag key in the store works):
+
+- `$field` / `${field}` — substitute a tag field (e.g. `$artist`, `$album`,
+  `$title`, `$tracknumber`, `$date`, `$genre`).
+- `${albumartist|artist}` — **fallback chain**: the first present field wins,
+  before the `--default-fallback` value (default `Unknown`) is used.
+- `[ … ]` — **conditional section**: the bracketed text is emitted only when at
+  least one field inside it is present. So `$album[ - CD $disc]` yields
+  `Album - CD 2`, or just `Album` on a single-disc release. Write `$[` / `$]`
+  for literal brackets.
+- `$!{field}` — **path field**: the value's `/` are kept as directory
+  separators (each segment sanitized; empty/`.`/`..` dropped). Lets an external
+  tool precompute a whole relative path into one tag and mount it as
+  `--template '$!{beets_path}'`.
+
+Anything else is literal. Name collisions get a deterministic `(2)`, `(3)`, …
+suffix. The default template is `$artist/$title`.
+```
+
+- [ ] **Step 2: Update the ARCHITECTURE Virtual tree paragraph**
+
+In `ARCHITECTURE.md`, replace the sentence in the **Virtual tree** section that currently reads:
+
+```markdown
+Paths come from beets-style templates
+(`template.rs`): `$field` / `${field}` substitutions over the track's tag
+fields, each resolving through per-field fallbacks and then a global
+`default_fallback`; rendered values are sanitized to a single path component
+('/' and control characters become '_').
+```
+
+with:
+
+```markdown
+Paths come from beets-style templates
+(`template.rs`): `$field` / `${field}` substitutions (with `${a|b}` fallback
+chains) over the track's tag fields, each resolving through per-field fallbacks
+and then a global `default_fallback`; `[...]` conditional sections suppress
+their literals when every field they reference is empty. Plain values are
+sanitized to a single path component ('/' and control characters become '_'),
+while a `$!{field}` path field keeps '/' as directory separators (sanitizing
+each segment and dropping empty/`.`/`..` segments) so a precomputed multi-level
+path expands into real directories.
+```
+
+- [ ] **Step 3: Document the computed-path tag workflow**
+
+In `ARCHITECTURE.md`, in **The external-writer contract** section, insert this paragraph immediately before the line that begins `Connections are mode-typed`:
+
+```markdown
+External tools can also offload path layout entirely: a plugin evaluates its own
+(arbitrarily complex) path logic, writes the resulting relative path into a
+custom text tag — e.g. `INSERT INTO tags (track_id, key, value, ordinal) VALUES
+(?, 'beets_path', 'Pink Floyd/Animals/01 Pigs', 0)` — and the user mounts with
+`--template '$!{beets_path}'`. Because the field map is just the (lowercased) tag
+keys, any number of such tags (`beets_path`, `lidarr_path`, …) can back
+different concurrent mounts. The path field keeps embedded `/` as directory
+separators but sanitizes each segment and drops empty/`.`/`..` segments, so a
+misbehaving writer cannot inject traversal or empty components into the tree.
+
+```
+
+- [ ] **Step 4: Update the CLI doc-comment**
+
+In `musefs-cli/src/lib.rs`, replace the doc-comment line:
+
+```rust
+    /// Path template, e.g. "$albumartist/$album/$title".
+```
+
+with:
+
+```rust
+    /// Path template, e.g. "$albumartist/$album/$title". Supports ${a|b}
+    /// fallback chains, [...] conditional sections ($[/$] for literal
+    /// brackets), and $!{field} path fields that keep '/' as separators.
+```
+
+- [ ] **Step 5: Verify docs build cleanly and CLI still parses**
+
+Run: `cargo build -p musefs-cli && cargo test -p musefs-cli`
+Expected: PASS (the doc-comment change is a comment; the `default-fallback`/`template` default-value tests at `musefs-cli/src/lib.rs:254-255` are unaffected).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+cargo fmt
+git add README.md ARCHITECTURE.md musefs-cli/src/lib.rs
+git commit -m "docs(template): document fallback chains, sections, path fields
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full workspace suite (mirrors the pre-commit gate):**
+
+Run: `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test`
+Expected: all green.
+
+- [ ] **Manual end-to-end smoke check (optional, exercises the real mount):**
+
+Demonstrate each feature against a real store/mount, e.g.:
+
+```bash
+# fallback chain + conditional section
+musefs mount <db> <mnt> --template '${albumartist|artist}/$album[ - CD $disc]/$track $title' &
+# computed-path tag (after a plugin/SQL writes a 'beets_path' tag)
+musefs mount <db> <mnt2> --template '$!{beets_path}' &
+```
+
+Confirm: a track missing `albumartist` falls back to `artist`; single-disc albums show no `CD` folder; a `beets_path` value with `/` expands into nested directories; original audio bytes are untouched (the cardinal invariant — only paths change).

--- a/docs/superpowers/specs/2026-06-08-path-template-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-08-path-template-expansion-design.md
@@ -1,0 +1,249 @@
+# Path-Template Expansion — Design
+
+Date: 2026-06-08
+Status: Approved (pending spec review)
+
+## Context
+
+musefs renders each track's virtual path from a beets-style template string
+(`$albumartist/$album/$title`). The current engine (`musefs-core/src/template.rs`)
+supports only `$field` / `${field}` substitution, with a single global
+`--default-fallback` string substituted for *any* missing field. Two gaps hurt
+real users:
+
+- **No inline fallback.** A user who wants "album artist, else artist" gets
+  `Unknown/Album/Title` the moment `albumartist` is missing, because the global
+  fallback fires before `artist` is ever consulted.
+- **No conditional text.** Multi-disc handling (`CD 2/`) or a bracketed year
+  (` [1999]`) leaks empty boilerplate (`CD /`, ` []`) onto single-disc or
+  undated tracks.
+
+Separately, because the store is an EAV tag table, heavy/Turing-complete path
+logic can be offloaded to external plugins (beets/Picard/Lidarr): a plugin
+computes the full relative path and writes it as a custom text tag, and the user
+mounts with that one tag as the template. The only blocker is that the current
+sanitizer flattens `/`, so a computed multi-segment path can't expand into real
+directories.
+
+This design expands the template engine to cover inline fallbacks, conditional
+sections, and a slash-preserving "path field", plus documents the computed-tag
+workflow that the path field unlocks.
+
+## Goals
+
+- Inline fallback chains so the standalone daemon is sufficient for most
+  non-plugin users.
+- Conditional sections that suppress surrounding literal text when fields are
+  absent, composing and nesting cleanly.
+- A path field that lets a single plugin-computed tag expand into a directory
+  hierarchy, without a path-traversal / empty-component footgun.
+- Keep `parse` infallible and `render`'s public signature unchanged (minimal
+  blast radius on the two `facade.rs` call sites).
+
+## Non-goals
+
+- Turing-complete templating in Rust (string functions, arithmetic, regex).
+  That deliberately stays in external plugins via the computed-tag workflow.
+- Removing the per-field `fallbacks` map or `--default-fallback`; both stay and
+  compose with the new syntax.
+- Whitespace/normalization beyond what's specified (no trimming, no case
+  folding beyond the existing key lowercasing).
+
+## Grammar
+
+| Syntax | Meaning |
+| --- | --- |
+| `$field`, `${field}` | Substitute a field. **Unchanged.** |
+| `${a\|b\|c}` | Fallback chain: first present of `a`, `b`, `c` wins. `\|` is special only inside `${…}` / `$!{…}`. |
+| `[ … ]` | Conditional section: kept iff ≥1 field referenced inside (transitively) is present; otherwise the whole section (literals + nested sections) vanishes. Nests. |
+| `$!{field}`, `$!{a\|b}` | Path field: the resolved value's `/` are kept as directory separators; each segment is sanitized, and empty / `.` / `..` segments are dropped. |
+| `$[`, `$]` | Escaped literal `[` / `]`. |
+
+## Semantics
+
+- **Presence.** A plain field (`$field`, `${field}`) or fallback chain is
+  *present* iff a candidate exists in the row **and** its value is non-empty
+  (`""` ⇒ absent). No whitespace trimming — only the truly empty string is
+  absent. A **path field** (`$!{…}`) is *present* iff it yields **at least one
+  surviving segment** after sanitization; a value of `""`, `/`, `.`, `..`, or
+  `././..` therefore counts as absent (this supersedes the non-empty-value rule
+  for raw fields, since such values produce zero segments).
+- **Outside a section.** A missing/empty field falls through the per-field
+  `fallbacks` map and then to `--default-fallback` — today's exact behavior,
+  preserved. A fallback chain `${a|b}` that resolves to nothing also lands on
+  `default_fallback` here.
+- **Inside a section.** A missing/empty field renders blank and does **not**
+  pull `default_fallback`; emptiness is what drives suppression. A section is
+  kept iff at least one referenced field — including fields inside nested
+  sections — is present. Each nested section is additionally evaluated on its
+  own closure, so it can be dropped while its parent is kept.
+- **Path field.** Resolve the value (honoring an inner fallback chain), split on
+  `/`, sanitize each segment with the existing per-character rule (control chars
+  and any residual illegal chars → `_`), drop empty / `.` / `..` segments, and
+  rejoin with `/`. A path field is *present* iff it yields at least one
+  non-empty segment.
+- Fallback chains and path fields compose anywhere (top level or inside
+  sections).
+
+### Braced-expression lexing and escaping
+
+- Inside `${…}` and `$!{…}`, the content runs up to the first `}`; it is split
+  on `|` into the candidate name list, and each candidate is taken verbatim
+  (then ASCII-lowercased for lookup, matching `tags_to_fields`). A literal `|`
+  or `}` cannot appear inside a braced name — this is a documented limitation,
+  consistent with today's "consume until `}`" behavior.
+- Unbraced `$field` keeps today's `is_field_char` charset (ASCII alphanumeric +
+  `_`); `|` is not a field char, so `$a|b` is `$a` followed by the literal
+  `|b`. Fallback chains therefore require braces.
+- `$[` and `$]` are the only escapes for the new metacharacters. There is no
+  escape for a literal `|`/`}` inside braces (see above) — outside braces both
+  are ordinary literals.
+
+### Degenerate constructs
+
+These resolve predictably rather than erroring (parser stays infallible):
+
+- `[]` — empty section, no field references ⇒ `any_present` is false ⇒ emits
+  nothing and contributes *absent* to an enclosing section.
+- `${}` / `${|}` — one or more empty candidate names, all *absent* ⇒
+  `default_fallback` at top level, blank inside a section.
+- `$!{}` — zero surviving segments ⇒ *absent* (same handling as above).
+
+### Worked examples
+
+```
+$albumartist/${albumartist|artist}/$title     # albumartist, else artist
+$album[ - CD $disc]                            # "Album - CD 2", or "Album" if no disc
+$artist[/$[$date$] ]$album/$title              # "AC/[1999] LP/Song", date optional
+$!{beets_path}                                 # "Pink Floyd/Animals/01 Pigs" -> real dirs
+```
+
+Nesting (the rule that motivated "all-empty suppresses"):
+
+```
+$artist[/[$date - ]$album]/$title
+  date='', album='LP'  ->  AC/LP/Song
+    outer kept (album present); inner [$date - ] dropped (date empty)
+```
+
+## Implementation
+
+All changes are in `musefs-core/src/template.rs` plus tests and docs.
+
+### Parser
+
+`Part` becomes recursive:
+
+```rust
+enum Part {
+    Literal(String),
+    Field { names: Vec<String>, raw: bool }, // names: fallback chain; raw: path field
+    Section(Vec<Part>),
+}
+```
+
+`parse` stays **infallible** and becomes a small recursive/stack descent:
+
+- `[` opens a `Section`; `]` closes the innermost open section.
+- An unclosed `[` runs to EOF as a section (mirrors today's unterminated-`${`
+  rule). A stray `]` with no open section is a literal `]`.
+- `$[` / `$]` emit literal brackets; the existing lone-`$` rule is unchanged.
+- `|` splits the name list only within `${…}` / `$!{…}`; outside braces it is a
+  literal.
+- `$!{…}` parses as a `Field` with `raw = true`; `$field` / `${…}` parse with
+  `raw = false`.
+
+### Render
+
+`render` keeps its public signature
+`(&self, fields, fallbacks, default_fallback, ext) -> String` — the two call
+sites in `facade.rs` (`render_one`, and the test) are untouched.
+
+Internally it recurses over parts via a helper
+`render_parts(parts, …, in_section: bool) -> (String, bool)` returning
+`(text, any_present)`. The `in_section` flag is what makes "default_fallback
+top-level only" precise: the top-level call passes `in_section = false`; every
+`Section` renders its children with `in_section = true`.
+
+- `Literal` → push text, contributes no presence.
+- `Field { names, raw }` → resolve the first present candidate (each candidate
+  checked against `fields` then the per-field `fallbacks` map). If `raw`, run
+  `sanitize_path_segments` and presence = ≥1 surviving segment; else
+  `sanitize_into` and presence = candidate value non-empty. If no candidate is
+  present: when `in_section == false`, substitute `default_fallback` (today's
+  behavior); when `in_section == true`, emit nothing. A field that resolved to
+  `default_fallback` still counts as *not present* for section purposes (but at
+  top level there is no enclosing section to suppress).
+- `Section(parts)` → render children with `in_section = true`; if their
+  `any_present` is true, emit the concatenated text, else emit nothing. The
+  section's own presence (for an enclosing section) is that same `any_present`,
+  which is how a nested section's fields propagate transitively to the parent.
+
+New helper `sanitize_path_segments(out, value)`: split on `/`, sanitize each
+segment via the existing per-char logic, drop empty / `.` / `..` segments, join
+surviving segments with `/`. Because empty segments are dropped, a path field
+never emits a leading, trailing, or doubled `/`, and never a `.`/`..`
+component.
+
+### Extension append and trailing separators
+
+The `.` + `ext` append is unchanged: it is concatenated to the final rendered
+string. A path field cannot introduce a trailing `/` (empty trailing segment is
+dropped), so `$!{beets_path}` → `…/01 Pigs.flac`. A trailing **literal** `/` in
+the template (e.g. `$album/`) still yields `Album/.flac` exactly as today — this
+is pre-existing template-author responsibility and is not changed by this work.
+
+## Backward compatibility
+
+`[` and `]` become metacharacters. Any existing template containing **literal
+square brackets** changes meaning — e.g. `$album [$date]` previously rendered
+`Album [1999]` literally and now treats `[$date]` as a conditional section
+(`Album 1999` / `Album `). The escape hatch is `$[` / `$]`. The default template
+(`$artist/$title`) and all current tests are unaffected. This is an accepted,
+documented breaking change (approved during brainstorming).
+
+## Testing
+
+Unit tests in `musefs-core/tests/template.rs` (extending the existing 5, which
+must stay green). Each case asserts an exact output string. Representative
+acceptance cases (`default_fallback = "Unknown"`, `ext = "flac"`):
+
+| Template | Fields | Expected |
+| --- | --- | --- |
+| `${albumartist\|artist}/$title` | `artist=Beck, title=Loser` | `Beck/Loser.flac` |
+| `${albumartist\|artist}/$title` | `albumartist="", artist=Beck, title=Loser` | `Beck/Loser.flac` |
+| `${albumartist\|artist}/$title` | `title=Loser` | `Unknown/Loser.flac` |
+| `$album[ - CD $disc]` | `album=LP` | `LP.flac` |
+| `$album[ - CD $disc]` | `album=LP, disc=2` | `LP - CD 2.flac` |
+| `$artist[/[$date - ]$album]/$title` | `artist=AC, album=LP, title=Song` | `AC/LP/Song.flac` |
+| `$artist[/[$date - ]$album]/$title` | `artist=AC, date=1999, album=LP, title=Song` | `AC/1999 - LP/Song.flac` |
+| `$album[ $[$date$]]` | `album=LP, date=1999` | `LP [1999].flac` |
+| `$album[ $[$date$]]` | `album=LP` | `LP.flac` |
+| `$!{p}` | `p=Pink Floyd/Animals/01 Pigs` | `Pink Floyd/Animals/01 Pigs.flac` |
+| `$!{p}` | `p=a//../b` | `a/b.flac` |
+| `$!{p}` | `p=..` | `Unknown.flac` (absent ⇒ top-level default) |
+
+Plus coverage for: all-empty chain suppressing a section; empty-but-kept field
+renders blank; fallback chain *inside* a path field; degenerate `[]`, `${}`,
+`$!{}`; `$[`/`$]` literal brackets and unchanged lone `$`; parser edge cases
+(unterminated `[`, unterminated `${`, stray `]`).
+
+Invariants (assert in tests, and extend the `fuzz/` template target if one
+exists — `fuzz/` is out-of-workspace per CLAUDE.md):
+
+- `render` never panics on any template/field combination.
+- A non-raw substitution never introduces `/` into a path component.
+- **Path-traversal safety:** no `$!{…}` value can produce a path component equal
+  to `.` or `..`, a leading `/` (absolute path), an empty component, or a `..`
+  that would escape the mount root. A fuzz/property assertion feeds adversarial
+  values (`../../etc/passwd`, `/abs`, `a/../../b`, `....//`) and confirms every
+  emitted component is non-empty and `∉ {".", ".."}`.
+
+## Documentation
+
+- README template section and CLI `--help` text: document fallback chains,
+  conditional sections (with the `$[` / `$]` escape), and the path field.
+- ARCHITECTURE.md external-writer contract: document the computed-tag workflow —
+  a plugin (beets/Picard/Lidarr) computes the full relative path and writes it
+  as a custom text tag; the user mounts with `$!{that_tag}`. Note the
+  segment-sanitization rules so plugin authors know what is dropped.

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -46,7 +46,9 @@ pub struct MountArgs {
     /// Path to the SQLite database.
     #[arg(long)]
     pub db: PathBuf,
-    /// Path template, e.g. "$albumartist/$album/$title".
+    /// Path template, e.g. "$albumartist/$album/$title". Supports ${a|b}
+    /// fallback chains, [...] conditional sections ($[/$] for literal
+    /// brackets), and $!{field} path fields that keep '/' as separators.
     #[arg(long, default_value = "$artist/$title")]
     pub template: String,
     /// Fallback value substituted for any missing template field.

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -1,8 +1,11 @@
 use std::collections::BTreeMap;
+use std::iter::Peekable;
+use std::str::Chars;
 
-/// A parsed path template: literal runs interleaved with `$field` / `${field}`
-/// substitutions. Parse once per mount; `render` then costs one output `String`
-/// per call, with no re-parse and no per-field intermediates.
+/// A parsed path template: literal runs, `$field` / `${field}` substitutions
+/// (with optional `${a|b}` fallback chains and `$!{field}` slash-preserving path
+/// fields), and `[...]` conditional sections. Parse once per mount; `render`
+/// then costs one output `String` per call, with no re-parse.
 #[derive(Debug, Clone)]
 pub struct Template {
     parts: Vec<Part>,
@@ -11,64 +14,38 @@ pub struct Template {
 #[derive(Debug, Clone)]
 enum Part {
     Literal(String),
-    Field(String),
+    /// `names` is the `|`-separated fallback chain (length 1 for a plain field);
+    /// `raw` marks a `$!{…}` path field whose '/' are kept as separators.
+    Field {
+        names: Vec<String>,
+        raw: bool,
+    },
+    /// A `[...]` conditional section: emitted only if at least one field
+    /// referenced within it (transitively) is present.
+    Section(Vec<Part>),
 }
 
 impl Template {
-    /// Parse a beets-style template. Infallible: `$field` and `${field}` become
-    /// substitutions, a `$` not followed by a field name stays literal, and an
-    /// unterminated `${` consumes the rest of the template as the field name.
+    /// Parse a beets-style template. Infallible.
+    ///
+    /// - `$field` / `${field}` substitute a tag field; `${a|b|c}` is a fallback
+    ///   chain (first present wins). Names are matched case-insensitively.
+    /// - `$!{field}` is a path field: the value's '/' are kept as directory
+    ///   separators (each segment sanitized; empty / `.` / `..` dropped).
+    /// - `[...]` is a conditional section, suppressed when every field it
+    ///   references is empty. `$[` and `$]` emit literal brackets.
+    /// - A `$` not followed by a recognized form stays literal; an unterminated
+    ///   `${`/`$!{` consumes the rest as the name; an unterminated `[` runs to
+    ///   end of input.
     pub fn parse(template: &str) -> Template {
-        let mut parts = Vec::new();
-        let mut literal = String::new();
         let mut chars = template.chars().peekable();
-        while let Some(c) = chars.next() {
-            if c != '$' {
-                literal.push(c);
-                continue;
-            }
-            match chars.peek() {
-                Some('{') => {
-                    chars.next(); // consume '{'
-                    let mut name = String::new();
-                    for nc in chars.by_ref() {
-                        if nc == '}' {
-                            break;
-                        }
-                        name.push(nc);
-                    }
-                    if !literal.is_empty() {
-                        parts.push(Part::Literal(std::mem::take(&mut literal)));
-                    }
-                    parts.push(Part::Field(name));
-                }
-                Some(&nc) if is_field_char(nc) => {
-                    let mut name = String::new();
-                    while let Some(&nc) = chars.peek() {
-                        if is_field_char(nc) {
-                            name.push(nc);
-                            chars.next();
-                        } else {
-                            break;
-                        }
-                    }
-                    if !literal.is_empty() {
-                        parts.push(Part::Literal(std::mem::take(&mut literal)));
-                    }
-                    parts.push(Part::Field(name));
-                }
-                _ => literal.push('$'), // a literal '$' not followed by a field name
-            }
-        }
-        if !literal.is_empty() {
-            parts.push(Part::Literal(literal));
-        }
+        let parts = parse_parts(&mut chars, false);
         Template { parts }
     }
 
-    /// Render one track's path. Each field resolves through `fields`, then
-    /// `fallbacks`, then `default_fallback`, and is sanitized to a single path
-    /// component as it is appended. The extension is appended after a '.'.
+    /// Render one track's path. Outside a section a missing field resolves
+    /// through `fallbacks` then `default_fallback`; inside a section a missing
+    /// field renders blank and drives suppression. The extension follows a '.'.
     pub fn render(
         &self,
         fields: &BTreeMap<String, &str>,
@@ -76,24 +53,197 @@ impl Template {
         default_fallback: &str,
         ext: &str,
     ) -> String {
-        let mut out = String::new();
-        for part in &self.parts {
-            match part {
-                Part::Literal(lit) => out.push_str(lit),
-                Part::Field(name) => {
-                    let value = fields
-                        .get(name)
-                        .copied()
-                        .or_else(|| fallbacks.get(name).map(String::as_str))
-                        .unwrap_or(default_fallback);
-                    sanitize_into(&mut out, value);
-                }
-            }
-        }
+        let (mut out, _) = render_parts(&self.parts, fields, fallbacks, default_fallback, false);
         out.push('.');
         out.push_str(ext);
         out
     }
+}
+
+/// Parse parts until a closing `]` (when `in_section`) or end of input.
+fn parse_parts(chars: &mut Peekable<Chars>, in_section: bool) -> Vec<Part> {
+    let mut parts = Vec::new();
+    let mut literal = String::new();
+    while let Some(&c) = chars.peek() {
+        match c {
+            ']' if in_section => {
+                chars.next(); // consume the closing ']'
+                break;
+            }
+            '[' => {
+                chars.next();
+                push_literal(&mut parts, &mut literal);
+                let inner = parse_parts(chars, true);
+                parts.push(Part::Section(inner));
+            }
+            '$' => {
+                chars.next(); // consume '$'
+                match chars.peek() {
+                    Some('[') => {
+                        chars.next();
+                        literal.push('[');
+                    }
+                    Some(']') => {
+                        chars.next();
+                        literal.push(']');
+                    }
+                    Some('{') => {
+                        chars.next();
+                        let names = parse_braced_names(chars);
+                        push_literal(&mut parts, &mut literal);
+                        parts.push(Part::Field { names, raw: false });
+                    }
+                    Some('!') => {
+                        chars.next(); // consume '!'
+                        if chars.peek() == Some(&'{') {
+                            chars.next(); // consume '{'
+                            let names = parse_braced_names(chars);
+                            push_literal(&mut parts, &mut literal);
+                            parts.push(Part::Field { names, raw: true });
+                        } else {
+                            literal.push('$');
+                            literal.push('!');
+                        }
+                    }
+                    Some(&nc) if is_field_char(nc) => {
+                        let name = parse_unbraced_name(chars);
+                        push_literal(&mut parts, &mut literal);
+                        parts.push(Part::Field {
+                            names: vec![name],
+                            raw: false,
+                        });
+                    }
+                    _ => literal.push('$'),
+                }
+            }
+            _ => {
+                literal.push(c);
+                chars.next();
+            }
+        }
+    }
+    push_literal(&mut parts, &mut literal);
+    parts
+}
+
+fn push_literal(parts: &mut Vec<Part>, literal: &mut String) {
+    if !literal.is_empty() {
+        parts.push(Part::Literal(std::mem::take(literal)));
+    }
+}
+
+/// Consume up to the next `}` (or end of input) and split on `|` into the
+/// candidate name list, lowercased for case-insensitive lookup.
+fn parse_braced_names(chars: &mut Peekable<Chars>) -> Vec<String> {
+    let mut content = String::new();
+    for nc in chars.by_ref() {
+        if nc == '}' {
+            break;
+        }
+        content.push(nc);
+    }
+    content.split('|').map(str::to_ascii_lowercase).collect()
+}
+
+fn parse_unbraced_name(chars: &mut Peekable<Chars>) -> String {
+    let mut name = String::new();
+    while let Some(&nc) = chars.peek() {
+        if is_field_char(nc) {
+            name.push(nc);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    name.to_ascii_lowercase()
+}
+
+/// Render `parts`, returning the text and whether at least one referenced field
+/// was present. `in_section` gates `default_fallback`: it is substituted only at
+/// the top level (outside any `[...]`).
+fn render_parts(
+    parts: &[Part],
+    fields: &BTreeMap<String, &str>,
+    fallbacks: &BTreeMap<String, String>,
+    default_fallback: &str,
+    in_section: bool,
+) -> (String, bool) {
+    let mut out = String::new();
+    let mut any_present = false;
+    for part in parts {
+        match part {
+            Part::Literal(lit) => out.push_str(lit),
+            Part::Field { names, raw: false } => {
+                if let Some(value) = resolve_plain(names, fields, fallbacks) {
+                    sanitize_into(&mut out, value);
+                    any_present = true;
+                } else if !in_section {
+                    sanitize_into(&mut out, default_fallback);
+                }
+            }
+            Part::Field { names, raw: true } => {
+                if let Some(path) = resolve_path(names, fields, fallbacks) {
+                    out.push_str(&path);
+                    any_present = true;
+                } else if !in_section {
+                    sanitize_into(&mut out, default_fallback);
+                }
+            }
+            Part::Section(inner) => {
+                let (text, present) =
+                    render_parts(inner, fields, fallbacks, default_fallback, true);
+                if present {
+                    out.push_str(&text);
+                    any_present = true;
+                }
+            }
+        }
+    }
+    (out, any_present)
+}
+
+/// First candidate with a non-empty value, checked against `fields` then
+/// `fallbacks`.
+fn resolve_plain<'a>(
+    names: &[String],
+    fields: &BTreeMap<String, &'a str>,
+    fallbacks: &'a BTreeMap<String, String>,
+) -> Option<&'a str> {
+    for name in names {
+        if let Some(v) = fields.get(name).copied().filter(|v| !v.is_empty()) {
+            return Some(v);
+        }
+        if let Some(v) = fallbacks
+            .get(name)
+            .map(String::as_str)
+            .filter(|v| !v.is_empty())
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// First candidate that yields at least one surviving path segment, returned as
+/// the sanitized multi-segment path.
+fn resolve_path(
+    names: &[String],
+    fields: &BTreeMap<String, &str>,
+    fallbacks: &BTreeMap<String, String>,
+) -> Option<String> {
+    for name in names {
+        let value = fields
+            .get(name)
+            .copied()
+            .or_else(|| fallbacks.get(name).map(String::as_str));
+        if let Some(value) = value {
+            let path = sanitize_path(value);
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+    }
+    None
 }
 
 /// Append `value` with '/' and control characters replaced by '_' so it stays a
@@ -107,6 +257,23 @@ fn sanitize_into(out: &mut String, value: &str) {
             out.push(c);
         }
     }
+}
+
+/// Split `value` on '/', drop empty / `.` / `..` segments, sanitize each
+/// surviving segment, and rejoin with '/'. Guarantees no empty, `.`, `..`, or
+/// leading/trailing-slash components reach the virtual tree.
+fn sanitize_path(value: &str) -> String {
+    let mut out = String::new();
+    for segment in value.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('/');
+        }
+        sanitize_into(&mut out, segment);
+    }
+    out
 }
 
 fn is_field_char(c: char) -> bool {

--- a/musefs-core/tests/template.rs
+++ b/musefs-core/tests/template.rs
@@ -59,3 +59,196 @@ fn unterminated_brace_consumes_rest_as_field_name() {
     let path = Template::parse("${album").render(&f, &BTreeMap::new(), "Unknown", "ogg");
     assert_eq!(path, "X.ogg");
 }
+
+#[test]
+fn fallback_chain_uses_first_present_candidate() {
+    let f = fields(&[("artist", "Beck"), ("title", "Loser")]);
+    let path = Template::parse("${albumartist|artist}/$title").render(
+        &f,
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "Beck/Loser.flac");
+}
+
+#[test]
+fn fallback_chain_skips_empty_value() {
+    let f = fields(&[("albumartist", ""), ("artist", "Beck"), ("title", "Loser")]);
+    let path = Template::parse("${albumartist|artist}/$title").render(
+        &f,
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "Beck/Loser.flac");
+}
+
+#[test]
+fn fallback_chain_all_empty_falls_to_default_at_top_level() {
+    let f = fields(&[("title", "Loser")]);
+    let path = Template::parse("${albumartist|artist}/$title").render(
+        &f,
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "Unknown/Loser.flac");
+}
+
+#[test]
+fn field_names_are_case_insensitive() {
+    let f = fields(&[("albumartist", "VA")]);
+    let path = Template::parse("$AlbumArtist").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "VA.flac");
+}
+
+#[test]
+fn section_suppressed_when_field_absent() {
+    let f = fields(&[("album", "LP")]);
+    let path =
+        Template::parse("$album[ - CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP.flac");
+}
+
+#[test]
+fn section_emitted_when_field_present() {
+    let f = fields(&[("album", "LP"), ("disc", "2")]);
+    let path =
+        Template::parse("$album[ - CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP - CD 2.flac");
+}
+
+#[test]
+fn nested_section_outer_kept_inner_dropped() {
+    let f = fields(&[("artist", "AC"), ("album", "LP"), ("title", "Song")]);
+    let path = Template::parse("$artist[/[$date - ]$album]/$title").render(
+        &f,
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "AC/LP/Song.flac");
+}
+
+#[test]
+fn nested_section_inner_present_renders_prefix() {
+    let f = fields(&[
+        ("artist", "AC"),
+        ("date", "1999"),
+        ("album", "LP"),
+        ("title", "Song"),
+    ]);
+    let path = Template::parse("$artist[/[$date - ]$album]/$title").render(
+        &f,
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "AC/1999 - LP/Song.flac");
+}
+
+#[test]
+fn section_all_referenced_fields_empty_is_suppressed() {
+    let f = fields(&[("album", "LP")]);
+    let path =
+        Template::parse("$album[ $[$date$]]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP.flac");
+}
+
+#[test]
+fn escaped_brackets_render_literally_inside_kept_section() {
+    let f = fields(&[("album", "LP"), ("date", "1999")]);
+    let path =
+        Template::parse("$album[ $[$date$]]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP [1999].flac");
+}
+
+#[test]
+fn empty_field_inside_kept_section_renders_blank_not_default() {
+    let f = fields(&[("album", "LP")]);
+    let path = Template::parse("[$album$disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP.flac");
+}
+
+#[test]
+fn empty_section_emits_nothing() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$title[]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Song.flac");
+}
+
+#[test]
+fn path_field_keeps_slashes_as_separators() {
+    let f = fields(&[("p", "Pink Floyd/Animals/01 Pigs")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Pink Floyd/Animals/01 Pigs.flac");
+}
+
+#[test]
+fn path_field_drops_empty_and_dot_segments() {
+    let f = fields(&[("p", "a//../b/./c")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "a/b/c.flac");
+}
+
+#[test]
+fn path_field_all_segments_dropped_falls_to_default() {
+    let f = fields(&[("p", "..")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Unknown.flac");
+}
+
+#[test]
+fn path_field_fallback_chain() {
+    let f = fields(&[("lidarr_path", "Artist/Album/Song")]);
+    let path = Template::parse("$!{beets_path|lidarr_path}").render(
+        &f,
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "Artist/Album/Song.flac");
+}
+
+#[test]
+fn path_field_sanitizes_control_chars_within_segments() {
+    let f = fields(&[("p", "a\u{0001}b/c")]);
+    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "a_b/c.flac");
+}
+
+#[test]
+fn escaped_brackets_at_top_level_render_literally() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$[$title$]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "[Song].flac");
+}
+
+#[test]
+fn stray_closing_bracket_is_literal() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$title]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Song].flac");
+}
+
+#[test]
+fn unterminated_section_runs_to_end_of_input() {
+    let f = fields(&[("album", "LP"), ("disc", "2")]);
+    let path = Template::parse("$album[ CD $disc").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "LP CD 2.flac");
+}
+
+#[test]
+fn dollar_bang_without_brace_stays_literal() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("$!x/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "$!x/Song.flac");
+}
+
+#[test]
+fn empty_braced_field_is_absent() {
+    let f = fields(&[("title", "Song")]);
+    let path = Template::parse("${}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(path, "Unknown/Song.flac");
+}

--- a/musefs-core/tests/template.rs
+++ b/musefs-core/tests/template.rs
@@ -1,4 +1,5 @@
 use musefs_core::Template;
+use proptest::prelude::*;
 use std::collections::BTreeMap;
 
 fn fields<'a>(pairs: &[(&str, &'a str)]) -> BTreeMap<String, &'a str> {
@@ -251,4 +252,47 @@ fn empty_braced_field_is_absent() {
     let f = fields(&[("title", "Song")]);
     let path = Template::parse("${}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Unknown/Song.flac");
+}
+
+proptest! {
+    // render must never panic, and a path field must never emit an empty,
+    // '.', or '..' component (no traversal / no absolute path into the tree).
+    #[test]
+    fn render_never_panics_and_path_fields_stay_safe(tmpl in ".{0,64}", value in ".{0,64}") {
+        let f = fields(&[("p", value.as_str())]);
+
+        // arbitrary templates must not panic
+        let _ = Template::parse(&tmpl).render(&f, &BTreeMap::new(), "Unknown", "flac");
+
+        // a path field over an adversarial value yields only safe components
+        let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let body = rendered.strip_suffix(".flac").expect("ext appended");
+        for component in body.split('/') {
+            prop_assert!(!component.is_empty());
+            prop_assert_ne!(component, ".");
+            prop_assert_ne!(component, "..");
+        }
+    }
+}
+
+#[test]
+fn path_field_neutralizes_traversal_values() {
+    for value in [
+        "../../etc/passwd",
+        "/abs/path",
+        "a/../../b",
+        "....//",
+        "/",
+        "..",
+        ".",
+    ] {
+        let f = fields(&[("p", value)]);
+        let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let body = rendered.strip_suffix(".flac").unwrap();
+        for component in body.split('/') {
+            assert!(!component.is_empty(), "empty component from {value:?}");
+            assert_ne!(component, ".", "'.' component from {value:?}");
+            assert_ne!(component, "..", "'..' component from {value:?}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Expands the beets-style path-template engine (`musefs-core/src/template.rs`) with four user-facing features, keeping `parse` infallible and `render`'s public signature unchanged (the sole call site `render_one` in `facade.rs` is untouched):

- **Inline fallback chains** — `${albumartist|artist}`: first present (non-empty) candidate wins before the global `--default-fallback`. Field names are now matched case-insensitively.
- **Conditional sections** — `[ ... ]` (foobar2000-style): a bracketed section is emitted only when at least one field it references (transitively, across nesting) is present; otherwise it vanishes. `$[` / `$]` escape literal brackets. Inside a section a missing field renders blank and never pulls `default_fallback`.
- **Path fields** — `$!{field}`: the value's `/` are kept as directory separators (each segment sanitized; empty / `.` / `..` segments dropped), so a plugin-computed relative path stored in one tag expands into real directories. Enables the **computed-tag workflow** (beets/Picard/Lidarr write a whole path into a custom tag; mount with `--template '$!{beets_path}'`).

### ⚠️ Breaking change
`[` and `]` are now metacharacters. Existing templates containing literal square brackets change meaning; use `$[` / `$]` for literals. The default template (`$artist/$title`) and prior behavior for bracket-free templates are unaffected.

## Implementation

Recursive `Part` model (`Literal` / `Field { names, raw }` / `Section`). `parse` is a recursive descent over `Peekable<Chars>`; `render` delegates to `render_parts(..., in_section)` returning `(text, any_present)`, applying `default_fallback` only at the top level and suppressing a section when none of its fields are present. A new `sanitize_path` enforces segment-level safety. Rendered multi-segment paths flow through the existing `VirtualTree::build` splitter (which already splits on `/` and filters empty components) — no tree-layer changes needed.

## Testing

- 24 new unit tests in `musefs-core/tests/template.rs` (fallback chains, sections incl. nesting, path fields, escaping, parser edges, degenerate constructs) covering every acceptance case in the spec.
- A `proptest` invariant + explicit adversarial-value test asserting **path-traversal safety**: no `$!{}` value can produce an empty, `.`, or `..` path component (`../../etc/passwd`, `/abs`, `a/../../b`, …).
- Full gate green: `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, and the full workspace suite (**733 passed, 22 ignored**).

## Docs

README template section, ARCHITECTURE (virtual-tree + external-writer computed-tag workflow), and the CLI `--template` doc-comment updated. Design spec and TDD implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended template syntax with inline fallback chains (`${a|b|c}`)
  * Conditional sections (`[...]`) that suppress when fields are missing
  * Slash-preserving path fields (`$!{field}`) with segment sanitization

* **Tests**
  * Added comprehensive unit and property-based tests for new template functionality

* **Documentation**
  * Updated README, architecture docs, and CLI help with new syntax details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->