### PR TITLE
test(fuzz): drive ogg art coverage through arb_arts (#195)

### DIFF
--- a/fuzz/fuzz_targets/ogg.rs
+++ b/fuzz/fuzz_targets/ogg.rs
@@ -2,8 +2,8 @@
 use arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use musefs_format::ogg::OggArt;
-use musefs_format::{ArtInput, BlobLen, Extent, PictureType, fuzz_check::assert_backing_covers_audio, ogg};
-use musefs_fuzz::{MAX_INPUT, arb_tags};
+use musefs_format::{Extent, fuzz_check::assert_backing_covers_audio, ogg};
+use musefs_fuzz::{MAX_INPUT, arb_arts, arb_tags};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() > MAX_INPUT {
@@ -32,30 +32,24 @@ fuzz_target!(|data: &[u8]| {
     let mut u = Unstructured::new(data);
     let tags = arb_tags(&mut u).unwrap_or_default();
 
-    let n = u.int_in_range(0..=2u8).unwrap_or(0);
-    let mut images: Vec<Vec<u8>> = Vec::new();
-    let mut inputs: Vec<ArtInput> = Vec::new();
-    for i in 0..n {
-        let len = u.int_in_range(1..=8192usize).unwrap_or(1);
-        let bytes = u.bytes(len).map(<[u8]>::to_vec).unwrap_or_default();
-        if bytes.is_empty() {
-            continue;
-        }
-        inputs.push(ArtInput {
-            art_id: i as i64,
-            mime: "image/png".to_string(),
-            description: String::new(),
-            picture_type: PictureType::new(u.int_in_range(0..=20u32).unwrap_or(3))
-                .unwrap_or(PictureType::ZERO),
-            width: 0,
-            height: 0,
-            data_len: BlobLen::new(bytes.len() as u64).expect("non-empty"),
-        });
-        images.push(bytes);
-    }
-    let arts: Vec<OggArt> = inputs
+    // Derive art metadata from the shared helper (so OGG exercises the same
+    // randomized width/height/data_len as every other format target), then
+    // generate each image's bytes independently. OGG is the one synthesis path
+    // carrying both a `data_len` field and a separate `image` slice, so their
+    // lengths must be free to disagree. Images stay non-empty: synthesize_layout
+    // documents that the bridge drops zero-length art at construction.
+    let arts_meta = arb_arts(&mut u).unwrap_or_default();
+    let images: Vec<Vec<u8>> = arts_meta
+        .iter()
+        .map(|_| {
+            let len = u.int_in_range(1..=8192usize).unwrap_or(1);
+            u.bytes(len).map(<[u8]>::to_vec).unwrap_or_default()
+        })
+        .collect();
+    let arts: Vec<OggArt> = arts_meta
         .iter()
         .zip(images.iter())
+        .filter(|(_, image)| !image.is_empty())
         .map(|(meta, image)| OggArt {
             meta,
             image: image.as_slice(),


### PR DESCRIPTION
Closes #195.

## Problem

The `ogg` fuzz target hand-built each `ArtInput` with `width`/`height` pinned to zero and `data_len == image.len()`, so two parts of the OGG art path went unfuzzed:

- non-zero picture dimensions, and
- the `data_len`-vs-`image`-slice-length disagreement that only OGG's `OggArt` wrapper (carrying both a `data_len` field and a separate `image: &[u8]`) can express.

## Change

`fuzz/fuzz_targets/ogg.rs` now derives art metadata from the shared `arb_arts` helper (matching every other format target) and generates each image's bytes independently, letting `data_len` and the slice length diverge. Images stay non-empty to honor the `synthesize_layout` contract that the bridge drops zero-length art at construction.

## Verification

- `cargo +nightly fuzz build ogg` — clean.
- 30s `cargo +nightly fuzz run ogg` smoke run — 733k execs, no crash, 974 new coverage units (the wider input shape reaches new code).
- Pre-commit hook (fmt, clippy `-D warnings`, full workspace tests, ruff) — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OGG audio fuzzing by improving how test art images are generated. Images are now created independently with varying byte lengths, and empty images are filtered out to provide more diverse and robust test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->