### PR TITLE
fix(core): fail on orphaned track_art rows instead of dropping art (#202)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,6 +144,10 @@ rather than compute them. Nothing in SQLite *prevents* an external writer
 from mutating scanner-owned fields — musefs treats such rows as untrusted
 input and degrades to a controlled `BackingChanged`/layout error when a row
 no longer matches its backing file, never undefined behavior.
+Referential gaps are treated the same way: a `track_art` row whose `art_id`
+has no matching `art` row (an orphan an external writer can produce with FK
+enforcement disabled) fails the serve with `EIO` rather than silently dropping
+the art.
 
 The shared Python library (`contrib/python-musefs/`) encodes this contract
 for plugin authors, including a generated copy of the schema

--- a/docs/superpowers/plans/2026-06-10-orphaned-track-art-hard-error.md
+++ b/docs/superpowers/plans/2026-06-10-orphaned-track-art-hard-error.md
@@ -1,0 +1,272 @@
+# Fail on Orphaned `track_art` Rows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the silent art-drop in `track_art_to_inputs` into a hard `CoreError::OrphanedArt`, surfaced as `EIO` at the FUSE boundary, so an orphaned `track_art` row (an `art_id` with no `art` metadata row) reports DB corruption instead of serving a file with missing art.
+
+**Architecture:** A new `CoreError::OrphanedArt { track_id, art_id }` variant is added in `musefs-core`. `track_art_to_inputs` returns it when `get_art_meta` yields `Ok(None)` instead of silently skipping the row. The FUSE errno mapper routes the variant to `EIO`, alongside the other structural-corruption errors. Two unit tests cover the new branch (one in core for the error, one in fuse for the errno mapping).
+
+**Tech Stack:** Rust, `thiserror` (`CoreError`), `rusqlite` (raw connection for FK-off test setup), `fuser` (errno mapping).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-orphaned-track-art-hard-error-design.md`
+
+---
+
+## File Structure
+
+- `musefs-core/src/error.rs` — add the `OrphanedArt` variant to `CoreError`.
+- `musefs-fuse/src/lib.rs` — add the `OrphanedArt → EIO` arm in `errno`; extend the `maps_core_errors_to_errno` test.
+- `musefs-core/src/mapping.rs` — change `track_art_to_inputs` to error on `None`; add the orphan test in the existing `tests` module.
+- `ARCHITECTURE.md` — one sentence in the external-writer contract section.
+
+Three commits: (1) variant + errno mapping + errno test, (2) the core fix + core test, (3) docs.
+
+---
+
+### Task 1: Add `CoreError::OrphanedArt` and map it to `EIO`
+
+The variant and its errno arm land together: adding the variant alone makes `errno`'s exhaustive `match` fail to compile, so they are one atomic, compiling change. TDD here means the new errno assertion is written first and fails to compile until the variant and arm exist.
+
+**Files:**
+- Modify: `musefs-core/src/error.rs` (the `CoreError` enum, closes at line 35)
+- Modify: `musefs-fuse/src/lib.rs:87-91` (the `errno` `EIO` arm) and `musefs-fuse/src/lib.rs:520-534` (the `maps_core_errors_to_errno` test)
+
+- [ ] **Step 1: Add the failing errno assertion**
+
+In `musefs-fuse/src/lib.rs`, inside `fn maps_core_errors_to_errno` (after the `io_other` assertion at line 533), add:
+
+```rust
+        assert_eq!(
+            errno(&CoreError::OrphanedArt {
+                track_id: 1,
+                art_id: 2
+            })
+            .code(),
+            libc::EIO
+        );
+```
+
+- [ ] **Step 2: Run it to confirm it fails (compile error)**
+
+Run: `cargo test -p musefs-fuse maps_core_errors_to_errno`
+Expected: FAIL — compile error, `no variant named OrphanedArt found for enum CoreError`.
+
+- [ ] **Step 3: Add the variant to `CoreError`**
+
+In `musefs-core/src/error.rs`, add this variant inside the `CoreError` enum (e.g. just before `TrackNotFound`):
+
+```rust
+    #[error("track {track_id} references art {art_id}, which has no metadata row (orphaned track_art — DB contract violation)")]
+    OrphanedArt { track_id: i64, art_id: i64 },
+```
+
+- [ ] **Step 4: Add the `EIO` arm in `errno`**
+
+In `musefs-fuse/src/lib.rs`, extend the `EIO` match arm (currently lines 87-91) so it reads:
+
+```rust
+        CoreError::BackingChanged(_)
+        | CoreError::Db(_)
+        | CoreError::DbOpen { .. }
+        | CoreError::Mp4MetadataTooLarge { .. }
+        | CoreError::OrphanedArt { .. }
+        | CoreError::Format(_) => fuser::Errno::EIO,
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `cargo test -p musefs-fuse maps_core_errors_to_errno`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/error.rs musefs-fuse/src/lib.rs
+git commit -m "feat(core): add CoreError::OrphanedArt, map to EIO (#202)"
+```
+
+---
+
+### Task 2: Reject orphaned rows in `track_art_to_inputs`
+
+**Files:**
+- Modify: `musefs-core/src/mapping.rs:33-54` (`track_art_to_inputs`)
+- Test: `musefs-core/src/mapping.rs` — new test in the existing `mod tests` (after `track_art_to_inputs_errors_on_negative_byte_len`, around line 283)
+
+- [ ] **Step 1: Write the failing test**
+
+In `musefs-core/src/mapping.rs`, inside `mod tests`, add this test immediately after `track_art_to_inputs_errors_on_negative_byte_len`. It links a track to one valid art row, then orphans it by deleting the `art` row through a **raw** `rusqlite` connection (the production `Db` sets `PRAGMA foreign_keys=true` and `track_art.art_id` has no `ON DELETE`, so the delete must happen on a fresh raw connection where FK enforcement defaults off):
+
+```rust
+    #[test]
+    fn track_art_to_inputs_errors_on_orphaned_row() {
+        use crate::CoreError;
+        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art.db");
+        let db = Db::open(&path).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let orphan_id = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3, 4],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[TrackArt {
+                art_id: orphan_id,
+                picture_type: 3,
+                description: String::new(),
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+
+        // Well-formed art resolves to one input (kills the "always error" mutant).
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        assert_eq!(inputs.len(), 1);
+
+        // Orphan the track_art row: delete the referenced art row on a raw
+        // connection (FK enforcement off by default), leaving the track_art
+        // link dangling. The production Db sets foreign_keys=true, so the
+        // delete would RESTRICT-fail there.
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        let deleted = raw
+            .execute("DELETE FROM art WHERE id = ?1", [orphan_id])
+            .unwrap();
+        assert_eq!(deleted, 1, "delete must remove exactly one art row");
+        drop(raw);
+
+        let err = super::track_art_to_inputs(&db, tid).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CoreError::OrphanedArt { track_id, art_id }
+                    if track_id == tid && art_id == orphan_id
+            ),
+            "orphaned track_art must yield OrphanedArt with the offending ids, got {err:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p musefs-core track_art_to_inputs_errors_on_orphaned_row`
+Expected: FAIL — the second `track_art_to_inputs` call returns `Ok` (the row is silently skipped today), so `unwrap_err()` panics with "called `Result::unwrap_err()` on an `Ok` value".
+
+- [ ] **Step 3: Make the orphan a hard error**
+
+In `musefs-core/src/mapping.rs`, replace the whole `track_art_to_inputs` function (lines 37-55, from the `pub(crate) fn` signature through its closing `}`; the doc comment above it stays) with this self-contained block — it includes the signature, so paste it over the entire function rather than trusting the line range:
+
+```rust
+pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<ArtInput>> {
+    let mut inputs = Vec::new();
+    for ta in db.get_track_art(track_id)? {
+        // `track_art.art_id` is a foreign key into `art`, but SQLite FK
+        // enforcement is per-connection and external writers can disable it or
+        // import a partial DB. A missing `art` row is a contract violation we
+        // surface (the read fails) rather than silently dropping the art.
+        let Some(meta) = db.get_art_meta(ta.art_id)? else {
+            return Err(crate::error::CoreError::OrphanedArt {
+                track_id,
+                art_id: ta.art_id,
+            });
+        };
+        inputs.push(ArtInput {
+            art_id: ta.art_id,
+            mime: meta.mime,
+            description: ta.description,
+            picture_type: ta.picture_type,
+            width: meta.width.unwrap_or(0),
+            height: meta.height.unwrap_or(0),
+            data_len: meta.byte_len,
+        });
+    }
+    Ok(inputs)
+}
+```
+
+- [ ] **Step 4: Run the new test to confirm it passes**
+
+Run: `cargo test -p musefs-core track_art_to_inputs_errors_on_orphaned_row`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full mapping test module to confirm no regressions**
+
+Run: `cargo test -p musefs-core mapping`
+Expected: PASS — including `track_art_to_inputs_errors_on_negative_byte_len` and `track_art_images_reads_stored_blob_bytes`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/mapping.rs
+git commit -m "fix(core): fail on orphaned track_art rows instead of dropping art (#202)"
+```
+
+---
+
+### Task 3: Document the behavior in the external-writer contract
+
+**Files:**
+- Modify: `ARCHITECTURE.md:143-146` (the controlled-degradation paragraph in "The external-writer contract")
+
+- [ ] **Step 1: Add the sentence**
+
+In `ARCHITECTURE.md`, in the paragraph ending at line 146 (`...never undefined behavior.`), append after that sentence:
+
+```markdown
+Referential gaps are treated the same way: a `track_art` row whose `art_id`
+has no matching `art` row (an orphan an external writer can produce with FK
+enforcement disabled) fails the serve with `EIO` rather than silently dropping
+the art.
+```
+
+- [ ] **Step 2: Verify the wording reads correctly in context**
+
+Run: `sed -n '143,150p' ARCHITECTURE.md`
+Expected: the new sentence follows "...never undefined behavior." within the same paragraph.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md
+git commit -m "docs: orphaned track_art rows fail the serve with EIO (#202)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full workspace test suite** (the pre-commit hook runs this too):
+
+Run: `cargo test`
+Expected: PASS.
+
+- [ ] **Lint:**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Format check:**
+
+Run: `cargo fmt --all --check`
+Expected: clean (no diff).
+
+## Notes
+
+- No schema change → no Python schema-mirror regeneration.
+- No format-layer signature change → fuzz targets unaffected (no `cargo +nightly fuzz build` needed).
+- `track_art_images` (`mapping.rs:72`) is intentionally left unchanged: it runs only after `track_art_to_inputs` succeeds, so orphans are already rejected upstream before it is reached.
+- No new logging code: `reply_errno` in `musefs-fuse/src/lib.rs` already routes non-routine `CoreError`s through a `warn!` arm, so an `OrphanedArt` is logged with its ids automatically.

--- a/docs/superpowers/specs/2026-06-10-orphaned-track-art-hard-error-design.md
+++ b/docs/superpowers/specs/2026-06-10-orphaned-track-art-hard-error-design.md
@@ -1,0 +1,97 @@
+# Fail on orphaned `track_art` rows (issue #202)
+
+## Problem
+
+`track_art_to_inputs` (`musefs-core/src/mapping.rs:33-54`) builds a track's
+synthesis art inputs by iterating `track_art` rows and looking up each one's
+metadata with `db.get_art_meta(ta.art_id)`. When that lookup returns
+`Ok(None)` — a `track_art` row whose `art_id` has no corresponding `art` row —
+the code silently drops the art inside an `if let Some(meta)` and a comment
+asserts the branch is impossible because `track_art.art_id` is a foreign key.
+
+That assumption is unsafe at the external-writer boundary. SQLite FK
+enforcement is per-connection and off by default; an external writer can
+disable it, import a partial DB, or otherwise create an orphaned `track_art`
+row. The current behavior turns that broken-contract state into silent content
+loss: musefs serves a synthesized file missing art rather than reporting the
+corruption.
+
+This is distinct from the already-handled malformed-row case at
+`mapping.rs:274-282`, where an `art` row *exists* but carries an invalid
+`byte_len` and already errors at row-read. Issue #202 is specifically the
+*missing referenced row* case.
+
+## Decision
+
+Make a missing referenced `art` row a **hard error**, consistent with how the
+negative-`byte_len` case already fails and with the CLAUDE.md framing that the
+SQLite store is the source of truth and the external-writer contract. The
+degraded-mode alternative (keep skipping, document it) was considered and
+rejected.
+
+## Changes
+
+### 1. New error variant — `musefs-core/src/error.rs`
+
+Add to `CoreError`:
+
+```rust
+#[error("track {track_id} references art {art_id}, which has no metadata row (orphaned track_art — DB contract violation)")]
+OrphanedArt { track_id: i64, art_id: i64 },
+```
+
+Both ids are carried so the `EIO` reply and the existing serve-path warning
+point directly at the offending rows. (No new logging is needed: `reply_errno`
+in `musefs-fuse/src/lib.rs` already routes non-routine `CoreError`s through a
+`warn!` arm, so an orphan is logged with its ids automatically.)
+
+### 2. The fix — `musefs-core/src/mapping.rs:33-54`
+
+In `track_art_to_inputs`, replace the silent-skip `if let Some(meta)` with a
+`let … else` that returns `CoreError::OrphanedArt { track_id, art_id: ta.art_id }`
+on `None`. Rewrite the now-incorrect comment: an orphaned row is a contract
+violation we surface, not an impossible branch, because external writers can
+disable FK enforcement.
+
+`track_art_images` (`mapping.rs:72`) needs no change — it runs only after
+`track_art_to_inputs` succeeds, so orphans are rejected upstream before it is
+reached.
+
+### 3. errno mapping — `musefs-fuse/src/lib.rs:87-91`
+
+Add `CoreError::OrphanedArt { .. }` to the `EIO` arm alongside `Db`,
+`DbOpen`, `Mp4MetadataTooLarge`, and `Format`. An orphan is structural
+corruption, so a read of the affected file fails loudly with `EIO` instead of
+serving art-less bytes.
+
+### 4. Tests
+
+- `musefs-core/src/mapping.rs` tests: a new test that creates a track and an
+  `art` row, wires them with `set_track_art`, then orphans the row via a raw
+  `rusqlite::Connection`. This **must** be a raw connection: the production
+  `Db` sets `PRAGMA foreign_keys=true` (`musefs-db/src/lib.rs:78`) and
+  `track_art.art_id` has no `ON DELETE`, so a delete on the production handle
+  would RESTRICT-fail; a fresh raw `rusqlite` connection defaults FK
+  enforcement off, allowing the orphan. Assert the `DELETE FROM art WHERE
+  id = ?` affected exactly one row (guards against a no-op false pass), then
+  assert `track_art_to_inputs` returns `Err` and pin the variant + ids with
+  `matches!(err, CoreError::OrphanedArt { track_id, art_id } if track_id == tid && art_id == orphan_id)`
+  — a bare `is_err()` lets a wrong-variant mutant survive the gate. Keep the
+  existing happy-path assertions (well-formed art still yields inputs) so the
+  "always error" mutant is also killed. Mirrors the raw-connection mutation
+  technique of the negative-`byte_len` test at lines 274-282.
+- `musefs-fuse/src/lib.rs`: extend the existing `maps_core_errors_to_errno`
+  test (around line 520) with
+  `assert_eq!(errno(&CoreError::OrphanedArt { track_id: 1, art_id: 2 }).code(), libc::EIO);`.
+
+### 5. Docs
+
+One line in ARCHITECTURE.md's external-writer contract section: an orphaned
+`track_art` row (an `art_id` with no `art` row) now fails the serve with `EIO`
+rather than silently dropping the art.
+
+## Out of scope
+
+- No schema change → no Python schema-mirror regeneration.
+- No format-layer signature change → fuzz targets unaffected.
+- No broader audit of other `if let Some` sites in core.

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -22,6 +22,10 @@ pub enum CoreError {
     Io(#[from] std::io::Error),
     #[error("backing file changed since scan: {0}")]
     BackingChanged(String),
+    #[error(
+        "track {track_id} references art {art_id}, which has no metadata row (orphaned track_art — DB contract violation)"
+    )]
+    OrphanedArt { track_id: i64, art_id: i64 },
     #[error("track {0} not found")]
     TrackNotFound(i64),
     #[error("no such inode: {0}")]

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -37,19 +37,25 @@ pub(crate) fn tags_to_fields(tags: &[Tag]) -> BTreeMap<String, &str> {
 pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<ArtInput>> {
     let mut inputs = Vec::new();
     for ta in db.get_track_art(track_id)? {
-        // `track_art.art_id` is a foreign key into `art` (enforced, no ON DELETE),
-        // so the row always exists; the `if let` is defensive, not a real branch.
-        if let Some(meta) = db.get_art_meta(ta.art_id)? {
-            inputs.push(ArtInput {
+        // `track_art.art_id` is a foreign key into `art`, but SQLite FK
+        // enforcement is per-connection and external writers can disable it or
+        // import a partial DB. A missing `art` row is a contract violation we
+        // surface (the read fails) rather than silently dropping the art.
+        let Some(meta) = db.get_art_meta(ta.art_id)? else {
+            return Err(crate::error::CoreError::OrphanedArt {
+                track_id,
                 art_id: ta.art_id,
-                mime: meta.mime,
-                description: ta.description,
-                picture_type: ta.picture_type,
-                width: meta.width.unwrap_or(0),
-                height: meta.height.unwrap_or(0),
-                data_len: meta.byte_len,
             });
-        }
+        };
+        inputs.push(ArtInput {
+            art_id: ta.art_id,
+            mime: meta.mime,
+            description: ta.description,
+            picture_type: ta.picture_type,
+            width: meta.width.unwrap_or(0),
+            height: meta.height.unwrap_or(0),
+            data_len: meta.byte_len,
+        });
     }
     Ok(inputs)
 }
@@ -279,6 +285,69 @@ mod tests {
         assert!(
             super::track_art_to_inputs(&db, tid).is_err(),
             "negative byte_len must error at row-read, not be skipped"
+        );
+    }
+
+    #[test]
+    fn track_art_to_inputs_errors_on_orphaned_row() {
+        use crate::CoreError;
+        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art.db");
+        let db = Db::open(&path).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let orphan_id = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3, 4],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[TrackArt {
+                art_id: orphan_id,
+                picture_type: 3,
+                description: String::new(),
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+
+        // Well-formed art resolves to one input (kills the "always error" mutant).
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        assert_eq!(inputs.len(), 1);
+
+        // Orphan the track_art row: delete the referenced art row on a raw
+        // connection (FK enforcement off by default), leaving the track_art
+        // link dangling. The production Db sets foreign_keys=true, so the
+        // delete would RESTRICT-fail there.
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.pragma_update(None, "foreign_keys", false).unwrap();
+        let deleted = raw
+            .execute("DELETE FROM art WHERE id = ?1", [orphan_id])
+            .unwrap();
+        assert_eq!(deleted, 1, "delete must remove exactly one art row");
+        drop(raw);
+
+        let err = super::track_art_to_inputs(&db, tid).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CoreError::OrphanedArt { track_id, art_id }
+                    if track_id == tid && art_id == orphan_id
+            ),
+            "orphaned track_art must yield OrphanedArt with the offending ids, got {err:?}"
         );
     }
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -88,6 +88,7 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         | CoreError::Db(_)
         | CoreError::DbOpen { .. }
         | CoreError::Mp4MetadataTooLarge { .. }
+        | CoreError::OrphanedArt { .. }
         | CoreError::Format(_) => fuser::Errno::EIO,
     }
 }
@@ -531,6 +532,14 @@ mod tests {
         assert_eq!(errno(&io).code(), libc::ENOENT);
         let io_other = CoreError::Io(std::io::Error::other("boom"));
         assert_eq!(errno(&io_other).code(), libc::EIO);
+        assert_eq!(
+            errno(&CoreError::OrphanedArt {
+                track_id: 1,
+                art_id: 2
+            })
+            .code(),
+            libc::EIO
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes #202.

`track_art_to_inputs` documented `track_art.art_id` as guaranteed by a foreign
key, then treated a missing referenced `art` row as a defensive branch and
silently omitted the art — turning a broken DB contract into silent content
loss. SQLite FK enforcement is per-connection and external writers can disable
it or import a partial DB, so an orphaned `track_art` row is reachable.

This makes a missing referenced `art` row a hard error, consistent with how the
malformed-`byte_len` case already fails and with the "SQLite store is the source
of truth / external-writer contract" framing.

## Changes

- **`CoreError::OrphanedArt { track_id, art_id }`** — new variant carrying both
  ids so the failure points straight at the offending rows.
- **`track_art_to_inputs`** — returns `OrphanedArt` when `get_art_meta` yields
  `Ok(None)` instead of silently skipping; the misleading "impossible branch"
  comment is replaced with the real rationale.
- **FUSE errno mapping** — `OrphanedArt → EIO`, alongside the other
  structural-corruption variants, so a read of the affected file fails loudly.
- **Tests** — a core test that orphans a `track_art` row via a raw FK-off
  `rusqlite` connection and pins the variant + both ids; an errno-mapping
  assertion in `maps_core_errors_to_errno`.
- **Docs** — ARCHITECTURE.md external-writer contract notes the EIO behavior.

## Out of scope

No schema change (no Python mirror regen), no format-layer signature change
(fuzz unaffected). `track_art_images` is unchanged — it only runs after
`track_art_to_inputs` succeeds.

## Verification

- `cargo test` (full workspace) green; both new tests pass.
- `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean.
- In-diff mutation gate: 2 mutants, 1 caught + 1 unviable, **0 survivors**;
  mutant-anchor check passes.

Spec: `docs/superpowers/specs/2026-06-10-orphaned-track-art-hard-error-design.md`
Plan: `docs/superpowers/plans/2026-06-10-orphaned-track-art-hard-error.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The system now detects orphaned track-art references and reports an I/O error instead of silently dropping art, preventing data corruption.

* **Documentation**
  * Updated architecture documentation and added design/implementation guides for handling missing art metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->