### PR TITLE
feat(scan): opt-in --follow-symlinks with cycle guard (#189)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -80,13 +80,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_file" rows=2
-    'musefs-core/src/scan\.rs:270:31:',
+    'musefs-core/src/scan\.rs:341:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:277:30:',
+    'musefs-core/src/scan\.rs:348:30:',
     # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -94,18 +94,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:288:21:',
+    'musefs-core/src/scan\.rs:359:21:',
     # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:293:17:',
+    'musefs-core/src/scan\.rs:364:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:641:46:',
+    'musefs-core/src/scan\.rs:716:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -115,24 +115,24 @@ exclude_re = [
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `replace += with` and
     # `>=`/`||` repeat in run_pipeline (e.g. the killable `*scanned += 1` at
-    # 712), so these cannot be safely description-anchored. Re-verify these
+    # 787), so these cannot be safely description-anchored. Re-verify these
     # coordinates after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:734:29:',
+    'musefs-core/src/scan\.rs:809:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:736:32:',
+    'musefs-core/src/scan\.rs:811:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:736:47:',
+    'musefs-core/src/scan\.rs:811:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:736:62:',
+    'musefs-core/src/scan\.rs:811:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:744:37:',
+    'musefs-core/src/scan\.rs:819:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:746:40:',
+    'musefs-core/src/scan\.rs:821:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:746:55:',
+    'musefs-core/src/scan\.rs:821:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:746:70:',
+    'musefs-core/src/scan\.rs:821:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -140,11 +140,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:850:25:',
+    'musefs-core/src/scan\.rs:925:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:854:25:',
+    'musefs-core/src/scan\.rs:929:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:890:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:965:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,6 +28,31 @@ if ! cargo test --workspace --quiet; then
     exit 1
 fi
 
+# Mutant-exclusion anchor drift guard. The .cargo/mutants.toml exclude_re entries
+# are anchored on file:line:col; a code edit that shifts a line can silently
+# re-point an anchor onto a killable mutant. Re-validate (mirroring the CI job in
+# mutants.yml) whenever the config, the guard script, or a mutation-scoped source
+# file (musefs-core / musefs-format) is staged. Skipped — not enforced — when
+# cargo-mutants is absent, since CI re-checks it on every PR regardless.
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+if echo "$STAGED" | grep -qE '^(\.cargo/mutants\.toml|scripts/check_mutant_anchors\.py|musefs-(core|format)/src/.*\.rs)$'; then
+    if command -v cargo-mutants >/dev/null 2>&1; then
+        echo "pre-commit: mutant-anchor drift guard"
+        MUTANTS_LIST=$(mktemp)
+        trap 'rm -f "$MUTANTS_LIST"' EXIT
+        if ! cargo mutants --no-config --list --json >"$MUTANTS_LIST"; then
+            echo "✗ mutant-anchor guard: 'cargo mutants --list' failed." >&2
+            exit 1
+        fi
+        if ! python3 scripts/check_mutant_anchors.py --mutants-json "$MUTANTS_LIST"; then
+            echo "✗ mutant-anchor guard: re-anchor .cargo/mutants.toml to the current coordinates." >&2
+            exit 1
+        fi
+    else
+        echo "pre-commit: cargo-mutants not installed — skipping anchor guard (CI enforces it)." >&2
+    fi
+fi
+
 # Lint the union of every path the beets, picard, lidarr, python-musefs, and
 # scripts CI jobs lint, so a commit can't pass the hook yet fail CI.
 RUFF_PATHS=(contrib/beets/ contrib/lidarr/ contrib/picard/ contrib/python-musefs/ scripts/ tests/interop/)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -252,7 +252,10 @@ files whose size/mtime changed (skipping unchanged files **preserves
 external tag edits** in the DB), delete tracks under the scanned root whose
 backing file is gone, and garbage-collect now-unreferenced art. Pruning is
 scoped to the scanned root, so revalidating one library root never removes
-tracks belonging to another.
+tracks belonging to another. Because a track is keyed by its *canonical*
+backing path, a file scanned via `--follow-symlinks` whose real target lives
+outside the scanned root falls outside the prune scope: if that target later
+disappears, its stale row is not pruned by revalidating this root.
 
 ## The contrib ecosystem
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -239,6 +239,14 @@ are bounded — the scanner never slurps whole files — and ingestion caps
 per-item sizes (`MAX_ART_BYTES`, `MAX_BINARY_TAG_BYTES`) so a crafted file
 cannot balloon the store.
 
+Symlinks are **not followed by default**: a symlinked file or directory is
+logged (`RUST_LOG=info`/`warn`) and skipped, which keeps the walk immune to
+directory-symlink cycles. Passing `--follow-symlinks` resolves them — symlinked
+audio files and directories are scanned — guarded by a visited `(dev, ino)` set
+so symlink cycles terminate. Broken symlinks are logged and skipped without
+aborting the scan. The `root` argument is always followed regardless of the
+flag; only links encountered during recursion are gated.
+
 `revalidate` is the maintenance pass (`scan --revalidate`): re-probe only
 files whose size/mtime changed (skipping unchanged files **preserves
 external tag edits** in the DB), delete tracks under the scanned root whose

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ musefs scan /path/to/music --db library.db --revalidate
 
 `scan` probes each audio file (FLAC, MP3, M4A/M4B, Ogg, WAV), recording its
 audio byte range, tags, and embedded art in the store. It takes one or more
-files or directories, and `--jobs N` controls probe parallelism. `--quiet`
+files or directories, and `--jobs N` controls probe parallelism.
+`--follow-symlinks` walks symlinked files and directories (off by default, so
+symlinks are logged and skipped). `--quiet`
 (`-q`) suppresses the per-target summary for scripting; scan failures still
 surface on stderr (raise detail with `RUST_LOG=info`).
 `--revalidate` is the maintenance pass: it skips unchanged files —

--- a/docs/superpowers/plans/2026-06-09-scan-follow-symlinks.md
+++ b/docs/superpowers/plans/2026-06-09-scan-follow-symlinks.md
@@ -1,0 +1,561 @@
+# Scan: follow symlinks (opt-in, cycle-guarded) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `--follow-symlinks` flag so the scanner can traverse symlinked audio files and directories (with a cycle guard), and make the default-off path log a diagnostic instead of silently dropping symlinks.
+
+**Architecture:** The fix lives entirely in the collection phase, `collect_audio` (`musefs-core/src/scan.rs`). `collect_audio` is split into a thin entry point that owns a `HashSet<(dev, ino)>` visited set and a recursive inner walker. A new `ftype.is_symlink()` arm logs-and-skips when the flag is off and resolves-and-recurses (cycle-guarded) when on. The flag rides on the existing `ScanOptions` struct, so both `scan_directory_with` and `revalidate_with` honor it; the CLI plumbs a clap flag into `ScanOptions`.
+
+**Tech Stack:** Rust, `std::fs` (`read_dir`/`metadata`/`symlink`), `std::os::unix::fs::MetadataExt` (Unix-only — musefs is a FUSE filesystem), `clap` derive, `log`, `tempfile` (test-only).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-scan-follow-symlinks-design.md`
+
+---
+
+## Critical constraint: every commit must be green
+
+The pre-commit hook runs `cargo fmt`, `cargo clippy --all-targets -D warnings`, and the **full workspace test suite**. A commit with red tests or clippy warnings is rejected. Therefore:
+
+- Within each task, write the test(s) and the implementation, confirm green locally, *then* commit. Never commit a red tree.
+- Changing `collect_audio`'s arity breaks every caller at compile time, so Task 2 updates the signature **and** all callers **and** the existing test caller in one commit — that is the smallest compilable unit.
+- Run the full check before each commit: `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test`.
+
+## File structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs-core/src/scan.rs` | `ScanOptions` flag + `Default`; `collect_audio` split + symlink arm + cycle guard; update 3 callers + 1 test caller; new `hardening_tests` cases | Modify |
+| `musefs-cli/src/lib.rs` | `Command::Scan` clap flag; `run_scan` param; `run` dispatch; `ScanOptions` literal; parse tests | Modify |
+| `musefs-cli/tests/scan.rs` | Update 3 positional `run_scan` callers | Modify |
+| `ARCHITECTURE.md` | Document symlink scanning behavior + flag | Modify |
+| `README.md` | Document `--follow-symlinks` flag | Modify |
+
+Note: all `ScanOptions { … }` literals in the workspace use `..Default::default()` (verified across `musefs-core/tests/*` and `musefs-cli/src/lib.rs`), so adding a struct field does not break them. The only positional break is `run_scan`'s three callers in `musefs-cli/tests/scan.rs` (Task 3).
+
+---
+
+## Task 1: Add `follow_symlinks` to `ScanOptions`
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` — `ScanOptions` struct (`scan.rs:378-386`) and `impl Default for ScanOptions` (`scan.rs:388-396`)
+- Test: `musefs-core/src/scan.rs` — `hardening_tests` module (`scan.rs:1203+`)
+
+- [ ] **Step 1: Write the failing test**
+
+In the `hardening_tests` module (after the existing `collect_audio_skips_unsupported_files` test), add:
+
+```rust
+    #[test]
+    fn scan_options_default_does_not_follow_symlinks() {
+        assert!(!ScanOptions::default().follow_symlinks);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core scan_options_default_does_not_follow_symlinks`
+Expected: FAIL — compile error `no field 'follow_symlinks' on type 'ScanOptions'`.
+
+- [ ] **Step 3: Add the field and default**
+
+Edit the struct (use Serena `replace_symbol_body` on `ScanOptions`) to:
+
+```rust
+/// Knobs for a scan. `jobs == 0` means "use available parallelism".
+#[derive(Debug, Clone)]
+pub struct ScanOptions {
+    pub jobs: usize,
+    /// Initial probe read window in bytes; widened on `NeedMore`.
+    pub window: usize,
+    /// In-flight art-byte budget and per-batch byte-flush threshold.
+    pub batch_bytes: u64,
+    /// Follow symlinks during collection. Off by default: symlinks are logged
+    /// and skipped, which keeps the walk immune to directory-symlink cycles.
+    pub follow_symlinks: bool,
+}
+```
+
+Edit `impl Default for ScanOptions` (use Serena `replace_symbol_body` on `impl Default for ScanOptions`) to:
+
+```rust
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            jobs: 0,
+            window: WINDOW,
+            batch_bytes: BATCH_BYTES,
+            follow_symlinks: false,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p musefs-core scan_options_default_does_not_follow_symlinks`
+Expected: PASS.
+
+- [ ] **Step 5: Full check + commit**
+
+```bash
+cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test
+git add musefs-core/src/scan.rs
+git commit -m "$(cat <<'EOF'
+feat(core): add follow_symlinks to ScanOptions (#189)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Follow symlinks in `collect_audio` (core mechanism)
+
+This task changes `collect_audio`'s signature, so it updates **all four call sites** (3 production + 1 existing test) and adds the new tests in the same commit — that is the smallest compilable unit.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs`
+  - `collect_audio` (`scan.rs:76-88`) — split into entry + inner, add `descend` + `dir_key` helpers, add symlink arm
+  - `scan_directory_with` call site (`scan.rs:612`)
+  - `revalidate_with` call site (`scan.rs:823`)
+  - `scan_directory_full_oracle` call site (`scan.rs:781`)
+  - existing test caller `hardening_tests::collect_audio_skips_unsupported_files` (`scan.rs:1235`)
+- Test: `musefs-core/src/scan.rs` — `hardening_tests` module (new cases)
+
+- [ ] **Step 1: Write the failing tests**
+
+In the `hardening_tests` module, add these five tests:
+
+```rust
+    #[test]
+    fn collect_audio_follows_symlinked_file_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.flac");
+        std::fs::write(&real, b"x").unwrap();
+        let lib = dir.path().join("lib");
+        std::fs::create_dir(&lib).unwrap();
+        std::os::unix::fs::symlink(&real, lib.join("link.flac")).unwrap();
+
+        let mut on = Vec::new();
+        collect_audio(&lib, &mut on, true).unwrap();
+        assert_eq!(on.len(), 1, "symlinked file should be collected when following");
+
+        let mut off = Vec::new();
+        collect_audio(&lib, &mut off, false).unwrap();
+        assert!(off.is_empty(), "symlinked file should be skipped by default");
+    }
+
+    #[test]
+    fn collect_audio_follows_symlinked_dir_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("music");
+        std::fs::create_dir(&real_dir).unwrap();
+        std::fs::write(real_dir.join("song.flac"), b"x").unwrap();
+        let root = dir.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::os::unix::fs::symlink(&real_dir, root.join("linkdir")).unwrap();
+
+        let mut on = Vec::new();
+        collect_audio(&root, &mut on, true).unwrap();
+        assert_eq!(on.len(), 1, "files under a symlinked dir should be collected");
+
+        let mut off = Vec::new();
+        collect_audio(&root, &mut off, false).unwrap();
+        assert!(off.is_empty(), "symlinked dir should be skipped by default");
+    }
+
+    #[test]
+    fn collect_audio_terminates_on_symlink_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::write(a.join("song.flac"), b"x").unwrap();
+        // a/loop -> the root, which contains a, which contains loop, ...
+        std::os::unix::fs::symlink(dir.path(), a.join("loop")).unwrap();
+
+        let mut out = Vec::new();
+        collect_audio(dir.path(), &mut out, true).unwrap(); // must return, not hang
+        assert_eq!(
+            out.iter().filter(|p| p.ends_with("song.flac")).count(),
+            1,
+            "each real file collected at most once despite the cycle"
+        );
+    }
+
+    #[test]
+    fn collect_audio_skips_broken_symlink_when_following() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("real.flac"), b"x").unwrap();
+        std::os::unix::fs::symlink(
+            dir.path().join("nonexistent"),
+            dir.path().join("dangling"),
+        )
+        .unwrap();
+
+        let mut out = Vec::new();
+        let result = collect_audio(dir.path(), &mut out, true);
+        assert!(result.is_ok(), "a dangling symlink must not abort collection");
+        assert_eq!(out.len(), 1);
+        assert!(out[0].ends_with("real.flac"));
+    }
+
+    #[test]
+    fn collect_audio_does_not_follow_symlinks_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("real.flac"), b"x").unwrap();
+        let other = dir.path().join("other.flac");
+        std::fs::write(&other, b"x").unwrap();
+        std::os::unix::fs::symlink(&other, dir.path().join("link.flac")).unwrap();
+
+        let mut out = Vec::new();
+        collect_audio(dir.path(), &mut out, false).unwrap();
+        // Both real files collected; the symlink is skipped (not double-counted).
+        assert_eq!(out.len(), 2);
+    }
+```
+
+Also update the existing test `collect_audio_skips_unsupported_files` (`scan.rs:1235`) — change its call from `collect_audio(dir.path(), &mut out).unwrap();` to:
+
+```rust
+        collect_audio(dir.path(), &mut out, false).unwrap();
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-core collect_audio`
+Expected: FAIL — compile error: `collect_audio` takes 2 arguments but 3 were supplied (the whole crate fails to compile until Step 3 is complete).
+
+- [ ] **Step 3: Rewrite `collect_audio` and update all call sites**
+
+Replace `collect_audio` (`scan.rs:76-88`) with the entry point plus two helpers. Use Serena `replace_symbol_body` on `collect_audio` for the entry body, then `insert_after_symbol` to add `collect_audio_inner`, `descend`, and `dir_key`. Add `use std::collections::HashSet;` and `use std::os::unix::fs::MetadataExt;` at the top of the file (alongside the existing `use std::collections::HashMap;` at `scan.rs:1`).
+
+```rust
+fn collect_audio(root: &Path, out: &mut Vec<PathBuf>, follow_symlinks: bool) -> std::io::Result<()> {
+    let mut visited = HashSet::new();
+    if follow_symlinks {
+        // Seed with the root's identity so a symlink pointing back to it is
+        // caught as a cycle on the first descent.
+        if let Ok(meta) = std::fs::metadata(root) {
+            visited.insert(dir_key(&meta));
+        }
+    }
+    collect_audio_inner(root, out, follow_symlinks, &mut visited)
+}
+
+fn collect_audio_inner(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ftype = entry.file_type()?;
+        if ftype.is_dir() {
+            descend(&path, out, follow_symlinks, visited)?;
+        } else if ftype.is_file() {
+            if is_supported_audio(&path) {
+                out.push(path);
+            }
+        } else if ftype.is_symlink() {
+            if !follow_symlinks {
+                log::warn!(
+                    "skipping symlink {} (pass --follow-symlinks to scan it)",
+                    path.display()
+                );
+                continue;
+            }
+            match std::fs::metadata(&path) {
+                Ok(meta) if meta.is_dir() => descend(&path, out, follow_symlinks, visited)?,
+                Ok(meta) if meta.is_file() => {
+                    if is_supported_audio(&path) {
+                        out.push(path);
+                    }
+                }
+                Ok(_) => {} // target is neither file nor directory — ignore
+                Err(e) => {
+                    log::warn!("skipping broken symlink {}: {e}", path.display());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Recurse into a directory `path`. When following symlinks, guard against
+/// cycles by recording every entered directory's `(dev, ino)`; otherwise recurse
+/// directly (the walk is cycle-immune because nothing is followed).
+fn descend(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+) -> std::io::Result<()> {
+    if !follow_symlinks {
+        return collect_audio_inner(path, out, follow_symlinks, visited);
+    }
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("skipping directory {}: {e}", path.display());
+            return Ok(());
+        }
+    };
+    if !visited.insert(dir_key(&meta)) {
+        log::warn!("skipping symlink cycle at {}", path.display());
+        return Ok(());
+    }
+    collect_audio_inner(path, out, follow_symlinks, visited)
+}
+
+/// `(st_dev, st_ino)` identity of a path, used to break symlink cycles.
+fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
+    (meta.dev(), meta.ino())
+}
+```
+
+Now update the three production call sites:
+
+- `scan_directory_with` (`scan.rs:612`): change `collect_audio(root, &mut files)?;` to
+  ```rust
+        collect_audio(root, &mut files, opts.follow_symlinks)?;
+  ```
+- `revalidate_with` (`scan.rs:823`): change `collect_audio(root, &mut files)?;` to
+  ```rust
+        collect_audio(root, &mut files, opts.follow_symlinks)?;
+  ```
+- `scan_directory_full_oracle` (`scan.rs:781`): change `collect_audio(root, &mut files)?;` to
+  ```rust
+        collect_audio(root, &mut files, false)?;
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core collect_audio`
+Expected: PASS — all six `collect_audio_*` tests green.
+
+- [ ] **Step 5: Full check + commit**
+
+```bash
+cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test
+git add musefs-core/src/scan.rs
+git commit -m "$(cat <<'EOF'
+feat(core): follow symlinks during scan collection (#189)
+
+collect_audio now logs-and-skips symlinks by default (no longer silent)
+and, with follow_symlinks on, resolves them with a (dev, ino) cycle
+guard. Both scan and revalidate honor the flag via ScanOptions.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: CLI `--follow-symlinks` flag
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs`
+  - `Command::Scan` variant (`lib.rs:93-111`)
+  - `run_scan` signature + `ScanOptions` literal (`lib.rs:122-134`)
+  - `run` dispatch (`lib.rs:203-209`)
+- Modify: `musefs-cli/tests/scan.rs` — three positional `run_scan` callers (`scan.rs:57`, `:84`, `:114`)
+- Test: `musefs-cli/src/lib.rs` — `tests` module (`lib.rs:214+`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In the `tests` module of `musefs-cli/src/lib.rs` (alongside `scan_command_parses_jobs_flag`), add:
+
+```rust
+    #[test]
+    fn scan_command_parses_follow_symlinks_flag() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "scan",
+            "/m",
+            "--db",
+            "/tmp/x.db",
+            "--follow-symlinks",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Scan { follow_symlinks, .. } => assert!(follow_symlinks),
+            _ => panic!("expected scan command"),
+        }
+    }
+
+    #[test]
+    fn scan_command_follow_symlinks_defaults_off() {
+        use clap::Parser;
+        let cli =
+            Cli::try_parse_from(["musefs", "scan", "/m", "--db", "/tmp/x.db"]).unwrap();
+        match cli.command {
+            Command::Scan { follow_symlinks, .. } => assert!(!follow_symlinks),
+            _ => panic!("expected scan command"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-cli scan_command_parses_follow_symlinks_flag scan_command_follow_symlinks_defaults_off`
+Expected: FAIL — compile error: no field `follow_symlinks` on the `Scan` variant.
+
+- [ ] **Step 3: Add the flag and plumb it through**
+
+Add the field to the `Command::Scan` variant (after the `quiet` field at `lib.rs:110`, before the closing `}`):
+
+```rust
+        /// Follow symlinks while walking directories. Off by default: symlinked
+        /// files and directories are logged and skipped.
+        #[arg(long)]
+        follow_symlinks: bool,
+```
+
+Change the `run_scan` signature (`lib.rs:122-128`) to insert `follow_symlinks` before `quiet`:
+
+```rust
+pub fn run_scan(
+    db_path: &Path,
+    targets: &[PathBuf],
+    revalidate: bool,
+    jobs: usize,
+    follow_symlinks: bool,
+    quiet: bool,
+) -> Result<()> {
+```
+
+Change the `ScanOptions` literal (`lib.rs:131-134`) to:
+
+```rust
+    let opts = musefs_core::ScanOptions {
+        jobs,
+        follow_symlinks,
+        ..Default::default()
+    };
+```
+
+Change the `run` dispatch (`lib.rs:203-209`) to:
+
+```rust
+        Command::Scan {
+            targets,
+            db,
+            revalidate,
+            jobs,
+            quiet,
+            follow_symlinks,
+        } => run_scan(&db, &targets, revalidate, jobs, follow_symlinks, quiet),
+```
+
+Update the three `run_scan` callers in `musefs-cli/tests/scan.rs` to pass `false` for the new `follow_symlinks` parameter (it sits between `jobs` and `quiet`):
+
+- `scan.rs:57`:
+  ```rust
+      run_scan(&db_path, &[backing.path().to_path_buf()], false, 0, false, false).unwrap();
+  ```
+- `scan.rs:84-93` (the multi-path call) — change the trailing args so the call ends:
+  ```rust
+          false,
+          0,
+          false,
+          false,
+      )
+  ```
+- `scan.rs:114-120` (the missing-path call):
+  ```rust
+      let result = run_scan(
+          &db_path,
+          &[backing.path().to_path_buf(), missing],
+          false,
+          0,
+          false,
+          false,
+      );
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-cli`
+Expected: PASS — both new parse tests green and the existing `tests/scan.rs` integration tests still pass.
+
+- [ ] **Step 5: Full check + commit**
+
+```bash
+cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test
+git add musefs-cli/src/lib.rs musefs-cli/tests/scan.rs
+git commit -m "$(cat <<'EOF'
+feat(cli): add --follow-symlinks to scan (#189)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Documentation
+
+No tests — documentation only. Verify the wording matches the implemented behavior, then commit.
+
+**Files:**
+- Modify: `ARCHITECTURE.md` — Scanning section (`ARCHITECTURE.md:232-247`)
+- Modify: `README.md` — scan usage prose (`README.md:50-54`)
+
+- [ ] **Step 1: Update ARCHITECTURE.md**
+
+In the `## Scanning` section, insert a new paragraph after the `scan_directory` paragraph (after `ARCHITECTURE.md:240`, before the `revalidate` paragraph):
+
+```markdown
+Symlinks are **not followed by default**: a symlinked file or directory is
+logged (`RUST_LOG=info`/`warn`) and skipped, which keeps the walk immune to
+directory-symlink cycles. Passing `--follow-symlinks` resolves them — symlinked
+audio files and directories are scanned — guarded by a visited `(dev, ino)` set
+so symlink cycles terminate. Broken symlinks are logged and skipped without
+aborting the scan. The `root` argument is always followed regardless of the
+flag; only links encountered during recursion are gated.
+```
+
+- [ ] **Step 2: Update README.md**
+
+In the scan prose, change the `--jobs N` sentence (`README.md:51-52`) so it reads:
+
+```markdown
+files or directories, and `--jobs N` controls probe parallelism.
+`--follow-symlinks` walks symlinked files and directories (off by default, so
+symlinks are logged and skipped). `--quiet`
+```
+
+(The sentence continues with the existing `(\`-q\`) suppresses the per-target summary …` text — leave that intact.)
+
+- [ ] **Step 3: Verify docs build/render**
+
+Run: `grep -n "follow-symlinks" ARCHITECTURE.md README.md`
+Expected: matches in both files; read the surrounding prose to confirm it flows.
+
+- [ ] **Step 4: Full check + commit**
+
+```bash
+cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test
+git add ARCHITECTURE.md README.md
+git commit -m "$(cat <<'EOF'
+docs: document --follow-symlinks scan behavior (#189)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full workspace suite once more: `cargo test`
+- [ ] Confirm clippy is clean: `cargo clippy --all-targets -- -D warnings`
+- [ ] Confirm formatting: `cargo fmt --all --check`
+- [ ] Manual smoke (optional): create a temp dir with a symlinked audio file, run `cargo run -p musefs-cli -- scan <dir> --db /tmp/t.db` (symlink skipped, warning logged) then `... --follow-symlinks` (symlink scanned).
+- [ ] The `fuzz/` crate is outside the workspace but only format-layer signatures break it; this change touches `musefs-core` collection only, so no `cargo +nightly fuzz build` is needed.

--- a/docs/superpowers/specs/2026-06-09-scan-follow-symlinks-design.md
+++ b/docs/superpowers/specs/2026-06-09-scan-follow-symlinks-design.md
@@ -1,0 +1,139 @@
+# Scan: follow symlinks (opt-in, cycle-guarded)
+
+**Issue:** [#189](https://github.com/Sohex/musefs/issues/189) — Scan silently
+skips symlinked files and directories with no log or skipped count.
+
+## Problem
+
+`collect_audio` (`musefs-core/src/scan.rs:76`) classifies directory entries with
+`entry.file_type()`, which does **not** follow symlinks. A symlink dirent is
+therefore neither `is_dir()` nor `is_file()`, so it falls through both arms:
+
+```rust
+let ftype = entry.file_type()?;
+if ftype.is_dir() {
+    collect_audio(&path, out)?;
+} else if ftype.is_file() && is_supported_audio(&path) {
+    out.push(path);
+}
+```
+
+Symlinked audio files and symlinked subdirectories are never recursed into, never
+added to the candidate set, and never counted in `ScanStats::skipped` (the skip
+tally happens later in the probe phase, which these entries never reach). There
+is no log line. For libraries that rely on symlinks — the Lidarr integration
+creates symlink destinations by default (`CONTRIBUTING.md:300`), and symlinked
+libraries are common on seedbox/NAS setups — this produces a "half my library is
+missing" outcome with no diagnostic.
+
+The current "symlinks are not followed" behavior is undocumented. It also makes
+the scan incidentally immune to directory-symlink cycles: because nothing is
+followed, no cycle guard is needed today.
+
+## Goals
+
+- Symlinked audio files and directories can be scanned.
+- The current silent skip is replaced by a diagnostic, even when symlinks are
+  not followed.
+- Directory-symlink cycles cannot cause infinite recursion once following is
+  enabled.
+- The default behavior stays cycle-immune and free of new overhead on the
+  non-symlink path.
+
+## Non-goals
+
+- Changing the cardinal read-only-passthrough invariant. Following a symlink only
+  changes *which* backing file is read; `run_pipeline` already canonicalizes
+  every collected path before storing it, so a followed symlink is stored by its
+  real target path exactly like any other file.
+- Deduplicating individual files reachable via more than one symlink path. The
+  directory cycle guard prevents re-walking the same directory; a file reachable
+  through two distinct symlinked directories would be probed twice, but
+  `ingest_bulk` upserts by canonical path, so the second write is idempotent.
+  This edge case is accepted, not engineered against.
+- Changing `ScanStats` semantics or the CLI summary line.
+
+## Behavior
+
+A new `--follow-symlinks` flag on the `scan` subcommand controls the behavior.
+It is **off by default**.
+
+### Flag off (default)
+
+A symlink dirent is no longer silently dropped. `collect_audio` emits a
+`log::warn!` per skipped symlink, naming the path and hinting that
+`--follow-symlinks` will scan it. `ScanStats` is untouched — `scanned`,
+`skipped`, and `failed` keep their current meanings (`skipped` remains
+"unsupported-format files probed"). Nothing is followed, so cycle-immunity is
+preserved.
+
+### Flag on
+
+Symlinks are resolved (stat following the link, via `std::fs::metadata`):
+
+- a symlink whose target is a supported audio file is collected;
+- a symlink whose target is a directory is recursed into, subject to the cycle
+  guard below;
+- a target that is neither file nor directory (socket, fifo, …) is ignored;
+- a **broken/dangling** symlink (target stat fails) is logged with `log::warn!`
+  and skipped. Collection never aborts on a single bad link — the error is **not**
+  propagated via `?`, and `ScanStats` is not touched (the collection phase has no
+  counters today).
+
+## Cycle guard
+
+When following is on, the collection walk maintains a
+`HashSet<(u64, u64)>` of visited `(st_dev, st_ino)` pairs, obtained via
+`std::os::unix::fs::MetadataExt` (musefs is Unix-only — it is a FUSE
+filesystem). The guard:
+
+- records **every directory the walk descends into — real or symlinked — not
+  just symlinked ones**, and
+- before descending into a directory, skips it (logged as a cycle) if its
+  `(dev, ino)` is already in the set.
+
+Recording only symlinked directories is **insufficient**: a symlink pointing back
+to a real *ancestor* would loop forever through ordinary directory recursion (the
+walk re-enters the symlink on each pass). Recording every entered directory
+breaks both direct symlink loops and ancestor loops.
+
+The set lives only for the duration of one `collect_audio` walk and is only
+populated when the flag is on, so the default path gains no per-directory `stat`
+overhead beyond the new symlink branch.
+
+## Code shape
+
+- `ScanOptions` (`scan.rs:378`) gains `follow_symlinks: bool`; its `Default` impl
+  sets it `false`.
+- `collect_audio` (`scan.rs:76`) gains the `follow` flag and a
+  `&mut HashSet<(u64, u64)>` visited set, threaded from `scan_directory_with`
+  (`scan.rs:596`). `scan_directory_with` seeds the set with the root directory's
+  `(dev, ino)` before the first call (when following).
+- A `ftype.is_symlink()` arm is added to `collect_audio`. The existing
+  `is_dir()` / `is_file()` arms behave exactly as today when the flag is off; the
+  directory arm consults the cycle guard when the flag is on.
+- CLI (`musefs-cli/src/lib.rs`): parse `--follow-symlinks` into
+  `opts.follow_symlinks`. The `scanned … skipped … failed` summary line is
+  unchanged.
+
+## Testing
+
+Added to the existing `hardening_tests` module in `scan.rs`, creating links with
+`std::os::unix::fs::symlink`:
+
+- **symlinked audio file** — collected when the flag is on; logged and skipped
+  (not collected) when off.
+- **symlinked directory** — its contents are recursed into and scanned when on.
+- **cycle** — a directory symlink pointing to an ancestor terminates rather than
+  recursing infinitely.
+- **broken symlink, flag on** — logged, skipped, and the scan completes
+  successfully (does not abort).
+- **default-off regression** — real files are still scanned and symlinks are not
+  followed.
+
+## Docs
+
+- `ARCHITECTURE.md` scanning section: document the symlink behavior and the
+  `--follow-symlinks` flag (currently undocumented; the only symlink mention,
+  `ARCHITECTURE.md:153`, is about the external destination tree).
+- `README.md`: add `--follow-symlinks` to the `scan` flags.

--- a/docs/superpowers/specs/2026-06-09-scan-follow-symlinks-design.md
+++ b/docs/superpowers/specs/2026-06-09-scan-follow-symlinks-design.md
@@ -101,35 +101,98 @@ The set lives only for the duration of one `collect_audio` walk and is only
 populated when the flag is on, so the default path gains no per-directory `stat`
 overhead beyond the new symlink branch.
 
+## The root argument is always followed
+
+The flag governs symlinks **encountered during recursion**, not the `root`
+argument itself. Both `scan_directory_with` and `revalidate_with` dispatch on
+`root.is_file()` (which follows the link) before calling `collect_audio`, and
+`collect_audio`'s `read_dir(root)` likewise follows a symlinked root directory.
+So a symlinked-file root is already scanned and a symlinked-directory root is
+already walked **today, regardless of the flag** — and that does not change. Only
+links found *inside* the tree are gated. When following, the cycle guard is
+seeded with the followed root's `(dev, ino)`.
+
 ## Code shape
 
+### `collect_audio` signature and the cycle-guard ownership
+
+`collect_audio` is recursive and has **three production callers**
+(`find_referencing_symbols`): `scan_directory_with` (`scan.rs:596`),
+`revalidate_with` (`scan.rs:802`), and `scan_directory_full_oracle`
+(`scan.rs:771`, a `#[doc(hidden)]` test oracle) — plus one unit-test caller,
+`hardening_tests::collect_audio_skips_unsupported_files` (`scan.rs:1229`).
+
+To keep the public signature minimal and the visited-set bookkeeping
+encapsulated, split into two functions:
+
+- `collect_audio(root, out, follow_symlinks: bool)` — the entry point all callers
+  use. It creates the `HashSet<(u64, u64)>`, seeds it with `root`'s `(dev, ino)`
+  when `follow_symlinks` is true, then delegates to the recursive inner function.
+- a private recursive `collect_audio_inner(root, out, follow_symlinks, visited)`
+  carrying the set.
+
+This means each caller's call site changes only by passing one `bool`, not two
+new arguments.
+
+### Per-caller changes (all must be updated — the blocker)
+
+- `scan_directory_with` (`scan.rs:596`): pass `opts.follow_symlinks`.
+- `revalidate_with` (`scan.rs:802`): pass `opts.follow_symlinks`. **This is
+  required, not optional.** `revalidate_with` walks the same tree via
+  `collect_audio` and then prunes tracks under the root whose backing file is
+  gone. If scan follows symlinks but revalidate does not, symlinked tracks are
+  scanned once and then never re-probed on subsequent revalidations — a silent
+  scan/revalidate divergence. It already takes `&ScanOptions`, so threading the
+  flag through is the whole fix.
+- `scan_directory_full_oracle` (`scan.rs:771`): pass `false`. It is the legacy
+  test oracle, takes no `ScanOptions`, and does not need symlink support; it only
+  needs to satisfy the new signature.
+- `hardening_tests::collect_audio_skips_unsupported_files` (`scan.rs:1229`):
+  update the existing call to pass `false`.
+
+### `ScanOptions` and the symlink arm
+
 - `ScanOptions` (`scan.rs:378`) gains `follow_symlinks: bool`; its `Default` impl
-  sets it `false`.
-- `collect_audio` (`scan.rs:76`) gains the `follow` flag and a
-  `&mut HashSet<(u64, u64)>` visited set, threaded from `scan_directory_with`
-  (`scan.rs:596`). `scan_directory_with` seeds the set with the root directory's
-  `(dev, ino)` before the first call (when following).
-- A `ftype.is_symlink()` arm is added to `collect_audio`. The existing
+  (`scan.rs:387`) sets it `false`. Grep for `ScanOptions {` literals before
+  building — the CLI uses `..Default::default()` so it is unaffected, but any full
+  literal construction in tests must add the field.
+- A `ftype.is_symlink()` arm is added to `collect_audio_inner`. The existing
   `is_dir()` / `is_file()` arms behave exactly as today when the flag is off; the
-  directory arm consults the cycle guard when the flag is on.
-- CLI (`musefs-cli/src/lib.rs`): parse `--follow-symlinks` into
-  `opts.follow_symlinks`. The `scanned … skipped … failed` summary line is
-  unchanged.
+  directory descent consults the cycle guard when the flag is on.
+
+### CLI plumbing (`musefs-cli/src/lib.rs`)
+
+- The `Command::Scan` variant (`lib.rs:93`) gains `follow_symlinks: bool` with
+  `#[arg(long)]` (default false), mirroring the existing `jobs` / `quiet` flags.
+- `run_scan` (`lib.rs:122`) gains a `follow_symlinks: bool` parameter and builds
+  `ScanOptions { jobs, follow_symlinks, ..Default::default() }` (`lib.rs:131`).
+  Because `opts` is shared by both the scan and the revalidate branches, the
+  revalidate path honors the flag with no further change.
+- `run` (`lib.rs:201`) threads the parsed field into the `run_scan` call.
+- The `scanned … skipped … failed` summary line is unchanged.
 
 ## Testing
 
 Added to the existing `hardening_tests` module in `scan.rs`, creating links with
-`std::os::unix::fs::symlink`:
+`std::os::unix::fs::symlink`. The project has **no log-capture harness** (`log`
+is the only logging dep, no `testing_logger`/`logtest`), so tests assert on the
+**observable collection result** (the contents of the `out` vec, or `ScanStats`
+after a full scan) — not on log emission. The `log::warn!` lines are a diagnostic
+side effect, verified by inspection, not by assertion. Tests drive
+`collect_audio(root, &mut out, follow_symlinks)` directly where possible.
 
-- **symlinked audio file** — collected when the flag is on; logged and skipped
-  (not collected) when off.
-- **symlinked directory** — its contents are recursed into and scanned when on.
-- **cycle** — a directory symlink pointing to an ancestor terminates rather than
-  recursing infinitely.
-- **broken symlink, flag on** — logged, skipped, and the scan completes
-  successfully (does not abort).
-- **default-off regression** — real files are still scanned and symlinks are not
-  followed.
+- **symlinked audio file** — present in `out` when the flag is on; **absent** from
+  `out` when off (the observable form of "logged and skipped").
+- **symlinked directory** — files beneath it appear in `out` when on; absent when
+  off.
+- **cycle** — a directory symlink pointing to an ancestor: the call **returns**
+  (terminates) rather than recursing infinitely, and each real file appears in
+  `out` at most once. (A test that hangs on failure is acceptable here — the
+  assertion is "it completes.")
+- **broken symlink, flag on** — `collect_audio` returns `Ok(())` (does not abort
+  via `?`) and the valid sibling files are still collected.
+- **default-off regression** — real files are still collected and symlinks are
+  not followed (guards against a behavior change on the default path).
 
 ## Docs
 

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -104,6 +104,10 @@ pub enum Command {
         /// Probe worker threads (0 = available parallelism). 1 = sequential.
         #[arg(long, default_value_t = 0)]
         jobs: usize,
+        /// Follow symlinks while walking directories. Off by default: symlinked
+        /// files and directories are logged and skipped.
+        #[arg(long)]
+        follow_symlinks: bool,
         /// Suppress the per-target summary on stdout (failures still surface via
         /// the `log` facade on stderr; raise detail with `RUST_LOG=info`).
         #[arg(long, short)]
@@ -124,12 +128,14 @@ pub fn run_scan(
     targets: &[PathBuf],
     revalidate: bool,
     jobs: usize,
+    follow_symlinks: bool,
     quiet: bool,
 ) -> Result<()> {
     let db =
         Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
     let opts = musefs_core::ScanOptions {
         jobs,
+        follow_symlinks,
         ..Default::default()
     };
     for target in targets {
@@ -205,8 +211,9 @@ pub fn run(cli: Cli) -> Result<()> {
             db,
             revalidate,
             jobs,
+            follow_symlinks,
             quiet,
-        } => run_scan(&db, &targets, revalidate, jobs, quiet),
+        } => run_scan(&db, &targets, revalidate, jobs, follow_symlinks, quiet),
         Command::Mount(args) => run_mount(&args),
     }
 }
@@ -244,6 +251,38 @@ mod tests {
                 Command::Scan { quiet, .. } => assert!(quiet),
                 Command::Mount(..) => panic!("expected Scan"),
             }
+        }
+    }
+
+    #[test]
+    fn scan_command_parses_follow_symlinks_flag() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "scan",
+            "/m",
+            "--db",
+            "/tmp/x.db",
+            "--follow-symlinks",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Scan {
+                follow_symlinks, ..
+            } => assert!(follow_symlinks),
+            Command::Mount(..) => panic!("expected scan command"),
+        }
+    }
+
+    #[test]
+    fn scan_command_follow_symlinks_defaults_off() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "scan", "/m", "--db", "/tmp/x.db"]).unwrap();
+        match cli.command {
+            Command::Scan {
+                follow_symlinks, ..
+            } => assert!(!follow_symlinks),
+            Command::Mount(..) => panic!("expected scan command"),
         }
     }
 

