### PR TITLE
wav: serve oversize files via the data-chunk header instead of skipping

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -72,20 +72,25 @@ exclude_re = [
     # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
-    'musefs-core/src/scan\.rs:264:31:',
+    'musefs-core/src/scan\.rs:270:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
-    'musefs-core/src/scan\.rs:271:30:',
-    # probe_file oversize-skip diagnostic `probed.is_none() && file_len >
-    # MAX_PROBE_BYTES`: gates only a `log::warn!` (mirroring the M4A
-    # `MetadataTooLarge` warn). It has no effect on the returned `Probed`/skip
-    # decision or any persisted state, so every mutation of the condition is
-    # unobservable — a pure observability shim, like the metrics counters above.
-    # Both operands (`&&` at :25, the `>` compare at :37) excluded.
-    'musefs-core/src/scan\.rs:275:25:',
-    'musefs-core/src/scan\.rs:275:37:',
+    'musefs-core/src/scan\.rs:277:30:',
+    # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
+    # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
+    # whole file already fits within probe_cap — so `probe_full` parses it (valid)
+    # or `locate_audio_at_ceiling` rejects it on the same off+len>file_len bound
+    # (corrupt), giving the identical skip either way. The ceiling branch is never
+    # the deciding path at the boundary, so the mutant is equivalent.
+    'musefs-core/src/scan\.rs:288:21:',
+    # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
+    # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
+    # no effect on the returned `Probed`/skip decision or any persisted state, so
+    # every mutation of the condition is unobservable — a pure observability shim,
+    # like the metrics counters above.
+    'musefs-core/src/scan\.rs:293:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     'musefs-core/src/scan\.rs:620:46:',

--- a/docs/WAV.md
+++ b/docs/WAV.md
@@ -41,6 +41,11 @@ precedence** and INFO filling gaps; only chunk headers are walked — the
   output, `COMM`/`USLT` language/description reset, `POPM` owner dropped,
   ID3v1 ignored, the OOM-guard skips (the authoritative list lives in
   [MP3.md](MP3.md#lossy-edges)).
+- **Tags trailing a very large `data` payload are not seen.** When the `data`
+  payload pushes any `LIST`/`INFO` or `id3 ` chunk beyond the scan probe
+  ceiling (64 MiB), the file is still ingested — the `data` chunk header gives
+  the audio bounds without reading the payload — but those trailing tag chunks
+  are not read at scan time. Front-positioned metadata is unaffected.
 
 ## How synthesis works
 

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -101,6 +101,23 @@ pub(crate) struct Probed {
     structural_blocks: Vec<(String, Vec<u8>)>,
 }
 
+/// Assemble a WAV [`Probed`] from located audio bounds, reading tags and pictures
+/// from `prefix`. Shared by the bounded, full-buffer, and ceiling probe paths.
+fn wav_probed(prefix: &[u8], bounds: &wav::WavBounds) -> Probed {
+    let (binary_tags, promoted) = wav::read_binary_tags(prefix);
+    let mut tags = wav::read_tags(prefix);
+    tags.extend(promoted);
+    Probed {
+        format: Format::Wav,
+        audio_offset: bounds.audio_offset,
+        audio_length: bounds.audio_length,
+        tags,
+        pictures: wav::read_pictures(prefix),
+        binary_tags,
+        structural_blocks: Vec::new(),
+    }
+}
+
 /// Full-buffer probe (legacy path). Retained as the reference implementation the
 /// bounded path is checked against (see the equivalence property test).
 pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
@@ -159,18 +176,7 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
         })
     } else if has_ext(path, "wav") {
         let bounds = wav::locate_audio(bytes).ok()?;
-        let (binary_tags, promoted) = wav::read_binary_tags(bytes);
-        let mut tags = wav::read_tags(bytes);
-        tags.extend(promoted);
-        Some(Probed {
-            format: Format::Wav,
-            audio_offset: bounds.audio_offset,
-            audio_length: bounds.audio_length,
-            tags,
-            pictures: wav::read_pictures(bytes),
-            binary_tags,
-            structural_blocks: Vec::new(),
-        })
+        Some(wav_probed(bytes, &bounds))
     } else {
         None
     }
