### PR TITLE
fix(core): make full-rebuild disambiguation order self-established (#188)

### DIFF
--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1599,4 +1599,62 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn full_rebuild_gives_bare_colliding_name_to_lower_id() {
+        use musefs_db::{Format, NewTrack, Tag};
+        use std::collections::BTreeMap;
+
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        // Two tracks whose `$title` both render to "Same" -> colliding "Same.flac".
+        // Insertion order fixes ascending ids: id_a < id_b.
+        let id_a = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 1,
+                backing_size: 1,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let id_b = db
+            .upsert_track(&NewTrack {
+                backing_path: "/b.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 1,
+                backing_size: 1,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        assert!(id_a < id_b, "insertion assigns ascending ids");
+        db.replace_tags(id_a, &[Tag::new("title", "Same", 0)])
+            .unwrap();
+        db.replace_tags(id_b, &[Tag::new("title", "Same", 0)])
+            .unwrap();
+
+        let config = MountConfig {
+            template: "$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+        };
+        let template = Template::parse(&config.template);
+
+        let mut alloc = InodeAllocator::new();
+        let (tree, _snapshot) = Musefs::build_full(&db, &template, &config, &mut alloc).unwrap();
+
+        let root = VirtualTree::ROOT;
+        let bare = tree.lookup(root, "Same.flac").expect("bare name exists");
+        let suffixed = tree
+            .lookup(root, "Same (2).flac")
+            .expect("suffixed name exists");
+        // The LOWER id owns the bare name; the higher id is disambiguated. This
+        // matches the incremental path's min-id rule (tree.rs introducing_id).
+        assert_eq!(tree.inode_of_track(id_a), Some(bare));
+        assert_eq!(tree.inode_of_track(id_b), Some(suffixed));
+    }
 }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -288,6 +288,13 @@ impl Musefs {
     /// DB read + path render with no allocator: the lock-free phase shared by
     /// `build_full` and `rebuild_full`. Confining all `Db` access here is what
     /// lets `rebuild_full` hold `inodes` only across the pure-CPU `build_with`.
+    ///
+    /// The returned entries are ordered by `order_entries` (ascending by track
+    /// `id`), which is what makes both full-rebuild paths establish disambiguation
+    /// order locally rather than inheriting it from `list_tracks`'s `ORDER BY id`
+    /// (#188): the build path's insertion order decides which member of a colliding
+    /// path keeps the bare name, and that must match the incremental path's min-id
+    /// rule regardless of the source query's ordering.
     #[allow(clippy::type_complexity)]
     fn render_entries<M>(
         db: &Db<M>,
@@ -313,7 +320,18 @@ impl Musefs {
             );
             entries.push((t.id, path));
         }
-        Ok((entries, snapshot))
+        Ok((Self::order_entries(entries), snapshot))
+    }
+
+    /// Establish the canonical full-rebuild order: ascending by track `id`. This
+    /// is the single point that fixes which member of a colliding rendered path
+    /// keeps the bare name in `build_with_ci`'s insertion order (#188); it must NOT
+    /// move into the build primitive, whose `tree.rs` tests feed it id-unordered
+    /// entries on purpose. Kept as a pure helper so its sort is observable (and
+    /// mutation-testable) independent of `list_tracks`'s incidental `ORDER BY id`.
+    fn order_entries(mut entries: Vec<(i64, String)>) -> Vec<(i64, String)> {
+        entries.sort_by_key(|(id, _)| *id);
+        entries
     }
 
     /// Full rebuild: render every track and build the tree from scratch. Used by
@@ -1552,5 +1570,33 @@ mod tests {
         let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
         let fh = fs.open_handle(file_inode).unwrap();
         assert!(fs.passthrough_fd(fh).is_none());
+    }
+
+    #[test]
+    fn order_entries_sorts_ascending_by_id() {
+        // A real Db never hands render_entries id-unordered rows (list_tracks is
+        // ORDER BY id), so this descending input is constructed directly to pin
+        // the sort itself. Deleting/mutating order_entries' sort fails this test.
+        let unordered = vec![
+            (9_i64, "z.flac".to_string()),
+            (2_i64, "a.flac".to_string()),
+            (5_i64, "m.flac".to_string()),
+        ];
+        let ordered = Musefs::order_entries(unordered);
+        let ids: Vec<i64> = ordered.iter().map(|(id, _)| *id).collect();
+        assert_eq!(
+            ids,
+            vec![2, 5, 9],
+            "order_entries must sort ascending by id"
+        );
+        // The pairing is preserved, not just the id column.
+        assert_eq!(
+            ordered,
+            vec![
+                (2_i64, "a.flac".to_string()),
+                (5_i64, "m.flac".to_string()),
+                (9_i64, "z.flac".to_string()),
+            ]
+        );
     }
 }

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1347,9 +1347,12 @@ mod tests {
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         // Delete track 1 (the dir's min). Dir's introducing id rises to 9; file 5 (id 5 < 9)
         // should now claim base "X.flac" and the dir become "X.flac (2)".
-        // Production always feeds `build_with` entries sorted ascending by id
-        // (`list_tracks` ORDER BY id; `rebuild_incremental` sort_by_key). The
-        // reference must use that same canonical order to be a meaningful oracle.
+        // Production establishes the build path's canonical order by sorting
+        // ascending by id in `render_entries` (its `order_entries` helper, #188)
+        // — not by inheriting `list_tracks`'s ORDER BY. The reference must use
+        // that same canonical order to be a meaningful oracle; the inner build
+        // primitive deliberately does NOT sort (these tests feed it id-unordered
+        // inputs).
         let mut new_entries = vec![(9, "X.flac/b.flac".to_string()), (5, "X.flac".to_string())];
         new_entries.sort_by_key(|(id, _)| *id);
         let reference = VirtualTree::build(&new_entries);
@@ -1455,6 +1458,10 @@ mod tests {
     /// facade's debug-assert uses — AND that exactly `expected_rebuilds`
     /// subtree rebuilds ran (the O(changed) contract: a needless rebuild yields
     /// the same tree, so only the count can pin it).
+    ///
+    /// `after` is sorted ascending by id before building the reference, mirroring
+    /// the canonical order production establishes in `render_entries` (#188). The
+    /// `build_with` primitive itself does NOT sort, so the oracle must.
     fn assert_apply_matches_build(
         before: &[(i64, String)],
         after: &[(i64, String)],


### PR DESCRIPTION
## Summary

Closes #188. Makes the full-rebuild tree's colliding-path disambiguation order **self-established** instead of inheriting it from `list_tracks`'s `ORDER BY id`.

Inode stability for colliding paths depends on disambiguation being deterministic (which member of a colliding pair keeps the bare name vs ` (2)`). Both full-rebuild paths (`build_full`, `rebuild_full`) source entries from `render_entries`, which previously preserved `list_tracks`' order — so determinism rested on a non-local SQL clause. This sorts entries by track `id` in `render_entries` via a small pure helper, fixing the order at one local point.

## What changed

- `render_entries` now returns `order_entries(entries)` — ascending by track `id`. Covers both `build_full` and `rebuild_full` (they share `render_entries`).
- The sort lives in a **pure `order_entries` helper**, deliberately *not* in the `build_with_ci` primitive (whose `tree.rs` unit tests feed it id-unordered entries on purpose).
- `list_tracks`' `ORDER BY id` is kept (incidental, good for locality) but demoted from load-bearing.
- Comments in `tree.rs` re-attribute the canonical build order to `render_entries`/`order_entries`.

## Why a pure helper

A real `Db` can never hand `render_entries` id-unordered rows (SQLite assigns ids ascending; `list_tracks` is `ORDER BY id`), so the sort is unobservable through a DB-backed path — a bare sort there would survive the mutation gate. Extracting `order_entries` makes the sort directly unit-testable: `order_entries_sorts_ascending_by_id` feeds a descending input and fails if the sort is removed.

## Behavior

Pure hardening — **zero production behavior change**. The DB-backed path was already id-ordered, so `order_entries` produces the identical slice; it just makes the guarantee local rather than inherited.

## Verification

- `cargo test -p musefs-core` — 322 passed, 0 failed.
- `cargo clippy --all-targets -p musefs-core -- -D warnings` — clean.
- In-diff mutation gate on the changed functions — **0 survivors** (all 7 `order_entries` mutants caught).

Implements Plan B from the contract-invariant-hardening spec (#230). Independent of Plans A/C/D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic ordering of entries when multiple tracks map to the same filename; lower track IDs now consistently receive the base name while higher IDs are disambiguated with suffixes.

* **Tests**
  * Added unit tests to verify deterministic entry ordering and correct filename assignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->