### PR TITLE
test(fuse): fail loudly when ffmpeg fixtures don't generate

### DIFF
--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -31,6 +31,18 @@ fn make_fixture(path: &std::path::Path, codec_args: &[&str]) -> bool {
         && path.exists()
 }
 
+/// Whether the ffmpeg binary is present. Distinguishes a genuinely-absent
+/// toolchain (legitimate skip) from a present ffmpeg whose codec/invocation
+/// failed to produce a fixture (a real failure to surface, not swallow).
+fn ffmpeg_available() -> bool {
+    std::process::Command::new("ffmpeg")
+        .arg("-version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
 /// Read every Ogg packet's data. The `ogg` crate validates page CRCs while
 /// reading, so a corrupt page makes `read_packet` error (panicking the test).
 fn read_packets(bytes: &[u8]) -> Vec<Vec<u8>> {
@@ -186,13 +198,13 @@ fn make_fixture_with_cover(
 #[test]
 #[ignore = "requires /dev/fuse + libfuse + ffmpeg; run with --ignored"]
 fn opus_read_through_preserves_embedded_art() {
-    let backing = tempfile::tempdir().unwrap();
-    let Some((src, _cover)) =
-        make_fixture_with_cover(backing.path(), "in.opus", &["-c:a", "libopus"])
-    else {
-        eprintln!("ffmpeg/libopus unavailable; skipping");
+    if !ffmpeg_available() {
+        eprintln!("ffmpeg unavailable; skipping");
         return;
-    };
+    }
+    let backing = tempfile::tempdir().unwrap();
+    let (src, _cover) = make_fixture_with_cover(backing.path(), "in.opus", &["-c:a", "libopus"])
+        .expect("ffmpeg present but the libopus cover fixture failed to generate");
 
     // The source's own embedded art (as the scanner will ingest it).
     let source_bytes = std::fs::read(&src).unwrap();
@@ -219,36 +231,48 @@ fn opus_read_through_preserves_embedded_art() {
 #[test]
 #[ignore = "requires /dev/fuse + libfuse + ffmpeg; run with --ignored"]
 fn opus_read_through_validates_pages_and_audio() {
-    let backing = tempfile::tempdir().unwrap();
-    let src = backing.path().join("in.opus");
-    if !make_fixture(&src, &["-c:a", "libopus"]) {
-        eprintln!("ffmpeg/libopus unavailable; skipping");
+    if !ffmpeg_available() {
+        eprintln!("ffmpeg unavailable; skipping");
         return;
     }
+    let backing = tempfile::tempdir().unwrap();
+    let src = backing.path().join("in.opus");
+    assert!(
+        make_fixture(&src, &["-c:a", "libopus"]),
+        "ffmpeg present but the libopus fixture failed to generate"
+    );
     mount_and_validate(&src);
 }
 
 #[test]
 #[ignore = "requires /dev/fuse + libfuse + ffmpeg; run with --ignored"]
 fn vorbis_read_through_validates_pages_and_audio() {
-    let backing = tempfile::tempdir().unwrap();
-    let src = backing.path().join("in.ogg");
-    if !make_fixture(&src, &["-c:a", "libvorbis"]) {
-        eprintln!("ffmpeg/libvorbis unavailable; skipping");
+    if !ffmpeg_available() {
+        eprintln!("ffmpeg unavailable; skipping");
         return;
     }
+    let backing = tempfile::tempdir().unwrap();
+    let src = backing.path().join("in.ogg");
+    assert!(
+        make_fixture(&src, &["-c:a", "libvorbis"]),
+        "ffmpeg present but the libvorbis fixture failed to generate"
+    );
     mount_and_validate(&src);
 }
 
 #[test]
 #[ignore = "requires /dev/fuse + libfuse + ffmpeg; run with --ignored"]
 fn oggflac_read_through_validates_pages_and_audio() {
+    if !ffmpeg_available() {
+        eprintln!("ffmpeg unavailable; skipping");
+        return;
+    }
     let backing = tempfile::tempdir().unwrap();
     let src = backing.path().join("in.oga");
     // FLAC-in-Ogg: flac codec in the ogg container.
-    if !make_fixture(&src, &["-c:a", "flac", "-f", "ogg"]) {
-        eprintln!("ffmpeg/flac-in-ogg unavailable; skipping");
-        return;
-    }
+    assert!(
+        make_fixture(&src, &["-c:a", "flac", "-f", "ogg"]),
+        "ffmpeg present but the flac-in-ogg fixture failed to generate"
+    );
     mount_and_validate(&src);
 }

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -187,21 +187,22 @@ fn all_supported_formats_decode_to_same_pcm_sha_as_source() {
 
     let backing = tempfile::tempdir().unwrap();
     let mut generated = Vec::new();
+    let mut missing = Vec::new();
     for case in playback_cases() {
         let src = backing.path().join(case.source_name);
         if make_audio_fixture(&src, case) {
             generated.push((case, src));
         } else {
-            eprintln!(
-                "ffmpeg codec/container unavailable for {}; skipping",
-                case.source_name
-            );
+            missing.push(case.source_name);
         }
     }
 
+    // ffmpeg is present (checked above), so a fixture that fails to generate is a
+    // missing codec or a broken invocation, not an absent toolchain — fail loudly
+    // naming it rather than passing on a degenerate subset of "all" formats.
     assert!(
-        !generated.is_empty(),
-        "no playback fixtures could be generated; ffmpeg codecs may be unavailable"
+        missing.is_empty(),
+        "ffmpeg fixtures failed to generate (codec missing or broken invocation): {missing:?}"
     );
 
     let db = musefs_db::Db::open_in_memory().unwrap();


### PR DESCRIPTION
## Summary

Follow-up to #225 (mount-boundary read-consistency). That work uncovered an e2e test that had been silently passing for months — its ffmpeg fixture generation failed while the test reported `ok`. This PR audits the suite for the same class of "vacuous test" and hardens the remaining instances.

## Audit findings

Ran the full `--ignored` suite verbosely on a full-codec ffmpeg: nothing is currently vacuous. The real issues are tests that would silently pass if a fixture failed to generate (missing codec or broken invocation) rather than failing loudly:

- **`playback_pcm.rs::all_supported_formats_decode_to_same_pcm_sha_as_source`** guarded only on `!generated.is_empty()`, so a test literally named "all_supported_formats" could pass while covering as few as one of seven — the same degenerate-subset trap the read-consistency breadth sweep had. Now collects and asserts no format is missing.
- **`ogg_read_through.rs`** (`opus`/`vorbis`/`oggflac` validate tests + the opus art test) skipped on *any* `make_fixture` failure, conflating "ffmpeg absent" (a legitimate skip) with "ffmpeg present but the codec/invocation failed" (a real failure — exactly how the opus art test went silent). Added an `ffmpeg_available()` probe: skip only when ffmpeg is entirely absent, otherwise assert the fixture generates.

The breadth sweep and `playback_pcm`'s top-level check already follow this shape (skip if ffmpeg absent → otherwise require all), so the suite is now consistent.

## Not changed (deliberate)

These are legitimate environmental gates, not vacuous tests: `passthrough.rs` (needs kernel ≥6.9 + CAP_SYS_ADMIN), `scan_counters.rs` (skips when run as root, where `chmod 000` is a no-op), `bench_ingest.rs` (opt-in via env var). Python contrib suites gate optional deps with `importorskip`/`skipif` and CI installs those deps, so they run in CI.

## Verification

Full workspace suite + `cargo test -p musefs-fuse -- --ignored`: all green, every ffmpeg-backed test runs (no skips) on a full-codec box; a missing codec now fails the relevant test by name instead of vanishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test initialization with dependency availability checks to gracefully skip tests when required tools are unavailable.
  * Improved test reliability by enforcing stricter validation of fixture generation, now failing tests when essential resources cannot be created rather than continuing with partial coverage.
  * Updated error reporting for better diagnostic information when test fixture generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->