### PR TITLE
ci(dependabot): monitor all Python dependency manifests (#165)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,18 @@ updates:
     directory: "/contrib/beets"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/contrib/python-musefs"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/contrib/picard"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/tests/interop"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Dependabot only covered pip at `/contrib/beets`, leaving three Python manifests unmonitored.
- Add pip entries (weekly) so dependency updates and security notices aren't missed for:
  - `/contrib/python-musefs` (pytest)
  - `/contrib/picard` (pytest, pytest-qt)
  - `/tests/interop` (mutagen)
- `/contrib/beets` left as-is.

## Test Plan
- [x] `.github/dependabot.yml` parses as valid YAML with all four pip directories present.
- [x] Pre-commit hook passed (fmt, clippy `-D warnings`, full workspace test suite, ruff).

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management configuration to include automated weekly update checks for multiple Python directories using Dependabot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->