--- a/musefs-cli/tests/scan.rs
+++ b/musefs-cli/tests/scan.rs
@@ -54,7 +54,15 @@ fn scan_ingests_flacs_into_a_fresh_db() {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("musefs.db");
 
-    run_scan(&db_path, &[backing.path().to_path_buf()], false, 0, false).unwrap();
+    run_scan(
+        &db_path,
+        &[backing.path().to_path_buf()],
+        false,
+        0,
+        false,
+        false,
+    )
+    .unwrap();
 
     // The DB file was created and persists the track.
     let db = musefs_db::Db::open(&db_path).unwrap();
@@ -90,6 +98,7 @@ fn scan_ingests_multiple_targets_under_one_db() {
         false,
         0,
         false,
+        false,
     )
     .unwrap();
 
@@ -116,6 +125,7 @@ fn scan_fails_fast_on_a_bad_target() {
         &[backing.path().to_path_buf(), missing],
         false,
         0,
+        false,
         false,
     );
     assert!(result.is_err());

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use musefs_db::convert::usize_from;
@@ -74,18 +74,85 @@ fn is_supported_audio(path: &Path) -> bool {
         || has_ext(path, "wav")
 }
 
-fn collect_audio(root: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+fn collect_audio(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+) -> std::io::Result<()> {
+    let mut visited = HashSet::new();
+    if let (true, Ok(meta)) = (follow_symlinks, std::fs::metadata(root)) {
+        visited.insert(dir_key(&meta));
+    }
+    collect_audio_inner(root, out, follow_symlinks, &mut visited)
+}
+
+fn collect_audio_inner(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+) -> std::io::Result<()> {
     for entry in std::fs::read_dir(root)? {
         let entry = entry?;
         let path = entry.path();
         let ftype = entry.file_type()?;
         if ftype.is_dir() {
-            collect_audio(&path, out)?;
-        } else if ftype.is_file() && is_supported_audio(&path) {
-            out.push(path);
+            descend(&path, out, follow_symlinks, visited)?;
+        } else if ftype.is_file() {
+            if is_supported_audio(&path) {
+                out.push(path);
+            }
+        } else if ftype.is_symlink() {
+            if !follow_symlinks {
+                log::warn!(
+                    "skipping symlink {} (pass --follow-symlinks to scan it)",
+                    path.display()
+                );
+                continue;
+            }
+            match std::fs::metadata(&path) {
+                Ok(meta) if meta.is_dir() => descend(&path, out, follow_symlinks, visited)?,
+                Ok(meta) if meta.is_file() => {
+                    if is_supported_audio(&path) {
+                        out.push(path);
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("skipping broken symlink {}: {e}", path.display());
+                }
+            }
         }
     }
     Ok(())
+}
+
+fn descend(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+) -> std::io::Result<()> {
+    if !follow_symlinks {
+        return collect_audio_inner(path, out, follow_symlinks, visited);
+    }
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("skipping directory {}: {e}", path.display());
+            return Ok(());
+        }
+    };
+    if !visited.insert(dir_key(&meta)) {
+        log::warn!("skipping symlink cycle at {}", path.display());
+        return Ok(());
+    }
+    collect_audio_inner(path, out, follow_symlinks, visited)
+}
+
+fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
+    use std::os::unix::fs::MetadataExt;
+    (meta.dev(), meta.ino())
 }
 
 /// A backing file parsed into the fields a track row needs, plus its raw
