### PR TITLE
cli: add `--quiet`/`-q` to scan to suppress the per-target summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ musefs scan /path/to/music --db library.db --revalidate
 
 `scan` probes each audio file (FLAC, MP3, M4A/M4B, Ogg, WAV), recording its
 audio byte range, tags, and embedded art in the store. It takes one or more
-files or directories, and `--jobs N` controls probe parallelism.
+files or directories, and `--jobs N` controls probe parallelism. `--quiet`
+(`-q`) suppresses the per-target summary for scripting; scan failures still
+surface on stderr (raise detail with `RUST_LOG=info`).
 `--revalidate` is the maintenance pass: it skips unchanged files —
 **preserving any tag edits you made in the store** — prunes tracks whose
 backing file is gone, and garbage-collects orphaned art.

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -102,6 +102,10 @@ pub enum Command {
         /// Probe worker threads (0 = available parallelism). 1 = sequential.
         #[arg(long, default_value_t = 0)]
         jobs: usize,
+        /// Suppress the per-target summary on stdout (failures still surface via
+        /// the `log` facade on stderr; raise detail with `RUST_LOG=info`).
+        #[arg(long, short)]
+        quiet: bool,
     },
     /// Mount a read-only FUSE view of the store.
     Mount(MountArgs),
@@ -110,9 +114,16 @@ pub enum Command {
 /// Open (creating/migrating) the DB at `db_path` once, then scan each target in
 /// `targets` (a file or a directory; directories recurse). With `revalidate`,
 /// run the maintenance pass (skip-unchanged, prune, GC) instead of a full
-/// ingest. Fails fast: the first failing target aborts the batch; targets
-/// already scanned stay committed (ingest is an idempotent upsert).
-pub fn run_scan(db_path: &Path, targets: &[PathBuf], revalidate: bool, jobs: usize) -> Result<()> {
+/// ingest. With `quiet`, suppress the per-target summary on stdout. Fails fast:
+/// the first failing target aborts the batch; targets already scanned stay
+/// committed (ingest is an idempotent upsert).
+pub fn run_scan(
+    db_path: &Path,
+    targets: &[PathBuf],
+    revalidate: bool,
+    jobs: usize,
+    quiet: bool,
+) -> Result<()> {
     let db =
         Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
     let opts = musefs_core::ScanOptions {
@@ -123,24 +134,28 @@ pub fn run_scan(db_path: &Path, targets: &[PathBuf], revalidate: bool, jobs: usi
         if revalidate {
             let stats = musefs_core::revalidate_with(&db, target, &opts)
                 .with_context(|| format!("revalidating {}", target.display()))?;
-            println!(
-                "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed",
-                target.display(),
-                stats.updated,
-                stats.unchanged,
-                stats.pruned,
-                stats.failed
-            );
+            if !quiet {
+                println!(
+                    "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed",
+                    target.display(),
+                    stats.updated,
+                    stats.unchanged,
+                    stats.pruned,
+                    stats.failed
+                );
+            }
         } else {
             let stats = musefs_core::scan_directory_with(&db, target, &opts)
                 .with_context(|| format!("scanning {}", target.display()))?;
-            println!(
-                "scanned {}: {} file(s), skipped {}, failed {}",
-                target.display(),
-                stats.scanned,
-                stats.skipped,
-                stats.failed
-            );
+            if !quiet {
+                println!(
+                    "scanned {}: {} file(s), skipped {}, failed {}",
+                    target.display(),
+                    stats.scanned,
+                    stats.skipped,
+                    stats.failed
+                );
+            }
         }
     }
     Ok(())
@@ -186,7 +201,8 @@ pub fn run(cli: Cli) -> Result<()> {
             db,
             revalidate,
             jobs,
-        } => run_scan(&db, &targets, revalidate, jobs),
+            quiet,
+        } => run_scan(&db, &targets, revalidate, jobs, quiet),
         Command::Mount(args) => run_mount(&args),
     }
 }
@@ -206,6 +222,24 @@ mod tests {
                 assert_eq!(targets, vec![PathBuf::from("/m")]);
             }
             Command::Mount(..) => panic!("expected Scan"),
+        }
+    }
+
+    #[test]
+    fn scan_command_quiet_flag_defaults_off_and_parses() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "scan", "/m", "--db", "/tmp/x.db"]).unwrap();
+        match cli.command {
+            Command::Scan { quiet, .. } => assert!(!quiet),
+            Command::Mount(..) => panic!("expected Scan"),
+        }
+        for arg in ["--quiet", "-q"] {
+            let cli =
+                Cli::try_parse_from(["musefs", "scan", "/m", "--db", "/tmp/x.db", arg]).unwrap();
+            match cli.command {
+                Command::Scan { quiet, .. } => assert!(quiet),
+                Command::Mount(..) => panic!("expected Scan"),
+            }
         }
     }
 

--- a/musefs-cli/tests/scan.rs
+++ b/musefs-cli/tests/scan.rs
@@ -54,7 +54,7 @@ fn scan_ingests_flacs_into_a_fresh_db() {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("musefs.db");
 
-    run_scan(&db_path, &[backing.path().to_path_buf()], false, 0).unwrap();
+    run_scan(&db_path, &[backing.path().to_path_buf()], false, 0, false).unwrap();
 
     // The DB file was created and persists the track.
     let db = musefs_db::Db::open(&db_path).unwrap();
@@ -89,6 +89,7 @@ fn scan_ingests_multiple_targets_under_one_db() {
         ],
         false,
         0,
+        false,
     )
     .unwrap();
 
@@ -110,6 +111,12 @@ fn scan_fails_fast_on_a_bad_target() {
     // Second target does not exist; collect_audio's read_dir errors, so the
     // batch aborts with Err.
     let missing = backing.path().join("does-not-exist");
-    let result = run_scan(&db_path, &[backing.path().to_path_buf(), missing], false, 0);
+    let result = run_scan(
+        &db_path,
+        &[backing.path().to_path_buf(), missing],
+        false,
+        0,
+        false,
+    );
     assert!(result.is_err());
 }


### PR DESCRIPTION
## What

Adds `--quiet` (`-q`) to `musefs scan`. The flag gates the per-target summary
lines (both the full-scan and `--revalidate` variants), which are otherwise
unconditional `println!` output on stdout — noise for scripted invocations.

## Why

Surfaced in a code review: the scan output had no way to suppress it for
scripting. Verbosity for diagnostics already exists (`RUST_LOG=info/debug` via
the `log` facade), so this PR adds only the genuinely-missing piece.

Failures are unaffected: per-file errors still surface through `log` on stderr,
so `-q` only silences the success summary.

## Notes

- The other review items (a `--continue-on-error` flag, mmap, lock/cache/PRAGMA
  rework, etc.) were evaluated and not actioned — they were either already
  handled in the codebase or based on misreads (e.g. a corrupt file does *not*
  abort the batch; tag parsing *is* covered by the core scan tests).
- No mutation coverage change: `musefs-cli` is permanently excluded from the
  mutation gate in `mutants.toml` (thin CLI dispatch, covered by integration
  tests). The new behavior is covered by a clap parse test; the in-diff gate
  generates 0 mutants for this diff by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--quiet` / `-q` flag to the `scan` command to suppress per-target summary output while maintaining error reporting.

* **Documentation**
  * Updated `scan` command documentation to clarify argument handling, parallelism controls, and quiet mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->