@@ -271,14 +277,26 @@ fn probe_file(path: &Path, file_len: u64, window: usize) -> std::io::Result<Opti
     if (prefix.len() as u64) < probe_cap {
         prefix = read_window(&file, usize_from(probe_cap))?;
     }
-    let probed = probe_full(path, &prefix);
-    if probed.is_none() && file_len > MAX_PROBE_BYTES {
+    if let Some(p) = probe_full(path, &prefix) {
+        return Ok(Some(p));
+    }
+    // A WAV whose `data` payload runs past the probe ceiling fails the strict
+    // full-buffer parse (the payload isn't present to bound), yet its `fmt `/`data`
+    // headers sit at the front: trust the declared bounds and serve the audio,
+    // accepting the loss of any tag chunks trailing the payload.
+    if has_ext(path, "wav")
+        && file_len > MAX_PROBE_BYTES
+        && let Ok(bounds) = wav::locate_audio_at_ceiling(&prefix, file_len)
+    {
+        return Ok(Some(wav_probed(&prefix, &bounds)));
+    }
+    if file_len > MAX_PROBE_BYTES {
         log::warn!(
             "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
             path.display()
         );
     }
-    Ok(probed)
+    Ok(None)
 }
 
 /// Outcome of a single bounded dispatch attempt against the current `prefix`.
@@ -349,20 +367,7 @@ fn probe_prefix(path: &Path, prefix: &[u8], file_len: u64, tail: Option<&[u8; 12
         }
     } else if has_ext(path, "wav") {
         match wav::locate_audio_bounded(prefix, file_len) {
-            Ok(Extent::Complete(b)) => {
-                let (binary_tags, promoted) = wav::read_binary_tags(prefix);
-                let mut tags = wav::read_tags(prefix);
-                tags.extend(promoted);
-                Probe::Done(Probed {
-                    format: Format::Wav,
-                    audio_offset: b.audio_offset,
-                    audio_length: b.audio_length,
-                    tags,
-                    pictures: wav::read_pictures(prefix),
-                    binary_tags,
-                    structural_blocks: Vec::new(),
-                })
-            }
+            Ok(Extent::Complete(b)) => Probe::Done(wav_probed(prefix, &b)),
             Ok(Extent::NeedMore { up_to }) => Probe::NeedMore(up_to),
             Err(_) => Probe::Skip,
         }
@@ -1797,5 +1802,50 @@ mod bounded_probe_tests {
         drop(f);
 
         assert!(probe_file(&path, len, WINDOW).unwrap().is_none());
+    }
+
+    #[test]
+    fn oversize_wav_is_served_via_data_header() {
+        // A valid WAV whose `data` payload exceeds the probe ceiling (any
+        // recording more than a few minutes long) must still be ingested: the
+        // `data` chunk header sits at the front, so the declared audio bounds
+        // are known without reading the payload. Skipping it would drop every
+        // sufficiently long WAV in the library.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("long.wav");
+
+        let data_len: u64 = MAX_PROBE_BYTES + (16 << 20); // 80 MiB payload
+        let mut fmt = Vec::new();
+        fmt.extend_from_slice(&1u16.to_le_bytes());
+        fmt.extend_from_slice(&1u16.to_le_bytes());
+        fmt.extend_from_slice(&44_100u32.to_le_bytes());
+        fmt.extend_from_slice(&88_200u32.to_le_bytes());
+        fmt.extend_from_slice(&2u16.to_le_bytes());
+        fmt.extend_from_slice(&16u16.to_le_bytes());
+
+        let mut front = b"RIFF".to_vec();
+        // The RIFF size field is not validated by the chunk walk; placeholder.
+        front.extend_from_slice(&0u32.to_le_bytes());
+        front.extend_from_slice(b"WAVE");
+        front.extend_from_slice(b"fmt ");
+        front.extend_from_slice(&u32::try_from(fmt.len()).unwrap().to_le_bytes());
+        front.extend_from_slice(&fmt);
+        front.extend_from_slice(b"data");
+        front.extend_from_slice(&u32::try_from(data_len).unwrap().to_le_bytes());
+        let audio_offset = front.len() as u64;
+        let file_len = audio_offset + data_len;
+
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&front).unwrap();
+        f.set_len(file_len).unwrap();
+        drop(f);
+
+        let probed = probe_file(&path, file_len, WINDOW)
+            .unwrap()
+            .expect("oversize wav should probe");
+        assert_eq!(probed.format, Format::Wav);
+        assert_eq!(probed.audio_offset, audio_offset);
+        assert_eq!(probed.audio_length, data_len);
     }
 }

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -96,6 +96,32 @@ pub fn locate_audio_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<WavBo
     Ok(Extent::Complete(locate_audio(prefix)?))
 }
 