@@ -614,7 +681,7 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
             files.push(root.to_path_buf());
         }
     } else {
-        collect_audio(root, &mut files)?;
+        collect_audio(root, &mut files, opts.follow_symlinks)?;
     }
     db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
     let stats = run_pipeline(db, files, opts)?;
@@ -783,7 +850,7 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
             files.push(root.to_path_buf());
         }
     } else {
-        collect_audio(root, &mut files)?;
+        collect_audio(root, &mut files, false)?;
     }
     let mut stats = ScanStats {
         scanned: 0,
@@ -825,7 +892,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
             files.push(root.to_path_buf());
         }
     } else {
-        collect_audio(root, &mut files)?;
+        collect_audio(root, &mut files, opts.follow_symlinks)?;
     }
     db.apply_bulk_pragmas_self()?;
 
@@ -1237,7 +1304,7 @@ mod hardening_tests {
         std::fs::write(dir.path().join("keep.flac"), b"x").unwrap();
         std::fs::write(dir.path().join("skip.txt"), b"x").unwrap();
         let mut out = Vec::new();
-        collect_audio(dir.path(), &mut out).unwrap();
+        collect_audio(dir.path(), &mut out, false).unwrap();
         assert_eq!(out.len(), 1);
         assert!(out[0].ends_with("keep.flac"));
     }
