### PR TITLE
build(hooks): shellcheck/yamllint legs + docs-only cargo skip

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# musefs pre-commit hook: formatting + curated clippy gate.
+# musefs pre-commit hook: formatting + curated clippy gate + shell/YAML lint.
 #
 # Canonical (version-controlled) copy. `.git/hooks/pre-commit` symlinks here so
 # the hook is active locally. To enable in a fresh clone, run one of:
@@ -8,24 +8,40 @@
 #
 # The clippy lint policy (pedantic, minus intentional/noisy groups) lives in the
 # root Cargo.toml under [workspace.lints]; this hook just denies any warning.
+# The shellcheck/yamllint legs need `shellcheck` and `yamllint` on PATH; both
+# skip with a notice if their tool is absent.
 set -euo pipefail
 
-echo "pre-commit: cargo fmt --check"
-if ! cargo fmt --all -- --check; then
-    echo "✗ formatting: run 'cargo fmt' and re-stage." >&2
-    exit 1
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+
+# The cargo gate (fmt/clippy/test) can't be affected by a commit that only
+# touches docs/ or Markdown, so skip it there. Any other staged path — source,
+# Cargo.toml, fixtures, CI, scripts — runs the full gate.
+docs_only=false
+if [ -n "$STAGED" ] && ! echo "$STAGED" | grep -qvE '^(docs/.*|.*\.md)$'; then
+    docs_only=true
 fi
 
-echo "pre-commit: cargo clippy --all-targets -- -D warnings"
-if ! cargo clippy --all-targets --quiet -- -D warnings; then
-    echo "✗ clippy: fix the warnings above and re-stage." >&2
-    exit 1
-fi
+if $docs_only; then
+    echo "pre-commit: docs-only commit — skipping cargo fmt/clippy/test"
+else
+    echo "pre-commit: cargo fmt --check"
+    if ! cargo fmt --all -- --check; then
+        echo "✗ formatting: run 'cargo fmt' and re-stage." >&2
+        exit 1
+    fi
 
-echo "pre-commit: cargo test --workspace"
-if ! cargo test --workspace --quiet; then
-    echo "✗ tests: fix the failures above and re-stage." >&2
-    exit 1
+    echo "pre-commit: cargo clippy --all-targets -- -D warnings"
+    if ! cargo clippy --all-targets --quiet -- -D warnings; then
+        echo "✗ clippy: fix the warnings above and re-stage." >&2
+        exit 1
+    fi
+
+    echo "pre-commit: cargo test --workspace"
+    if ! cargo test --workspace --quiet; then
+        echo "✗ tests: fix the failures above and re-stage." >&2
+        exit 1
+    fi
 fi
 
 # Mutant-exclusion anchor drift guard. The .cargo/mutants.toml exclude_re entries
@@ -34,7 +50,6 @@ fi
 # mutants.yml) whenever the config, the guard script, or a mutation-scoped source
 # file (musefs-core / musefs-format) is staged. Skipped — not enforced — when
 # cargo-mutants is absent, since CI re-checks it on every PR regardless.
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 if echo "$STAGED" | grep -qE '^(\.cargo/mutants\.toml|scripts/check_mutant_anchors\.py|musefs-(core|format)/src/.*\.rs)$'; then
     if command -v cargo-mutants >/dev/null 2>&1; then
         echo "pre-commit: mutant-anchor drift guard"
@@ -50,6 +65,35 @@ if echo "$STAGED" | grep -qE '^(\.cargo/mutants\.toml|scripts/check_mutant_ancho
         fi
     else
         echo "pre-commit: cargo-mutants not installed — skipping anchor guard (CI enforces it)." >&2
