### PR TITLE
feat(cli): expose per-field fallbacks via --fallback FIELD=VALUE (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ backing file is gone, and garbage-collects orphaned art.
 musefs mount /path/to/mountpoint --db library.db \
     --template '$albumartist/$album/$title' \
     --default-fallback Unknown \
+    --fallback albumartist='Unknown Artist' \
     --mode synthesis        # or: structure-only
 ```
 
@@ -75,6 +76,10 @@ any tag key in the store works):
   `$title`, `$tracknumber`, `$date`, `$genre`).
 - `${albumartist|artist}` — **fallback chain**: the first present field wins,
   before the `--default-fallback` value (default `Unknown`) is used.
+- A missing field resolves in order: the field's value, then a **per-field
+  fallback** from `--fallback FIELD=VALUE` (repeatable, e.g. `--fallback
+  albumartist='Unknown Artist'`), then `--default-fallback`. Per-field
+  fallbacks let one field default differently from the rest.
 - `[ … ]` — **conditional section**: the bracketed text is emitted only when at
   least one field inside it is present. So `$album[ - CD $disc]` yields
   `Album - CD 2`, or just `Album` on a single-disc release. Write `$[` / `$]`

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -1,7 +1,6 @@
 //! The `musefs` command-line interface: `scan` (ingest a backing directory into a
 //! SQLite store) and `mount` (serve a read-only FUSE view of that store).
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -56,6 +55,11 @@ pub struct MountArgs {
     /// Fallback value substituted for any missing template field.
     #[arg(long, default_value = "Unknown")]
     pub default_fallback: String,
+    /// Per-field fallback `FIELD=VALUE`, overriding `--default-fallback` for
+    /// just that field when it is missing. Repeatable, e.g. `--fallback
+    /// albumartist="Unknown Artist" --fallback genre=Misc`.
+    #[arg(long = "fallback", value_name = "FIELD=VALUE", value_parser = parse_fallback)]
+    pub fallbacks: Vec<(String, String)>,
     /// How file contents are served.
     #[arg(long, value_enum, default_value_t = CliMode::Synthesis)]
     pub mode: CliMode,
@@ -169,12 +173,24 @@ pub fn run_scan(
     Ok(())
 }
 
+/// Split a `--fallback FIELD=VALUE` argument. The value may contain '=' (only
+/// the first one separates); the field name must be non-empty.
+fn parse_fallback(s: &str) -> Result<(String, String), String> {
+    let (field, value) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected FIELD=VALUE, got `{s}`"))?;
+    if field.is_empty() {
+        return Err(format!("empty field name in `{s}`"));
+    }
+    Ok((field.to_string(), value.to_string()))
+}
+
 /// Parse mount CLI flags into `MountConfig` and `FuseConfig`. Pure function —
 /// no DB access, no mounting. Exported for unit testing.
 pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseConfig) {
     let config = MountConfig {
         template: args.template.clone(),
-        fallbacks: BTreeMap::new(),
+        fallbacks: args.fallbacks.iter().cloned().collect(),
         default_fallback: args.default_fallback.clone(),
         mode: args.mode.into(),
         poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -123,6 +123,7 @@ fn parse_mount_config_defaults_are_sensible() {
         db: "/tmp/x.db".into(),
         template: "$artist/$title".to_string(),
         default_fallback: "Unknown".to_string(),
+        fallbacks: vec![],
         mode: musefs_cli::CliMode::Synthesis,
         poll_interval_ms: 1000,
         attr_ttl_ms: 1000,
@@ -150,6 +151,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         db: "/tmp/x.db".into(),
         template: "$title".to_string(),
         default_fallback: "Unknown".to_string(),
+        fallbacks: vec![],
         mode: musefs_cli::CliMode::StructureOnly,
         poll_interval_ms: 250,
         attr_ttl_ms: 5000,
@@ -173,6 +175,7 @@ fn parse_mount_config_saturating_readahead() {
         db: "/tmp/x.db".into(),
         template: "$title".to_string(),
         default_fallback: "Unknown".to_string(),
+        fallbacks: vec![],
         mode: musefs_cli::CliMode::Synthesis,
         poll_interval_ms: 1000,
         attr_ttl_ms: 1000,
@@ -183,4 +186,110 @@ fn parse_mount_config_saturating_readahead() {
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
+}
+
+#[test]
+fn parses_repeatable_fallback_flag() {
+    let cli = Cli::parse_from([
+        "musefs",
+        "mount",
+        "/mnt/x",
+        "--db",
+        "/tmp/m.db",
+        "--fallback",
+        "albumartist=Unknown Artist",
+        "--fallback",
+        "genre=Misc",
+    ]);
+    match cli.command {
+        Command::Mount(args) => assert_eq!(
+            args.fallbacks,
+            vec![
+                ("albumartist".to_string(), "Unknown Artist".to_string()),
+                ("genre".to_string(), "Misc".to_string()),
+            ]
+        ),
+        Command::Scan { .. } => panic!("expected mount"),
+    }
+}
+
+#[test]
+fn parse_mount_config_populates_per_field_fallbacks() {
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$albumartist/$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        fallbacks: vec![
+            ("albumartist".to_string(), "Unknown Artist".to_string()),
+            ("genre".to_string(), "Misc".to_string()),
+        ],
+        mode: musefs_cli::CliMode::Synthesis,
+        poll_interval_ms: 1000,
+        attr_ttl_ms: 1000,
+        max_readahead_kib: 512,
+        max_background: 64,
+        keep_cache: false,
+        case_insensitive: false,
+    };
+    let (config, _) = parse_mount_config(&args);
+    assert_eq!(
+        config.fallbacks.get("albumartist").map(String::as_str),
+        Some("Unknown Artist")
+    );
+    assert_eq!(
+        config.fallbacks.get("genre").map(String::as_str),
+        Some("Misc")
+    );
+}
+
+#[test]
+fn fallback_value_may_contain_equals_and_last_duplicate_wins() {
+    let cli = Cli::parse_from([
+        "musefs",
+        "mount",
+        "/mnt/x",
+        "--db",
+        "/tmp/m.db",
+        "--fallback",
+        "comment=a=b",
+        "--fallback",
+        "artist=first",
+        "--fallback",
+        "artist=second",
+    ]);
+    let args = match cli.command {
+        Command::Mount(args) => args,
+        Command::Scan { .. } => panic!("expected mount"),
+    };
+    // Only the first '=' separates; the value keeps the rest verbatim.
+    assert_eq!(
+        args.fallbacks[0],
+        ("comment".to_string(), "a=b".to_string())
+    );
+    let (config, _) = parse_mount_config(&args);
+    // Duplicate field: the last value wins in the resulting map.
+    assert_eq!(
+        config.fallbacks.get("artist").map(String::as_str),
+        Some("second")
+    );
+    assert_eq!(
+        config.fallbacks.get("comment").map(String::as_str),
+        Some("a=b")
+    );
+}
+
+#[test]
+fn fallback_without_equals_is_rejected() {
+    let err = Cli::try_parse_from([
+        "musefs",
+        "mount",
+        "/mnt/x",
+        "--db",
+        "/tmp/m.db",
+        "--fallback",
+        "noequals",
+    ])
+    .unwrap_err();
+    assert!(err.to_string().contains("FIELD=VALUE"), "{err}");
 }


### PR DESCRIPTION
## Summary

`MountConfig.fallbacks` and the template engine's per-field fallback resolution (`musefs-core/src/template.rs`) were unreachable from the binary: the CLI hardcoded `fallbacks: BTreeMap::new()`. A user who wanted, e.g., a per-field `albumartist -> "Unknown Artist"` fallback distinct from the global `--default-fallback` could not express it without editing code.

This adds a repeatable `--fallback FIELD=VALUE` flag that populates the map:

```bash
musefs mount /mnt --db library.db \
  --template '$albumartist/$album/$title' \
  --fallback albumartist='Unknown Artist' \
  --fallback genre=Misc
```

Resolution order for a missing field is now: field value → per-field `--fallback` → `--default-fallback`.

## Details

- `parse_fallback` splits on the **first** `=` only (values may contain `=`); an empty field name or a missing `=` is rejected at parse time with a clear message. Duplicate fields take the last value (`BTreeMap` collect).
- No core changes — the template engine already implemented and tested per-field resolution; this only adds the missing CLI wiring.
- README documents the flag and the resolution order.

## Tests

- `parses_repeatable_fallback_flag` — clap parsing of repeated `--fallback`.
- `parse_mount_config_populates_per_field_fallbacks` — `Vec` → `BTreeMap` wiring.
- `fallback_value_may_contain_equals_and_last_duplicate_wins` — first-`=` split + last-duplicate-wins.
- `fallback_without_equals_is_rejected` — parse-time error path.

Full workspace suite + clippy `-D warnings` + fmt green (pre-commit hook).

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--fallback FIELD=VALUE` support for per-field fallback values, enabling customized defaults for different fields.

* **Documentation**
  * Expanded documentation clarifying fallback resolution: field value → per-field fallback → default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->