### PR TITLE
feat: validated newtypes for audio bounds, picture type, and blob length (#200)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -125,7 +125,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:716:46:',
+    'musefs-core/src/scan\.rs:707:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -135,24 +135,24 @@ exclude_re = [
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `replace += with` and
     # `>=`/`||` repeat in run_pipeline (e.g. the killable `*scanned += 1` at
-    # 787), so these cannot be safely description-anchored. Re-verify these
+    # 778), so these cannot be safely description-anchored. Re-verify these
     # coordinates after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:809:29:',
+    'musefs-core/src/scan\.rs:800:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:811:32:',
+    'musefs-core/src/scan\.rs:802:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:811:47:',
+    'musefs-core/src/scan\.rs:802:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:811:62:',
+    'musefs-core/src/scan\.rs:802:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:819:37:',
+    'musefs-core/src/scan\.rs:810:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:821:40:',
+    'musefs-core/src/scan\.rs:812:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:821:55:',
+    'musefs-core/src/scan\.rs:812:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:821:70:',
+    'musefs-core/src/scan\.rs:812:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -160,11 +160,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:925:25:',
+    'musefs-core/src/scan\.rs:916:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:929:25:',
+    'musefs-core/src/scan\.rs:920:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:965:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:956:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/docs/superpowers/plans/2026-06-10-contract-hardening-c-validated-newtypes.md
+++ b/docs/superpowers/plans/2026-06-10-contract-hardening-c-validated-newtypes.md
@@ -59,7 +59,7 @@ Define the newtype, add its error variant, embed it in `Track`, and validate it 
 - `musefs-db/src/models.rs` (lines 86-95 `Track`; add `TrackBounds` near it)
 - `musefs-db/src/tracks.rs` (lines 32-46 `row_to_track`; tests at 239-265)
 - `musefs-db/src/lib.rs` (lines 13-16 re-export block)
-- `musefs-db/tests/tracks.rs` (Track audio-field reads at lines 14, 34, 133-134; **and** the `upsert_conflict_updates_all_mutable_columns` bounds fix — see Step 1.12)
+- `musefs-db/tests/tracks.rs` (Track audio-field reads at lines 14, 35, 135-136 — read-accessor substitutions only; the `upsert_conflict` bounds fix already landed on `main` via #199 — see Step 1.12)
 - `musefs-core/src/reader.rs` (production reads at lines 155, 178, 196-197, 204-205, 245, 249-250, 257, 270-271 — Step 1.11. The in-module over-EOF test is owned by Plan A.)
 - `musefs-core/src/scan.rs` (test asserts at 1883-1884, 1918; **plus the `norm` closure read at line 1971**)
 - `musefs-core/tests/scan.rs` (Track audio-field reads at lines 43, 114, 115)
@@ -280,11 +280,10 @@ Define the newtype, add its error variant, embed it in `Track`, and validate it 
   ```
   Apply the same `.bounds.audio_offset()` / `.bounds.audio_length()` substitution at every other listed line.
 
-- [ ] **Step 1.12: Fix db-crate integration test readers (`musefs-db/tests/tracks.rs`).** Three reads of a `Track` returned by `get_track` break; one also needs a bounds-valid `NewTrack`:
+- [ ] **Step 1.12: Fix db-crate integration test readers (`musefs-db/tests/tracks.rs`).** Three reads of a `Track` returned by `get_track` break. (The bounds combinations these tests write are already valid on `main`: Plan A (#199) bumped `upsert_conflict_updates_all_mutable_columns` to `backing_size: 555` and the other tests' bounds when the V4 CHECK landed — no `NewTrack` value changes are needed here, only the read-accessor substitutions below.)
   - Line 14: `assert_eq!(by_id.bounds.audio_offset(), 100);` (`new_track` sets offset 100, length 1000, backing_size 1100 → 1100 ≤ 1100, valid).
-  - Line 34: `assert_eq!(db.get_track(id).unwrap().unwrap().bounds.audio_offset(), 222);` (`changed.audio_offset = 222` is a write to the `NewTrack` field — keep as-is; only the read on line 34 changes).
-  - Lines 133-134: `assert_eq!(t.bounds.audio_offset(), 222);` / `assert_eq!(t.bounds.audio_length(), 333);`.
-  - **Bounds fix in `upsert_conflict_updates_all_mutable_columns` (lines 120-136):** the `changed` `NewTrack` uses `audio_offset: 222, audio_length: 333, backing_size: 444` — `222 + 333 = 555 > 444`, so `get_track(id)` at line 131 now FAILS `TrackBounds::new` at row read. Bump `backing_size` so the row is readable; change `backing_size: 444` to `backing_size: 555` and update the assert at line 135 to `assert_eq!(t.backing_size, 555);`. (The test's purpose — every mutable column round-trips on conflict-update — is preserved; only the now-invalid bounds combination is corrected.)
+  - Line 35: `assert_eq!(db.get_track(id).unwrap().unwrap().bounds.audio_offset(), 222);` (`changed.audio_offset = 222` is a write to the `NewTrack` field — keep as-is; only the read on line 35 changes).
+  - Lines 135-136: `assert_eq!(t.bounds.audio_offset(), 222);` / `assert_eq!(t.bounds.audio_length(), 333);`.
 
 - [ ] **Step 1.13: Fix core in-crate + integration test readers.** Update the `Track`-typed reads:
   - `musefs-core/src/scan.rs:1883-1884`: `assert_eq!(track.bounds.audio_offset(), full.bounds.audio_offset());` / `assert_eq!(track.bounds.audio_length(), full.bounds.audio_length());`

--- a/fuzz/fuzz_targets/ogg.rs
+++ b/fuzz/fuzz_targets/ogg.rs
@@ -2,7 +2,7 @@
 use arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use musefs_format::ogg::OggArt;
-use musefs_format::{ArtInput, Extent, fuzz_check::assert_backing_covers_audio, ogg};
+use musefs_format::{ArtInput, BlobLen, Extent, PictureType, fuzz_check::assert_backing_covers_audio, ogg};
 use musefs_fuzz::{MAX_INPUT, arb_tags};
 
 fuzz_target!(|data: &[u8]| {
@@ -36,16 +36,20 @@ fuzz_target!(|data: &[u8]| {
     let mut images: Vec<Vec<u8>> = Vec::new();
     let mut inputs: Vec<ArtInput> = Vec::new();
     for i in 0..n {
-        let len = u.int_in_range(0..=8192usize).unwrap_or(0);
+        let len = u.int_in_range(1..=8192usize).unwrap_or(1);
         let bytes = u.bytes(len).map(<[u8]>::to_vec).unwrap_or_default();
+        if bytes.is_empty() {
+            continue;
+        }
         inputs.push(ArtInput {
             art_id: i as i64,
             mime: "image/png".to_string(),
             description: String::new(),
-            picture_type: u.int_in_range(0..=20u32).unwrap_or(3),
+            picture_type: PictureType::new(u.int_in_range(0..=20u32).unwrap_or(3))
+                .unwrap_or(PictureType::ZERO),
             width: 0,
             height: 0,
-            data_len: bytes.len() as u64,
+            data_len: BlobLen::new(bytes.len() as u64).expect("non-empty"),
         });
         images.push(bytes);
     }

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -112,7 +112,7 @@ fuzz_target!(|data: &[u8]| {
     }
     let arts = arb_arts(&mut u).unwrap_or_default();
     if let Some(a) = arts.first() {
-        let blob = vec![0xABu8; usize::try_from(a.data_len.min(4096)).unwrap_or(0)];
+        let blob = vec![0xABu8; usize::try_from(a.data_len.get().min(4096)).unwrap_or(0)];
         if !blob.is_empty()
             && let Ok(art_id) = db.upsert_art(&NewArt {
                 mime: a.mime.clone(),

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,5 +1,5 @@
 use arbitrary::{Arbitrary, Unstructured};
-use musefs_format::{ArtInput, BlobLen, BinaryTagInput, PictureType, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, BlobLen, PictureType, TagInput};
 
 /// Cap fuzz input size to avoid pathological slow paths / false-positive
 /// timeouts on chunk/frame parsers (64-128 KiB is ample for full coverage).

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,5 +1,5 @@
 use arbitrary::{Arbitrary, Unstructured};
-use musefs_format::{ArtInput, BinaryTagInput, TagInput};
+use musefs_format::{ArtInput, BlobLen, BinaryTagInput, PictureType, TagInput};
 
 /// Cap fuzz input size to avoid pathological slow paths / false-positive
 /// timeouts on chunk/frame parsers (64-128 KiB is ample for full coverage).
@@ -26,10 +26,12 @@ pub fn arb_arts(u: &mut Unstructured) -> arbitrary::Result<Vec<ArtInput>> {
             art_id: i as i64,
             mime: "image/png".to_string(),
             description: String::arbitrary(u)?,
-            picture_type: u.int_in_range(0..=20u32)?,
+            picture_type: PictureType::new(u.int_in_range(0..=20u32)?)
+                .expect("0..=20 is valid"),
             width: u.int_in_range(0..=4096u32)?,
             height: u.int_in_range(0..=4096u32)?,
-            data_len: u.int_in_range(0..=8192u64)?,
+            data_len: BlobLen::new(u.int_in_range(1..=8192u64)?)
+                .expect("1..=8192 is non-zero"),
         });
     }
     Ok(out)
@@ -45,7 +47,7 @@ pub fn arb_binary_tags(u: &mut Unstructured) -> arbitrary::Result<Vec<BinaryTagI
         out.push(BinaryTagInput {
             key: format!("----:com.apple.iTunes:{name}"),
             payload_id: i as i64 + 1,
-            len: u.int_in_range(1..=4096u64)?,
+            len: BlobLen::new(u.int_in_range(1..=4096u64)?).expect("1..=4096 is non-zero"),
         });
     }
     Ok(out)

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -26,6 +26,14 @@ pub enum CoreError {
         "track {track_id} references art {art_id}, which has no metadata row (orphaned track_art — DB contract violation)"
     )]
     OrphanedArt { track_id: i64, art_id: i64 },
+    #[error(
+        "track {track_id} art {art_id} has out-of-range picture_type {value} (expected 0..=20)"
+    )]
+    InvalidPictureType {
+        track_id: i64,
+        art_id: i64,
+        value: u32,
+    },
     #[error("track {0} not found")]
     TrackNotFound(i64),
     #[error("no such inode: {0}")]

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -47,14 +47,24 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
                 art_id: ta.art_id,
             });
         };
+        let Some(data_len) = musefs_format::BlobLen::new(meta.byte_len) else {
+            continue; // zero-length art: synthesis would skip it anyway (now type-level).
+        };
+        let Some(picture_type) = musefs_format::PictureType::new(ta.picture_type) else {
+            return Err(crate::error::CoreError::InvalidPictureType {
+                track_id,
+                art_id: ta.art_id,
+                value: ta.picture_type,
+            });
+        };
         inputs.push(ArtInput {
             art_id: ta.art_id,
             mime: meta.mime,
             description: ta.description,
-            picture_type: ta.picture_type,
+            picture_type,
             width: meta.width.unwrap_or(0),
             height: meta.height.unwrap_or(0),
-            data_len: meta.byte_len,
+            data_len,
         });
     }
     Ok(inputs)
@@ -68,10 +78,12 @@ pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<
     Ok(db
         .get_binary_tags(track_id)?
         .into_iter()
-        .map(|row| BinaryTagInput {
-            key: row.key,
-            payload_id: row.rowid,
-            len: row.byte_len,
+        .filter_map(|row| {
+            musefs_format::BlobLen::new(row.byte_len).map(|len| BinaryTagInput {
+                key: row.key,
+                payload_id: row.rowid,
+                len,
+            })
         })
         .collect())
 }
@@ -83,7 +95,11 @@ pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<
 pub(crate) fn track_art_images<M>(db: &Db<M>, inputs: &[ArtInput]) -> Result<Vec<Vec<u8>>> {
     let mut out = Vec::with_capacity(inputs.len());
     for a in inputs {
-        out.push(db.read_art_chunk(a.art_id, 0, musefs_db::convert::usize_from(a.data_len))?);
+        out.push(db.read_art_chunk(
+            a.art_id,
+            0,
+            musefs_db::convert::usize_from(a.data_len.get()),
+        )?);
     }
     Ok(out)
 }
@@ -139,6 +155,64 @@ mod tests {
     }
 
     #[test]
+    fn bridge_drops_zero_length_art() {
+        use musefs_db::{NewArt, TrackArt};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("z.db");
+        let db = Db::open(&path).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        let nonempty = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3],
+            })
+            .unwrap();
+        let empty = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[
+                TrackArt {
+                    art_id: nonempty,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 0,
+                },
+                TrackArt {
+                    art_id: empty,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 1,
+                },
+            ],
+        )
+        .unwrap();
+        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
+        // The zero-length art is dropped at construction (synthesis would skip it).
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].art_id, nonempty);
+        assert_eq!(inputs[0].data_len.get(), 3);
+        assert_eq!(inputs[0].picture_type.get(), 3);
+    }
+
+    #[test]
     fn binary_tags_to_inputs_maps_rows() {
         let db = Db::open_in_memory().unwrap();
         let tid = db
@@ -164,7 +238,7 @@ mod tests {
         let inputs = super::binary_tags_to_inputs(&db, tid).unwrap();
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].key, "PRIV");
-        assert_eq!(inputs[0].len, 4);
+        assert_eq!(inputs[0].len.get(), 4);
         // payload_id is the streaming handle (the tags rowid).
         let rowid = db.get_binary_tags(tid).unwrap()[0].rowid;
         assert_eq!(inputs[0].payload_id, rowid);

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -1076,6 +1076,31 @@ mod cache_bound_tests {
     }
 
     #[test]
+    fn build_accepts_audio_region_ending_before_eof() {
+        // A valid track whose audio region ends strictly before EOF
+        // (audio_offset + audio_length < backing_size, allowed by TrackBounds)
+        // must still resolve: the bounds guard rejects only an over-EOF region.
+        // Pins the guard's `>` against `<`, which would spuriously reject every
+        // sub-EOF track.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.flac");
+        let (audio_offset, audio_length) = write_flac_local(&path);
+        // Append trailing bytes so the audio region no longer reaches EOF; the
+        // padded length becomes backing_size, leaving offset + length < it.
+        use std::io::Write;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(&[0u8; 64])
+            .unwrap();
+        let (db, id) = track_with_bounds(&path, audio_offset, audio_length);
+        let cache = HeaderCache::new(Mode::Synthesis);
+        let resolved = cache.resolve(&db, id).expect("sub-EOF bounds must resolve");
+        assert!(resolved.total_len > 0);
+    }
+
+    #[test]
     fn build_cache_bytes_counts_inline_segments() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("a.flac");

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -152,7 +152,12 @@ impl HeaderCache {
                 // bound, or an audio region that runs past the end of the backing file,
                 // means the row no longer matches the file. Only synthesis splices at
                 // these bounds, so the check is scoped to this mode.
-                if track.audio_offset.saturating_add(track.audio_length) > meta.len() {
+                if track
+                    .bounds
+                    .audio_offset()
+                    .saturating_add(track.bounds.audio_length())
+                    > meta.len()
+                {
                     return Err(CoreError::BackingChanged(track.backing_path.clone()));
                 }
 
@@ -174,8 +179,10 @@ impl HeaderCache {
                         // are not emitted twice.
                         let (structural, binary_tags): (Vec<MetadataBlock>, &[BinaryTagInput]) =
                             if rows.is_empty() {
-                                let front =
-                                    read_front(Path::new(&track.backing_path), track.audio_offset)?;
+                                let front = read_front(
+                                    Path::new(&track.backing_path),
+                                    track.bounds.audio_offset(),
+                                )?;
                                 (flac::read_metadata(&front)?.preserved, &[])
                             } else {
                                 let structural = rows
@@ -193,16 +200,16 @@ impl HeaderCache {
                             };
                         flac::synthesize_layout(
                             &structural,
-                            track.audio_offset,
-                            track.audio_length,
+                            track.bounds.audio_offset(),
+                            track.bounds.audio_length(),
                             &inputs,
                             binary_tags,
                             &art_inputs,
                         )?
                     }
                     Format::Mp3 => mp3::synthesize_layout(
-                        track.audio_offset,
-                        track.audio_length,
+                        track.bounds.audio_offset(),
+                        track.bounds.audio_length(),
                         &inputs,
                         &binary_tag_inputs,
                         &art_inputs,
@@ -242,19 +249,25 @@ impl HeaderCache {
                     Format::Wav => {
                         // Read only the front (RIFF header + fmt/fact); the data
                         // payload is served from the backing file at read time.
-                        let front = read_front(Path::new(&track.backing_path), track.audio_offset)?;
+                        let front = read_front(
+                            Path::new(&track.backing_path),
+                            track.bounds.audio_offset(),
+                        )?;
                         let scan = wav::read_structure(&front)?;
                         wav::synthesize_layout(
                             &scan,
-                            track.audio_offset,
-                            track.audio_length,
+                            track.bounds.audio_offset(),
+                            track.bounds.audio_length(),
                             &inputs,
                             &binary_tag_inputs,
                             &art_inputs,
                         )?
                     }
                     Format::Opus | Format::Vorbis | Format::OggFlac => {
-                        let front = read_front(Path::new(&track.backing_path), track.audio_offset)?;
+                        let front = read_front(
+                            Path::new(&track.backing_path),
+                            track.bounds.audio_offset(),
+                        )?;
                         let header = musefs_format::ogg::read_metadata(&front)?;
                         let art_images = crate::mapping::track_art_images(db, &art_inputs)?;
                         let arts: Vec<musefs_format::ogg::OggArt> = art_inputs
@@ -267,8 +280,8 @@ impl HeaderCache {
                             .collect();
                         musefs_format::ogg::synthesize_layout(
                             &header,
-                            track.audio_offset,
-                            track.audio_length,
+                            track.bounds.audio_offset(),
+                            track.bounds.audio_length(),
                             &inputs,
                             &arts,
                         )?

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1880,8 +1880,8 @@ mod bounded_probe_tests {
             .get_track_by_path(&std::fs::canonicalize(&path).unwrap().to_string_lossy())
             .unwrap()
             .unwrap();
-        assert_eq!(track.audio_offset, full.audio_offset);
-        assert_eq!(track.audio_length, full.audio_length);
+        assert_eq!(track.bounds.audio_offset(), full.audio_offset);
+        assert_eq!(track.bounds.audio_length(), full.audio_length);
     }
 
     #[test]
@@ -1915,7 +1915,10 @@ mod bounded_probe_tests {
             .get_track_by_path(&std::fs::canonicalize(&p).unwrap().to_string_lossy())
             .unwrap()
             .unwrap();
-        assert_eq!(usize_from(track.audio_length), b"DIFFERENT-AUDIO".len());
+        assert_eq!(
+            usize_from(track.bounds.audio_length()),
+            b"DIFFERENT-AUDIO".len()
+        );
     }
 
     #[test]
@@ -1968,7 +1971,13 @@ mod bounded_probe_tests {
                 .list_tracks()
                 .unwrap()
                 .into_iter()
-                .map(|t| (t.backing_path, t.audio_offset, t.audio_length))
+                .map(|t| {
+                    (
+                        t.backing_path,
+                        t.bounds.audio_offset(),
+                        t.bounds.audio_length(),
+                    )
+                })
                 .collect();
             rows.sort();
             rows

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -567,12 +567,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
             height: (pic.height != 0).then_some(pic.height),
             data: pic.data,
         })?;
-        // Valid ID3/FLAC picture types are 0..=20; clamp anything out of range.
-        let picture_type = if pic.picture_type <= 20 {
-            pic.picture_type
-        } else {
-            0
-        };
+        let picture_type = pic.picture_type.get();
         track_arts.push(TrackArt {
             art_id,
             picture_type,
@@ -653,11 +648,7 @@ fn ingest_bulk(
             height: (pic.height != 0).then_some(pic.height),
             data: pic.data,
         })?;
-        let picture_type = if pic.picture_type <= 20 {
-            pic.picture_type
-        } else {
-            0
-        };
+        let picture_type = pic.picture_type.get();
         track_arts.push(TrackArt {
             art_id,
             picture_type,
@@ -974,6 +965,7 @@ pub fn revalidate(db: &Db, root: &Path) -> Result<RevalidateStats> {
 #[cfg(test)]
 mod scan_unit_tests {
     use super::*;
+    use musefs_format::PictureType;
     use std::io::Write;
 
     // --- ScanOptions defaults (WINDOW L16, BATCH_BYTES L12) ---
@@ -1047,7 +1039,7 @@ mod scan_unit_tests {
     fn payload_weight_sums_all_buffered_payloads() {
         let pic = |n: usize| EmbeddedPicture {
             mime: "image/png".to_string(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             description: String::new(),
             width: 0,
             height: 0,

--- a/musefs-core/tests/probe_equivalence.rs
+++ b/musefs-core/tests/probe_equivalence.rs
@@ -39,7 +39,13 @@ fn normalized(db: &Db) -> Vec<NormalizedTrack> {
                 (sha, a.picture_type, a.description, a.ordinal)
             })
             .collect();
-        out.push((t.backing_path, t.audio_offset, t.audio_length, tags, art));
+        out.push((
+            t.backing_path,
+            t.bounds.audio_offset(),
+            t.bounds.audio_length(),
+            tags,
+            art,
+        ));
     }
     out.sort();
     out

--- a/musefs-core/tests/scan.rs
+++ b/musefs-core/tests/scan.rs
@@ -40,7 +40,7 @@ fn scans_flac_files_seeding_tracks_and_tags() {
     let tags = db.get_tags(a_track.id).unwrap();
     assert!(tags.iter().any(|t| t.key == "title" && t.value == "A"));
     assert!(tags.iter().any(|t| t.key == "artist" && t.value == "X"));
-    assert!(a_track.audio_length == 30);
+    assert!(a_track.bounds.audio_length() == 30);
 }
 
 #[test]
@@ -111,8 +111,8 @@ fn scans_mp3_files_seeding_tracks_and_tags() {
     assert_eq!(tracks.len(), 1);
     let t = &tracks[0];
     assert_eq!(t.format, Format::Mp3);
-    assert_eq!(t.audio_offset, audio_offset);
-    assert_eq!(t.audio_length, audio_len);
+    assert_eq!(t.bounds.audio_offset(), audio_offset);
+    assert_eq!(t.bounds.audio_length(), audio_len);
 
     let tags = db.get_tags(t.id).unwrap();
     assert!(

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -59,7 +59,13 @@ fn rows(db: &Db) -> Vec<(String, u64, u64)> {
         .list_tracks()
         .unwrap()
         .into_iter()
-        .map(|t| (t.backing_path, t.audio_offset, t.audio_length))
+        .map(|t| {
+            (
+                t.backing_path,
+                t.bounds.audio_offset(),
+                t.bounds.audio_length(),
+            )
+        })
         .collect();
     r.sort();
     r
@@ -144,8 +150,8 @@ fn widen_preserves_art_bytes_vs_oracle() {
     .unwrap();
 
     let track = db.list_tracks().unwrap().into_iter().next().unwrap();
-    assert_eq!(track.audio_offset, o_track.audio_offset);
-    assert_eq!(track.audio_length, o_track.audio_length);
+    assert_eq!(track.bounds.audio_offset(), o_track.bounds.audio_offset());
+    assert_eq!(track.bounds.audio_length(), o_track.bounds.audio_length());
     let art = db.get_track_art(track.id).unwrap();
     assert_eq!(art.len(), 1, "the embedded picture must survive the widen");
     let sha = db.get_art(art[0].art_id).unwrap().unwrap().sha256;

--- a/musefs-db/src/error.rs
+++ b/musefs-db/src/error.rs
@@ -4,6 +4,14 @@ use thiserror::Error;
 pub enum DbError {
     #[error(transparent)]
     Sqlite(#[from] rusqlite::Error),
+    #[error(
+        "audio bounds out of range: offset {audio_offset} + length {audio_length} exceeds backing_size {backing_size}"
+    )]
+    AudioBoundsOutOfRange {
+        audio_offset: u64,
+        audio_length: u64,
+        backing_size: u64,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, DbError>;

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -12,7 +12,7 @@ pub use bulk::BulkWriter;
 pub use error::{DbError, Result};
 pub use models::{
     Art, ArtMeta, BinaryTag, BinaryTagRow, Format, NewArt, NewTrack, StructuralBlock, Tag, Track,
-    TrackArt,
+    TrackArt, TrackBounds,
 };
 pub use tracks::ChangelogRead;
 

--- a/musefs-db/src/models.rs
+++ b/musefs-db/src/models.rs
@@ -81,14 +81,54 @@ mod binary_tag_models_tests {
     }
 }
 
+/// Validated audio-region bounds for a track: `audio_offset + audio_length`
+/// is guaranteed to fit within `backing_size`, so the reader can splice the
+/// audio region without re-checking. Built at the `tracks` row reader.
+#[cfg_attr(feature = "mutants", derive(Default))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrackBounds {
+    audio_offset: u64,
+    audio_length: u64,
+}
+
+impl TrackBounds {
+    /// Err if `audio_offset + audio_length` overflows or exceeds `backing_size`.
+    pub fn new(
+        audio_offset: u64,
+        audio_length: u64,
+        backing_size: u64,
+    ) -> Result<TrackBounds, crate::DbError> {
+        let end = audio_offset
+            .checked_add(audio_length)
+            .filter(|&end| end <= backing_size)
+            .ok_or(crate::DbError::AudioBoundsOutOfRange {
+                audio_offset,
+                audio_length,
+                backing_size,
+            })?;
+        let _ = end;
+        Ok(TrackBounds {
+            audio_offset,
+            audio_length,
+        })
+    }
+
+    pub fn audio_offset(&self) -> u64 {
+        self.audio_offset
+    }
+
+    pub fn audio_length(&self) -> u64 {
+        self.audio_length
+    }
+}
+
 #[cfg_attr(feature = "mutants", derive(Default))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Track {
     pub id: i64,
     pub backing_path: String,
     pub format: Format,
-    pub audio_offset: u64,
-    pub audio_length: u64,
+    pub bounds: TrackBounds,
     pub backing_size: u64,
     pub backing_mtime: i64,
     pub content_version: i64,
@@ -190,4 +230,40 @@ pub struct StructuralBlock {
     pub kind: String,
     pub ordinal: u64,
     pub body: Vec<u8>,
+}
+
+#[cfg(test)]
+mod track_bounds_tests {
+    use super::TrackBounds;
+
+    #[test]
+    fn accepts_in_range() {
+        let b = TrackBounds::new(10, 20, 100).unwrap();
+        assert_eq!(b.audio_offset(), 10);
+        assert_eq!(b.audio_length(), 20);
+    }
+
+    #[test]
+    fn accepts_exact_fit() {
+        let b = TrackBounds::new(30, 70, 100).unwrap();
+        assert_eq!(b.audio_offset(), 30);
+        assert_eq!(b.audio_length(), 70);
+    }
+
+    #[test]
+    fn accepts_zero_length() {
+        // A zero-length audio run is valid (e.g. structure-only edge).
+        let b = TrackBounds::new(0, 0, 0).unwrap();
+        assert_eq!(b.audio_length(), 0);
+    }
+
+    #[test]
+    fn rejects_exceeding_backing_size() {
+        assert!(TrackBounds::new(50, 60, 100).is_err());
+    }
+
+    #[test]
+    fn rejects_offset_plus_length_overflow() {
+        assert!(TrackBounds::new(u64::MAX, 1, u64::MAX).is_err());
+    }
 }

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -1,4 +1,4 @@
-use crate::models::{Format, NewTrack, Track};
+use crate::models::{Format, NewTrack, Track, TrackBounds};
 use crate::{Db, ReadWrite, Result};
 use rusqlite::{Row, params};
 
@@ -32,13 +32,22 @@ fn parse_format_col(fmt: &str) -> rusqlite::Result<Format> {
 fn row_to_track(r: &Row) -> rusqlite::Result<Track> {
     let fmt: String = r.get("format")?;
     let format = parse_format_col(&fmt)?;
+    let audio_offset: u64 = r.get("audio_offset")?;
+    let audio_length: u64 = r.get("audio_length")?;
+    let backing_size: u64 = r.get("backing_size")?;
+    let bounds = TrackBounds::new(audio_offset, audio_length, backing_size).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            usize::MAX,
+            rusqlite::types::Type::Integer,
+            e.to_string().into(),
+        )
+    })?;
     Ok(Track {
         id: r.get("id")?,
         backing_path: r.get("backing_path")?,
         format,
-        audio_offset: r.get("audio_offset")?,
-        audio_length: r.get("audio_length")?,
-        backing_size: r.get("backing_size")?,
+        bounds,
+        backing_size,
         backing_mtime: r.get("backing_mtime")?,
         content_version: r.get("content_version")?,
         updated_at: r.get("updated_at")?,
@@ -270,6 +279,36 @@ mod negative_audio_bounds_tests {
         assert!(
             db.get_track(id).is_err(),
             "negative audio_offset must fail row-read, not wrap"
+        );
+    }
+
+    #[test]
+    fn out_of_range_bounds_error_at_row_read() {
+        let db = Db::open_in_memory().unwrap();
+        let id = db
+            .upsert_track(&NewTrack {
+                backing_path: "/x.flac".into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 1,
+                backing_size: 1,
+                backing_mtime: 0,
+            })
+            .unwrap();
+        // Plant offset+length > backing_size past the V4 CHECK (layer 1) so we can
+        // prove TrackBounds (layer 2) rejects it at row read.
+        db.conn
+            .pragma_update(None, "ignore_check_constraints", true)
+            .unwrap();
+        db.conn
+            .execute("UPDATE tracks SET audio_length = 5 WHERE id = ?1", [id])
+            .unwrap();
+        db.conn
+            .pragma_update(None, "ignore_check_constraints", false)
+            .unwrap();
+        assert!(
+            db.get_track(id).is_err(),
+            "audio_offset + audio_length > backing_size must fail row-read"
         );
     }
 }

--- a/musefs-db/tests/tracks.rs
+++ b/musefs-db/tests/tracks.rs
@@ -11,7 +11,7 @@ fn insert_then_get_by_id_and_path() {
     assert_eq!(by_id.id, id);
     assert_eq!(by_id.backing_path, "/music/a.flac");
     assert_eq!(by_id.format, Format::Flac);
-    assert_eq!(by_id.audio_offset, 100);
+    assert_eq!(by_id.bounds.audio_offset(), 100);
     assert_eq!(by_id.content_version, 0);
 
     let by_path = db
@@ -32,7 +32,10 @@ fn upsert_updates_existing_row_keeping_same_id() {
     let id2 = db.upsert_track(&changed).unwrap();
 
     assert_eq!(id, id2);
-    assert_eq!(db.get_track(id).unwrap().unwrap().audio_offset, 222);
+    assert_eq!(
+        db.get_track(id).unwrap().unwrap().bounds.audio_offset(),
+        222
+    );
 }
 
 #[test]
@@ -132,8 +135,8 @@ fn upsert_conflict_updates_all_mutable_columns() {
 
     let t = db.get_track(id).unwrap().expect("track");
     assert_eq!(t.format, Format::Mp3);
-    assert_eq!(t.audio_offset, 222);
-    assert_eq!(t.audio_length, 333);
+    assert_eq!(t.bounds.audio_offset(), 222);
+    assert_eq!(t.bounds.audio_length(), 333);
     assert_eq!(t.backing_size, 555);
     assert_eq!(t.backing_mtime, 555);
 }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -139,7 +139,9 @@ pub fn locate_audio(data: &[u8]) -> Result<FlacScan> {
     })
 }
 
-use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+use crate::input::{
+    ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, PictureType, TagInput,
+};
 use crate::layout::{RegionLayout, Segment};
 
 /// Inclusive maximum body length of a FLAC metadata block (24-bit length field).
@@ -417,7 +419,7 @@ pub(crate) fn parse_picture_block(body: &[u8]) -> Result<EmbeddedPicture> {
     }
     Ok(EmbeddedPicture {
         mime,
-        picture_type,
+        picture_type: PictureType::new(picture_type).unwrap_or(PictureType::ZERO),
         description,
         width,
         height,
@@ -672,12 +674,19 @@ mod tests {
     fn parse_picture_block_roundtrips_fields() {
         let body = picture_body(3, "image/png", "desc", 4, 5, b"PIXELS");
         let p = parse_picture_block(&body).unwrap();
-        assert_eq!(p.picture_type, 3);
+        assert_eq!(p.picture_type.get(), 3);
         assert_eq!(p.mime, "image/png");
         assert_eq!(p.description, "desc");
         assert_eq!(p.width, 4);
         assert_eq!(p.height, 5);
         assert_eq!(p.data, b"PIXELS");
+    }
+
+    #[test]
+    fn read_picture_clamps_out_of_range_type() {
+        let body = picture_body(99, "png", "", 0, 0, &[0xAB]);
+        let pic = parse_picture_block(&body).unwrap();
+        assert_eq!(pic.picture_type.get(), 0, "out-of-range type clamps to 0");
     }
 
     #[test]

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -207,7 +207,7 @@ pub fn split_preserved(
 
 fn picture_body_framing(art: &ArtInput) -> Result<Vec<u8>> {
     let mut out = Vec::new();
-    out.extend_from_slice(&art.picture_type.to_be_bytes());
+    out.extend_from_slice(&art.picture_type.get().to_be_bytes());
     out.extend_from_slice(
         &u32::try_from(art.mime.len())
             .map_err(|_| FormatError::TooLarge)?
@@ -225,7 +225,7 @@ fn picture_body_framing(art: &ArtInput) -> Result<Vec<u8>> {
     out.extend_from_slice(&0u32.to_be_bytes()); // color depth (unknown)
     out.extend_from_slice(&0u32.to_be_bytes()); // number of colors (non-indexed)
     out.extend_from_slice(
-        &u32::try_from(art.data_len)
+        &u32::try_from(art.data_len.get())
             .map_err(|_| FormatError::TooLarge)?
             .to_be_bytes(),
     ); // picture data length
@@ -253,7 +253,7 @@ pub fn synthesize_layout(
         .filter(|bt| matches!(bt.key.as_str(), "APPLICATION" | "CUESHEET"))
         .collect();
 
-    let nonempty_art = arts.iter().filter(|a| a.data_len > 0).count();
+    let nonempty_art = arts.len();
     let num_blocks = ordered.len() + 1 + valid_binary.len() + nonempty_art;
     let last_index = num_blocks - 1;
 
@@ -282,29 +282,26 @@ pub fn synthesize_layout(
             "CUESHEET" => BLOCK_CUESHEET,
             _ => continue,
         };
-        if bt.len > MAX_BLOCK_BODY {
+        if bt.len.get() > MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
         }
         push_block_header(
             &mut buf,
             block_type,
-            crate::convert::usize_from(bt.len),
+            crate::convert::usize_from(bt.len.get()),
             idx == last_index,
         )?;
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::BinaryTag {
             payload_id: bt.payload_id,
-            len: bt.len,
+            len: bt.len.get(),
         });
         idx += 1;
     }
 
     for art in arts {
-        if art.data_len == 0 {
-            continue;
-        }
         let framing = picture_body_framing(art)?;
-        let body_len = framing.len() as u64 + art.data_len;
+        let body_len = framing.len() as u64 + art.data_len.get();
         if body_len > MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
         }
@@ -318,7 +315,7 @@ pub fn synthesize_layout(
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::ArtImage {
             art_id: art.art_id,
-            len: art.data_len,
+            len: art.data_len.get(),
         });
         idx += 1;
     }
@@ -462,6 +459,7 @@ pub fn read_pictures(data: &[u8]) -> Result<Vec<EmbeddedPicture>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::{BlobLen, PictureType};
     use crate::probe::Extent;
 
     /// Build a minimal FLAC: marker + a single last STREAMINFO (type 0, 34-byte
@@ -961,15 +959,15 @@ mod tests {
             art_id: 1,
             mime: "image/png".to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len,
+            data_len: BlobLen::new(data_len).unwrap(),
         };
         // Derive the exact framing length from production rather than hardcoding it
         // (it is independent of the data_len *value* — that field is always 4 bytes).
         // This keeps the boundary correct regardless of the framing's field count.
-        let framing_len = picture_body_framing(&mk(0)).unwrap().len() as u64;
+        let framing_len = picture_body_framing(&mk(1)).unwrap().len() as u64;
         let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
         // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
         // (data_len is only a count; no large allocation occurs.)
@@ -1012,7 +1010,7 @@ mod tests {
         let mk = |len: u64| BinaryTagInput {
             key: "APPLICATION".to_string(),
             payload_id: 1,
-            len,
+            len: BlobLen::new(len).unwrap(),
         };
         // len == 0x00FF_FFFF exactly must succeed.
         assert!(synthesize_layout(&[], 0, 0, &[], &[mk(0x00FF_FFFF)], &[]).is_ok());

--- a/musefs-format/src/input.rs
+++ b/musefs-format/src/input.rs
@@ -1,3 +1,41 @@
+use std::num::NonZeroU64;
+
+/// An ID3/FLAC picture type, validated to the `0..=20` range (the #199
+/// `track_art` CHECK, mirrored Rust-side at the synthesis-input boundary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PictureType(u8);
+
+impl PictureType {
+    /// The "Other" picture type (0); the clamp target for an out-of-range byte.
+    pub const ZERO: PictureType = PictureType(0);
+
+    pub fn new(v: u32) -> Option<PictureType> {
+        let b = u8::try_from(v).ok()?;
+        if b > 20 { None } else { Some(PictureType(b)) }
+    }
+
+    pub fn get(self) -> u32 {
+        u32::from(self.0)
+    }
+}
+
+/// A non-zero payload length for an art image or binary tag. The non-zero
+/// invariant encodes the layout's `EmptySegment` rule at the type level:
+/// a degenerate empty payload is dropped at the construction boundary, so a
+/// metadata segment can never carry a zero length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobLen(NonZeroU64);
+
+impl BlobLen {
+    pub fn new(v: u64) -> Option<BlobLen> {
+        NonZeroU64::new(v).map(BlobLen)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
 /// One Vorbis/ID3 tag value to synthesize. Multi-valued tags are passed as
 /// multiple `TagInput`s in the desired order.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,5 +125,29 @@ mod tests {
         };
         assert_eq!(e.key, "PRIV");
         assert_eq!(e.payload.len(), 3);
+    }
+
+    #[test]
+    fn picture_type_accepts_full_range() {
+        for v in 0..=20u32 {
+            assert_eq!(super::PictureType::new(v).unwrap().get(), v);
+        }
+    }
+
+    #[test]
+    fn picture_type_rejects_out_of_range() {
+        assert!(super::PictureType::new(21).is_none());
+        assert!(super::PictureType::new(u32::MAX).is_none());
+    }
+
+    #[test]
+    fn blob_len_rejects_zero() {
+        assert!(super::BlobLen::new(0).is_none());
+    }
+
+    #[test]
+    fn blob_len_round_trips_nonzero() {
+        assert_eq!(super::BlobLen::new(1).unwrap().get(), 1);
+        assert_eq!(super::BlobLen::new(u64::MAX).unwrap().get(), u64::MAX);
     }
 }

--- a/musefs-format/src/input.rs
+++ b/musefs-format/src/input.rs
@@ -73,7 +73,7 @@ pub struct ArtInput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EmbeddedPicture {
     pub mime: String,
-    pub picture_type: u32,
+    pub picture_type: PictureType,
     pub description: String,
     pub width: u32,
     pub height: u32,

--- a/musefs-format/src/input.rs
+++ b/musefs-format/src/input.rs
@@ -62,10 +62,10 @@ pub struct ArtInput {
     pub art_id: i64,
     pub mime: String,
     pub description: String,
-    pub picture_type: u32,
+    pub picture_type: PictureType,
     pub width: u32,
     pub height: u32,
-    pub data_len: u64,
+    pub data_len: BlobLen,
 }
 
 /// An embedded picture extracted from a backing file at scan time (a FLAC PICTURE
@@ -89,7 +89,7 @@ pub struct EmbeddedPicture {
 pub struct BinaryTagInput {
     pub key: String,
     pub payload_id: i64,
-    pub len: u64,
+    pub len: BlobLen,
 }
 
 /// A binary tag frame extracted at scan time: the format-private identifier
@@ -104,17 +104,17 @@ pub struct EmbeddedBinaryTag {
 
 #[cfg(test)]
 mod tests {
-    use super::BinaryTagInput;
+    use super::{BinaryTagInput, BlobLen};
 
     #[test]
     fn binary_tag_input_constructs() {
         let b = BinaryTagInput {
             key: "PRIV".into(),
             payload_id: 7,
-            len: 3,
+            len: BlobLen::new(3).unwrap(),
         };
         assert_eq!(b.payload_id, 7);
-        assert_eq!(b.len, 3);
+        assert_eq!(b.len.get(), 3);
     }
 
     #[test]

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -15,7 +15,9 @@ pub mod wav;
 pub mod fuzz_check;
 
 pub use error::{FormatError, Result};
-pub use input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+pub use input::{
+    ArtInput, BinaryTagInput, BlobLen, EmbeddedBinaryTag, EmbeddedPicture, PictureType, TagInput,
+};
 pub use layout::{LayoutError, RegionLayout, Segment};
 pub use ogg::{Codec, OggHeader, OggScan};
 pub use probe::Extent;

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -534,8 +534,11 @@ pub fn read_pictures(data: &[u8]) -> Vec<EmbeddedPicture> {
     tag.pictures()
         .map(|p| EmbeddedPicture {
             mime: p.mime_type.clone(),
+            // The id3 crate's PictureType has an `Undefined(u8)` variant that can
+            // exceed 20; clamp out-of-range to 0, matching the FLAC parser and
+            // scan's prior policy.
             picture_type: PictureType::new(u8::from(p.picture_type).into())
-                .expect("id3 picture_type is always 0..=20"),
+                .unwrap_or(PictureType::ZERO),
             description: p.description.clone(),
             width: 0,
             height: 0,

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1,6 +1,8 @@
 use crate::convert::usize_from;
 use crate::error::{FormatError, Result};
-use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+use crate::input::{
+    ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, PictureType, TagInput,
+};
 use crate::layout::{RegionLayout, Segment};
 use crate::probe::Extent;
 
@@ -542,7 +544,8 @@ pub fn read_pictures(data: &[u8]) -> Vec<EmbeddedPicture> {
     tag.pictures()
         .map(|p| EmbeddedPicture {
             mime: p.mime_type.clone(),
-            picture_type: u8::from(p.picture_type).into(),
+            picture_type: PictureType::new(u8::from(p.picture_type).into())
+                .expect("id3 picture_type is always 0..=20"),
             description: p.description.clone(),
             width: 0,
             height: 0,

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1056,10 +1056,9 @@ mod tests {
     }
 
     #[test]
-    fn build_id3v2_segments_keeps_real_art_when_mixed_with_empty() {
-        // An empty art alongside a real one: only the non-empty art is emitted.
-        // (Zero-length art is now dropped at the bridge, so the in-synthesis skip
-        // is dead code; this test verifies the real art still works.)
+    fn build_id3v2_segments_emits_art_segment_with_correct_id_and_len() {
+        // Feed a single art entry and verify the emitted ArtImage segment carries
+        // the correct art_id and data length.
         let mk = |art_id: i64, data_len: u64| ArtInput {
             art_id,
             mime: "image/png".to_string(),

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -198,7 +198,7 @@ fn apic_framing(art: &ArtInput) -> Vec<u8> {
         clippy::cast_possible_truncation,
         reason = "ID3 APIC type is one byte; valid picture types are 0..=20"
     )]
-    d.push(art.picture_type as u8);
+    d.push(art.picture_type.get() as u8);
     d.extend_from_slice(art.description.as_bytes());
     d.push(0x00);
     d
@@ -346,38 +346,28 @@ pub fn build_id3v2_segments(
 
     // Opaque binary frames: header (inline) + streamed body (BinaryTag segment).
     for bt in binary_tags {
-        if bt.len == 0 {
-            // An empty BinaryTag fails `RegionLayout::validate` (`EmptySegment`).
-            continue;
-        }
         // Defensive: ID3 opaque keys are 4-byte frame ids.
         let Ok(id): std::result::Result<[u8; 4], _> = bt.key.as_bytes().try_into() else {
             continue;
         };
-        push_frame_header(&mut buf, &id, usize_from(bt.len))?;
+        push_frame_header(&mut buf, &id, usize_from(bt.len.get()))?;
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::BinaryTag {
             payload_id: bt.payload_id,
-            len: bt.len,
+            len: bt.len.get(),
         });
-        frames_len += 10 + bt.len;
+        frames_len += 10 + bt.len.get();
     }
 
     for art in arts {
-        if art.data_len == 0 {
-            // Skip degenerate empty art: an `ArtImage { len: 0 }` segment fails
-            // `RegionLayout::validate` (`EmptySegment`) and would make the whole
-            // track unreadable at serve time (finding #16).
-            continue;
-        }
         let framing = apic_framing(art);
-        let data_len = framing.len() as u64 + art.data_len;
+        let data_len = framing.len() as u64 + art.data_len.get();
         push_frame_header(&mut buf, b"APIC", usize_from(data_len))?;
         buf.extend_from_slice(&framing);
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
         segments.push(Segment::ArtImage {
             art_id: art.art_id,
-            len: art.data_len,
+            len: art.data_len.get(),
         });
         frames_len += 10 + data_len;
     }
@@ -695,6 +685,7 @@ fn classify_binary_frame(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::{BlobLen, PictureType};
 
     /// Build a minimal ID3v2.3 tag with a single frame whose declared size
     /// overflows the tag bounds, and assert the guard rejects it.
@@ -1036,10 +1027,10 @@ mod tests {
             art_id: 1,
             mime: "image/png".to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len,
+            data_len: BlobLen::new(data_len).unwrap(),
         };
         assert_eq!(
             build_id3v2_segments(&[], &[], &[mk(0x1000_0000)]).err(),
@@ -1065,52 +1056,20 @@ mod tests {
     }
 
     #[test]
-    fn build_id3v2_segments_skips_zero_byte_art() {
-        // A zero-byte APIC would emit `Segment::ArtImage { len: 0 }`, which
-        // `RegionLayout::validate` rejects as `EmptySegment` -> the whole track
-        // becomes unreadable at serve time. Degenerate empty art must be skipped
-        // at synthesis (mirrors the FLAC fix for finding #16).
-        let empty = ArtInput {
-            art_id: 1,
-            mime: "image/png".to_string(),
-            description: String::new(),
-            picture_type: 3,
-            width: 0,
-            height: 0,
-            data_len: 0,
-        };
-        let (segments, _len) = build_id3v2_segments(&[], &[], &[empty]).unwrap();
-        assert!(
-            !segments
-                .iter()
-                .any(|s| matches!(s, Segment::ArtImage { .. })),
-            "zero-byte art must not emit an ArtImage segment"
-        );
-        let mut buf = Vec::new();
-        for seg in &segments {
-            if let Segment::Inline(b) = seg {
-                buf.extend_from_slice(b);
-            }
-        }
-        assert!(
-            !buf.windows(4).any(|w| w == b"APIC"),
-            "zero-byte art must not emit an APIC frame"
-        );
-    }
-
-    #[test]
     fn build_id3v2_segments_keeps_real_art_when_mixed_with_empty() {
         // An empty art alongside a real one: only the non-empty art is emitted.
+        // (Zero-length art is now dropped at the bridge, so the in-synthesis skip
+        // is dead code; this test verifies the real art still works.)
         let mk = |art_id: i64, data_len: u64| ArtInput {
             art_id,
             mime: "image/png".to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len,
+            data_len: BlobLen::new(data_len).unwrap(),
         };
-        let (segments, _len) = build_id3v2_segments(&[], &[], &[mk(1, 0), mk(2, 16)]).unwrap();
+        let (segments, _len) = build_id3v2_segments(&[], &[], &[mk(2, 16)]).unwrap();
         let art_segs: Vec<_> = segments
             .iter()
             .filter_map(|s| match s {
@@ -1965,7 +1924,7 @@ mod tests {
         let bin = vec![BinaryTagInput {
             key: "PRIV".into(),
             payload_id: 1,
-            len: 7,
+            len: BlobLen::new(7).unwrap(),
         }];
         let (_segs, total) = build_id3v2_segments(&[], &bin, &[]).unwrap();
         assert_eq!(total, 10 + 10 + 7, "opaque binary frame length accounting");
@@ -2056,7 +2015,7 @@ mod tests {
         let bin = vec![BinaryTagInput {
             key: "PRIV".into(),
             payload_id: 42,
-            len: 3,
+            len: BlobLen::new(3).unwrap(),
         }];
         let (segments, _len) = super::build_id3v2_segments(&tags, &bin, &[]).unwrap();
 

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -669,27 +669,23 @@ fn build_udta(
     let mut streamed_total: u64 = 0;
 
     for bt in binary_tags {
-        if bt.len == 0 {
-            // An empty BinaryTag fails `RegionLayout::validate` (EmptySegment).
-            continue;
-        }
         let Some((mean, name)) = parse_freeform_key(&bt.key) else {
             // Not a `----:<mean>:<name>` key; skip defensively (no double-store path).
             continue;
         };
-        ilst_inline.extend_from_slice(&freeform_binary_prefix(mean, name, bt.len)?);
+        ilst_inline.extend_from_slice(&freeform_binary_prefix(mean, name, bt.len.get())?);
         ilst_segments.push(Segment::Inline(std::mem::take(&mut ilst_inline)));
         ilst_segments.push(Segment::BinaryTag {
             payload_id: bt.payload_id,
-            len: bt.len,
+            len: bt.len.get(),
         });
-        streamed_total += bt.len;
+        streamed_total += bt.len.get();
     }
 
     if !arts.is_empty() {
         // One covr atom; each art is its own `data` child (the iTunes
         // convention for multiple artworks).
-        let covr_size: u64 = 8 + arts.iter().map(|a| 16 + a.data_len).sum::<u64>();
+        let covr_size: u64 = 8 + arts.iter().map(|a| 16 + a.data_len.get()).sum::<u64>();
         ilst_inline.extend_from_slice(
             &u32::try_from(covr_size)
                 .map_err(|_| FormatError::TooLarge)?
@@ -698,7 +694,7 @@ fn build_udta(
         ilst_inline.extend_from_slice(b"covr");
         for a in arts {
             let type_code: u32 = if a.mime == "image/png" { 14 } else { 13 };
-            let data_size = 8 + 8 + a.data_len; // data header + type + locale + image
+            let data_size = 8 + 8 + a.data_len.get(); // data header + type + locale + image
             ilst_inline.extend_from_slice(
                 &u32::try_from(data_size)
                     .map_err(|_| FormatError::TooLarge)?
@@ -710,9 +706,9 @@ fn build_udta(
             ilst_segments.push(Segment::Inline(std::mem::take(&mut ilst_inline)));
             ilst_segments.push(Segment::ArtImage {
                 art_id: a.art_id,
-                len: a.data_len,
+                len: a.data_len.get(),
             });
-            streamed_total += a.data_len;
+            streamed_total += a.data_len.get();
         }
     } else if !ilst_inline.is_empty() {
         ilst_segments.push(Segment::Inline(std::mem::take(&mut ilst_inline)));
@@ -834,8 +830,8 @@ pub fn synthesize_layout(
         }
     }
 
-    // Skip zero-byte art (an empty ArtImage segment fails layout validation).
-    let arts: Vec<ArtInput> = arts.iter().filter(|a| a.data_len > 0).cloned().collect();
+    // All art inputs are non-zero-length (the bridge drops zero-length at construction).
+    let arts: Vec<ArtInput> = arts.to_vec();
     let (udta_segments, _streamed_total) = build_udta(tags, binary_tags, &arts)?;
     let udta_total: u64 = udta_segments.iter().map(Segment::len).sum();
 
@@ -884,6 +880,7 @@ pub fn synthesize_layout(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::{BlobLen, PictureType};
 
     /// Build a 32-bit-size box: [size][type][payload].
     fn bx(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
@@ -1153,10 +1150,10 @@ mod tests {
             art_id: 1,
             mime: "image/png".into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: 100,
+            data_len: BlobLen::new(100).unwrap(),
         };
         let (segs, streamed) = build_udta(&[TagInput::new("title", "T")], &[], &[art]).unwrap();
         assert_eq!(streamed, 100);
@@ -1187,10 +1184,10 @@ mod tests {
             art_id: 1,
             mime: "image/jpeg".into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: u64::from(u32::MAX) + 1,
+            data_len: BlobLen::new(u64::from(u32::MAX) + 1).unwrap(),
         };
         assert!(matches!(
             build_udta(&[TagInput::new("title", "T")], &[], &[art]),
@@ -1403,10 +1400,10 @@ mod tests {
             art_id: 7,
             mime: "image/jpeg".into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: 50,
+            data_len: BlobLen::new(50).unwrap(),
         };
         let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[], &[art]).unwrap();
         let segs = layout.segments();
@@ -1416,64 +1413,21 @@ mod tests {
     }
 
     #[test]
-    fn synthesize_skips_zero_length_art() {
-        // A zero-byte art must be skipped at synthesis (mirrors flac.rs finding
-        // #16): an ArtImage { len: 0 } segment fails layout validation
-        // (EmptySegment), making the track unreadable. The track must still
-        // synthesize with its tags, just without a cover-art segment or covr box.
-        let buf = mk_mp4(false, b"AUDIODATA", &[0]);
-        let scan = read_structure(&buf).unwrap();
-        let art = ArtInput {
-            art_id: 7,
-            mime: "image/jpeg".into(),
-            description: String::new(),
-            picture_type: 3,
-            width: 0,
-            height: 0,
-            data_len: 0,
-        };
-        let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &[], &[art]).unwrap();
-        let segs = layout.segments();
-        assert!(
-            !segs.iter().any(|s| matches!(s, Segment::ArtImage { .. })),
-            "zero-byte art must not emit an ArtImage segment"
-        );
-        let Segment::Inline(head) = &segs[0] else {
-            panic!("first segment should be the inline head");
-        };
-        assert!(
-            head.windows(4).all(|w| w != b"covr"),
-            "no covr box should be emitted for zero-byte art"
-        );
-        assert!(matches!(segs.last().unwrap(), Segment::BackingAudio { .. }));
-    }
-
-    #[test]
     fn synthesize_picks_first_nonempty_art() {
-        // With a zero-byte art ahead of a real one, the real art must still be
-        // served (the first nonempty art wins, not merely the first art).
+        // With multiple non-empty arts, the real art must be served.
         let buf = mk_mp4(false, b"AUDIODATA", &[0]);
         let scan = read_structure(&buf).unwrap();
-        let empty = ArtInput {
-            art_id: 1,
-            mime: "image/jpeg".into(),
-            description: String::new(),
-            picture_type: 3,
-            width: 0,
-            height: 0,
-            data_len: 0,
-        };
         let real = ArtInput {
             art_id: 9,
             mime: "image/png".into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: 40,
+            data_len: BlobLen::new(40).unwrap(),
         };
         let layout =
-            synthesize_layout(&scan, &[TagInput::new("title", "T")], &[], &[empty, real]).unwrap();
+            synthesize_layout(&scan, &[TagInput::new("title", "T")], &[], &[real]).unwrap();
         let segs = layout.segments();
         assert!(
             segs.iter()
@@ -1942,10 +1896,10 @@ mod tests {
                 art_id: 1,
                 mime: mime.into(),
                 description: String::new(),
-                picture_type: 3,
+                picture_type: PictureType::new(3).unwrap(),
                 width: 0,
                 height: 0,
-                data_len: 10,
+                data_len: BlobLen::new(10).unwrap(),
             };
             let (segs, _) = build_udta(&[TagInput::new("title", "T")], &[], &[art]).unwrap();
             let prefix = materialize_udta(&segs);
@@ -1965,10 +1919,10 @@ mod tests {
             art_id: 1,
             mime: "image/jpeg".into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: 10,
+            data_len: BlobLen::new(10).unwrap(),
         };
         let (segs, _) = build_udta(&[TagInput::new("title", "T")], &[], &[art]).unwrap();
         let prefix = materialize_udta(&segs);
@@ -1985,10 +1939,10 @@ mod tests {
             art_id: id,
             mime: mime.into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: len,
+            data_len: BlobLen::new(len).unwrap(),
         };
         let arts = [art(1, "image/jpeg", 10), art(2, "image/png", 20)];
         let (segs, streamed) = build_udta(&[TagInput::new("title", "T")], &[], &arts).unwrap();
@@ -2047,10 +2001,10 @@ mod tests {
             art_id: id,
             mime: mime.into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: len,
+            data_len: BlobLen::new(len).unwrap(),
         };
         let arts = [art(1, "image/jpeg", 5), art(2, "image/png", 9)];
         let (segs, _) = build_udta(&[TagInput::new("title", "Song")], &[], &arts).unwrap();
@@ -2079,19 +2033,19 @@ mod tests {
                 art_id: 1,
                 mime: "image/jpeg".into(),
                 description: String::new(),
-                picture_type: 3,
+                picture_type: PictureType::new(3).unwrap(),
                 width: 0,
                 height: 0,
-                data_len,
+                data_len: BlobLen::new(data_len).unwrap(),
             }
         }
         // Derive the fixed overhead from the udta size field (segs[0] inline), with
-        // data_len 0, without materializing any image bytes.
-        let (segs0, _) = build_udta(&[TagInput::new("title", "T")], &[], &[art(0)]).unwrap();
+        // data_len 1 (BlobLen is non-zero), without materializing any image bytes.
+        let (segs0, _) = build_udta(&[TagInput::new("title", "T")], &[], &[art(1)]).unwrap();
         let Segment::Inline(h0) = &segs0[0] else {
             panic!("inline head")
         };
-        let overhead = u64::from(u32::from_be_bytes(h0[0..4].try_into().unwrap()));
+        let overhead = u64::from(u32::from_be_bytes(h0[0..4].try_into().unwrap())) - 1;
         let max_len = u64::from(u32::MAX) - overhead;
 
         let (segs_max, streamed) =
@@ -2252,7 +2206,7 @@ mod tests {
         let bins = vec![BinaryTagInput {
             key: "----:com.serato.dj:analysis".into(),
             payload_id: 7,
-            len: payload.len() as u64,
+            len: BlobLen::new(payload.len() as u64).unwrap(),
         }];
         let layout = synthesize_layout(&scan, &[TagInput::new("title", "T")], &bins, &[]).unwrap();
 
@@ -2317,10 +2271,10 @@ mod tests {
                 art_id: 1,
                 mime: "image/jpeg".into(),
                 description: String::new(),
-                picture_type: 3,
+                picture_type: PictureType::new(3).unwrap(),
                 width: 0,
                 height: 0,
-                data_len,
+                data_len: BlobLen::new(data_len).unwrap(),
             }
         }
         let buf = mk_mp4(true, b"AUDIO", &[0]);
@@ -2348,15 +2302,15 @@ mod tests {
 
     #[test]
     fn synthesize_layout_emits_all_nonzero_arts() {
-        // Zero-byte art is filtered; both non-empty arts stream, in input order.
+        // Both non-empty arts stream, in input order.
         let art = |id: i64, len: u64| ArtInput {
             art_id: id,
             mime: "image/jpeg".into(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: len,
+            data_len: BlobLen::new(len).unwrap(),
         };
         let buf = mk_mp4(true, b"AUDIO", &[0]);
         let scan = read_structure(&buf).unwrap();
@@ -2364,7 +2318,7 @@ mod tests {
             &scan,
             &[TagInput::new("title", "T")],
             &[],
-            &[art(1, 5), art(2, 0), art(3, 7)],
+            &[art(1, 5), art(3, 7)],
         )
         .unwrap();
         let art_segs: Vec<(i64, u64)> = layout

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -5,7 +5,9 @@
 
 use crate::convert::usize_from;
 use crate::error::{FormatError, Result};
-use crate::input::{ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, TagInput};
+use crate::input::{
+    ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, PictureType, TagInput,
+};
 use crate::layout::{RegionLayout, Segment};
 use std::io::{self, Read, Seek, SeekFrom};
 
@@ -457,7 +459,7 @@ pub fn read_pictures(buf: &[u8]) -> Vec<EmbeddedPicture> {
             };
             out.push(EmbeddedPicture {
                 mime: mime.to_string(),
-                picture_type: 3,
+                picture_type: PictureType::new(3).expect("3 is in range"),
                 description: String::new(),
                 width: 0,
                 height: 0,

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -1268,7 +1268,7 @@ mod tests {
         body.extend(std::iter::repeat_n(0u8, 12345));
         let pic = crate::flac::parse_picture_block(&body).unwrap();
         assert_eq!(pic.mime, "image/png");
-        assert_eq!(pic.picture_type, 3);
+        assert_eq!(pic.picture_type.get(), 3);
     }
 
     #[test]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -254,14 +254,8 @@ pub fn synthesize_layout(
     tags: &[TagInput],
     arts: &[OggArt],
 ) -> Result<RegionLayout> {
-    // Exclude zero-byte art: an empty image yields a meaningless
-    // METADATA_BLOCK_PICTURE comment (and an empty OggArtSlice run). Mirrors the
-    // FLAC/MP3/MP4/WAV synthesis skip so every format drops degenerate art.
-    let arts: Vec<OggArt> = arts
-        .iter()
-        .filter(|a| a.meta.data_len > 0)
-        .copied()
-        .collect();
+    // All art inputs are non-zero-length (the bridge drops zero-length at construction).
+    let arts: Vec<OggArt> = arts.to_vec();
     let packet_chunks = build_packets_with_art(header, tags, &arts)?;
     let mut segments: Vec<Segment> = Vec::new();
     let mut seq = 0u32;
@@ -294,7 +288,7 @@ fn picture_prefix(art: &crate::input::ArtInput) -> Result<Vec<u8>> {
     let description = format!("{}{}", art.description, " ".repeat(pad));
 
     let mut out = Vec::new();
-    out.extend_from_slice(&art.picture_type.to_be_bytes());
+    out.extend_from_slice(&art.picture_type.get().to_be_bytes());
     out.extend_from_slice(
         &u32::try_from(art.mime.len())
             .map_err(|_| FormatError::TooLarge)?
@@ -312,7 +306,7 @@ fn picture_prefix(art: &crate::input::ArtInput) -> Result<Vec<u8>> {
     out.extend_from_slice(&0u32.to_be_bytes()); // depth
     out.extend_from_slice(&0u32.to_be_bytes()); // colors
     out.extend_from_slice(
-        &u32::try_from(art.data_len)
+        &u32::try_from(art.data_len.get())
             .map_err(|_| FormatError::TooLarge)?
             .to_be_bytes(),
     ); // image data length
@@ -354,7 +348,7 @@ fn build_packets_with_art(
                 let b64_prefix_len = b64_len(prefix.len() as u64);
                 let value_len = METADATA_BLOCK_PICTURE_KEY.len() as u64
                     + b64_prefix_len
-                    + b64_len(a.meta.data_len);
+                    + b64_len(a.meta.data_len.get());
                 if value_len > u64::from(u32::MAX) {
                     return Err(FormatError::TooLarge);
                 }
@@ -404,7 +398,7 @@ fn comment_packet_chunks(
         let b64_prefix = b64_encode(&prefix);
         let value_len = METADATA_BLOCK_PICTURE_KEY.len()
             + b64_prefix.len()
-            + crate::convert::usize_from(b64_len(art.meta.data_len));
+            + crate::convert::usize_from(b64_len(art.meta.data_len.get()));
         head.extend_from_slice(
             &u32::try_from(value_len)
                 .map_err(|_| FormatError::TooLarge)?
@@ -417,7 +411,7 @@ fn comment_packet_chunks(
             art_id: art.meta.art_id,
             out: b64_encode(art.image),
             base64: true,
-            art_total: art.meta.data_len,
+            art_total: art.meta.data_len.get(),
         });
     }
     if framing_bit {
@@ -465,7 +459,7 @@ fn oggflac_packets_with_art(
     block_packets.push(vec![PayloadChunk::Bytes(comment)]);
     for art in arts {
         let prefix = picture_prefix(art.meta)?;
-        let body_len = prefix.len() as u64 + art.meta.data_len;
+        let body_len = prefix.len() as u64 + art.meta.data_len.get();
         if body_len > crate::flac::MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
         }
@@ -478,7 +472,7 @@ fn oggflac_packets_with_art(
                 art_id: art.meta.art_id,
                 out: art.image.to_vec(),
                 base64: false,
-                art_total: art.meta.data_len,
+                art_total: art.meta.data_len.get(),
             },
         ]);
     }
@@ -911,10 +905,10 @@ mod tests {
             art_id: 7,
             mime: "image/jpeg".to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 64,
             height: 64,
-            data_len: image.len() as u64,
+            data_len: crate::input::BlobLen::new(image.len() as u64).unwrap(),
         };
         let layout = synthesize_layout(
             &header,
@@ -1007,10 +1001,10 @@ mod tests {
             art_id,
             mime: mime.to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 10,
             height: 10,
-            data_len: len as u64,
+            data_len: crate::input::BlobLen::new(len as u64).unwrap(),
         }
     }
 
@@ -1116,52 +1110,13 @@ mod tests {
     }
 
     #[test]
-    fn synthesize_opus_skips_zero_byte_art() {
-        let mut data = opus_headers();
-        let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 64]);
-        data.extend_from_slice(&audio);
-        let scan = locate_audio(&data).unwrap();
-        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
-
-        let img: Vec<u8> = (0..2000u32).map(|i| (i % 251) as u8).collect();
-        let empty: Vec<u8> = Vec::new();
-        let meta_empty = art_input(1, "image/jpeg", 0);
-        let meta_real = art_input(2, "image/png", img.len());
-        // Empty art listed first: it must be dropped without disturbing the real one.
-        let layout = synthesize_layout(
-            &header,
-            scan.audio_offset,
-            scan.audio_length,
-            &[TagInput::new("title", "Skip")],
-            &[
-                OggArt {
-                    meta: &meta_empty,
-                    image: &empty,
-                },
-                OggArt {
-                    meta: &meta_real,
-                    image: &img,
-                },
-            ],
-        )
-        .unwrap();
-
-        let bytes = materialize_header(&layout, &[(2, &img)]);
-        let h = read_header(&bytes).unwrap();
-        assert_eq!(h.codec, Codec::Opus);
-        let pics = read_pictures(&bytes).unwrap();
-        assert_eq!(pics.len(), 1, "zero-byte art must be skipped at synthesis");
-        assert_eq!(pics[0].data, img);
-    }
-
-    #[test]
     fn oversized_full_art_value_rejected_by_build_packets() {
         let meta = crate::input::ArtInput {
             art_id: 0,
             mime: "image/jpeg".to_string(),
             description: String::new(),
-            data_len: u64::from(u32::MAX),
-            picture_type: 3,
+            data_len: crate::input::BlobLen::new(u64::from(u32::MAX)).unwrap(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
         };
@@ -1188,8 +1143,8 @@ mod tests {
             art_id: 0,
             mime: "image/png".to_string(),
             description: "x".repeat(256),
-            data_len: 3_221_225_470, // b64_len = 4_294_967_294 < u32::MAX
-            picture_type: 3,
+            data_len: crate::input::BlobLen::new(3_221_225_470).unwrap(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
         };
@@ -1223,8 +1178,8 @@ mod tests {
             art_id: 0,
             mime: "image/png".to_string(),
             description: String::new(),
-            data_len: 3_221_225_412,
-            picture_type: 3,
+            data_len: crate::input::BlobLen::new(3_221_225_412).unwrap(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
         };
@@ -1252,10 +1207,10 @@ mod tests {
             art_id: 1,
             mime: "image/png".to_string(), // 9 -> base = 32+9+0 = 41 -> pad 1
             description: String::new(),
-            picture_type: 3,
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 1,
             height: 1,
-            data_len: 12345,
+            data_len: crate::input::BlobLen::new(12345).unwrap(),
         };
         let p = picture_prefix(&art).unwrap();
         assert_eq!(p.len() % 3, 0);
@@ -1355,12 +1310,12 @@ mod tests {
             art_id: 1,
             mime: "image/png".to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len,
+            data_len: crate::input::BlobLen::new(data_len).unwrap(),
         };
-        let framing_len = picture_prefix(&mk(0)).unwrap().len() as u64;
+        let framing_len = picture_prefix(&mk(1)).unwrap().len() as u64;
         let at_limit = mk(crate::flac::MAX_BLOCK_BODY - framing_len);
         let arts = [OggArt {
             meta: &at_limit,
@@ -1429,10 +1384,10 @@ mod tests {
             art_id: 1,
             mime: "image/png".into(), // 9
             description: "x".into(),  // 1 -> base = 42, 42 % 3 == 0 -> pad 0
-            picture_type: 3,
+            picture_type: crate::input::PictureType::new(3).unwrap(),
             width: 1,
             height: 1,
-            data_len: 100,
+            data_len: crate::input::BlobLen::new(100).unwrap(),
         };
         let prefix = picture_prefix(&art).unwrap();
         assert_eq!(prefix.len() % 3, 0);

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -249,9 +249,8 @@ pub fn synthesize_layout(
     }
 
     // Embedded `id3 ` chunk: 8-byte chunk header + the ID3v2 tag segments, padded.
-    // `build_id3v2_segments` already skips degenerate zero-byte art (finding #16) —
-    // an empty `ArtImage { len: 0 }` would fail `RegionLayout::validate` and brick
-    // the track — so WAV inherits that handling by delegating to it.
+    // Zero-length art inputs are impossible (BlobLen is non-zero by construction),
+    // so WAV inherits that invariant by delegating to `build_id3v2_segments`.
     let (tag_segments, tag_len) = crate::mp3::build_id3v2_segments(tags, binary_tags, arts)?;
     let tag_len_u32 = u32::try_from(tag_len).map_err(|_| FormatError::TooLarge)?;
     segments.push(Segment::Inline(chunk_header(b"id3 ", tag_len_u32).to_vec()));

--- a/musefs-format/tests/flac_pictures.rs
+++ b/musefs-format/tests/flac_pictures.rs
@@ -33,7 +33,7 @@ fn extracts_picture_blocks() {
     let pics = read_pictures(&flac).unwrap();
     assert_eq!(pics.len(), 1);
     let p = &pics[0];
-    assert_eq!(p.picture_type, 3);
+    assert_eq!(p.picture_type.get(), 3);
     assert_eq!(p.mime, "image/png");
     assert_eq!(p.description, "front");
     assert_eq!(p.width, 10);

--- a/musefs-format/tests/mp3_pictures.rs
+++ b/musefs-format/tests/mp3_pictures.rs
@@ -26,6 +26,32 @@ fn extracts_apic_pictures() {
 }
 
 #[test]
+fn clamps_out_of_range_picture_type() {
+    use id3::TagLike;
+
+    // The id3 crate's PictureType::Undefined(u8) can hold a value past 20; the
+    // parser must clamp it to 0 (the FLAC/scan policy) rather than panic.
+    let mut tag = id3::Tag::new();
+    tag.add_frame(id3::frame::Picture {
+        mime_type: "image/png".to_string(),
+        picture_type: id3::frame::PictureType::Undefined(99),
+        description: String::new(),
+        data: vec![0x11u8; 8],
+    });
+    let mut bytes = Vec::new();
+    tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+    bytes.extend_from_slice(&[0xFF, 0xFB, 0, 0]);
+
+    let pics = read_pictures(&bytes);
+    assert_eq!(pics.len(), 1);
+    assert_eq!(
+        pics[0].picture_type.get(),
+        0,
+        "out-of-range type clamps to 0"
+    );
+}
+
+#[test]
 fn no_tag_yields_empty() {
     let data = [0xFF, 0xFB, 0, 0, 0, 0];
     assert!(read_pictures(&data).is_empty());

--- a/musefs-format/tests/mp3_pictures.rs
+++ b/musefs-format/tests/mp3_pictures.rs
@@ -20,7 +20,7 @@ fn extracts_apic_pictures() {
     assert_eq!(pics.len(), 1);
     let p = &pics[0];
     assert_eq!(p.mime, "image/jpeg");
-    assert_eq!(p.picture_type, 3); // front cover
+    assert_eq!(p.picture_type.get(), 3); // front cover
     assert_eq!(p.description, "cover");
     assert_eq!(p.data, img);
 }

--- a/musefs-format/tests/mp3_synthesize.rs
+++ b/musefs-format/tests/mp3_synthesize.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use id3::TagLike;
 use musefs_format::mp3::synthesize_layout;
-use musefs_format::{ArtInput, RegionLayout, Segment, TagInput};
+use musefs_format::{ArtInput, BlobLen, PictureType, RegionLayout, Segment, TagInput};
 
 /// Flatten a layout into a byte buffer, substituting `audio` for the backing-audio
 /// segment and the matching bytes for each `ArtImage` segment.
@@ -65,10 +65,10 @@ fn synthesizes_apic_with_streamed_image_bytes() {
         art_id: 7,
         mime: "image/jpeg".to_string(),
         description: String::new(),
-        picture_type: 3, // front cover
+        picture_type: PictureType::new(3).unwrap(), // front cover
         width: 0,
         height: 0,
-        data_len: art_bytes.len() as u64,
+        data_len: BlobLen::new(art_bytes.len() as u64).unwrap(),
     }];
     let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &arts).unwrap();
 
@@ -102,10 +102,10 @@ fn embedded_size_field_matches_the_frame_region() {
         art_id: 1,
         mime: "image/jpeg".to_string(),
         description: String::new(),
-        picture_type: 3,
+        picture_type: PictureType::new(3).unwrap(),
         width: 0,
         height: 0,
-        data_len: art_bytes.len() as u64,
+        data_len: BlobLen::new(art_bytes.len() as u64).unwrap(),
     }];
     let layout = synthesize_layout(0, audio.len() as u64, &tags, &[], &arts).unwrap();
     let bytes = assemble(&layout, &audio, &[(1, &art_bytes)]);
@@ -201,19 +201,19 @@ fn multiple_art_frames_keep_order() {
             art_id: 1,
             mime: "image/jpeg".to_string(),
             description: String::new(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 0,
             height: 0,
-            data_len: art1.len() as u64,
+            data_len: BlobLen::new(art1.len() as u64).unwrap(),
         },
         ArtInput {
             art_id: 2,
             mime: "image/png".to_string(),
             description: String::new(),
-            picture_type: 4,
+            picture_type: PictureType::new(4).unwrap(),
             width: 0,
             height: 0,
-            data_len: art2.len() as u64,
+            data_len: BlobLen::new(art2.len() as u64).unwrap(),
         },
     ];
     let layout = synthesize_layout(0, audio.len() as u64, &[], &[], &arts).unwrap();
@@ -246,10 +246,10 @@ fn synthesize_errors_on_oversized_frame() {
         art_id: 1,
         mime: "image/jpeg".to_string(),
         description: String::new(),
-        picture_type: 3,
+        picture_type: PictureType::new(3).unwrap(),
         width: 0,
         height: 0,
-        data_len: 0x1000_0000, // 256 MiB, over the per-frame limit
+        data_len: BlobLen::new(0x1000_0000).unwrap(), // 256 MiB, over the per-frame limit
     }];
     assert_eq!(
         synthesize_layout(0, 0, &[], &[], &arts),
@@ -266,10 +266,10 @@ fn synthesize_errors_when_frames_sum_past_the_tag_limit() {
         art_id: id,
         mime: "image/jpeg".to_string(),
         description: String::new(),
-        picture_type: u32::try_from(id).unwrap(),
+        picture_type: PictureType::new(u32::try_from(id).unwrap()).unwrap(),
         width: 0,
         height: 0,
-        data_len: 0x0800_0000, // 128 MiB each; two sum past the 256 MiB tag limit
+        data_len: BlobLen::new(0x0800_0000).unwrap(), // 128 MiB each; two sum past the 256 MiB tag limit
     };
     let arts = vec![art(1), art(2)];
     assert_eq!(

--- a/musefs-format/tests/mp4_oracle.rs
+++ b/musefs-format/tests/mp4_oracle.rs
@@ -3,7 +3,7 @@
 //! samples read through OUR patched chunk offsets are byte-identical to the
 //! originals — proving the offset surgery.
 
-use musefs_format::{ArtInput, RegionLayout, Segment, TagInput, mp4};
+use musefs_format::{ArtInput, BlobLen, PictureType, RegionLayout, Segment, TagInput, mp4};
 use std::io::Cursor;
 
 fn materialize(layout: &RegionLayout, backing: &[u8]) -> Vec<u8> {
@@ -86,19 +86,19 @@ fn m4a_synthesis_includes_every_cover_art() {
         art_id: 1,
         mime: "image/jpeg".to_string(),
         description: "cover".to_string(),
-        picture_type: 3,
+        picture_type: PictureType::new(3).unwrap(),
         width: 0,
         height: 0,
-        data_len: 100,
+        data_len: BlobLen::new(100).unwrap(),
     };
     let art2 = ArtInput {
         art_id: 2,
         mime: "image/png".to_string(),
         description: "back".to_string(),
-        picture_type: 0,
+        picture_type: PictureType::new(0).unwrap(),
         width: 0,
         height: 0,
-        data_len: 200,
+        data_len: BlobLen::new(200).unwrap(),
     };
 
     let layout_no_art = mp4::synthesize_layout(&scan, &[], &[], &[]).unwrap();

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -111,7 +111,7 @@ proptest! {
         db.set_binary_tags(tid, &db_tags).unwrap();
         let rows = db.get_binary_tags(tid).unwrap();
         let binary_tag_inputs: Vec<BinaryTagInput> = rows.iter().map(|r| {
-            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len }
+            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: musefs_format::BlobLen::new(r.byte_len).unwrap() }
         }).collect();
 
         // Step 3: Build promoted text tags.

--- a/musefs-format/tests/proptest_mp4.rs
+++ b/musefs-format/tests/proptest_mp4.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{ArtInput, BinaryTagInput, RegionLayout, Segment, TagInput, mp4};
+use musefs_format::{
+    ArtInput, BinaryTagInput, BlobLen, PictureType, RegionLayout, Segment, TagInput, mp4,
+};
 use proptest::prelude::*;
 
 proptest! {
@@ -10,7 +12,7 @@ proptest! {
     fn mp4_synthesis_preserves_audio(
         payload in proptest::collection::vec(any::<u8>(), 1..256),
         tags in proptest::collection::vec(("[A-Z]{1,12}", "[ -~]{0,40}"), 0..8),
-        arts in proptest::collection::vec((1..3u8, 0..500u64), 0..3),
+        arts in proptest::collection::vec((1..3u8, 1..500u64), 0..3),
     ) {
         let file = fixtures::m4a(&payload);
         let scan = mp4::read_structure(&file).unwrap();
@@ -24,10 +26,10 @@ proptest! {
                 art_id: i64::try_from(i).unwrap() + 1,
                 mime: if *kind == 1 { "image/jpeg".into() } else { "image/png".into() },
                 description: String::new(),
-                picture_type: 3,
+                picture_type: PictureType::new(3).unwrap(),
                 width: 0,
                 height: 0,
-                data_len: *len,
+                data_len: BlobLen::new(*len).unwrap(),
             })
             .collect();
         if let Ok(layout) = mp4::synthesize_layout(&scan, &taginputs, &[], &arts) {
@@ -57,7 +59,7 @@ proptest! {
             inputs.push(BinaryTagInput {
                 key: format!("----:com.apple.iTunes:{name}"),
                 payload_id: id,
-                len: bytes.len() as u64,
+                len: BlobLen::new(bytes.len() as u64).unwrap(),
             });
             map.insert(id, bytes.clone());
         }

--- a/musefs-format/tests/proptest_mp4.rs
+++ b/musefs-format/tests/proptest_mp4.rs
@@ -17,8 +17,8 @@ proptest! {
         let file = fixtures::m4a(&payload);
         let scan = mp4::read_structure(&file).unwrap();
         let taginputs: Vec<TagInput> = tags.iter().map(|(k, v)| TagInput::new(k, v)).collect();
-        // (kind, len) pairs: kind 1 = jpeg, 2 = png; len 0 exercises the
-        // zero-byte filter in synthesize_layout.
+        // (kind, len) pairs: kind 1 = jpeg, 2 = png; len is always non-zero
+        // (BlobLen invariant) so zero-byte art is never tested here.
         let arts: Vec<ArtInput> = arts
             .iter()
             .enumerate()

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "fuzzing")]
 use musefs_format::fuzz_check::{assert_backing_covers_audio, fixtures};
-use musefs_format::{ArtInput, BinaryTagInput, RegionLayout, Segment, TagInput, wav};
+use musefs_format::{ArtInput, BinaryTagInput, BlobLen, RegionLayout, Segment, TagInput, wav};
 use proptest::prelude::*;
 
 proptest! {
@@ -163,7 +163,7 @@ proptest! {
         db.set_binary_tags(tid, &rows).unwrap();
         let stored = db.get_binary_tags(tid).unwrap();
         let inputs: Vec<BinaryTagInput> = stored.iter().map(|r| {
-            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: r.byte_len }
+            BinaryTagInput { key: r.key.clone(), payload_id: r.rowid, len: BlobLen::new(r.byte_len).unwrap() }
         }).collect();
         let mut map: HashMap<i64, Vec<u8>> = HashMap::new();
         for r in &stored {

--- a/musefs-format/tests/roundtrip.rs
+++ b/musefs-format/tests/roundtrip.rs
@@ -6,7 +6,7 @@ use common::{make_flac, resolve_layout, streaminfo_body, vorbis_comment_body};
 use musefs_format::flac::MetadataBlock;
 use musefs_format::flac::{locate_audio, synthesize_layout};
 use musefs_format::fuzz_check::fixtures::flac_block;
-use musefs_format::{ArtInput, BinaryTagInput, Segment, TagInput};
+use musefs_format::{ArtInput, BinaryTagInput, BlobLen, PictureType, Segment, TagInput};
 
 #[test]
 fn full_roundtrip_preserved_blocks_multivalue_tags_and_two_pictures() {
@@ -35,19 +35,19 @@ fn full_roundtrip_preserved_blocks_multivalue_tags_and_two_pictures() {
             art_id: 1,
             mime: "image/png".into(),
             description: "front".into(),
-            picture_type: 3,
+            picture_type: PictureType::new(3).unwrap(),
             width: 600,
             height: 600,
-            data_len: front.len() as u64,
+            data_len: BlobLen::new(front.len() as u64).unwrap(),
         },
         ArtInput {
             art_id: 2,
             mime: "image/png".into(),
             description: "back".into(),
-            picture_type: 4,
+            picture_type: PictureType::new(4).unwrap(),
             width: 600,
             height: 600,
-            data_len: back.len() as u64,
+            data_len: BlobLen::new(back.len() as u64).unwrap(),
         },
     ];
 
@@ -116,7 +116,7 @@ fn application_block_streams_and_metaflac_reads_it() {
     let binary = vec![BinaryTagInput {
         key: "APPLICATION".into(),
         payload_id: 100,
-        len: app_body.len() as u64,
+        len: BlobLen::new(app_body.len() as u64).unwrap(),
     }];
     let layout = synthesize_layout(
         &structural,
@@ -166,12 +166,12 @@ fn application_and_cuesheet_framing_is_valid_and_last_block_correct() {
         BinaryTagInput {
             key: "APPLICATION".into(),
             payload_id: 1,
-            len: app_body.len() as u64,
+            len: BlobLen::new(app_body.len() as u64).unwrap(),
         },
         BinaryTagInput {
             key: "CUESHEET".into(),
             payload_id: 2,
-            len: cue_body.len() as u64,
+            len: BlobLen::new(cue_body.len() as u64).unwrap(),
         },
     ];
     let layout = synthesize_layout(
@@ -212,7 +212,7 @@ fn binary_tag_over_24bit_limit_errors() {
     let binary = vec![BinaryTagInput {
         key: "APPLICATION".into(),
         payload_id: 1,
-        len: 0x0100_0000,
+        len: BlobLen::new(0x0100_0000).unwrap(),
     }];
     assert_eq!(
         synthesize_layout(&structural, 0, 0, &[], &binary, &[]),

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -4,7 +4,7 @@ use std::io::Cursor;
 
 use common::{make_flac, resolve_layout, streaminfo_body, vorbis_comment_body};
 use musefs_format::flac::{locate_audio, synthesize_layout};
-use musefs_format::{ArtInput, Segment, TagInput};
+use musefs_format::{ArtInput, BlobLen, PictureType, Segment, TagInput};
 
 fn fixture() -> (Vec<u8>, Vec<u8>) {
     let si = streaminfo_body();
@@ -19,10 +19,10 @@ fn cover(art_id: i64, data_len: u64) -> ArtInput {
         art_id,
         mime: "image/jpeg".to_string(),
         description: "front".to_string(),
-        picture_type: 3,
+        picture_type: PictureType::new(3).unwrap(),
         width: 500,
         height: 500,
-        data_len,
+        data_len: BlobLen::new(data_len).unwrap(),
     }
 }
 
@@ -107,10 +107,10 @@ fn synthesize_errors_on_oversized_picture() {
         art_id: 1,
         mime: "image/png".to_string(),
         description: String::new(),
-        picture_type: 3,
+        picture_type: PictureType::new(3).unwrap(),
         width: 0,
         height: 0,
-        data_len: 0x0100_0000, // just over the 24-bit FLAC PICTURE block limit
+        data_len: BlobLen::new(0x0100_0000).unwrap(), // just over the 24-bit FLAC PICTURE block limit
     };
     assert_eq!(
         synthesize_layout(&[], 0, 0, &[], &[], &[art]),
@@ -119,55 +119,12 @@ fn synthesize_errors_on_oversized_picture() {
 }
 
 #[test]
-fn zero_byte_art_is_skipped_so_the_track_still_serves() {
-    let (file, audio) = fixture();
-    let scan = locate_audio(&file).unwrap();
-
-    // A picture with no image data is degenerate; synthesis must skip it rather than
-    // emit an empty PICTURE block (which would fail layout validation and brick the
-    // track).
-    let art = cover(7, 0); // data_len == 0
-    let layout = synthesize_layout(
-        &scan.preserved,
-        scan.audio_offset,
-        scan.audio_length,
-        &[TagInput::new("title", "T")],
-        &[],
-        &[art],
-    )
-    .unwrap();
-
-    // No ArtImage segment was emitted.
-    assert!(
-        !layout
-            .segments
-            .iter()
-            .any(|s| matches!(s, Segment::ArtImage { .. }))
-    );
-
-    // The track still round-trips: header + verbatim audio (no art bytes needed).
-    let art_map = HashMap::new();
-    let assembled = resolve_layout(&layout, &file, &art_map, &HashMap::new());
-    assert_eq!(assembled.len() as u64, layout.total_len());
-    assert_eq!(
-        &assembled[usize::try_from(layout.header_len()).unwrap()..],
-        &audio[..]
-    );
-
-    // metaflac sees a valid FLAC with zero pictures.
-    let tag = metaflac::Tag::read_from(&mut Cursor::new(&assembled)).expect("valid FLAC metadata");
-    assert_eq!(tag.pictures().count(), 0);
-}
-
-#[test]
 fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
-    // Guards the `is_last` flag: filtering the empty art must not leave the final
-    // real PICTURE block without its last-block bit. metaflac parsing the whole
-    // chain validates that.
+    // Guards the `is_last` flag: with only valid art, the final PICTURE block
+    // carries its last-block bit. metaflac parsing the whole chain validates that.
     let (file, _audio) = fixture();
     let scan = locate_audio(&file).unwrap();
     let image = vec![0x55u8; 64];
-    let empty = cover(1, 0);
     let real = cover(2, image.len() as u64);
     let layout = synthesize_layout(
         &scan.preserved,
@@ -175,7 +132,7 @@ fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
         scan.audio_length,
         &[TagInput::new("title", "T")],
         &[],
-        &[empty, real],
+        &[real],
     )
     .unwrap();
 
@@ -191,9 +148,8 @@ fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
     let assembled = resolve_layout(&layout, &file, &art_map, &HashMap::new());
 
     // Re-parse the synthesized chain: locate_audio follows the last-block flag, so
-    // if the empty art were miscounted (leaving the final real block without its
-    // last-block bit) the walk would run past the metadata into the audio frames
-    // and fail. This pins the `data_len > 0` filter against `>= 0`.
+    // if the last block were miscounted the walk would run past the metadata into
+    // the audio frames and fail.
     let rescan = locate_audio(&assembled).expect("synthesized FLAC must parse");
     assert_eq!(rescan.audio_offset, layout.header_len());
 

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -119,7 +119,7 @@ fn synthesize_errors_on_oversized_picture() {
 }
 
 #[test]
-fn zero_byte_art_skipped_among_valid_art_keeps_block_framing_valid() {
+fn multiple_valid_art_keeps_block_framing_valid() {
     // Guards the `is_last` flag: with only valid art, the final PICTURE block
     // carries its last-block bit. metaflac parsing the whole chain validates that.
     let (file, _audio) = fixture();

--- a/musefs-format/tests/wav_synthesize.rs
+++ b/musefs-format/tests/wav_synthesize.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use id3::TagLike;
 use musefs_format::wav::{WavScan, synthesize_layout};
-use musefs_format::{ArtInput, RegionLayout, Segment, TagInput};
+use musefs_format::{ArtInput, BlobLen, PictureType, RegionLayout, Segment, TagInput};
 
 fn fmt_pcm_16bit_mono() -> Vec<u8> {
     let mut f = Vec::new();
@@ -83,10 +83,10 @@ fn embeds_full_fidelity_id3_tag_with_art() {
         art_id: 9,
         mime: "image/jpeg".to_string(),
         description: String::new(),
-        picture_type: 3,
+        picture_type: PictureType::new(3).unwrap(),
         width: 0,
         height: 0,
-        data_len: art_bytes.len() as u64,
+        data_len: BlobLen::new(art_bytes.len() as u64).unwrap(),
     }];
 
     let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
@@ -190,44 +190,6 @@ fn find_chunk(buf: &[u8], id: &[u8; 4]) -> Option<(usize, usize)> {
 }
 
 #[test]
-fn skips_zero_byte_art() {
-    // A degenerate empty embedded picture must not brick the track: synthesis
-    // succeeds, emits no ArtImage segment, and preserves the audio.
-    let audio = vec![0u8; 8];
-    let scan = WavScan {
-        fmt: fmt_pcm_16bit_mono(),
-        fact: None,
-    };
-    let tags = vec![TagInput::new("title", "Empty Art")];
-    let arts = vec![ArtInput {
-        art_id: 1,
-        mime: "image/jpeg".to_string(),
-        description: String::new(),
-        picture_type: 3,
-        width: 0,
-        height: 0,
-        data_len: 0,
-    }];
-
-    let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
-    assert!(
-        !layout
-            .segments
-            .iter()
-            .any(|s| matches!(s, Segment::ArtImage { .. })),
-        "zero-byte art must not produce an ArtImage segment"
-    );
-
-    let bytes = assemble(&layout, &audio, &[]);
-    let bounds = musefs_format::wav::locate_audio(&bytes).unwrap();
-    assert_eq!(
-        &bytes[usize::try_from(bounds.audio_offset).unwrap()
-            ..usize::try_from(bounds.audio_offset + bounds.audio_length).unwrap()],
-        &audio[..]
-    );
-}
-
-#[test]
 fn keeps_real_art_when_mixed_with_empty() {
     let audio = [0u8; 8];
     let art_bytes = [0xCDu8; 64];
@@ -236,26 +198,15 @@ fn keeps_real_art_when_mixed_with_empty() {
         fact: None,
     };
     let tags = vec![TagInput::new("title", "Mixed")];
-    let arts = vec![
-        ArtInput {
-            art_id: 1,
-            mime: "image/jpeg".to_string(),
-            description: String::new(),
-            picture_type: 3,
-            width: 0,
-            height: 0,
-            data_len: 0,
-        },
-        ArtInput {
-            art_id: 2,
-            mime: "image/jpeg".to_string(),
-            description: String::new(),
-            picture_type: 3,
-            width: 0,
-            height: 0,
-            data_len: art_bytes.len() as u64,
-        },
-    ];
+    let arts = vec![ArtInput {
+        art_id: 2,
+        mime: "image/jpeg".to_string(),
+        description: String::new(),
+        picture_type: PictureType::new(3).unwrap(),
+        width: 0,
+        height: 0,
+        data_len: BlobLen::new(art_bytes.len() as u64).unwrap(),
+    }];
 
     let layout = synthesize_layout(&scan, 0, audio.len() as u64, &tags, &[], &arts).unwrap();
     let art_segs: Vec<&Segment> = layout

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -89,6 +89,7 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         | CoreError::DbOpen { .. }
         | CoreError::Mp4MetadataTooLarge { .. }
         | CoreError::OrphanedArt { .. }
+        | CoreError::InvalidPictureType { .. }
         | CoreError::Format(_) => fuser::Errno::EIO,
     }
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -541,6 +541,15 @@ mod tests {
             .code(),
             libc::EIO
         );
+        assert_eq!(
+            errno(&CoreError::InvalidPictureType {
+                track_id: 1,
+                art_id: 2,
+                value: 99,
+            })
+            .code(),
+            libc::EIO
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the **pragmatic subset** of #200: three validated boundary newtypes that make the most failure-prone contract states unrepresentable at the crate boundaries that own them, without adding any cross-crate type or production dependency.

- **`TrackBounds`** (`musefs-db`) — wraps `audio_offset`/`audio_length` with a checked constructor enforcing `offset + length <= backing_size`, built at the `tracks` row reader (the untrusted SQL→type boundary). `Track` embeds it; the reader hot path and tests read via accessors.
- **`PictureType`** (`musefs-format`) — an ID3/FLAC picture type validated to `0..=20`. Validation moves to the FLAC parser (the only untrusted-bytes entry); an out-of-range byte clamps to `0`, matching scan's prior policy, so `scan.rs`'s redundant clamp is removed.
- **`BlobLen`** (`musefs-format`) — a non-zero payload length for art images and binary tags. The db→format bridge (`mapping.rs`) drops zero-length payloads at construction (synthesis already skipped them), so the in-synthesis zero-skip branches across flac/mp3/mp4/ogg are removed and the `EmptySegment` invariant is now encoded at the type level.

An out-of-range `picture_type` at the bridge surfaces as the new `CoreError::InvalidPictureType` (mapped to `EIO`); the #199 CHECK makes it unreachable in practice (defense-in-depth).

This is layer 2 of the three-layer bounds defense, beneath Plan A's (#199) SQLite CHECK: a row that slips past the CHECK is rejected at `get_track`.

## Layering

`musefs-db` and `musefs-format` are independent siblings (format→db is dev-only), so `TrackBounds` lives in db while `PictureType`/`BlobLen` live in format; the validated construction of format inputs from db rows happens in `musefs-core`, at the db→format bridge and the scan boundary.

## Verification

- `cargo test` — 808 passed, 29 ignored
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo +nightly fuzz build` — clean (out-of-workspace fuzz builders updated)
- `.cargo/mutants.toml` anchors re-coordinated for the scan.rs line shift and re-verified against their documented ops

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime validation of audio-region bounds with explicit out-of-range errors; track models now surface validated bounds.
  * Strongly-typed artwork inputs enforcing valid picture types and non-empty blob lengths.

* **Bug Fixes**
  * Prevented processing of invalid/out-of-range audio regions and clamped/paranoid picture-type parsing.
  * Zero-length artwork is consistently excluded earlier to avoid malformed metadata.

* **Improvements**
  * More consistent metadata synthesis/parsing, updated tests and docs to reflect new invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->