+    fi
+fi
+
+# Shell lint: when any shell script is staged, run shellcheck over every tracked
+# script (plus this hook), so a change can't pass yet break a sibling script.
+if echo "$STAGED" | grep -qE '(\.sh$|^\.githooks/pre-commit$)'; then
+    if command -v shellcheck >/dev/null 2>&1; then
+        echo "pre-commit: shellcheck"
+        mapfile -t SH_FILES < <(git ls-files '*.sh' .githooks/pre-commit)
+        if ! shellcheck "${SH_FILES[@]}"; then
+            echo "✗ shellcheck: fix the findings above and re-stage." >&2
+            exit 1
+        fi
+    else
+        echo "pre-commit: shellcheck not installed — skipping." >&2
+    fi
+fi
+
+# yamllint: same all-tracked policy for YAML, using the relaxed .yamllint config.
+if echo "$STAGED" | grep -qE '\.ya?ml$'; then
+    if command -v yamllint >/dev/null 2>&1; then
+        echo "pre-commit: yamllint"
+        mapfile -t YML_FILES < <(git ls-files '*.yml' '*.yaml')
+        if ! yamllint -c .yamllint "${YML_FILES[@]}"; then
+            echo "✗ yamllint: fix the findings above and re-stage." >&2
+            exit 1
+        fi
+    else
+        echo "pre-commit: yamllint not installed — skipping." >&2
     fi
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,7 +12,10 @@
 # skip with a notice if their tool is absent.
 set -euo pipefail
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+# Include deletions (D) and disable rename collapsing so a removed/renamed-away
+# source path stays visible to the docs-only check below — otherwise deleting a
+# code file alongside a doc edit could be misread as a docs-only commit.
+STAGED=$(git diff --cached --name-only --no-renames --diff-filter=ACMRD)
 
 # The cargo gate (fmt/clippy/test) can't be affected by a commit that only
 # touches docs/ or Markdown, so skip it there. Any other staged path — source,

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,19 @@
+---
+# Relaxed yamllint policy used by the pre-commit hook. GitHub Actions workflows
+# drive the relaxations: long lines, the `on:` trigger key, `${{ }}`/flow-map
+# spacing, and `# vX.Y` action-pin comments are all idiomatic there. Genuine
+# errors (syntax, duplicate keys, inconsistent indentation, trailing whitespace,
+# truthy *values*) still gate.
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+  truthy:
+    check-keys: false
+  braces:
+    max-spaces-inside: 1
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    indent-sequences: consistent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,11 @@ Consult these before exploring by hand; they are kept current.
 ## Repo-operational facts
 
 - The pre-commit hook runs fmt, clippy (`-D warnings`), the **full workspace
