### PR TITLE
Fix issues #176–#179: readdir O(N²), tag pruning, and path-safety

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -282,4 +282,27 @@ exclude_re = [
     # in-diff gate builds. The two `+` in fixtures::wav are this one expression; both
     # `+` elsewhere are absent (`samples.len() * 2` is `*`), so description-anchored.
     'replace \+ with \* in fixtures::wav',
+
+    # truncate_bytes char-boundary back-off loop `while end > 0 && ...`, `>`->`>=`:
+    # equivalent. `end` is usize so `end >= 0` is always true, but byte 0 is always a
+    # char boundary, so `!s.is_char_boundary(0)` is false and the `&&` short-circuits
+    # the loop to the same exit — identical `&s[..end]`. The sole `>` in truncate_bytes,
+    # so operator+function-anchored.
+    'replace > with >= in truncate_bytes',
+    # truncate_bytes back-off step `end -= 1` -> `end /= 1`: `/= 1` leaves `end`
+    # unchanged, so once the loop is entered on a non-boundary index it never advances
+    # — non-terminating (TIMEOUT-only, never a clean kill), the SP3 hang-class
+    # precedent. The decrement's correctness is pinned by the UTF-8-boundary truncation
+    # tests; only the un-steppable `/=` replacement is excluded. Sole `-=` in the fn.
+    'replace -= with /= in truncate_bytes',
+    # truncate_component empty-string const returns (`Cow::Borrowed("")` /
+    # `Cow::Owned("".to_owned())`): hang-class. An empty component is unreachable in
+    # production — callers pass non-empty `/`-split path components and the fn never
+    # shrinks a non-empty name to "" — and forcing every component empty makes a
+    # rebuild test spin past the timeout (reported TIMEOUT, never a clean kill). The
+    # NON-empty const returns (`"xyzzy"`) stay in scope and ARE caught, so the fn's real
+    # behavior is still pinned; only the unreachable empty returns are excluded. (`.`
+    # stands in for the `'` in `Cow<'_, str>`, which a TOML literal string can't hold.)
+    'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)',
+    'replace truncate_component -> Cow<._, str> with Cow::Owned\(""\.to_owned\(\)\)',
 ]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,7 +204,9 @@ mapping from rendered paths. Paths come from beets-style templates
 chains) over the track's tag fields, each resolving through per-field fallbacks
 and then a global `default_fallback`; `[...]` conditional sections suppress
 their literals when every field they reference is empty. Plain values are
-sanitized to a single path component ('/' and control characters become '_'),
+sanitized to a single path component ('/' and control characters become '_',
+components equal to `.` or `..` are dropped, and any component is truncated to
+255 bytes on a UTF-8 boundary so it stays within NAME_MAX),
 while a `$!{field}` path field keeps '/' as directory separators (sanitizing
 each segment and dropping empty/`.`/`..` segments) so a precomputed multi-level
 path expands into real directories. Path collisions are resolved

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ any tag key in the store works):
   `--template '$!{beets_path}'`.
 
 Anything else is literal. Name collisions get a deterministic `(2)`, `(3)`, …
-suffix. The default template is `$artist/$title`.
+suffix. Every rendered component is capped at 255 bytes (NAME_MAX, truncated on
+a UTF-8 boundary, extension preserved), and a plain field whose value is
+exactly `.` or `..` is dropped rather than creating an unusable directory. The
+default template is `$artist/$title`.
 
 Two modes:
 