+/// Best-effort WAV bounds when the file exceeds the probe budget: the `fmt `/`data`
+/// chunk headers sit at the front and are present in `prefix`, but the `data`
+/// payload — and hence any metadata chunks trailing it — lie beyond what we are
+/// willing to read. Trusts the declared `data` length, validated against the real
+/// `file_len` so a corrupt header claiming a payload larger than the file is still
+/// rejected. Unlike [`locate_audio`] the payload need not be present in `prefix`;
+/// any tags trailing it are necessarily lost.
+pub fn locate_audio_at_ceiling(prefix: &[u8], file_len: u64) -> Result<WavBounds> {
+    riff_wave_start(prefix)?;
+    let chunks = walk_chunks(prefix);
+    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
+    let data = chunks.iter().find(|(id, _, _)| id == b"data");
+    match (has_fmt, data) {
+        (true, Some(&(_, off, len))) => {
+            if (off as u64).saturating_add(len) > file_len {
+                return Err(FormatError::Malformed);
+            }
+            Ok(WavBounds {
+                audio_offset: off as u64,
+                audio_length: len,
+            })
+        }
+        _ => Err(FormatError::NotWav),
+    }
+}
+
 /// Read the preserved structural chunks (`fmt `, optional `fact`) from the front
 /// of the file (everything before the `data` payload). Errors if `fmt ` is absent
 /// or a preserved chunk's payload is truncated.
@@ -692,6 +718,76 @@ mod tests {
             Extent::NeedMore { up_to } => assert_eq!(up_to, file_len),
             other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
         }