-  test suite**, and ruff over the Python paths — a commit with red tests is
-  always rejected, so TDD plans need each commit green.
+  test suite**, `shellcheck`/`yamllint` over tracked shell/YAML files, and ruff
+  over the Python paths — a commit with red tests is always rejected, so TDD
+  plans need each commit green. The cargo gate is skipped for docs-only commits
+  (every staged path under `docs/` or a `*.md` file); the shell/YAML legs skip
+  when their tool is absent.
 - The `fuzz/` crate is outside the workspace: format-layer API changes can
   break it silently — `cargo +nightly fuzz build` to check
   ([CONTRIBUTING.md](CONTRIBUTING.md#coverage-guided-fuzzing)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ the FUSE end-to-end tests you need a FUSE-capable OS: Linux with `/dev/fuse` and
 libfuse (`libfuse3-dev` / `libfuse3` plus `pkg-config`), or FreeBSD with
 `/dev/fuse` and the `fusefs` kernel module (no libfuse — see [FreeBSD
 e2e](#freebsd-e2e) for the in-tree VM harness). The Python plugin suites
-additionally want Python 3 with `ruff` and `pytest`.
+additionally want Python 3 with `ruff` and `pytest`. The pre-commit hook's
+shell and YAML lint legs use `shellcheck` and `yamllint` — both optional, each
+skips with a notice if not installed.
 
 Enable the repo's pre-commit hook once per clone:
 
@@ -21,16 +23,23 @@ git config core.hooksPath .githooks
 
 The hook (`.githooks/pre-commit`) runs, in order: `cargo fmt --all --check`,
 `cargo clippy --all-targets -- -D warnings`, **the full workspace test
-suite** (`cargo test --workspace`), and `ruff check` + `ruff format --check`
-over `contrib/beets/`, `contrib/picard/`, `contrib/lidarr/`,
-`contrib/python-musefs/`, and `tests/interop/`. Two consequences worth
-internalizing:
+suite** (`cargo test --workspace`), `shellcheck` over every tracked shell
+script, `yamllint` (relaxed [`.yamllint`](.yamllint)) over every tracked YAML
+file, and `ruff check` + `ruff format --check` over `contrib/beets/`,
+`contrib/picard/`, `contrib/lidarr/`, `contrib/python-musefs/`, and
+`tests/interop/`. A few consequences worth internalizing:
 
 - A commit with red tests is always rejected — there is no
   "commit-now-fix-later" workflow here.
 - Python-only changes hit the hook too: the ruff gate lints exactly the
   union of paths the CI jobs lint, so a commit can't pass the hook yet fail
   CI lint.
+- The cargo gate (fmt/clippy/test) is skipped when every staged path is under
+  `docs/` or is a Markdown file, so a docs-only commit stays fast.
+- The `shellcheck`/`yamllint` legs fire only when a shell or YAML file is
+  staged, and skip with a notice when the tool is absent; when they do run they
+  lint *all* tracked files of that type, so a sibling file can't drift
+  unnoticed.
 
 ## Build & test
 

--- a/benches/passthrough_dd.sh
+++ b/benches/passthrough_dd.sh
@@ -12,16 +12,22 @@ WAV="$WORK/backing/track.wav"
 if [ ! -f "$WAV" ]; then
   # Minimal 44-byte PCM WAV header for SIZE_MIB of 16-bit stereo 44.1k data, then zero-fill.
   DATA=$(( SIZE_MIB * 1024 * 1024 )); RIFF=$(( DATA + 36 ))
-  printf 'RIFF' > "$WAV"
-  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((RIFF&255)) $((RIFF>>8&255)) $((RIFF>>16&255)) $((RIFF>>24&255)))" >> "$WAV"
-  printf 'WAVEfmt ' >> "$WAV"
-  printf '\x10\x00\x00\x00\x01\x00\x02\x00\x44\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00' >> "$WAV"
-  printf 'data' >> "$WAV"
-  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((DATA&255)) $((DATA>>8&255)) $((DATA>>16&255)) $((DATA>>24&255)))" >> "$WAV"
-  dd if=/dev/zero bs=1M count="$SIZE_MIB" >> "$WAV" 2>/dev/null
+  # RIFF/data sizes are little-endian bytes produced by interpreting printf hex
+  # escapes; group the writes into a single redirect.
+  # shellcheck disable=SC2059  # the format string is generated hex escapes, by design
+  {
+    printf 'RIFF'
+    printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((RIFF&255)) $((RIFF>>8&255)) $((RIFF>>16&255)) $((RIFF>>24&255)))"
+    printf 'WAVEfmt '
+    printf '\x10\x00\x00\x00\x01\x00\x02\x00\x44\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00'
+    printf 'data'
+    printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((DATA&255)) $((DATA>>8&255)) $((DATA>>16&255)) $((DATA>>24&255)))"
+    dd if=/dev/zero bs=1M count="$SIZE_MIB" 2>/dev/null
+  } >> "$WAV"
 fi
 DB="$WORK/m.db"; rm -f "$DB"
 "$BIN" scan "$WORK/backing" --db "$DB" >/dev/null
+# shellcheck disable=SC2016  # '$title' is a musefs output-template literal, not a shell variable
 "$BIN" mount "$WORK/mnt" --db "$DB" --mode structure-only --template '$title' &
 MPID=$!
 # Poll for mount readiness instead of a fixed sleep (the CLI gives no ready signal).
@@ -33,6 +39,6 @@ for _ in $(seq 1 60); do
 done
 if [ -z "$VIRT" ]; then echo "ERROR: mount never exposed a file" >&2; kill "$MPID" 2>/dev/null || true; exit 1; fi
 cat "$VIRT" > /dev/null   # warm backing into page cache