@@ -1245,6 +1312,101 @@ mod hardening_tests {
     #[test]
     fn scan_options_default_does_not_follow_symlinks() {
         assert!(!ScanOptions::default().follow_symlinks);
+    }
+
+    #[test]
+    fn collect_audio_follows_symlinked_file_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.flac");
+        std::fs::write(&real, b"x").unwrap();
+        let lib = dir.path().join("lib");
+        std::fs::create_dir(&lib).unwrap();
+        std::os::unix::fs::symlink(&real, lib.join("link.flac")).unwrap();
+
+        let mut on = Vec::new();
+        collect_audio(&lib, &mut on, true).unwrap();
+        assert_eq!(
+            on.len(),
+            1,
+            "symlinked file should be collected when following"
+        );
+
+        let mut off = Vec::new();
+        collect_audio(&lib, &mut off, false).unwrap();
+        assert!(
+            off.is_empty(),
+            "symlinked file should be skipped by default"
+        );
+    }
+
+    #[test]
+    fn collect_audio_follows_symlinked_dir_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("music");
+        std::fs::create_dir(&real_dir).unwrap();
+        std::fs::write(real_dir.join("song.flac"), b"x").unwrap();
+        let root = dir.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+        std::os::unix::fs::symlink(&real_dir, root.join("linkdir")).unwrap();
+
+        let mut on = Vec::new();
+        collect_audio(&root, &mut on, true).unwrap();
+        assert_eq!(
+            on.len(),
+            1,
+            "files under a symlinked dir should be collected"
+        );
+
+        let mut off = Vec::new();
+        collect_audio(&root, &mut off, false).unwrap();
+        assert!(off.is_empty(), "symlinked dir should be skipped by default");
+    }
+
+    #[test]
+    fn collect_audio_terminates_on_symlink_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::write(a.join("song.flac"), b"x").unwrap();
+        std::os::unix::fs::symlink(dir.path(), a.join("loop")).unwrap();
+
+        let mut out = Vec::new();
+        collect_audio(dir.path(), &mut out, true).unwrap();
+        assert_eq!(
+            out.iter().filter(|p| p.ends_with("song.flac")).count(),
+            1,
+            "each real file collected at most once despite the cycle"
+        );
+    }
+
+    #[test]
+    fn collect_audio_skips_broken_symlink_when_following() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("real.flac"), b"x").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("nonexistent"), dir.path().join("dangling"))
+            .unwrap();
+
+        let mut out = Vec::new();
+        let result = collect_audio(dir.path(), &mut out, true);
+        assert!(
+            result.is_ok(),
+            "a dangling symlink must not abort collection"
+        );
+        assert_eq!(out.len(), 1);
+        assert!(out[0].ends_with("real.flac"));
+    }
+
+    #[test]
+    fn collect_audio_does_not_follow_symlinks_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("real.flac"), b"x").unwrap();
+        let other = dir.path().join("other.flac");
+        std::fs::write(&other, b"x").unwrap();
+        std::os::unix::fs::symlink(&other, dir.path().join("link.flac")).unwrap();
+
+        let mut out = Vec::new();
+        collect_audio(dir.path(), &mut out, false).unwrap();
+        assert_eq!(out.len(), 2);
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1414,6 +1414,24 @@ mod hardening_tests {
     }
 
     #[test]