+    }
+
+    /// A front-only RIFF/WAVE buffer: `fmt ` (16 bytes) plus a `data` chunk header
+    /// declaring `data_len` bytes of payload, with the payload itself absent — the
+    /// shape the ceiling probe sees when the audio runs past the read budget. The
+    /// `data` payload begins at offset 44.
+    fn wav_front(data_len: u64) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"fmt ");
+        body.extend_from_slice(&16u32.to_le_bytes());
+        body.extend(std::iter::repeat_n(0u8, 16));
+        body.extend_from_slice(b"data");
+        body.extend_from_slice(&u32::try_from(data_len).unwrap().to_le_bytes());
+        let mut v = b"RIFF".to_vec();
+        v.extend_from_slice(&0u32.to_le_bytes()); // size field unused by the walk
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(&body);
+        v
+    }
+
+    #[test]
+    fn locate_audio_at_ceiling_trusts_data_header_without_payload() {
+        let data_len = 200u64;
+        let front = wav_front(data_len);
+        let audio_offset = front.len() as u64; // 44
+        let file_len = audio_offset + data_len;
+        let b = locate_audio_at_ceiling(&front, file_len).unwrap();
+        assert_eq!(b.audio_offset, audio_offset);
+        assert_eq!(b.audio_length, data_len);
+    }
+
+    #[test]
+    fn locate_audio_at_ceiling_accepts_data_shorter_than_file() {
+        // Chunks trailing the payload make the file larger than `off + len`.
+        let data_len = 200u64;
+        let front = wav_front(data_len);
+        let audio_offset = front.len() as u64;
+        let file_len = audio_offset + data_len + 64;
+        let b = locate_audio_at_ceiling(&front, file_len).unwrap();
+        assert_eq!(b.audio_offset, audio_offset);
+        assert_eq!(b.audio_length, data_len);
+    }
+
+    #[test]
+    fn locate_audio_at_ceiling_rejects_data_running_past_file() {
+        // A header claiming more payload than the file holds is corrupt, not trusted.
+        let front = wav_front(1_000);
+        let audio_offset = front.len() as u64;
+        let file_len = audio_offset + 10;
+        assert_eq!(
+            locate_audio_at_ceiling(&front, file_len),
+            Err(FormatError::Malformed)
+        );
+    }
+
+    #[test]
+    fn locate_audio_at_ceiling_requires_fmt_chunk() {
+        // `data` present but no `fmt `: not a usable WAV, must be rejected.
+        let mut body = Vec::new();
+        body.extend_from_slice(b"data");
+        body.extend_from_slice(&200u32.to_le_bytes());
+        let mut front = b"RIFF".to_vec();
+        front.extend_from_slice(&0u32.to_le_bytes());
+        front.extend_from_slice(b"WAVE");
+        front.extend_from_slice(&body);
+        let file_len = front.len() as u64 + 200;
+        assert_eq!(
+            locate_audio_at_ceiling(&front, file_len),
+            Err(FormatError::NotWav)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A WAV whose `data` payload exceeds the 64 MiB scan probe ceiling (`MAX_PROBE_BYTES`) was **silently skipped from scanning**. The bounded probe widens to the cap, the strict full-buffer parse then rejects it (`off + len > buf.len()` → `Malformed` → `None`), and the file is dropped. That hits essentially every full-length WAV — roughly anything longer than ~6 min at CD quality or ~2 min hi-res.

(This started from a review flag that also claimed an OOM; that half was stale — #172 already caps reads at `MAX_PROBE_BYTES`, so there's no whole-file allocation. The real, surviving issue was the silent skip.)

## Fix

The `fmt `/`data` chunk headers sit at the front of the file, so the audio bounds are known without reading the payload. Add `wav::locate_audio_at_ceiling`, which trusts the declared `data` length **validated against the real `file_len`** — a corrupt header claiming more payload than the file holds is still rejected.

`probe_file` falls back to it **only** when the strict parse fails *and* the file genuinely exceeds the probe ceiling, so whole-file completion — and full trailing-metadata capture (`id3 `/`LIST` chunks that trail `data`) — is preserved for every file that fits in the budget. Tags trailing the oversize payload are necessarily lost; documented as a lossy edge in `docs/WAV.md`.

Also extracts the duplicated WAV `Probed` builder into `wav_probed`, shared by the bounded, full-buffer, and ceiling paths.

## Why not complete early in `locate_audio_bounded`

Completing as soon as the `fmt `/`data` headers appear (the obvious fix) would drop trailing `id3 `/`LIST` tags for normal-sized WAVs and break the `probe_full` equivalence property test. Keeping the degradation at the probe ceiling — where `probe_cap` is known — confines the metadata loss to genuinely oversized files.

## Tests

- New `musefs-core` regression test: an 80 MiB-payload sparse WAV is now ingested with correct bounds (previously skipped).
- New `musefs-format` unit tests for `locate_audio_at_ceiling`: trusts the data header (`off+len == file_len`), accepts data shorter than the file, rejects data running past the file, requires `fmt `.

Verified via the in-diff mutation gate (`cargo mutants --in-diff`): the format-layer tests are required because the gate is per-package, so a `musefs-format` mutant is only killable by `musefs-format` tests. Final gate: **8 caught, 7 unviable, 0 missed.** Full suite 739 passed; clippy/fmt clean.

`.cargo/mutants.toml`: re-anchored the probe_file widen/fallback excludes that the helper insertion shifted (264→270, 271→277), and replaced the obsolete oversize-warn exclude (old 275) with the relocated warn guard (293) and the new equivalent ceiling-fallback guard (288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for large WAV files (exceeding 64 MiB); files with front-loaded metadata are now successfully ingested even when data payloads exceed the probe ceiling.

* **Bug Fixes**
  * Enhanced fallback scanning logic to recover audio bounds from oversized WAV files when trailing metadata cannot be fully processed.

* **Documentation**
  * Clarified scanning behavior for WAV files with large data payloads and documented which metadata chunks may be skipped.

* **Tests**
  * Added test coverage for oversized WAV file ingestion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->