-for i in 1 2 3; do dd if="$VIRT" of=/dev/null bs=1M 2>&1 | tail -1; done
+for _ in 1 2 3; do dd if="$VIRT" of=/dev/null bs=1M 2>&1 | tail -1; done
 fusermount3 -u "$WORK/mnt" 2>/dev/null || umount "$WORK/mnt" 2>/dev/null || true
 kill "$MPID" 2>/dev/null || true

--- a/scripts/freebsd-vm/run-local.sh
+++ b/scripts/freebsd-vm/run-local.sh
@@ -45,6 +45,7 @@ HTTP_PIDFILE="$WORK/http.pid"
 
 log() { printf '\n=== %s ===\n' "$*"; }
 
+# shellcheck disable=SC2329  # invoked via 'trap cleanup EXIT INT TERM' below
 cleanup() {
     for pf in "$PIDFILE" "$HTTP_PIDFILE"; do
         if [ -f "$pf" ]; then

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -31,7 +31,7 @@
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 # Scratch parent. cargo-mutants copies the source tree into a build dir under
 # TMPDIR, so the scratch parent MUST live OUTSIDE this repo — a dir inside the
@@ -49,6 +49,7 @@ case "$SCRATCH_PARENT" in
 esac
 mkdir -p "$SCRATCH_PARENT"
 CREATED_TMPS=()
+# shellcheck disable=SC2329  # invoked via 'trap cleanup EXIT' below
 cleanup() {
   # Remove only the unique per-crate scratch children we created (never the
   # possibly-shared parent), even on abnormal exit.


### PR DESCRIPTION
## What

Three changes to the `.githooks/pre-commit` hook:

1. **shellcheck leg** — when any shell script is staged, lint every tracked
   script (plus the hook itself). Skips with a notice if `shellcheck` isn't
   installed.
2. **yamllint leg** — when any YAML is staged, lint every tracked YAML against a
   new relaxed [`.yamllint`](.yamllint). Skips with a notice if `yamllint` isn't
   installed.
3. **docs-only cargo skip** — the `cargo fmt`/`clippy`/`test` gate is skipped
   when every staged path is under `docs/` or is a Markdown file, so a docs-only
   commit stays fast.

Both lint legs use the same all-tracked policy as the existing cargo/ruff gates,
so a sibling file can't drift unnoticed.

## Relaxed `.yamllint`

Disables `line-length`/`document-start`, allows GitHub Actions `${{ }}`/flow-map
spacing, `# vX.Y` action-pin comments, and the `on:` trigger key. Genuine errors
(syntax, duplicate keys, inconsistent indentation, trailing whitespace, truthy
*values*) still gate.

## Pre-existing shellcheck fixes

All-tracked scoping surfaced existing findings; fixed so the hook is green on day
one:

- `benches/passthrough_dd.sh` — grouped the WAV-header redirects (SC2129),
  documented the intentional hex-printf (SC2059) and `$title` template literal
  (SC2016), `for i` → `for _` (SC2034).
- `scripts/mutants.sh` — `cd "$ROOT" || exit 1` (SC2164), documented the
  trap-invoked `cleanup` (SC2329).
- `scripts/freebsd-vm/run-local.sh` — documented the trap-invoked `cleanup`
  (SC2329).

## Docs

`CONTRIBUTING.md` and `CLAUDE.md` updated to describe the new legs, the docs-only
skip, and the optional `shellcheck`/`yamllint` tooling.

## Note

These legs are **local-hook-only** — deliberately not mirrored in CI, so they're
a convenience gate rather than an enforced check.

## Verification

Full hook run green end-to-end (cargo + shellcheck + yamllint + ruff, exit 0);
docs-only path confirmed to skip cargo and run ruff; trigger/detection logic
checked across docs/rust/shell/yaml staged-file combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-commit hook now conditionally skips cargo checks for docs-/Markdown-only commits.
  * Hook runs shell and YAML linters when related files are staged, linting all tracked files of that type and skipping with a notice if tools are absent.

* **Chores**
  * Added/updated YAML lint config.
  * Updated CONTRIBUTING and repo docs to clarify hook behavior and optional tooling.

* **Bug Fixes / Style**
  * Improved shell script robustness (safer exits and trap handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->