### PR TITLE
beets: compute a beets_path tag for $!{beets_path} mounts

### DIFF
--- a/contrib/beets/README.md
+++ b/contrib/beets/README.md
@@ -54,6 +54,9 @@ beet musefs -n                   # dry run: report counts, write nothing
 # Mount the re-tagged view.
 musefs mount ~/mnt --db ~/musefs.db \
     --template '$albumartist/$album/$tracknumber - $title'
+
+# ...or mirror your beets library layout exactly, via the computed beets_path tag.
+musefs mount ~/mnt --db ~/musefs.db --template '$!{beets_path}'
 ```
 
 Imports and tag write-backs auto-sync via event hooks: `beet import` and
@@ -69,6 +72,14 @@ first; the hooks then skip gracefully if the DB is missing.
 - **Cover art:** taken from the album's `artpath` (beets' external cover file).
   beets art wins when present; otherwise any art `musefs scan` ingested from
   embedded pictures is preserved.
+- **Computed path (`beets_path`):** each sync also writes a `beets_path` text tag
+  holding the track's beets library-relative path (from your `paths:` config, via
+  `item.destination`), with the file extension removed — musefs re-appends it. Mount
+  with `--template '$!{beets_path}'` (the `$!{}` path field keeps `/` as directory
+  separators) to mirror your beets layout, including layouts musefs's own template
+  engine can't express. Set `write_path: no` in the `musefs:` config to skip it.
+  Do not add an extension in a template that consumes `beets_path`. See the
+  computed-tag workflow in [ARCHITECTURE.md](../../ARCHITECTURE.md).
 - **Moves & deletes:** every sync (the command and the end-of-command reconcile)
   prunes track rows whose backing file is no longer present, so renames/moves
   don't leave stale entries. Caveat: a file that's merely offline at sync time

--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -144,18 +144,54 @@ def _read_album_art(item, cache, stats):
     return art
 
 
-def build_records(items, *, fields=None, stats):
+def _computed_path(item):
+    """Beets' library-relative path for ``item``, decoded to a SQLite-safe str
+    with the file extension removed (musefs re-appends it at render time).
+
+    Mirrors ``realpath_key``'s lossy normalization (U+FFFD for undecodable
+    bytes) so the value is always valid UTF-8, but without realpath's on-disk
+    resolution. Returns "" when beets yields no usable path.
+    """
+    raw = item.destination(relative_to_libdir=True)
+    decoded = os.fsdecode(raw)
+    safe = decoded.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
+    return os.path.splitext(safe)[0].lstrip("/")
+
+
+def _computed_path_or_skip(item, log):
+    """``_computed_path`` guarded so a bad destination never aborts a sync.
+
+    Returns "" (skip the tag) on any failure, warning through ``log`` if given.
+    """
+    try:
+        return _computed_path(item)
+    except Exception as exc:
+        if log is not None:
+            # beets' plugin logger is a StrFormatLogger ({}-style, not %-style).
+            log.warning("musefs: skipping beets_path for {!r}: {}", item.path, exc)
+        return ""
+
+
+def build_records(items, *, fields=None, stats, write_path=True, log=None):
     """Build ``Record``s for beets items: map tags and resolve album art (with a
     per-run cache; unreadable/over-cap covers counted into ``stats.skipped_art``).
-    ``stats`` is mutated and must be the same instance passed to ``sync_files``."""
+    When ``write_path`` is set, also emit a ``beets_path`` tag with the track's
+    beets library-relative path (extension stripped); a failed computation is
+    skipped and warned through ``log``. ``stats`` is mutated and must be the same
+    instance passed to ``sync_files``."""
     records = []
     art_cache = {}
     for item in items:
         cover = _read_album_art(item, art_cache, stats)
+        pairs = map_fields(item, fields)
+        if write_path:
+            path = _computed_path_or_skip(item, log)
+            if path:
+                pairs.append(("beets_path", path))
         records.append(
             Record(
                 key=realpath_key(item.path),
-                pairs=map_fields(item, fields),
+                pairs=pairs,
                 art=[ArtImage(*cover)] if cover else None,
             )
         )

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -31,6 +31,7 @@ class MusefsPlugin(BeetsPlugin):
             "fields": {},
             "bin": "musefs",  # musefs executable (PATH name or full path)
             "autoscan": True,  # run `musefs scan` automatically before syncing
+            "write_path": True,  # emit a beets_path tag for $!{beets_path} mounts
         })
         # beets has no file-move event, and `after_write` fires *before* a move
         # (at the old path). So imports/writes are recorded and reconciled once
@@ -144,6 +145,9 @@ class MusefsPlugin(BeetsPlugin):
     def _autoscan(self):
         return bool(self.config["autoscan"].get(bool))
 
+    def _write_path(self):
+        return bool(self.config["write_path"].get(bool))
+
     def _bin(self):
         return self.config["bin"].get(str) or "musefs"
 
@@ -206,7 +210,13 @@ class MusefsPlugin(BeetsPlugin):
         try:
             check_schema_version(conn)
             stats = SyncStats()
-            records = _core.build_records(items, fields=self._fields(), stats=stats)
+            records = _core.build_records(
+                items,
+                fields=self._fields(),
+                stats=stats,
+                write_path=self._write_path(),
+                log=self._log,
+            )
             sync_files(conn, records, dry_run=dry_run, stats=stats)
             if dry_run:
                 conn.rollback()

--- a/contrib/beets/tests/conftest.py
+++ b/contrib/beets/tests/conftest.py
@@ -58,8 +58,17 @@ class FakeItem:
         self.year = fields.pop("year", 0)
         self.month = fields.pop("month", 0)
         self.day = fields.pop("day", 0)
+        # beets' Item.destination(relative_to_libdir=True) returns a bytes path;
+        # default to the item's own path so existing tests keep working.
+        self._destination = fields.pop("destination", path)
+        self._destination_raises = fields.pop("destination_raises", False)
         for k, v in fields.items():
             setattr(self, k, v)
+
+    def destination(self, relative_to_libdir=False):
+        if self._destination_raises:
+            raise RuntimeError("destination boom")
+        return self._destination
 
     def get_album(self):
         return self._album

--- a/contrib/beets/tests/test_build_records.py
+++ b/contrib/beets/tests/test_build_records.py
@@ -51,3 +51,68 @@ def test_build_records_counts_oversized_art_once(fake_item, fake_album, tmp_path
     records = _core.build_records(items, fields=None, stats=stats)
     assert all(r.art is None for r in records)
     assert stats.skipped_art == 1
+
+
+class _RecordingLog:
+    """Duck-typed stand-in for the plugin's logger."""
+
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, *args):
+        self.warnings.append(args)
+
+
+def test_build_records_writes_beets_path_stripping_extension(fake_item):
+    item = fake_item(b"/m/a.flac", title="T", destination=b"Artist/Album/01 Song.flac")
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats)
+    assert ("beets_path", "Artist/Album/01 Song") in records[0].pairs
+
+
+def test_build_records_omits_beets_path_when_write_path_false(fake_item):
+    item = fake_item(b"/m/a.flac", title="T", destination=b"Artist/Album/01 Song.flac")
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats, write_path=False)
+    assert all(k != "beets_path" for k, _ in records[0].pairs)
+
+
+def test_build_records_skips_beets_path_on_error_and_warns(fake_item):
+    item = fake_item(b"/m/a.flac", title="T", destination_raises=True)
+    log = _RecordingLog()
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats, log=log)
+    assert all(k != "beets_path" for k, _ in records[0].pairs)
+    assert ("title", "T") in records[0].pairs  # other tags still sync
+    assert log.warnings  # a warning was emitted
+
+
+def test_build_records_beets_path_is_utf8_safe_for_non_unicode_paths(fake_item):
+    # A non-UTF-8 byte must normalize to valid UTF-8 (U+FFFD), never a lone
+    # surrogate that SQLite's TEXT encoder would reject.
+    item = fake_item(b"/m/a.flac", destination=b"Art\xffist/Album/01 Song.flac")
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats)
+    value = dict(records[0].pairs)["beets_path"]
+    value.encode("utf-8")  # must not raise
+    assert value.startswith("Art")
+    assert value.endswith("/Album/01 Song")
+
+
+def test_build_records_uses_real_beets_destination(tmp_path):
+    # Exercises the REAL beets API (not FakeItem), so the default test tier
+    # covers item.destination(relative_to_libdir=True), not just our decode.
+    from beets.library import Item, Library
+
+    lib = Library(
+        ":memory:",
+        directory=str(tmp_path),
+        path_formats=[("default", "$artist/$album/$track $title")],
+    )
+    item = Item(artist="AC/DC", album="Back in Black", title="Hells Bells", track=1)
+    item.path = b"/music/x.flac"  # supplies the .flac extension
+    lib.add(item)  # assigns an id and binds the library, required by destination()
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats)
+    # beets sanitizes "AC/DC" -> "AC_DC" and zero-pads $track; we strip ".flac".
+    assert ("beets_path", "AC_DC/Back in Black/01 Hells Bells") in records[0].pairs

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -73,7 +73,7 @@ def _autoscan_plugin(db_path, monkeypatch):
     monkeypatch.setattr(
         plugin,
         "config",
-        FakeConfigView({"db": db_path, "fields": {}, "autoscan": True}),
+        FakeConfigView({"db": db_path, "fields": {}, "autoscan": True, "write_path": True}),
         raising=False,
     )
     calls = []

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -284,3 +284,61 @@ def test_reconcile_best_effort_on_scan_failure(db_path, fake_item, monkeypatch):
     plugin._record(item=fake_item(os.fsencode("/music/a.flac")))
     # A passive hook must swallow the error (warn), never abort the beets op.
     plugin._reconcile_pending()
+
+
+def test_sync_writes_beets_path_when_enabled(db_path, make_track, fake_item, tmp_path, monkeypatch):
+    real, tid, item = _real_track(
+        tmp_path,
+        make_track,
+        fake_item,
+        title="Song",
+        destination=b"Artist/Album/01 Song.flac",
+    )
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": True}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item])
+
+    conn = connect(db_path)
+    try:
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='beets_path'", (tid,)
+            ).fetchone()[0]
+            == "Artist/Album/01 Song"
+        )
+    finally:
+        conn.close()
+
+
+def test_sync_omits_beets_path_when_disabled(db_path, make_track, fake_item, tmp_path, monkeypatch):
+    real, tid, item = _real_track(
+        tmp_path,
+        make_track,
+        fake_item,
+        title="Song",
+        destination=b"Artist/Album/01 Song.flac",
+    )
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": False}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item])
+
+    conn = connect(db_path)
+    try:
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='beets_path'", (tid,)
+            ).fetchone()
+            is None
+        )
+    finally:
+        conn.close()

--- a/docs/superpowers/plans/2026-06-08-beets-computed-path.md
+++ b/docs/superpowers/plans/2026-06-08-beets-computed-path.md
@@ -1,0 +1,458 @@
+# Beets Computed-Path Tag (`beets_path`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The beets plugin writes one extra text tag, `beets_path`, per synced track — the beets library-relative path (`item.destination`, extension stripped) — so users can mount musefs with `--template '$!{beets_path}'` and get a tree mirroring their beets library.
+
+**Architecture:** Path computation lives in `contrib/beets/beetsplug/_core.py` (the existing `build_records` chokepoint that feeds both the import-time listeners and the `musefs` command). It appends `("beets_path", value)` to the existing `Record.pairs` list, which flows unchanged through `replace_tags`/`sync_files`. The shared `python-musefs` library and the musefs Rust core are untouched. Computation reuses `realpath_key`'s lossy-UTF-8 normalization so the value is always SQLite-safe; failures skip just that tag and warn via the plugin logger.
+
+**Tech Stack:** Python (beets 2.x plugin). Tests with pytest in the beets venv. Lint: ruff (`select = ["E","F","I","N","W"]`, line-length 100).
+
+**Reference:** Spec at `docs/superpowers/specs/2026-06-08-beets-computed-path-design.md`. Branch `plugin-computed-paths`.
+
+**Gate notes:**
+- The pre-commit hook runs `cargo` fmt/clippy/test + `ruff check` + `ruff format --check`. It does **not** run the Python test suite — run beets pytest manually in each task: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -q`.
+- Keep Python lines ≤ 100 chars. A plain `except Exception:` is lint-clean here (no BLE rule selected); do **not** add a `# noqa`.
+
+## File structure
+
+- `contrib/beets/beetsplug/_core.py` — add `_computed_path` + `_computed_path_or_skip` helpers; extend `build_records` with `write_path`/`log` params and the `beets_path` append. (No beets imports here; the logger is passed in, duck-typed.)
+- `contrib/beets/beetsplug/musefs.py` — register the `write_path: True` config default, add `_write_path()`, thread `write_path`/`log` into the `_sync` → `build_records` call.
+- `contrib/beets/tests/conftest.py` — extend `FakeItem` with a `destination()` method (+ a raise toggle).
+- `contrib/beets/tests/test_build_records.py` — `_core`-level tests.
+- `contrib/beets/tests/test_plugin.py` — DB-level enabled/disabled tests.
+- `contrib/beets/README.md` — document the tag, `write_path`, and the `$!{beets_path}` mount.
+
+---
+
+## Task 1: Compute `beets_path` in `_core.build_records`
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/_core.py`
+- Modify: `contrib/beets/tests/conftest.py` (extend `FakeItem`)
+- Test: `contrib/beets/tests/test_build_records.py`
+
+- [ ] **Step 1: Extend `FakeItem` with a `destination()` method**
+
+In `contrib/beets/tests/conftest.py`, in `FakeItem.__init__`, the tail currently reads:
+
+```python
+        self.day = fields.pop("day", 0)
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+    def get_album(self):
+        return self._album
+```
+
+Replace that block with (adds two pops before the catch-all, and a `destination` method):
+
+```python
+        self.day = fields.pop("day", 0)
+        # beets' Item.destination(relative_to_libdir=True) returns a bytes path;
+        # default to the item's own path so existing tests keep working.
+        self._destination = fields.pop("destination", path)
+        self._destination_raises = fields.pop("destination_raises", False)
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+    def destination(self, relative_to_libdir=False):
+        if self._destination_raises:
+            raise RuntimeError("destination boom")
+        return self._destination
+
+    def get_album(self):
+        return self._album
+```
+
+- [ ] **Step 2: Write the failing `_core` tests**
+
+Append to `contrib/beets/tests/test_build_records.py`:
+
+```python
+class _RecordingLog:
+    """Duck-typed stand-in for the plugin's logger."""
+
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, *args):
+        self.warnings.append(args)
+
+
+def test_build_records_writes_beets_path_stripping_extension(fake_item):
+    item = fake_item(b"/m/a.flac", title="T", destination=b"Artist/Album/01 Song.flac")
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats)
+    assert ("beets_path", "Artist/Album/01 Song") in records[0].pairs
+
+
+def test_build_records_omits_beets_path_when_write_path_false(fake_item):
+    item = fake_item(b"/m/a.flac", title="T", destination=b"Artist/Album/01 Song.flac")
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats, write_path=False)
+    assert all(k != "beets_path" for k, _ in records[0].pairs)
+
+
+def test_build_records_skips_beets_path_on_error_and_warns(fake_item):
+    item = fake_item(b"/m/a.flac", title="T", destination_raises=True)
+    log = _RecordingLog()
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats, log=log)
+    assert all(k != "beets_path" for k, _ in records[0].pairs)
+    assert ("title", "T") in records[0].pairs  # other tags still sync
+    assert log.warnings  # a warning was emitted
+
+
+def test_build_records_beets_path_is_utf8_safe_for_non_unicode_paths(fake_item):
+    # A non-UTF-8 byte must normalize to valid UTF-8 (U+FFFD), never a lone
+    # surrogate that SQLite's TEXT encoder would reject.
+    item = fake_item(b"/m/a.flac", destination=b"Art\xffist/Album/01 Song.flac")
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats)
+    value = dict(records[0].pairs)["beets_path"]
+    value.encode("utf-8")  # must not raise
+    assert value.startswith("Art")
+    assert value.endswith("/Album/01 Song")
+
+
+def test_build_records_uses_real_beets_destination(tmp_path):
+    # Exercises the REAL beets API (not FakeItem), so the default test tier
+    # covers item.destination(relative_to_libdir=True), not just our decode.
+    from beets.library import Item, Library
+
+    lib = Library(
+        ":memory:",
+        directory=str(tmp_path),
+        path_formats=[("default", "$artist/$album/$track $title")],
+    )
+    item = Item(artist="AC/DC", album="Back in Black", title="Hells Bells", track=1)
+    item.path = b"/music/x.flac"  # supplies the .flac extension
+    lib.add(item)  # assigns an id and binds the library, required by destination()
+    stats = SyncStats()
+    records = _core.build_records([item], fields=None, stats=stats)
+    # beets sanitizes "AC/DC" -> "AC_DC" and zero-pads $track; we strip ".flac".
+    assert ("beets_path", "AC_DC/Back in Black/01 Hells Bells") in records[0].pairs
+```
+
+(`_core` and `SyncStats` are already imported at the top of `test_build_records.py`; if not, add `from beetsplug import _core` and `from musefs_common import SyncStats`. The `beets` import is local to the test — beets is installed in the venv.)
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_build_records.py -q`
+Expected: FAIL — `build_records` doesn't accept `write_path`/`log` yet and emits no `beets_path` pair (`TypeError: build_records() got an unexpected keyword argument 'write_path'` for the relevant cases; the first test fails its assertion).
+
+- [ ] **Step 4: Add the path helpers to `_core.py`**
+
+In `contrib/beets/beetsplug/_core.py`, insert these two functions immediately above `build_records`:
+
+```python
+def _computed_path(item):
+    """Beets' library-relative path for ``item``, decoded to a SQLite-safe str
+    with the file extension removed (musefs re-appends it at render time).
+
+    Mirrors ``realpath_key``'s lossy normalization (U+FFFD for undecodable
+    bytes) so the value is always valid UTF-8, but without realpath's on-disk
+    resolution. Returns "" when beets yields no usable path.
+    """
+    raw = item.destination(relative_to_libdir=True)
+    decoded = os.fsdecode(raw)
+    safe = decoded.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
+    return os.path.splitext(safe)[0].lstrip("/")
+
+
+def _computed_path_or_skip(item, log):
+    """``_computed_path`` guarded so a bad destination never aborts a sync.
+
+    Returns "" (skip the tag) on any failure, warning through ``log`` if given.
+    """
+    try:
+        return _computed_path(item)
+    except Exception as exc:
+        if log is not None:
+            # beets' plugin logger is a StrFormatLogger ({}-style, not %-style).
+            log.warning("musefs: skipping beets_path for {!r}: {}", item.path, exc)
+        return ""
+```
+
+- [ ] **Step 5: Thread `write_path`/`log` through `build_records`**
+
+In `contrib/beets/beetsplug/_core.py`, replace the whole `build_records` function with:
+
+```python
+def build_records(items, *, fields=None, stats, write_path=True, log=None):
+    """Build ``Record``s for beets items: map tags and resolve album art (with a
+    per-run cache; unreadable/over-cap covers counted into ``stats.skipped_art``).
+    When ``write_path`` is set, also emit a ``beets_path`` tag with the track's
+    beets library-relative path (extension stripped); a failed computation is
+    skipped and warned through ``log``. ``stats`` is mutated and must be the same
+    instance passed to ``sync_files``."""
+    records = []
+    art_cache = {}
+    for item in items:
+        cover = _read_album_art(item, art_cache, stats)
+        pairs = map_fields(item, fields)
+        if write_path:
+            path = _computed_path_or_skip(item, log)
+            if path:
+                pairs.append(("beets_path", path))
+        records.append(
+            Record(
+                key=realpath_key(item.path),
+                pairs=pairs,
+                art=[ArtImage(*cover)] if cover else None,
+            )
+        )
+    return records
+```
+
+- [ ] **Step 6: Run the `_core` tests to verify they pass**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_build_records.py -q`
+Expected: PASS (all five new tests — including the real-beets-`destination` one — plus the existing `build_records` tests).
+
+- [ ] **Step 7: Run the full beets suite + ruff to confirm no regressions**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -q && ruff check contrib/beets && ruff format --check contrib/beets`
+Expected: PASS, no lint findings. (Existing tests use membership/specific-key assertions, so the added default `beets_path` pair is harmless.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add contrib/beets/beetsplug/_core.py contrib/beets/tests/conftest.py contrib/beets/tests/test_build_records.py
+git commit -m "feat(beets): compute beets_path tag in build_records
+
+item.destination(relative_to_libdir=True), decoded with lossy-UTF-8
+normalization and extension stripped, appended as a beets_path tag.
+write_path-gated; failures skip the tag and warn. FakeItem gains a
+destination() method.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire the `write_path` config into the plugin
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/musefs.py`
+- Test: `contrib/beets/tests/test_plugin.py`
+
+- [ ] **Step 1: Write the failing plugin tests**
+
+Append to `contrib/beets/tests/test_plugin.py`:
+
+```python
+def test_sync_writes_beets_path_when_enabled(
+    db_path, make_track, fake_item, tmp_path, monkeypatch
+):
+    real, tid, item = _real_track(
+        tmp_path,
+        make_track,
+        fake_item,
+        title="Song",
+        destination=b"Artist/Album/01 Song.flac",
+    )
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": True}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item])
+
+    conn = connect(db_path)
+    try:
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='beets_path'", (tid,)
+            ).fetchone()[0]
+            == "Artist/Album/01 Song"
+        )
+    finally:
+        conn.close()
+
+
+def test_sync_omits_beets_path_when_disabled(
+    db_path, make_track, fake_item, tmp_path, monkeypatch
+):
+    real, tid, item = _real_track(
+        tmp_path,
+        make_track,
+        fake_item,
+        title="Song",
+        destination=b"Artist/Album/01 Song.flac",
+    )
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": False}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item])
+
+    conn = connect(db_path)
+    try:
+        assert (
+            conn.execute(
+                "SELECT value FROM tags WHERE track_id=? AND key='beets_path'", (tid,)
+            ).fetchone()
+            is None
+        )
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_plugin.py -q -k beets_path`
+Expected: FAIL — `_sync` doesn't pass `write_path`/`log` yet, and there's no `write_path` config default, so `_write_path()` doesn't exist. (The disabled test may pass spuriously since nothing reads the flag yet; the enabled test fails because `_write_path` is undefined once Step 3 lands — confirm both after Step 3.)
+
+- [ ] **Step 3: Register the `write_path` default and add the accessor**
+
+In `contrib/beets/beetsplug/musefs.py`, in `__init__`, replace this exact block:
+
+```python
+        self.config.add({
+            "db": None,
+            "fields": {},
+            "bin": "musefs",  # musefs executable (PATH name or full path)
+            "autoscan": True,  # run `musefs scan` automatically before syncing
+        })
+```
+
+with:
+
+```python
+        self.config.add({
+            "db": None,
+            "fields": {},
+            "bin": "musefs",  # musefs executable (PATH name or full path)
+            "autoscan": True,  # run `musefs scan` automatically before syncing
+            "write_path": True,  # emit a beets_path tag for $!{beets_path} mounts
+        })
+```
+
+Then add this accessor next to `_autoscan`/`_bin`:
+
+```python
+    def _write_path(self):
+        return bool(self.config["write_path"].get(bool))
+```
+
+- [ ] **Step 4: Pass `write_path`/`log` into `build_records`**
+
+In `contrib/beets/beetsplug/musefs.py`, in `_sync`, replace this line:
+
+```python
+        records = _core.build_records(items, fields=self._fields(), stats=stats)
+```
+
+with:
+
+```python
+        records = _core.build_records(
+            items,
+            fields=self._fields(),
+            stats=stats,
+            write_path=self._write_path(),
+            log=self._log,
+        )
+```
+
+- [ ] **Step 5: Run the plugin tests to verify they pass**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_plugin.py -q`
+Expected: PASS (both new tests and all existing plugin tests).
+
+- [ ] **Step 6: Full beets suite + ruff**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -q && ruff check contrib/beets && ruff format --check contrib/beets`
+Expected: PASS, no lint findings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add contrib/beets/beetsplug/musefs.py contrib/beets/tests/test_plugin.py
+git commit -m "feat(beets): write_path config gates the beets_path tag
+
+Registers write_path (default on) and threads it plus the plugin logger
+into build_records.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Documentation
+
+**Files:**
+- Modify: `contrib/beets/README.md`
+
+- [ ] **Step 1: Add the `$!{beets_path}` mount to the Workflow example**
+
+In `contrib/beets/README.md`, in the `## Workflow (test drive)` code block, after these lines:
+
+```bash
+# Mount the re-tagged view.
+musefs mount ~/mnt --db ~/musefs.db \
+    --template '$albumartist/$album/$tracknumber - $title'
+```
+
+add:
+
+```bash
+
+# ...or mirror your beets library layout exactly, via the computed beets_path tag.
+musefs mount ~/mnt --db ~/musefs.db --template '$!{beets_path}'
+```
+
+- [ ] **Step 2: Add a Notes bullet documenting the tag and `write_path`**
+
+In `contrib/beets/README.md`, in the `## Notes` list, add this bullet (after the **Cover art** bullet):
+
+```markdown
+- **Computed path (`beets_path`):** each sync also writes a `beets_path` text tag
+  holding the track's beets library-relative path (from your `paths:` config, via
+  `item.destination`), with the file extension removed — musefs re-appends it. Mount
+  with `--template '$!{beets_path}'` (the `$!{}` path field keeps `/` as directory
+  separators) to mirror your beets layout, including layouts musefs's own template
+  engine can't express. Set `write_path: no` in the `musefs:` config to skip it.
+  Do not add an extension in a template that consumes `beets_path`. See the
+  computed-tag workflow in [ARCHITECTURE.md](../../ARCHITECTURE.md).
+```
+
+- [ ] **Step 3: Verify docs render and links resolve**
+
+Run: `test -f ARCHITECTURE.md && grep -q "beets_path\|computed" ARCHITECTURE.md && echo "cross-ref target OK"`
+Expected: `cross-ref target OK` (the computed-tag workflow was documented in `ARCHITECTURE.md` by PR #170).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add contrib/beets/README.md
+git commit -m "docs(beets): document beets_path computed-path tag and write_path
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full beets suite (incl. opt-in tiers off by default) + lint:**
+
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -v && ruff check contrib/beets && ruff format --check contrib/beets`
+Expected: all green, no lint findings.
+
+- [ ] **Manual end-to-end (optional; needs a real library + the musefs binary):**
+
+```bash
+beet musefs                                            # sync, writes beets_path
+sqlite3 ~/musefs.db "SELECT value FROM tags WHERE key='beets_path' LIMIT 3;"
+musefs mount ~/mnt --db ~/musefs.db --template '$!{beets_path}'
+```
+
+Confirm: `beets_path` values are extension-less relative paths, and the mounted tree mirrors the beets library layout. (Cardinal invariant unchanged — only paths/metadata are virtual; audio bytes untouched.)

--- a/docs/superpowers/plans/2026-06-08-beets-computed-path.md
+++ b/docs/superpowers/plans/2026-06-08-beets-computed-path.md
@@ -32,7 +32,7 @@
 - Modify: `contrib/beets/tests/conftest.py` (extend `FakeItem`)
 - Test: `contrib/beets/tests/test_build_records.py`
 
-- [ ] **Step 1: Extend `FakeItem` with a `destination()` method**
+- [x] **Step 1: Extend `FakeItem` with a `destination()` method**
 
 In `contrib/beets/tests/conftest.py`, in `FakeItem.__init__`, the tail currently reads:
 
@@ -65,7 +65,7 @@ Replace that block with (adds two pops before the catch-all, and a `destination`
         return self._album
 ```
 
-- [ ] **Step 2: Write the failing `_core` tests**
+- [x] **Step 2: Write the failing `_core` tests**
 
 Append to `contrib/beets/tests/test_build_records.py`:
 
@@ -137,12 +137,12 @@ def test_build_records_uses_real_beets_destination(tmp_path):
 
 (`_core` and `SyncStats` are already imported at the top of `test_build_records.py`; if not, add `from beetsplug import _core` and `from musefs_common import SyncStats`. The `beets` import is local to the test — beets is installed in the venv.)
 
-- [ ] **Step 3: Run the new tests to verify they fail**
+- [x] **Step 3: Run the new tests to verify they fail**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_build_records.py -q`
 Expected: FAIL — `build_records` doesn't accept `write_path`/`log` yet and emits no `beets_path` pair (`TypeError: build_records() got an unexpected keyword argument 'write_path'` for the relevant cases; the first test fails its assertion).
 
-- [ ] **Step 4: Add the path helpers to `_core.py`**
+- [x] **Step 4: Add the path helpers to `_core.py`**
 
 In `contrib/beets/beetsplug/_core.py`, insert these two functions immediately above `build_records`:
 
@@ -175,7 +175,7 @@ def _computed_path_or_skip(item, log):
         return ""
 ```
 
-- [ ] **Step 5: Thread `write_path`/`log` through `build_records`**
+- [x] **Step 5: Thread `write_path`/`log` through `build_records`**
 
 In `contrib/beets/beetsplug/_core.py`, replace the whole `build_records` function with:
 
@@ -206,17 +206,17 @@ def build_records(items, *, fields=None, stats, write_path=True, log=None):
     return records
 ```
 
-- [ ] **Step 6: Run the `_core` tests to verify they pass**
+- [x] **Step 6: Run the `_core` tests to verify they pass**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_build_records.py -q`
 Expected: PASS (all five new tests — including the real-beets-`destination` one — plus the existing `build_records` tests).
 
-- [ ] **Step 7: Run the full beets suite + ruff to confirm no regressions**
+- [x] **Step 7: Run the full beets suite + ruff to confirm no regressions**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -q && ruff check contrib/beets && ruff format --check contrib/beets`
 Expected: PASS, no lint findings. (Existing tests use membership/specific-key assertions, so the added default `beets_path` pair is harmless.)
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add contrib/beets/beetsplug/_core.py contrib/beets/tests/conftest.py contrib/beets/tests/test_build_records.py
@@ -238,7 +238,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Modify: `contrib/beets/beetsplug/musefs.py`
 - Test: `contrib/beets/tests/test_plugin.py`
 
-- [ ] **Step 1: Write the failing plugin tests**
+- [x] **Step 1: Write the failing plugin tests**
 
 Append to `contrib/beets/tests/test_plugin.py`:
 
@@ -305,12 +305,12 @@ def test_sync_omits_beets_path_when_disabled(
         conn.close()
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_plugin.py -q -k beets_path`
 Expected: FAIL — `_sync` doesn't pass `write_path`/`log` yet, and there's no `write_path` config default, so `_write_path()` doesn't exist. (The disabled test may pass spuriously since nothing reads the flag yet; the enabled test fails because `_write_path` is undefined once Step 3 lands — confirm both after Step 3.)
 
-- [ ] **Step 3: Register the `write_path` default and add the accessor**
+- [x] **Step 3: Register the `write_path` default and add the accessor**
 
 In `contrib/beets/beetsplug/musefs.py`, in `__init__`, replace this exact block:
 
@@ -342,7 +342,7 @@ Then add this accessor next to `_autoscan`/`_bin`:
         return bool(self.config["write_path"].get(bool))
 ```
 
-- [ ] **Step 4: Pass `write_path`/`log` into `build_records`**
+- [x] **Step 4: Pass `write_path`/`log` into `build_records`**
 
 In `contrib/beets/beetsplug/musefs.py`, in `_sync`, replace this line:
 
@@ -362,17 +362,17 @@ with:
         )
 ```
 
-- [ ] **Step 5: Run the plugin tests to verify they pass**
+- [x] **Step 5: Run the plugin tests to verify they pass**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests/test_plugin.py -q`
 Expected: PASS (both new tests and all existing plugin tests).
 
-- [ ] **Step 6: Full beets suite + ruff**
+- [x] **Step 6: Full beets suite + ruff**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -q && ruff check contrib/beets && ruff format --check contrib/beets`
 Expected: PASS, no lint findings.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add contrib/beets/beetsplug/musefs.py contrib/beets/tests/test_plugin.py
@@ -391,7 +391,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 **Files:**
 - Modify: `contrib/beets/README.md`
 
-- [ ] **Step 1: Add the `$!{beets_path}` mount to the Workflow example**
+- [x] **Step 1: Add the `$!{beets_path}` mount to the Workflow example**
 
 In `contrib/beets/README.md`, in the `## Workflow (test drive)` code block, after these lines:
 
@@ -409,7 +409,7 @@ add:
 musefs mount ~/mnt --db ~/musefs.db --template '$!{beets_path}'
 ```
 
-- [ ] **Step 2: Add a Notes bullet documenting the tag and `write_path`**
+- [x] **Step 2: Add a Notes bullet documenting the tag and `write_path`**
 
 In `contrib/beets/README.md`, in the `## Notes` list, add this bullet (after the **Cover art** bullet):
 
@@ -424,12 +424,12 @@ In `contrib/beets/README.md`, in the `## Notes` list, add this bullet (after the
   computed-tag workflow in [ARCHITECTURE.md](../../ARCHITECTURE.md).
 ```
 
-- [ ] **Step 3: Verify docs render and links resolve**
+- [x] **Step 3: Verify docs render and links resolve**
 
 Run: `test -f ARCHITECTURE.md && grep -q "beets_path\|computed" ARCHITECTURE.md && echo "cross-ref target OK"`
 Expected: `cross-ref target OK` (the computed-tag workflow was documented in `ARCHITECTURE.md` by PR #170).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add contrib/beets/README.md
@@ -442,7 +442,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ## Final verification
 
-- [ ] **Full beets suite (incl. opt-in tiers off by default) + lint:**
+- [x] **Full beets suite (incl. opt-in tiers off by default) + lint:**
 
 Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets/tests -v && ruff check contrib/beets && ruff format --check contrib/beets`
 Expected: all green, no lint findings.

--- a/docs/superpowers/specs/2026-06-08-beets-computed-path-design.md
+++ b/docs/superpowers/specs/2026-06-08-beets-computed-path-design.md
@@ -1,0 +1,145 @@
+# Beets Computed-Path Tag (`beets_path`) — Design
+
+Date: 2026-06-08
+Status: Approved (pending spec review)
+
+## Context
+
+musefs now supports a slash-preserving path field, `$!{field}`
+(`musefs-core/src/template.rs`, merged in #170): the value of the named tag is
+kept with its `/` as directory separators, so a precomputed relative path
+expands into a real directory hierarchy. `ARCHITECTURE.md` documents the
+intended "computed-tag" workflow — an external tool evaluates its own
+(Turing-complete) path logic and writes the resulting relative path into a
+custom text tag, which the user then mounts with `--template '$!{that_tag}'`.
+
+This spec wires that workflow into the **beets** plugin. beets already owns a
+rich path-templating system (the `paths:` config / `path_formats`), and exposes
+it programmatically via `Item.destination()`. The plugin should compute each
+track's beets library path and write it as a `beets_path` text tag, so a musefs
+mount can mirror the user's beets library layout with zero extra configuration.
+
+Picard support (`picard_path`) is intentionally deferred to a separate
+follow-up spec: Picard has no "library destination" concept and would require
+evaluating its file-naming script via `ScriptParser`, a materially larger and
+less certain piece.
+
+## Goal
+
+The beets plugin writes one extra text tag per synced track, `beets_path`,
+whose value is the beets-computed relative path (no leading slash, no file
+extension). A user mounting with `--template '$!{beets_path}'` then sees a tree
+matching their beets library layout. Zero config required; opt-out available.
+
+## Non-goals
+
+- A plugin-side `path_template` override. Reorganizing the view to a *different*
+  layout already happens at mount time using musefs's own template engine
+  (`--template '$genre/$album/...'`, with fallbacks and conditional sections).
+  The only thing an override would add is an alternate **beets-function-powered**
+  layout that differs from on-disk — niche, and better served by a future
+  "multiple named templates" feature if demand appears.
+- Picard support (separate spec).
+- Any change to the shared `python-musefs` library or the musefs Rust core.
+
+## Behavior
+
+For each track the plugin syncs, it emits a text tag:
+
+- **key:** `beets_path` (fixed, lowercase; this is what users type in
+  `$!{beets_path}`).
+- **value:** `item.destination(relative_to_libdir=True)`, decoded with
+  `os.fsdecode`, with the trailing file extension removed via
+  `os.path.splitext`.
+
+Rationale for the transforms:
+
+- `relative_to_libdir=True` yields the path fragment under the beets library
+  base — a relative path, never absolute. beets has already sanitized each path
+  component per the user's `replace` config.
+- The extension is stripped because musefs's `render` appends `.{ext}` itself
+  (from the track's scanned `format`); leaving it would double the extension
+  (`…/01 Pigs.flac.flac`). `destination()` always appends exactly one extension
+  at the end, so `os.path.splitext` removes precisely that. `splitext` strips
+  only the suffix after the last dot in the final path component, so dotted
+  directory or file names (e.g. `Vol. 2`) are unaffected, and because beets
+  always appends an extension there is always exactly one to remove.
+- musefs's `$!{}` path field re-sanitizes each segment (control chars → `_`,
+  empty/`.`/`..` dropped) at render time, so the stored value is defense-in-depth
+  safe regardless of beets' output.
+
+## Configuration
+
+beets `config.yaml`, under the existing `musefs:` block:
+
+```yaml
+musefs:
+  db: ~/musefs.db
+  write_path: yes      # default yes; set no to skip the beets_path tag entirely
+```
+
+`write_path` defaults **on**. The `beets_path` tag is inert for any mount that
+does not reference `$!{beets_path}`, so writing it by default is harmless and
+keeps the feature zero-config. `write_path: no` is provided for users who sync
+tags but do not want the extra row.
+
+## Integration
+
+- **Where:** `contrib/beets/beetsplug/_core.py`, in `build_records` (the single
+  function that turns beets Items into `Record`s for both trigger sites — the
+  import-time listeners and the `musefs` command). It appends
+  `("beets_path", value)` to the `Record.pairs` list when `write_path` is on.
+- **Plumbing:** `MusefsPlugin.__init__` registers a `write_path: True` config
+  default alongside the existing `db`/`fields`/`bin`/`autoscan` defaults, and
+  `_sync` passes the resolved value into `build_records` (mirroring how `fields`
+  is already threaded). The computed pair flows through the existing, unchanged
+  `replace_tags` → `sync_files` path. The shared `python-musefs` library and the
+  musefs Rust core are untouched.
+- **Idempotency:** `replace_tags` already deletes a track's text tags before
+  re-inserting, so re-syncing overwrites a stale `beets_path` cleanly. A path
+  that later becomes uncomputable (see below) simply isn't re-written.
+
+## Error handling
+
+Computing the path must never abort a sync, and must never introduce a value
+the store cannot hold. In any of these cases the plugin **skips only the
+`beets_path` tag** for that item — all other tags still sync — and logs a
+warning via the plugin's logger:
+
+- `item.destination()` raises (e.g. a `paths:` template referencing a missing
+  field).
+- The path is empty after decoding and stripping (musefs treats an empty value
+  as absent anyway).
+- The decoded path is not UTF-8-encodable. `os.fsdecode` of a non-UTF-8 beets
+  path produces lone surrogate code points, which SQLite's TEXT encoder rejects
+  — writing such a value would raise mid-transaction. Decode/validate using the
+  same approach the plugin already applies to the backing-path key so the two
+  stay consistent; if the result still contains surrogates, skip the tag.
+
+No aggregate counter is added: keeping the skip purely a log line avoids any
+change to the shared `python-musefs` library's `SyncStats` (and to its
+exact-string `summary()` output, which existing tests assert on).
+
+## Testing
+
+beets unit tests (`contrib/beets/tests/`), run via the venv harness
+(`contrib/beets/.venv/bin/python -m pytest`):
+
+- Extend the test `FakeItem` with a `destination(relative_to_libdir=...)` method
+  returning a bytes path that includes an extension, and a way to make it raise
+  (e.g. a constructor flag) for the error-path test.
+- `beets_path` equals the destination with the extension stripped and no leading
+  slash.
+- `write_path: no` → no `beets_path` tag is written.
+- `destination()` raising → `beets_path` skipped, other tags still present, and
+  the sync completes (no exception propagates).
+- DB-level assertion: after a sync, `SELECT value FROM tags WHERE key='beets_path'`
+  returns the expected relative path for the track.
+
+## Documentation
+
+- `contrib/beets/README.md` (or the plugin's documented config): add `write_path`
+  and a worked example — sync, then `musefs mount … --template '$!{beets_path}'`
+  — cross-referencing the computed-tag workflow in `ARCHITECTURE.md`.
+- Note the extension is added by musefs, so users must not append one in any
+  mount template that consumes `beets_path`.


### PR DESCRIPTION
## Summary

Wires the computed-tag path workflow (the `$!{field}` path field from #170) into the **beets** plugin. Each sync now writes one extra text tag, `beets_path`, holding the track's beets library-relative path. Mount with:

```bash
musefs mount ~/mnt --db ~/musefs.db --template '$!{beets_path}'
```

and the musefs tree mirrors your beets library layout — including layouts musefs's own template engine can't express (beets' `%the{}`, `$first{}`, plugins, etc.). Zero config; opt-out via `write_path: no`.

## How it works

- `beets_path` = `item.destination(relative_to_libdir=True)`, decoded with the same lossy-UTF-8 normalization as `realpath_key` (U+FFFD for undecodable bytes, so the value is always SQLite-safe), with the trailing extension stripped (musefs re-appends `.{ext}` at render time).
- Computed in `build_records` (`contrib/beets/beetsplug/_core.py`) — the single chokepoint feeding both the import-time listeners and the `musefs` command — and appended to the existing `Record.pairs`, so it flows through the unchanged `replace_tags`/`sync_files` path.
- Gated by a new `write_path` config (default **on**). The tag is inert for any mount that doesn't reference `$!{beets_path}`.
- A failed/empty/non-UTF-8 computation skips just that tag (other tags still sync) and warns via the plugin logger — never aborts the sync.

The shared `python-musefs` library and the musefs Rust core are **untouched**; this is purely additive in `contrib/beets/`.

## Testing

7 new tests (49 pass total, ruff clean):
- `build_records`: extension stripping, `write_path` off, error → skip + warn, non-UTF-8 → UTF-8-safe value, and a **real `beets.library.Item`** case exercising the actual `destination()` API (not just the fake).
- plugin/DB: `_sync` writes the `beets_path` row when enabled, omits it when disabled.

## Scope

Picard (`picard_path` via `ScriptParser`) is intentionally deferred to a separate follow-up spec — Picard has no library-destination concept and needs file-naming-script evaluation. Spec + implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a computed `beets_path` tag that reflects the beets library-relative path for use in musefs mount templates.
  * Added `write_path` configuration option (default enabled) to control whether the computed path tag is written.

* **Documentation**
  * Updated README with mount template examples using the new computed path tag.
  * Added guidance on configuring and using the computed path in library layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->