### PR TITLE
Mutant-anchor drift guard + re-anchor 12 drifted exclusions

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -33,6 +33,13 @@ exclude_globs = [
 # results, or live in unreachable defensive branches). Documented per class.
 # Anchored on file:line:col so only the proven-equivalent sites are suppressed;
 # killable siblings (e.g. flac `|`->`&`, scan 871 `+`->`*`) stay in scope.
+#
+# Every entry carries a machine-checked `# guard:` tag on the line directly above
+# it (`op=`/`fn=`/`rows=` for file:line:col anchors, `count=` for multi-site
+# description anchors). scripts/check_mutant_anchors.py re-validates them against
+# the live mutant set in CI so a `cargo fmt` line shift can't silently re-point an
+# anchor onto a killable mutant. See CONTRIBUTING.md "Mutation testing" before
+# editing; run the guard locally after any change here.
 exclude_re = [
     # musefs-format's sanctioned u64->usize helper: replacing its body with a
     # constant (`-> 0` / `-> 1`) is a MACHINE-KILLER, not an equivalent mutant.

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -108,7 +108,7 @@ exclude_re = [
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `replace += with` and
     # `>=`/`||` repeat in run_pipeline (e.g. the killable `*scanned += 1` at
-    # 691), so these cannot be safely description-anchored. Re-verify these
+    # 712), so these cannot be safely description-anchored. Re-verify these
     # coordinates after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
     'musefs-core/src/scan\.rs:734:29:',

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -72,11 +72,13 @@ exclude_re = [
     # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
+    # guard: op="+" fn="probe_file" rows=2
     'musefs-core/src/scan\.rs:270:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
+    # guard: op="<" fn="probe_file" rows=3
     'musefs-core/src/scan\.rs:277:30:',
     # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
@@ -84,16 +86,19 @@ exclude_re = [
     # or `locate_audio_at_ceiling` rejects it on the same off+len>file_len bound
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
+    # guard: op=">" fn="probe_file" rows=3
     'musefs-core/src/scan\.rs:288:21:',
     # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
+    # guard: op=">" fn="probe_file" rows=3
     'musefs-core/src/scan\.rs:293:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
-    'musefs-core/src/scan\.rs:620:46:',
+    # guard: op="*" fn="run_pipeline" rows=2
+    'musefs-core/src/scan\.rs:641:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -105,23 +110,34 @@ exclude_re = [
     # `>=`/`||` repeat in run_pipeline (e.g. the killable `*scanned += 1` at
     # 691), so these cannot be safely description-anchored. Re-verify these
     # coordinates after any change that reformats scan.rs.
-    'musefs-core/src/scan\.rs:713:29:',
-    'musefs-core/src/scan\.rs:715:32:',
-    'musefs-core/src/scan\.rs:715:47:',
-    'musefs-core/src/scan\.rs:715:62:',
-    'musefs-core/src/scan\.rs:723:37:',
-    'musefs-core/src/scan\.rs:725:40:',
-    'musefs-core/src/scan\.rs:725:55:',
-    'musefs-core/src/scan\.rs:725:70:',
+    # guard: op="+=" fn="run_pipeline" rows=2
+    'musefs-core/src/scan\.rs:734:29:',
+    # guard: op=">=" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:736:32:',
+    # guard: op="||" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:736:47:',
+    # guard: op=">=" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:736:62:',
+    # guard: op="+=" fn="run_pipeline" rows=2
+    'musefs-core/src/scan\.rs:744:37:',
+    # guard: op=">=" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:746:40:',
+    # guard: op="||" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:746:55:',
+    # guard: op=">=" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:746:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
     # from a deterministic test. With skip_failed identically 0, the `failed =
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
-    'musefs-core/src/scan\.rs:829:25:',
-    'musefs-core/src/scan\.rs:833:25:',
-    'musefs-core/src/scan\.rs:869:29: replace \+ with -',
+    # guard: op="+=" fn="revalidate_with" rows=2
+    'musefs-core/src/scan\.rs:850:25:',
+    # guard: op="+=" fn="revalidate_with" rows=2
+    'musefs-core/src/scan\.rs:854:25:',
+    # guard: op="+" fn="revalidate_with" rows=1
+    'musefs-core/src/scan\.rs:890:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are
@@ -133,6 +149,7 @@ exclude_re = [
     # so the operands are bit-disjoint and `|`/`^` agree for every input (same
     # equivalence class as classify_binary_frame above). Description-anchored so
     # `cargo fmt` line drift can't silently retire it.
+    # guard: count=3
     'replace \| with \^ in synchsafe_decode',
     # fuzz_check fixtures::flac_block header byte
     # `(if is_last { 0x80 } else { 0 }) | (block_type & 0x7F)` -> `^`: the right
@@ -192,6 +209,7 @@ exclude_re = [
     # 0 disables the short-circuit (falls to the scan, also correct). So the served
     # output is byte-identical either way. (`+`->`-` underflows and is caught.) Pinned
     # by line:col — one of several `+` in this fn; the others ARE caught.
+    # guard: op="+" fn="serve_ogg_window" rows=1
     'musefs-core/src/ogg_index\.rs:205:41: replace \+ with \* in serve_ogg_window',
 
     # SP4 crc_shift_zeros — equivalent mutants inherent to the loop/matrix hybrid.
@@ -235,7 +253,9 @@ exclude_re = [
     # byte-identical proptest_read_fidelity pass with both mutations applied). They
     # were reported TIMEOUT under the parallel gate's load, not as a real hang. Pinned
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
+    # guard: op="<" fn="serve_ogg_window" rows=1
     'musefs-core/src/ogg_index\.rs:216:15: replace < with <= in serve_ogg_window',
+    # guard: op="<" fn="serve_ogg_window" rows=1
     'musefs-core/src/ogg_index\.rs:225:15: replace < with <= in serve_ogg_window',
 
     # Phase 4 poll_due (#89) — equivalent `<`->`<=` on the two wall-clock gates
@@ -250,7 +270,9 @@ exclude_re = [
     # once the edition-2024 let-chain reformat pulled the refresh_retry_backoff
     # gate into a diff. The `<`->`>`/`==` variants ARE caught and stay in scope;
     # anchored on operator+function since both `<` in each fn are this class.
+    # guard: count=2
     'musefs-core/src/facade\.rs:\d+:\d+: replace < with <= in Musefs::poll_due',
+    # guard: count=2
     'replace < with <= in Musefs::poll_refresh_notify',
 
     # CACHE_ESTIMATED_ITEMS const arithmetic — equivalent mutant. This is the
@@ -261,6 +283,7 @@ exclude_re = [
     # quick_cache accepts any usize. (cargo-mutants DOES mutate const
     # initializers — the equivalence rests on unobservability, not on the
     # const being out of reach.)
+    # guard: op="/" fn="" rows=2
     'musefs-core/src/reader\.rs:71:60: replace / with [%*]',
 
     # wav walk_chunks advance guard `next <= buf.len() as u64` -> `true`: forcing
@@ -281,6 +304,7 @@ exclude_re = [
     # So any value the mutated sum produces is unobservable through the format API the
     # in-diff gate builds. The two `+` in fixtures::wav are this one expression; both
     # `+` elsewhere are absent (`samples.len() * 2` is `*`), so description-anchored.
+    # guard: count=2
     'replace \+ with \* in fixtures::wav',
 
     # truncate_bytes char-boundary back-off loop `while end > 0 && ...`, `>`->`>=`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
         run: python -m pytest contrib/python-musefs/tests -v
       - name: Test bump script
         run: python -m pytest scripts/test_bump_python_version.py -v
+      - name: Test mutant-anchor guard
+        run: python -m pytest scripts/test_check_mutant_anchors.py -v
 
   beets:
     needs: changes

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -75,6 +75,10 @@ jobs:
         # Unpinned (like fuzz.yml installs cargo-fuzz) for toolchain-compat;
         # known-good version is 27.0.0 (documented in scripts/mutants.sh).
         run: cargo install cargo-mutants
+      - name: Check mutant-exclusion anchors
+        run: |
+          cargo mutants --no-config --list --json > mutants-list.json
+          python3 scripts/check_mutant_anchors.py --mutants-json mutants-list.json
       - name: Build the merge-base diff
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -7,6 +7,10 @@ on:
       - 'musefs-core/**'
       - 'musefs-format/**'
       - 'scripts/mutants.sh'
+      # The anchor guard validates these against the live mutant set, so a PR that
+      # only touches the exclusion config or the guard itself must still run it.
+      - '.cargo/mutants.toml'
+      - 'scripts/check_mutant_anchors.py'
       - '.github/workflows/mutants.yml'
   schedule:
     - cron: '0 4 * * 1'  # Mondays 04:00 UTC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,43 @@ Sharp edges:
   `.cargo/mutants.toml`, not test contortions. Note that cargo-mutants
   mutates `const` initializer expressions too — a constant is not a hiding
   place for arithmetic the gate flags.
+- **`exclude_re` entries are guarded against drift.** A few exclusions must
+  pin a specific `file:line:col:` (the operator+function alone isn't unique in
+  the function); those coordinates rot silently when `cargo fmt` shifts the
+  code, and a stale anchor can re-point onto a *killable* mutant — a silent
+  false pass. `scripts/check_mutant_anchors.py` prevents that: it lists the
+  full unfiltered mutant set (`cargo mutants --no-config --list --json`) and
+  re-validates every `exclude_re` entry. It runs in the per-PR `in-diff` job
+  (`.github/workflows/mutants.yml`) and its unit tests run in CI's
+  `python-musefs` job. Run it locally with:
+
+  ```bash
+  cargo mutants --no-config --list --json > /tmp/mutants-list.json
+  python3 scripts/check_mutant_anchors.py --mutants-json /tmp/mutants-list.json
+  ```
+
+  Each entry carries a machine-checked `# guard:` comment on the line directly
+  above it:
+  - **`file:line:col` anchors** — `# guard: op="<" fn="probe_file" rows=3`. The
+    guard asserts the matched mutants all share that operator and function,
+    occupy one site, and number exactly `rows` (use `fn=""` for a const-level
+    site with no enclosing function). A *narrowing* entry (one that embeds a
+    replacement to leave same-site siblings killable) sets `rows` to that
+    subset's size.
+  - **description anchors** — `# guard: count=N` (default 1) asserts the entry
+    matches mutants spanning exactly `N` distinct sites; this is what catches a
+    newly-added killable sibling silently joining the match set. A bare
+    single-site description entry needs no tag.
+
+  When the guard fails: a `found none` message means a line:col anchor drifted
+  — re-anchor it to the current coordinates from the listing **and re-confirm
+  the mutant there is still genuinely equivalent** (a reformat can change
+  surrounding logic, not just line numbers). A `count`/`rows` mismatch means a
+  sibling appeared or disappeared — investigate before bumping the number.
+  Every new `file:line:col` exclusion needs a `# guard:` tag (the guard rejects
+  an untagged one), and `exclude_re` patterns must stay within the
+  Rust-regex/Python-`re` shared subset the guard allows (`\. \d + | ^ ( ) *`,
+  no inline `(?...)` groups).
 
 ### Coverage
 

--- a/docs/superpowers/plans/2026-06-09-mutant-anchor-drift-guard.md
+++ b/docs/superpowers/plans/2026-06-09-mutant-anchor-drift-guard.md
@@ -1,0 +1,1076 @@
+# Mutant-anchor Drift Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a CI guard that validates every `.cargo/mutants.toml` `exclude_re` entry still suppresses exactly the mutant(s) it documents, and re-anchor the 12 entries that have already silently drifted to zero matches.
+
+**Architecture:** A stdlib-only Python script (`scripts/check_mutant_anchors.py`) runs `cargo mutants --no-config --list --json` to get the full *unfiltered* mutant set, replays each `exclude_re` pattern itself, and checks it against a machine-readable `# guard:` tag in the toml comment. Line:col entries are checked by operator+function+row-count; description entries by distinct-site count. The guard runs in the `in-diff` job of `mutants.yml`; its pure-logic core is unit-tested in ci.yml's `python-musefs` job.
+
+**Tech Stack:** Python 3 (stdlib `re`, `json`, `subprocess`, `argparse`, `dataclasses`, `fnmatch`), pytest, ruff; cargo-mutants 27.0.0; GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-mutant-anchor-drift-guard-design.md`
+
+---
+
+## Background the engineer needs
+
+A cargo-mutants mutant is named `<file>:<line>:<col>: replace <op> with <repl> in <fn>` (the ` in <fn>` suffix is absent for const-level mutants). cargo-mutants emits **one mutant per (site, replacement)** — a single `<` site yields three rows (`< with ==`, `< with >`, `< with <=`). `exclude_re` patterns in `.cargo/mutants.toml` are matched (unanchored) against that name string.
+
+Two anchoring styles exist, auto-detected from the regex:
+- **line:col** — the regex contains literal digits `:NNN:CC:` (e.g. `scan\.rs:277:30:`). Fragile to `cargo fmt`.
+- **description** — line-agnostic (`replace | with ^ in synchsafe_decode`, or a `:\d+:\d+:` prefix). Survives reformat.
+
+The guard gets the unfiltered set with `cargo mutants --no-config --list --json` (`--no-config` ignores `.cargo/mutants.toml` entirely, so excluded mutants reappear and can be validated).
+
+## File structure
+
+- **Create** `scripts/check_mutant_anchors.py` — the guard. One file: pure-logic functions (`parse_mutant`, `parse_guard_tag`, `parse_toml_entries`, `classify`, `validate_regex_subset`, `check`) plus a thin `main()` that shells out to cargo. No third-party imports.
+- **Create** `scripts/test_check_mutant_anchors.py` — pytest unit tests over synthetic fixtures (no cargo invocation), mirroring `scripts/test_bump_python_version.py`.
+- **Modify** `.cargo/mutants.toml` — re-anchor 12 drifted entries; add `# guard:` tags to all line:col entries and the 4 multi-site description entries.
+- **Modify** `.github/workflows/mutants.yml` — add a guard step to the `in-diff` job.
+- **Modify** `.github/workflows/ci.yml` — add a pytest step to the `python-musefs` job.
+
+## Conventions
+
+- The pre-commit hook runs `cargo fmt`, `clippy -D warnings`, the **full Rust workspace test suite**, and `ruff` over the Python paths. It does **not** run pytest. So every commit must keep Rust green (these changes don't touch Rust, so it stays green) and every Python file must be **ruff-clean** (`ruff check scripts/` and `ruff format --check scripts/`).
+- Run pytest manually during TDD: `python -m pytest scripts/test_check_mutant_anchors.py -v`.
+- The repo `ruff.toml` enables isort (`select = [..., "I", ...]`), so imports must be alphabetically ordered (`import` statements before `from` imports, each sorted). `ruff format` does NOT reorder imports — only `ruff check --fix` does. So each commit step runs `ruff check --fix` (sorts + autofixes) THEN `ruff format`. The pre-commit hook then runs `ruff check` (no fix) and passes because imports are already sorted. Keep the import block alphabetical as you add imports across tasks.
+
+---
+
+## Task 1: Script skeleton — data types + `parse_guard_tag`
+
+**Files:**
+- Create: `scripts/check_mutant_anchors.py`
+- Test: `scripts/test_check_mutant_anchors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/test_check_mutant_anchors.py`:
+
+```python
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import check_mutant_anchors as g  # noqa: E402
+
+
+def test_parse_guard_tag_linecol():
+    t = g.parse_guard_tag(' op="<" fn="probe_file" rows=3')
+    assert t.op == "<"
+    assert t.fn == "probe_file"
+    assert t.fn_present is True
+    assert t.rows == 3
+    assert t.count is None
+
+
+def test_parse_guard_tag_const_empty_fn():
+    t = g.parse_guard_tag(' op="/" fn="" rows=2')
+    assert t.op == "/"
+    assert t.fn == ""
+    assert t.fn_present is True
+    assert t.rows == 2
+
+
+def test_parse_guard_tag_count():
+    t = g.parse_guard_tag(" count=3")
+    assert t.count == 3
+    assert t.op is None
+    assert t.fn_present is False
+
+
+def test_parse_guard_tag_rejects_unknown_field():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.parse_guard_tag(" bogus=1")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'check_mutant_anchors'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/check_mutant_anchors.py`:
+
+```python
+#!/usr/bin/env python3
+"""Validate that .cargo/mutants.toml exclude_re anchors still suppress exactly the
+mutants they document. See docs/superpowers/specs/2026-06-09-mutant-anchor-drift-guard-design.md."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class Tag:
+    op: str | None = None
+    fn: str | None = None
+    fn_present: bool = False
+    rows: int | None = None
+    count: int | None = None
+
+
+_TAG_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
+
+
+def parse_guard_tag(text: str) -> Tag:
+    tag = Tag()
+    for m in _TAG_FIELD.finditer(text):
+        key = m.group(1)
+        val = m.group(2) if m.group(2) is not None else m.group(3)
+        if key == "op":
+            tag.op = val
+        elif key == "fn":
+            tag.fn = val
+            tag.fn_present = True
+        elif key == "rows":
+            tag.rows = int(val)
+        elif key == "count":
+            tag.count = int(val)
+        else:
+            raise ValueError(f"unknown guard tag field: {key}")
+    return tag
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check --fix scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(mutants): guard skeleton + parse_guard_tag
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `parse_mutant` — name → site + best-effort op/repl/fn
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py`
+- Test: `scripts/test_check_mutant_anchors.py`
+
+The site is always extractable from the `file:line:col:` prefix; `op`/`repl`/`fn` are populated only for the binary-operator shape (else `None`). ~40% of real mutants are non-binop (FnValue, MatchArmGuard, UnaryOperator); the description check needs only the site, so `None` op/fn for them is correct.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/test_check_mutant_anchors.py`:
+
+```python
+def test_parse_mutant_binop_with_fn():
+    m = g.parse_mutant("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")
+    assert m.site == ("musefs-core/src/scan.rs", 277, 30)
+    assert m.op == "<"
+    assert m.repl == "=="
+    assert m.fn == "probe_file"
+
+
+def test_parse_mutant_binop_const_no_fn():
+    m = g.parse_mutant("musefs-core/src/reader.rs:71:60: replace / with %")
+    assert m.site == ("musefs-core/src/reader.rs", 71, 60)
+    assert m.op == "/"
+    assert m.repl == "%"
+    assert m.fn is None
+
+
+def test_parse_mutant_fnvalue_is_site_only():
+    m = g.parse_mutant("musefs-format/src/convert.rs:21:5: replace usize_from -> usize with 0")
+    assert m.site == ("musefs-format/src/convert.rs", 21, 5)
+    assert m.op is None and m.repl is None and m.fn is None
+
+
+def test_parse_mutant_matchguard_is_site_only():
+    m = g.parse_mutant(
+        "musefs-core/src/tree.rs:641:30: replace match guard self.path_of(ino) == new_path with false in VirtualTree::apply_changes"
+    )
+    assert m.site == ("musefs-core/src/tree.rs", 641, 30)
+    assert m.op is None and m.fn is None
+
+
+def test_parse_mutant_unary_delete_is_site_only():
+    m = g.parse_mutant("musefs-core/src/scan.rs:874:12: delete ! in revalidate_with")
+    assert m.op is None and m.fn is None
+
+
+def test_parse_mutant_rejects_no_prefix():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.parse_mutant("not a mutant name")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k parse_mutant -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'parse_mutant'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/check_mutant_anchors.py` (after the `Tag` block):
+
+```python
+@dataclass(frozen=True)
+class Mutant:
+    name: str
+    file: str
+    line: int
+    col: int
+    op: str | None
+    repl: str | None
+    fn: str | None
+
+    @property
+    def site(self) -> tuple[str, int, int]:
+        return (self.file, self.line, self.col)
+
+
+_NAME_RE = re.compile(r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+): (?P<body>.*)$")
+_BINOP_RE = re.compile(r"^replace (?P<op>\S+) with (?P<repl>\S+)(?: in (?P<fn>.+))?$")
+
+
+def parse_mutant(name: str) -> Mutant:
+    m = _NAME_RE.match(name)
+    if not m:
+        raise ValueError(f"unparseable mutant name (no file:line:col prefix): {name!r}")
+    op = repl = fn = None
+    b = _BINOP_RE.match(m.group("body"))
+    if b:
+        op, repl, fn = b.group("op"), b.group("repl"), b.group("fn")
+    return Mutant(
+        name=name,
+        file=m.group("file"),
+        line=int(m.group("line")),
+        col=int(m.group("col")),
+        op=op,
+        repl=repl,
+        fn=fn,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k parse_mutant -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check --fix scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(mutants): parse_mutant (site always; op/fn best-effort)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `classify` + `validate_regex_subset`
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py`
+- Test: `scripts/test_check_mutant_anchors.py`
+
+`classify` distinguishes a literal `:277:30:` (line:col) from an escaped `:\d+:\d+:` (description). `validate_regex_subset` allowlists escape characters so a future pattern using a Rust/Python-divergent construct (`\b`, `\w`, `\s`, inline `(?...)`) fails loudly instead of silently mismatching.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+def test_classify_linecol_vs_desc():
+    assert g.classify(r"musefs-core/src/scan\.rs:277:30:") == "linecol"
+    assert g.classify(r"musefs-format/src/convert\.rs:\d+:\d+: replace usize_from -> usize") == "desc"
+    assert g.classify(r"replace < with <= in Musefs::poll_due") == "desc"
+
+
+def test_validate_regex_subset_accepts_current_constructs():
+    patterns = [
+        r"musefs-core/src/scan\.rs:277:30:",
+        r"replace < with (==|>|<=) in crc_shift_zeros",
+        r"musefs-core/src/reader\.rs:71:60: replace / with [%*]",
+        r"replace match guard .* with false in VirtualTree::apply_changes",
+        r"replace \+ with \* in fixtures::wav",
+        r'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)',
+    ]
+    for pat in patterns:
+        g.validate_regex_subset(pat)  # must not raise
+
+
+def test_validate_regex_subset_rejects_divergent_escape():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.validate_regex_subset(r"replace \b foo")
+    with pytest.raises(ValueError):
+        g.validate_regex_subset(r"replace \w+ foo")
+
+
+def test_validate_regex_subset_rejects_inline_group():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.validate_regex_subset(r"foo(?=bar)")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k "classify or subset" -v`
+Expected: FAIL — attributes `classify` / `validate_regex_subset` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add:
+
+```python
+_LITERAL_LINECOL = re.compile(r":[0-9]+:[0-9]+:")
+
+# Escape chars proven equivalent between Rust `regex` and Python `re` and actually
+# used by current patterns: \.  \d  \+  \|  \^  \(  \)  \*
+_ALLOWED_ESCAPES = set(".d+|^()*")
+
+
+def classify(regex: str) -> str:
+    return "linecol" if _LITERAL_LINECOL.search(regex) else "desc"
+
+
+def validate_regex_subset(regex: str) -> None:
+    i = 0
+    while i < len(regex):
+        c = regex[i]
+        if c == "\\":
+            if i + 1 >= len(regex):
+                raise ValueError("trailing backslash in regex")
+            nxt = regex[i + 1]
+            if nxt not in _ALLOWED_ESCAPES:
+                raise ValueError(
+                    rf"disallowed escape \{nxt} (outside the Rust/Python shared subset)"
+                )
+            i += 2
+            continue
+        if regex[i : i + 2] == "(?":
+            raise ValueError("inline group/flag (?...) not in the shared subset")
+        i += 1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k "classify or subset" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check --fix scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(mutants): classify + regex subset allowlist
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `parse_toml_entries` — raw-text parser pairing `# guard:` to elements
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py`
+- Test: `scripts/test_check_mutant_anchors.py`
+
+Parses the toml as raw text (a TOML library would discard the `# guard:` comments). Returns the `exclude_re` entries (each paired with the nearest preceding `# guard:` tag, last wins) and the `exclude_globs` list.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+SAMPLE_TOML = """\
+exclude_globs = [
+    "musefs-fuse/**",
+    "musefs-core/src/metrics.rs",
+]
+exclude_re = [
+    # a bare line:col entry
+    # guard: op="<" fn="probe_file" rows=3
+    'musefs-core/src/scan\\.rs:277:30:',
+
+    # a description entry, multi-site (note the blank line above — must be skipped)
+    # guard: count=3
+    'replace \\| with \\^ in synchsafe_decode',
+    # an untagged description entry (defaults count=1)
+    'replace == with != in VirtualTree::ancestor_in',
+]
+"""
+
+
+def test_parse_toml_entries_pairs_tags():
+    entries, globs = g.parse_toml_entries(SAMPLE_TOML)
+    assert globs == ["musefs-fuse/**", "musefs-core/src/metrics.rs"]
+    assert len(entries) == 3
+    assert entries[0].regex == r"musefs-core/src/scan\.rs:277:30:"
+    assert entries[0].tag.op == "<" and entries[0].tag.rows == 3
+    assert entries[1].regex == r"replace \| with \^ in synchsafe_decode"
+    assert entries[1].tag.count == 3
+    assert entries[2].tag is None  # untagged → default later
+
+
+def test_parse_toml_entries_last_guard_wins():
+    toml = (
+        "exclude_re = [\n"
+        "    # guard: count=2\n"
+        "    # guard: count=5\n"
+        "    'replace a with b in foo',\n"
+        "]\n"
+    )
+    entries, _ = g.parse_toml_entries(toml)
+    assert entries[0].tag.count == 5
+
+
+def test_parse_toml_entries_hash_inside_regex_not_a_comment():
+    toml = "exclude_re = [\n    'replace # with x in foo',\n]\n"
+    entries, _ = g.parse_toml_entries(toml)
+    assert entries[0].regex == "replace # with x in foo"
+    assert entries[0].tag is None
+```
+
+Note: `SAMPLE_TOML` is a non-raw `"""..."""` string, so `\\` in the source is **one** backslash in the toml text — matching the real toml's literal `scan\.rs`. After parsing, `entries[0].regex` holds `musefs-core/src/scan\.rs:277:30:` (one backslash), equal to the `r"..."` assertion. The blank line inside the array exercises the blank-line skip in `parse_toml_entries`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k toml_entries -v`
+Expected: FAIL — `parse_toml_entries` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add:
+
+```python
+@dataclass
+class Entry:
+    regex: str
+    toml_line: int
+    tag: Tag | None
+
+
+def _unquote_toml_string(s: str) -> str:
+    s = s.rstrip(",").strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "'\"":
+        return s[1:-1]
+    raise ValueError(f"malformed TOML string element: {s!r}")
+
+
+def parse_toml_entries(text: str) -> tuple[list[Entry], list[str]]:
+    entries: list[Entry] = []
+    globs: list[str] = []
+    section: str | None = None  # "re" | "globs" | None
+    pending: Tag | None = None
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        s = raw.strip()
+        if s.startswith("exclude_re"):
+            section, pending = "re", None
+            continue
+        if s.startswith("exclude_globs"):
+            section = "globs"
+            continue
+        if s == "]":
+            section, pending = None, None
+            continue
+        if section is None:
+            continue
+        if not s:
+            continue
+        if s.startswith("#"):
+            body = s[1:].strip()
+            if body.startswith("guard:"):
+                pending = parse_guard_tag(body[len("guard:") :])
+            continue
+        if s[:1] in "'\"":
+            value = _unquote_toml_string(s)
+            if section == "re":
+                entries.append(Entry(regex=value, toml_line=lineno, tag=pending))
+                pending = None
+            else:
+                globs.append(value)
+    return entries, globs
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k toml_entries -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check --fix scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(mutants): raw-text toml parser pairing guard tags
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `check` — the core validation
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py`
+- Test: `scripts/test_check_mutant_anchors.py`
+
+For each entry: compile (with allowlist), collect matching mutants, fail if any match lands in an `exclude_globs` file, then apply the type-specific check. Line:col: all matched share `op`+`fn` (tag `fn=""` ≡ parsed `fn=None`), one site, count == `rows`. Description: distinct-site count == `count` (default 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+def _m(name):
+    return g.parse_mutant(name)
+
+
+def test_check_linecol_ok():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            1,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=3),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file"),
+        _m("musefs-core/src/scan.rs:277:30: replace < with > in probe_file"),
+        _m("musefs-core/src/scan.rs:277:30: replace < with <= in probe_file"),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_linecol_drift_to_nothing():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:713:29:",
+            1,
+            g.Tag(op="+=", fn="run_pipeline", fn_present=True, rows=2),
+        )
+    ]
+    fails = g.check(entries, [], [])
+    assert len(fails) == 1 and "found none" in fails[0]
+
+
+def test_check_linecol_repoint_wrong_op():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            1,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace + with - in probe_file")]
+    fails = g.check(entries, muts, [])
+    assert any("expected op" in f for f in fails)
+
+
+def test_check_linecol_over_suppress_rows():
+    # narrowing entry (rows=1) accidentally matches 3 siblings
+    entries = [
+        g.Entry(
+            r"musefs-core/src/ogg_index\.rs:216:15:",
+            1,
+            g.Tag(op="<", fn="serve_ogg_window", fn_present=True, rows=1),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/ogg_index.rs:216:15: replace < with == in serve_ogg_window"),
+        _m("musefs-core/src/ogg_index.rs:216:15: replace < with > in serve_ogg_window"),
+        _m("musefs-core/src/ogg_index.rs:216:15: replace < with <= in serve_ogg_window"),
+    ]
+    fails = g.check(entries, muts, [])
+    assert any("rows=1" in f for f in fails)
+
+
+def test_check_linecol_const_empty_fn():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/reader\.rs:71:60: replace / with [%*]",
+            1,
+            g.Tag(op="/", fn="", fn_present=True, rows=2),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/reader.rs:71:60: replace / with %"),
+        _m("musefs-core/src/reader.rs:71:60: replace / with *"),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_linecol_missing_field():
+    entries = [g.Entry(r"musefs-core/src/scan\.rs:277:30:", 1, g.Tag(op="<"))]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
+    fails = g.check(entries, muts, [])
+    assert any("needs `op=`, `fn=`, and `rows=`" in f for f in fails)
+
+
+def test_check_desc_site_count_ok_multisite():
+    entries = [g.Entry(r"replace \| with \^ in synchsafe_decode", 1, g.Tag(count=3))]
+    muts = [
+        _m("musefs-format/src/mp3.rs:10:5: replace | with ^ in synchsafe_decode"),
+        _m("musefs-format/src/mp3.rs:11:5: replace | with ^ in synchsafe_decode"),
+        _m("musefs-format/src/mp3.rs:12:5: replace | with ^ in synchsafe_decode"),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_desc_sibling_mask():
+    # count=1 default, but a new same-op site joined → 2 sites
+    entries = [g.Entry(r"replace \| with \^ in synchsafe_decode", 1, None)]
+    muts = [
+        _m("musefs-format/src/mp3.rs:10:5: replace | with ^ in synchsafe_decode"),
+        _m("musefs-format/src/mp3.rs:99:5: replace | with ^ in synchsafe_decode"),
+    ]
+    fails = g.check(entries, muts, [])
+    assert any("count=1" in f for f in fails)
+
+
+def test_check_desc_dead_entry_zero():
+    entries = [g.Entry(r"replace == with != in VirtualTree::gone", 1, None)]
+    fails = g.check(entries, [], [])
+    assert any("count=1" in f for f in fails)
+
+
+def test_check_desc_count_zero_rejected():
+    # an explicit count=0 tag is always a failure, even with zero matches
+    entries = [g.Entry(r"replace == with != in VirtualTree::gone", 1, g.Tag(count=0))]
+    fails = g.check(entries, [], [])
+    assert any("invalid" in f for f in fails)
+
+
+def test_check_desc_over_nonbinop_matches():
+    # description anchor whose matches are FnValue mutants (op/fn None) — site-count works
+    entries = [
+        g.Entry(r'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)', 1, None)
+    ]
+    muts = [
+        _m('musefs-core/src/tree.rs:848:5: replace truncate_component -> Cow<\'_, str> with Cow::Borrowed("")'),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_glob_excluded_match_fails():
+    entries = [g.Entry(r"metrics\.rs:\d+:\d+: replace \+ with -", 1, None)]
+    muts = [_m("musefs-core/src/metrics.rs:5:5: replace + with - in bump")]
+    fails = g.check(entries, muts, ["musefs-core/src/metrics.rs"])
+    assert any("exclude_globs" in f for f in fails)
+
+
+def test_check_uncompilable_regex_reported():
+    entries = [g.Entry(r"replace \q foo", 1, None)]
+    fails = g.check(entries, [], [])
+    assert any("regex error" in f for f in fails)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k check_ -v`
+Expected: FAIL — `check` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add:
+
+```python
+import fnmatch
+
+
+def _glob_match(glob: str, file: str) -> bool:
+    return fnmatch.fnmatch(file, glob)
+
+
+def _fmt(entry: Entry, msg: str) -> str:
+    return f"[mutants.toml:{entry.toml_line}] /{entry.regex}/ — {msg}"
+
+
+def _check_linecol(entry: Entry, matched: list[Mutant]) -> list[str]:
+    t = entry.tag
+    if t is None or t.op is None or not t.fn_present or t.rows is None:
+        return [_fmt(entry, "line:col entry needs `op=`, `fn=`, and `rows=` in its # guard: tag")]
+    if not matched:
+        return [
+            _fmt(
+                entry,
+                f"expected {t.rows} mutant(s), found none "
+                "(line likely shifted — re-anchor to current coordinates)",
+            )
+        ]
+    fails = []
+    sites = {m.site for m in matched}
+    if len(sites) != 1:
+        fails.append(_fmt(entry, f"expected one site, matched {len(sites)}: {sorted(sites)}"))
+    if len(matched) != t.rows:
+        fails.append(
+            _fmt(entry, f"expected rows={t.rows}, matched {len(matched)}: {[m.name for m in matched]}")
+        )
+    expected_fn = None if t.fn == "" else t.fn
+    bad = [m for m in matched if m.op != t.op or m.fn != expected_fn]
+    if bad:
+        fails.append(
+            _fmt(entry, f'expected op "{t.op}" in fn "{t.fn}", coordinate holds: {[m.name for m in bad]}')
+        )
+    return fails
+
+
+def _check_desc(entry: Entry, matched: list[Mutant]) -> list[str]:
+    count = entry.tag.count if entry.tag and entry.tag.count is not None else 1
+    if count < 1:
+        return [_fmt(entry, f"count={count} is invalid; an entry must suppress >=1 site (delete a dead rule)")]
+    sites = sorted({m.site for m in matched})
+    if len(sites) != count:
+        return [_fmt(entry, f"expected count={count} sites, matched {len(sites)}: {sites}")]
+    return []
+
+
+def check(entries: list[Entry], mutants: list[Mutant], globs: list[str]) -> list[str]:
+    failures: list[str] = []
+    for entry in entries:
+        try:
+            validate_regex_subset(entry.regex)
+            rx = re.compile(entry.regex)
+        except (ValueError, re.error) as ex:
+            failures.append(_fmt(entry, f"regex error: {ex}"))
+            continue
+        matched = [m for m in mutants if rx.search(m.name)]
+        glob_hits = [m for m in matched if any(_glob_match(g, m.file) for g in globs)]
+        if glob_hits:
+            failures.append(
+                _fmt(entry, f"matches mutant(s) in an exclude_globs file: {[m.name for m in glob_hits]}")
+            )
+            continue
+        if classify(entry.regex) == "linecol":
+            failures.extend(_check_linecol(entry, matched))
+        else:
+            failures.extend(_check_desc(entry, matched))
+    return failures
+```
+
+Move `import fnmatch` to the top import block (don't leave it inline — ruff flags `E402`/`I001`). Alphabetical stdlib order at this point is `import fnmatch` then `import re`, followed by `from dataclasses import dataclass`. (`ruff check --fix` in Step 5 enforces this automatically.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check --fix scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(mutants): check core (line:col op/fn/rows, desc site-count, globs)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `load_mutants` + `main()` (CLI)
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py`
+- Test: `scripts/test_check_mutant_anchors.py`
+
+`load_mutants` turns `--list --json` output into `Mutant`s. `main()` reads the toml, gets the mutant list (from `--mutants-json <file>` or by invoking cargo), runs `check`, prints failures, and exits non-zero on any failure (or on an empty mutant list, which is a hard error).
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+def test_load_mutants_from_json():
+    payload = (
+        '[{"name": "musefs-core/src/scan.rs:277:30: replace < with == in probe_file",'
+        ' "file": "musefs-core/src/scan.rs"}]'
+    )
+    muts = g.load_mutants(payload)
+    assert len(muts) == 1
+    assert muts[0].site == ("musefs-core/src/scan.rs", 277, 30)
+
+
+def test_load_mutants_empty_is_error():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.load_mutants("[]")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k load_mutants -v`
+Expected: FAIL — `load_mutants` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the remaining imports at the top (`import argparse`, `import json`, `import subprocess`, `import sys`, `from pathlib import Path`) and append:
+
+```python
+def load_mutants(json_text: str) -> list[Mutant]:
+    data = json.loads(json_text)
+    if not data:
+        raise ValueError("cargo mutants --list returned no mutants (build/feature problem?)")
+    return [parse_mutant(item["name"]) for item in data]
+
+
+def _run_cargo_list() -> str:
+    proc = subprocess.run(
+        ["cargo", "mutants", "--no-config", "--list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"cargo mutants --list failed:\n{proc.stderr}")
+    return proc.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--mutants-json",
+        type=Path,
+        help="read the mutant list from this file instead of invoking cargo "
+        "(must be `cargo mutants --no-config --list --json` output)",
+    )
+    ap.add_argument(
+        "--toml",
+        type=Path,
+        default=Path(".cargo/mutants.toml"),
+        help="path to mutants.toml (default: .cargo/mutants.toml)",
+    )
+    args = ap.parse_args(argv)
+
+    entries, globs = parse_toml_entries(args.toml.read_text())
+    json_text = args.mutants_json.read_text() if args.mutants_json else _run_cargo_list()
+    mutants = load_mutants(json_text)
+
+    failures = check(entries, mutants, globs)
+    if failures:
+        print(f"{len(failures)} mutant-anchor failure(s):\n")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print(f"OK: {len(entries)} exclude_re entries validated against {len(mutants)} mutants.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check --fix scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(mutants): load_mutants + main CLI
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Migrate `.cargo/mutants.toml` — re-anchor + tag
+
+**Files:**
+- Modify: `.cargo/mutants.toml`
+
+This is the verified data. Generate the live list once for reference:
+
+```bash
+cargo mutants --no-config --list --json > /tmp/mutants-list.json
+```
+
+- [ ] **Step 1: Re-anchor the 12 drifted line:col entries and add their tags.**
+
+Apply these exact regex coordinate changes and insert the `# guard:` line directly above each entry (keep the existing explanatory comment block; the `# guard:` line goes as the last comment line before the `'...'`):
+
+| Current regex (drifted) | New regex | `# guard:` line to add |
+| --- | --- | --- |
+| `'musefs-core/src/scan\.rs:620:46:'` | `'musefs-core/src/scan\.rs:641:46:'` | `# guard: op="*" fn="run_pipeline" rows=2` |
+| `'musefs-core/src/scan\.rs:713:29:'` | `'musefs-core/src/scan\.rs:734:29:'` | `# guard: op="+=" fn="run_pipeline" rows=2` |
+| `'musefs-core/src/scan\.rs:715:32:'` | `'musefs-core/src/scan\.rs:736:32:'` | `# guard: op=">=" fn="run_pipeline" rows=1` |
+| `'musefs-core/src/scan\.rs:715:47:'` | `'musefs-core/src/scan\.rs:736:47:'` | `# guard: op="\|\|" fn="run_pipeline" rows=1` |
+| `'musefs-core/src/scan\.rs:715:62:'` | `'musefs-core/src/scan\.rs:736:62:'` | `# guard: op=">=" fn="run_pipeline" rows=1` |
+| `'musefs-core/src/scan\.rs:723:37:'` | `'musefs-core/src/scan\.rs:744:37:'` | `# guard: op="+=" fn="run_pipeline" rows=2` |
+| `'musefs-core/src/scan\.rs:725:40:'` | `'musefs-core/src/scan\.rs:746:40:'` | `# guard: op=">=" fn="run_pipeline" rows=1` |
+| `'musefs-core/src/scan\.rs:725:55:'` | `'musefs-core/src/scan\.rs:746:55:'` | `# guard: op="\|\|" fn="run_pipeline" rows=1` |
+| `'musefs-core/src/scan\.rs:725:70:'` | `'musefs-core/src/scan\.rs:746:70:'` | `# guard: op=">=" fn="run_pipeline" rows=1` |
+| `'musefs-core/src/scan\.rs:829:25:'` | `'musefs-core/src/scan\.rs:850:25:'` | `# guard: op="+=" fn="revalidate_with" rows=2` |
+| `'musefs-core/src/scan\.rs:833:25:'` | `'musefs-core/src/scan\.rs:854:25:'` | `# guard: op="+=" fn="revalidate_with" rows=2` |
+| `'musefs-core/src/scan\.rs:869:29: replace \+ with -'` | `'musefs-core/src/scan\.rs:890:29: replace \+ with -'` | `# guard: op="+" fn="revalidate_with" rows=1` |
+
+The `op` values use the **mutant-name** spelling of the operator (`\|\|` in the tag is the literal `||`; the double-quote value preserves it verbatim — write `op="||"`). The new coordinates are confirmed correct: the `run_pipeline` cluster shifted +21 lines (identical columns) and `scan.rs:712:22` / `861:27` are the *killable* `*scanned += 1` / `unchanged += 1` and remain out of scope (do not anchor onto them).
+
+> Equivalence note (required human check, per spec Step 0): each re-anchored coordinate still names the same equivalent mutant described in its existing comment — `734/744` are the two `batch_bytes += unit.weight` accumulations, `736/746` the two `len >= BATCH_FILES || batch_bytes >= cap` flush conditions, `850/854` the two `skip_failed += 1` defensive counters, `890` the `failed: scan.failed + skip_failed` sum, `641` the `sync_channel(jobs * 2)` capacity. Confirm by eye against `musefs-core/src/scan.rs` before committing; the surrounding logic is unchanged (pure reformat).
+
+- [ ] **Step 2: Add tags to the 8 already-correct line:col entries.**
+
+Insert the `# guard:` line above each (regex unchanged):
+
+| Regex | `# guard:` line |
+| --- | --- |
+| `'musefs-core/src/scan\.rs:270:31:'` | `# guard: op="+" fn="probe_file" rows=2` |
+| `'musefs-core/src/scan\.rs:277:30:'` | `# guard: op="<" fn="probe_file" rows=3` |
+| `'musefs-core/src/scan\.rs:288:21:'` | `# guard: op=">" fn="probe_file" rows=3` |
+| `'musefs-core/src/scan\.rs:293:17:'` | `# guard: op=">" fn="probe_file" rows=3` |
+| `'musefs-core/src/ogg_index\.rs:205:41: replace \+ with \* in serve_ogg_window'` | `# guard: op="+" fn="serve_ogg_window" rows=1` |
+| `'musefs-core/src/ogg_index\.rs:216:15: replace < with <= in serve_ogg_window'` | `# guard: op="<" fn="serve_ogg_window" rows=1` |
+| `'musefs-core/src/ogg_index\.rs:225:15: replace < with <= in serve_ogg_window'` | `# guard: op="<" fn="serve_ogg_window" rows=1` |
+| `'musefs-core/src/reader\.rs:71:60: replace / with [%*]'` | `# guard: op="/" fn="" rows=2` |
+
+- [ ] **Step 3: Add `count=` tags to the 4 multi-site description entries.**
+
+Insert above each (regex unchanged):
+
+| Regex | `# guard:` line |
+| --- | --- |
+| `'replace \| with \^ in synchsafe_decode'` | `# guard: count=3` |
+| `'musefs-core/src/facade\.rs:\d+:\d+: replace < with <= in Musefs::poll_due'` | `# guard: count=2` |
+| `'replace < with <= in Musefs::poll_refresh_notify'` | `# guard: count=2` |
+| `'replace \+ with \* in fixtures::wav'` | `# guard: count=2` |
+
+All other description entries are single-site and need no tag (default `count=1`).
+
+- [ ] **Step 4: Run the guard against the live tree to verify it now passes.**
+
+Run:
+```bash
+cargo mutants --no-config --list --json > /tmp/mutants-list.json
+python3 scripts/check_mutant_anchors.py --mutants-json /tmp/mutants-list.json
+```
+Expected: `OK: 44 exclude_re entries validated against <N> mutants.` and exit 0.
+
+If any failure prints, fix the offending tag/coordinate per the message and re-run until exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .cargo/mutants.toml
+git commit -m "fix(mutants): re-anchor 12 drifted exclusions + add guard tags
+
+The scan.rs run_pipeline/revalidate_with clusters were reformatted and the
+line:col exclusions silently drifted to zero matches, suppressing nothing.
+Re-anchor to current coordinates and annotate every line:col and multi-site
+description entry with a machine-checkable # guard: tag.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Wire CI
+
+**Files:**
+- Modify: `.github/workflows/mutants.yml`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the live guard step to the `in-diff` job in `.github/workflows/mutants.yml`.**
+
+Insert immediately **after** the `Install cargo-mutants` step (line ~74-77) and **before** the `Build the merge-base diff` step:
+
+```yaml
+      - name: Check mutant-exclusion anchors
+        run: |
+          cargo mutants --no-config --list --json > mutants-list.json
+          python3 scripts/check_mutant_anchors.py --mutants-json mutants-list.json
+```
+
+(It is placed before the diff build so a drift failure is reported even when there are no changed lines to mutate. `actions/setup-python` is not needed — ubuntu-latest runners ship a `python3`, and the guard is stdlib-only.)
+
+- [ ] **Step 2: Add the unit-test step to the `python-musefs` job in `.github/workflows/ci.yml`.**
+
+Insert immediately **after** the `Test bump script` step (`run: python -m pytest scripts/test_bump_python_version.py -v`, line ~146):
+
+```yaml
+      - name: Test mutant-anchor guard
+        run: python -m pytest scripts/test_check_mutant_anchors.py -v
+```
+
+The new script is already covered by that job's existing `ruff check scripts/` / `ruff format --check scripts/` steps.
+
+- [ ] **Step 3: Validate the workflow YAML parses.**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/mutants.yml')); yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/mutants.yml .github/workflows/ci.yml
+git commit -m "ci(mutants): run anchor guard in in-diff job + unit tests in ci
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Acceptance — full local run + negative check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full unit suite green.**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Guard exits 0 against the real tree.**
+
+Run:
+```bash
+cargo mutants --no-config --list --json > /tmp/mutants-list.json
+python3 scripts/check_mutant_anchors.py --mutants-json /tmp/mutants-list.json; echo "exit: $?"
+```
+Expected: `OK: 44 exclude_re entries validated...` and `exit: 0`.
+
+- [ ] **Step 3: Negative check — perturb one anchor, confirm a loud failure.**
+
+```bash
+sed -i 's#scan\\.rs:277:30:#scan\\.rs:277:31:#' .cargo/mutants.toml
+python3 scripts/check_mutant_anchors.py --mutants-json /tmp/mutants-list.json; echo "exit: $?"
+git checkout .cargo/mutants.toml
+```
+Expected: a `found none (line likely shifted...)` failure for the `277:31` entry and `exit: 1`. The `git checkout` reverts the perturbation.
+
+- [ ] **Step 4: Lint clean.**
+
+Run: `ruff check scripts/ && ruff format --check scripts/`
+Expected: no errors.
+
+- [ ] **Step 5: Final ruff format check / no uncommitted changes.**
+
+Run: `git status --porcelain`
+Expected: empty (all work committed across Tasks 1-8).
+
+---
+
+## Self-review notes (for the implementer)
+
+- The guard is intentionally NOT added to the pre-commit hook or the normal `cargo test` suite — it needs `cargo mutants --list` (a build), which is too heavy there. It lives in the `in-diff` mutants job (runs on every PR).
+- `op` in a tag is the operator as it appears in the mutant **name** (`||`, `+=`, `>=`, `<`, `+`, `*`, `/`). The tag value is a literal double-quoted string; do not regex-escape it.
+- A description entry's `file:\d+:\d+:` prefix can be load-bearing site-narrowing (e.g. `usize_from` matches 3 sites bare but 1 with the `convert.rs` prefix). Do not strip such prefixes.
+- If a future cargo-mutants version changes the per-site replacement set, `rows=`/`count=` will fail loudly — update the tags and re-confirm equivalence; that is the gate working as intended.

--- a/docs/superpowers/specs/2026-06-09-mutant-anchor-drift-guard-design.md
+++ b/docs/superpowers/specs/2026-06-09-mutant-anchor-drift-guard-design.md
@@ -1,0 +1,482 @@
+# Mutant-anchor drift guard — design
+
+Date: 2026-06-09
+
+## Problem
+
+`.cargo/mutants.toml` suppresses a curated set of equivalent / unkillable
+mutants via `exclude_re`, each matched against the mutant name cargo-mutants
+prints in `--list` (`<file>:<line>:<col>: <description>`). Two anchoring styles
+are in use:
+
+- **Description anchors** — `replace | with ^ in synchsafe_decode`. Line-agnostic
+  (they carry no concrete line number), so `cargo fmt` can shift code freely
+  without retiring them. These are the default and the majority.
+- **Line:col anchors** — `musefs-core/src/scan\.rs:713:29:`. Used only where the
+  operator+function description is *not unique within the function* and so cannot
+  identify a single site (e.g. `run_pipeline` has several `+=` and `>=`, only some
+  of which are equivalent). The note at `.cargo/mutants.toml` lines 104–107 records
+  this constraint.
+
+The line:col anchors are fragile. The failures are:
+
+1. **Re-point (line:col anchors).** A reformat moves an equivalent site from line
+   713 to 712. If line 713 then hosts a *different, killable* mutant of a similar
+   shape, the anchor silently suppresses the killable one — a real test gap passes
+   the gate unnoticed.
+
+2. **Drift-to-nothing (line:col anchors).** More commonly, the reformat leaves
+   *no* mutant at the old coordinate, so the anchor matches nothing and suppresses
+   nothing. This is only "loud" if the now-unsuppressed equivalent mutant happens
+   to land in a PR's changed lines (the per-PR gate is `--in-diff`); otherwise it
+   sits latent — the toml claims a suppression it is no longer performing.
+
+3. **Sibling-mask (description anchors).** Today `replace | with ^ in
+   synchsafe_decode` matches a fixed set of sites. If someone later adds a
+   *killable* `|` to `synchsafe_decode`, the entry silently begins excluding it
+   too. The toml's repeated promise that "killable siblings stay in scope" rests
+   on an assumption nothing currently enforces.
+
+**This is not hypothetical — the tree is already drifted.** Replaying every
+current `exclude_re` against the live unfiltered mutant set (cargo-mutants 27.0.0)
+shows **12 line:col anchors matching zero mutants today**: `scan.rs` `620:46`,
+`713:29`, `715:{32,47,62}`, `723:37`, `725:{40,55,70}`, `829:25`, `833:25`,
+`869:29`. A past `scan.rs` reformat moved their sites (the `run_pipeline` cluster
+is now at `712/734/736/744/746`, `revalidate_with` at `850/854/861/881`), and the
+toml was never re-anchored. So the gate is presently suppressing nothing at those
+12 coordinates while the toml asserts it is. Re-anchoring them is folded into this
+change (see Migration).
+
+This spec adds a guard that converts all three failures into loud, actionable CI
+failures, while keeping the precise line:col anchors (no churn to `scan.rs` /
+`ogg_index.rs` / `reader.rs`).
+
+## Goals
+
+- Detect a line:col anchor that no longer suppresses exactly its documented
+  mutant(s): re-pointed (different operator/function now at the coordinate),
+  drifted-to-nothing, or over/under-suppressing (wrong number of replacement
+  variants), with a message naming the entry and what it now hits.
+- Detect a description anchor whose set of suppressed *sites* differs from its
+  declared expectation (sibling-mask, or a dead entry after a rename).
+- Single source of truth: the expectation lives next to the entry it governs.
+- Run in CI on every PR that could shift the anchors, reusing the existing
+  cargo-mutants install in the `in-diff` job. Also runnable locally on demand.
+- Pure-logic core that is unit-testable without invoking cargo.
+
+## Non-goals
+
+- Auto-repairing or auto-updating anchors. The guard reports; a human fixes.
+- Validating that each `exclude_globs` pattern still matches a file (those govern
+  whole-crate scope, are not line-fragile, and a stale glob harmlessly over-excludes
+  an already-out-of-scope crate). The guard *reads* `exclude_globs` only to reject an
+  `exclude_re` match that lands inside a glob-excluded file — it does not check the
+  globs themselves.
+- Replacing the existing in-diff / full / canary mutation legs. This is an
+  additional check, not a change to how mutants are run.
+- Changing the anchoring strategy itself (no helper-extraction refactors). The
+  guard makes the current strategy safe; it does not migrate away from it.
+
+## The mutant grouping model
+
+cargo-mutants emits **one mutant per (source site, replacement)**. A single
+binary-operator *site* therefore yields several mutant rows — e.g.
+`scan.rs:277:30:` (a `<`) yields three: `replace < with ==`, `replace < with >`,
+`replace < with <=`. This one-site-many-rows fact is central; an earlier draft of
+this spec wrongly assumed one site = one mutant.
+
+The guard parses each mutant `name` (`<file>:<line>:<col>: replace <op> with
+<repl> in <fn>`, or — for const-level mutants — the same with no ` in <fn>`
+suffix) into four fields: **site** `(file,line,col)`, **op** (the source
+operator), **repl** (the replacement), and **fn** (function, possibly absent).
+
+Two distinct kinds of line:col entry exist in the current toml, and the model must
+serve both:
+
+- **Bare** — regex is `<file>:<line>:<col>:` with no replacement, suppressing
+  *every* replacement at the site (e.g. `277:30:` excludes all three `<` variants;
+  all are equivalent). Most line:col entries.
+- **Narrowing** — regex embeds a specific replacement, suppressing a *subset* and
+  deliberately leaving its same-site siblings killable (e.g. `216:15: replace <
+  with <=` excludes only `<=`; the `==` and `>` mutants at `216:15` stay in
+  scope). Verified narrowing entries: `ogg_index.rs` `205:41` (`+ with *`, leaving
+  `+ with -`), `216:15` and `225:15` (`< with <=`), and `scan.rs:869:29`
+  (`+ with -`, leaving `+ with *`).
+
+The over-suppress failure mode is unique to this: a narrowing entry that
+accidentally broadens would silently swallow a killable sibling. So the line:col
+check cannot be op+fn alone — it must also pin the matched row count.
+
+## The two checks, by anchor type
+
+The guard auto-detects an entry's type from its regex (literal `:<digits>:<digits>:`
+⇒ line:col; otherwise description) and applies the check that closes that entry's
+hole:
+
+| Anchor type | What can go wrong | Check applied |
+| ----------- | ----------------- | ------------- |
+| **Line:col** | re-point (coord now holds a different op/fn); drift-to-nothing (coord empty); over/under-suppress (wrong replacement set) | every matched row shares the tag's `op` + `fn`; matched rows occupy exactly one site; matched row count equals the tag's `rows` (≥1) |
+| **Description** | sibling-mask (a new killable site joins the match set); dead entry (rename → 0 matches) | the number of distinct *sites* matched equals the tag's `count` (default 1). op+fn are already pinned by the regex text. |
+
+`op`+`fn` catches re-point; `rows` catches drift-to-nothing (rows would be 0) and
+over/under-suppress; *sites*-counting (not row-counting) is what makes the
+description check sensitive to a new killable sibling — a new same-op site moves
+the site count, whereas a row count can be confounded by per-site replacement
+multiplicity.
+
+Residual limitation (documented, accepted): the line:col check cannot distinguish
+two mutants that share op, fn, and replacement at the *same* coordinate, so a
+reformat that coincidentally lands a different-but-identically-shaped killable
+mutant at the exact `file:line:col` would pass. This is a measure-zero edge far
+smaller than today's bare-coordinate exposure; closing it would require pinning
+surrounding source context, which is itself fmt-fragile.
+
+## The structured guard tag
+
+Each `exclude_re` array element is preceded by a comment block (already the
+convention). The guard reads one machine-readable line from that block:
+
+```
+# guard: op="<" fn="probe_file" rows=3          (line:col, bare)
+# guard: op="<" fn="serve_ogg_window" rows=1    (line:col, narrowing)
+# guard: op="/" fn="" rows=2                     (line:col, const-level: no fn)
+# guard: count=3                                 (description, multi-site)
+```
+
+Grammar: `# guard:` prefix (after optional leading whitespace), then
+space-separated `key=value` fields; string values are double-quoted, integers
+bare.
+
+- `op=` — the source operator the matched rows must all share (line:col only).
+- `fn=` — the function the matched rows must all be in; empty string `""` for
+  const-level mutants whose name has no ` in <fn>` suffix (line:col only). The
+  guard normalizes the tag's `fn=""` to the parsed `fn=None`, so the two compare
+  equal.
+- `rows=` — the exact number of mutant rows the regex must match (line:col only).
+- `count=` — the number of distinct sites the regex must match (description only;
+  default 1).
+
+Resolution rules:
+
+- **Line:col anchor:** `op`, `fn`, and `rows` are **all required** (guard errors
+  if any is missing). The guard asserts: the regex matches `rows` mutant rows; all
+  of them parse to operator `op` and function `fn`; and they occupy exactly one
+  `(file,line,col)` site.
+- **Description anchor:** `count=` is optional, **default 1**. The guard asserts
+  the regex matches mutants spanning exactly `count` distinct sites.
+- An entry with **no** `# guard:` line is treated as a description anchor with
+  `count=1`. So a bare description anchor that already matches a single site needs
+  no tag; only multi-site description anchors and all line:col anchors must be
+  annotated.
+
+`op`/`fn` for line:col anchors live in the tag (not parsed back out of the regex)
+to keep one authoritative source: a bare regex carries no description at all, and
+for a narrowing regex the tag is checked *against* the rows the regex selects, so
+a typo that desynchronizes the two surfaces as a guard failure rather than passing
+silently.
+
+## How the guard gets the unfiltered mutant set
+
+`cargo mutants --list` honours the config's `exclude_re`, so excluded mutants are
+absent from its output — which would make it impossible to confirm an anchor still
+hits a real mutant. The guard therefore lists with the config disabled:
+
+```
+cargo mutants --no-config --list --json
+```
+
+`--no-config` (cargo-mutants 27.0.0) ignores `.cargo/mutants.toml` entirely, so the
+output is the complete pre-exclusion mutant set across the workspace. The guard
+then *replays* each toml `exclude_re` pattern itself (in Python) against the
+`name` field of every listed mutant. This is the inversion that makes the checks
+meaningful: cargo applies the exclusions and hides the result; the guard sees
+everything and verifies the exclusions land where documented.
+
+`--no-config` also drops `exclude_globs`, so the list includes the 191 mutants
+from `musefs-latencyfs` / `musefs-fuse` / `musefs-cli` / `musefs` / `metrics.rs`.
+Today **zero** `exclude_re` patterns match any of them (verified), so they are
+inert. But the guard's job is to catch drift, so it does not merely ignore them:
+the guard reads `exclude_globs` from the toml and **fails** if any `exclude_re`
+match lands in a glob-excluded file. Such a match means an `exclude_re` is
+"suppressing" a mutant that is not a real gate participant — a sign the pattern has
+drifted onto the wrong file, which would otherwise be a silent hole.
+
+**Feature set.** The guard runs `--no-config --list` with the *default* feature
+set — the same set the per-PR `in-diff` gate builds with (no `--features metrics`,
+no `--features fuzzing`). This is deliberate and load-bearing: several entries'
+equivalence is premised on that exact config (`metrics.rs` is glob-excluded
+precisely because its counters aren't compiled there; the `fuzz_check.rs::fixtures`
+mutants are present because cargo-mutants builds under `cfg(test)`). Any future
+change to the gate's feature set must be mirrored here, and any entry whose
+equivalence depends on a feature flag must be reasoned about in this config.
+
+### Regex-replay fidelity
+
+cargo-mutants matches `exclude_re` with the Rust `regex` crate; the guard replays
+with Python `re`. All 44 current patterns were checked to compile under Python `re`
+and use only a small shared subset — `\.`, `\d+`, literal alternation `(==|>|<=)`,
+character classes `[%*]`, escaped operators (`\+`, `\|`, `\^`). The guard compiles
+each pattern with `re.search` (cargo-mutants uses unanchored search). A pattern
+that fails to compile under Python `re` is a guard error naming the entry.
+
+Scope and honest limits: the compile-check catches Python-incompatible patterns
+(and Rust `regex` lacks backreferences/look-around, so Python-only features cannot
+appear in a *working* toml). It does **not** detect *semantic divergence within a
+pattern valid in both engines* — e.g. `\b` word-boundary or `\d` Unicode-vs-ASCII
+differences. To make that detectable rather than merely "documented," the guard
+also validates each pattern against an **allowlist of regex tokens** (literals plus
+the subset above) and fails on any token outside it. This keeps future entries
+provably within the shared subset instead of relying on a prose constraint.
+
+## Components
+
+### `scripts/check_mutant_anchors.py`
+
+The guard. Single-file, stdlib-only (no third-party imports; `tomllib` is 3.11+
+stdlib but is **not** used — see below). Structure:
+
+- `parse_toml_entries(text) -> list[Entry]` — reads `.cargo/mutants.toml` as raw
+  text (not via a TOML parser, because the `# guard:` expectations live in
+  comments, which a TOML parser discards). Walks the `exclude_re = [ … ]` array,
+  pairing each string element with the nearest preceding `# guard:` line in its
+  comment block. Returns `Entry { regex, line_in_toml, tag }`.
+- `classify(entry) -> "linecol" | "desc"` — detects a literal `:[0-9]+:[0-9]+:`
+  in the regex.
+- `parse_mutant(name) -> Mutant` — parses a mutant `name` into
+  `{site:(file,line,col), op, repl, fn}`. **The `site` is always extracted** from
+  the `<file>:<line>:<col>:` prefix that *every* mutant name carries, regardless of
+  genre. `op`/`repl`/`fn` are **best-effort**: they are populated only for the
+  binary-operator shape `<site>: replace <op> with <repl> in <fn>` (and `fn=None`
+  for the const-level binop variant with no ` in <fn>` suffix, e.g.
+  `reader.rs:71:60: replace / with %`); for every other genre — FnValue
+  (`replace usize_from -> usize with 0`), MatchArm/MatchArmGuard
+  (`replace match guard … with false in …`), UnaryOperator (`delete ! …`),
+  StructField — `op`/`repl`/`fn` are `None`. This matters because ~40% of the
+  unfiltered corpus is non-binop, and 8 description anchors deliberately target
+  those names; the description check needs only `site`, so leaving op/fn `None` for
+  them is correct, not a parse failure.
+- `load_mutants(json_text) -> list[Mutant]` — extracts every mutant `name` from
+  `cargo mutants --no-config --list --json` and runs it through `parse_mutant`. It
+  never errors on a name shape (site extraction is total); an unparseable
+  *prefix* (no `file:line:col:`) is the only hard error.
+- `check(entries, mutants, exclude_globs) -> list[Failure]` — the unit-tested
+  core, pure, no I/O. For each entry: compile the regex (allowlist + compile
+  check); collect matching mutants; fail if any match lands in an `exclude_globs`
+  file; then apply the type-specific check — line:col: matched count == `rows`,
+  all share `op`+`fn` (line:col entries only ever match binop-shaped names, so
+  op/fn are always present there), single site; description: distinct-site count
+  == `count` (uses `site` only — never op/fn — so non-binop genres are handled
+  uniformly).
+- `main()` — shells out to `cargo mutants --no-config --list --json`, reads
+  `.cargo/mutants.toml`, runs `check`, prints each failure with the entry's toml
+  line number, the regex, expected vs actual, and the offending mutant name(s).
+  Exits non-zero on any failure.
+
+`main()` accepts `--mutants-json <file>` to read a pre-generated list instead of
+invoking cargo (used by the CI step to avoid a redundant second `--list`, and
+handy locally). Default behaviour invokes cargo itself.
+
+Raw-text parsing rationale: the expectations are in TOML comments, which any TOML
+library drops. Reading the file as text and pairing comment→element is the only way
+to keep the expectation co-located with its entry (the chosen single-source-of-
+truth design). The parser is small and unit-tested.
+
+### `scripts/test_check_mutant_anchors.py`
+
+pytest unit tests for the pure core, mirroring
+`scripts/test_bump_python_version.py` (same directory, same `sys.path` insert
+idiom, ruff-clean). Covers, against synthetic toml + JSON fixtures:
+
+- `parse_mutant`: binary-operator name; const-level binop name (no `in <fn>` →
+  `fn=None`); **non-binop names** — FnValue (`replace usize_from -> usize with 0`),
+  MatchArmGuard (`replace match guard … with false in …`), UnaryOperator
+  (`delete ! …`) — each yields a valid `site` with `op`/`repl`/`fn` all `None`; a
+  name with no `file:line:col:` prefix is the one hard error.
+- description anchor over **non-binop** matches (e.g. the `truncate_component ->
+  Cow` or `force_apply_failure_for_test with ()` entries): site-counting works with
+  op/fn `None`.
+- description anchor: site count matches / too high (sibling-mask — a new same-op
+  site joins) / zero (dead entry after a rename);
+- multi-site description anchor (`count=3`, the `synchsafe_decode` shape: one repl
+  across three `|` sites);
+- line:col **bare**: exact (`rows=3`, all `<`/`probe_file`, one site); re-point
+  (coord now holds a different op → op mismatch) and (different fn → fn mismatch);
+  drift-to-nothing (`rows` expected ≥1, matched 0); over-suppress (regex broadened,
+  matched > `rows`);
+- line:col **narrowing**: `rows=1` exact; broadened regex swallows a killable
+  sibling → matched 2 ≠ `rows=1` → caught;
+- line:col const-level entry with `fn=""`;
+- line:col entry missing a required field (`op`/`fn`/`rows`) → guard error;
+- a pattern that doesn't compile, or uses a token outside the allowlist → reported;
+- an `exclude_re` whose match lands in an `exclude_globs` file → reported;
+- empty unfiltered mutant list → hard error (not a flood of count=0 failures);
+- entry with no `# guard:` line defaults to description/count=1;
+- the comment→element pairing parser (blank lines, multi-line comment blocks,
+  multiple `# guard:` lines in one block — last wins, inline `#` inside a regex
+  string must not be read as a tag).
+
+No cargo invocation in the unit tests — they exercise `check`, `parse_toml_entries`,
+`classify`, `parse_mutant`, and `load_mutants` directly on fixtures, so they run in
+milliseconds in the normal Python test path.
+
+## CI integration
+
+### Live guard — `in-diff` job in `.github/workflows/mutants.yml`
+
+The drift the guard catches is introduced by source edits/reformats, which land in
+the same PRs the `in-diff` job already runs on, and that job already installs
+cargo-mutants and has the toolchain warm. Add a step there, after
+`Install cargo-mutants` and independent of `mutants.diff` (the guard validates the
+whole anchor set, not just changed lines):
+
+```yaml
+- name: Check mutant-exclusion anchors
+  run: |
+    cargo mutants --no-config --list --json > mutants-list.json
+    python3 scripts/check_mutant_anchors.py --mutants-json mutants-list.json
+```
+
+Placed before the diff build so a drift failure is reported even when there are no
+in-scope changed lines to mutate. It runs on every PR (`in-diff` is
+`if: github.event_name == 'pull_request'`), so a reformatting PR is caught in the
+same PR that introduces the drift.
+
+### Unit tests — `python-musefs` job in `.github/workflows/ci.yml`
+
+The per-PR home for `scripts/` Python tests is the `python-musefs` job in ci.yml,
+which already runs `python -m pytest scripts/test_bump_python_version.py -v` (the
+"Test bump script" step) on every PR and lints `scripts/` with ruff.
+(`release-python.yml` runs the same bump test but only fires on `py-v*` tags, so it
+is not a per-PR gate.) Add a sibling step:
+
+```yaml
+- name: Test mutant-anchor guard
+  run: python -m pytest scripts/test_check_mutant_anchors.py -v
+```
+
+The new script is covered by that job's existing `ruff check scripts/` /
+`ruff format --check scripts/` steps and must pass both. Mirroring the step into
+release-python.yml is optional and not required for the gate.
+
+## Migration: re-anchor and annotate existing entries
+
+The migration is a substantial part of this change, not a footnote — and its first
+step fixes a pre-existing bug. The verified current state (from replaying every
+pattern against the live unfiltered set) drives it:
+
+**Step 0 — re-anchor the 12 drifted line:col entries (do this first).** These
+match zero mutants today and must be re-pointed to current coordinates *and* their
+equivalence re-judged, because the surrounding `scan.rs` code was reformatted (a
+human must confirm each still names a genuinely-equivalent mutant, not merely
+update digits):
+
+| Drifted entry | Now at | Notes |
+| ------------- | ------ | ----- |
+| `scan.rs:620:46` (sync_channel `jobs * 2`) | re-derive | bare |
+| `713:29`, `715:{32,47,62}`, `723:37`, `725:{40,55,70}` (`run_pipeline` flush cadence) | `712/734/736/744/746` cluster | bare; `+=` and `>=`/`||` |
+| `829:25`, `833:25` (`revalidate_with` `skip_failed += 1`) | `850/854/861/881` cluster | bare; `+=` |
+| `869:29` (`revalidate_with` `failed = … + skip_failed`) | re-derive | **narrowing** (`+ with -` only; `+ with *` stays killable) |
+
+**Step 1 — add `op`/`fn`/`rows` to every line:col entry.** Derived from the live
+data; the live-and-correct ones are: `scan.rs:270:31` (`op=+ fn=probe_file
+rows=2`), `277:30` / `288:21` / `293:17` (`probe_file`, `rows=3` each — confirm op
+per entry; `293:17` is a `>` diagnostic, not `<`), `ogg_index.rs:205:41`
+(`op=+ fn=serve_ogg_window rows=1`, narrowing), `216:15` / `225:15`
+(`op=< fn=serve_ogg_window rows=1`, narrowing), `reader.rs:71:60`
+(`op=/ fn="" rows=2`, const-level). The re-anchored Step-0 entries get theirs from
+the new coordinates.
+
+**Step 2 — add `count=` to the four multi-site description entries.** Only these
+span more than one site (verified): `synchsafe_decode` `| with ^` (**count=3**, one
+repl across three `|` sites), `poll_due` `< with <=` (**count=2**),
+`poll_refresh_notify` `< with <=` (**count=2**), `fixtures::wav` `+ with *`
+(**count=2**). Note `crc_shift_zeros < (==|>|<=)` is **count=1** (one site, three
+repl rows) — site-counting, not row-counting, is why it needs no tag despite three
+matches.
+
+A subtlety to preserve: some description anchors carry a `<file>:\d+:\d+:` prefix
+that is doing *load-bearing site-narrowing*, not decoration. `usize_from -> usize`
+matches **three** sites bare (`musefs-db`, `musefs-format`, `musefs-latencyfs`);
+the real entry is `musefs-format/src/convert\.rs:\d+:\d+: replace usize_from ->
+usize`, whose file prefix narrows it to the one intended site (count=1). Dropping
+such a prefix would change the site count and the guard would (correctly) fail —
+do not "simplify" these to the bare description form.
+
+**Step 3 — leave the remaining single-site description anchors untagged**
+(they default to `count=1`).
+
+The pass is complete when `scripts/check_mutant_anchors.py` exits 0 against the
+tree — the acceptance test for the whole change. Expect the guard's *first* run to
+fail loudly on the 12 Step-0 drifts; that failure is the feature demonstrating its
+value, and is the strongest argument for the change.
+
+## Failure output
+
+Each failure is one block naming: the entry's `.cargo/mutants.toml` line number,
+the regex string, the check that failed, and the specifics:
+
+- Line:col re-point — `expected op "<op>" in fn "<fn>", coordinate now holds
+  "<actual mutant name(s)>"`.
+- Line:col drift-to-nothing — `expected <rows> mutant(s) at <file>:<line>:<col>,
+  found none (line likely shifted — re-anchor to the current coordinates)`.
+- Line:col rows mismatch — `expected rows=<n>, matched <m>: [<names…>]` (an over-
+  suppress reads as m>n and lists the swallowed siblings).
+- Description site-count mismatch — `expected count=<n> sites, matched <m>:
+  [<site → name(s)>]` (lists matched sites so a sibling-mask is obvious).
+- Missing required `op`/`fn`/`rows` on a line:col entry, an uncompilable or
+  non-allowlisted regex, or a match in an `exclude_globs` file — names the entry.
+
+The exit is non-zero if any block is emitted, failing the `in-diff` job.
+
+## Edge cases
+
+- **`--no-config` listing is empty / cargo errors** — guard exits non-zero with
+  the cargo stderr; an empty list is treated as a hard error (it would otherwise
+  make every count=0 and report spurious dead-entry failures, masking the real
+  cargo problem).
+- **A description anchor legitimately wants count=0** — not supported; count=0 is
+  always a failure (a rule that excludes nothing is dead and should be deleted, not
+  kept). If a future case needs it, it is added explicitly then.
+- **Inline `#` inside a regex string** (e.g. a pattern containing `#`) — the parser
+  only treats a `#` as a comment when it begins a line (after whitespace), never
+  inside a quoted array element. Covered by a unit test.
+- **Multiple `# guard:` lines in one comment block** — the last one wins; a unit
+  test pins this so a stale tag left above a fresh one can't be silently honoured.
+
+## Testing strategy
+
+- Unit: `scripts/test_check_mutant_anchors.py` over synthetic fixtures (above) —
+  the correctness proof for the parser and checker, cargo-free, runs in the Python
+  test leg.
+- Integration / acceptance: `scripts/check_mutant_anchors.py` exits 0 against the
+  real `.cargo/mutants.toml` + live `cargo mutants --no-config --list --json` after
+  the migration pass. This is run once during implementation and continuously by
+  the new CI step.
+- Negative integration (manual, documented in the PR): temporarily perturb one
+  line:col anchor by ±1 line and confirm the guard fails loudly; revert.
+
+## Risks
+
+- **cargo-mutants `--list --json` shape changes across versions.** `load_mutants`
+  depends only on the top-level `name` field, the most stable part of the schema;
+  the known-good version (27.0.0) is already pinned-by-documentation in
+  `scripts/mutants.sh`. A schema break surfaces as a guard failure, not a silent
+  pass.
+- **Rust-vs-Python regex divergence on a future exotic pattern.** Mitigated by the
+  token allowlist (rejects anything outside the proven shared subset) plus the
+  compile-check; the current 44 entries are all within the subset. Semantic
+  divergence is detectable, not merely documented.
+- **`--no-config --list` cost.** Verified ~2s, parse-time only (2867 mutants
+  enumerated, no tests run) — far cheaper than the mutation run the same job
+  already performs. On a cold `rust-cache` it also pays a baseline build; the cost
+  note assumes the warm cache the `in-diff` job normally has.
+- **Replacement-table change on a cargo-mutants upgrade.** `rows=`/`count=` pin the
+  current per-site mutant multiplicity; a future cargo-mutants that adds or removes
+  a replacement variant would shift those counts and fail the guard loudly. That is
+  correct-to-investigate (the version is documentation-pinned at 27.0.0), not a
+  silent pass — but it is a maintenance cost to note.
+- **`--mutants-json` feature/flag skew.** The file-input mode trusts the caller to
+  have generated the JSON with the exact documented command
+  (`cargo mutants --no-config --list --json`, default features). The guard cannot
+  detect a file produced with different flags; the CI step and docs use the canonical
+  command, and `main()`'s default (self-invoking) path avoids the risk locally.

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -55,6 +55,34 @@ def parse_mutant(name: str) -> Mutant:
     )
 
 
+_LITERAL_LINECOL = re.compile(r":[0-9]+:[0-9]+:")
+
+_ALLOWED_ESCAPES = set(".d+|^()*")
+
+
+def classify(regex: str) -> str:
+    return "linecol" if _LITERAL_LINECOL.search(regex) else "desc"
+
+
+def validate_regex_subset(regex: str) -> None:
+    i = 0
+    while i < len(regex):
+        c = regex[i]
+        if c == "\\":
+            if i + 1 >= len(regex):
+                raise ValueError("trailing backslash in regex")
+            nxt = regex[i + 1]
+            if nxt not in _ALLOWED_ESCAPES:
+                raise ValueError(
+                    rf"disallowed escape \{nxt} (outside the Rust/Python shared subset)"
+                )
+            i += 2
+            continue
+        if regex[i : i + 2] == "(?":
+            raise ValueError("inline group/flag (?...) not in the shared subset")
+        i += 1
+
+
 _TAG_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
 
 

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Validate that .cargo/mutants.toml exclude_re anchors still suppress exactly the
+mutants they document. See docs/superpowers/specs/2026-06-09-mutant-anchor-drift-guard-design.md."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class Tag:
+    op: str | None = None
+    fn: str | None = None
+    fn_present: bool = False
+    rows: int | None = None
+    count: int | None = None
+
+
+_TAG_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
+
+
+def parse_guard_tag(text: str) -> Tag:
+    tag = Tag()
+    for m in _TAG_FIELD.finditer(text):
+        key = m.group(1)
+        val = m.group(2) if m.group(2) is not None else m.group(3)
+        if key == "op":
+            tag.op = val
+        elif key == "fn":
+            tag.fn = val
+            tag.fn_present = True
+        elif key == "rows":
+            tag.rows = int(val)
+        elif key == "count":
+            tag.count = int(val)
+        else:
+            raise ValueError(f"unknown guard tag field: {key}")
+    return tag

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -103,3 +103,52 @@ def parse_guard_tag(text: str) -> Tag:
         else:
             raise ValueError(f"unknown guard tag field: {key}")
     return tag
+
+
+@dataclass
+class Entry:
+    regex: str
+    toml_line: int
+    tag: Tag | None
+
+
+def _unquote_toml_string(s: str) -> str:
+    s = s.rstrip(",").strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "'\"":
+        return s[1:-1]
+    raise ValueError(f"malformed TOML string element: {s!r}")
+
+
+def parse_toml_entries(text: str) -> tuple[list[Entry], list[str]]:
+    entries: list[Entry] = []
+    globs: list[str] = []
+    section: str | None = None  # "re" | "globs" | None
+    pending: Tag | None = None
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        s = raw.strip()
+        if s.startswith("exclude_re"):
+            section, pending = "re", None
+            continue
+        if s.startswith("exclude_globs"):
+            section = "globs"
+            continue
+        if s == "]":
+            section, pending = None, None
+            continue
+        if section is None:
+            continue
+        if not s:
+            continue
+        if s.startswith("#"):
+            body = s[1:].strip()
+            if body.startswith("guard:"):
+                pending = parse_guard_tag(body[len("guard:") :])
+            continue
+        if s[:1] in "'\"":
+            value = _unquote_toml_string(s)
+            if section == "re":
+                entries.append(Entry(regex=value, toml_line=lineno, tag=pending))
+                pending = None
+            else:
+                globs.append(value)
+    return entries, globs

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -4,9 +4,14 @@ mutants they document. See docs/superpowers/specs/2026-06-09-mutant-anchor-drift
 
 from __future__ import annotations
 
+import argparse
 import fnmatch
+import json
 import re
+import subprocess
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass
@@ -221,3 +226,55 @@ def check(entries: list[Entry], mutants: list[Mutant], globs: list[str]) -> list
         else:
             failures.extend(_check_desc(entry, matched))
     return failures
+
+
+def load_mutants(json_text: str) -> list[Mutant]:
+    data = json.loads(json_text)
+    if not data:
+        raise ValueError("cargo mutants --list returned no mutants (build/feature problem?)")
+    return [parse_mutant(item["name"]) for item in data]
+
+
+def _run_cargo_list() -> str:
+    proc = subprocess.run(
+        ["cargo", "mutants", "--no-config", "--list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"cargo mutants --list failed:\n{proc.stderr}")
+    return proc.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--mutants-json",
+        type=Path,
+        help="read the mutant list from this file instead of invoking cargo "
+        "(must be `cargo mutants --no-config --list --json` output)",
+    )
+    ap.add_argument(
+        "--toml",
+        type=Path,
+        default=Path(".cargo/mutants.toml"),
+        help="path to mutants.toml (default: .cargo/mutants.toml)",
+    )
+    args = ap.parse_args(argv)
+
+    entries, globs = parse_toml_entries(args.toml.read_text())
+    json_text = args.mutants_json.read_text() if args.mutants_json else _run_cargo_list()
+    mutants = load_mutants(json_text)
+
+    failures = check(entries, mutants, globs)
+    if failures:
+        print(f"{len(failures)} mutant-anchor failure(s):\n")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print(f"OK: {len(entries)} exclude_re entries validated against {len(mutants)} mutants.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -4,6 +4,7 @@ mutants they document. See docs/superpowers/specs/2026-06-09-mutant-anchor-drift
 
 from __future__ import annotations
 
+import fnmatch
 import re
 from dataclasses import dataclass
 
@@ -152,3 +153,71 @@ def parse_toml_entries(text: str) -> tuple[list[Entry], list[str]]:
             else:
                 globs.append(value)
     return entries, globs
+
+
+def _glob_match(glob: str, file: str) -> bool:
+    return fnmatch.fnmatch(file, glob)
+
+
+def _fmt(entry: Entry, msg: str) -> str:
+    return f"[mutants.toml:{entry.toml_line}] /{entry.regex}/ — {msg}"
+
+
+def _check_linecol(entry: Entry, matched: list[Mutant]) -> list[str]:
+    t = entry.tag
+    if t is None or t.op is None or not t.fn_present or t.rows is None:
+        return [_fmt(entry, "line:col entry needs `op=`, `fn=`, and `rows=` in its # guard: tag")]
+    if not matched:
+        return [
+            _fmt(
+                entry,
+                f"expected {t.rows} mutant(s), found none "
+                "(line likely shifted — re-anchor to current coordinates)",
+            )
+        ]
+    fails = []
+    sites = {m.site for m in matched}
+    if len(sites) != 1:
+        fails.append(_fmt(entry, f"expected one site, matched {len(sites)}: {sorted(sites)}"))
+    if len(matched) != t.rows:
+        names = [m.name for m in matched]
+        fails.append(_fmt(entry, f"expected rows={t.rows}, matched {len(matched)}: {names}"))
+    expected_fn = None if t.fn == "" else t.fn
+    bad = [m for m in matched if m.op != t.op or m.fn != expected_fn]
+    if bad:
+        names = [m.name for m in bad]
+        fails.append(_fmt(entry, f'expected op "{t.op}" in fn "{t.fn}", coordinate holds: {names}'))
+    return fails
+
+
+def _check_desc(entry: Entry, matched: list[Mutant]) -> list[str]:
+    count = entry.tag.count if entry.tag and entry.tag.count is not None else 1
+    if count < 1:
+        msg = f"count={count} is invalid; must suppress >=1 site (delete a dead rule)"
+        return [_fmt(entry, msg)]
+    sites = sorted({m.site for m in matched})
+    if len(sites) != count:
+        return [_fmt(entry, f"expected count={count} sites, matched {len(sites)}: {sites}")]
+    return []
+
+
+def check(entries: list[Entry], mutants: list[Mutant], globs: list[str]) -> list[str]:
+    failures: list[str] = []
+    for entry in entries:
+        try:
+            validate_regex_subset(entry.regex)
+            rx = re.compile(entry.regex)
+        except (ValueError, re.error) as ex:
+            failures.append(_fmt(entry, f"regex error: {ex}"))
+            continue
+        matched = [m for m in mutants if rx.search(m.name)]
+        glob_hits = [m for m in matched if any(_glob_match(g, m.file) for g in globs)]
+        if glob_hits:
+            names = [m.name for m in glob_hits]
+            failures.append(_fmt(entry, f"matches mutant(s) in an exclude_globs file: {names}"))
+            continue
+        if classify(entry.regex) == "linecol":
+            failures.extend(_check_linecol(entry, matched))
+        else:
+            failures.extend(_check_desc(entry, matched))
+    return failures

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -17,6 +17,44 @@ class Tag:
     count: int | None = None
 
 
+@dataclass(frozen=True)
+class Mutant:
+    name: str
+    file: str
+    line: int
+    col: int
+    op: str | None
+    repl: str | None
+    fn: str | None
+
+    @property
+    def site(self) -> tuple[str, int, int]:
+        return (self.file, self.line, self.col)
+
+
+_NAME_RE = re.compile(r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+): (?P<body>.*)$")
+_BINOP_RE = re.compile(r"^replace (?P<op>\S+) with (?P<repl>\S+)(?: in (?P<fn>.+))?$")
+
+
+def parse_mutant(name: str) -> Mutant:
+    m = _NAME_RE.match(name)
+    if not m:
+        raise ValueError(f"unparseable mutant name (no file:line:col prefix): {name!r}")
+    op = repl = fn = None
+    b = _BINOP_RE.match(m.group("body"))
+    if b:
+        op, repl, fn = b.group("op"), b.group("repl"), b.group("fn")
+    return Mutant(
+        name=name,
+        file=m.group("file"),
+        line=int(m.group("line")),
+        col=int(m.group("col")),
+        op=op,
+        repl=repl,
+        fn=fn,
+    )
+
+
 _TAG_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
 
 

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -43,6 +43,12 @@ _BINOP_RE = re.compile(r"^replace (?P<op>\S+) with (?P<repl>\S+)(?: in (?P<fn>.+
 
 
 def parse_mutant(name: str) -> Mutant:
+    """Parse a cargo-mutants name into its site and (best-effort) op/repl/fn.
+
+    The site is always extracted; op/repl/fn are populated only for binary-operator
+    mutants (None for FnValue/MatchArm/UnaryOperator/etc., which the site-count
+    check handles fine). Raises ValueError if the name lacks a file:line:col prefix.
+    """
     m = _NAME_RE.match(name)
     if not m:
         raise ValueError(f"unparseable mutant name (no file:line:col prefix): {name!r}")
@@ -71,6 +77,13 @@ def classify(regex: str) -> str:
 
 
 def validate_regex_subset(regex: str) -> None:
+    """Reject patterns outside the Rust-regex/Python-re shared subset.
+
+    Only the escapes actually used by the toml (``.d+|^()*``) are allowed, and
+    inline groups ``(?...)`` are forbidden, so a future pattern relying on a
+    construct whose meaning diverges between the two engines fails loudly here
+    rather than silently matching a different set. Raises ValueError on violation.
+    """
     i = 0
     while i < len(regex):
         c = regex[i]
@@ -93,8 +106,18 @@ _TAG_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
 
 
 def parse_guard_tag(text: str) -> Tag:
+    """Parse a ``# guard:`` body into a Tag, rejecting malformed residue.
+
+    Any non-whitespace outside the recognized ``key=value`` tokens (e.g. a typo'd
+    ``count = 3`` with stray spaces) raises ValueError rather than being silently
+    dropped, so a broken tag can't quietly degrade to the defaults.
+    """
     tag = Tag()
+    cursor = 0
     for m in _TAG_FIELD.finditer(text):
+        if text[cursor : m.start()].strip():
+            raise ValueError(f"malformed guard tag near: {text[cursor : m.start()]!r}")
+        cursor = m.end()
         key = m.group(1)
         val = m.group(2) if m.group(2) is not None else m.group(3)
         if key == "op":
@@ -108,6 +131,8 @@ def parse_guard_tag(text: str) -> Tag:
             tag.count = int(val)
         else:
             raise ValueError(f"unknown guard tag field: {key}")
+    if text[cursor:].strip():
+        raise ValueError(f"malformed guard tag near: {text[cursor:]!r}")
     return tag
 
 
@@ -126,6 +151,13 @@ def _unquote_toml_string(s: str) -> str:
 
 
 def parse_toml_entries(text: str) -> tuple[list[Entry], list[str]]:
+    """Raw-text parse of mutants.toml into (exclude_re entries, exclude_globs).
+
+    Raw text rather than a TOML library because the ``# guard:`` expectations live
+    in comments. Each entry is paired with the nearest preceding ``# guard:`` tag
+    (last one wins); a ``#`` only starts a comment at line start, never inside a
+    quoted regex.
+    """
     entries: list[Entry] = []
     globs: list[str] = []
     section: str | None = None  # "re" | "globs" | None
@@ -207,6 +239,12 @@ def _check_desc(entry: Entry, matched: list[Mutant]) -> list[str]:
 
 
 def check(entries: list[Entry], mutants: list[Mutant], globs: list[str]) -> list[str]:
+    """Validate every entry against the unfiltered mutant set; return failure lines.
+
+    Line:col anchors are checked by operator+function+row-count; description anchors
+    by distinct-site count. A match landing in an exclude_globs file is also a
+    failure (the pattern has drifted onto a non-gated file).
+    """
     failures: list[str] = []
     for entry in entries:
         try:
@@ -236,11 +274,15 @@ def load_mutants(json_text: str) -> list[Mutant]:
 
 
 def _run_cargo_list() -> str:
-    proc = subprocess.run(
-        ["cargo", "mutants", "--no-config", "--list", "--json"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            ["cargo", "mutants", "--no-config", "--list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired as ex:
+        raise SystemExit("cargo mutants --list timed out after 600s") from ex
     if proc.returncode != 0:
         raise SystemExit(f"cargo mutants --list failed:\n{proc.stderr}")
     return proc.stdout
@@ -262,9 +304,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
 
-    entries, globs = parse_toml_entries(args.toml.read_text())
-    json_text = args.mutants_json.read_text() if args.mutants_json else _run_cargo_list()
-    mutants = load_mutants(json_text)
+    try:
+        entries, globs = parse_toml_entries(args.toml.read_text())
+        json_text = args.mutants_json.read_text() if args.mutants_json else _run_cargo_list()
+        mutants = load_mutants(json_text)
+    except (OSError, json.JSONDecodeError, ValueError, KeyError) as ex:
+        print(f"error: failed to load toml/mutants: {ex}", file=sys.stderr)
+        return 1
 
     failures = check(entries, mutants, globs)
     if failures:

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 import check_mutant_anchors as g  # noqa: E402
@@ -31,10 +33,16 @@ def test_parse_guard_tag_count():
 
 
 def test_parse_guard_tag_rejects_unknown_field():
-    import pytest
-
     with pytest.raises(ValueError):
         g.parse_guard_tag(" bogus=1")
+
+
+def test_parse_guard_tag_rejects_malformed_residue():
+    # stray spaces around '=' would otherwise be silently dropped to defaults
+    with pytest.raises(ValueError):
+        g.parse_guard_tag(" count = 3")
+    with pytest.raises(ValueError):
+        g.parse_guard_tag(' op="<" garbage rows=3')
 
 
 def test_parse_mutant_binop_with_fn():
@@ -75,8 +83,6 @@ def test_parse_mutant_unary_delete_is_site_only():
 
 
 def test_parse_mutant_rejects_no_prefix():
-    import pytest
-
     with pytest.raises(ValueError):
         g.parse_mutant("not a mutant name")
 
@@ -102,8 +108,6 @@ def test_validate_regex_subset_accepts_current_constructs():
 
 
 def test_validate_regex_subset_rejects_divergent_escape():
-    import pytest
-
     with pytest.raises(ValueError):
         g.validate_regex_subset(r"replace \b foo")
     with pytest.raises(ValueError):
@@ -111,8 +115,6 @@ def test_validate_regex_subset_rejects_divergent_escape():
 
 
 def test_validate_regex_subset_rejects_inline_group():
-    import pytest
-
     with pytest.raises(ValueError):
         g.validate_regex_subset(r"foo(?=bar)")
 
@@ -166,7 +168,7 @@ def test_parse_toml_entries_hash_inside_regex_not_a_comment():
     assert entries[0].tag is None
 
 
-def _m(name):
+def _m(name: str) -> g.Mutant:
     return g.parse_mutant(name)
 
 
@@ -319,7 +321,5 @@ def test_load_mutants_from_json():
 
 
 def test_load_mutants_empty_is_error():
-    import pytest
-
     with pytest.raises(ValueError):
         g.load_mutants("[]")

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -164,3 +164,145 @@ def test_parse_toml_entries_hash_inside_regex_not_a_comment():
     entries, _ = g.parse_toml_entries(toml)
     assert entries[0].regex == "replace # with x in foo"
     assert entries[0].tag is None
+
+
+def _m(name):
+    return g.parse_mutant(name)
+
+
+def test_check_linecol_ok():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            1,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=3),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file"),
+        _m("musefs-core/src/scan.rs:277:30: replace < with > in probe_file"),
+        _m("musefs-core/src/scan.rs:277:30: replace < with <= in probe_file"),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_linecol_drift_to_nothing():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:713:29:",
+            1,
+            g.Tag(op="+=", fn="run_pipeline", fn_present=True, rows=2),
+        )
+    ]
+    fails = g.check(entries, [], [])
+    assert len(fails) == 1 and "found none" in fails[0]
+
+
+def test_check_linecol_repoint_wrong_op():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            1,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace + with - in probe_file")]
+    fails = g.check(entries, muts, [])
+    assert any("expected op" in f for f in fails)
+
+
+def test_check_linecol_over_suppress_rows():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/ogg_index\.rs:216:15:",
+            1,
+            g.Tag(op="<", fn="serve_ogg_window", fn_present=True, rows=1),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/ogg_index.rs:216:15: replace < with == in serve_ogg_window"),
+        _m("musefs-core/src/ogg_index.rs:216:15: replace < with > in serve_ogg_window"),
+        _m("musefs-core/src/ogg_index.rs:216:15: replace < with <= in serve_ogg_window"),
+    ]
+    fails = g.check(entries, muts, [])
+    assert any("rows=1" in f for f in fails)
+
+
+def test_check_linecol_const_empty_fn():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/reader\.rs:71:60: replace / with [%*]",
+            1,
+            g.Tag(op="/", fn="", fn_present=True, rows=2),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/reader.rs:71:60: replace / with %"),
+        _m("musefs-core/src/reader.rs:71:60: replace / with *"),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_linecol_missing_field():
+    entries = [g.Entry(r"musefs-core/src/scan\.rs:277:30:", 1, g.Tag(op="<"))]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
+    fails = g.check(entries, muts, [])
+    assert any("needs `op=`, `fn=`, and `rows=`" in f for f in fails)
+
+
+def test_check_desc_site_count_ok_multisite():
+    entries = [g.Entry(r"replace \| with \^ in synchsafe_decode", 1, g.Tag(count=3))]
+    muts = [
+        _m("musefs-format/src/mp3.rs:10:5: replace | with ^ in synchsafe_decode"),
+        _m("musefs-format/src/mp3.rs:11:5: replace | with ^ in synchsafe_decode"),
+        _m("musefs-format/src/mp3.rs:12:5: replace | with ^ in synchsafe_decode"),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_desc_sibling_mask():
+    entries = [g.Entry(r"replace \| with \^ in synchsafe_decode", 1, None)]
+    muts = [
+        _m("musefs-format/src/mp3.rs:10:5: replace | with ^ in synchsafe_decode"),
+        _m("musefs-format/src/mp3.rs:99:5: replace | with ^ in synchsafe_decode"),
+    ]
+    fails = g.check(entries, muts, [])
+    assert any("count=1" in f for f in fails)
+
+
+def test_check_desc_dead_entry_zero():
+    entries = [g.Entry(r"replace == with != in VirtualTree::gone", 1, None)]
+    fails = g.check(entries, [], [])
+    assert any("count=1" in f for f in fails)
+
+
+def test_check_desc_count_zero_rejected():
+    entries = [g.Entry(r"replace == with != in VirtualTree::gone", 1, g.Tag(count=0))]
+    fails = g.check(entries, [], [])
+    assert any("invalid" in f for f in fails)
+
+
+def test_check_desc_over_nonbinop_matches():
+    entries = [
+        g.Entry(r'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)', 1, None)
+    ]
+    muts = [
+        _m(
+            "musefs-core/src/tree.rs:848:5: replace truncate_component"
+            ' -> Cow<\'_, str> with Cow::Borrowed("")'
+        ),
+    ]
+    assert g.check(entries, muts, []) == []
+
+
+def test_check_glob_excluded_match_fails():
+    entries = [g.Entry(r"metrics\.rs:\d+:\d+: replace \+ with -", 1, None)]
+    muts = [_m("musefs-core/src/metrics.rs:5:5: replace + with - in bump")]
+    fails = g.check(entries, muts, ["musefs-core/src/metrics.rs"])
+    assert any("exclude_globs" in f for f in fails)
+
+
+def test_check_uncompilable_regex_reported():
+    entries = [g.Entry(r"replace \q foo", 1, None)]
+    fails = g.check(entries, [], [])
+    assert any("regex error" in f for f in fails)

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -306,3 +306,20 @@ def test_check_uncompilable_regex_reported():
     entries = [g.Entry(r"replace \q foo", 1, None)]
     fails = g.check(entries, [], [])
     assert any("regex error" in f for f in fails)
+
+
+def test_load_mutants_from_json():
+    payload = (
+        '[{"name": "musefs-core/src/scan.rs:277:30: replace < with == in probe_file",'
+        ' "file": "musefs-core/src/scan.rs"}]'
+    )
+    muts = g.load_mutants(payload)
+    assert len(muts) == 1
+    assert muts[0].site == ("musefs-core/src/scan.rs", 277, 30)
+
+
+def test_load_mutants_empty_is_error():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.load_mutants("[]")

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -35,3 +35,47 @@ def test_parse_guard_tag_rejects_unknown_field():
 
     with pytest.raises(ValueError):
         g.parse_guard_tag(" bogus=1")
+
+
+def test_parse_mutant_binop_with_fn():
+    m = g.parse_mutant("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")
+    assert m.site == ("musefs-core/src/scan.rs", 277, 30)
+    assert m.op == "<"
+    assert m.repl == "=="
+    assert m.fn == "probe_file"
+
+
+def test_parse_mutant_binop_const_no_fn():
+    m = g.parse_mutant("musefs-core/src/reader.rs:71:60: replace / with %")
+    assert m.site == ("musefs-core/src/reader.rs", 71, 60)
+    assert m.op == "/"
+    assert m.repl == "%"
+    assert m.fn is None
+
+
+def test_parse_mutant_fnvalue_is_site_only():
+    m = g.parse_mutant("musefs-format/src/convert.rs:21:5: replace usize_from -> usize with 0")
+    assert m.site == ("musefs-format/src/convert.rs", 21, 5)
+    assert m.op is None and m.repl is None and m.fn is None
+
+
+def test_parse_mutant_matchguard_is_site_only():
+    m = g.parse_mutant(
+        "musefs-core/src/tree.rs:641:30: replace match guard"
+        " self.path_of(ino) == new_path with false"
+        " in VirtualTree::apply_changes"
+    )
+    assert m.site == ("musefs-core/src/tree.rs", 641, 30)
+    assert m.op is None and m.fn is None
+
+
+def test_parse_mutant_unary_delete_is_site_only():
+    m = g.parse_mutant("musefs-core/src/scan.rs:874:12: delete ! in revalidate_with")
+    assert m.op is None and m.fn is None
+
+
+def test_parse_mutant_rejects_no_prefix():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.parse_mutant("not a mutant name")

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -115,3 +115,52 @@ def test_validate_regex_subset_rejects_inline_group():
 
     with pytest.raises(ValueError):
         g.validate_regex_subset(r"foo(?=bar)")
+
+
+SAMPLE_TOML = """\
+exclude_globs = [
+    "musefs-fuse/**",
+    "musefs-core/src/metrics.rs",
+]
+exclude_re = [
+    # a bare line:col entry
+    # guard: op="<" fn="probe_file" rows=3
+    'musefs-core/src/scan\\.rs:277:30:',
+
+    # a description entry, multi-site (note the blank line above — must be skipped)
+    # guard: count=3
+    'replace \\| with \\^ in synchsafe_decode',
+    # an untagged description entry (defaults count=1)
+    'replace == with != in VirtualTree::ancestor_in',
+]
+"""
+
+
+def test_parse_toml_entries_pairs_tags():
+    entries, globs = g.parse_toml_entries(SAMPLE_TOML)
+    assert globs == ["musefs-fuse/**", "musefs-core/src/metrics.rs"]
+    assert len(entries) == 3
+    assert entries[0].regex == r"musefs-core/src/scan\.rs:277:30:"
+    assert entries[0].tag.op == "<" and entries[0].tag.rows == 3
+    assert entries[1].regex == r"replace \| with \^ in synchsafe_decode"
+    assert entries[1].tag.count == 3
+    assert entries[2].tag is None  # untagged → default later
+
+
+def test_parse_toml_entries_last_guard_wins():
+    toml = (
+        "exclude_re = [\n"
+        "    # guard: count=2\n"
+        "    # guard: count=5\n"
+        "    'replace a with b in foo',\n"
+        "]\n"
+    )
+    entries, _ = g.parse_toml_entries(toml)
+    assert entries[0].tag.count == 5
+
+
+def test_parse_toml_entries_hash_inside_regex_not_a_comment():
+    toml = "exclude_re = [\n    'replace # with x in foo',\n]\n"
+    entries, _ = g.parse_toml_entries(toml)
+    assert entries[0].regex == "replace # with x in foo"
+    assert entries[0].tag is None

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import check_mutant_anchors as g  # noqa: E402
+
+
+def test_parse_guard_tag_linecol():
+    t = g.parse_guard_tag(' op="<" fn="probe_file" rows=3')
+    assert t.op == "<"
+    assert t.fn == "probe_file"
+    assert t.fn_present is True
+    assert t.rows == 3
+    assert t.count is None
+
+
+def test_parse_guard_tag_const_empty_fn():
+    t = g.parse_guard_tag(' op="/" fn="" rows=2')
+    assert t.op == "/"
+    assert t.fn == ""
+    assert t.fn_present is True
+    assert t.rows == 2
+
+
+def test_parse_guard_tag_count():
+    t = g.parse_guard_tag(" count=3")
+    assert t.count == 3
+    assert t.op is None
+    assert t.fn_present is False
+
+
+def test_parse_guard_tag_rejects_unknown_field():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.parse_guard_tag(" bogus=1")

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -79,3 +79,39 @@ def test_parse_mutant_rejects_no_prefix():
 
     with pytest.raises(ValueError):
         g.parse_mutant("not a mutant name")
+
+
+def test_classify_linecol_vs_desc():
+    assert g.classify(r"musefs-core/src/scan\.rs:277:30:") == "linecol"
+    pat = r"musefs-format/src/convert\.rs:\d+:\d+: replace usize_from -> usize"
+    assert g.classify(pat) == "desc"
+    assert g.classify(r"replace < with <= in Musefs::poll_due") == "desc"
+
+
+def test_validate_regex_subset_accepts_current_constructs():
+    patterns = [
+        r"musefs-core/src/scan\.rs:277:30:",
+        r"replace < with (==|>|<=) in crc_shift_zeros",
+        r"musefs-core/src/reader\.rs:71:60: replace / with [%*]",
+        r"replace match guard .* with false in VirtualTree::apply_changes",
+        r"replace \+ with \* in fixtures::wav",
+        r'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)',
+    ]
+    for pat in patterns:
+        g.validate_regex_subset(pat)  # must not raise
+
+
+def test_validate_regex_subset_rejects_divergent_escape():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.validate_regex_subset(r"replace \b foo")
+    with pytest.raises(ValueError):
+        g.validate_regex_subset(r"replace \w+ foo")
+
+
+def test_validate_regex_subset_rejects_inline_group():
+    import pytest
+
+    with pytest.raises(ValueError):
+        g.validate_regex_subset(r"foo(?=bar)")


### PR DESCRIPTION
## What

Adds a CI guard that validates every `.cargo/mutants.toml` `exclude_re` entry still suppresses exactly the mutant(s) it documents, and fixes a **pre-existing latent bug**: 12 line:col exclusions had silently drifted to zero matches after a `scan.rs` reformat, so the gate was suppressing nothing at those coordinates while the toml claimed otherwise.

## How it works

`scripts/check_mutant_anchors.py` runs `cargo mutants --no-config --list --json` to get the full *unfiltered* mutant set, then replays each `exclude_re` pattern itself and checks it against a machine-readable `# guard:` tag in the toml comment:

- **line:col anchors** (`# guard: op=… fn=… rows=…`) — every matched row must share the operator + function, occupy one site, and match the row count. Catches re-point, drift-to-nothing, and over/under-suppression.
- **description anchors** (`# guard: count=N`, default 1) — the number of distinct *sites* matched must equal `count`. Catches a new killable sibling silently joining the match set.

It also fails if a match lands in an `exclude_globs` file and rejects regex tokens outside the Rust/Python shared subset.

## Changes

- `scripts/check_mutant_anchors.py` — the guard (stdlib-only) + `scripts/test_check_mutant_anchors.py` (32 unit tests).
- `.cargo/mutants.toml` — re-anchored the 12 drifted entries to current coordinates (run_pipeline cluster +21 lines, revalidate_with, sync_channel) and added `# guard:` tags to all line:col + the 4 multi-site description entries. Equivalence re-confirmed by hand against `scan.rs`; the killable `*scanned += 1` / `unchanged += 1` counters stay out of scope.
- `.github/workflows/mutants.yml` — guard step in the per-PR `in-diff` job.
- `.github/workflows/ci.yml` — unit-test step in the `python-musefs` job.
- `docs/superpowers/{specs,plans}/` — design spec + implementation plan.

## Verification

- `python -m pytest scripts/test_check_mutant_anchors.py` — 32 passed; ruff clean.
- Guard against the live tree: `OK: 44 exclude_re entries validated against 2867 mutants` (exit 0).
- Negative check: perturbing an anchor by one line produces a loud `found none (line likely shifted…)` failure (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated guard script that verifies mutation-test exclusion anchors against current mutant output.

* **Documentation**
  * Added design spec, migration plan, and contributing guidance for the mutant-anchor drift guard.

* **Tests**
  * Added a comprehensive pytest suite covering guard parsing and validation scenarios.

* **Chores**
  * CI updated to run the guard during PR checks.
  * Mutation-test exclusion entries re-anchored and annotated with machine-checkable guard tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->