--- a/docs/superpowers/plans/2026-06-08-issues-176-179.md
+++ b/docs/superpowers/plans/2026-06-08-issues-176-179.md
@@ -1,0 +1,854 @@
+# Issues #176–#179 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four independent issues in the path-render → virtual-tree → readdir path: drop `.`/`..` plain-field components (#178), truncate components to the 255-byte NAME_MAX (#179), load only template-referenced tags during tree build (#177), and serve paginated `readdir` from a per-fh snapshot instead of rebuilding O(N) per call (#176).
+
+**Architecture:** #178 and #179 add per-component normalization at the single tree-insertion choke point (`tree.rs`: `insert_file`, `ensure_dir`, `suffix_candidate`). #177 adds `Template::referenced_fields` + a key-filtered DB query and wires them into `render_entries`. #176 adds `opendir`/`releasedir` and a FUSE-layer dir-handle table; `readdir` serves a cloned `Arc` snapshot lock-free.
+
+**Tech Stack:** Rust workspace (`musefs-db` → `musefs-core` → `musefs-fuse`), `rusqlite`, `fuser` 0.17, `threadpool`, `im` (persistent `OrdMap`).
+
+**Branch:** `issues-176-179` (already checked out; spec at `docs/superpowers/specs/2026-06-08-issues-176-179-design.md`).
+
+**Pre-commit gate:** the hook runs `cargo fmt`, `cargo clippy --all-targets -D warnings`, the **full workspace test suite**, and ruff. Every commit below must be green. Run `cargo fmt` before each commit.
+
+---
+
+## File Structure
+
+- `musefs-core/src/tree.rs` — **modify.** `insert_file` filter (#178); new `NAME_MAX` const, `truncate_bytes`, `truncate_component` helpers, leaf truncation in `insert_file`, dir truncation in `ensure_dir`, budget-aware `suffix_candidate` (#179). New unit tests.
+- `musefs-core/src/template.rs` — **modify.** New `Template::referenced_fields` + private `collect_field_names` walker (#177). New unit test.
+- `musefs-db/src/tags.rs` — **modify.** New `Db::tags_grouped_for_keys` (#177). New unit tests.
+- `musefs-core/src/facade.rs` — **modify.** `render_entries` calls `referenced_fields` + `tags_grouped_for_keys` instead of `tags_grouped` (#177).
+- `musefs-fuse/src/lib.rs` — **modify.** `MusefsFs` gains a dir-handle table + fh counter; new free fn `build_dir_listing`; new `opendir`/`releasedir`; rewritten `readdir` (#176).
+- `musefs-fuse/tests/mount.rs` — **modify.** New ignored large-directory e2e (#176).
+- `ARCHITECTURE.md`, `README.md` — **modify.** Document the `.`/`..`-drop and 255-byte-truncation rules.
+
+Implementation order: **Task 1 (#178) → Task 2 (#179) → Task 3 (#177) → Task 4 (#176) → Task 5 (docs).** Each task is one commit.
+
+---
+
+## Task 1: #178 — Drop `.`/`..` plain-field components
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs` (`insert_file`, ~line 197)
+- Test: `musefs-core/src/tree.rs` (`mod tests`, ~line 844)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `musefs-core/src/tree.rs`:
+
+```rust
+#[test]
+fn dot_and_dotdot_plain_components_are_dropped() {
+    // A plain field rendering to exactly "." or ".." (e.g. an artist tagged ".")
+    // must not create a directory that collides with readdir's hardcoded "."/"..".
+    let t = VirtualTree::build(&[
+        (10, "./Song.flac".into()),
+        (20, "../Tune.flac".into()),
+    ]);
+    assert!(t.lookup(VirtualTree::ROOT, ".").is_none());
+    assert!(t.lookup(VirtualTree::ROOT, "..").is_none());
+    // The dropped level collapses; the leaf lands directly under root.
+    assert!(t.lookup(VirtualTree::ROOT, "Song.flac").is_some());
+    assert!(t.lookup(VirtualTree::ROOT, "Tune.flac").is_some());
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core dot_and_dotdot_plain_components_are_dropped`
+Expected: FAIL — currently `.`/`..` survive as directories, so `lookup(ROOT, ".")` is `Some` and `lookup(ROOT, "Song.flac")` is `None`.
+
+- [ ] **Step 3: Implement the filter change**
+
+In `insert_file`, change the component split (currently `.filter(|c| !c.is_empty())`):
+
+```rust
+let comps: Vec<&str> = path
+    .split('/')
+    .filter(|c| !c.is_empty() && *c != "." && *c != "..")
+    .collect();
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core dot_and_dotdot_plain_components_are_dropped`
+Expected: PASS
+
+- [ ] **Step 5: Run the crate suite to confirm no regression**
+
+Run: `cargo test -p musefs-core`
+Expected: PASS (all)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add musefs-core/src/tree.rs
+git commit -m "$(cat <<'EOF'
+tree: drop `.`/`..` plain-field path components (#178)
+
+A plain template field whose value renders to exactly `.` or `..` produced a
+directory that readdir then emitted a second time (it hardcodes `.`/`..`),
+violating POSIX and breaking recursive tools. Drop those components at the
+insert_file choke point, unifying with the existing `$!{...}`/sanitize_path
+behavior. The leaf always carries an extension, so only intermediate directory
+components are ever affected.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: #179 — Truncate components to the 255-byte NAME_MAX limit
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs` (`insert_file` ~197, `ensure_dir` ~231, `suffix_candidate` ~818, imports, new helpers)
+- Test: `musefs-core/src/tree.rs` (`mod tests`)
+
+The truncation invariant lives at one site: the raw component is truncated **before** `disambiguate`, and the truncated value is stored as `rendered_name` — so `disambiguate` (generation) and `collision_gate` (probe) both feed `suffix_candidate` the identical base. `suffix_candidate` trims the stem per-`k` to keep `stem (k).ext` ≤ 255.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` in `musefs-core/src/tree.rs`:
+
+```rust
+#[test]
+fn over_long_leaf_truncates_to_255_keeping_extension() {
+    let path = format!("{}.flac", "t".repeat(300));
+    let t = VirtualTree::build(&[(10, path)]);
+    let kids = t.children(VirtualTree::ROOT).unwrap();
+    assert_eq!(kids.len(), 1);
+    let name = kids.keys().next().unwrap();
+    assert!(name.len() <= 255, "leaf is {} bytes", name.len());
+    assert!(name.ends_with(".flac"), "extension preserved");
+}
+
+#[test]
+fn over_long_directory_component_truncates_to_255() {
+    let path = format!("{}/Song.flac", "d".repeat(300));
+    let t = VirtualTree::build(&[(10, path)]);
+    let dir = t.children(VirtualTree::ROOT).unwrap().keys().next().unwrap().clone();
+    assert!(dir.len() <= 255, "dir is {} bytes", dir.len());
+}
+
+#[test]
+fn over_long_component_truncates_on_utf8_boundary() {
+    // '€' is 3 bytes; 100 of them = 300 bytes. Slicing off a char boundary
+    // would panic, so a successful build proves boundary-safe truncation.
+    let path = format!("{}.flac", "€".repeat(100));
+    let t = VirtualTree::build(&[(10, path)]);
+    let name = t.children(VirtualTree::ROOT).unwrap().keys().next().unwrap().clone();
+    assert!(name.len() <= 255);
+    assert!(name.ends_with(".flac"));
+}
+
+#[test]
+fn colliding_over_long_leaves_stay_distinct_and_within_255() {
+    // 12 identical 300-byte names force disambiguation up to rank (12),
+    // exercising the multi-digit suffix budget.
+    let path = format!("{}.flac", "x".repeat(300));
+    let entries: Vec<(i64, String)> = (0..12).map(|i| (i, path.clone())).collect();
+    let t = VirtualTree::build(&entries);
+    let kids = t.children(VirtualTree::ROOT).unwrap();
+    assert_eq!(kids.len(), 12, "all collisions disambiguated distinctly");
+    for name in kids.keys() {
+        assert!(name.len() <= 255, "{} bytes", name.len());
+    }
+}
+
+#[test]
+fn over_long_collisions_render_deterministically() {
+    // Guards the rendered_name <-> suffix_candidate consistency rule: building
+    // the same entries twice must yield identical keys.
+    let path = format!("{}.flac", "y".repeat(300));
+    let entries: Vec<(i64, String)> = (0..5).map(|i| (i, path.clone())).collect();
+    let a = VirtualTree::build(&entries);
+    let b = VirtualTree::build(&entries);
+    let ak: Vec<_> = a.children(VirtualTree::ROOT).unwrap().keys().cloned().collect();
+    let bk: Vec<_> = b.children(VirtualTree::ROOT).unwrap().keys().cloned().collect();
+    assert_eq!(ak, bk);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-core over_long_ colliding_over_long over_long_collisions`
+Expected: FAIL — currently nothing truncates, so the 300-byte names exceed 255 (assertions fire; the multibyte test may panic on a non-boundary slice inside the renderer, which also counts as failure).
+
+- [ ] **Step 3: Add the `Cow` import**
+
+`musefs-core/src/tree.rs` starts with only `use im::{HashMap as ImHashMap, OrdMap};` (no `std` import block). Add a new import line directly below it:
+
+```rust
+use std::borrow::Cow;
+```
+
+- [ ] **Step 4: Add `NAME_MAX` and the truncation helpers**
+
+Add these near `suffix_candidate` / `split_suffix_parts` (bottom of `musefs-core/src/tree.rs`, outside the `impl`):
+
+```rust
+/// Linux NAME_MAX: a single path component may be at most this many *bytes*.
+/// A longer component makes lookup/readdir/stat fail with ENAMETOOLONG.
+const NAME_MAX: usize = 255;
+
+/// Largest char-boundary prefix of `s` that is at most `max` bytes.
+fn truncate_bytes(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Truncate a rendered component to NAME_MAX bytes. For a leaf (`preserve_ext`),
+/// the stem is trimmed so `stem.ext` fits while the extension survives; if the
+/// extension alone is too long, the whole name is truncated. Borrows when the
+/// component already fits, so the common short-name path allocates nothing.
+fn truncate_component(name: &str, preserve_ext: bool) -> Cow<'_, str> {
+    if name.len() <= NAME_MAX {
+        return Cow::Borrowed(name);
+    }
+    if preserve_ext {
+        if let (stem, Some(ext)) = split_suffix_parts(name) {
+            // +1 for the '.' separator.
+            if let Some(budget) = NAME_MAX.checked_sub(ext.len() + 1).filter(|b| *b > 0) {
+                let stem_t = truncate_bytes(stem, budget);
+                return Cow::Owned(format!("{stem_t}.{ext}"));
+            }
+        }
+    }
+    Cow::Owned(truncate_bytes(name, NAME_MAX).to_string())
+}
+```
+
+- [ ] **Step 5: Apply leaf truncation in `insert_file`**
+
+In `insert_file`, the leaf is `let raw_name = comps[comps.len() - 1];`. Replace the leaf handling so the truncated value is both disambiguated and stored as `rendered_name`:
+
+```rust
+let raw_name = comps[comps.len() - 1];
+let truncated = truncate_component(raw_name, true);
+let raw_name = truncated.as_ref();
+let name = self.disambiguate(dir, raw_name);
+```
+
+The rest of `insert_file` already uses `raw_name` for `rendered_name` and
+`insert_rendered_child`, so those now see the truncated value automatically. Do
+not change `rendered_name: raw_name.to_string()` or the
+`insert_rendered_child(dir, raw_name, &name, inode)` line — they pick up the
+shadowed (truncated) `raw_name`.
+
+- [ ] **Step 6: Apply directory truncation in `ensure_dir`**
+
+At the very top of `ensure_dir` (before `dir_child_named`), shadow `name` with its truncated form so every downstream use (`dir_child_named`, `disambiguate`, `rendered_name`) sees it:
+
+```rust
+let truncated = truncate_component(name, false);
+let name = truncated.as_ref();
+```
+
+- [ ] **Step 7: Make `suffix_candidate` budget-aware**
+
+Replace `suffix_candidate` with a version that trims the stem to keep the whole candidate ≤ NAME_MAX. The budget is recomputed per `k`, so multi-digit ranks stay within the limit:
+
+```rust
+fn suffix_candidate(name: &str, k: u32) -> String {
+    let (stem, ext) = split_suffix_parts(name);
+    let suffix = format!(" ({k})");
+    let ext_part = match ext {
+        Some(e) => format!(".{e}"),
+        None => String::new(),
+    };
+    let budget = NAME_MAX.saturating_sub(suffix.len() + ext_part.len());
+    let stem_t = truncate_bytes(stem, budget);
+    format!("{stem_t}{suffix}{ext_part}")
+}
+```
+
+For names that already fit, `budget >= stem.len()` so `truncate_bytes` returns the full stem — byte-for-byte identical to the previous behavior.
+
+- [ ] **Step 8: Run the new tests to verify they pass**
+
+Run: `cargo test -p musefs-core over_long_ colliding_over_long over_long_collisions`
+Expected: PASS
+
+- [ ] **Step 9: Run the full crate suite (guards the collision_gate equivalence)**
+
+Run: `cargo test -p musefs-core`
+Expected: PASS — including the existing rebuild/disambiguation tests, which exercise `collision_gate`/`suffix_candidate`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cargo fmt
+git add musefs-core/src/tree.rs
+git commit -m "$(cat <<'EOF'
+tree: truncate rendered path components to the 255-byte NAME_MAX (#179)
+
+Long classical/audiobook titles routinely exceed NAME_MAX, making the entry
+inaccessible (ENAMETOOLONG). Truncate each component at a UTF-8 boundary at the
+insert_file choke point, preserving the leaf's extension. The truncated value is
+stored as rendered_name so disambiguate and collision_gate stay consistent, and
+suffix_candidate trims the stem per-k so a truncated-then-disambiguated leaf
+never bounces back over the limit.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: #177 — Load only template-referenced tags during tree build
+
+**Files:**
+- Modify: `musefs-core/src/template.rs` (new `referenced_fields` + `collect_field_names`)
+- Modify: `musefs-db/src/tags.rs` (new `tags_grouped_for_keys`)
+- Modify: `musefs-core/src/facade.rs` (`render_entries`, ~line 287)
+- Test: `musefs-core/src/template.rs`, `musefs-db/src/tags.rs`
+
+### Part A — `Template::referenced_fields`
+
+- [ ] **Step 1: Write the failing test**
+
+`musefs-core/src/template.rs` has **no test module** — create one at the end of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn referenced_fields_collects_plain_path_section_and_fallback_names() {
+        let t = Template::parse("$artist/$!{beets_path}/[$disc - ]${title|name}");
+        let f = t.referenced_fields();
+        assert!(f.contains("artist"));
+        assert!(f.contains("beets_path"));
+        assert!(f.contains("disc"));
+        assert!(f.contains("title"));
+        assert!(f.contains("name"));
+        // No spurious entries from literals.
+        assert_eq!(f.len(), 5);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core referenced_fields_collects`
+Expected: FAIL — `no method named referenced_fields`.
+
+- [ ] **Step 3: Implement `referenced_fields` and the walker**
+
+Add `use std::collections::BTreeSet;` to the imports in `musefs-core/src/template.rs` (it already imports `BTreeMap`). Add the method inside `impl Template` (after `render`):
+
+```rust
+/// The set of field names this template references, across plain fields, `$!{}`
+/// path fields, `|` fallback chains, and `[...]` sections. Names are already
+/// ASCII-lowercased at parse time, matching `tags_to_fields`'s key folding, so a
+/// key-filtered tag load (`Db::tags_grouped_for_keys`) fetches exactly what
+/// rendering consumes.
+pub fn referenced_fields(&self) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    collect_field_names(&self.parts, &mut out);
+    out
+}
+```
+
+Add this free function near `render_parts`:
+
+```rust
+fn collect_field_names(parts: &[Part], out: &mut BTreeSet<String>) {
+    for part in parts {
+        match part {
+            Part::Literal(_) => {}
+            Part::Field { names, .. } => {
+                for name in names {
+                    out.insert(name.clone());
+                }
+            }
+            Part::Section(inner) => collect_field_names(inner, out),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core referenced_fields_collects`
+Expected: PASS
+
+### Part B — `Db::tags_grouped_for_keys`
+
+- [ ] **Step 5: Write the failing tests**
+
+Add to the existing `mod tags_for_tracks_tests` in `musefs-db/src/tags.rs` (`tags.rs:176`) — it already has the `open_mem`/`new_track` helpers and the `Tag`/`Format`/`NewTrack` imports these tests rely on:
+
+```rust
+#[test]
+fn tags_grouped_for_keys_filters_case_insensitively() {
+    let db = open_mem();
+    let a = db.upsert_track(&new_track("/a.flac")).unwrap();
+    db.replace_tags(
+        a,
+        &[
+            Tag::new("ARTIST", "Pix", 0),
+            Tag::new("Title", "Song", 0),
+            Tag::new("LYRICS", "la la", 0),
+        ],
+    )
+    .unwrap();
+    let got = db.tags_grouped_for_keys(&["artist", "title"]).unwrap();
+    let tags = &got[&a];
+    assert!(tags.iter().any(|t| t.value == "Pix"), "ARTIST matched");
+    assert!(tags.iter().any(|t| t.value == "Song"), "Title matched");
+    assert!(!tags.iter().any(|t| t.value == "la la"), "LYRICS excluded");
+}
+
+#[test]
+fn tags_grouped_for_keys_empty_keys_is_empty_map() {
+    let db = open_mem();
+    let a = db.upsert_track(&new_track("/a.flac")).unwrap();
+    db.replace_tags(a, &[Tag::new("ARTIST", "Pix", 0)]).unwrap();
+    let got = db.tags_grouped_for_keys(&[]).unwrap();
+    assert!(got.is_empty());
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-db tags_grouped_for_keys`
+Expected: FAIL — `no method named tags_grouped_for_keys`.
+
+- [ ] **Step 7: Implement `tags_grouped_for_keys`**
+
+Add to `impl<M> Db<M>` in `musefs-db/src/tags.rs` (next to `tags_for_tracks`):
+
+```rust
+/// Text tags whose key matches one of `keys` case-insensitively, grouped by
+/// track id and ordered `track_id, key, ordinal` (same as `tags_grouped`). The
+/// `IN (…)` list is chunked under SQLite's bound-variable limit. Empty `keys`
+/// yields an empty map (no query). Used by the virtual-tree build to load only
+/// the fields a path template references (#177).
+pub fn tags_grouped_for_keys(
+    &self,
+    keys: &[&str],
+) -> Result<std::collections::HashMap<i64, Vec<Tag>>> {
+    const CHUNK: usize = 900;
+    let mut out: std::collections::HashMap<i64, Vec<Tag>> = std::collections::HashMap::new();
+    for chunk in keys.chunks(CHUNK) {
+        let lowered: Vec<String> = chunk.iter().map(|k| k.to_ascii_lowercase()).collect();
+        let placeholders = vec!["?"; lowered.len()].join(",");
+        let sql = format!(
+            "SELECT track_id, key, value, ordinal FROM tags \
+             WHERE value_blob IS NULL AND lower(key) IN ({placeholders}) \
+             ORDER BY track_id, key, ordinal"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let params = rusqlite::params_from_iter(lowered.iter());
+        let rows = stmt.query_map(params, |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                Tag {
+                    key: r.get(1)?,
+                    value: r.get(2)?,
+                    ordinal: r.get(3)?,
+                },
+            ))
+        })?;
+        for row in rows {
+            let (track_id, tag) = row?;
+            out.entry(track_id).or_default().push(tag);
+        }
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-db tags_grouped_for_keys`
+Expected: PASS
+
+### Part C — Wire into `render_entries`
+
+- [ ] **Step 9: Switch `render_entries` to the key-filtered load**
+
+In `musefs-core/src/facade.rs`, `render_entries` (~line 287), replace:
+
+```rust
+let tracks = db.list_tracks()?;
+let mut tags_by_track = db.tags_grouped()?;
+```
+
+with:
+
+```rust
+let tracks = db.list_tracks()?;
+let field_names = template.referenced_fields();
+let keys: Vec<&str> = field_names.iter().map(String::as_str).collect();
+let mut tags_by_track = db.tags_grouped_for_keys(&keys)?;
+```
+
+- [ ] **Step 10: Run the full workspace suite (guards render equivalence)**
+
+Run: `cargo test`
+Expected: PASS — the existing facade/integration render tests now run against the key-filtered load; identical rendered paths confirm equivalence.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cargo fmt
+git add musefs-core/src/template.rs musefs-db/src/tags.rs musefs-core/src/facade.rs
+git commit -m "$(cat <<'EOF'
+core: load only template-referenced tags during tree build (#177)
+
+render_entries pulled every text tag for every track via tags_grouped(), then
+discarded all but the handful the path template references. Add
+Template::referenced_fields and Db::tags_grouped_for_keys (case-insensitive
+key match, chunked IN list) and load just those fields, so peak memory at mount
+and on poll_refresh scales with referenced fields, not total tag rows.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: #176 — `opendir` snapshot keyed by file handle
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` (imports, `MusefsFs` struct ~158, `new` ~177, new free fn, `readdir` ~388, new `opendir`/`releasedir`)
+- Test: `musefs-fuse/tests/mount.rs` (ignored e2e)
+
+> This is a performance fix (eliminates O(N²) re-materialization). The e2e test guards correctness of the rewrite — it lists a large directory and asserts every entry appears across the kernel's paginated `readdir` calls. It passes before and after; there is no red-first step.
+
+- [ ] **Step 1: Add imports**
+
+In `musefs-fuse/src/lib.rs`, change the atomic import:
+
+```rust
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+```
+
+(`Mutex` is already imported; the dir-handle map uses fully-qualified `std::collections::HashMap`.)
+
+- [ ] **Step 2: Add the dir-handle fields to `MusefsFs`**
+
+In the `MusefsFs` struct (after `passthrough`), add:
+
+```rust
+    /// Per-open directory listing snapshots, keyed by the fh handed out by
+    /// `opendir`. A paginated `readdir` clones the `Arc` under the lock and
+    /// serves it lock-free, so building the listing is O(N) per `ls`, not per
+    /// `readdir` call (#176).
+    dir_handles: Arc<Mutex<std::collections::HashMap<u64, Arc<Vec<(u64, FileType, String)>>>>>,
+    /// Monotonic dir-handle id (starts at 1; 0 stays the stateless sentinel).
+    dir_fh: Arc<AtomicU64>,
+```
+
+- [ ] **Step 3: Initialize them in `MusefsFs::new`**
+
+In the `MusefsFs { … }` literal inside `new`, after `passthrough: …`, add:
+
+```rust
+            dir_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            dir_fh: Arc::new(AtomicU64::new(1)),
+```
+
+- [ ] **Step 4: Add the listing-build free functions**
+
+Add near the other free functions (e.g. after `to_file_attr`). The pure assembly is split into `assemble_dir_listing` so it can be unit-tested without a kernel or a `Musefs`:
+
+```rust
+/// Assemble a directory's readdir listing: `.`, `..`, the children, then the
+/// optional Spotlight marker. Pure (no DB/tree access) so it is unit-testable.
+fn assemble_dir_listing(
+    ino: u64,
+    parent: u64,
+    entries: Vec<(String, u64, bool)>,
+    marker: Option<(u64, FileType, String)>,
+) -> Vec<(u64, FileType, String)> {
+    let mut listing: Vec<(u64, FileType, String)> = Vec::with_capacity(entries.len() + 2);
+    listing.push((ino, FileType::Directory, ".".to_string()));
+    listing.push((parent, FileType::Directory, "..".to_string()));
+    for (name, child, is_dir) in entries {
+        let kind = if is_dir {
+            FileType::Directory
+        } else {
+            FileType::RegularFile
+        };
+        listing.push((child, kind, name));
+    }
+    if let Some(entry) = marker {
+        listing.push(entry);
+    }
+    listing
+}
+
+/// Build a directory's full readdir listing once. Shared by `opendir`
+/// (snapshotted per fh) and the `readdir` fallback for an unknown fh.
+fn build_dir_listing(core: &Musefs, ino: u64) -> Result<Vec<(u64, FileType, String)>, CoreError> {
+    let entries = core.readdir(ino)?;
+    let parent = core.parent(ino).unwrap_or(ino);
+    let marker = platform::spotlight::marker_dir_entry(ino);
+    Ok(assemble_dir_listing(ino, parent, entries, marker))
+}
+```
+
+- [ ] **Step 4b: Add a gate-runnable unit test for the assembly**
+
+The FUSE `readdir`/`opendir` need a kernel, so the only end-to-end coverage (Step 9) is `#[ignore]`. Add this unit test to the existing `#[cfg(test)] mod tests` in `musefs-fuse/src/lib.rs` (it has `use super::*;`) so the pre-commit gate actually runs the ordering/length logic:
+
+```rust
+#[test]
+fn assemble_dir_listing_puts_dot_and_dotdot_first() {
+    let entries = vec![
+        ("Song.flac".to_string(), 42, false),
+        ("Sub".to_string(), 43, true),
+    ];
+    let listing = assemble_dir_listing(7, 3, entries, None);
+    assert_eq!(listing.len(), 4);
+    assert_eq!(listing[0], (7, FileType::Directory, ".".to_string()));
+    assert_eq!(listing[1], (3, FileType::Directory, "..".to_string()));
+    assert_eq!(listing[2], (42, FileType::RegularFile, "Song.flac".to_string()));
+    assert_eq!(listing[3], (43, FileType::Directory, "Sub".to_string()));
+}
+```
+
+Run: `cargo test -p musefs-fuse assemble_dir_listing_puts_dot_and_dotdot_first`
+Expected: PASS
+
+- [ ] **Step 5: Add `opendir`**
+
+Add to `impl Filesystem for MusefsFs` (next to `open`). It fires freshness, builds the snapshot on the worker pool, inserts it **before** replying so the snapshot exists by the time `readdir` runs:
+
+```rust
+fn opendir(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    self.fire_poll_refresh();
+    let core = Arc::clone(&self.core);
+    let handles = Arc::clone(&self.dir_handles);
+    let counter = Arc::clone(&self.dir_fh);
+    self.pool.execute(move || {
+        let listing = match build_dir_listing(&core, ino.0) {
+            Ok(l) => l,
+            Err(e) => return reply.error(reply_errno("opendir", ino.0, &e)),
+        };
+        let fh = counter.fetch_add(1, Ordering::Relaxed);
+        handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(fh, Arc::new(listing));
+        reply.opened(FileHandle(fh), FopenFlags::empty());
+    });
+}
+```
+
+- [ ] **Step 6: Rewrite `readdir`**
+
+Replace the body of `readdir` (~line 388) so it serves from the snapshot, cloning the `Arc` under the lock then releasing it before the reply loop (so `PARALLEL_DIROPS` reads don't serialize). Keep `fire_poll_refresh` for freshness parity:
+
+```rust
+fn readdir(
+    &self,
+    _req: &Request,
+    ino: INodeNo,
+    fh: FileHandle,
+    offset: u64,
+    mut reply: ReplyDirectory,
+) {
+    self.fire_poll_refresh();
+    let snapshot = self
+        .dir_handles
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&fh.0)
+        .map(Arc::clone);
+    // Lock released; the reply loop below runs without holding it.
+    let listing = match snapshot {
+        Some(l) => l,
+        // Unknown fh (e.g. fh 0): build once inline so we never regress.
+        None => match build_dir_listing(&self.core, ino.0) {
+            Ok(l) => Arc::new(l),
+            Err(e) => return reply.error(reply_errno("readdir", ino.0, &e)),
+        },
+    };
+    for (i, (child, kind, name)) in listing.iter().enumerate().skip(usize_from(offset)) {
+        // The stored offset is the index of the *next* entry to return.
+        if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
+            break;
+        }
+    }
+    reply.ok();
+}
+```
+
+- [ ] **Step 7: Add `releasedir`**
+
+Add to `impl Filesystem for MusefsFs` (next to `release`):
+
+```rust
+fn releasedir(
+    &self,
+    _req: &Request,
+    _ino: INodeNo,
+    fh: FileHandle,
+    _flags: OpenFlags,
+    reply: ReplyEmpty,
+) {
+    // The kernel issues exactly one releasedir per opendir, so the table can't leak.
+    self.dir_handles
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&fh.0);
+    reply.ok();
+}
+```
+
+- [ ] **Step 8: Build and lint**
+
+Run: `cargo clippy -p musefs-fuse --all-targets`
+Expected: no warnings (the `-D warnings` gate must stay clean).
+
+- [ ] **Step 9: Add the large-directory e2e test**
+
+Add to `musefs-fuse/tests/mount.rs` (it already has `make_flac`, `config`, and the `spawn` mount pattern):
+
+```rust
+#[test]
+#[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse -- --ignored"]
+fn large_directory_lists_fully_across_paginated_readdir() {
+    // Many files under one artist force the kernel to issue multiple readdir
+    // calls; every entry must appear exactly once.
+    let backing = tempfile::tempdir().unwrap();
+    const N: usize = 5000;
+    for i in 0..N {
+        let flac = make_flac(&["ARTIST=Alice", &format!("TITLE=Song{i:05}")], &[0xAB; 8]);
+        std::fs::write(backing.path().join(format!("t{i:05}.flac")), &flac).unwrap();
+    }
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-test").unwrap();
+
+    let names: std::collections::HashSet<String> =
+        std::fs::read_dir(mountpoint.path().join("Alice"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+    assert_eq!(names.len(), N, "every entry listed exactly once");
+    assert!(names.contains("Song00000.flac"));
+    assert!(names.contains("Song04999.flac"));
+
+    drop(session);
+    drop(backing);
+}
+```
+
+- [ ] **Step 10: Run the workspace suite (non-ignored) + the e2e**
+
+Run: `cargo test`
+Expected: PASS (all non-ignored).
+
+Run (needs `/dev/fuse` + libfuse): `cargo test -p musefs-fuse -- --ignored large_directory_lists_fully_across_paginated_readdir`
+Expected: PASS. If `/dev/fuse` is unavailable in this environment, note it and rely on the non-ignored suite; do not claim the e2e passed without running it.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cargo fmt
+git add musefs-fuse/src/lib.rs musefs-fuse/tests/mount.rs
+git commit -m "$(cat <<'EOF'
+fuse: snapshot directory listings in opendir to fix O(N^2) readdir (#176)
+
+readdir rebuilt and re-cloned the entire listing on every paginated call, so a
+single `ls` of a large directory did work quadratic in its size. Build the
+listing once in opendir, store it in a per-fh handle table, and serve readdir
+from a cloned Arc snapshot lock-free; releasedir frees it. The listing is now
+also stable across an ls's paginated calls.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (~line 206-209)
+- Modify: `README.md` (~line 80)
+
+- [ ] **Step 1: Update ARCHITECTURE.md**
+
+In the paragraph describing plain-value sanitization (the sentence ending "…'/' and control characters become '_'"), extend it to state the new invariants. Change:
+
+```
+Plain values are
+sanitized to a single path component ('/' and control characters become '_'),
+```
+
+to:
+
+```
+Plain values are
+sanitized to a single path component ('/' and control characters become '_',
+components equal to `.` or `..` are dropped, and any component is truncated to
+255 bytes on a UTF-8 boundary so it stays within NAME_MAX),
+```
+
+- [ ] **Step 2: Update README.md**
+
+After the `$!{field}` path-field bullet (~line 80), confirm the general rule is documented. Add a sentence to the "Anything else is literal…" paragraph (~line 84):
+
+```
+Anything else is literal. Name collisions get a deterministic `(2)`, `(3)`, …
+```
+
+Append to that paragraph:
+
+```
+Every rendered component is capped at 255 bytes (NAME_MAX, truncated on a UTF-8
+boundary, extension preserved), and a plain field whose value is exactly `.` or
+`..` is dropped rather than creating an unusable directory.
+```
+
+- [ ] **Step 3: Verify docs build / no broken references**
+
+Run: `cargo test`
+Expected: PASS (docs are prose; this just confirms the tree is still green before committing).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ARCHITECTURE.md README.md
+git commit -m "$(cat <<'EOF'
+docs: document `.`/`..`-drop and 255-byte component truncation (#178, #179)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Verification checklist (before opening PRs)
+
+- [ ] `cargo fmt --all --check` clean.
+- [ ] `cargo clippy --all-targets` clean (`-D warnings`).
+- [ ] `cargo test` (full workspace) green.
+- [ ] `cargo test -p musefs-fuse -- --ignored` green where `/dev/fuse` is available.
+- [ ] Each of the 5 commits is individually green (pre-commit hook enforces this).
+- [ ] `cargo +nightly fuzz build` if any format-layer signature changed — none did here, so optional.

--- a/docs/superpowers/specs/2026-06-08-issues-176-179-design.md
+++ b/docs/superpowers/specs/2026-06-08-issues-176-179-design.md
@@ -1,0 +1,247 @@
+# Issues #176–#179: readdir pagination, tag-load pruning, and path-component safety
+
+**Status:** Design approved, pending implementation
+**Date:** 2026-06-08
+**Issues:** #176, #177, #178, #179
+
+## Overview
+
+Four independent fixes that cluster around the path-render → virtual-tree →
+readdir path. Two are correctness bugs in how rendered path components reach the
+tree (#178, #179); two are performance issues in directory listing (#176) and
+virtual-tree construction (#177). They share no state and land as four separate,
+individually-green commits.
+
+Implementation order: #178 → #179 → #177 → #176.
+
+---
+
+## #178 — Drop `.` / `..` plain-field components
+
+### Problem
+
+A plain template field (`$artist`, `${album}`) whose tag value is exactly `.`
+or `..` renders that value as a standalone path component. `sanitize_into`
+(`musefs-core/src/template.rs`) only rewrites `/` and control characters, and
+`insert_file` (`musefs-core/src/tree.rs`) filters only empty components, so a
+directory named `.` or `..` reaches the virtual tree. `readdir`
+(`musefs-fuse/src/lib.rs`) hardcodes `.`/`..` as the first two entries, so such a
+child is emitted twice — violating POSIX and breaking recursive tools
+(`find`, `ls -R`) and kernel path caching.
+
+### Decision
+
+**Drop** the offending component, unifying with the existing `$!{...}` path-field
+behavior (`sanitize_path` already drops `.`/`..`). One mental model: `.`/`..`
+never reach the tree, regardless of field kind. Rejected the alternative
+(rewrite to a placeholder like `_`): the only genuine win for rewrite is uniform
+tree depth for depth-sensitive tooling, which is niche, and a tag value of
+literally `.` is already garbage data.
+
+### Approach
+
+In `insert_file` (`tree.rs`), extend the component split filter:
+
+```rust
+let comps: Vec<&str> = path
+    .split('/')
+    .filter(|c| !c.is_empty() && *c != "." && *c != "..")
+    .collect();
+```
+
+This is the single choke point every rendered path passes through. Because
+`Template::render` always appends `.<ext>` to the leaf, the filename can never be
+exactly `.`/`..`; only intermediate directory components are ever affected, so no
+track loses its leaf. `sanitize_into` and `sanitize_path` are untouched.
+
+---
+
+## #179 — Truncate components to the 255-byte NAME_MAX limit
+
+### Problem
+
+`Template::render` appends tag values into path components with no length bound.
+Long classical/audiobook titles routinely exceed 255 bytes. The Linux kernel
+caps a single name at `NAME_MAX` (255 bytes), so `lookup`/`readdir`/`stat` on an
+over-long entry fail (`ENAMETOOLONG`) and the file is inaccessible.
+
+### Decision
+
+Enforce a ≤255-byte invariant per component at the same `insert_file` choke
+point. Preserve the leaf's extension when truncating (extension-based tools rely
+on it); directory components truncate plainly.
+
+### Approach
+
+- **`truncate_bytes(s: &str, max: usize) -> &str`** (new helper, `tree.rs`):
+  returns the largest char-boundary prefix of `s` that is ≤ `max` bytes.
+  Implemented as a manual scan down from `max` to the nearest
+  `s.is_char_boundary(i)` — no nightly `floor_char_boundary`.
+- **Directory components:** `truncate_bytes(comp, 255)`.
+- **Leaf component:** split stem/ext via the existing `split_suffix_parts`;
+  truncate the *stem* so `stem.ext` is ≤ 255 bytes, keeping the extension. If the
+  extension alone is ≥ 255 bytes, fall back to truncating the whole name.
+- **Disambiguation budget:** `suffix_candidate` (`tree.rs:818`, the single source
+  of the ` (k)` suffix used by both `disambiguate` *and* `collision_gate`) trims
+  the stem so `stem (k).ext` stays ≤ 255 bytes. The budget is recomputed per `k`,
+  so it is correct for multi-digit ranks (` (10)` is 5 bytes, not 4). Without
+  this, a truncated leaf that collides bounces back over the limit — a realistic
+  audiobook case: two 300-byte chapter titles sharing a 255-byte prefix both
+  truncate to the same 255 bytes, collide, and disambiguation appends ` (2)` →
+  259 bytes.
+
+### Single truncation site — the `rendered_name` consistency rule
+
+Truncation happens in **one** place: the raw component is truncated up-front in
+`insert_file` (and `ensure_dir`) *before* `disambiguate` is called, and the
+**truncated value is what gets stored as `rendered_name`** (`tree.rs` `Node`),
+not the original. This is load-bearing for the rename gate:
+
+- `disambiguate` (`tree.rs:269`) generates candidate keys via
+  `suffix_candidate(truncated, k)`.
+- `collision_gate` (`tree.rs:335`) probes via `suffix_candidate(rendered_name, k)`.
+
+If `rendered_name` held the *un-truncated* value while keys were generated from
+the truncated one, the gate would probe a different base string than the one
+actually inserted — a false-negative rebuild gate, which `collision_gate`'s own
+contract says "would break equivalence." Storing the truncated value as
+`rendered_name` keeps both call sites feeding `suffix_candidate` the identical
+base, so generation and probe agree for every `k`. `ensure_dir` already stores
+`rendered_name: name` and needs no further change once `name` is the truncated
+component.
+
+Common-case note: non-colliding names use the full 255-byte budget; only a
+collision-forced suffix triggers `suffix_candidate`'s stem trimming, so the
+overwhelmingly common short-name path is byte-for-byte unchanged.
+
+### Known accepted limitation
+
+Two distinct directory names sharing a 255-byte prefix merge into one directory,
+because `ensure_dir` merges same-named directories by design. Leaf files never
+merge — `disambiguate` keeps colliding leaves distinct (and suffix-aware
+truncation keeps them ≤ 255), so no track is lost. This trade-off is documented,
+not fixed.
+
+---
+
+## #177 — Load only template-referenced tags during virtual-tree build
+
+### Problem
+
+`render_entries` (`musefs-core/src/facade.rs:287`) builds the virtual tree via
+`tags_grouped()`, which loads every text tag for every track. Path rendering
+consumes only the handful of fields referenced by the mount's template. For large
+libraries this materializes far more tag data than rendering uses (lyrics,
+comments, MBIDs, all discarded). Peak resident memory at mount and on every full
+`poll_refresh` scales with total tag rows rather than referenced fields.
+
+### Approach
+
+- **`Template::referenced_fields(&self) -> BTreeSet<String>`** (new,
+  `template.rs`): walk `parts` recursively (descending into `Section`s),
+  collecting every name from every `Field` — both plain and `raw` path fields,
+  across whole `|` fallback chains. Names are ASCII-lowercased to match
+  `tags_to_fields`'s key normalization (`mapping.rs:25`).
+- **`Db::tags_grouped_for_keys(&self, keys: &[&str])`** (new, `tags.rs`): same
+  return shape as `tags_grouped`, with
+  `WHERE value_blob IS NULL AND lower(key) IN (?, ?, …) ORDER BY track_id, key,
+  ordinal`, binding the lowercased names. The `lower(key)` match is required
+  because tag keys are stored with arbitrary case but `tags_to_fields` resolves
+  fields case-insensitively. `tags_grouped` stays — it is a documented `get_tags`
+  drop-in with other callers.
+- **`render_entries`:** compute the key set once from the template and call the
+  filtered query instead of `tags_grouped`.
+- **Empty key set** (template references no fields — only literals/fallbacks):
+  skip the tags query entirely and render every track from an empty tag map.
+  Avoids an invalid `IN ()`.
+
+`tags_to_fields` is unchanged; it simply receives fewer rows. Templates resolve
+fields only from stored tag rows: `render_one` (`facade.rs:270`) builds its field
+map solely from `&[Tag]` via `tags_to_fields` (`mapping.rs:19`) — there is no
+track-column-derived synthetic field a template could reference, and the
+synthesized `beets_path` value is itself stored as a real tag row. So a key-filter
+provably loses nothing the renderer would have used. (Verified against the code,
+not deferred to implementation.)
+
+This is the only cross-crate change (`musefs-db` → `musefs-core`); the
+`referenced_fields` ↔ stored-key case-folding contract is the correctness-critical
+interface.
+
+---
+
+## #176 — `opendir` snapshot keyed by file handle
+
+### Problem
+
+FUSE reads a directory in chunks: the kernel calls `readdir` repeatedly with an
+increasing `offset` until the listing is exhausted. `Musefs::readdir`
+(`facade.rs:931`) reconstructs the entire listing — cloning every child name into
+a fresh `Vec` — on every call, and the FUSE layer (`musefs-fuse/src/lib.rs`)
+clones them again before skipping to `offset`. Result: O(N²) time and
+allocations across a full scan of a large directory.
+
+### Decision
+
+`opendir` snapshot keyed by fh — the canonical FUSE fix. The dir-handle table
+lives in the FUSE layer (pagination is presentation plumbing); `core.readdir` is
+called once per `opendir` instead of once per `readdir` and is otherwise
+unchanged.
+
+### Approach
+
+- **Dir-handle table** on `MusefsFs`:
+  `Mutex<HashMap<u64, Arc<Vec<(u64, FileType, String)>>>>` plus an `AtomicU64` fh
+  counter starting at 1 (0 remains the stateless sentinel, mirroring `open`).
+- **`opendir`** (new): call `fire_poll_refresh()`, then build the full listing
+  once on the worker pool (`self.pool.execute`, consistent with
+  `open`/`lookup`/`getattr`/`read`) — `.`, `..`, `core.readdir(ino)` children, and
+  the optional spotlight marker — allocate a fresh fh, insert the `Arc<Vec>` into
+  the table, and `reply.opened(fh, flags)`. (`core.readdir` is an in-memory
+  arc-swapped tree read, but the O(N) name-clone for a huge directory should not
+  block the FUSE dispatch thread.)
+- **`readdir`:** lock the table, `Arc::clone` the snapshot, **unlock**, then serve
+  the slice from `offset` — the `reply.add` loop never runs while holding the
+  lock, so `PARALLEL_DIROPS` (`lib.rs:258`) reads of different directories don't
+  serialize on it. No rebuild, no re-clone of names. If the fh is absent (fh 0 /
+  unexpected), fall back to building the listing inline once — preserves
+  correctness, never regresses.
+- **`releasedir`** (new): drop the fh from the table and `reply.ok()`. The kernel
+  always issues `releasedir` for an `opendir`'d handle, so the table does not leak.
+
+Effect: one `core.readdir` + one listing build per `ls` → O(N) total. The listing
+is also now *stable* across an `ls`'s paginated calls — a mid-scan `poll_refresh`
+no longer mutates an in-flight listing (`readdir` serves from the captured `Arc`).
+
+### Freshness — no regression
+
+`fire_poll_refresh` currently fires on `lookup` (`lib.rs:266`), `getattr`
+(`lib.rs:288`), and `readdir` (`lib.rs:396`). It is **added** to `opendir` (before
+the snapshot build, so the snapshot reflects fresh data) and **left in place** on
+`readdir` and the others — nothing is removed. Firing on `readdir` is harmless to
+the snapshot (the in-flight listing is already captured in the `Arc`), so we keep
+the existing per-`readdir` freshness coverage rather than narrowing it.
+
+---
+
+## Testing
+
+- **#178 / #179** (`tree.rs`, `template.rs` unit tests): `.`/`..` plain values are
+  dropped; a 300-byte title truncates to ≤255 bytes with its extension intact;
+  two long titles sharing a 255-byte prefix get distinct disambiguated leaves that
+  are both ≤255 bytes; a multibyte UTF-8 title truncates on a char boundary; a
+  collision group large enough to reach a multi-digit rank (` (10)`) still yields
+  leaves ≤255 bytes; an incremental rebuild over a tree containing truncated
+  colliding leaves is equivalent to a full rebuild (guards the `rendered_name` ↔
+  `collision_gate` consistency rule).
+- **#177**: `musefs-db` test for `tags_grouped_for_keys` (case-insensitive key
+  match; empty-keys path); `template.rs` test for `referenced_fields` covering
+  sections, fallback chains, and path fields.
+- **#176**: `musefs-fuse` test that a large directory lists fully across multiple
+  paginated `readdir` calls; an `--ignored` e2e for real `ls`.
+
+All four commits must pass the full workspace suite (pre-commit gate).
+
+## Documentation
+
+Refresh the path-template / path-safety notes (`docs/` and the README template
+section) to state the `.`/`..`-drop and 255-byte-truncation rules.

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -295,7 +295,9 @@ impl Musefs {
         config: &MountConfig,
     ) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
         let tracks = db.list_tracks()?;
-        let mut tags_by_track = db.tags_grouped()?;
+        let field_names = template.referenced_fields();
+        let keys: Vec<&str> = field_names.iter().map(String::as_str).collect();
+        let mut tags_by_track = db.tags_grouped_for_keys(&keys)?;
         let mut entries = Vec::with_capacity(tracks.len());
         let mut snapshot = HashMap::with_capacity(tracks.len());
         for t in &tracks {

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::iter::Peekable;
 use std::str::Chars;
 
@@ -41,6 +42,17 @@ impl Template {
         let mut chars = template.chars().peekable();
         let parts = parse_parts(&mut chars, false);
         Template { parts }
+    }
+
+    /// The set of field names this template references, across plain fields, `$!{}`
+    /// path fields, `|` fallback chains, and `[...]` sections. Names are already
+    /// ASCII-lowercased at parse time, matching `tags_to_fields`'s key folding, so a
+    /// key-filtered tag load (`Db::tags_grouped_for_keys`) fetches exactly what
+    /// rendering consumes.
+    pub fn referenced_fields(&self) -> BTreeSet<String> {
+        let mut out = BTreeSet::new();
+        collect_field_names(&self.parts, &mut out);
+        out
     }
 
     /// Render one track's path. Outside a section a missing field resolves
@@ -156,6 +168,20 @@ fn parse_unbraced_name(chars: &mut Peekable<Chars>) -> String {
         }
     }
     name.to_ascii_lowercase()
+}
+
+fn collect_field_names(parts: &[Part], out: &mut BTreeSet<String>) {
+    for part in parts {
+        match part {
+            Part::Literal(_) => {}
+            Part::Field { names, .. } => {
+                for name in names {
+                    out.insert(name.clone());
+                }
+            }
+            Part::Section(inner) => collect_field_names(inner, out),
+        }
+    }
 }
 
 /// Render `parts`, returning the text and whether at least one referenced field
@@ -278,4 +304,22 @@ fn sanitize_path(value: &str) -> String {
 
 fn is_field_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn referenced_fields_collects_plain_path_section_and_fallback_names() {
+        let t = Template::parse("$artist/$!{beets_path}/[$disc - ]${title|name}");
+        let f = t.referenced_fields();
+        assert!(f.contains("artist"));
+        assert!(f.contains("beets_path"));
+        assert!(f.contains("disc"));
+        assert!(f.contains("title"));
+        assert!(f.contains("name"));
+        // No spurious entries from literals.
+        assert_eq!(f.len(), 5);
+    }
 }

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1,4 +1,5 @@
 use im::{HashMap as ImHashMap, OrdMap};
+use std::borrow::Cow;
 
 /// Case-fold a name for case-insensitive comparison. Unicode-aware lowercasing;
 /// ASCII is the floor. Applied identically to every comparison (collision,
@@ -211,6 +212,8 @@ impl VirtualTree {
             dir_path = child_path;
         }
         let raw_name = comps[comps.len() - 1];
+        let truncated = truncate_component(raw_name, true);
+        let raw_name = truncated.as_ref();
         let name = self.disambiguate(dir, raw_name);
         let full = join_path(&dir_path, &name);
         let inode = alloc.intern(&full);
@@ -239,6 +242,8 @@ impl VirtualTree {
         name: &str,
         alloc: &mut InodeAllocator,
     ) -> (u64, String) {
+        let truncated = truncate_component(name, false);
+        let name = truncated.as_ref();
         if let Some(existing) = self.dir_child_named(parent, name) {
             let stored = self
                 .node(existing)
@@ -819,14 +824,53 @@ fn split_suffix_parts(name: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Linux NAME_MAX: a single path component may be at most this many *bytes*.
+/// A longer component makes lookup/readdir/stat fail with ENAMETOOLONG.
+const NAME_MAX: usize = 255;
+
+/// Largest char-boundary prefix of `s` that is at most `max` bytes.
+fn truncate_bytes(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Truncate a rendered component to NAME_MAX bytes. For a leaf (`preserve_ext`),
+/// the stem is trimmed so `stem.ext` fits while the extension survives; if the
+/// extension alone is too long, the whole name is truncated. Borrows when the
+/// component already fits, so the common short-name path allocates nothing.
+fn truncate_component(name: &str, preserve_ext: bool) -> Cow<'_, str> {
+    if name.len() <= NAME_MAX {
+        return Cow::Borrowed(name);
+    }
+    if preserve_ext && let (stem, Some(ext)) = split_suffix_parts(name) {
+        // +1 for the '.' separator.
+        if let Some(budget) = NAME_MAX.checked_sub(ext.len() + 1).filter(|b| *b > 0) {
+            let stem_t = truncate_bytes(stem, budget);
+            return Cow::Owned(format!("{stem_t}.{ext}"));
+        }
+    }
+    Cow::Owned(truncate_bytes(name, NAME_MAX).to_string())
+}
+
 /// The rank-`k` disambiguated candidate for `name` (k >= 2): ` (k)` appended to
 /// the stem, before any extension. Single source of the suffix format —
 /// `disambiguate` generates with it and `collision_gate` probes with it.
 fn suffix_candidate(name: &str, k: u32) -> String {
-    match split_suffix_parts(name) {
-        (stem, Some(ext)) => format!("{stem} ({k}).{ext}"),
-        (stem, None) => format!("{stem} ({k})"),
-    }
+    let (stem, ext) = split_suffix_parts(name);
+    let suffix = format!(" ({k})");
+    let ext_part = match ext {
+        Some(e) => format!(".{e}"),
+        None => String::new(),
+    };
+    let budget = NAME_MAX.saturating_sub(suffix.len() + ext_part.len());
+    let stem_t = truncate_bytes(stem, budget);
+    format!("{stem_t}{suffix}{ext_part}")
 }
 
 /// True if `name` could be a `suffix_candidate` output. Such a name may be the
@@ -1668,6 +1712,88 @@ mod tests {
             !t.ancestor_in(b, &empty),
             "no ancestor present (guards ancestor_in->false)"
         );
+    }
+
+    #[test]
+    fn over_long_leaf_truncates_to_255_keeping_extension() {
+        let path = format!("{}.flac", "t".repeat(300));
+        let t = VirtualTree::build(&[(10, path)]);
+        let kids = t.children(VirtualTree::ROOT).unwrap();
+        assert_eq!(kids.len(), 1);
+        let name = kids.keys().next().unwrap();
+        assert!(name.len() <= 255, "leaf is {} bytes", name.len());
+        assert!(
+            std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("flac")),
+            "extension preserved"
+        );
+    }
+
+    #[test]
+    fn over_long_directory_component_truncates_to_255() {
+        let path = format!("{}/Song.flac", "d".repeat(300));
+        let t = VirtualTree::build(&[(10, path)]);
+        let dir = t
+            .children(VirtualTree::ROOT)
+            .unwrap()
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        assert!(dir.len() <= 255, "dir is {} bytes", dir.len());
+    }
+
+    #[test]
+    fn over_long_component_truncates_on_utf8_boundary() {
+        let path = format!("{}.flac", "€".repeat(100));
+        let t = VirtualTree::build(&[(10, path)]);
+        let name = t
+            .children(VirtualTree::ROOT)
+            .unwrap()
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        assert!(name.len() <= 255);
+        assert!(
+            std::path::Path::new(&name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("flac"))
+        );
+    }
+
+    #[test]
+    fn colliding_over_long_leaves_stay_distinct_and_within_255() {
+        let path = format!("{}.flac", "x".repeat(300));
+        let entries: Vec<(i64, String)> = (0..12).map(|i| (i, path.clone())).collect();
+        let t = VirtualTree::build(&entries);
+        let kids = t.children(VirtualTree::ROOT).unwrap();
+        assert_eq!(kids.len(), 12, "all collisions disambiguated distinctly");
+        for name in kids.keys() {
+            assert!(name.len() <= 255, "{} bytes", name.len());
+        }
+    }
+
+    #[test]
+    fn over_long_collisions_render_deterministically() {
+        let path = format!("{}.flac", "y".repeat(300));
+        let entries: Vec<(i64, String)> = (0..5).map(|i| (i, path.clone())).collect();
+        let a = VirtualTree::build(&entries);
+        let b = VirtualTree::build(&entries);
+        let ak: Vec<_> = a
+            .children(VirtualTree::ROOT)
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        let bk: Vec<_> = b
+            .children(VirtualTree::ROOT)
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        assert_eq!(ak, bk);
     }
 
     #[test]

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1771,8 +1771,38 @@ mod tests {
         let kids = t.children(VirtualTree::ROOT).unwrap();
         assert_eq!(kids.len(), 12, "all collisions disambiguated distinctly");
         for name in kids.keys() {
-            assert!(name.len() <= 255, "{} bytes", name.len());
+            // Each name packs to the full NAME_MAX: the base leaf trims its stem to
+            // leave room for `.flac`, and every ` (k)`-disambiguated sibling trims
+            // per-rank to land on exactly 255 bytes. Pinning the exact length (not
+            // just `<= 255`) guards suffix_candidate's budget arithmetic.
+            assert_eq!(name.len(), 255, "{name:?}");
         }
+    }
+
+    #[test]
+    fn over_long_leaf_with_oversize_extension_truncates_whole_name() {
+        // When the extension alone is NAME_MAX-1 bytes there is zero byte budget for
+        // any stem, so the leaf falls back to a plain whole-name truncation rather
+        // than emitting an empty-stem `.ext`. Guards truncate_component's
+        // `budget > 0` filter.
+        let path = format!("{}.{}", "s".repeat(300), "e".repeat(254));
+        let t = VirtualTree::build(&[(10, path)]);
+        let name = t
+            .children(VirtualTree::ROOT)
+            .unwrap()
+            .keys()
+            .next()
+            .unwrap()
+            .clone();
+        assert!(name.len() <= 255, "{} bytes", name.len());
+        assert!(
+            !name.starts_with('.'),
+            "no empty-stem leading dot: {name:?}"
+        );
+        assert!(
+            name.starts_with('s'),
+            "whole-name truncation keeps the stem prefix"
+        );
     }
 
     #[test]

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -196,7 +196,10 @@ impl VirtualTree {
     }
 
     fn insert_file(&mut self, track_id: i64, path: &str, alloc: &mut InodeAllocator) {
-        let comps: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
+        let comps: Vec<&str> = path
+            .split('/')
+            .filter(|c| !c.is_empty() && *c != "." && *c != "..")
+            .collect();
         if comps.is_empty() {
             return;
         }
@@ -1665,5 +1668,17 @@ mod tests {
             !t.ancestor_in(b, &empty),
             "no ancestor present (guards ancestor_in->false)"
         );
+    }
+
+    #[test]
+    fn dot_and_dotdot_plain_components_are_dropped() {
+        // A plain field rendering to exactly "." or ".." (e.g. an artist tagged ".")
+        // must not create a directory that collides with readdir's hardcoded "."/"..".
+        let t = VirtualTree::build(&[(10, "./Song.flac".into()), (20, "../Tune.flac".into())]);
+        assert!(t.lookup(VirtualTree::ROOT, ".").is_none());
+        assert!(t.lookup(VirtualTree::ROOT, "..").is_none());
+        // The dropped level collapses; the leaf lands directly under root.
+        assert!(t.lookup(VirtualTree::ROOT, "Song.flac").is_some());
+        assert!(t.lookup(VirtualTree::ROOT, "Tune.flac").is_some());
     }
 }

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -82,6 +82,45 @@ impl<M> Db<M> {
         Ok(out)
     }
 
+    /// Text tags whose key matches one of `keys` case-insensitively, grouped by
+    /// track id and ordered `track_id, key, ordinal` (same as `tags_grouped`). The
+    /// `IN (…)` list is chunked under SQLite's bound-variable limit. Empty `keys`
+    /// yields an empty map (no query). Used by the virtual-tree build to load only
+    /// the fields a path template references (#177).
+    pub fn tags_grouped_for_keys(
+        &self,
+        keys: &[&str],
+    ) -> Result<std::collections::HashMap<i64, Vec<Tag>>> {
+        const CHUNK: usize = 900;
+        let mut out: std::collections::HashMap<i64, Vec<Tag>> = std::collections::HashMap::new();
+        for chunk in keys.chunks(CHUNK) {
+            let lowered: Vec<String> = chunk.iter().map(|k| k.to_ascii_lowercase()).collect();
+            let placeholders = vec!["?"; lowered.len()].join(",");
+            let sql = format!(
+                "SELECT track_id, key, value, ordinal FROM tags \
+                 WHERE value_blob IS NULL AND lower(key) IN ({placeholders}) \
+                 ORDER BY track_id, key, ordinal"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params = rusqlite::params_from_iter(lowered.iter());
+            let rows = stmt.query_map(params, |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    Tag {
+                        key: r.get(1)?,
+                        value: r.get(2)?,
+                        ordinal: r.get(3)?,
+                    },
+                ))
+            })?;
+            for row in rows {
+                let (track_id, tag) = row?;
+                out.entry(track_id).or_default().push(tag);
+            }
+        }
+        Ok(out)
+    }
+
     /// Binary tag rows for a track: streaming handle (rowid), key, and payload
     /// length. Ordered by (key, ordinal) to match `get_binary_tags`/synthesis order.
     pub fn get_binary_tags(&self, track_id: i64) -> Result<Vec<BinaryTagRow>> {
@@ -310,5 +349,34 @@ mod tags_for_tracks_tests {
             db.get_tags(a).unwrap(),
             vec![Tag::new("artist", "Alice", 0)]
         );
+    }
+
+    #[test]
+    fn tags_grouped_for_keys_filters_case_insensitively() {
+        let db = open_mem();
+        let a = db.upsert_track(&new_track("/a.flac")).unwrap();
+        db.replace_tags(
+            a,
+            &[
+                Tag::new("ARTIST", "Pix", 0),
+                Tag::new("Title", "Song", 0),
+                Tag::new("LYRICS", "la la", 0),
+            ],
+        )
+        .unwrap();
+        let got = db.tags_grouped_for_keys(&["artist", "title"]).unwrap();
+        let tags = &got[&a];
+        assert!(tags.iter().any(|t| t.value == "Pix"), "ARTIST matched");
+        assert!(tags.iter().any(|t| t.value == "Song"), "Title matched");
+        assert!(!tags.iter().any(|t| t.value == "la la"), "LYRICS excluded");
+    }
+
+    #[test]
+    fn tags_grouped_for_keys_empty_keys_is_empty_map() {
+        let db = open_mem();
+        let a = db.upsert_track(&new_track("/a.flac")).unwrap();
+        db.replace_tags(a, &[Tag::new("ARTIST", "Pix", 0)]).unwrap();
+        let got = db.tags_grouped_for_keys(&[]).unwrap();
+        assert!(got.is_empty());
     }
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::ffi::OsStr;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
 
@@ -141,6 +141,40 @@ pub fn to_file_attr(attr: &Attr, uid: u32, gid: u32, fallback_mtime: SystemTime)
         flags: 0,
     }
 }
+/// Assemble a directory's readdir listing: `.`, `..`, the children, then the
+/// optional Spotlight marker. Pure (no DB/tree access) so it is unit-testable.
+fn assemble_dir_listing(
+    ino: u64,
+    parent: u64,
+    entries: Vec<(String, u64, bool)>,
+    marker: Option<(u64, FileType, String)>,
+) -> Vec<(u64, FileType, String)> {
+    let mut listing: Vec<(u64, FileType, String)> = Vec::with_capacity(entries.len() + 2);
+    listing.push((ino, FileType::Directory, ".".to_string()));
+    listing.push((parent, FileType::Directory, "..".to_string()));
+    for (name, child, is_dir) in entries {
+        let kind = if is_dir {
+            FileType::Directory
+        } else {
+            FileType::RegularFile
+        };
+        listing.push((child, kind, name));
+    }
+    if let Some(entry) = marker {
+        listing.push(entry);
+    }
+    listing
+}
+
+/// Build a directory's full readdir listing once. Shared by `opendir`
+/// (snapshotted per fh) and the `readdir` fallback for an unknown fh.
+fn build_dir_listing(core: &Musefs, ino: u64) -> Result<Vec<(u64, FileType, String)>, CoreError> {
+    let entries = core.readdir(ino)?;
+    let parent = core.parent(ino).unwrap_or(ino);
+    let marker = platform::spotlight::marker_dir_entry(ino);
+    Ok(assemble_dir_listing(ino, parent, entries, marker))
+}
+
 /// Clears the `fire_poll_refresh` single-flight gate when the poll task ends,
 /// on every exit path including a panic in `poll_refresh_notify` (#89).
 struct PollPendingGuard<'a>(&'a AtomicBool);
@@ -171,6 +205,14 @@ pub struct MusefsFs {
     /// Per-OS kernel-passthrough state (live backing registrations + sticky
     /// disable on Linux; a no-op marker elsewhere).
     passthrough: platform::passthrough::PassthroughState,
+    /// Per-open directory listing snapshots, keyed by the fh handed out by
+    /// `opendir`. A paginated `readdir` clones the `Arc` under the lock and
+    /// serves it lock-free, so building the listing is O(N) per `ls`, not per
+    /// `readdir` call (#176).
+    #[allow(clippy::type_complexity)]
+    dir_handles: Arc<Mutex<std::collections::HashMap<u64, Arc<Vec<(u64, FileType, String)>>>>>,
+    /// Monotonic dir-handle id (starts at 1; 0 stays the stateless sentinel).
+    dir_fh: Arc<AtomicU64>,
 }
 
 impl MusefsFs {
@@ -192,6 +234,8 @@ impl MusefsFs {
             notifier: Arc::new(OnceLock::new()),
             poll_pending: Arc::new(AtomicBool::new(false)),
             passthrough: platform::passthrough::PassthroughState::new(structure_only),
+            dir_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            dir_fh: Arc::new(AtomicU64::new(1)),
         }
     }
 
@@ -316,6 +360,25 @@ impl Filesystem for MusefsFs {
         });
     }
 
+    fn opendir(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        self.fire_poll_refresh();
+        let core = Arc::clone(&self.core);
+        let handles = Arc::clone(&self.dir_handles);
+        let counter = Arc::clone(&self.dir_fh);
+        self.pool.execute(move || {
+            let listing = match build_dir_listing(&core, ino.0) {
+                Ok(l) => l,
+                Err(e) => return reply.error(reply_errno("opendir", ino.0, &e)),
+            };
+            let fh = counter.fetch_add(1, Ordering::Relaxed);
+            handles
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(fh, Arc::new(listing));
+            reply.opened(FileHandle(fh), FopenFlags::empty());
+        });
+    }
+
     fn release(
         &self,
         _req: &Request,
@@ -333,6 +396,21 @@ impl Filesystem for MusefsFs {
             self.passthrough.remove(fh.get());
             self.core.release_handle(Fh::from(fh));
         }
+        reply.ok();
+    }
+
+    fn releasedir(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: FileHandle,
+        _flags: OpenFlags,
+        reply: ReplyEmpty,
+    ) {
+        self.dir_handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&fh.0);
         reply.ok();
     }
 
@@ -389,39 +467,29 @@ impl Filesystem for MusefsFs {
         &self,
         _req: &Request,
         ino: INodeNo,
-        _fh: FileHandle,
+        fh: FileHandle,
         offset: u64,
         mut reply: ReplyDirectory,
     ) {
         self.fire_poll_refresh();
-        let entries = match self.core.readdir(ino.0) {
-            Ok(e) => e,
-            Err(e) => return reply.error(reply_errno("readdir", ino.0, &e)),
+        let snapshot = self
+            .dir_handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&fh.0)
+            .map(Arc::clone);
+        // Lock released; the reply loop below runs without holding it.
+        let listing = match snapshot {
+            Some(l) => l,
+            // Unknown fh (e.g. fh 0): build once inline so we never regress.
+            None => match build_dir_listing(&self.core, ino.0) {
+                Ok(l) => Arc::new(l),
+                Err(e) => return reply.error(reply_errno("readdir", ino.0, &e)),
+            },
         };
-        let parent = self.core.parent(ino.0).unwrap_or(ino.0);
-
-        // `.` and `..` first, then the children. `offset` is the index already
-        // consumed by a previous call; `reply.add` returns true when the buffer
-        // is full, at which point we stop and reply.
-        let mut listing: Vec<(u64, fuser::FileType, String)> =
-            Vec::with_capacity(entries.len() + 2);
-        listing.push((ino.0, fuser::FileType::Directory, ".".to_string()));
-        listing.push((parent, fuser::FileType::Directory, "..".to_string()));
-        for (name, child, is_dir) in entries {
-            let kind = if is_dir {
-                fuser::FileType::Directory
-            } else {
-                fuser::FileType::RegularFile
-            };
-            listing.push((child, kind, name));
-        }
-        if let Some(entry) = platform::spotlight::marker_dir_entry(ino.0) {
-            listing.push(entry);
-        }
-
-        for (i, (child, kind, name)) in listing.into_iter().enumerate().skip(usize_from(offset)) {
-            // The offset stored is the index of the *next* entry to return.
-            if reply.add(INodeNo(child), (i + 1) as u64, kind, &name) {
+        for (i, (child, kind, name)) in listing.iter().enumerate().skip(usize_from(offset)) {
+            // The stored offset is the index of the *next* entry to return.
+            if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
                 break;
             }
         }
@@ -633,6 +701,23 @@ mod tests {
             !fs.poll_pending.load(Ordering::SeqCst),
             "guard must clear the gate after the task finishes"
         );
+    }
+
+    #[test]
+    fn assemble_dir_listing_puts_dot_and_dotdot_first() {
+        let entries = vec![
+            ("Song.flac".to_string(), 42, false),
+            ("Sub".to_string(), 43, true),
+        ];
+        let listing = assemble_dir_listing(7, 3, entries, None);
+        assert_eq!(listing.len(), 4);
+        assert_eq!(listing[0], (7, FileType::Directory, ".".to_string()));
+        assert_eq!(listing[1], (3, FileType::Directory, "..".to_string()));
+        assert_eq!(
+            listing[2],
+            (42, FileType::RegularFile, "Song.flac".to_string())
+        );
+        assert_eq!(listing[3], (43, FileType::Directory, "Sub".to_string()));
     }
 }
 

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -220,3 +220,32 @@ fn concurrent_spawns_do_not_race() {
         h.join().expect("a concurrent mount thread panicked (race)");
     }
 }
+
+#[test]
+#[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse -- --ignored"]
+fn large_directory_lists_fully_across_paginated_readdir() {
+    let backing = tempfile::tempdir().unwrap();
+    const N: usize = 5000;
+    for i in 0..N {
+        let flac = make_flac(&["ARTIST=Alice", &format!("TITLE=Song{i:05}")], &[0xAB; 8]);
+        std::fs::write(backing.path().join(format!("t{i:05}.flac")), &flac).unwrap();
+    }
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-test").unwrap();
+
+    let names: std::collections::HashSet<String> =
+        std::fs::read_dir(mountpoint.path().join("Alice"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+    assert_eq!(names.len(), N, "every entry listed exactly once");
+    assert!(names.contains("Song00000.flac"));
+    assert!(names.contains("Song04999.flac"));
+
+    drop(session);
+    drop(backing);
+}


### PR DESCRIPTION
Closes #176, closes #177, closes #178, closes #179.

Fixes four independent issues in the path-render → virtual-tree → readdir path. Each is one commit; the implementation followed `docs/superpowers/plans/2026-06-08-issues-176-179.md`.

## Changes

- **#178 — drop `.`/`..` plain-field components.** A plain template field rendering to exactly `.` or `..` produced a directory that `readdir` then emitted a second time (it hardcodes `.`/`..`), violating POSIX. Dropped at the `insert_file` choke point. (`musefs-core/src/tree.rs`)
- **#179 — truncate components to the 255-byte NAME_MAX.** Long titles exceeded NAME_MAX, making entries inaccessible (ENAMETOOLONG). Truncate each component at a UTF-8 boundary, preserving the leaf extension; the truncated value is stored as `rendered_name` so `disambiguate`/`collision_gate` stay consistent, and `suffix_candidate` trims the stem per-`k`. (`musefs-core/src/tree.rs`)
- **#177 — load only template-referenced tags during tree build.** `render_entries` pulled every text tag per track via `tags_grouped()`, then discarded all but the few the template references. Added `Template::referenced_fields` + `Db::tags_grouped_for_keys` (case-insensitive, chunked `IN`) so peak memory at mount/poll scales with referenced fields, not total tag rows. (`musefs-core/src/{template,facade}.rs`, `musefs-db/src/tags.rs`)
- **#176 — snapshot directory listings in `opendir`.** `readdir` rebuilt and re-cloned the whole listing on every paginated call, making one `ls` of a large dir O(N²). Build the listing once in `opendir`, store it in a per-fh handle table, and serve `readdir` from a cloned `Arc` snapshot lock-free; `releasedir` frees it. (`musefs-fuse/src/lib.rs`)

Docs (`ARCHITECTURE.md`, `README.md`) document the `.`/`..`-drop and 255-byte-truncation rules.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets` (`-D warnings`), full `cargo test` — green (pre-commit hook enforces per-commit).
- `#176` large-directory e2e (`musefs-fuse/tests/mount.rs`, `#[ignore]`) run with `/dev/fuse`: 5000 entries listed exactly once across the kernel's paginated `readdir`.
- **In-diff mutation gate green** (`cargo mutants --in-diff`): 0 missed, 0 timeout. Two real coverage gaps in the #179 truncation helpers were closed with tests (exact 255-byte length pin; 254-byte-extension whole-name fallback); four equivalent/hang-class mutants are documented as `exclude_re` in `.cargo/mutants.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