+    fn collect_audio_ignores_symlink_to_non_file_target_when_following() {
+        let dir = tempfile::tempdir().unwrap();
+        // A unix socket is neither a regular file nor a directory.
+        let sock = dir.path().join("sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        // Name the link with a supported audio extension so the only thing
+        // keeping it out of `out` is the resolved target's is_file() check.
+        std::os::unix::fs::symlink(&sock, dir.path().join("link.flac")).unwrap();
+
+        let mut out = Vec::new();
+        collect_audio(dir.path(), &mut out, true).unwrap();
+        assert!(
+            out.is_empty(),
+            "a symlink to a non-file, non-dir target must not be collected"
+        );
+    }
+
+    #[test]
     fn probe_returns_none_for_supported_ext_with_garbage_contents() {
         let dir = tempfile::tempdir().unwrap();
         for name in ["bad.flac", "bad.mp3", "bad.m4a", "bad.wav", "bad.opus"] {

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -384,6 +384,9 @@ pub struct ScanOptions {
     pub window: usize,
     /// In-flight art-byte budget and per-batch byte-flush threshold.
     pub batch_bytes: u64,
+    /// Follow symlinks during collection. Off by default: symlinks are logged
+    /// and skipped, which keeps the walk immune to directory-symlink cycles.
+    pub follow_symlinks: bool,
 }
 
 impl Default for ScanOptions {
@@ -392,6 +395,7 @@ impl Default for ScanOptions {
             jobs: 0,
             window: WINDOW,
             batch_bytes: BATCH_BYTES,
+            follow_symlinks: false,
         }
     }
 }
@@ -1236,6 +1240,11 @@ mod hardening_tests {
         collect_audio(dir.path(), &mut out).unwrap();
         assert_eq!(out.len(), 1);
         assert!(out[0].ends_with("keep.flac"));
+    }
+
+    #[test]
+    fn scan_options_default_does_not_follow_symlinks() {
+        assert!(!ScanOptions::default().follow_symlinks);
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -80,8 +80,12 @@ fn collect_audio(
     follow_symlinks: bool,
 ) -> std::io::Result<()> {
     let mut visited = HashSet::new();
-    if let (true, Ok(meta)) = (follow_symlinks, std::fs::metadata(root)) {
-        visited.insert(dir_key(&meta));
+    if follow_symlinks {
+        // Seed with the root's identity so a symlink pointing back to it is
+        // caught as a cycle on the first descent.
+        if let Ok(meta) = std::fs::metadata(root) {
+            visited.insert(dir_key(&meta));
+        }
     }
     collect_audio_inner(root, out, follow_symlinks, &mut visited)
 }


### PR DESCRIPTION
Closes #189.

## Problem

`collect_audio` classified dirents with `entry.file_type()`, which does not follow symlinks — a symlink matched neither `is_dir()` nor `is_file()` and fell through silently: not recursed, not collected, not counted in `skipped`, no log line. Symlinked libraries (Lidarr creates symlink destinations by default; common on seedbox/NAS) produced a "half my library is missing" outcome with no diagnostic.

## Change

A new opt-in `--follow-symlinks` flag on `scan` (default off):

- **Off (default):** symlinks are now logged (`log::warn!`) and skipped instead of dropped silently. `ScanStats` semantics and the cycle-immunity of the walk are unchanged.
- **On:** symlinked audio files and directories are scanned, guarded by a visited `(dev, ino)` set that records **every** descended directory — terminating both direct symlink loops and symlink-to-ancestor loops. Broken/dangling symlinks are logged and skipped without aborting the scan.

The flag rides on `ScanOptions`, so both `scan_directory_with` and `revalidate_with` honor it (avoiding a scan/revalidate divergence). The `root` argument is always followed regardless of the flag, as today.

## Notes

- A track is keyed by its canonical backing path, so a `--follow-symlinks` file whose real target lives outside the scanned root falls outside revalidate's prune scope (documented in ARCHITECTURE.md). The read-only invariant is untouched throughout.

## Tests

New `hardening_tests` cases (symlinked file, symlinked dir, cycle termination, broken symlink, default-off regression) asserting observable collection state, plus CLI flag parse tests. Full workspace suite: 763 passed.

Design + plan: `docs/superpowers/specs/2026-06-09-scan-follow-symlinks-design.md`, `docs/superpowers/plans/2026-06-09-scan-follow-symlinks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in --follow-symlinks scan option (off by default) to traverse symlink targets while guarding against cycles.

* **Bug Fixes**
  * Broken symlinks are logged and skipped without aborting scans; cycle detection prevents infinite traversal and unwanted revalidation.

* **Documentation**
  * Updated usage and architecture docs to clarify symlink behavior and pruning scope.

* **Tests**
  * Added/updated tests covering symlink behaviors and cycle termination.

* **Chores**
  * Pre-commit hook and mutation-anchor updates to keep tooling checks in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->