### PR TITLE
fix(core): re-stat held backing fd on per-handle read path (#186)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,7 +178,9 @@ default) of resolved layouts — keys each entry on it: a hit with a stale
 `content_version` rebuilds the layout. Independently of the cache, **every**
 resolve re-stats the backing file and errors with `BackingChanged` if its
 size or mtime drifted from the scanned values, so a silently replaced backing
-file is never spliced at stale offsets.
+file is never spliced at stale offsets. The per-handle read path re-stats the
+held descriptor on every read too, so this guarantee holds on the hot path and
+not only through `resolve()`.
 
 **`data_version`** (`PRAGMA data_version`, whole-DB) answers *"did anyone
 commit anything?"*. `Musefs::poll_refresh` compares it to the last seen

--- a/docs/superpowers/plans/2026-06-09-per-handle-backing-restat.md
+++ b/docs/superpowers/plans/2026-06-09-per-handle-backing-restat.md
@@ -247,6 +247,13 @@ Use the Serena editing tools for this change (it edits inside the `read_into`
 method body — `replace_content` with the three-line anchor above is the precise
 way).
 
+**Do NOT add a `metrics::on_stat()` call here.** `validate_opened_backing` does
+its fstat via `file.metadata()` and is deliberately *not* counted by the stat
+metric (the only `on_stat()` site is `reader.rs:117` in `resolve()`'s
+path-stat). `tests/metrics.rs:156` asserts `s.stats == 0` on the per-handle read
+path; that assertion stays green precisely because this fstat is uncounted.
+Adding an `on_stat()` call would break it.
+
 - [ ] **Step 7: Run the facade tests to confirm green**
 
 Run:
@@ -263,7 +270,8 @@ cargo test -p musefs-core 2>&1 | tail -20
 ```
 Expected: all pass. (Confirms no other test depended on the old
 serve-after-grow behavior. The only test asserting it was the one converted in
-Step 1.)
+Step 1. Note `tests/metrics.rs:156` asserts zero stats on the handle path — it
+stays green because the new fstat is uncounted; see the note in Step 6.)
 
 - [ ] **Step 9: Add the ARCHITECTURE.md freshness note**
 

--- a/docs/superpowers/plans/2026-06-09-per-handle-backing-restat.md
+++ b/docs/superpowers/plans/2026-06-09-per-handle-backing-restat.md
@@ -1,0 +1,343 @@
+# Per-handle backing re-stat (issue #186) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the per-handle read fast path re-stat the held backing fd on every read so an in-place backing rewrite under a live handle is detected (`BackingChanged`) instead of silently splicing stale-offset bytes.
+
+**Architecture:** Add one `validate_opened_backing(&h.file, r)?` call in `Musefs::read_into`'s per-handle fast path, after the resolved layout is loaded and before the DB-read serve block, on each retry iteration. The error propagates immediately (a genuine out-of-band rewrite is terminal — not a DB-retag race the loop retries). This reuses the exact validation `open_handle` already performs and makes the hot path consistent with `resolve()`, which already stats on every call.
+
+**Tech Stack:** Rust (edition 2024), `std::os::unix` file metadata, `std::fs::File::set_times` / `std::fs::FileTimes` for deterministic test mtime control, `tempfile`, the in-crate `musefs-db` + `scan_directory` test harness.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md`
+
+---
+
+## Background the implementer needs
+
+The fix and tests live in two files:
+
+- **`musefs-core/src/facade.rs`** — the one-line fix in `read_into`, and the
+  primitive `validate_opened_backing`.
+- **`musefs-core/tests/facade.rs`** — an *integration* test crate (external to
+  `musefs-core`). It already imports everything needed:
+  `use musefs_core::{CoreError, MountConfig, Musefs, VirtualTree, scan_directory};`
+  and has helpers `config()`, `scanned_db(dir)`, `make_flac`, `streaminfo_body`,
+  `vorbis_comment_body`.
+
+Key facts (verified against the current tree):
+
+- `read_into` fast path: `musefs-core/src/facade.rs:949-1037`. The insertion
+  point is between these two existing lines (currently around line 982-984):
+
+  ```rust
+  let resolved = h.resolved.load();
+  let r: &ResolvedFile = &resolved;
+  let served = self.pool.with(|db| -> Result<Option<()>> {
+  ```
+
+- `validate_opened_backing(file, resolved) -> Result<()>`
+  (`musefs-core/src/facade.rs:110`) fstat's the fd and returns
+  `Err(CoreError::BackingChanged(path))` when `meta.len() != resolved.backing_size`
+  **or** `mtime_secs(&meta) != resolved.backing_mtime_secs`. It is `Ok(())`
+  otherwise.
+
+- `mtime_secs` is **whole seconds** (`facade.rs:103-108`). The scanner stamps
+  `backing_mtime` from the file's real mtime at scan time. In a test,
+  write→scan→read→rewrite all happen in one wall-clock second, so a same-length
+  rewrite leaves `mtime_secs` unchanged unless the test **explicitly** sets a
+  distinct mtime. This is correctness-load-bearing, not flake avoidance.
+
+- `scanned_db` creates `a.flac` (a real FLAC, backing audio = `[0xAB; 64]`)
+  under `dir`, scans it, returns an in-memory `Db`. `config()` uses template
+  `$artist/$title`, tags `ARTIST=Alice` / `TITLE=Song`.
+
+- `Musefs::read(inode, fh, offset, size) -> Result<Vec<u8>>` is the allocating
+  wrapper over `read_into`; tests call it.
+
+**Commit discipline (critical):** the pre-commit hook runs the **full workspace
+test suite** and rejects any commit with red tests. A red-test-only commit is
+impossible here. Therefore the failing tests and the fix must land in **one
+commit**: write tests (red, uncommitted) → confirm red by running them directly
+→ implement the fix → confirm green → update docs → commit everything together.
+
+---
+
+## File Structure
+
+- `musefs-core/src/facade.rs` — modify `read_into` (one added line). No new
+  symbols, no new error variant.
+- `musefs-core/tests/facade.rs` — convert one existing test; add three tests.
+- `ARCHITECTURE.md` — one-line freshness note.
+
+---
+
+## Task 1: Tests + fix for per-handle backing re-stat (single commit)
+
+**Files:**
+- Modify: `musefs-core/tests/facade.rs` (convert `read_uses_cached_handle_after_backing_grows`; add three test fns)
+- Modify: `musefs-core/src/facade.rs:982-984` (`read_into` fast path)
+- Modify: `ARCHITECTURE.md` (freshness note)
+
+---
+
+- [ ] **Step 1: Convert the bug-encoding test into the rewrite-longer regression test**
+
+In `musefs-core/tests/facade.rs`, replace the existing function
+`read_uses_cached_handle_after_backing_grows` (currently at lines 1041-1061,
+which asserts the grown-backing read *succeeds*) entirely with the version
+below. The append grows the file → size drift → `BackingChanged`.
+
+```rust
+#[test]
+fn read_through_handle_errors_after_backing_grows_in_place() {
+    use std::io::Write;
+    let dir = tempfile::tempdir().unwrap();
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    // Warm the per-handle fast path.
+    let warm = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    assert_eq!(warm.len() as u64, size);
+
+    // In-place grow (same inode), no DB change.
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(dir.path().join("a.flac"))
+            .unwrap();
+        f.write_all(&[0u8; 64]).unwrap();
+    }
+
+    // Size drift must be detected on the held fd, not served silently.
+    let err = fs.read(file_inode, Some(fh), 0, size).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+```
+
+- [ ] **Step 2: Add the truncate-shorter test**
+
+Append this new function to `musefs-core/tests/facade.rs` (after the function
+from Step 1). A shorter file is size drift, caught before any positioned read —
+this confirms the normalization to `BackingChanged` (not a raw io error from
+reading past EOF).
+
+```rust
+#[test]
+fn read_through_handle_errors_after_backing_truncated_in_place() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    fs.read(file_inode, Some(fh), 0, size).unwrap(); // warm
+
+    // Truncate in place (same inode): std::fs::write create+truncates the path.
+    std::fs::write(dir.path().join("a.flac"), [0xCDu8; 8]).unwrap();
+
+    let err = fs.read(file_inode, Some(fh), 0, size).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+```
+
+- [ ] **Step 3: Add the same-length-rewrite test (the core gap)**
+
+Append this new function. This is the only variant exercising the mtime branch
+and the issue's silent-corruption-at-unchanged-length mode. It **must** set a
+distinct mtime, or `mtime_secs` stays equal to the scan-time value and the
+re-stat returns `Ok` — passing while detecting nothing.
+
+```rust
+#[test]
+fn read_through_handle_errors_after_same_length_rewrite_with_new_mtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("a.flac");
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    fs.read(file_inode, Some(fh), 0, size).unwrap(); // warm
+
+    // Same-length in-place rewrite (same inode), then a distinct mtime second.
+    let original_len = std::fs::metadata(&path).unwrap().len() as usize;
+    std::fs::write(&path, vec![0xEEu8; original_len]).unwrap();
+    // mtime_secs is whole-second; the rewrite above lands in the scan's second,
+    // so set a deterministic, distinct timestamp. (Year ~2001 — well clear of
+    // the scan second regardless of wall clock.)
+    let distinct = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+    let f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(distinct)).unwrap();
+
+    let err = fs.read(file_inode, Some(fh), 0, size).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+```
+
+- [ ] **Step 4: Add the positive-guard test**
+
+Append this new function. With no rewrite and no DB change, repeated reads on
+the same handle must still succeed — guards against the new `?` becoming
+over-eager.
+
+```rust
+#[test]
+fn read_through_handle_keeps_succeeding_when_backing_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    let first = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    let second = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(first.len() as u64, size);
+}
+```
+
+- [ ] **Step 5: Run the new/changed tests to confirm they fail (red)**
+
+Run:
+```bash
+cargo test -p musefs-core --test facade read_through_handle 2>&1 | tail -30
+```
+Expected: the three new error-expecting tests FAIL because the current fast
+path serves successfully (so `unwrap_err()` panics on an `Ok`), or — for the
+truncate case — surfaces a non-`BackingChanged` io error. The positive-guard
+test (`..._keeps_succeeding_when_backing_unchanged`) PASSES already. Confirm the
+three `errors_after_*` tests are red before implementing the fix.
+
+- [ ] **Step 6: Implement the fix in `read_into`**
+
+In `musefs-core/src/facade.rs`, in the per-handle fast path of `read_into`,
+insert the re-stat between the resolved-layout load and the serve block. The
+surrounding lines are currently:
+
+```rust
+                    let resolved = h.resolved.load();
+                    let r: &ResolvedFile = &resolved;
+                    let served = self.pool.with(|db| -> Result<Option<()>> {
+```
+
+Change to (add the one `validate_opened_backing` line):
+
+```rust
+                    let resolved = h.resolved.load();
+                    let r: &ResolvedFile = &resolved;
+                    // Re-stat the held fd every read: a pure in-place backing
+                    // rewrite (same inode) leaves both DB-side staleness signals
+                    // unchanged, so this is the only check that catches it. A
+                    // genuine drift is terminal — propagate, don't retry the loop.
+                    validate_opened_backing(&h.file, r)?;
+                    let served = self.pool.with(|db| -> Result<Option<()>> {
+```
+
+Use the Serena editing tools for this change (it edits inside the `read_into`
+method body — `replace_content` with the three-line anchor above is the precise
+way).
+
+- [ ] **Step 7: Run the facade tests to confirm green**
+
+Run:
+```bash
+cargo test -p musefs-core --test facade read_through_handle 2>&1 | tail -20
+```
+Expected: all four `read_through_handle_*` tests PASS.
+
+- [ ] **Step 8: Run the full musefs-core test crate**
+
+Run:
+```bash
+cargo test -p musefs-core 2>&1 | tail -20
+```
+Expected: all pass. (Confirms no other test depended on the old
+serve-after-grow behavior. The only test asserting it was the one converted in
+Step 1.)
+
+- [ ] **Step 9: Add the ARCHITECTURE.md freshness note**
+
+Open `ARCHITECTURE.md` around lines 178-181 (the freshness paragraph beginning
+"every resolve re-stats the backing file..."). Add a sentence making explicit
+that the per-handle hot path honors the same guarantee. Use Read to find the
+exact surrounding text, then append a sentence such as:
+
+> The per-handle read path also re-stats the held descriptor on every read, so
+> this guarantee holds on the hot path and not only through `resolve()`.
+
+Keep it to one sentence; match the surrounding prose style.
+
+- [ ] **Step 10: Pre-commit dry run (fmt + clippy + full suite)**
+
+Run:
+```bash
+cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test --workspace 2>&1 | tail -15
+```
+Expected: fmt clean, clippy clean (`-D warnings`), all tests pass. Fix any
+issue before committing — the pre-commit hook runs the same gates and will
+reject a red commit.
+
+- [ ] **Step 11: Commit (tests + fix + doc together)**
+
+```bash
+git add musefs-core/src/facade.rs musefs-core/tests/facade.rs ARCHITECTURE.md
+git commit -m "$(cat <<'EOF'
+fix(core): re-stat held backing fd on per-handle read path (#186)
+
+The per-handle read fast path only re-resolved on DB-side signals
+(refresh_gen / content_version), so an in-place backing rewrite under a
+live fd (same inode: rsync --inplace, reflink swap, in-place re-encode)
+spliced new bytes at the cached layout's audio offsets with no error —
+silent corruption violating the cardinal invariant and the ARCHITECTURE.md
+freshness guarantee.
+
+Call the existing validate_opened_backing on the fast path before serving,
+on each retry iteration, propagating BackingChanged immediately rather than
+through the stale-layout retry loop. This makes the hot path consistent with
+resolve(), which already stats on every call. The fstat is on an already-open
+fd (~microseconds), negligible next to the pread and FUSE round-trip.
+
+Convert read_uses_cached_handle_after_backing_grows (which asserted the old
+serve-after-grow behavior) into a BackingChanged regression test, and add
+truncate-shorter, same-length-with-new-mtime, and unchanged-backing
+positive-guard tests through the per-handle read path.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Out of scope (do not do)
+
+- No change to `read_segments_into`, `read_at_with_file_into`, `resolve`, or the
+  fallback `read_at_into` path.
+- No mtime-granularity change (no scanner/schema change). The same-second miss
+  and the stat→pread TOCTOU are documented inherent residuals.
+- No new `CoreError` variant — reuse `BackingChanged`.
+- No `filetime` dev-dependency — `std::fs::File::set_times` is stable on this
+  edition-2024 toolchain.
+
+---
+
+## Self-review notes (already reconciled with the spec)
+
+- **Spec coverage:** fix (Step 6) ✓; rewrite-longer (Step 1) ✓; truncate-shorter
+  (Step 2) ✓; same-length+mtime (Step 3) ✓; positive guard (Step 4) ✓;
+  ARCHITECTURE.md note (Step 9) ✓.
+- **Single-commit discipline** is required by the pre-commit full-suite gate —
+  tests and fix cannot be split across commits.
+- **Type/name consistency:** `validate_opened_backing(&std::fs::File, &ResolvedFile) -> Result<()>`,
+  `CoreError::BackingChanged(String)`, `Musefs::read(...) -> Result<Vec<u8>>` —
+  all match the current tree.

--- a/docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md
+++ b/docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md
@@ -1,0 +1,175 @@
+# Per-handle read path re-stats the backing file (issue #186)
+
+**Date:** 2026-06-09
+**Issue:** [#186](https://github.com/Sohex/musefs/issues/186) — Per-handle read
+path skips backing re-stat: in-place backing rewrite under a live fd serves
+stale-offset bytes silently.
+
+## Problem
+
+The per-handle read fast path in `Musefs::read_into`
+(`musefs-core/src/facade.rs`) never re-validates the backing file between
+DB-side refreshes. An in-place rewrite of a backing file while a handle is open
+(same inode — `rsync --inplace`, btrfs dedup/reflink swap, in-place re-encode),
+with no corresponding DB change, causes positioned reads to splice the new
+file's bytes at the *old* layout's audio offsets: silent wrong bytes, no error.
+
+This violates the cardinal invariant (served audio is byte-identical to a
+coherent backing file) and contradicts the freshness guarantee documented at
+`ARCHITECTURE.md:178-181` ("**every** resolve re-stats the backing file and
+errors with `BackingChanged` if its size or mtime drifted").
+
+### Why the existing signals miss it
+
+The fast path only re-resolves when:
+- `refresh_gen` advances (a DB refresh landed), or
+- for binary-tag layouts, `content_version` drifts.
+
+Both are **DB-side** signals. A pure backing-file rewrite touches neither, so
+the path goes straight to `read_at_with_file_into` → `read_segments_into` →
+`f.read_exact_at(...)` at cached offsets, with no `stat`, no size/mtime check.
+
+### Failure modes (from the issue)
+
+- **Truncate-shorter:** `read_exact_at` past the new EOF errors out (raw io
+  error).
+- **Same-length rewrite**, or **rewrite-longer** where old offsets stay in
+  bounds: positioned reads return wrong bytes with **no error** — the Inline
+  metadata region comes from the old DB-derived layout while audio is read at
+  old offsets from the new file (incoherent splice, silent corruption).
+
+Atomic-replace (temp file + `rename`) is **not** affected: the held fd stays on
+the old unlinked inode, which remains coherent with the old layout.
+
+## The validation primitive already exists
+
+`validate_opened_backing(file, resolved)` (`facade.rs:110`) does an `fstat` on
+an already-open fd and compares `len`/`mtime_secs` against the captured
+`resolved.backing_size`/`resolved.backing_mtime_secs`, returning
+`CoreError::BackingChanged` on drift. It is called exactly once today — in
+`open_handle` (`facade.rs:1070`). The fix is to call it again on the hot path.
+
+## Approach
+
+Add a single `validate_opened_backing(&h.file, r)?` call inside the per-handle
+fast path of `read_into`, on each retry iteration, **after** loading the
+resolved layout (`let r: &ResolvedFile = &resolved;`) and **before** the
+`self.pool.with(...)` block that serves the read.
+
+```rust
+let resolved = h.resolved.load();
+let r: &ResolvedFile = &resolved;
+validate_opened_backing(&h.file, r)?;   // re-stat the held fd; BackingChanged on drift
+let served = self.pool.with(|db| -> Result<Option<()>> { /* unchanged */ })?;
+```
+
+### Why this placement
+
+- **Reuses the proven primitive.** Same function `open_handle` already relies
+  on; same `fstat`-on-fd (no path traversal).
+- **Error propagates immediately, not through the retry loop.** A genuine
+  out-of-band backing rewrite is terminal — `?` returns `BackingChanged`
+  straight to the caller. It must *not* be treated as a stale-layout/DB-retag
+  race (which the loop retries); the loop is for DB-side version drift only.
+- **Independent of the DB.** A filesystem stat does not belong inside the
+  `pool.with` / `begin_read` snapshot, so it sits just before it. It runs the
+  same way for both the plain and the `has_binary_tag` branches.
+- **Runs every read.** The `fstat` is on an already-open fd (~microseconds),
+  negligible next to the pread and FUSE round-trip.
+
+### Why not push the stat into `read_segments_into`
+
+`read_segments_into` is shared with the fallback path (`read_at_into`), which
+has already validated via `resolve()` and opened a fresh fd. Statting there
+would either double-stat the fallback or require a flag to suppress it — added
+branching on a hot, shared path for no benefit.
+
+### Why "stat every read" over "stat only on backing-touching reads"
+
+Considered skipping the stat for reads landing entirely in the small `Inline`
+metadata header (those bytes are DB-derived and correct regardless of the
+backing). Rejected: a synthesized audio file is a small inline header followed
+by one large `BackingAudio` segment to ~EOF, so nearly every read of any size
+overlaps a backing segment. The optimization would spare the cheap `fstat` on
+only the first read or two of a file, at the cost of read-range/segment-overlap
+branching on the hot path. Not worth it.
+
+### Why "stat every read" over a throttled / time-windowed re-stat
+
+A throttle (stat at most once per handle per N ms) would open a bounded window
+where stale bytes are served — relaxing the cardinal invariant. Off the table.
+
+## Effect on the reported failure modes
+
+Because the `fstat` runs *before* any `read_exact_at`:
+
+- **Rewrite-longer** → `len` differs → `BackingChanged`. ✓
+- **Same-length rewrite** → caught when the new `mtime_secs` differs from the
+  captured one. The captured `backing_mtime_secs` comes from the DB scan
+  (typically well in the past) and a live rewrite stamps a fresh mtime, so this
+  differs in virtually all real cases. ✓
+- **Truncate-shorter** → `len` differs → `BackingChanged`, caught by the stat
+  *before* the pread. This **normalizes** the previous raw-io-error behavior to
+  `BackingChanged` with no special-casing. ✓
+
+### Residual, documented-as-inherent limitations
+
+- **Seconds-granularity mtime.** `mtime_secs` is whole-seconds, shared with
+  `resolve()`. A same-length rewrite landing in the *exact same wall-clock
+  second* that was captured evades detection. Pre-existing; not introduced by
+  this path. Closing it would require nanosecond mtime through the scanner and
+  the DB schema — out of scope (YAGNI for this fix).
+- **Stat→pread TOCTOU.** A rewrite landing in the narrow window *between* the
+  `fstat` and a subsequent `read_exact_at` within one read call can still
+  surface a raw io error (e.g. truncate past EOF). No stat-then-read scheme can
+  close this; documented as inherent rather than normalized.
+
+## Testing
+
+Add a test to `musefs-core/tests/facade.rs` (which already drives
+`open_handle` + `read_into` through the full facade) that exercises validation
+**through the per-handle read path** — the exact gap the issue names. Existing
+tests (`resolve_errors_when_backing_file_changes` at `tests/reader.rs:96`, the
+`validate_opened_backing` unit test at `facade.rs:1085`) exercise validation
+directly, never via `open_handle -> read`.
+
+Test shape:
+
+1. Build a store + backing file; `open_handle(inode)`.
+2. First `read_into(.., Some(fh), ..)` succeeds (warms the per-handle path).
+3. In-place rewrite the backing file at the **same inode** (open the existing
+   path for write / truncate, not temp+rename), in two variants:
+   - **rewrite-longer or same-length** with an advanced mtime → assert the next
+     `read_into` on the *same handle* returns `CoreError::BackingChanged`.
+   - **truncate-shorter** → assert the next `read_into` on the same handle also
+     returns `CoreError::BackingChanged` (confirms normalization, not a raw io
+     error).
+4. (Optional) Assert no DB change occurred between the reads, to make explicit
+   that the detection is backing-side, not DB-side.
+
+mtime control: set the backing file's mtime explicitly (e.g. via
+`std::fs::File::set_times` / `filetime`) so the same-length variant is
+deterministic and not dependent on test wall-clock crossing a second boundary.
+
+## Docs
+
+`ARCHITECTURE.md:178-181` currently describes the freshness guarantee in terms
+of `resolve()`; after this fix the per-handle hot path honors the same
+guarantee. Add a one-line note that the per-handle read path also re-stats the
+held fd on every read, so the documented guarantee holds on the hot path and
+not only through `resolve()`.
+
+## Scope / non-goals
+
+- No change to `read_segments_into`, `read_at_with_file_into`, `resolve`, or the
+  fallback (`read_at_into`) path.
+- No mtime-granularity change (no scanner/schema change).
+- No new error variant — reuse `CoreError::BackingChanged`.
+- No change to atomic-replace behavior (already correct).
+
+## Files touched
+
+- `musefs-core/src/facade.rs` — one `validate_opened_backing` call in
+  `read_into`'s fast path.
+- `musefs-core/tests/facade.rs` — new through-the-handle test.
+- `ARCHITECTURE.md` — one-line freshness note.

--- a/docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md
+++ b/docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md
@@ -156,6 +156,15 @@ existing path for write / truncate — never temp+rename); then assert the next
 `read_into` on the *same handle*. No DB change happens between reads, so any
 detection is purely backing-side.
 
+**Existing test that encodes the bug.**
+`read_uses_cached_handle_after_backing_grows` (`tests/facade.rs:1041`) currently
+opens a handle, appends 64 bytes to the backing file in place, reads via the
+handle, and asserts the read *succeeds*. That is exactly the rewrite-longer
+behavior the fix now rejects (and is already inconsistent with `resolve()`,
+which errors on any size/mtime drift). This test must be **converted** into a
+regression test that asserts `CoreError::BackingChanged`, becoming variant 1
+below. It is not a separate addition — it is the rewrite-longer variant.
+
 Three variants, asserted **separately** — they exercise different branches and
 must not be collapsed:
 
@@ -208,5 +217,7 @@ not only through `resolve()`.
 
 - `musefs-core/src/facade.rs` — one `validate_opened_backing` call in
   `read_into`'s fast path.
-- `musefs-core/tests/facade.rs` — new through-the-handle test.
+- `musefs-core/tests/facade.rs` — convert `read_uses_cached_handle_after_backing_grows`
+  into the rewrite-longer regression test; add truncate-shorter, same-length, and
+  positive-guard tests.
 - `ARCHITECTURE.md` — one-line freshness note.

--- a/docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md
+++ b/docs/superpowers/specs/2026-06-09-per-handle-backing-restat-design.md
@@ -71,6 +71,15 @@ let served = self.pool.with(|db| -> Result<Option<()>> { /* unchanged */ })?;
   out-of-band backing rewrite is terminal — `?` returns `BackingChanged`
   straight to the caller. It must *not* be treated as a stale-layout/DB-retag
   race (which the loop retries); the loop is for DB-side version drift only.
+- **Complementary to `resolve()`'s path-stat, not redundant.** On a
+  gen-change iteration the loop re-resolves via `cache.resolve(...)`, which
+  stats the backing **by path** and can itself return `BackingChanged`
+  (`reader.rs:117-120`). The new call stats the **held fd**. These check
+  different things: the path-stat can pass while the held fd points at a
+  now-incoherent inode (and vice-versa after an atomic replace). The fd-stat
+  is therefore not dead code on the gen-change branch — it is the only check
+  that covers the live handle. The redundant fstat on that rare iteration is
+  the negligible cost already covered by the perf argument above.
 - **Independent of the DB.** A filesystem stat does not belong inside the
   `pool.with` / `begin_read` snapshot, so it sits just before it. It runs the
   same way for both the plain and the `has_binary_tag` branches.
@@ -107,10 +116,14 @@ Because the `fstat` runs *before* any `read_exact_at`:
 - **Same-length rewrite** → caught when the new `mtime_secs` differs from the
   captured one. The captured `backing_mtime_secs` comes from the DB scan
   (typically well in the past) and a live rewrite stamps a fresh mtime, so this
-  differs in virtually all real cases. ✓
+  differs in virtually all real cases. ✓ (The one window where it does *not* is
+  the same-second miss in the residual-limitations list below — it applies only
+  when the rewrite shares the scan's wall-clock second.)
 - **Truncate-shorter** → `len` differs → `BackingChanged`, caught by the stat
-  *before* the pread. This **normalizes** the previous raw-io-error behavior to
-  `BackingChanged` with no special-casing. ✓
+  *before* the pread, **regardless of the requested read range** (truncation
+  changes total len, so the size check fires for any offset). This
+  **normalizes** the previous raw-io-error behavior to `BackingChanged` with no
+  special-casing. ✓
 
 ### Residual, documented-as-inherent limitations
 
@@ -121,8 +134,11 @@ Because the `fstat` runs *before* any `read_exact_at`:
   the DB schema — out of scope (YAGNI for this fix).
 - **Stat→pread TOCTOU.** A rewrite landing in the narrow window *between* the
   `fstat` and a subsequent `read_exact_at` within one read call can still
-  surface a raw io error (e.g. truncate past EOF). No stat-then-read scheme can
-  close this; documented as inherent rather than normalized.
+  surface a raw io error (e.g. truncate past EOF). This is a strict shrink, not
+  a hole the fix opens: pre-fix, *every* read on a rewritten backing could
+  splice silently; post-fix the only surviving raw-io exposure is this
+  intra-call window. No stat-then-read scheme can close it; documented as
+  inherent rather than normalized.
 
 ## Testing
 
@@ -133,23 +149,44 @@ tests (`resolve_errors_when_backing_file_changes` at `tests/reader.rs:96`, the
 `validate_opened_backing` unit test at `facade.rs:1085`) exercise validation
 directly, never via `open_handle -> read`.
 
-Test shape:
+Common shape: build a store + backing file; `open_handle(inode)`; a first
+`read_into(.., Some(fh), ..)` succeeds (warms the per-handle path); then an
+**in-place** rewrite of the backing file at the **same inode** (open the
+existing path for write / truncate — never temp+rename); then assert the next
+`read_into` on the *same handle*. No DB change happens between reads, so any
+detection is purely backing-side.
 
-1. Build a store + backing file; `open_handle(inode)`.
-2. First `read_into(.., Some(fh), ..)` succeeds (warms the per-handle path).
-3. In-place rewrite the backing file at the **same inode** (open the existing
-   path for write / truncate, not temp+rename), in two variants:
-   - **rewrite-longer or same-length** with an advanced mtime → assert the next
-     `read_into` on the *same handle* returns `CoreError::BackingChanged`.
-   - **truncate-shorter** → assert the next `read_into` on the same handle also
-     returns `CoreError::BackingChanged` (confirms normalization, not a raw io
-     error).
-4. (Optional) Assert no DB change occurred between the reads, to make explicit
-   that the detection is backing-side, not DB-side.
+Three variants, asserted **separately** — they exercise different branches and
+must not be collapsed:
 
-mtime control: set the backing file's mtime explicitly (e.g. via
-`std::fs::File::set_times` / `filetime`) so the same-length variant is
-deterministic and not dependent on test wall-clock crossing a second boundary.
+1. **Rewrite-longer** → exercises the **size** branch. Next read returns
+   `CoreError::BackingChanged`. (Mtime irrelevant here — this is the same
+   branch the existing `resolve_errors_when_backing_file_changes` already
+   covers via `resolve()`; included only to confirm it also fires through the
+   per-handle path.)
+2. **Truncate-shorter** → exercises the **size** branch *and* the
+   normalization claim. Next read returns `CoreError::BackingChanged` (not a
+   raw io error from `read_exact_at` past EOF).
+3. **Same-length rewrite** → exercises the **mtime** branch and is the **only**
+   variant matching the issue's silent-corruption-at-unchanged-length mode.
+   This is the core gap; the other two are guards.
+4. **Positive guard** — after a no-op (no rewrite, no DB change), a second read
+   on the same handle still succeeds. Ensures the new `?` is not over-eager and
+   does not reject valid reads.
+
+**Mtime control is correctness-load-bearing for variant 3, not flake-avoidance.**
+`mtime_secs` is whole-seconds (`facade.rs:103-108`) and the scanner stamps
+`backing_mtime` from the file's real mtime at scan time. In a test, write →
+scan → first read → rewrite all occur within one wall-clock second, so a
+same-length rewrite leaves `mtime_secs` byte-identical to the captured value and
+`validate_opened_backing` returns `Ok` — the test would pass having detected
+nothing. Variant 3 **must** explicitly set the rewritten file's mtime to a
+distinct second (e.g. scan-time + 2s) after rewriting, or it silently no-ops.
+
+Use `std::fs::File::set_times` with `std::fs::FileTimes` (stable since Rust
+1.75; the workspace is edition 2024 / MSRV ≥ 1.85). Do **not** add a `filetime`
+dev-dependency — it is not currently a dependency and `set_times` makes it
+unnecessary, avoiding a `Cargo.lock` / vendoring change.
 
 ## Docs
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -981,6 +981,11 @@ impl Musefs {
                     }
                     let resolved = h.resolved.load();
                     let r: &ResolvedFile = &resolved;
+                    // Re-stat the held fd every read: a pure in-place backing
+                    // rewrite (same inode) leaves both DB-side staleness signals
+                    // unchanged, so this is the only check that catches it. A
+                    // genuine drift is terminal — propagate, don't retry the loop.
+                    validate_opened_backing(&h.file, r)?;
                     let served = self.pool.with(|db| -> Result<Option<()>> {
                         if r.has_binary_tag {
                             // Snapshot-consistent: version check + blob reads see one

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -1040,7 +1040,7 @@ fn open_handle_returns_distinct_ids_and_rejects_dirs() {
 }
 
 #[test]
-fn read_uses_cached_handle_after_backing_grows() {
+fn read_through_handle_errors_after_backing_grows_in_place() {
     use std::io::Write;
     let dir = tempfile::tempdir().unwrap();
     let db = scanned_db(dir.path());
@@ -1050,6 +1050,11 @@ fn read_uses_cached_handle_after_backing_grows() {
     let size = fs.getattr(file_inode).unwrap().size;
 
     let fh = fs.open_handle(file_inode).unwrap();
+    // Warm the per-handle fast path.
+    let warm = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    assert_eq!(warm.len() as u64, size);
+
+    // In-place grow (same inode), no DB change.
     {
         let mut f = std::fs::OpenOptions::new()
             .append(true)
@@ -1057,8 +1062,73 @@ fn read_uses_cached_handle_after_backing_grows() {
             .unwrap();
         f.write_all(&[0u8; 64]).unwrap();
     }
-    let via_handle = fs.read(file_inode, Some(fh), 0, size).unwrap();
-    assert_eq!(via_handle.len() as u64, size);
+
+    // Size drift must be detected on the held fd, not served silently.
+    let err = fs.read(file_inode, Some(fh), 0, size).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+#[test]
+fn read_through_handle_errors_after_backing_truncated_in_place() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    fs.read(file_inode, Some(fh), 0, size).unwrap(); // warm
+
+    // Truncate in place (same inode): std::fs::write create+truncates the path.
+    std::fs::write(dir.path().join("a.flac"), [0xCDu8; 8]).unwrap();
+
+    let err = fs.read(file_inode, Some(fh), 0, size).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+#[test]
+fn read_through_handle_errors_after_same_length_rewrite_with_new_mtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("a.flac");
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    fs.read(file_inode, Some(fh), 0, size).unwrap(); // warm
+
+    // Same-length in-place rewrite (same inode), then a distinct mtime second.
+    let original_len = std::fs::read(&path).unwrap().len();
+    std::fs::write(&path, vec![0xEEu8; original_len]).unwrap();
+    // mtime_secs is whole-second; the rewrite above lands in the scan's second,
+    // so set a deterministic, distinct timestamp. (Year ~2001 — well clear of
+    // the scan second regardless of wall clock.)
+    let distinct = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+    let f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(distinct))
+        .unwrap();
+
+    let err = fs.read(file_inode, Some(fh), 0, size).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+#[test]
+fn read_through_handle_keeps_succeeding_when_backing_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = scanned_db(dir.path());
+    let fs = Musefs::open(db, config()).unwrap();
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let size = fs.getattr(file_inode).unwrap().size;
+
+    let fh = fs.open_handle(file_inode).unwrap();
+    let first = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    let second = fs.read(file_inode, Some(fh), 0, size).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(first.len() as u64, size);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #186.

## Problem

The per-handle read fast path in `Musefs::read_into` only re-resolved on **DB-side** signals (`refresh_gen` / `content_version`). A pure in-place rewrite of a backing file under a live fd (same inode — `rsync --inplace`, btrfs dedup/reflink swap, in-place re-encode), with no DB change, touches neither signal, so positioned reads spliced the new file's bytes at the **old** layout's audio offsets:

- **rewrite-longer / same-length** → wrong bytes, **no error** (silent corruption).
- **truncate-shorter** → raw `UnexpectedEof` io error.

This violated the cardinal invariant (served audio byte-identical to a coherent backing file) and the freshness guarantee documented at `ARCHITECTURE.md:178-181`, which holds for `resolve()` but not for reads on a live handle.

## Fix

Call the existing `validate_opened_backing(&h.file, r)?` on the fast path before serving, on each retry iteration. It `fstat`s the held fd and returns `BackingChanged` on size/mtime drift. The error propagates immediately rather than through the stale-layout retry loop — a genuine out-of-band rewrite is terminal, not a DB-retag race. This makes the hot path consistent with `resolve()`, which already stats on every call.

The `fstat` is on an already-open fd (no path traversal, ~microseconds), negligible next to the pread and FUSE round-trip. It is deliberately **not** counted by `metrics::on_stat()`, so the `tests/metrics.rs` zero-stat-on-handle-path assertion stays valid.

## Tests

Through the per-handle read path (the gap the issue named — existing tests only exercised validation directly):

- Converted `read_uses_cached_handle_after_backing_grows` (which asserted the old serve-after-grow behavior) into a `BackingChanged` regression test.
- Added **truncate-shorter** (confirms normalization to `BackingChanged`, not a raw io error), **same-length rewrite with a distinct mtime** (the core silent-corruption-at-unchanged-length case; mtime is set explicitly via `std::fs::File::set_times` because whole-second `mtime_secs` would otherwise no-op), and an **unchanged-backing positive guard**.

All three error tests were red before the fix and green after; the guard stayed green throughout. Full workspace suite + clippy `-D warnings` + fmt pass.

## Residual limitations (documented, inherent)

- Whole-second `mtime_secs`: a same-length rewrite landing in the exact second of the original scan evades detection (pre-existing, shared with `resolve()`).
- stat→pread TOCTOU: a rewrite landing between the `fstat` and the pread within one read call can still surface a raw io error. Exposure strictly shrank from "always" to this narrow intra-call window.

## Scope

One-line behavioral change in `read_into`; no new error variant, no schema/scanner change, no new dependency, fallback path untouched. Spec and plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed silent data corruption by detecting in-place backing file rewrites (size or timestamp changes) and returning an error instead of serving stale data.

* **Documentation**
  * Added design specification and implementation plan documenting the backing file change detection mechanism on read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->