### PR TITLE
Publish musl + glibc release binaries (4 targets) with a graceful-unmount CLI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,7 +80,10 @@ jobs:
         # llvm-cov); see docs/audits/2026-05-29-test-audit.md.
         run: cargo llvm-cov --workspace --exclude musefs-fuse --exclude musefs-latencyfs --lcov --output-path lcov.info
       - name: Upload to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        # v6.0.2: Codecov deleted the `codecovsecurity` keybase account that
+        # earlier versions fetch the CLI signing key from, so <=v6.0.1 fail
+        # signature verification deterministically. v6.0.2 moves to `codecovsecops`.
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,52 @@ jobs:
           path: dist/*
           if-no-files-found: error
           retention-days: 7
+
+  smoke:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            mode: host
+          - triple: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            mode: host
+          - triple: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            mode: alpine
+          - triple: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            mode: alpine
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Download artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: musefs-${{ matrix.triple }}
+          path: dist
+      - name: Extract binary
+        run: |
+          set -euo pipefail
+          tar -xzf dist/musefs-*-${{ matrix.triple }}.tar.gz -C .
+          ./musefs --version || true   # glibc/musl host may differ; real check is the smoke
+      - name: Smoke (host)
+        if: matrix.mode == 'host'
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y fuse3 ffmpeg
+          ./scripts/smoke-binary.sh ./musefs
+      - name: Smoke (Alpine container)
+        if: matrix.mode == 'alpine'
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+            -v "$PWD":/w -w /w \
+            alpine:3.20 \
+            sh -c 'apk add --no-cache fuse3 ffmpeg >/dev/null && sh scripts/smoke-binary.sh ./musefs'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,56 @@ jobs:
             echo "=== publishing $c ==="
             cargo publish -p "$c" --locked
           done
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-gnu
+            zig_target: x86_64-unknown-linux-gnu.2.17
+          - triple: aarch64-unknown-linux-gnu
+            zig_target: aarch64-unknown-linux-gnu.2.17
+          - triple: x86_64-unknown-linux-musl
+            zig_target: x86_64-unknown-linux-musl
+          - triple: aarch64-unknown-linux-musl
+            zig_target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          key: ${{ matrix.triple }}
+      - name: Install Zig and cargo-zigbuild
+        env:
+          ZIG_VERSION: "0.13.0"
+          CARGO_ZIGBUILD_VERSION: "0.22.3"
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar -xJ
+          echo "$PWD/zig-linux-x86_64-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          curl -fsSL "https://github.com/rust-cross/cargo-zigbuild/releases/download/v${CARGO_ZIGBUILD_VERSION}/cargo-zigbuild-v${CARGO_ZIGBUILD_VERSION}.x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz -C "$HOME/.cargo/bin" cargo-zigbuild
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.triple }}
+      - name: Build
+        run: cargo zigbuild --release -p musefs --target ${{ matrix.zig_target }}
+      - name: Package
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          NAME="musefs-${VERSION}-${{ matrix.triple }}"
+          mkdir -p dist
+          tar -C "target/${{ matrix.triple }}/release" -czf "dist/${NAME}.tar.gz" musefs
+          ( cd dist && sha256sum "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256" )
+          ls -l dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: musefs-${{ matrix.triple }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,3 +146,30 @@ jobs:
             -v "$PWD":/w -w /w \
             alpine:3.20 \
             sh -c 'apk add --no-cache fuse3 ffmpeg >/dev/null && sh scripts/smoke-binary.sh ./musefs'
+
+  release-assets:
+    needs: smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ls -l dist
+          # Create the release for this tag if it doesn't exist yet, then upload
+          # (idempotent on re-run via --clobber).
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --verify-tag \
+              --title "$GITHUB_REF_NAME" \
+              --notes "Prebuilt binaries for ${GITHUB_REF_NAME}. Verify with: sha256sum -c <file>.sha256"
+          fi
+          gh release upload "$GITHUB_REF_NAME" dist/*.tar.gz dist/*.sha256 --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,8 @@ dependencies = [
  "clap",
  "env_logger",
  "musefs-cli",
+ "rustix",
+ "tempfile",
 ]
 
 [[package]]
@@ -885,6 +887,7 @@ dependencies = [
  "musefs-core",
  "musefs-db",
  "musefs-fuse",
+ "signal-hook",
  "tempfile",
 ]
 
@@ -1542,6 +1545,26 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ similar_names = "allow"         # flags legitimately-distinct nearby bindings
 inline_always = "allow"         # a few deliberate hot-path annotations
 trivially_copy_pass_by_ref = "allow" # `&[u8; 4]` FourCCs read better than `*b"..."` call sites
 items_after_statements = "allow"     # helper structs/consts defined adjacent to their use
+
+[profile.release]
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,7 @@ trivially_copy_pass_by_ref = "allow" # `&[u8; 4]` FourCCs read better than `*b".
 items_after_statements = "allow"     # helper structs/consts defined adjacent to their use
 
 [profile.release]
-strip = true
+# "debuginfo" (not "symbols"/true): keep the symbol table so field panic
+# backtraces stay symbolicated, while still dropping the bulk of the size. This
+# profile also governs local `cargo build --release` debugging builds.
+strip = "debuginfo"

--- a/README.md
+++ b/README.md
@@ -167,10 +167,39 @@ The most common cause is a backing file that changed since its last scan
 (musefs refuses to serve a file whose size or mtime drifted, rather than
 splice at stale offsets). Run `musefs scan --revalidate` to re-probe it.
 
+## Prebuilt binaries
+
+Each tagged release attaches static/portable Linux binaries for four targets:
+
+| Target | libc | Notes |
+| --- | --- | --- |
+| `x86_64-unknown-linux-gnu`  | glibc | Pinned to glibc 2.17 — runs on essentially any current distro. |
+| `aarch64-unknown-linux-gnu` | glibc | glibc 2.17 floor, ARM64. |
+| `x86_64-unknown-linux-musl`  | musl | Fully static — runs on Alpine / scratch containers. |
+| `aarch64-unknown-linux-musl` | musl | Fully static, ARM64. |
+
+Download the tarball for your target from the
+[latest release](https://github.com/Sohex/musefs/releases/latest), verify it,
+and extract:
+
+```bash
+sha256sum -c musefs-<version>-<target>.tar.gz.sha256
+tar -xzf musefs-<version>-<target>.tar.gz   # yields ./musefs
+```
+
+**Runtime requirements:** the binaries mount via FUSE's `fusermount3` helper, so
+the target needs the FUSE userspace tools and `/dev/fuse`:
+
+- Debian/Ubuntu: `apt-get install fuse3`
+- Alpine: `apk add fuse3`
+
+No glibc/libfuse install is needed for the musl binaries beyond `fuse3`.
+
 ## Requirements
 
 - Rust (2024 edition) and Cargo to build/install.
-- A supported OS with FUSE to mount — Linux (`/dev/fuse` + libfuse) or FreeBSD
+- A supported OS with FUSE to mount — Linux (`/dev/fuse` + `fusermount3`, from
+  the `fuse3` package) or FreeBSD
   (`/dev/fuse` + the `fusefs` kernel module; no libfuse). macOS (FUSE-T) is
   best-effort. See [Platform support](#platform-support) for details.
 

--- a/docs/superpowers/plans/2026-06-09-musl-glibc-release-binaries.md
+++ b/docs/superpowers/plans/2026-06-09-musl-glibc-release-binaries.md
@@ -27,6 +27,7 @@ Artifact form throughout (build output, CI artifact, release asset): `musefs-<ve
 - `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10`
 - `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
 - `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32`
+- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (already used in `mutants.yml`/`fuzz.yml` — v4)
 
 ---
 
@@ -35,6 +36,8 @@ Artifact form throughout (build output, CI artifact, release asset): `musefs-<ve
 **Purpose:** Prove all four targets build + run before writing any CI, and capture the exact `zig` and `cargo-zigbuild` versions the workflow will pin. This is the spec's first milestone. The highest risk is `aarch64-unknown-linux-musl` + bundled SQLite and the glibc-2.17 floor.
 
 **Files:** none (local only).
+
+**Precondition:** Step 3 mounts a real FUSE filesystem, so the de-risk host needs `/dev/fuse` present and the `fuse3` package (`fusermount3`) installed. If the host lacks `/dev/fuse`, Steps 1–2 (the builds) still validate; Step 3 must be run somewhere with FUSE — flag this rather than treating a missing `/dev/fuse` as a code failure.
 
 - [ ] **Step 1: Install the toolchain locally**
 
@@ -74,10 +77,10 @@ Expected: all four compile (bundled SQLite cross-compiles); the musl binaries re
 - [ ] **Step 3: Confirm a real FUSE mount works with the pure-rust fuser path**
 
 ```bash
-cargo test -p musefs-fuse -- --ignored
+cargo test -p musefs-fuse --test mount -- --ignored
 ```
 
-Expected: the existing FUSE e2e tests pass (this is today's behavior; it confirms the mount path before any change).
+Expected: the `mount.rs` synthesis e2e tests pass (this is today's behavior; it confirms the mount path before any change). Scope to `--test mount` deliberately: a bare `-- --ignored` also runs `passthrough.rs`, whose backing-open ioctl is `CAP_SYS_ADMIN`-gated and only passes under sudo on the prebuilt test binary — running it here would be a false red.
 
 - [ ] **Step 4: Record the working versions**
 
@@ -128,7 +131,7 @@ Leave the macOS-only `fuser = { version = "0.17", features = ["macos-no-mount"] 
 
 - [ ] **Step 2: Add a release strip profile to the workspace root**
 
-Append to `/home/cfutro/git/musefs/Cargo.toml` (after the existing `[workspace.lints.*]` blocks):
+Append to `/home/cfutro/git/musefs/Cargo.toml` as a **new top-level table at end of file** (not nested under `[workspace.*]` — `[profile.release]` is a top-level manifest table):
 
 ```toml
 [profile.release]
@@ -142,8 +145,8 @@ Expected: clean build (no new warnings/errors).
 
 - [ ] **Step 4: Confirm the mount still works (manual, not in pre-commit)**
 
-Run: `cargo test -p musefs-fuse -- --ignored`
-Expected: PASS — mounting via the pure-rust path is unaffected.
+Run: `cargo test -p musefs-fuse --test mount -- --ignored`
+Expected: PASS — mounting via the pure-rust path is unaffected. (Scoped to `--test mount`; `passthrough.rs` is sudo-gated, see Task 0 Step 3.)
 
 - [ ] **Step 5: Commit**
 
@@ -236,8 +239,10 @@ fn run_unmount(mountpoint: &Path) {
             }
         }
     }
-    log::warn!(
-        "could not unmount {} after stop signal; run `fusermount3 -u {}` manually",
+    // Best-effort: a stop signal must never panic. Use eprintln! rather than a
+    // new `log` dependency on the CLI path.
+    eprintln!(
+        "musefs: could not unmount {} after stop signal; run `fusermount3 -u {}` manually",
         mountpoint.display(),
         mountpoint.display()
     );
@@ -268,10 +273,9 @@ In `musefs-cli/Cargo.toml`, under `[dependencies]`, add:
 
 ```toml
 signal-hook = "0.3"
-log = "0.4"
 ```
 
-(`log` is needed for the `log::warn!` in `run_unmount`; add it if not already present.)
+No `log` dependency — `run_unmount` uses `eprintln!` for its best-effort warning. After this step run `cargo build -p musefs-cli` to confirm `signal-hook` links cleanly (no unused-dep / `-D warnings` surprise at the Step 9 commit boundary).
 
 - [ ] **Step 5: Wire the module and installer into the CLI**
 
@@ -443,7 +447,7 @@ Run (compile-check, ignored, runs by default in pre-commit only as a compile):
 cargo test -p musefs --no-run
 cargo test -p musefs -- --ignored sigterm_unmounts_cleanly
 ```
-Expected: first compiles clean; second PASSES (mounts, SIGTERM, clean unmount). If `rustix::process::Signal::TERM` or `Pid::from_child` differ in the installed rustix `1.x`, adjust to the actual API (`rustix::process::test_kill_process`/`Signal` variants) — confirm via `cargo doc -p rustix --open` and keep it `unsafe`-free.
+Expected: first compiles clean; second PASSES (mounts, SIGTERM, clean unmount). The API used (`rustix::process::Pid::from_child`, `kill_process`, `Signal::TERM`) is correct for the locked rustix 1.x and is `unsafe`-free; if anything mismatches, confirm via `cargo doc -p rustix`.
 
 - [ ] **Step 9: Full gate + commit**
 
@@ -471,6 +475,8 @@ Expected: pre-commit passes (full suite green; ignored e2e compiled but not run)
 - Create: `scripts/smoke-binary.sh`
 
 POSIX `sh` so it runs under both bash (host) and busybox ash (Alpine). It scans an ffmpeg-generated FLAC, mounts the binary, reads the synthesized file, then SIGTERMs the daemon and asserts a clean unmount — exercising the real artifact and the Task 2 handler.
+
+Scope note: this smoke is a **liveness + format** check (the served file mounts, is readable, and is a valid non-empty FLAC). Byte-exact verification of the cardinal "audio bytes unchanged" invariant is already covered by the Rust e2e suite (`musefs-fuse/tests/`), which runs against the same code; the smoke deliberately keeps to a portable shell check rather than re-deriving byte equality in `sh`.
 
 - [ ] **Step 1: Write the script**
 
@@ -566,16 +572,17 @@ assert clean unmount) reused by the release smoke jobs for all four targets."
 
 Add a `build` matrix job that cross-builds all four targets on amd64 via `cargo-zigbuild`, packages each as a `.tar.gz` (+ `.sha256`), and uploads them as workflow artifacts. The existing `publish` (crates.io) job is left untouched.
 
-- [ ] **Step 1: Resolve and pin the artifact-action SHAs**
+- [ ] **Step 1: Pin the artifact-action SHAs**
 
-`upload-artifact`/`download-artifact` are new to this repo. Pin them to commit SHAs (the repo convention; the annotated-tag object SHA would fail at run time — use the commits endpoint):
+`upload-artifact` is **already used and pinned in this repo** (`mutants.yml`/`fuzz.yml`) at `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v4) — reuse that SHA verbatim, do not re-resolve.
+
+Only `download-artifact` is new. Resolve its commit SHA (the repo convention; the annotated-tag object SHA would fail at run time — use the commits endpoint), pinning the **same major (v4)** so it's compatible with the v4 upload action:
 
 ```bash
-gh api repos/actions/upload-artifact/commits/v4 --jq .sha
 gh api repos/actions/download-artifact/commits/v4 --jq .sha
 ```
 
-Use the returned 40-char SHAs in place of `<UPLOAD_ARTIFACT_SHA>` / `<DOWNLOAD_ARTIFACT_SHA>` below (and in Task 5).
+Use `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` for `<UPLOAD_ARTIFACT_SHA>` and the resolved SHA for `<DOWNLOAD_ARTIFACT_SHA>` below (and in Tasks 5–6).
 
 - [ ] **Step 2: Add the `build` job**
 
@@ -628,7 +635,7 @@ In `.github/workflows/release.yml`, keep `permissions: contents: read` at the to
           ( cd dist && sha256sum "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256" )
           ls -l dist
       - name: Upload artifact
-        uses: actions/upload-artifact@<UPLOAD_ARTIFACT_SHA>
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: musefs-${{ matrix.triple }}
           path: dist/*
@@ -912,7 +919,7 @@ Expected: prints the new issue URL. Record it in the handoff.
 - Container packaging follow-up issue → Task 8. ✅
 - Optional CI `libfuse3-dev` cleanup → intentionally left out (spec marked it optional/harmless).
 
-**Placeholder scan:** The only intentionally-unresolved tokens are `<UPLOAD_ARTIFACT_SHA>` / `<DOWNLOAD_ARTIFACT_SHA>` (resolved by the exact `gh api` commands in Task 4 Step 1) and the `ZIG_VERSION` / `CARGO_ZIGBUILD_VERSION` values (resolved by Task 0 and carried forward). These are concrete resolve-then-fill steps, not vague placeholders.
+**Placeholder scan:** The only intentionally-unresolved token is `<DOWNLOAD_ARTIFACT_SHA>` (resolved by the exact `gh api` command in Task 4 Step 1; `upload-artifact` reuses the repo's existing `043fb46…` pin) and the `ZIG_VERSION` / `CARGO_ZIGBUILD_VERSION` values (resolved by Task 0 and carried forward). These are concrete resolve-then-fill steps, not vague placeholders.
 
 **Type/name consistency:** `unmount_commands` / `run_unmount` / `install_unmount_on_signal` are defined in Task 2 Step 3 and used in Steps 1/5/6; the smoke script name `scripts/smoke-binary.sh` and the artifact name pattern `musefs-${triple}` / `musefs-<version>-<triple>.tar.gz` are consistent across Tasks 3–7. Matrix `triple`/`zig_target`/`runner`/`mode` keys match between Tasks 4 and 5.
 

--- a/docs/superpowers/plans/2026-06-09-musl-glibc-release-binaries.md
+++ b/docs/superpowers/plans/2026-06-09-musl-glibc-release-binaries.md
@@ -135,7 +135,9 @@ Append to `/home/cfutro/git/musefs/Cargo.toml` as a **new top-level table at end
 
 ```toml
 [profile.release]
-strip = true
+# "debuginfo" (not true/"symbols"): keep the symbol table so field panic
+# backtraces stay symbolicated, while still dropping the bulk of the size.
+strip = "debuginfo"
 ```
 
 - [ ] **Step 3: Build to confirm nothing broke**

--- a/docs/superpowers/plans/2026-06-09-musl-glibc-release-binaries.md
+++ b/docs/superpowers/plans/2026-06-09-musl-glibc-release-binaries.md
@@ -1,0 +1,919 @@
+# musl + glibc release binaries — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish four portable binaries on every `v*` tag — `{glibc, musl} × {x86_64, aarch64}` — each verified by a real FUSE mount smoke, with a graceful SIGTERM/SIGINT unmount in the CLI.
+
+**Architecture:** A local de-risk milestone proves all four targets build via `cargo-zigbuild` (Zig as cross-linker/C-compiler for the bundled SQLite). Two small source changes land first (make the no-libfuse choice explicit; add a `fusermount3 -u`-based signal handler in the CLI mount path). A reusable in-tree smoke script exercises a built binary end-to-end. Finally `release.yml` gains build → smoke → release-asset jobs that cross-build on amd64, smoke each artifact on its native runner (musl inside an Alpine container via `docker run`), and upload to the GitHub Release with `gh`.
+
+**Tech Stack:** Rust (2024 edition), `cargo-zigbuild` + Zig, `signal-hook`, `rustix` (test-only), GitHub Actions, `gh` CLI, Alpine/Docker, ffmpeg (smoke fixture), `fusermount3`/`fuse3`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md`
+
+---
+
+## The four targets (referenced throughout)
+
+| # | Rust triple (artifact name) | zigbuild `--target` | Smoke runner | Smoke mode |
+| - | --------------------------- | ------------------- | ------------ | ---------- |
+| 1 | `x86_64-unknown-linux-gnu`   | `x86_64-unknown-linux-gnu.2.17`  | `ubuntu-latest`   | host (apt `fuse3`) |
+| 2 | `aarch64-unknown-linux-gnu`  | `aarch64-unknown-linux-gnu.2.17` | `ubuntu-24.04-arm`| host (apt `fuse3`) |
+| 3 | `x86_64-unknown-linux-musl`  | `x86_64-unknown-linux-musl`      | `ubuntu-latest`   | Alpine `docker run` |
+| 4 | `aarch64-unknown-linux-musl` | `aarch64-unknown-linux-musl`     | `ubuntu-24.04-arm`| Alpine `docker run` |
+
+Artifact form throughout (build output, CI artifact, release asset): `musefs-<version>-<triple>.tar.gz` containing a single stripped, executable `musefs` at the archive root, plus a `musefs-<version>-<triple>.tar.gz.sha256` in `sha256sum` two-column format.
+
+**Pinned action SHAs already used in this repo (reuse verbatim):**
+- `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10`
+- `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`
+- `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32`
+
+---
+
+## Task 0: Local de-risk milestone (no commit)
+
+**Purpose:** Prove all four targets build + run before writing any CI, and capture the exact `zig` and `cargo-zigbuild` versions the workflow will pin. This is the spec's first milestone. The highest risk is `aarch64-unknown-linux-musl` + bundled SQLite and the glibc-2.17 floor.
+
+**Files:** none (local only).
+
+- [ ] **Step 1: Install the toolchain locally**
+
+```bash
+# Zig (pin a known-good version; this exact version goes into the workflow).
+ZIG_VERSION=0.13.0
+curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar -xJ
+export PATH="$PWD/zig-linux-x86_64-${ZIG_VERSION}:$PATH"
+zig version
+
+# cargo-zigbuild (prefer the prebuilt release binary; pin the version).
+cargo install --locked cargo-zigbuild
+cargo zigbuild --version
+
+rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu \
+                 x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+```
+
+- [ ] **Step 2: Build all four targets and run each that can run locally**
+
+```bash
+for T in x86_64-unknown-linux-gnu.2.17 aarch64-unknown-linux-gnu.2.17 \
+         x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+  echo "=== $T ==="
+  cargo zigbuild --release -p musefs --target "$T"
+done
+# amd64 ones run on this host:
+./target/x86_64-unknown-linux-gnu/release/musefs --version
+./target/x86_64-unknown-linux-musl/release/musefs --version
+file ./target/x86_64-unknown-linux-musl/release/musefs   # expect: statically linked
+# aarch64 ones: confirm they built; optionally run under qemu-user if installed:
+#   qemu-aarch64-static ./target/aarch64-unknown-linux-musl/release/musefs --version
+```
+
+Expected: all four compile (bundled SQLite cross-compiles); the musl binaries report "statically linked".
+
+- [ ] **Step 3: Confirm a real FUSE mount works with the pure-rust fuser path**
+
+```bash
+cargo test -p musefs-fuse -- --ignored
+```
+
+Expected: the existing FUSE e2e tests pass (this is today's behavior; it confirms the mount path before any change).
+
+- [ ] **Step 4: Record the working versions**
+
+Note the exact `ZIG_VERSION` and `cargo-zigbuild` version that worked — Tasks 4 pins these. If `aarch64-unknown-linux-musl` cannot be made to build after reasonable effort, STOP and report back: that cell is the spec's documented drop candidate and the matrix below must be trimmed with a logged note (do not silently skip).
+
+**No commit** — this milestone gates the rest.
+
+---
+
+## Task 1: Make the no-libfuse choice explicit + strip release binaries
+
+**Files:**
+- Modify: `musefs-fuse/Cargo.toml:13`
+- Modify: `musefs-latencyfs/Cargo.toml:11`
+- Modify: `Cargo.toml` (workspace root — add `[profile.release]`)
+
+Background (verified against vendored `fuser-0.17.0/build.rs:11-15`): `fuser` has `default = []`, so on Linux the pure-rust `fusermount3` path is already used and **no libfuse is linked today**. `default-features = false` is a no-op now but documents intent and guards a future fuser default change. This task is functionally a no-op; the existing suite is the test.
+
+- [ ] **Step 1: Pin `default-features = false` on both fuser deps**
+
+In `musefs-fuse/Cargo.toml`, change line 13 from:
+
+```toml
+fuser = "0.17"
+```
+
+to:
+
+```toml
+# Pure-rust fusermount3 mount path; never enable `libfuse` (static musl can't link it).
+fuser = { version = "0.17", default-features = false }
+```
+
+In `musefs-latencyfs/Cargo.toml`, change line 11 from:
+
+```toml
+fuser = "0.17"
+```
+
+to:
+
+```toml
+# Pure-rust fusermount3 mount path; never enable `libfuse` (keeps workspace feature unification consistent).
+fuser = { version = "0.17", default-features = false }
+```
+
+Leave the macOS-only `fuser = { version = "0.17", features = ["macos-no-mount"] }` target dependency in `musefs-fuse/Cargo.toml` unchanged.
+
+- [ ] **Step 2: Add a release strip profile to the workspace root**
+
+Append to `/home/cfutro/git/musefs/Cargo.toml` (after the existing `[workspace.lints.*]` blocks):
+
+```toml
+[profile.release]
+strip = true
+```
+
+- [ ] **Step 3: Build to confirm nothing broke**
+
+Run: `cargo build --workspace`
+Expected: clean build (no new warnings/errors).
+
+- [ ] **Step 4: Confirm the mount still works (manual, not in pre-commit)**
+
+Run: `cargo test -p musefs-fuse -- --ignored`
+Expected: PASS — mounting via the pure-rust path is unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-fuse/Cargo.toml musefs-latencyfs/Cargo.toml Cargo.toml
+git commit -m "build: pin fuser to no-libfuse explicitly; strip release binaries
+
+fuser 0.17 already uses the pure-rust fusermount3 path on Linux (default
+features are empty); make that explicit on both fuser-dependent crates so a
+future fuser default change can't pull libfuse and break static musl builds.
+Add [profile.release] strip = true for smaller release artifacts."
+```
+
+(The pre-commit hook runs fmt, clippy `-D warnings`, the full workspace suite, and ruff. The `Cargo.lock` may update; if `git status` shows it, `git add Cargo.lock` and amend into this commit before it lands — the hook will have regenerated it.)
+
+---
+
+## Task 2: SIGTERM/SIGINT graceful-unmount handler in the CLI
+
+**Files:**
+- Modify: `musefs-cli/Cargo.toml` (add `signal-hook` dependency)
+- Create: `musefs-cli/src/signal.rs`
+- Modify: `musefs-cli/src/lib.rs` (declare `mod signal`; call the installer in `run_mount`)
+- Modify: `musefs/Cargo.toml` (add `[dev-dependencies]` for the subprocess e2e)
+- Create: `musefs/tests/sigterm_unmount.rs`
+
+The handler lives in the **CLI binary path only** — never in the `musefs-fuse` library — so it can't hijack signals for the in-process e2e harness or any embedder. On SIGTERM/SIGINT it runs `fusermount3 -u <mountpoint>` (fallbacks `fusermount -u`, then `umount`), which EOFs `/dev/fuse` and lets the blocking `mount_with` return cleanly. (A `SessionUnmounter` handle does not work: `Session::spawn()` `mem::take`s the `Mount` and `Session::run()` is `pub(crate)`.)
+
+- [ ] **Step 1: Write the failing unit test for the unmount command list**
+
+Create `musefs-cli/src/signal.rs` with only this test module to start:
+
+```rust
+//! CLI-only graceful unmount on stop signals. Installed by `run_mount`; never
+//! in the `musefs-fuse` library (which must not hijack process signals).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    #[test]
+    fn unmount_commands_try_fusermount3_then_fallbacks() {
+        let cmds = unmount_commands(Path::new("/mnt/x"));
+        let progs: Vec<&str> = cmds.iter().map(|(p, _)| *p).collect();
+        assert_eq!(progs, ["fusermount3", "fusermount", "umount"]);
+        // fusermount variants pass `-u <mp>`; umount passes just `<mp>`.
+        assert_eq!(
+            cmds[0].1,
+            vec![OsString::from("-u"), OsString::from("/mnt/x")]
+        );
+        assert_eq!(cmds[2].1, vec![OsString::from("/mnt/x")]);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-cli unmount_commands_try_fusermount3_then_fallbacks`
+Expected: FAIL — `unmount_commands` not found (compile error).
+
+- [ ] **Step 3: Implement the signal module**
+
+Prepend to `musefs-cli/src/signal.rs` (above the test module):
+
+```rust
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Unmount commands tried in order, most-preferred first, as `(program, args)`.
+/// `fusermount3`/`fusermount` are the unprivileged FUSE unmount tools; `umount`
+/// is the last resort.
+fn unmount_commands(mountpoint: &Path) -> Vec<(&'static str, Vec<OsString>)> {
+    let mp = mountpoint.as_os_str().to_owned();
+    vec![
+        ("fusermount3", vec!["-u".into(), mp.clone()]),
+        ("fusermount", vec!["-u".into(), mp.clone()]),
+        ("umount", vec![mp]),
+    ]
+}
+
+/// Try each unmount command until one succeeds. Best-effort: a stop signal must
+/// never panic the process.
+fn run_unmount(mountpoint: &Path) {
+    for (prog, args) in unmount_commands(mountpoint) {
+        if let Ok(status) = std::process::Command::new(prog).args(&args).status() {
+            if status.success() {
+                return;
+            }
+        }
+    }
+    log::warn!(
+        "could not unmount {} after stop signal; run `fusermount3 -u {}` manually",
+        mountpoint.display(),
+        mountpoint.display()
+    );
+}
+
+/// Spawn a thread that unmounts `mountpoint` on the first SIGTERM/SIGINT, so a
+/// `Ctrl-C` / `systemctl stop` / container stop unwinds the blocking mount
+/// cleanly instead of leaving a stale FUSE endpoint. CLI-only.
+pub fn install_unmount_on_signal(mountpoint: PathBuf) -> std::io::Result<()> {
+    use signal_hook::consts::{SIGINT, SIGTERM};
+    use signal_hook::iterator::Signals;
+
+    let mut signals = Signals::new([SIGINT, SIGTERM])?;
+    std::thread::Builder::new()
+        .name("musefs-unmount-on-signal".into())
+        .spawn(move || {
+            if signals.forever().next().is_some() {
+                run_unmount(&mountpoint);
+            }
+        })?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Add the `signal-hook` dependency**
+
+In `musefs-cli/Cargo.toml`, under `[dependencies]`, add:
+
+```toml
+signal-hook = "0.3"
+log = "0.4"
+```
+
+(`log` is needed for the `log::warn!` in `run_unmount`; add it if not already present.)
+
+- [ ] **Step 5: Wire the module and installer into the CLI**
+
+In `musefs-cli/src/lib.rs`, add the module declaration near the top (with the other items):
+
+```rust
+mod signal;
+```
+
+Then change `run_mount` (currently `musefs-cli/src/lib.rs:183-193`) to install the handler before the blocking mount:
+
+```rust
+/// Build a `Musefs` from the DB at `args.db` and mount it (blocking) at
+/// `args.mountpoint`.
+pub fn run_mount(args: &MountArgs) -> Result<()> {
+    let db =
+        Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
+    let (config, fuse_config) = parse_mount_config(args);
+    let core = Musefs::open(db, config).context("building the virtual filesystem")?;
+    signal::install_unmount_on_signal(args.mountpoint.clone())
+        .context("installing the stop-signal unmount handler")?;
+    musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
+        .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Run the unit test to verify it passes**
+
+Run: `cargo test -p musefs-cli unmount_commands_try_fusermount3_then_fallbacks`
+Expected: PASS.
+
+- [ ] **Step 7: Add the subprocess e2e test (real SIGTERM unmount)**
+
+In `musefs/Cargo.toml`, add (the binary crate currently has no test deps):
+
+```toml
+[dev-dependencies]
+tempfile = "3"
+rustix = { version = "1", features = ["process"] }
+```
+
+Create `musefs/tests/sigterm_unmount.rs`:
+
+```rust
+//! End-to-end: the `musefs` binary unmounts cleanly when sent SIGTERM, via the
+//! CLI's fusermount3-based stop-signal handler. Ignored by default (needs
+//! /dev/fuse + fusermount3), like the other FUSE e2e tests.
+
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+// --- minimal proven FLAC fixture (mirrors musefs-fuse/tests/mount.rs) ---
+
+fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
+    let len = body.len();
+    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
+    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
+    out.push(u8::try_from(len & 0xFF).unwrap());
+    out.extend_from_slice(body);
+    out
+}
+
+fn streaminfo_body() -> Vec<u8> {
+    let mut b = vec![
+        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
+        0x00, 0x00, 0x00,
+    ];
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
+    out.extend_from_slice(vendor.as_bytes());
+    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
+    for c in comments {
+        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
+        out.extend_from_slice(c.as_bytes());
+    }
+    out
+}
+
+fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
+    out.extend_from_slice(audio);
+    out
+}
+
+fn wait_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    cond()
+}
+
+fn wait_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        match child.try_wait().unwrap() {
+            Some(status) => return Some(status),
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    }
+    None
+}
+
+#[test]
+#[ignore = "requires /dev/fuse + fusermount3; run with: cargo test -p musefs -- --ignored"]
+fn sigterm_unmounts_cleanly() {
+    let bin = env!("CARGO_BIN_EXE_musefs");
+
+    // Backing dir + on-disk DB scanned via the real binary.
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(
+        backing.path().join("a.flac"),
+        make_flac(&["ARTIST=Alice", "TITLE=Song"], &[0xAB; 64]),
+    )
+    .unwrap();
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = dbfile.path().to_str().unwrap();
+    let scan = Command::new(bin)
+        .args(["scan", backing.path().to_str().unwrap(), "--db", db])
+        .status()
+        .unwrap();
+    assert!(scan.success(), "scan failed");
+
+    // Mount as a child process.
+    let mp = tempfile::tempdir().unwrap();
+    let mut child = Command::new(bin)
+        .args(["mount", mp.path().to_str().unwrap(), "--db", db])
+        .spawn()
+        .unwrap();
+
+    let song = mp.path().join("Alice").join("Song.flac");
+    assert!(
+        wait_until(|| song.exists(), Duration::from_secs(15)),
+        "mount did not come up"
+    );
+
+    // Send SIGTERM and assert a clean exit + unmounted mountpoint.
+    let pid = rustix::process::Pid::from_child(&child);
+    rustix::process::kill_process(pid, rustix::process::Signal::TERM).unwrap();
+
+    let status = wait_exit(&mut child, Duration::from_secs(15))
+        .unwrap_or_else(|| panic!("daemon did not exit after SIGTERM"));
+    assert!(status.success(), "daemon exited non-zero: {status:?}");
+    assert!(
+        !song.exists(),
+        "mount still present after SIGTERM (stale endpoint)"
+    );
+}
+```
+
+- [ ] **Step 8: Verify the e2e test compiles and passes**
+
+Run (compile-check, ignored, runs by default in pre-commit only as a compile):
+```bash
+cargo test -p musefs --no-run
+cargo test -p musefs -- --ignored sigterm_unmounts_cleanly
+```
+Expected: first compiles clean; second PASSES (mounts, SIGTERM, clean unmount). If `rustix::process::Signal::TERM` or `Pid::from_child` differ in the installed rustix `1.x`, adjust to the actual API (`rustix::process::test_kill_process`/`Signal` variants) — confirm via `cargo doc -p rustix --open` and keep it `unsafe`-free.
+
+- [ ] **Step 9: Full gate + commit**
+
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo test --workspace        # ignored e2e is skipped here; must be green
+git add musefs-cli/Cargo.toml musefs-cli/src/signal.rs musefs-cli/src/lib.rs \
+        musefs/Cargo.toml musefs/tests/sigterm_unmount.rs Cargo.lock
+git commit -m "feat(cli): unmount cleanly on SIGTERM/SIGINT
+
+Install a CLI-only stop-signal handler that runs fusermount3 -u on the
+mountpoint, so Ctrl-C / systemctl stop / container stop unwind the blocking
+mount instead of leaving a stale FUSE endpoint. Kept out of the musefs-fuse
+library so it never hijacks signals for the e2e harness or embedders. Covered
+by a unit test for the command list and an --ignored subprocess e2e."
+```
+
+Expected: pre-commit passes (full suite green; ignored e2e compiled but not run).
+
+---
+
+## Task 3: Reusable in-tree smoke script
+
+**Files:**
+- Create: `scripts/smoke-binary.sh`
+
+POSIX `sh` so it runs under both bash (host) and busybox ash (Alpine). It scans an ffmpeg-generated FLAC, mounts the binary, reads the synthesized file, then SIGTERMs the daemon and asserts a clean unmount — exercising the real artifact and the Task 2 handler.
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/smoke-binary.sh`:
+
+```sh
+#!/bin/sh
+# Smoke-test a built musefs binary end-to-end: generate a tagged FLAC, scan it,
+# mount the binary, read the synthesized file through the mount, then SIGTERM the
+# daemon and assert the mount unmounts cleanly.
+#
+# POSIX sh (runs under bash and busybox ash). Requires on PATH: ffmpeg,
+# fusermount3 (fuse3 package), and /dev/fuse present.
+#
+# Usage: scripts/smoke-binary.sh /path/to/musefs
+set -eu
+
+MUSEFS="$1"
+WORK="$(mktemp -d)"
+cleanup() { fusermount3 -u "$WORK/mnt" 2>/dev/null || true; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "smoke: musefs = $MUSEFS"
+"$MUSEFS" --version
+
+mkdir -p "$WORK/backing" "$WORK/mnt"
+
+# 1s tagged FLAC fixture.
+ffmpeg -hide_banner -loglevel error -f lavfi -i "sine=frequency=440:duration=1" \
+  -metadata artist=Alice -metadata title=Song "$WORK/backing/a.flac"
+
+"$MUSEFS" scan "$WORK/backing" --db "$WORK/smoke.db"
+
+"$MUSEFS" mount "$WORK/mnt" --db "$WORK/smoke.db" &
+PID=$!
+
+SONG="$WORK/mnt/Alice/Song.flac"
+i=0
+while [ ! -f "$SONG" ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 30 ]; then echo "FAIL: mount did not come up"; exit 1; fi
+  sleep 1
+done
+
+# Served file must be a real, non-empty FLAC (magic 'fLaC').
+MAGIC="$(head -c 4 "$SONG")"
+if [ "$MAGIC" != "fLaC" ]; then echo "FAIL: served file is not FLAC (magic='$MAGIC')"; exit 1; fi
+BYTES="$(wc -c < "$SONG")"
+if [ "$BYTES" -le 0 ]; then echo "FAIL: served file is empty"; exit 1; fi
+echo "smoke: read $BYTES bytes from $SONG (fLaC OK)"
+
+# Exercise the SIGTERM graceful-unmount handler on the real binary.
+kill -TERM "$PID"
+i=0
+while kill -0 "$PID" 2>/dev/null; do
+  i=$((i + 1))
+  if [ "$i" -gt 30 ]; then echo "FAIL: daemon did not exit after SIGTERM"; exit 1; fi
+  sleep 1
+done
+wait "$PID" 2>/dev/null || true
+
+if [ -f "$SONG" ]; then echo "FAIL: mount still present after SIGTERM"; exit 1; fi
+echo "smoke: SIGTERM unmounted cleanly — PASS"
+```
+
+- [ ] **Step 2: Make it executable and run it against a local build**
+
+```bash
+chmod +x scripts/smoke-binary.sh
+# Needs ffmpeg + fuse3 locally; uses the binary from Task 0/Task 1.
+./scripts/smoke-binary.sh ./target/x86_64-unknown-linux-gnu/release/musefs
+```
+
+Expected output ends with `smoke: SIGTERM unmounted cleanly — PASS`. If `sleep 1` granularity feels slow locally that's fine — CI mounts come up in <1s.
+
+- [ ] **Step 3: Lint the script (best-effort) and commit**
+
+```bash
+command -v shellcheck >/dev/null && shellcheck scripts/smoke-binary.sh || echo "shellcheck not installed; skipping"
+git add scripts/smoke-binary.sh
+git commit -m "test: add reusable musefs binary smoke script
+
+POSIX-sh end-to-end smoke (generate FLAC, scan, mount, read, SIGTERM,
+assert clean unmount) reused by the release smoke jobs for all four targets."
+```
+
+---
+
+## Task 4: Release workflow — cross-build job
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+Add a `build` matrix job that cross-builds all four targets on amd64 via `cargo-zigbuild`, packages each as a `.tar.gz` (+ `.sha256`), and uploads them as workflow artifacts. The existing `publish` (crates.io) job is left untouched.
+
+- [ ] **Step 1: Resolve and pin the artifact-action SHAs**
+
+`upload-artifact`/`download-artifact` are new to this repo. Pin them to commit SHAs (the repo convention; the annotated-tag object SHA would fail at run time — use the commits endpoint):
+
+```bash
+gh api repos/actions/upload-artifact/commits/v4 --jq .sha
+gh api repos/actions/download-artifact/commits/v4 --jq .sha
+```
+
+Use the returned 40-char SHAs in place of `<UPLOAD_ARTIFACT_SHA>` / `<DOWNLOAD_ARTIFACT_SHA>` below (and in Task 5).
+
+- [ ] **Step 2: Add the `build` job**
+
+In `.github/workflows/release.yml`, keep `permissions: contents: read` at the top level. Add this job (sibling of `publish`). Replace `0.13.0` / `0.19.8` with the versions recorded in Task 0 Step 4:
+
+```yaml
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-gnu
+            zig_target: x86_64-unknown-linux-gnu.2.17
+          - triple: aarch64-unknown-linux-gnu
+            zig_target: aarch64-unknown-linux-gnu.2.17
+          - triple: x86_64-unknown-linux-musl
+            zig_target: x86_64-unknown-linux-musl
+          - triple: aarch64-unknown-linux-musl
+            zig_target: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          key: ${{ matrix.triple }}
+      - name: Install Zig and cargo-zigbuild
+        env:
+          ZIG_VERSION: "0.13.0"
+          CARGO_ZIGBUILD_VERSION: "0.19.8"
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar -xJ
+          echo "$PWD/zig-linux-x86_64-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          curl -fsSL "https://github.com/rust-cross/cargo-zigbuild/releases/download/v${CARGO_ZIGBUILD_VERSION}/cargo-zigbuild-v${CARGO_ZIGBUILD_VERSION}.x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz -C "$HOME/.cargo/bin" cargo-zigbuild
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.triple }}
+      - name: Build
+        run: cargo zigbuild --release -p musefs --target ${{ matrix.zig_target }}
+      - name: Package
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          NAME="musefs-${VERSION}-${{ matrix.triple }}"
+          mkdir -p dist
+          tar -C "target/${{ matrix.triple }}/release" -czf "dist/${NAME}.tar.gz" musefs
+          ( cd dist && sha256sum "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256" )
+          ls -l dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@<UPLOAD_ARTIFACT_SHA>
+        with:
+          name: musefs-${{ matrix.triple }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+```
+
+Note: `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` still emits to `target/x86_64-unknown-linux-gnu/release/musefs` (the glibc suffix doesn't change the output path), so the `Package` step uses the base `matrix.triple`.
+
+- [ ] **Step 3: Validate the workflow YAML**
+
+```bash
+command -v actionlint >/dev/null && actionlint .github/workflows/release.yml \
+  || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml')); print('yaml ok')"
+```
+
+Expected: no errors. (Full execution is only exercisable on a real `v*` tag — see Task 6 Step 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): cross-build four target binaries with cargo-zigbuild
+
+Build {glibc,musl} x {x86_64,aarch64} static/portable musefs binaries on the
+amd64 runner via cargo-zigbuild (Zig cross-links the bundled SQLite). glibc
+pinned to 2.17 for portability. Each target is packaged as a tar.gz + sha256
+and uploaded as a workflow artifact."
+```
+
+---
+
+## Task 5: Release workflow — smoke jobs
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+Add a `smoke` matrix job. Each target downloads its own artifact, extracts the `.tar.gz` (preserving the executable bit), and runs `scripts/smoke-binary.sh`. glibc targets run on the host; musl targets run inside an Alpine container via `docker run` (the binary executes under musl; checkout/download happen on the glibc host, avoiding the Node-on-Alpine problem).
+
+- [ ] **Step 1: Add the `smoke` job**
+
+Append to `.github/workflows/release.yml`:
+
+```yaml
+  smoke:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            mode: host
+          - triple: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            mode: host
+          - triple: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            mode: alpine
+          - triple: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            mode: alpine
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Download artifact
+        uses: actions/download-artifact@<DOWNLOAD_ARTIFACT_SHA>
+        with:
+          name: musefs-${{ matrix.triple }}
+          path: dist
+      - name: Extract binary
+        run: |
+          set -euo pipefail
+          tar -xzf dist/musefs-*-${{ matrix.triple }}.tar.gz -C .
+          ./musefs --version || true   # glibc/musl host may differ; real check is the smoke
+      - name: Smoke (host)
+        if: matrix.mode == 'host'
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y fuse3 ffmpeg
+          ./scripts/smoke-binary.sh ./musefs
+      - name: Smoke (Alpine container)
+        if: matrix.mode == 'alpine'
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+            -v "$PWD":/w -w /w \
+            alpine:3.20 \
+            sh -c 'apk add --no-cache fuse3 ffmpeg >/dev/null && sh scripts/smoke-binary.sh ./musefs'
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+```bash
+command -v actionlint >/dev/null && actionlint .github/workflows/release.yml \
+  || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml')); print('yaml ok')"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): real FUSE mount smoke for each target binary
+
+Each built artifact is smoke-tested on its native runner (amd64 on
+ubuntu-latest, aarch64 on ubuntu-24.04-arm). musl binaries run inside an Alpine
+container via docker run to prove they execute on musl; glibc binaries run on
+the host. The smoke generates a FLAC, mounts the binary, reads the synthesized
+file, and asserts SIGTERM unmounts cleanly."
+```
+
+---
+
+## Task 6: Release workflow — upload assets to the GitHub Release
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+Add a `release-assets` job gated on all four smokes; it downloads every artifact and uploads the tarballs + checksums to the tag's GitHub Release via `gh`. This job (and only this job) gets `contents: write`.
+
+- [ ] **Step 1: Add the `release-assets` job**
+
+Append to `.github/workflows/release.yml`:
+
+```yaml
+  release-assets:
+    needs: smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@<DOWNLOAD_ARTIFACT_SHA>
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ls -l dist
+          # Create the release for this tag if it doesn't exist yet, then upload
+          # (idempotent on re-run via --clobber).
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --verify-tag \
+              --title "$GITHUB_REF_NAME" \
+              --notes "Prebuilt binaries for ${GITHUB_REF_NAME}. Verify with: sha256sum -c <file>.sha256"
+          fi
+          gh release upload "$GITHUB_REF_NAME" dist/*.tar.gz dist/*.sha256 --clobber
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+```bash
+command -v actionlint >/dev/null && actionlint .github/workflows/release.yml \
+  || python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml')); print('yaml ok')"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): publish target binaries as GitHub Release assets
+
+Gated on all four smokes passing, a release-assets job (scoped contents:write)
+creates/updates the tag's GitHub Release and uploads the tarballs + sha256
+checksums via gh. The crates.io publish job is unchanged and independent."
+```
+
+- [ ] **Step 4: Document how to validate end-to-end (manual, externally visible — do NOT run without user sign-off)**
+
+The full pipeline only runs on a real `v*` tag. To validate safely without a real release, the maintainer can push a throwaway pre-release tag (e.g. `v0.0.0-rc-musl`) on a branch, watch `gh run watch`, confirm four green smokes + four uploaded assets, then delete the tag/release. Note this in the handoff; it is an externally visible action requiring user sign-off.
+
+---
+
+## Task 7: Document the prebuilt binaries in the README
+
+**Files:**
+- Modify: `README.md` (add a section before `## Requirements` at line 170; lightly correct the Requirements note)
+
+- [ ] **Step 1: Add a "Prebuilt binaries" section**
+
+In `README.md`, insert immediately before the `## Requirements` heading (currently line 170):
+
+```markdown
+## Prebuilt binaries
+
+Each tagged release attaches static/portable Linux binaries for four targets:
+
+| Target | libc | Notes |
+| --- | --- | --- |
+| `x86_64-unknown-linux-gnu`  | glibc | Pinned to glibc 2.17 — runs on essentially any current distro. |
+| `aarch64-unknown-linux-gnu` | glibc | glibc 2.17 floor, ARM64. |
+| `x86_64-unknown-linux-musl`  | musl | Fully static — runs on Alpine / scratch containers. |
+| `aarch64-unknown-linux-musl` | musl | Fully static, ARM64. |
+
+Download the tarball for your target from the
+[latest release](https://github.com/Sohex/musefs/releases/latest), verify it,
+and extract:
+
+```bash
+sha256sum -c musefs-<version>-<target>.tar.gz.sha256
+tar -xzf musefs-<version>-<target>.tar.gz   # yields ./musefs
+```
+
+**Runtime requirements:** the binaries mount via FUSE's `fusermount3` helper, so
+the target needs the FUSE userspace tools and `/dev/fuse`:
+
+- Debian/Ubuntu: `apt-get install fuse3`
+- Alpine: `apk add fuse3`
+
+No glibc/libfuse install is needed for the musl binaries beyond `fuse3`.
+```
+
+- [ ] **Step 2: Correct the Requirements wording**
+
+In `README.md`, change the Linux requirement bullet (currently line 173) from:
+
+```markdown
+- A supported OS with FUSE to mount — Linux (`/dev/fuse` + libfuse) or FreeBSD
+```
+
+to:
+
+```markdown
+- A supported OS with FUSE to mount — Linux (`/dev/fuse` + `fusermount3`, from
+  the `fuse3` package) or FreeBSD
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+# Sanity-check the markdown renders (no broken fences):
+grep -n "Prebuilt binaries" README.md
+git add README.md
+git commit -m "docs: document prebuilt release binaries and the fuse3 runtime requirement"
+```
+
+---
+
+## Task 8: Open the container-packaging follow-up issue (externally visible — confirm first)
+
+**Files:** none (creates a GitHub issue).
+
+Per the spec, container images / Alpine APK packaging are deferred. Open a short, problem-description-only issue (matching the repo's issue style: no proposed implementation, no schema, no open questions).
+
+- [ ] **Step 1: Confirm with the user, then create the issue**
+
+This is externally visible — get explicit sign-off before running:
+
+```bash
+gh issue create \
+  --title "Publish container images for musefs" \
+  --body "The release pipeline now ships standalone glibc and musl binaries for x86_64 and aarch64, but there is no official container image. Users running musefs alongside containerized media managers (e.g. Lidarr on Alpine) currently have to build their own image or install the binary into one by hand. Official multi-arch container images (glibc and musl based) would let those users pull and run musefs directly."
+```
+
+Expected: prints the new issue URL. Record it in the handoff.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Drop/keep libfuse explicit on both fuser crates → Task 1. ✅
+- `[profile.release] strip` → Task 1. ✅
+- SIGTERM/SIGINT graceful unmount via external `fusermount3 -u`, CLI-only, `signal-hook`, `--ignored` e2e → Task 2. ✅
+- `cargo-zigbuild`, four targets, glibc 2.17 pin, packaging + sha256 two-column → Tasks 0, 4. ✅
+- All-four local de-risk milestone first → Task 0. ✅
+- Real mount smoke on native amd64/arm64 runners; musl inside Alpine; cross-built artifact is the smoked artifact → Tasks 3, 5. ✅
+- GitHub Release upload via `gh`, `contents: write` scoped to one job, no new third-party action unpinned → Task 6 (artifact actions pinned via Task 4 Step 1). ✅
+- README musl/Alpine + portability + fuse3 runtime note → Task 7. ✅
+- Container packaging follow-up issue → Task 8. ✅
+- Optional CI `libfuse3-dev` cleanup → intentionally left out (spec marked it optional/harmless).
+
+**Placeholder scan:** The only intentionally-unresolved tokens are `<UPLOAD_ARTIFACT_SHA>` / `<DOWNLOAD_ARTIFACT_SHA>` (resolved by the exact `gh api` commands in Task 4 Step 1) and the `ZIG_VERSION` / `CARGO_ZIGBUILD_VERSION` values (resolved by Task 0 and carried forward). These are concrete resolve-then-fill steps, not vague placeholders.
+
+**Type/name consistency:** `unmount_commands` / `run_unmount` / `install_unmount_on_signal` are defined in Task 2 Step 3 and used in Steps 1/5/6; the smoke script name `scripts/smoke-binary.sh` and the artifact name pattern `musefs-${triple}` / `musefs-<version>-<triple>.tar.gz` are consistent across Tasks 3–7. Matrix `triple`/`zig_target`/`runner`/`mode` keys match between Tasks 4 and 5.
+
+**Residual risks (carried from spec):** `aarch64-unknown-linux-musl` bundled-SQLite cross-compile (gated by Task 0); Alpine `docker run --device /dev/fuse` mount capability on GH runners (Task 5 — if a cell can't mount, downgrade that cell to `--version` only with a logged note, never a silent skip); `ubuntu-24.04-arm` runner-label availability (confirm at Task 5 implementation).

--- a/docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md
+++ b/docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md
@@ -1,0 +1,214 @@
+# musl + glibc release binaries — design
+
+**Date:** 2026-06-09
+**Status:** Approved (pending implementation plan)
+
+## Problem
+
+musefs ships no downloadable binary today — `release.yml` only publishes crates
+to crates.io. Users on Alpine / musl-based systems cannot run a glibc binary
+(observed during the Lidarr smoke test: the glibc `musefs` binary would not run
+on Alpine). We want portable, downloadable binaries for the common Linux
+targets, built and verified on every release tag.
+
+## Goal
+
+On every `v*` tag, publish four downloadable, portable binaries as GitHub
+Release assets, each verified by a real FUSE mount smoke test:
+
+| libc  | x86_64 | aarch64 |
+| ----- | ------ | ------- |
+| glibc | ✅     | ✅      |
+| musl  | ✅     | ✅      |
+
+Triples: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
+`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`.
+
+## Non-goals (explicitly deferred)
+
+- Container images / Alpine APK packaging — tracked in a separate follow-up
+  issue. Not in this work.
+- Windows / FreeBSD / macOS binary artifacts.
+- A standalone CI build/test gate for musl outside the release flow. The release
+  build is the only musl build for now; between releases musl can break
+  silently. (If desired later, the matrix job can be reused in `ci.yml`.)
+
+## Source changes
+
+### Drop the `libfuse` feature
+
+`musefs-fuse/Cargo.toml`:
+
+```toml
+fuser = { version = "0.17", default-features = false }
+```
+
+The macOS target dependency keeps its existing `macos-no-mount` feature.
+
+**Why this is safe / transparent:**
+
+- musefs already mounts through `fusermount3` (see the handshake comment at
+  `musefs-fuse/src/lib.rs:507`), not a privileged libfuse syscall path.
+- musefs uses **no** `MountOption::AutoUnmount` anywhere (only `RO`, `FSName`,
+  and macOS-only `volname`/`noappledouble` customs — see
+  `musefs-fuse/src/platform/mount.rs`). `AutoUnmount` is the only fuser feature
+  that *requires* `libfuse`.
+- A static musl binary cannot easily link libfuse3 (C). The non-libfuse fuser
+  path shells out to the `fusermount3` binary at runtime, giving a fully static
+  binary with no functional loss on Linux.
+
+**Consequence:** dropping `libfuse` loses nothing musefs currently has, but
+permanently forecloses adding `MountOption::AutoUnmount` (the mechanism that
+cleans up a stale mount after a hard `SIGKILL`/segfault, and only on glibc
+anyway). We replace that gap with a portable signal handler (below).
+
+### Graceful unmount on SIGTERM/SIGINT
+
+Today the blocking mount path (`mount_with` → `new_session` →
+`session.spawn()` → `bg.join()` in `musefs-fuse/src/lib.rs`) installs no signal
+handler. On SIGINT/SIGTERM the process dies without running
+`BackgroundSession::Drop`, leaving a stale mount (`Transport endpoint is not
+connected`) until manual `fusermount3 -u`. This is true today even with
+libfuse linked.
+
+Add a SIGTERM/SIGINT handler that triggers a graceful session unmount before
+exit. This covers the realistic lifecycle cases — Ctrl-C, `systemctl stop`, and
+container / Lidarr stop all send SIGTERM — leaving only `SIGKILL`/segfault to
+manual recovery (same as today). Works identically on glibc and musl; no
+`libfuse` needed.
+
+**Approach:**
+
+- The workspace denies `unsafe_code`, so raw `libc::sigaction` is out. Use the
+  `signal-hook` crate for safe signal handling (new dependency, likely in
+  `musefs-fuse`; the exact crate boundary is an implementation detail for the
+  plan).
+- Obtain an unmount handle from the fuser session (fuser exposes a session
+  unmounter / `unmount_callable`-style handle). Restructure the blocking mount
+  entry so a signal-handler thread can call the unmounter, causing `bg.join()`
+  to return and the process to exit cleanly with the mount removed.
+- `musefs-cli` / the `musefs` binary stay thin; cross-cutting mount logic lives
+  in `musefs-fuse` per the workspace layering.
+
+## Build: `cargo-zigbuild`
+
+Build all four targets from a single amd64 host using `cargo-zigbuild`, which
+uses Zig as the cross-linker and C compiler. Zig compiles the bundled SQLite
+(`rusqlite` with `bundled`) for every target without Docker or per-target host
+toolchains.
+
+- Install Zig (e.g. `mlugg/setup-zig`) and `cargo-zigbuild`.
+- `rustup target add` the four triples.
+- Build: `cargo zigbuild --release -p musefs --target <triple>`.
+- **glibc portability:** pin glibc with the zigbuild target suffix (e.g.
+  `x86_64-unknown-linux-gnu.2.17`) so glibc binaries run on older
+  distributions. Pick a conservative, widely-available glibc version in the
+  plan.
+- **musl:** static by default — no extra flags.
+- Strip the release binaries.
+
+### Packaging
+
+Each target produces:
+
+- `musefs-<version>-<triple>.tar.gz` (the stripped binary)
+- `musefs-<version>-<triple>.tar.gz.sha256`
+
+`<version>` is the workspace version (already verified to match the tag by the
+existing `release.yml` step).
+
+## Smoke test: real FUSE mount, both arches
+
+The smoke exercises the **built binary** (not `cargo test`) and performs a real
+FUSE mount, on native runners — no qemu in CI.
+
+- **amd64** smokes run on `ubuntu-latest`.
+- **aarch64** smokes run on `ubuntu-24.04-arm` (free native arm64 hosted
+  runners for public repos — musefs is public/MIT). Real FUSE mounting already
+  works on GitHub Linux runners (the existing `musefs-fuse -- --ignored` e2e job
+  relies on it).
+- **musl** smokes run **inside an Alpine container** on the matching runner
+  (`apk add fuse3`, container needs `--device /dev/fuse --cap-add SYS_ADMIN`,
+  and `--security-opt apparmor:unconfined` if required). This proves the static
+  binary actually runs on Alpine — the original failure mode.
+- **glibc** smokes run directly on the runner (`apt-get install fuse3`).
+
+**Each smoke must, end-to-end:**
+
+1. Install the FUSE runtime (`fuse3` / `fusermount3`).
+2. Prepare a minimal backing fixture and scan it into a DB using the built
+   `musefs` binary (the exact fixture-generation approach — reuse of existing
+   test fixtures or ffmpeg-generated audio — is a plan detail; the existing e2e
+   job installs ffmpeg for this purpose).
+3. Mount the built binary at a temp mountpoint.
+4. Read at least one synthesized file through the mount and verify its bytes
+   (assert the central invariant holds for at least one format).
+5. Unmount cleanly.
+
+This is four smokes total (one per target) across two physical runner types.
+
+**Asset upload is gated on all four smokes passing.**
+
+There are four binaries but only two runner architectures; if a real mount
+proves infeasible inside the Alpine container in CI for a given arch, fall back
+to a `--version` smoke for that cell and **log the downgrade explicitly** rather
+than silently skipping (no silent coverage gaps).
+
+## Release workflow changes (`release.yml`)
+
+Current state: a single `publish` job installs libfuse3, verifies the tag
+matches the workspace version, and publishes crates to crates.io. It creates
+**no** GitHub Release.
+
+Add, alongside the unchanged `publish` job:
+
+1. **`build` matrix job** (4 targets) on amd64 — runs `cargo-zigbuild`, packages
+   tarballs + checksums, uploads them as workflow artifacts.
+2. **`smoke` jobs** — per target, on the matching runner / container, consuming
+   the build artifacts and running the real mount smoke above.
+3. **`release-assets` job** — depends on all smokes passing; downloads the
+   artifacts and creates/updates the GitHub Release for the tag, uploading the
+   tarballs + `.sha256` files via the **`gh` CLI** (`gh release create` /
+   `gh release upload`). Using `gh` avoids adding a third-party action that
+   would need SHA-pinning.
+
+**Permissions:** the `release-assets` job needs `permissions: contents: write`
+(scoped to that job; the rest of the workflow keeps `contents: read`). Any new
+third-party action that *is* added must be SHA-pinned to its commit (per the
+repo's action-pinning convention and the annotated-tag trap previously hit in
+CI).
+
+The crates.io `publish` job stays independent and may run in parallel; a binary
+smoke failure must not have published broken binaries, but crate publishing is a
+separate concern.
+
+## Validation & docs
+
+- **First implementation step:** confirm the workspace builds for
+  `x86_64-unknown-linux-musl` locally before wiring CI, to de-risk the
+  `fuser`/bundled-SQLite changes. (Local environment can run heavy Rust
+  tooling.)
+- **README:** add a musl / Alpine + portability note — the static binaries, the
+  runtime requirement of `fusermount3` / `fuse3` and `/dev/fuse`, and which
+  artifact to pick.
+- **Separate follow-up issue:** container images / Alpine APK packaging. Short,
+  problem-description-only, per repo issue conventions.
+
+## Risks / open items for the plan
+
+- **fuser without `libfuse` actually mounts:** validate a real mount works with
+  `default-features = false` on a normal glibc dev box before trusting it in the
+  release flow (the local first-step build/mount check covers this).
+- **Signal-handler wiring:** exact crate boundary (`musefs-fuse` vs
+  `musefs-cli`) and how the unmounter handle is threaded through the blocking
+  mount path. Must keep the pre-commit gate green (full workspace test suite),
+  so the change needs accompanying tests where feasible.
+- **glibc pin version:** choose a conservative glibc (e.g. 2.17 / 2.28) balancing
+  portability against bundled-SQLite/`cc` requirements.
+- **Alpine container FUSE in CI:** confirm `--device /dev/fuse --cap-add
+  SYS_ADMIN` is sufficient on GitHub runners; document the fallback if a real
+  mount can't run for an arch.
+- **Pre-commit hook:** runs fmt, clippy `-D warnings`, the full workspace test
+  suite, and ruff — each commit must be green; the `fuzz/` crate is outside the
+  workspace and a format-layer signature change could break it (not expected
+  here, but the fuser change touches `musefs-fuse` only).

--- a/docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md
+++ b/docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md
@@ -119,8 +119,40 @@ against the vendored source):
 
 So the handler instead runs the external **`fusermount3 -u <mountpoint>`** (the
 same command fuser's own pure-rust unmount path uses), falling back to
-`umount <mountpoint>`. Unmounting EOFs the `/dev/fuse` channel, the background
-session's worker returns, and `bg.join()` unblocks — clean exit, mount removed.
+`fusermount -u` then `umount`. Unmounting EOFs the `/dev/fuse` channel, the
+background session's worker returns, and `bg.join()` unblocks — clean exit,
+mount removed.
+
+The external-command design has a second, more durable justification than "the
+fuser API forces it": the handler thread **never touches core state** — not the
+slab, DB connections, or session locks. Pool workers and `poll_refresh` hold
+those guards; a handler that tried to manipulate session state from the signal
+thread could deadlock against an in-flight read. Shelling out and letting the
+kernel drive the unmount sidesteps that entirely.
+
+**Bounded exit (the unmount can fail or stall — don't hang past it):**
+
+A plain `fusermount3 -u` returns `EBUSY` when the mount is busy, and for a
+wedged backing store (dead NFS, a spun-down disk) an in-flight read may never
+drain — so the unmount does not free the channel and `bg.join()` would block
+indefinitely. Because installing the handler *replaces* SIGTERM's default
+"terminate immediately" disposition, an unbounded handler would be **worse than
+none** in that case: the process lingers until the init system's SIGKILL
+(systemd's default `TimeoutStopSec` is 90s). So the handler is bounded:
+
+1. First signal: attempt the unmount chain (errors are logged and **swallowed** —
+   the goal is exit, not unmount success; the mount may already be gone via a
+   manual `fusermount3 -u` or an `ENOTCONN` dead endpoint).
+2. If the blocking mount hasn't returned within a grace window (`GRACE`, 5s),
+   escalate to a lazy detach (`fusermount3 -u -z`, `MNT_DETACH`) and
+   `std::process::exit` — never wait on a join that may never come.
+3. **Second** SIGTERM/SIGINT while step 1–2 is in flight: hard-exit immediately
+   (`exit(130)`) — the operator/init system wants out now; "Ctrl-C twice does
+   nothing" is a real daemon footgun.
+
+On the happy path the unmount EOFs `/dev/fuse`, `bg.join()` returns, and `main`
+exits on its own well before `GRACE` (the handler thread is torn down with the
+process), so the escalation is invisible.
 
 **Placement and constraints:**
 
@@ -138,11 +170,15 @@ session's worker returns, and `bg.join()` unblocks — clean exit, mount removed
 **Test strategy (must land as a single green commit — the pre-commit hook runs
 the full workspace suite):**
 
-- An `--ignored` e2e test (in `musefs-fuse` tests or `musefs-cli`, gated on
-  `/dev/fuse` like the existing FUSE e2e): mount via the binary / a helper that
-  installs the handler, send `SIGTERM` to it, then assert the mountpoint is no
-  longer a FUSE mount (clean, not `ENOTCONN`). This exercises the real
+- An `--ignored` e2e test (gated on `/dev/fuse` like the existing FUSE e2e):
+  mount the real binary as a child, send `SIGTERM`, then assert it exited
+  cleanly and the mountpoint is no longer a FUSE mount. This exercises the real
   `fusermount3 -u` path.
+- A second `--ignored` e2e for the **bounded-exit** guarantee: hold an open fd
+  on a file inside the mount so a non-lazy unmount fails `EBUSY` (a
+  deterministic stand-in for the wedged-backing-store case), send `SIGTERM`, and
+  assert the daemon still exits within a bound (≈`GRACE`) via the lazy-detach +
+  forced-exit escalation — rather than hanging until SIGKILL.
 - Non-ignored unit coverage where feasible (e.g. the handler wiring / unmount
   command construction is unit-testable without an actual mount).
 - The default (non-ignored) suite must stay green without `/dev/fuse`, so the
@@ -164,9 +200,13 @@ toolchains.
   glibc binaries run on essentially any current distro. The local de-risking
   build (below) must confirm bundled SQLite compiles against this floor.
 - **musl:** static by default — no extra flags.
-- **Strip:** add `strip = true` to `[profile.release]` in the workspace
-  `Cargo.toml` (applies workspace-wide; acceptable). Avoids relying on a
-  zigbuild-specific strip flag.
+- **Strip:** add `strip = "debuginfo"` to `[profile.release]` in the workspace
+  `Cargo.toml`. Use `"debuginfo"` rather than `true`/`"symbols"`: it drops the
+  bulk of the size (debug info) but **keeps the symbol table**, so field panic
+  backtraces stay symbolicated. This profile also governs local `cargo build
+  --release` debugging builds, so a bus-factor-one maintainer keeps actionable
+  backtraces. (Panic *messages* print regardless of stripping; only backtrace
+  symbolication is at stake.)
 
 ### Packaging
 

--- a/docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md
+++ b/docs/superpowers/specs/2026-06-09-musl-glibc-release-binaries-design.md
@@ -35,32 +35,57 @@ Triples: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
 
 ## Source changes
 
-### Drop the `libfuse` feature
+### Keep `libfuse` disabled (it already is) and make that explicit
 
-`musefs-fuse/Cargo.toml`:
+**Important correction:** `fuser 0.17` has `default = []` (no default features),
+and its `build.rs` selects the pure-rust mount path on Linux whenever
+`not(feature = "libfuse")` (verified in the vendored
+`fuser-0.17.0/build.rs:11-15`). So the current `fuser = "0.17"` dependency
+**already** uses the `fusermount3` shell-out path and **does not link libfuse**.
+musl static linking already would not pull libfuse. There is no libfuse link to
+"remove."
+
+The change is therefore about *intent and future-proofing*, not switching off a
+link:
 
 ```toml
-fuser = { version = "0.17", default-features = false }
+# musefs-fuse/Cargo.toml and musefs-latencyfs/Cargo.toml
+fuser = { version = "0.17", default-features = false }  # pure-rust fusermount3; never enable `libfuse` (static musl can't link it)
 ```
 
-The macOS target dependency keeps its existing `macos-no-mount` feature.
+`default-features = false` is currently a no-op (the default set is empty) but
+guards against a future fuser release adding `libfuse` to its defaults. The
+macOS target dependency keeps its existing `macos-no-mount` feature.
 
-**Why this is safe / transparent:**
+- **`musefs-latencyfs` also depends on `fuser`** (`musefs-latencyfs/Cargo.toml:11`).
+  Cargo unifies features across the workspace, so for the "never link libfuse"
+  intent to hold for any `cargo build`/`clippy --all-targets`, both crates carry
+  `default-features = false`. (The release artifact itself is built `-p musefs`,
+  which does not pull `musefs-latencyfs`, but the explicit flag keeps the whole
+  workspace consistent.)
+
+**Why musl works without libfuse:**
 
 - musefs already mounts through `fusermount3` (see the handshake comment at
   `musefs-fuse/src/lib.rs:507`), not a privileged libfuse syscall path.
 - musefs uses **no** `MountOption::AutoUnmount` anywhere (only `RO`, `FSName`,
   and macOS-only `volname`/`noappledouble` customs — see
   `musefs-fuse/src/platform/mount.rs`). `AutoUnmount` is the only fuser feature
-  that *requires* `libfuse`.
-- A static musl binary cannot easily link libfuse3 (C). The non-libfuse fuser
-  path shells out to the `fusermount3` binary at runtime, giving a fully static
-  binary with no functional loss on Linux.
+  that *requires* `libfuse` to be linked — which we deliberately don't enable,
+  on any target.
 
-**Consequence:** dropping `libfuse` loses nothing musefs currently has, but
-permanently forecloses adding `MountOption::AutoUnmount` (the mechanism that
-cleans up a stale mount after a hard `SIGKILL`/segfault, and only on glibc
-anyway). We replace that gap with a portable signal handler (below).
+**Consequence:** `AutoUnmount` was never available to musefs (it would require
+enabling `libfuse`, which breaks static musl) and is not in use today. The
+mechanism that would clean up a stale mount after a hard `SIGKILL`/segfault is
+therefore unavailable by design; we cover the realistic lifecycle cases with a
+portable signal handler (below). A hard `SIGKILL`/segfault still leaks a mount —
+same as today.
+
+**Optional CI cleanup (not required):** `release.yml`/`ci.yml` install
+`libfuse3-dev` (dev headers, unused since nothing links libfuse) alongside
+`fuse3` (which provides the required `fusermount3` runtime). The `libfuse3-dev`
+install could be dropped, keeping only `fuse3`. The plan may do this or leave it;
+it is harmless either way.
 
 ### Graceful unmount on SIGTERM/SIGINT
 
@@ -71,24 +96,57 @@ handler. On SIGINT/SIGTERM the process dies without running
 connected`) until manual `fusermount3 -u`. This is true today even with
 libfuse linked.
 
-Add a SIGTERM/SIGINT handler that triggers a graceful session unmount before
-exit. This covers the realistic lifecycle cases — Ctrl-C, `systemctl stop`, and
-container / Lidarr stop all send SIGTERM — leaving only `SIGKILL`/segfault to
-manual recovery (same as today). Works identically on glibc and musl; no
-`libfuse` needed.
+Add a SIGTERM/SIGINT handler that triggers a graceful unmount before exit. This
+covers the realistic lifecycle cases — Ctrl-C, `systemctl stop`, and container /
+Lidarr stop all send SIGTERM — leaving only `SIGKILL`/segfault to manual
+recovery (same as today). Works identically on glibc and musl; no `libfuse`
+needed.
 
-**Approach:**
+**Mechanism: external `fusermount3 -u`, not a fuser unmounter handle.**
 
+The obvious approach — hold a fuser `SessionUnmounter` and call it from the
+handler thread — **does not work** with fuser 0.17's public API (verified
+against the vendored source):
+
+- `Session::spawn()` does `std::mem::take` on the shared `Mount`
+  (`fuser-0.17.0/src/session.rs:226`), moving it into the returned
+  `BackgroundSession`. A `SessionUnmounter` obtained before `spawn()` then reads
+  `None` and unmounts nothing.
+- `BackgroundSession` exposes no non-consuming unmount handle (only
+  `join(self)` / `umount_and_join(self)`, both consuming), and the blocking
+  `Session::run()` is `pub(crate)`. The only public blocking-mount shape is the
+  `spawn()` + `bg.join()` musefs already uses.
+
+So the handler instead runs the external **`fusermount3 -u <mountpoint>`** (the
+same command fuser's own pure-rust unmount path uses), falling back to
+`umount <mountpoint>`. Unmounting EOFs the `/dev/fuse` channel, the background
+session's worker returns, and `bg.join()` unblocks — clean exit, mount removed.
+
+**Placement and constraints:**
+
+- The handler is installed in the **CLI's blocking mount path**
+  (`musefs-cli::run_mount` / the `musefs` binary), **not** in the
+  `musefs-fuse` library functions (`mount_with` / `spawn_with`). A library
+  function must not install a process-global signal handler — it would hijack
+  signals for the in-process FUSE e2e harness and any embedder. `musefs-fuse`
+  stays a pure library; `run_mount` already has the `mountpoint` the handler
+  needs.
 - The workspace denies `unsafe_code`, so raw `libc::sigaction` is out. Use the
-  `signal-hook` crate for safe signal handling (new dependency, likely in
-  `musefs-fuse`; the exact crate boundary is an implementation detail for the
-  plan).
-- Obtain an unmount handle from the fuser session (fuser exposes a session
-  unmounter / `unmount_callable`-style handle). Restructure the blocking mount
-  entry so a signal-handler thread can call the unmounter, causing `bg.join()`
-  to return and the process to exit cleanly with the mount removed.
-- `musefs-cli` / the `musefs` binary stay thin; cross-cutting mount logic lives
-  in `musefs-fuse` per the workspace layering.
+  `signal-hook` crate (e.g. `signal_hook::iterator::Signals` on a dedicated
+  thread) for safe SIGTERM/SIGINT handling. New dependency in `musefs-cli`.
+
+**Test strategy (must land as a single green commit — the pre-commit hook runs
+the full workspace suite):**
+
+- An `--ignored` e2e test (in `musefs-fuse` tests or `musefs-cli`, gated on
+  `/dev/fuse` like the existing FUSE e2e): mount via the binary / a helper that
+  installs the handler, send `SIGTERM` to it, then assert the mountpoint is no
+  longer a FUSE mount (clean, not `ENOTCONN`). This exercises the real
+  `fusermount3 -u` path.
+- Non-ignored unit coverage where feasible (e.g. the handler wiring / unmount
+  command construction is unit-testable without an actual mount).
+- The default (non-ignored) suite must stay green without `/dev/fuse`, so the
+  signal-path e2e is `--ignored`, consistent with the rest of the FUSE e2e.
 
 ## Build: `cargo-zigbuild`
 
@@ -100,12 +158,15 @@ toolchains.
 - Install Zig (e.g. `mlugg/setup-zig`) and `cargo-zigbuild`.
 - `rustup target add` the four triples.
 - Build: `cargo zigbuild --release -p musefs --target <triple>`.
-- **glibc portability:** pin glibc with the zigbuild target suffix (e.g.
-  `x86_64-unknown-linux-gnu.2.17`) so glibc binaries run on older
-  distributions. Pick a conservative, widely-available glibc version in the
-  plan.
+- **glibc portability:** pin glibc to **2.17** via the zigbuild target suffix
+  (`x86_64-unknown-linux-gnu.2.17`, `aarch64-unknown-linux-gnu.2.17`). 2.17 is
+  the manylinux2014 floor (CentOS 7-era) and zigbuild's well-trodden default, so
+  glibc binaries run on essentially any current distro. The local de-risking
+  build (below) must confirm bundled SQLite compiles against this floor.
 - **musl:** static by default — no extra flags.
-- Strip the release binaries.
+- **Strip:** add `strip = true` to `[profile.release]` in the workspace
+  `Cargo.toml` (applies workspace-wide; acceptable). Avoids relying on a
+  zigbuild-specific strip flag.
 
 ### Packaging
 
@@ -115,7 +176,9 @@ Each target produces:
 - `musefs-<version>-<triple>.tar.gz.sha256`
 
 `<version>` is the workspace version (already verified to match the tag by the
-existing `release.yml` step).
+existing `release.yml` step). The `.sha256` is written in `sha256sum`
+two-column format (`<hash>␠␠<filename>`) so users can verify with
+`sha256sum -c <file>.sha256`; the README instructions must match.
 
 ## Smoke test: real FUSE mount, both arches
 
@@ -146,6 +209,10 @@ FUSE mount, on native runners — no qemu in CI.
 5. Unmount cleanly.
 
 This is four smokes total (one per target) across two physical runner types.
+The aarch64 binaries are **cross-built on the amd64 host** and the **exact
+artifact** is downloaded and smoked on the arm64 runner — no rebuild on arm.
+That is the whole point of cross-building; the plan must not re-run `cargo
+zigbuild` on the arm runner.
 
 **Asset upload is gated on all four smokes passing.**
 
@@ -184,10 +251,13 @@ separate concern.
 
 ## Validation & docs
 
-- **First implementation step:** confirm the workspace builds for
-  `x86_64-unknown-linux-musl` locally before wiring CI, to de-risk the
-  `fuser`/bundled-SQLite changes. (Local environment can run heavy Rust
-  tooling.)
+- **First implementation milestone (de-risk before any CI wiring):** locally,
+  via `cargo-zigbuild`, build + strip + *run* the binary for **all four
+  targets**, with special attention to `aarch64-unknown-linux-musl` (bundled
+  SQLite C cross-compile is the highest build risk) and the glibc-2.17 pin.
+  Confirm a real `fusermount3` mount works with the pure-rust fuser path on a
+  normal glibc dev box. Only proceed to CI once all four build and the mount
+  works. (Local environment can run heavy Rust tooling.)
 - **README:** add a musl / Alpine + portability note — the static binaries, the
   runtime requirement of `fusermount3` / `fuse3` and `/dev/fuse`, and which
   artifact to pick.
@@ -196,19 +266,31 @@ separate concern.
 
 ## Risks / open items for the plan
 
-- **fuser without `libfuse` actually mounts:** validate a real mount works with
-  `default-features = false` on a normal glibc dev box before trusting it in the
-  release flow (the local first-step build/mount check covers this).
-- **Signal-handler wiring:** exact crate boundary (`musefs-fuse` vs
-  `musefs-cli`) and how the unmounter handle is threaded through the blocking
-  mount path. Must keep the pre-commit gate green (full workspace test suite),
-  so the change needs accompanying tests where feasible.
-- **glibc pin version:** choose a conservative glibc (e.g. 2.17 / 2.28) balancing
-  portability against bundled-SQLite/`cc` requirements.
-- **Alpine container FUSE in CI:** confirm `--device /dev/fuse --cap-add
-  SYS_ADMIN` is sufficient on GitHub runners; document the fallback if a real
-  mount can't run for an arch.
-- **Pre-commit hook:** runs fmt, clippy `-D warnings`, the full workspace test
-  suite, and ruff — each commit must be green; the `fuzz/` crate is outside the
-  workspace and a format-layer signature change could break it (not expected
-  here, but the fuser change touches `musefs-fuse` only).
+Highest first. The top two are the reasons the first milestone is "build all four
+locally before any CI."
+
+- **`aarch64-unknown-linux-musl` + bundled SQLite via zigbuild** is the single
+  highest build risk (cross-compiled C). De-risked by the local all-four build
+  milestone; if it proves intractable, that one cell is the candidate to drop
+  with an explicit logged note (not a silent skip).
+- **Alpine container FUSE in CI:** the existing e2e mounts directly on the
+  runner, not in a container — mounting inside Alpine (`--device /dev/fuse
+  --cap-add SYS_ADMIN`, possibly `--security-opt apparmor:unconfined`) is a new,
+  untested capability here. Fallback is the logged `--version`-only smoke per the
+  smoke-test section.
+- **Native arm64 runner label:** `ubuntu-24.04-arm` is free for public repos as
+  of the cutoff and musefs is public/MIT, but treat the label as a value to
+  confirm at implementation time, not a guarantee.
+- **Signal-handler e2e as a single green commit:** the unmount-on-SIGTERM test
+  is `--ignored` (needs `/dev/fuse`), so the default suite the pre-commit hook
+  runs stays green; verify the handler wiring lands with its tests in one commit
+  (red-test intermediate commits are rejected by the hook).
+- **Pre-commit hook** runs fmt, clippy `-D warnings`, the full workspace test
+  suite, and ruff — each commit must be green. The `fuser` dependency change
+  touches `musefs-fuse` and `musefs-latencyfs` only; the `fuzz/` crate is outside
+  the workspace and unaffected (no format-layer signature change here).
+
+**Decided (previously open):** build tool (`cargo-zigbuild`); glibc floor
+(2.17); strip (`[profile.release] strip = true`); checksum format (`sha256sum`
+two-column); signal-handler mechanism (external `fusermount3 -u`, installed in
+the CLI path, not the library).

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 musefs-db = { path = "../musefs-db", version = "0.2.0" }
 musefs-core = { path = "../musefs-core", version = "0.2.0" }
 musefs-fuse = { path = "../musefs-fuse", version = "0.2.0" }
+signal-hook = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -9,6 +9,8 @@ use clap::{Parser, Subcommand};
 use musefs_core::{MountConfig, Musefs};
 use musefs_db::Db;
 
+mod signal;
+
 /// Mount content mode (CLI surface for `musefs_core::Mode`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum CliMode {
@@ -188,6 +190,8 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
     let (config, fuse_config) = parse_mount_config(args);
     let core = Musefs::open(db, config).context("building the virtual filesystem")?;
+    signal::install_unmount_on_signal(args.mountpoint.clone())
+        .context("installing the stop-signal unmount handler")?;
     musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
         .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
     Ok(())

--- a/musefs-cli/src/signal.rs
+++ b/musefs-cli/src/signal.rs
@@ -97,11 +97,17 @@ pub fn install_unmount_on_signal(mountpoint: PathBuf) -> std::io::Result<()> {
                 }
                 graceful_started = true;
                 // Drive the bounded unmount on its own thread so this loop stays
-                // responsive to that second signal.
+                // responsive to that second signal. If the thread can't be
+                // spawned (resource exhaustion), unmount inline rather than
+                // swallow the signal and leave the mount up.
                 let mp = mountpoint.clone();
-                let _ = std::thread::Builder::new()
+                if let Err(e) = std::thread::Builder::new()
                     .name("musefs-unmount".into())
-                    .spawn(move || graceful_unmount_then_exit(&mp));
+                    .spawn(move || graceful_unmount_then_exit(&mp))
+                {
+                    eprintln!("musefs: could not spawn unmount thread ({e}); unmounting inline");
+                    graceful_unmount_then_exit(&mountpoint);
+                }
             }
         })?;
     Ok(())

--- a/musefs-cli/src/signal.rs
+++ b/musefs-cli/src/signal.rs
@@ -1,0 +1,72 @@
+//! CLI-only graceful unmount on stop signals. Installed by `run_mount`; never
+//! in the `musefs-fuse` library (which must not hijack process signals).
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Unmount commands tried in order, most-preferred first, as `(program, args)`.
+/// `fusermount3`/`fusermount` are the unprivileged FUSE unmount tools; `umount`
+/// is the last resort.
+fn unmount_commands(mountpoint: &Path) -> Vec<(&'static str, Vec<OsString>)> {
+    let mp = mountpoint.as_os_str().to_owned();
+    vec![
+        ("fusermount3", vec!["-u".into(), mp.clone()]),
+        ("fusermount", vec!["-u".into(), mp.clone()]),
+        ("umount", vec![mp]),
+    ]
+}
+
+/// Try each unmount command until one succeeds. Best-effort: a stop signal must
+/// never panic the process.
+fn run_unmount(mountpoint: &Path) {
+    for (prog, args) in unmount_commands(mountpoint) {
+        if let Ok(status) = std::process::Command::new(prog).args(&args).status()
+            && status.success()
+        {
+            return;
+        }
+    }
+    eprintln!(
+        "musefs: could not unmount {} after stop signal; run `fusermount3 -u {}` manually",
+        mountpoint.display(),
+        mountpoint.display()
+    );
+}
+
+/// Spawn a thread that unmounts `mountpoint` on the first SIGTERM/SIGINT, so a
+/// `Ctrl-C` / `systemctl stop` / container stop unwinds the blocking mount
+/// cleanly instead of leaving a stale FUSE endpoint. CLI-only.
+pub fn install_unmount_on_signal(mountpoint: PathBuf) -> std::io::Result<()> {
+    use signal_hook::consts::{SIGINT, SIGTERM};
+    use signal_hook::iterator::Signals;
+
+    let mut signals = Signals::new([SIGINT, SIGTERM])?;
+    std::thread::Builder::new()
+        .name("musefs-unmount-on-signal".into())
+        .spawn(move || {
+            if signals.forever().next().is_some() {
+                run_unmount(&mountpoint);
+            }
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    #[test]
+    fn unmount_commands_try_fusermount3_then_fallbacks() {
+        let cmds = unmount_commands(Path::new("/mnt/x"));
+        let progs: Vec<&str> = cmds.iter().map(|(p, _)| *p).collect();
+        assert_eq!(progs, ["fusermount3", "fusermount", "umount"]);
+        // fusermount variants pass `-u <mp>`; umount passes just `<mp>`.
+        assert_eq!(
+            cmds[0].1,
+            vec![OsString::from("-u"), OsString::from("/mnt/x")]
+        );
+        assert_eq!(cmds[2].1, vec![OsString::from("/mnt/x")]);
+    }
+}

--- a/musefs-cli/src/signal.rs
+++ b/musefs-cli/src/signal.rs
@@ -1,8 +1,29 @@
 //! CLI-only graceful unmount on stop signals. Installed by `run_mount`; never
 //! in the `musefs-fuse` library (which must not hijack process signals).
+//!
+//! The handler shells out to `fusermount3 -u` from a dedicated thread and never
+//! touches core state — the slab, DB connections, or session locks. That is the
+//! durable reason for the external-command design (beyond fuser 0.17 not
+//! exposing a usable in-process unmounter): it cannot deadlock against an
+//! in-flight read or a `poll_refresh` worker that holds those guards, because
+//! the kernel drives the unmount, not us.
+//!
+//! Exit is *bounded*. A plain `fusermount3 -u` fails `EBUSY` (or, for a wedged
+//! backing store — dead NFS, a spun-down disk — never lets the in-flight read
+//! drain) when the mount is busy, so the blocking mount would not return. If the
+//! unmount has not let it return within [`GRACE`], the handler escalates to a
+//! lazy detach and hard-exits, so a stuck backing store cannot make us outlast
+//! the init system's stop-timeout escalation (systemd's default
+//! `TimeoutStopSec` is 90s).
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Window allowed for a clean unmount to let the blocking mount return before we
+/// escalate to a lazy detach + forced exit. Comfortably under systemd's default
+/// `TimeoutStopSec` (90s) so we exit well before it would SIGKILL us.
+const GRACE: Duration = Duration::from_secs(5);
 
 /// Unmount commands tried in order, most-preferred first, as `(program, args)`.
 /// `fusermount3`/`fusermount` are the unprivileged FUSE unmount tools; `umount`
@@ -16,8 +37,10 @@ fn unmount_commands(mountpoint: &Path) -> Vec<(&'static str, Vec<OsString>)> {
     ]
 }
 
-/// Try each unmount command until one succeeds. Best-effort: a stop signal must
-/// never panic the process.
+/// Try each unmount command until one succeeds. Errors are logged and swallowed:
+/// the goal is a bounded exit, not unmount success — the mount may already be
+/// gone (a manual `fusermount3 -u`, or an `ENOTCONN` dead endpoint), in which
+/// case every command "fails" and that is fine.
 fn run_unmount(mountpoint: &Path) {
     for (prog, args) in unmount_commands(mountpoint) {
         if let Ok(status) = std::process::Command::new(prog).args(&args).status()
@@ -27,15 +50,36 @@ fn run_unmount(mountpoint: &Path) {
         }
     }
     eprintln!(
-        "musefs: could not unmount {} after stop signal; run `fusermount3 -u {}` manually",
-        mountpoint.display(),
+        "musefs: could not unmount {} after stop signal; detaching lazily and exiting",
         mountpoint.display()
     );
 }
 
-/// Spawn a thread that unmounts `mountpoint` on the first SIGTERM/SIGINT, so a
-/// `Ctrl-C` / `systemctl stop` / container stop unwinds the blocking mount
-/// cleanly instead of leaving a stale FUSE endpoint. CLI-only.
+/// Best-effort lazy detach (`fusermount3 -u -z`, i.e. `MNT_DETACH`): drops the
+/// mountpoint from the namespace even while it is busy. The escalation step
+/// before a forced exit.
+fn lazy_detach(mountpoint: &Path) {
+    let _ = std::process::Command::new("fusermount3")
+        .args([OsStr::new("-u"), OsStr::new("-z"), mountpoint.as_os_str()])
+        .status();
+}
+
+/// First stop signal: attempt a clean unmount, then guarantee a bounded exit.
+/// On the happy path the unmount EOFs `/dev/fuse`, the blocking mount returns,
+/// and `main` exits on its own before [`GRACE`] elapses (this thread is torn
+/// down with the process). If the mount is busy/wedged, we escalate and
+/// hard-exit instead of waiting on a join that may never come.
+fn graceful_unmount_then_exit(mountpoint: &Path) -> ! {
+    run_unmount(mountpoint);
+    std::thread::sleep(GRACE);
+    lazy_detach(mountpoint);
+    std::process::exit(0);
+}
+
+/// Spawn a thread that, on the first SIGTERM/SIGINT, unmounts `mountpoint` with
+/// a bounded graceful sequence (so `Ctrl-C` / `systemctl stop` / container stop
+/// unwinds the blocking mount cleanly), and hard-exits on a second signal — the
+/// operator/init system wants out now. CLI-only.
 pub fn install_unmount_on_signal(mountpoint: PathBuf) -> std::io::Result<()> {
     use signal_hook::consts::{SIGINT, SIGTERM};
     use signal_hook::iterator::Signals;
@@ -44,8 +88,20 @@ pub fn install_unmount_on_signal(mountpoint: PathBuf) -> std::io::Result<()> {
     std::thread::Builder::new()
         .name("musefs-unmount-on-signal".into())
         .spawn(move || {
-            if signals.forever().next().is_some() {
-                run_unmount(&mountpoint);
+            let mut graceful_started = false;
+            for _signal in signals.forever() {
+                if graceful_started {
+                    // Second stop signal while the first unmount is still in
+                    // flight: don't wait on anything, leave now.
+                    std::process::exit(130);
+                }
+                graceful_started = true;
+                // Drive the bounded unmount on its own thread so this loop stays
+                // responsive to that second signal.
+                let mp = mountpoint.clone();
+                let _ = std::thread::Builder::new()
+                    .name("musefs-unmount".into())
+                    .spawn(move || graceful_unmount_then_exit(&mp));
             }
         })?;
     Ok(())

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -10,7 +10,8 @@ repository.workspace = true
 metrics = ["musefs-core/metrics"]
 
 [dependencies]
-fuser = "0.17"
+# Pure-rust fusermount3 mount path; never enable `libfuse` (static musl can't link it).
+fuser = { version = "0.17", default-features = false }
 libc = "0.2"
 log = "0.4"
 rustix = { version = "1", features = ["process"] }

--- a/musefs-latencyfs/Cargo.toml
+++ b/musefs-latencyfs/Cargo.toml
@@ -8,7 +8,8 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-fuser = "0.17"
+# Pure-rust fusermount3 mount path; never enable `libfuse` (keeps workspace feature unification consistent).
+fuser = { version = "0.17", default-features = false }
 libc = "0.2"
 rustix = { version = "1", features = ["process", "fs"] }
 tempfile = "3"

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -18,5 +18,9 @@ clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 musefs-cli = { path = "../musefs-cli", version = "0.2.0" }
 
+[dev-dependencies]
+tempfile = "3"
+rustix = { version = "1", features = ["process"] }
+
 [lints]
 workspace = true

--- a/musefs/tests/sigterm_unmount.rs
+++ b/musefs/tests/sigterm_unmount.rs
@@ -1,0 +1,117 @@
+//! End-to-end: the `musefs` binary unmounts cleanly when sent SIGTERM, via the
+//! CLI's fusermount3-based stop-signal handler. Ignored by default (needs
+//! /dev/fuse + fusermount3), like the other FUSE e2e tests.
+
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+// --- minimal proven FLAC fixture (mirrors musefs-fuse/tests/mount.rs) ---
+
+fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
+    let len = body.len();
+    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
+    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
+    out.push(u8::try_from(len & 0xFF).unwrap());
+    out.extend_from_slice(body);
+    out
+}
+
+fn streaminfo_body() -> Vec<u8> {
+    let mut b = vec![
+        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
+        0x00, 0x00, 0x00,
+    ];
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
+    out.extend_from_slice(vendor.as_bytes());
+    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
+    for c in comments {
+        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
+        out.extend_from_slice(c.as_bytes());
+    }
+    out
+}
+
+fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
+    out.extend_from_slice(audio);
+    out
+}
+
+fn wait_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    cond()
+}
+
+fn wait_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        match child.try_wait().unwrap() {
+            Some(status) => return Some(status),
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    }
+    None
+}
+
+#[test]
+#[ignore = "requires /dev/fuse + fusermount3; run with: cargo test -p musefs -- --ignored"]
+fn sigterm_unmounts_cleanly() {
+    let bin = env!("CARGO_BIN_EXE_musefs");
+
+    // Backing dir + on-disk DB scanned via the real binary.
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(
+        backing.path().join("a.flac"),
+        make_flac(&["ARTIST=Alice", "TITLE=Song"], &[0xAB; 64]),
+    )
+    .unwrap();
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = dbfile.path().to_str().unwrap();
+    let scan = Command::new(bin)
+        .args(["scan", backing.path().to_str().unwrap(), "--db", db])
+        .status()
+        .unwrap();
+    assert!(scan.success(), "scan failed");
+
+    // Mount as a child process.
+    let mp = tempfile::tempdir().unwrap();
+    let mut child = Command::new(bin)
+        .args(["mount", mp.path().to_str().unwrap(), "--db", db])
+        .spawn()
+        .unwrap();
+
+    let song = mp.path().join("Alice").join("Song.flac");
+    assert!(
+        wait_until(|| song.exists(), Duration::from_secs(15)),
+        "mount did not come up"
+    );
+
+    // Send SIGTERM and assert a clean exit + unmounted mountpoint.
+    let pid = rustix::process::Pid::from_child(&child);
+    rustix::process::kill_process(pid, rustix::process::Signal::TERM).unwrap();
+
+    let status = wait_exit(&mut child, Duration::from_secs(15))
+        .unwrap_or_else(|| panic!("daemon did not exit after SIGTERM"));
+    assert!(status.success(), "daemon exited non-zero: {status:?}");
+    assert!(
+        !song.exists(),
+        "mount still present after SIGTERM (stale endpoint)"
+    );
+}

--- a/musefs/tests/sigterm_unmount.rs
+++ b/musefs/tests/sigterm_unmount.rs
@@ -115,3 +115,60 @@ fn sigterm_unmounts_cleanly() {
         "mount still present after SIGTERM (stale endpoint)"
     );
 }
+
+#[test]
+#[ignore = "requires /dev/fuse + fusermount3; run with: cargo test -p musefs -- --ignored"]
+fn sigterm_exits_bounded_when_mount_is_busy() {
+    let bin = env!("CARGO_BIN_EXE_musefs");
+
+    // Backing dir + on-disk DB scanned via the real binary.
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(
+        backing.path().join("a.flac"),
+        make_flac(&["ARTIST=Alice", "TITLE=Song"], &[0xAB; 64]),
+    )
+    .unwrap();
+    let dbfile = tempfile::NamedTempFile::new().unwrap();
+    let db = dbfile.path().to_str().unwrap();
+    let scan = Command::new(bin)
+        .args(["scan", backing.path().to_str().unwrap(), "--db", db])
+        .status()
+        .unwrap();
+    assert!(scan.success(), "scan failed");
+
+    // Mount as a child process.
+    let mp = tempfile::tempdir().unwrap();
+    let mut child = Command::new(bin)
+        .args(["mount", mp.path().to_str().unwrap(), "--db", db])
+        .spawn()
+        .unwrap();
+
+    let song = mp.path().join("Alice").join("Song.flac");
+    assert!(
+        wait_until(|| song.exists(), Duration::from_secs(15)),
+        "mount did not come up"
+    );
+
+    // Hold an open fd on a file inside the mount: a non-lazy `fusermount3 -u`
+    // now fails EBUSY, so the daemon's normal unmount can't free the FUSE
+    // channel and it must fall back to lazy-detach + forced exit. This stands in
+    // — deterministically — for the real-world "in-flight read against a wedged
+    // backing store at SIGTERM" case, which is the same code path (unmount can't
+    // let the blocking mount return).
+    let busy = std::fs::File::open(&song).unwrap();
+
+    let pid = rustix::process::Pid::from_child(&child);
+    rustix::process::kill_process(pid, rustix::process::Signal::TERM).unwrap();
+
+    // The daemon must still exit within a bound (the handler's GRACE is 5s)
+    // rather than hanging until the init system's SIGKILL.
+    let status = wait_exit(&mut child, Duration::from_secs(20))
+        .unwrap_or_else(|| panic!("daemon hung on SIGTERM with the mount busy"));
+    assert!(status.success(), "daemon exited non-zero: {status:?}");
+
+    // Release the fd and best-effort clean up the lazily-detached mountpoint.
+    drop(busy);
+    let _ = Command::new("fusermount3")
+        .args(["-u", "-z", mp.path().to_str().unwrap()])
+        .status();
+}

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Smoke-test a built musefs binary end-to-end: generate a tagged FLAC, scan it,
+# mount the binary, read the synthesized file through the mount, then SIGTERM the
+# daemon and assert the mount unmounts cleanly.
+#
+# POSIX sh (runs under bash and busybox ash). Requires on PATH: ffmpeg,
+# fusermount3 (fuse3 package), and /dev/fuse present.
+#
+# Usage: scripts/smoke-binary.sh /path/to/musefs
+set -eu
+
+if [ $# -lt 1 ]; then echo "Usage: $0 /path/to/musefs"; exit 1; fi
+
+MUSEFS="$1"
+WORK="$(mktemp -d)"
+cleanup() { fusermount3 -u "$WORK/mnt" 2>/dev/null || true; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "smoke: musefs = $MUSEFS"
+
+# Validate the binary actually runs before doing any FUSE work.
+if ! "$MUSEFS" scan --help >/dev/null 2>&1; then
+  echo "FAIL: $MUSEFS did not run"; exit 1
+fi
+
+mkdir -p "$WORK/backing" "$WORK/mnt"
+
+# 1s tagged FLAC fixture.
+ffmpeg -hide_banner -loglevel error -f lavfi -i "sine=frequency=440:duration=1" \
+  -metadata artist=Alice -metadata title=Song "$WORK/backing/a.flac"
+
+"$MUSEFS" scan "$WORK/backing" --db "$WORK/smoke.db"
+
+"$MUSEFS" mount "$WORK/mnt" --db "$WORK/smoke.db" &
+PID=$!
+
+SONG="$WORK/mnt/Alice/Song.flac"
+i=0
+while [ ! -f "$SONG" ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 30 ]; then echo "FAIL: mount did not come up"; exit 1; fi
+  sleep 1
+done
+
+# Served file must be a real, non-empty FLAC (magic 'fLaC').
+MAGIC="$(head -c 4 "$SONG")"
+if [ "$MAGIC" != "fLaC" ]; then echo "FAIL: served file is not FLAC (magic='$MAGIC')"; exit 1; fi
+BYTES="$(wc -c < "$SONG")"
+if [ "$BYTES" -le 0 ]; then echo "FAIL: served file is empty"; exit 1; fi
+echo "smoke: read $BYTES bytes from $SONG (fLaC OK)"
+
+# Exercise the SIGTERM graceful-unmount handler on the real binary.
+kill -TERM "$PID"
+i=0
+while kill -0 "$PID" 2>/dev/null; do
+  i=$((i + 1))
+  if [ "$i" -gt 30 ]; then echo "FAIL: daemon did not exit after SIGTERM"; exit 1; fi
+  sleep 1
+done
+wait "$PID" 2>/dev/null || true
+
+if [ -f "$SONG" ]; then echo "FAIL: mount still present after SIGTERM"; exit 1; fi
+echo "smoke: SIGTERM unmounted cleanly — PASS"


### PR DESCRIPTION
## What

Publishes four downloadable, portable Linux binaries on every `v*` tag —
`{glibc, musl} × {x86_64, aarch64}` — each verified by a real FUSE mount smoke,
and gives the CLI a bounded graceful-unmount on stop signals. Container images
are deferred to #198.

Motivation: an Alpine/musl host couldn't run the glibc binary (surfaced during
the Lidarr smoke test); there was previously no binary release at all
(`release.yml` only published crates to crates.io).

## Targets

| Target | libc | smoke |
| --- | --- | --- |
| `x86_64-unknown-linux-gnu` (glibc 2.17 floor) | glibc | host, `ubuntu-latest` |
| `aarch64-unknown-linux-gnu` (glibc 2.17 floor) | glibc | host, `ubuntu-24.04-arm` |
| `x86_64-unknown-linux-musl` (static) | musl | Alpine container, `ubuntu-latest` |
| `aarch64-unknown-linux-musl` (static) | musl | Alpine container, `ubuntu-24.04-arm` |

## Changes

**Source**
- `fuser` → `default-features = false` on `musefs-fuse` and `musefs-latencyfs`.
  fuser 0.17 already uses the pure-rust `fusermount3` path on Linux (no libfuse
  linked today); this makes the intent explicit and future-proofs static musl
  against a future fuser default change.
- New CLI-only stop-signal handler (`musefs-cli/src/signal.rs`): on SIGTERM/SIGINT
  it unmounts via external `fusermount3 -u` (chosen over a fuser `SessionUnmounter`,
  which is unusable after `spawn()`, and because the handler thread never touches
  the slab/DB/session locks so it can't deadlock against in-flight reads).
  **Exit is bounded:** if the mount is busy/wedged it escalates to a lazy detach
  (`fusermount3 -u -z`) and `std::process::exit` after a 5s grace window rather
  than hanging until the init system's SIGKILL; a second signal hard-exits
  immediately.
- `[profile.release] strip = "debuginfo"` (keeps the symbol table so field panic
  backtraces stay symbolicated; still drops the bulk of the size).

**CI (`release.yml`)**
- `build` matrix: cross-builds all four targets on amd64 via `cargo-zigbuild`
  (Zig cross-links the bundled SQLite C); packages `tar.gz` + `sha256sum`.
- `smoke` matrix: real FUSE mount on native runners (musl inside an Alpine
  `docker run --device /dev/fuse`); reads a synthesized file and exercises the
  SIGTERM handler on the actual artifact.
- `release-assets`: gated on all four smokes, uploads to the GitHub Release via
  `gh` (`contents: write` scoped to that job). The crates.io `publish` job is
  unchanged and independent.

**Docs**
- README "Prebuilt binaries" section + corrected `fuse3`/`fusermount3` runtime
  note. Design spec and implementation plan under `docs/superpowers/`.

## Verification (local)

- All four targets build via `cargo-zigbuild`, including the high-risk
  `aarch64-musl` + bundled SQLite.
- `scripts/smoke-binary.sh` passes end-to-end against a freshly built static
  `x86_64-musl` binary (mount → read → SIGTERM clean unmount).
- `--ignored` e2e: clean SIGTERM unmount **and** bounded exit when the mount is
  busy (open-fd `EBUSY` stand-in for a wedged backing store) both pass.
- Existing FUSE mount e2e still green with the no-libfuse change.

## Not exercised until a tag

The `release.yml` jobs only run on a `v*` tag, so the GitHub-Actions specifics
(`ubuntu-24.04-arm` runners, `docker run --device /dev/fuse`, `gh release upload`)
are unproven in CI; local builds + smokes retire most of the risk. A throwaway
pre-release tag can dry-run the pipeline if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release pipeline publishes prebuilt static Linux binaries (glibc/musl × x86_64/aarch64), uploads archives and SHA256 checksums, and runs smoke validations.
  * CLI performs graceful shutdown on SIGINT/SIGTERM to enable clean unmounts.

* **Documentation**
  * Added “Prebuilt binaries” usage/verification and updated Linux FUSE runtime requirements; added design/plan docs.

* **Tests**
  * End-to-end SIGTERM unmount integration tests and a POSIX smoke-test script added.

* **Chores**
  * Release builds strip debug info; unmount path moved to pure-Rust configuration; CI coverage action updated; test helper dev-deps added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->