### PR TITLE
Mount owner & permission flags; album-oriented default template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "musefs-fuse",
  "signal-hook",
  "tempfile",
+ "uzers",
 ]
 
 [[package]]
@@ -1789,6 +1790,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uzers"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8275fb1afee25b4111d2dc8b5c505dbbc4afd0b990cb96deb2d88bff8be18d"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "vcpkg"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ All tuning flags have sensible defaults; adjust them to your backing store:
 | `--keep-cache` | disabled | Keep the kernel page cache across opens. External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
 | `--case-insensitive <true\|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files get a numeric suffix (e.g. `Song (2)`). Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
 
+### Ownership and permissions
+
+By default the mount presents the launching process's uid/gid and read-only
+permission bits (`555` dirs, `444` files). Override them to present a specific
+owner — e.g. a media-server service account — without running musefs as that
+user.
+
+| Flag | Default | What it does |
+| ---- | ------- | ------------ |
+| `--owner <NAME\|UID>` | process uid | User presented as the owner of every entry. Accepts a username or a numeric uid. |
+| `--group <NAME\|GID>` | process gid | Group presented for every entry. Accepts a group name or a numeric gid. |
+| `--file-mode <OCTAL>` | `444` | Permission bits for regular files, in octal. The mount is read-only, so write bits are advertised but writes still fail with `EROFS`. |
+| `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |
+
 ## Supported formats
 
 | Format | Extensions | What synthesis does | Details |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Anything else is literal. Name collisions get a deterministic `(2)`, `(3)`, …
 suffix. Every rendered component is capped at 255 bytes (NAME_MAX, truncated on
 a UTF-8 boundary, extension preserved), and a plain field whose value is
 exactly `.` or `..` is dropped rather than creating an unusable directory. The
-default template is `$artist/$title`.
+default template is `$albumartist/$album/$title`.
 
 Two modes:
 

--- a/docs/superpowers/plans/2026-06-10-mount-owner-perms-flags.md
+++ b/docs/superpowers/plans/2026-06-10-mount-owner-perms-flags.md
@@ -318,6 +318,8 @@ Expected: the dependency downloads and the crate builds (no source changes yet).
 
 Add these tests inside the existing `#[cfg(test)] mod tests` block in `musefs-cli/src/lib.rs` (e.g. after `mount_args_parse_into_configs`, around line 360). They reference `parse_octal_mode`, `write_bit_warning`, and the new `--owner`/`--file-mode` flags that don't exist yet.
 
+(Note: the spec suggested *extending* the existing `mount_args_parse_into_configs` test for the flag-flow and default-equivalence assertions. This plan instead adds two focused tests — `owner_and_modes_flow_into_fuse_config` and `owner_flags_default_to_process_identity` — and leaves `mount_args_parse_into_configs` untouched. Coverage is equivalent; the split keeps each test single-purpose.)
+
 ```rust
     #[test]
     fn octal_mode_parses_as_octal_not_decimal() {
@@ -380,6 +382,13 @@ Add these tests inside the existing `#[cfg(test)] mod tests` block in `musefs-cl
         assert_eq!(parse_owner("1234").unwrap(), 1234);
         assert!(parse_owner("").is_err());
         assert!(parse_owner("definitely-no-such-user-xyzzy").is_err());
+    }
+
+    #[test]
+    fn group_accepts_numeric_and_rejects_unknown_name() {
+        assert_eq!(parse_group("1234").unwrap(), 1234);
+        assert!(parse_group("").is_err());
+        assert!(parse_group("definitely-no-such-group-xyzzy").is_err());
     }
 ```
 
@@ -502,25 +511,29 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 **Files:**
 - Modify: `README.md` (CLI flags / mount options section)
 
-- [ ] **Step 1: Find the mount-flags section in the README**
+- [ ] **Step 1: Locate the mount flag documentation in the README**
 
-Run: `grep -n -- '--keep-cache\|--attr-ttl-ms\|--case-insensitive\|## .*[Mm]ount' README.md`
-Expected: the line numbers of the existing `mount` flag documentation (the four new flags go alongside these).
+Run: `grep -n -- '### Tuning\|### Supported formats\|case-insensitive' README.md`
+Expected: `### Tuning` at ~110 (a Markdown table of mount flags at ~114-121) and `## Supported formats` at ~123. The four new flags are ownership/permission concerns, not kernel tuning, so they get their **own subsection inserted between the `### Tuning` table and `## Supported formats`** — not appended to the Tuning table.
 
-- [ ] **Step 2: Add the four flags to the README**
+- [ ] **Step 2: Add an "Ownership and permissions" subsection**
 
-In the `mount` flags list (next to `--case-insensitive` / `--keep-cache`), add entries matching the surrounding style. Use the wording:
+Insert this new subsection immediately after the `### Tuning` table (after the `--case-insensitive` row, ~line 121) and before `## Supported formats`. It mirrors the Tuning table's `| Flag | Default | What it does |` format; note the `\|` escapes inside the `NAME\|UID` cells so the table stays well-formed:
 
 ```markdown
-- `--owner <NAME|UID>` — user presented as the owner of every entry. Accepts a
-  username or a numeric uid. Default: the launching process's uid.
-- `--group <NAME|GID>` — group presented for every entry. Accepts a group name
-  or numeric gid. Default: the launching process's gid.
-- `--file-mode <OCTAL>` — permission bits for regular files, in octal (e.g.
-  `444`). Default: `444`. The mount is read-only, so write bits are advertised
-  but writes still fail with `EROFS`.
-- `--dir-mode <OCTAL>` — permission bits for directories, in octal (e.g.
-  `555`). Default: `555`.
+### Ownership and permissions
+
+By default the mount presents the launching process's uid/gid and read-only
+permission bits (`555` dirs, `444` files). Override them to present a specific
+owner — e.g. a media-server service account — without running musefs as that
+user.
+
+| Flag | Default | What it does |
+| ---- | ------- | ------------ |
+| `--owner <NAME\|UID>` | process uid | User presented as the owner of every entry. Accepts a username or a numeric uid. |
+| `--group <NAME\|GID>` | process gid | Group presented for every entry. Accepts a group name or a numeric gid. |
+| `--file-mode <OCTAL>` | `444` | Permission bits for regular files, in octal. The mount is read-only, so write bits are advertised but writes still fail with `EROFS`. |
+| `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |
 ```
 
 - [ ] **Step 3: Verify the docs build/render and the binary help matches**
@@ -531,7 +544,7 @@ Expected: the four flags appear in the generated help with the documented value 
 - [ ] **Step 4: Confirm FreeBSD portability of `uzers` (verification, see spec Portability)**
 
 Run: `cargo build --target x86_64-unknown-freebsd -p musefs-cli 2>&1 | tail -15`
-Expected: builds. (`uzers` does not advertise a FreeBSD target on docs.rs but, as a `users` fork, builds via libc.) If it does **not** build, do not work around it here — stop and apply the spec's contingency: drop `uzers` and resolve names with `getpwnam_r`/`getgrnam_r` via `libc` behind a safe wrapper in `musefs-cli`, then re-run Tasks 2-3. If the FreeBSD target is not installed locally, note that the FreeBSD CI job is the gate and proceed.
+Expected: builds. (`uzers` does not advertise a FreeBSD target on docs.rs but, as a `users` fork, builds via libc.) If it does **not** build, do not work around it here — stop and apply the spec's contingency: drop `uzers` and resolve names with `getpwnam_r`/`getgrnam_r` via `libc` behind a safe wrapper in `musefs-cli` (this adds `libc` as a new `musefs-cli` dependency — it is currently only a `musefs-fuse` dep), then re-run Tasks 2-3. If the FreeBSD target is not installed locally, note that the FreeBSD CI job is the gate and proceed.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-06-10-mount-owner-perms-flags.md
+++ b/docs/superpowers/plans/2026-06-10-mount-owner-perms-flags.md
@@ -1,0 +1,557 @@
+# Mount owner & permission flags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--owner`, `--group`, `--file-mode`, `--dir-mode` flags to `musefs mount` so the mount can present a chosen owner and permission bits instead of the hardcoded process identity and `0o555`/`0o444`.
+
+**Architecture:** `FuseConfig` (musefs-fuse) gains four fields carrying the presented attribute identity; `FuseConfig::default()` resolves the process uid/gid and the current default modes, so existing `mount`/`spawn` helpers and tests are unchanged. Name→id resolution and octal parsing live entirely in the CLI layer via clap value_parsers, so musefs-fuse only ever receives numeric ids and stays free of user-database lookups.
+
+**Tech Stack:** Rust, clap (derive + value_parser), the `uzers` crate (Unix passwd/group lookup), `rustix::process` (getuid/getgid), `fuser`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-mount-owner-perms-flags-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs-fuse/src/lib.rs` | `FuseConfig` struct + `Default`; `MusefsFs::new`; `lookup`/`getattr` closures | add fields, resolve defaults, read identity from config, thread modes |
+| `musefs-fuse/src/convert.rs` | `to_file_attr` attribute rendering | take file/dir mode params instead of hardcoded constants |
+| `musefs-fuse/src/platform/spotlight.rs` | macOS Spotlight marker attrs | `marker_attr` gains a `file_mode` param |
+| `musefs-cli/src/lib.rs` | `MountArgs`, value_parsers, `parse_mount_config`, `run_mount` | new flags, parsers, wiring, write-bit warning |
+| `musefs-cli/Cargo.toml` | CLI dependencies | add `uzers` |
+| `README.md` | CLI flag docs | document the four flags |
+
+Task 1 makes the structural musefs-fuse change (behavior identical — defaults reproduce today's output). Task 2 adds the CLI flags that override those defaults. Task 3 documents them. Each task is a single green commit (the pre-commit hook runs the full workspace test suite, so every commit must compile and pass).
+
+---
+
+## Task 1: FuseConfig carries attribute identity (musefs-fuse)
+
+After this task, behavior is byte-for-byte identical to today, but `FuseConfig` holds uid/gid/file_mode/dir_mode and `to_file_attr`/`marker_attr` take the modes as parameters. No CLI flags yet.
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` (`FuseConfig` ~37-67, `MusefsFs::new` ~162-183, `lookup`/`getattr` closures ~266-285, test ~556-562)
+- Modify: `musefs-fuse/src/convert.rs` (`to_file_attr` 15-54, test 110-144)
+- Modify: `musefs-fuse/src/platform/spotlight.rs` (`marker_attr` 25-43, test 86-98)
+- Modify: `musefs-cli/src/lib.rs` (`parse_mount_config` struct literal 199-204) — needed so the workspace still compiles after the field addition
+
+- [ ] **Step 1: Extend the failing tests for the new defaults and mode params**
+
+In `musefs-fuse/src/lib.rs`, extend `fuse_config_default_is_conservative` (currently lines 556-562) to assert the four new fields:
+
+```rust
+    #[test]
+    fn fuse_config_default_is_conservative() {
+        let c = FuseConfig::default();
+        assert_eq!(c.ttl, Duration::from_secs(1));
+        assert_eq!(c.max_readahead, 512 * 1024);
+        assert_eq!(c.max_background, 64);
+        assert!(!c.keep_cache);
+        assert_eq!(c.file_mode, 0o444);
+        assert_eq!(c.dir_mode, 0o555);
+        assert_eq!(c.uid, rustix::process::getuid().as_raw());
+        assert_eq!(c.gid, rustix::process::getgid().as_raw());
+    }
+```
+
+In `musefs-fuse/src/convert.rs`, update the existing `converts_dir_and_file_attrs` test calls to pass modes, and add a new swap test that kills the dir/file-mode swap mutant. Replace the test body's two `to_file_attr` calls (lines 120 and 135) so they read:
+
+```rust
+        let fa = to_file_attr(&dir, 501, 20, 0o444, 0o555, fallback);
+```
+```rust
+        let fa = to_file_attr(&file, 501, 20, 0o444, 0o555, fallback);
+```
+
+Then add this new test immediately after `converts_dir_and_file_attrs` (after line 144):
+
+```rust
+    #[test]
+    fn to_file_attr_applies_distinct_dir_and_file_modes() {
+        let fallback = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+        let dir = Attr { inode: 1, is_dir: true, size: 0, mtime_secs: 0 };
+        let file = Attr { inode: 2, is_dir: false, size: 0, mtime_secs: 0 };
+        // Deliberately asymmetric so a dir/file swap is observable.
+        let d = to_file_attr(&dir, 0, 0, 0o400, 0o700, fallback);
+        let f = to_file_attr(&file, 0, 0, 0o400, 0o700, fallback);
+        assert_eq!(d.perm, 0o700, "dir must get dir_mode");
+        assert_eq!(f.perm, 0o400, "file must get file_mode");
+    }
+```
+
+In `musefs-fuse/src/platform/spotlight.rs`, update `marker_attr_is_zero_byte_read_only_file` (lines 86-98) to pass and assert a `file_mode`:
+
+```rust
+    #[test]
+    fn marker_attr_is_zero_byte_read_only_file() {
+        let mt = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+        let a = marker_attr(501, 20, 0o444, mt);
+        assert_eq!(a.ino, INodeNo(u64::MAX));
+        assert_eq!(a.kind, FileType::RegularFile);
+        assert_eq!(a.perm, 0o444);
+        assert_eq!(a.size, 0);
+        assert_eq!(a.nlink, 1);
+        assert_eq!(a.uid, 501);
+        assert_eq!(a.gid, 20);
+        assert_eq!(a.mtime, mt);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run: `cargo test -p musefs-fuse 2>&1 | head -30`
+Expected: compile error — `FuseConfig` has no field `file_mode`, and `to_file_attr`/`marker_attr` take the wrong number of arguments.
+
+- [ ] **Step 3: Add the fields and thread the modes**
+
+In `musefs-fuse/src/lib.rs`, add four fields to the `FuseConfig` struct (after `keep_cache`, before the closing brace at line 56):
+
+```rust
+    /// uid presented for every entry (the marker, synthetic dirs, real files).
+    pub uid: u32,
+    /// gid presented for every entry.
+    pub gid: u32,
+    /// Permission bits for regular files (bare mode word, no type bits).
+    pub file_mode: u16,
+    /// Permission bits for directories (bare mode word, no type bits).
+    pub dir_mode: u16,
+```
+
+Update the `FuseConfig` doc comment (lines 38-39) to note it now also carries attribute identity:
+
+```rust
+/// Fuse-layer mount knobs: kernel tuning, page-cache policy, and the ownership
+/// (`uid`/`gid`) and permission bits (`file_mode`/`dir_mode`) presented for
+/// every entry. Distinct from `musefs_core::MountConfig`, which governs how the
+/// virtual tree is rendered.
+```
+
+Update `FuseConfig::default()` (lines 58-67) to resolve the process identity and the current default modes:
+
+```rust
+impl Default for FuseConfig {
+    fn default() -> FuseConfig {
+        FuseConfig {
+            ttl: Duration::from_secs(1),
+            max_readahead: 512 * 1024,
+            max_background: 64,
+            keep_cache: false,
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
+            file_mode: 0o444,
+            dir_mode: 0o555,
+        }
+    }
+}
+```
+
+In `MusefsFs::new`, replace the `getuid`/`getgid` calls (lines 173-174) with reads from `config` (a u32 is `Copy`, so reading `config.uid` before `config` is moved at line 176 is fine):
+
+```rust
+            uid: config.uid,
+            gid: config.gid,
+```
+
+Update the `lookup` closure (lines 266-271) to capture and forward both modes:
+
+```rust
+        let core = Arc::clone(&self.core);
+        let (uid, gid, fm, dm, mt, ttl) = (
+            self.uid,
+            self.gid,
+            self.config.file_mode,
+            self.config.dir_mode,
+            self.mount_time,
+            self.config.ttl,
+        );
+        self.pool.execute(move || match core.getattr(child) {
+            Ok(attr) => {
+                reply.entry(&ttl, &to_file_attr(&attr, uid, gid, fm, dm, mt), Generation(0))
+            }
+            Err(e) => reply.error(reply_errno("lookup", child, &e)),
+        });
+```
+
+Update the `getattr` closure (lines 280-285) the same way:
+
+```rust
+        let core = Arc::clone(&self.core);
+        let (uid, gid, fm, dm, mt, ttl) = (
+            self.uid,
+            self.gid,
+            self.config.file_mode,
+            self.config.dir_mode,
+            self.mount_time,
+            self.config.ttl,
+        );
+        self.pool.execute(move || match core.getattr(ino.0) {
+            Ok(attr) => reply.attr(&ttl, &to_file_attr(&attr, uid, gid, fm, dm, mt)),
+            Err(e) => reply.error(reply_errno("getattr", ino.0, &e)),
+        });
+```
+
+Update the two `marker_attr` call sites (lines 258 and 277) to pass `self.config.file_mode`:
+
+```rust
+            let attr = platform::spotlight::marker_attr(
+                self.uid,
+                self.gid,
+                self.config.file_mode,
+                self.mount_time,
+            );
+```
+
+In `musefs-fuse/src/convert.rs`, change `to_file_attr` (lines 15-54). Update the doc comment and signature, and replace the hardcoded perms:
+
+```rust
+/// Translate a core `Attr` into a `fuser::FileAttr`. Permission bits come from
+/// `dir_mode`/`file_mode` (the mount is read-only, so these are advertised but
+/// inert for writes). A zero `mtime_secs` (e.g. synthetic directories) falls
+/// back to `fallback_mtime` so tools don't see a 1970 timestamp.
+pub(crate) fn to_file_attr(
+    attr: &Attr,
+    uid: u32,
+    gid: u32,
+    file_mode: u16,
+    dir_mode: u16,
+    fallback_mtime: SystemTime,
+) -> FileAttr {
+```
+
+and the kind/perm/nlink block (lines 33-37):
+
+```rust
+    let (kind, perm, nlink) = if attr.is_dir {
+        (FileType::Directory, dir_mode, 2)
+    } else {
+        (FileType::RegularFile, file_mode, 1)
+    };
+```
+
+In `musefs-fuse/src/platform/spotlight.rs`, change `marker_attr` (lines 25-43) to take `file_mode`:
+
+```rust
+/// The marker's attributes: a zero-byte, read-only regular file owned by the
+/// mount, all timestamps set to `mtime` (matching synthetic-node stamping).
+pub fn marker_attr(uid: u32, gid: u32, file_mode: u16, mtime: SystemTime) -> FileAttr {
+    FileAttr {
+        ino: INodeNo(MARKER_INO),
+        size: 0,
+        blocks: 0,
+        atime: mtime,
+        mtime,
+        ctime: mtime,
+        crtime: mtime,
+        kind: FileType::RegularFile,
+        perm: file_mode,
+        nlink: 1,
+        uid,
+        gid,
+        rdev: 0,
+        blksize: 512,
+        flags: 0,
+    }
+}
+```
+
+In `musefs-cli/src/lib.rs`, update the `parse_mount_config` `FuseConfig` literal (lines 199-204) so the workspace still compiles. Fill the new fields from `FuseConfig::default()` for now (Task 2 wires the flags):
+
+```rust
+    let defaults = musefs_fuse::FuseConfig::default();
+    let fuse_config = musefs_fuse::FuseConfig {
+        ttl: std::time::Duration::from_millis(args.attr_ttl_ms),
+        max_readahead: args.max_readahead_kib.saturating_mul(1024),
+        max_background: args.max_background,
+        keep_cache: args.keep_cache,
+        uid: defaults.uid,
+        gid: defaults.gid,
+        file_mode: defaults.file_mode,
+        dir_mode: defaults.dir_mode,
+    };
+```
+
+- [ ] **Step 4: Run the full workspace tests to verify they pass**
+
+Run: `cargo test --workspace 2>&1 | tail -15`
+Expected: all tests pass (the new default-field, swap, and marker assertions included).
+
+- [ ] **Step 5: Verify formatting and lint, then commit**
+
+Run: `cargo fmt --all && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: no warnings.
+
+```bash
+git add musefs-fuse/src/lib.rs musefs-fuse/src/convert.rs musefs-fuse/src/platform/spotlight.rs musefs-cli/src/lib.rs
+git commit -m "feat(fuse): carry presented uid/gid and perms in FuseConfig
+
+FuseConfig now holds the uid/gid and file/dir permission bits presented for
+every entry; FuseConfig::default() resolves the process identity and the
+existing 0o555/0o444 defaults, so mount/spawn helpers are unchanged. to_file_attr
+and marker_attr take the modes as parameters. Behavior is identical until the
+CLI flags land.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: CLI flags `--owner`/`--group`/`--file-mode`/`--dir-mode` (musefs-cli)
+
+**Files:**
+- Modify: `musefs-cli/Cargo.toml` (add `uzers`)
+- Modify: `musefs-cli/src/lib.rs` (`MountArgs` ~40-90, value_parsers near `parse_fallback` ~178, `parse_mount_config` ~190-205, `run_mount` ~207-219, tests ~325-360)
+
+- [ ] **Step 1: Add the `uzers` dependency**
+
+In `musefs-cli/Cargo.toml`, under `[dependencies]`, add:
+
+```toml
+uzers = "0.12"
+```
+
+Run: `cargo build -p musefs-cli 2>&1 | tail -5`
+Expected: the dependency downloads and the crate builds (no source changes yet).
+
+- [ ] **Step 2: Write the failing CLI tests**
+
+Add these tests inside the existing `#[cfg(test)] mod tests` block in `musefs-cli/src/lib.rs` (e.g. after `mount_args_parse_into_configs`, around line 360). They reference `parse_octal_mode`, `write_bit_warning`, and the new `--owner`/`--file-mode` flags that don't exist yet.
+
+```rust
+    #[test]
+    fn octal_mode_parses_as_octal_not_decimal() {
+        assert_eq!(parse_octal_mode("644").unwrap(), 0o644);
+        assert_eq!(parse_octal_mode("644").unwrap(), 420); // == decimal 420, proving octal
+        assert_eq!(parse_octal_mode("0755").unwrap(), 0o755);
+    }
+
+    #[test]
+    fn octal_mode_rejects_out_of_range_and_non_octal() {
+        assert!(parse_octal_mode("10000").is_err()); // 0o10000 > 0o7777
+        assert!(parse_octal_mode("8").is_err()); // not an octal digit
+        assert!(parse_octal_mode("xyz").is_err());
+    }
+
+    #[test]
+    fn write_bit_warning_fires_only_for_write_bits() {
+        assert!(write_bit_warning("file-mode", 0o444).is_none());
+        assert!(write_bit_warning("dir-mode", 0o555).is_none());
+        assert!(write_bit_warning("file-mode", 0o664).is_some());
+        assert!(write_bit_warning("dir-mode", 0o775).is_some());
+    }
+
+    #[test]
+    fn owner_and_modes_flow_into_fuse_config() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs", "mount", "/mnt", "--db", "/tmp/x.db",
+            "--owner", "0", "--group", "0",
+            "--file-mode", "640", "--dir-mode", "750",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        assert_eq!(fuse_config.uid, 0);
+        assert_eq!(fuse_config.gid, 0);
+        assert_eq!(fuse_config.file_mode, 0o640);
+        assert_eq!(fuse_config.dir_mode, 0o750);
+    }
+
+    #[test]
+    fn owner_flags_default_to_process_identity() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "mount", "/mnt", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        let defaults = musefs_fuse::FuseConfig::default();
+        assert_eq!(fuse_config.uid, defaults.uid);
+        assert_eq!(fuse_config.gid, defaults.gid);
+        assert_eq!(fuse_config.file_mode, 0o444);
+        assert_eq!(fuse_config.dir_mode, 0o555);
+    }
+
+    #[test]
+    fn owner_accepts_numeric_and_rejects_unknown_name() {
+        assert_eq!(parse_owner("1234").unwrap(), 1234);
+        assert!(parse_owner("").is_err());
+        assert!(parse_owner("definitely-no-such-user-xyzzy").is_err());
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify they fail to compile**
+
+Run: `cargo test -p musefs-cli 2>&1 | head -20`
+Expected: compile error — `parse_octal_mode`, `write_bit_warning`, `parse_owner` not found and `--owner` is an unexpected argument.
+
+- [ ] **Step 4: Implement the parsers, flags, wiring, and warning**
+
+In `musefs-cli/src/lib.rs`, add the value_parsers and the warning helper next to `parse_fallback` (after line 186):
+
+```rust
+/// Resolve `--owner`: a numeric uid is used directly; anything else is looked
+/// up as a username. An all-numeric string is always treated as an id (never a
+/// name), matching `chown`.
+fn parse_owner(s: &str) -> Result<u32, String> {
+    if let Ok(uid) = s.parse::<u32>() {
+        return Ok(uid);
+    }
+    uzers::get_user_by_name(s)
+        .map(|u| u.uid())
+        .ok_or_else(|| format!("no such user: {s}"))
+}
+
+/// Resolve `--group`: a numeric gid is used directly; anything else is looked
+/// up as a group name.
+fn parse_group(s: &str) -> Result<u32, String> {
+    if let Ok(gid) = s.parse::<u32>() {
+        return Ok(gid);
+    }
+    uzers::get_group_by_name(s)
+        .map(|g| g.gid())
+        .ok_or_else(|| format!("no such group: {s}"))
+}
+
+/// Parse a bare octal permission word (e.g. `644`, `0755`) — NOT decimal, and
+/// without an `0o` prefix. Range-checked to `0o7777`.
+fn parse_octal_mode(s: &str) -> Result<u16, String> {
+    let mode = u16::from_str_radix(s, 8).map_err(|_| format!("invalid octal mode: {s}"))?;
+    if mode > 0o7777 {
+        return Err(format!("octal mode out of range (max 7777): {s}"));
+    }
+    Ok(mode)
+}
+
+/// Warning text when a read-only mount is given a mode with write bits set;
+/// the bits are applied as requested, this only informs.
+fn write_bit_warning(flag: &str, mode: u16) -> Option<String> {
+    (mode & 0o222 != 0).then(|| {
+        format!("--{flag} {mode:o} sets write bits, but the mount is read-only; writes will fail with EROFS")
+    })
+}
+```
+
+Add the four flags to `MountArgs`, after the `case_insensitive` field (before the struct's closing brace at line 90):
+
+```rust
+    /// Owning user for every entry: a username or numeric uid. Defaults to the
+    /// launching process's uid.
+    #[arg(long, value_name = "NAME|UID", value_parser = parse_owner)]
+    pub owner: Option<u32>,
+    /// Owning group for every entry: a group name or numeric gid. Defaults to
+    /// the launching process's gid.
+    #[arg(long, value_name = "NAME|GID", value_parser = parse_group)]
+    pub group: Option<u32>,
+    /// Permission bits for regular files, octal (e.g. 444). Defaults to 444.
+    /// The mount is read-only, so write bits are advertised but inert.
+    #[arg(long, value_name = "OCTAL", value_parser = parse_octal_mode)]
+    pub file_mode: Option<u16>,
+    /// Permission bits for directories, octal (e.g. 555). Defaults to 555.
+    #[arg(long, value_name = "OCTAL", value_parser = parse_octal_mode)]
+    pub dir_mode: Option<u16>,
+```
+
+In `parse_mount_config`, replace the four default-filled fields (added in Task 1) so supplied flags override the defaults:
+
+```rust
+        uid: args.owner.unwrap_or(defaults.uid),
+        gid: args.group.unwrap_or(defaults.gid),
+        file_mode: args.file_mode.unwrap_or(defaults.file_mode),
+        dir_mode: args.dir_mode.unwrap_or(defaults.dir_mode),
+```
+
+In `run_mount`, emit the warning(s) after `parse_mount_config` (insert after the `let (config, fuse_config) = parse_mount_config(args);` line, around line 211):
+
+```rust
+    for (flag, mode) in [("file-mode", args.file_mode), ("dir-mode", args.dir_mode)] {
+        if let Some(w) = mode.and_then(|m| write_bit_warning(flag, m)) {
+            eprintln!("warning: {w}");
+        }
+    }
+```
+
+- [ ] **Step 5: Run the full workspace tests to verify they pass**
+
+Run: `cargo test --workspace 2>&1 | tail -15`
+Expected: all tests pass, including the six new CLI tests.
+
+- [ ] **Step 6: Verify formatting and lint, then commit**
+
+Run: `cargo fmt --all && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: no warnings.
+
+```bash
+git add musefs-cli/Cargo.toml musefs-cli/src/lib.rs Cargo.lock
+git commit -m "feat(cli): add --owner/--group/--file-mode/--dir-mode to mount
+
+Resolve owner/group names via uzers (numeric ids pass through), parse modes as
+octal, and override the FuseConfig defaults. Warn on stderr when a read-only
+mount is given write bits.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Document the flags and verify FreeBSD portability
+
+**Files:**
+- Modify: `README.md` (CLI flags / mount options section)
+
+- [ ] **Step 1: Find the mount-flags section in the README**
+
+Run: `grep -n -- '--keep-cache\|--attr-ttl-ms\|--case-insensitive\|## .*[Mm]ount' README.md`
+Expected: the line numbers of the existing `mount` flag documentation (the four new flags go alongside these).
+
+- [ ] **Step 2: Add the four flags to the README**
+
+In the `mount` flags list (next to `--case-insensitive` / `--keep-cache`), add entries matching the surrounding style. Use the wording:
+
+```markdown
+- `--owner <NAME|UID>` — user presented as the owner of every entry. Accepts a
+  username or a numeric uid. Default: the launching process's uid.
+- `--group <NAME|GID>` — group presented for every entry. Accepts a group name
+  or numeric gid. Default: the launching process's gid.
+- `--file-mode <OCTAL>` — permission bits for regular files, in octal (e.g.
+  `444`). Default: `444`. The mount is read-only, so write bits are advertised
+  but writes still fail with `EROFS`.
+- `--dir-mode <OCTAL>` — permission bits for directories, in octal (e.g.
+  `555`). Default: `555`.
+```
+
+- [ ] **Step 3: Verify the docs build/render and the binary help matches**
+
+Run: `cargo run -p musefs --quiet -- mount --help 2>&1 | grep -A1 -- '--owner\|--group\|--file-mode\|--dir-mode'`
+Expected: the four flags appear in the generated help with the documented value names and descriptions, confirming the README matches the CLI.
+
+- [ ] **Step 4: Confirm FreeBSD portability of `uzers` (verification, see spec Portability)**
+
+Run: `cargo build --target x86_64-unknown-freebsd -p musefs-cli 2>&1 | tail -15`
+Expected: builds. (`uzers` does not advertise a FreeBSD target on docs.rs but, as a `users` fork, builds via libc.) If it does **not** build, do not work around it here — stop and apply the spec's contingency: drop `uzers` and resolve names with `getpwnam_r`/`getgrnam_r` via `libc` behind a safe wrapper in `musefs-cli`, then re-run Tasks 2-3. If the FreeBSD target is not installed locally, note that the FreeBSD CI job is the gate and proceed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document mount --owner/--group/--file-mode/--dir-mode
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full suite once more from a clean state**
+
+Run: `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test --workspace 2>&1 | tail -20`
+Expected: formatting clean, no clippy warnings, all tests pass.
+
+- [ ] **Smoke-check the fuzz crate is unaffected** (format-layer signatures unchanged here, but the convention is to confirm)
+
+Run: `cargo +nightly fuzz build 2>&1 | tail -5`
+Expected: builds. (No format-layer API changed, so this should be unaffected; if nightly is unavailable, skip — CI covers it.)

--- a/docs/superpowers/specs/2026-06-10-mount-owner-perms-flags-design.md
+++ b/docs/superpowers/specs/2026-06-10-mount-owner-perms-flags-design.md
@@ -1,0 +1,158 @@
+# Mount owner & permission flags — design
+
+## Summary
+
+Add four optional flags to `musefs mount` that override the ownership and
+permission bits the mount presents:
+
+- `--owner <NAME|UID>` — owning user (username or numeric uid)
+- `--group <NAME|GID>` — owning group (groupname or numeric gid)
+- `--file-mode <OCTAL>` — permission bits for regular files
+- `--dir-mode <OCTAL>` — permission bits for directories
+
+All four are optional. Omitting them preserves today's behavior exactly, so the
+change is non-breaking.
+
+## Motivation
+
+Today the mount hardcodes ownership to the launching process's uid/gid
+(`musefs-fuse/src/lib.rs:173-174`) and permissions to `0o555` for directories
+and `0o444` for files (`musefs-fuse/src/convert.rs:33-36`), with the macOS
+Spotlight marker also fixed at `0o444` (`musefs-fuse/src/platform/spotlight.rs`).
+A mount serving a shared music library often needs to present a specific
+owner/group (e.g. a media-server service account) and tighter or looser perms
+than the launching process's identity. There is currently no way to set these
+without running the daemon as the target user.
+
+## Defaults (backward compatibility)
+
+| Flag | Default | Source of default |
+| ---- | ------- | ----------------- |
+| `--owner` | launching process uid | `rustix::process::getuid()` |
+| `--group` | launching process gid | `rustix::process::getgid()` |
+| `--file-mode` | `0o444` | current `to_file_attr` constant |
+| `--dir-mode` | `0o555` | current `to_file_attr` constant |
+
+With no flags supplied, the resolved values are byte-for-byte what the mount
+produces today.
+
+## Flag parsing & validation (musefs-cli)
+
+Resolution and validation live entirely in the CLI layer, via clap
+`value_parser` functions, so `musefs-fuse` only ever receives numeric `u32`s and
+stays free of user-database lookups.
+
+### Owner / group
+
+`--owner` and `--group` accept either form:
+
+- If the value parses as a `u32`, it is used directly as the uid/gid.
+- Otherwise it is treated as a name and resolved against the system
+  user/group database using the [`uzers`](https://crates.io/crates/uzers) crate
+  (`get_user_by_name` → `uid()`, `get_group_by_name` → `gid()`). `uzers` is a
+  maintained, *nix-only fork of `users` with a safe API, chosen over hand-rolled
+  `getpwnam_r`/`getgrnam_r` FFI to avoid unsafe code. All supported platforms
+  (Linux, macOS, FreeBSD) are *nix, so the *nix-only constraint is acceptable.
+- A name that does not resolve produces a clean startup error from clap
+  (e.g. `error: invalid value 'nobody2' for '--owner <NAME|UID>': no such user`).
+
+### File / dir modes
+
+`--file-mode` and `--dir-mode` parse as **octal** integers, range-checked to
+`0o7777`; out-of-range values are rejected by the parser.
+
+The mount is mounted `MountOption::RO`, so write bits in a mode are advertised
+but inert — the kernel rejects writes at the read-only-mount level regardless of
+the bits. To avoid surprising the user, if a supplied mode contains any write
+bit (`0o222` mask), the CLI prints a warning to stderr at startup
+(e.g. `warning: --file-mode 0664 sets write bits, but the mount is read-only;
+writes will fail with EROFS`). The bits are still applied as requested — the
+warning informs, it does not clamp.
+
+## Threading (musefs-cli → musefs-fuse)
+
+`FuseConfig` (`musefs-fuse/src/lib.rs`) gains four fields:
+
+```rust
+pub uid: u32,
+pub gid: u32,
+pub file_mode: u16,
+pub dir_mode: u16,
+```
+
+(`u16` matches `fuser::FileAttr::perm`.)
+
+`parse_mount_config` (`musefs-cli/src/lib.rs`) populates them: uid/gid from the
+resolved `--owner`/`--group` or the process ids when unset; modes from
+`--file-mode`/`--dir-mode` or the defaults.
+
+`MusefsFs::new` (`musefs-fuse/src/lib.rs:162`) reads `uid`/`gid` from the passed
+`config` instead of calling `getuid`/`getgid` directly. The
+process-id fallback moves up to the CLI, which is the only caller that should
+decide the default identity.
+
+`FuseConfig`'s doc comment, currently scoped to "kernel tuning + page-cache
+policy", is updated to note it also carries the presented attribute identity
+(owner and permission bits). A separate `AttrConfig` struct was considered but
+rejected as over-plumbing for four fields with a single consumer.
+
+## Attribute rendering (musefs-fuse)
+
+`to_file_attr` (`musefs-fuse/src/convert.rs`) takes the two modes instead of the
+hardcoded `0o555`/`0o444`:
+
+```rust
+let (kind, perm, nlink) = if attr.is_dir {
+    (FileType::Directory, dir_mode, 2)
+} else {
+    (FileType::RegularFile, file_mode, 1)
+};
+```
+
+uid/gid continue to be passed in as they are today.
+
+The macOS Spotlight marker `marker_attr`
+(`musefs-fuse/src/platform/spotlight.rs`) receives the same uid/gid and
+`file_mode`, so every entry the mount presents — real files, synthetic
+directories, and the marker — is uniform.
+
+## Components touched
+
+| Unit | Change |
+| ---- | ------ |
+| `musefs-cli` `MountArgs` | four new `#[arg]` fields + value_parsers |
+| `musefs-cli` value_parsers | `parse_owner`, `parse_group`, `parse_octal_mode` (with write-bit warning) |
+| `musefs-cli` `parse_mount_config` | populate new `FuseConfig` fields |
+| `musefs-cli` Cargo.toml | add `uzers` dependency |
+| `musefs-fuse` `FuseConfig` | four new fields + doc update |
+| `musefs-fuse` `MusefsFs::new` | read uid/gid from config |
+| `musefs-fuse` `to_file_attr` | take file/dir mode params |
+| `musefs-fuse` `marker_attr` callers | pass configured file_mode |
+| `README.md` | document the four flags |
+
+## Error handling
+
+- Unresolvable owner/group name → clap parse error, non-zero exit, no mount.
+- Out-of-range octal mode → clap parse error, non-zero exit, no mount.
+- Write bits in a mode → stderr warning, mount proceeds.
+
+## Testing
+
+- **CLI unit tests** (`musefs-cli`): `--owner`/`--group` accept numeric and name
+  forms; an unresolvable name errors; octal parsing accepts valid modes and
+  rejects out-of-range; the write-bit warning fires for modes with `0o222` bits;
+  defaults with no flags reproduce the current `FuseConfig` values (extend the
+  existing `parse_mount_config` tests).
+- **`convert.rs`**: `to_file_attr` honors custom file and dir modes (the
+  existing tests at `convert.rs:123-137` assert the defaults and are updated to
+  pass modes explicitly).
+- **Spotlight** (`spotlight.rs`): `marker_attr` test confirms configured uid/gid
+  and file_mode.
+- **README**: CLI-flags section lists the four flags with defaults.
+
+## Out of scope
+
+- Symbolic mode syntax (`u+rwx`) — octal only.
+- Per-entry or per-template ownership/perms — a single uniform owner/mode pair
+  for the whole mount.
+- Windows/non-*nix name resolution — all supported platforms are *nix.

--- a/docs/superpowers/specs/2026-06-10-mount-owner-perms-flags-design.md
+++ b/docs/superpowers/specs/2026-06-10-mount-owner-perms-flags-design.md
@@ -46,20 +46,34 @@ stays free of user-database lookups.
 
 `--owner` and `--group` accept either form:
 
-- If the value parses as a `u32`, it is used directly as the uid/gid.
+- If the value parses as a `u32`, it is used directly as the uid/gid. This
+  means an all-numeric *username* (legal on Linux) is always interpreted as a
+  raw id, never resolved as a name — matching `chown`'s long-standing
+  semantics. This is the intended, documented behavior.
 - Otherwise it is treated as a name and resolved against the system
   user/group database using the [`uzers`](https://crates.io/crates/uzers) crate
   (`get_user_by_name` → `uid()`, `get_group_by_name` → `gid()`). `uzers` is a
   maintained, *nix-only fork of `users` with a safe API, chosen over hand-rolled
   `getpwnam_r`/`getgrnam_r` FFI to avoid unsafe code. All supported platforms
-  (Linux, macOS, FreeBSD) are *nix, so the *nix-only constraint is acceptable.
-- A name that does not resolve produces a clean startup error from clap
+  (Linux, macOS, FreeBSD) are *nix, so the *nix-only constraint is acceptable
+  in principle — but FreeBSD support is a verification item, not a settled
+  fact (see [Portability](#portability)).
+- A name that does not resolve (including an empty string) produces a clean
+  startup error from clap
   (e.g. `error: invalid value 'nobody2' for '--owner <NAME|UID>': no such user`).
 
 ### File / dir modes
 
-`--file-mode` and `--dir-mode` parse as **octal** integers, range-checked to
-`0o7777`; out-of-range values are rejected by the parser.
+`--file-mode` and `--dir-mode` parse as **octal** integers via a custom
+`parse_octal_mode` value_parser using `u16::from_str_radix(s, 8)` — **not**
+clap's default value_parser, which parses decimal and would silently read
+`--file-mode 644` as decimal `644` instead of `0o644`. The parser returns
+`u16` (matching `fuser::FileAttr::perm` and the `FuseConfig` field type) and is
+range-checked to `0o7777`; out-of-range or non-octal values are rejected.
+
+The value masked and stored is the bare permission word (no `S_IFDIR`/`S_IFREG`
+type bits OR'd in) — consistent with how `to_file_attr` stores bare `0o555`/
+`0o444` in `perm` today, and the same bare value the write-bit check inspects.
 
 The mount is mounted `MountOption::RO`, so write bits in a mode are advertised
 but inert — the kernel rejects writes at the read-only-mount level regardless of
@@ -82,14 +96,27 @@ pub dir_mode: u16,
 
 (`u16` matches `fuser::FileAttr::perm`.)
 
-`parse_mount_config` (`musefs-cli/src/lib.rs`) populates them: uid/gid from the
-resolved `--owner`/`--group` or the process ids when unset; modes from
-`--file-mode`/`--dir-mode` or the defaults.
+**`FuseConfig::default()` (`musefs-fuse/src/lib.rs:58-67`) is the single source
+of the defaults.** It resolves `uid`/`gid` via `rustix::process::getuid()`/
+`getgid()` and sets `file_mode = 0o444`, `dir_mode = 0o555`. This keeps the
+existing `mount`/`spawn` convenience helpers (`lib.rs:475-497`, which pass
+`FuseConfig::default()`) and all `default()`-based tests presenting the current
+process identity — they would otherwise present uid/gid `0` (root). Putting the
+process-id default in `default()` rather than in `MusefsFs::new` or the CLI
+centralizes it in one place.
 
-`MusefsFs::new` (`musefs-fuse/src/lib.rs:162`) reads `uid`/`gid` from the passed
-`config` instead of calling `getuid`/`getgid` directly. The
-process-id fallback moves up to the CLI, which is the only caller that should
-decide the default identity.
+`MusefsFs::new` (`musefs-fuse/src/lib.rs:162`) **drops its own
+`getuid`/`getgid` calls** (`lib.rs:173-174`) and reads `uid`/`gid` from the
+passed `config`. The modes are read from `self.config` at the call sites (below),
+not promoted to top-level `MusefsFs` fields — consistent with how `ttl`/
+`keep_cache` are already accessed via `self.config`.
+
+`parse_mount_config` (`musefs-cli/src/lib.rs`) builds the `FuseConfig` starting
+from `FuseConfig::default()` and overrides only the fields whose flags were
+supplied: `uid` from a resolved `--owner` else the default, `gid` from
+`--group` else the default, `file_mode`/`dir_mode` from their flags else the
+defaults. The CLI therefore needs **no** `rustix`/`getuid` dependency of its
+own — it inherits the process-id default through `FuseConfig::default()`.
 
 `FuseConfig`'s doc comment, currently scoped to "kernel tuning + page-cache
 policy", is updated to note it also carries the presented attribute identity
@@ -109,12 +136,20 @@ let (kind, perm, nlink) = if attr.is_dir {
 };
 ```
 
-uid/gid continue to be passed in as they are today.
+uid/gid continue to be passed in as they are today. The two closures that call
+`to_file_attr` — `lookup` (`lib.rs:266-271`) and `getattr` (`lib.rs:280-285`) —
+currently capture `let (uid, gid, mt, ttl) = (self.uid, self.gid, ...)`; they
+must additionally capture `self.config.file_mode` and `self.config.dir_mode`
+and forward both to `to_file_attr`.
 
 The macOS Spotlight marker `marker_attr`
-(`musefs-fuse/src/platform/spotlight.rs`) receives the same uid/gid and
-`file_mode`, so every entry the mount presents — real files, synthetic
-directories, and the marker — is uniform.
+(`musefs-fuse/src/platform/spotlight.rs:25`) — today
+`marker_attr(uid, gid, mtime)` — gains a `file_mode` parameter, becoming
+`marker_attr(uid, gid, file_mode, mtime)`. Its two call sites (`lib.rs:258`,
+`lib.rs:277`) pass `self.config.file_mode`, and the existing non-macOS test
+(`spotlight.rs:87-98`) is updated for the new signature. So every entry the
+mount presents — real files, synthetic directories, and the marker — is
+uniform.
 
 ## Components touched
 
@@ -125,10 +160,29 @@ directories, and the marker — is uniform.
 | `musefs-cli` `parse_mount_config` | populate new `FuseConfig` fields |
 | `musefs-cli` Cargo.toml | add `uzers` dependency |
 | `musefs-fuse` `FuseConfig` | four new fields + doc update |
-| `musefs-fuse` `MusefsFs::new` | read uid/gid from config |
+| `musefs-fuse` `FuseConfig::default()` | resolve process uid/gid + default modes |
+| `musefs-fuse` `MusefsFs::new` | drop `getuid`/`getgid`; read uid/gid from config |
 | `musefs-fuse` `to_file_attr` | take file/dir mode params |
-| `musefs-fuse` `marker_attr` callers | pass configured file_mode |
+| `musefs-fuse` `lookup`/`getattr` closures | capture + forward both modes (`lib.rs:266-285`) |
+| `musefs-fuse` `marker_attr` + 2 call sites | new `file_mode` param (`spotlight.rs:25`, `lib.rs:258`,`277`) |
 | `README.md` | document the four flags |
+
+## Portability
+
+Name resolution runs at clap-parse time, as the launching user, before any
+mount or session work — so it reads the passwd/group DB with the invoking
+identity, which is exactly the intent (present an owner *without* running as
+that user).
+
+`uzers` advertises build targets for Linux and macOS (Darwin) but **not**
+FreeBSD on docs.rs. As a `users` fork it historically builds on FreeBSD via
+libc and will most likely work, but this is an explicit verification task, not
+an assumption: confirm `uzers` compiles and resolves names under the FreeBSD CI
+job (which must exercise `musefs-cli` for the dep to be covered). **Contingency
+if it does not build on FreeBSD:** drop `uzers` and hand-roll the lookup with
+`getpwnam_r`/`getgrnam_r` via `libc` (already a `musefs-fuse` dependency),
+guarded behind a small safe wrapper in `musefs-cli` — the same alternative
+weighed and deferred during design.
 
 ## Error handling
 
@@ -138,16 +192,33 @@ directories, and the marker — is uniform.
 
 ## Testing
 
-- **CLI unit tests** (`musefs-cli`): `--owner`/`--group` accept numeric and name
-  forms; an unresolvable name errors; octal parsing accepts valid modes and
-  rejects out-of-range; the write-bit warning fires for modes with `0o222` bits;
-  defaults with no flags reproduce the current `FuseConfig` values (extend the
-  existing `parse_mount_config` tests).
-- **`convert.rs`**: `to_file_attr` honors custom file and dir modes (the
-  existing tests at `convert.rs:123-137` assert the defaults and are updated to
-  pass modes explicitly).
+- **CLI unit tests** (`musefs-cli`):
+  - `--owner`/`--group` accept numeric and name forms; an all-numeric value
+    resolves as an id, not a name; an unresolvable name (and an empty string)
+    errors.
+  - Octal parsing: `--file-mode 644` yields `0o644` (== decimal 420), proving
+    octal-not-decimal; valid modes accepted; out-of-range (`> 0o7777`) and
+    non-octal rejected.
+  - The write-bit warning **fires** for a mode with `0o222` bits and is
+    **silent** for `0o444`/`0o555` (pins the mask boundary).
+  - End-to-end: extend the existing `mount_args_parse_into_configs` test
+    (`musefs-cli/src/lib.rs:326-360`) to assert that supplied `--owner`/
+    `--group`/`--file-mode`/`--dir-mode` land in the resulting `FuseConfig`
+    fields, and that with no flags the `FuseConfig` matches
+    `FuseConfig::default()` (catches broken wiring through `parse_mount_config`).
+- **`convert.rs`**: `to_file_attr` honors custom file and dir modes — the
+  existing default-asserting tests (`convert.rs:110-144`) are updated to pass
+  modes explicitly, **plus** a test with `dir_mode != file_mode` asserting the
+  dir gets `dir_mode` and the file gets `file_mode`. This last test kills the
+  dir/file-mode **swap mutant**: `to_file_attr` is the only mutation-tested
+  logic in `musefs-fuse` (gated by `.cargo/mutants.toml`, per the header
+  comment at `convert.rs:6-9`), and parameterizing the modes adds new mutable
+  branches, so the swap case must be covered or the gate surfaces a survivor.
+- **`FuseConfig::default()`**: extend `fuse_config_default_is_conservative`
+  (`musefs-fuse/src/lib.rs:556-562`) to assert `file_mode == 0o444`,
+  `dir_mode == 0o555`, and `uid`/`gid` equal `getuid()`/`getgid()`.
 - **Spotlight** (`spotlight.rs`): `marker_attr` test confirms configured uid/gid
-  and file_mode.
+  and file_mode under the new `(uid, gid, file_mode, mtime)` signature.
 - **README**: CLI-flags section lists the four flags with defaults.
 
 ## Out of scope

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -15,6 +15,7 @@ musefs-db = { path = "../musefs-db", version = "0.2.0" }
 musefs-core = { path = "../musefs-core", version = "0.2.0" }
 musefs-fuse = { path = "../musefs-fuse", version = "0.2.0" }
 signal-hook = "0.4"
+uzers = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -50,7 +50,7 @@ pub struct MountArgs {
     /// Path template, e.g. "$albumartist/$album/$title". Supports ${a|b}
     /// fallback chains, [...] conditional sections ($[/$] for literal
     /// brackets), and $!{field} path fields that keep '/' as separators.
-    #[arg(long, default_value = "$artist/$title")]
+    #[arg(long, default_value = "$albumartist/$album/$title")]
     pub template: String,
     /// Fallback value substituted for any missing template field.
     #[arg(long, default_value = "Unknown")]
@@ -414,7 +414,7 @@ mod tests {
         };
         let (config, fuse_config) = parse_mount_config(&args);
         // Defaults survive the move into the struct.
-        assert_eq!(config.template, "$artist/$title");
+        assert_eq!(config.template, "$albumartist/$album/$title");
         assert_eq!(config.default_fallback, "Unknown");
         assert_eq!(config.mode, musefs_core::Mode::Synthesis);
         assert!(!fuse_config.keep_cache);

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -88,6 +88,21 @@ pub struct MountArgs {
     /// with `--case-insensitive false` (e.g. a case-sensitive APFS volume).
     #[arg(long, default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set)]
     pub case_insensitive: bool,
+    /// Owning user for every entry: a username or numeric uid. Defaults to the
+    /// launching process's uid.
+    #[arg(long, value_name = "NAME|UID", value_parser = parse_owner)]
+    pub owner: Option<u32>,
+    /// Owning group for every entry: a group name or numeric gid. Defaults to
+    /// the launching process's gid.
+    #[arg(long, value_name = "NAME|GID", value_parser = parse_group)]
+    pub group: Option<u32>,
+    /// Permission bits for regular files, octal (e.g. 444). Defaults to 444.
+    /// The mount is read-only, so write bits are advertised but inert.
+    #[arg(long, value_name = "OCTAL", value_parser = parse_octal_mode)]
+    pub file_mode: Option<u16>,
+    /// Permission bits for directories, octal (e.g. 555). Defaults to 555.
+    #[arg(long, value_name = "OCTAL", value_parser = parse_octal_mode)]
+    pub dir_mode: Option<u16>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -185,6 +200,49 @@ fn parse_fallback(s: &str) -> Result<(String, String), String> {
     Ok((field.to_string(), value.to_string()))
 }
 
+/// Resolve `--owner`: a numeric uid is used directly; anything else is looked
+/// up as a username. An all-numeric string is always treated as an id (never a
+/// name), matching `chown`.
+fn parse_owner(s: &str) -> Result<u32, String> {
+    if let Ok(uid) = s.parse::<u32>() {
+        return Ok(uid);
+    }
+    uzers::get_user_by_name(s)
+        .map(|u| u.uid())
+        .ok_or_else(|| format!("no such user: {s}"))
+}
+
+/// Resolve `--group`: a numeric gid is used directly; anything else is looked
+/// up as a group name.
+fn parse_group(s: &str) -> Result<u32, String> {
+    if let Ok(gid) = s.parse::<u32>() {
+        return Ok(gid);
+    }
+    uzers::get_group_by_name(s)
+        .map(|g| g.gid())
+        .ok_or_else(|| format!("no such group: {s}"))
+}
+
+/// Parse a bare octal permission word (e.g. `644`, `0755`) — NOT decimal, and
+/// without an `0o` prefix. Range-checked to `0o7777`.
+fn parse_octal_mode(s: &str) -> Result<u16, String> {
+    let mode = u16::from_str_radix(s, 8).map_err(|_| format!("invalid octal mode: {s}"))?;
+    if mode > 0o7777 {
+        return Err(format!("octal mode out of range (max 7777): {s}"));
+    }
+    Ok(mode)
+}
+
+/// Warning text when a read-only mount is given a mode with write bits set;
+/// the bits are applied as requested, this only informs.
+fn write_bit_warning(flag: &str, mode: u16) -> Option<String> {
+    (mode & 0o222 != 0).then(|| {
+        format!(
+            "--{flag} {mode:o} sets write bits, but the mount is read-only; writes will fail with EROFS"
+        )
+    })
+}
+
 /// Parse mount CLI flags into `MountConfig` and `FuseConfig`. Pure function —
 /// no DB access, no mounting. Exported for unit testing.
 pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseConfig) {
@@ -202,10 +260,10 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         max_readahead: args.max_readahead_kib.saturating_mul(1024),
         max_background: args.max_background,
         keep_cache: args.keep_cache,
-        uid: defaults.uid,
-        gid: defaults.gid,
-        file_mode: defaults.file_mode,
-        dir_mode: defaults.dir_mode,
+        uid: args.owner.unwrap_or(defaults.uid),
+        gid: args.group.unwrap_or(defaults.gid),
+        file_mode: args.file_mode.unwrap_or(defaults.file_mode),
+        dir_mode: args.dir_mode.unwrap_or(defaults.dir_mode),
     };
     (config, fuse_config)
 }
@@ -216,6 +274,11 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
     let (config, fuse_config) = parse_mount_config(args);
+    for (flag, mode) in [("file-mode", args.file_mode), ("dir-mode", args.dir_mode)] {
+        if let Some(w) = mode.and_then(|m| write_bit_warning(flag, m)) {
+            eprintln!("warning: {w}");
+        }
+    }
     let core = Musefs::open(db, config).context("building the virtual filesystem")?;
     signal::install_unmount_on_signal(args.mountpoint.clone())
         .context("installing the stop-signal unmount handler")?;
@@ -394,5 +457,85 @@ mod tests {
             };
             assert_eq!(args.case_insensitive, want);
         }
+    }
+
+    #[test]
+    fn octal_mode_parses_as_octal_not_decimal() {
+        assert_eq!(parse_octal_mode("644").unwrap(), 0o644);
+        assert_eq!(parse_octal_mode("644").unwrap(), 420);
+        assert_eq!(parse_octal_mode("0755").unwrap(), 0o755);
+    }
+
+    #[test]
+    fn octal_mode_rejects_out_of_range_and_non_octal() {
+        assert!(parse_octal_mode("10000").is_err());
+        assert!(parse_octal_mode("8").is_err());
+        assert!(parse_octal_mode("xyz").is_err());
+    }
+
+    #[test]
+    fn write_bit_warning_fires_only_for_write_bits() {
+        assert!(write_bit_warning("file-mode", 0o444).is_none());
+        assert!(write_bit_warning("dir-mode", 0o555).is_none());
+        assert!(write_bit_warning("file-mode", 0o664).is_some());
+        assert!(write_bit_warning("dir-mode", 0o775).is_some());
+    }
+
+    #[test]
+    fn owner_and_modes_flow_into_fuse_config() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "mount",
+            "/mnt",
+            "--db",
+            "/tmp/x.db",
+            "--owner",
+            "0",
+            "--group",
+            "0",
+            "--file-mode",
+            "640",
+            "--dir-mode",
+            "750",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        assert_eq!(fuse_config.uid, 0);
+        assert_eq!(fuse_config.gid, 0);
+        assert_eq!(fuse_config.file_mode, 0o640);
+        assert_eq!(fuse_config.dir_mode, 0o750);
+    }
+
+    #[test]
+    fn owner_flags_default_to_process_identity() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "mount", "/mnt", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        let defaults = musefs_fuse::FuseConfig::default();
+        assert_eq!(fuse_config.uid, defaults.uid);
+        assert_eq!(fuse_config.gid, defaults.gid);
+        assert_eq!(fuse_config.file_mode, 0o444);
+        assert_eq!(fuse_config.dir_mode, 0o555);
+    }
+
+    #[test]
+    fn owner_accepts_numeric_and_rejects_unknown_name() {
+        assert_eq!(parse_owner("1234").unwrap(), 1234);
+        assert!(parse_owner("").is_err());
+        assert!(parse_owner("definitely-no-such-user-xyzzy").is_err());
+    }
+
+    #[test]
+    fn group_accepts_numeric_and_rejects_unknown_name() {
+        assert_eq!(parse_group("1234").unwrap(), 1234);
+        assert!(parse_group("").is_err());
+        assert!(parse_group("definitely-no-such-group-xyzzy").is_err());
     }
 }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -196,11 +196,16 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
         case_insensitive: args.case_insensitive,
     };
+    let defaults = musefs_fuse::FuseConfig::default();
     let fuse_config = musefs_fuse::FuseConfig {
         ttl: std::time::Duration::from_millis(args.attr_ttl_ms),
         max_readahead: args.max_readahead_kib.saturating_mul(1024),
         max_background: args.max_background,
         keep_cache: args.keep_cache,
+        uid: defaults.uid,
+        gid: defaults.gid,
+        file_mode: defaults.file_mode,
+        dir_mode: defaults.dir_mode,
     };
     (config, fuse_config)
 }

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -131,6 +131,10 @@ fn parse_mount_config_defaults_are_sensible() {
         max_background: 64,
         keep_cache: false,
         case_insensitive: false,
+        owner: None,
+        group: None,
+        file_mode: None,
+        dir_mode: None,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
@@ -159,6 +163,10 @@ fn parse_mount_config_keep_cache_sets_flag() {
         max_background: 32,
         keep_cache: true,
         case_insensitive: false,
+        owner: None,
+        group: None,
+        file_mode: None,
+        dir_mode: None,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
@@ -183,6 +191,10 @@ fn parse_mount_config_saturating_readahead() {
         max_background: 64,
         keep_cache: false,
         case_insensitive: false,
+        owner: None,
+        group: None,
+        file_mode: None,
+        dir_mode: None,
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
@@ -231,6 +243,10 @@ fn parse_mount_config_populates_per_field_fallbacks() {
         max_background: 64,
         keep_cache: false,
         case_insensitive: false,
+        owner: None,
+        group: None,
+        file_mode: None,
+        dir_mode: None,
     };
     let (config, _) = parse_mount_config(&args);
     assert_eq!(

--- a/musefs-fuse/src/convert.rs
+++ b/musefs-fuse/src/convert.rs
@@ -13,13 +13,16 @@ use std::time::{Duration, SystemTime};
 use fuser::{FileAttr, FileType, INodeNo};
 use musefs_core::Attr;
 
-/// Translate a core `Attr` into a `fuser::FileAttr`. Read-only perms (`0o555`
-/// dirs, `0o444` files). A zero `mtime_secs` (e.g. synthetic directories) falls
+/// Translate a core `Attr` into a `fuser::FileAttr`. Permission bits come from
+/// `dir_mode`/`file_mode` (the mount is read-only, so these are advertised but
+/// inert for writes). A zero `mtime_secs` (e.g. synthetic directories) falls
 /// back to `fallback_mtime` so tools don't see a 1970 timestamp.
 pub(crate) fn to_file_attr(
     attr: &Attr,
     uid: u32,
     gid: u32,
+    file_mode: u16,
+    dir_mode: u16,
     fallback_mtime: SystemTime,
 ) -> FileAttr {
     let mtime = if attr.mtime_secs > 0 {
@@ -31,9 +34,9 @@ pub(crate) fn to_file_attr(
         fallback_mtime
     };
     let (kind, perm, nlink) = if attr.is_dir {
-        (FileType::Directory, 0o555, 2)
+        (FileType::Directory, dir_mode, 2)
     } else {
-        (FileType::RegularFile, 0o444, 1)
+        (FileType::RegularFile, file_mode, 1)
     };
     FileAttr {
         ino: INodeNo(attr.inode),
@@ -117,7 +120,7 @@ mod tests {
             size: 0,
             mtime_secs: 0,
         };
-        let fa = to_file_attr(&dir, 501, 20, fallback);
+        let fa = to_file_attr(&dir, 501, 20, 0o444, 0o555, fallback);
         assert_eq!(fa.ino, INodeNo(1));
         assert_eq!(fa.kind, FileType::Directory);
         assert_eq!(fa.perm, 0o555);
@@ -132,7 +135,7 @@ mod tests {
             size: 4096,
             mtime_secs: 1_700_000_000,
         };
-        let fa = to_file_attr(&file, 501, 20, fallback);
+        let fa = to_file_attr(&file, 501, 20, 0o444, 0o555, fallback);
         assert_eq!(fa.kind, FileType::RegularFile);
         assert_eq!(fa.perm, 0o444);
         assert_eq!(fa.size, 4096);
@@ -141,6 +144,28 @@ mod tests {
             fa.mtime,
             SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
         );
+    }
+
+    #[test]
+    fn to_file_attr_applies_distinct_dir_and_file_modes() {
+        let fallback = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+        let dir = Attr {
+            inode: 1,
+            is_dir: true,
+            size: 0,
+            mtime_secs: 0,
+        };
+        let file = Attr {
+            inode: 2,
+            is_dir: false,
+            size: 0,
+            mtime_secs: 0,
+        };
+        // Deliberately asymmetric so a dir/file swap is observable.
+        let d = to_file_attr(&dir, 0, 0, 0o400, 0o700, fallback);
+        let f = to_file_attr(&file, 0, 0, 0o400, 0o700, fallback);
+        assert_eq!(d.perm, 0o700, "dir must get dir_mode");
+        assert_eq!(f.perm, 0o400, "file must get file_mode");
     }
 
     #[test]

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -35,8 +35,10 @@ thread_local! {
     static READ_BUF: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
-/// Fuse-layer mount knobs: kernel tuning + page-cache policy. Distinct from
-/// `musefs_core::MountConfig`, which governs how the virtual tree is rendered.
+/// Fuse-layer mount knobs: kernel tuning, page-cache policy, and the ownership
+/// (`uid`/`gid`) and permission bits (`file_mode`/`dir_mode`) presented for
+/// every entry. Distinct from `musefs_core::MountConfig`, which governs how the
+/// virtual tree is rendered.
 #[derive(Debug, Clone)]
 pub struct FuseConfig {
     /// Entry/attr cache lifetime the kernel may trust before re-validating.
@@ -53,6 +55,14 @@ pub struct FuseConfig {
     /// re-tag auto-invalidates the affected inode on refresh (`poll_refresh_notify`
     /// → `inval_inode`), so cached bytes are dropped when content changes.
     pub keep_cache: bool,
+    /// uid presented for every entry (the marker, synthetic dirs, real files).
+    pub uid: u32,
+    /// gid presented for every entry.
+    pub gid: u32,
+    /// Permission bits for regular files (bare mode word, no type bits).
+    pub file_mode: u16,
+    /// Permission bits for directories (bare mode word, no type bits).
+    pub dir_mode: u16,
 }
 
 impl Default for FuseConfig {
@@ -62,6 +72,10 @@ impl Default for FuseConfig {
             max_readahead: 512 * 1024,
             max_background: 64,
             keep_cache: false,
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
+            file_mode: 0o444,
+            dir_mode: 0o555,
         }
     }
 }
@@ -170,8 +184,8 @@ impl MusefsFs {
             // class of work; foreground reads are bounded only by client
             // concurrency, so a wide parallel read storm can still queue jobs.
             pool: ThreadPool::new(workers),
-            uid: rustix::process::getuid().as_raw(),
-            gid: rustix::process::getgid().as_raw(),
+            uid: config.uid,
+            gid: config.gid,
             mount_time: SystemTime::now(),
             config,
             notifier: Arc::new(OnceLock::new()),
@@ -255,7 +269,12 @@ impl Filesystem for MusefsFs {
             return reply.error(fuser::Errno::ENOENT);
         };
         if platform::spotlight::marker_lookup(parent.0, name).is_some() {
-            let attr = platform::spotlight::marker_attr(self.uid, self.gid, self.mount_time);
+            let attr = platform::spotlight::marker_attr(
+                self.uid,
+                self.gid,
+                self.config.file_mode,
+                self.mount_time,
+            );
             return reply.entry(&self.config.ttl, &attr, Generation(0));
         }
         // Inode resolution is an in-memory tree read; the attr (which may touch
@@ -264,9 +283,20 @@ impl Filesystem for MusefsFs {
             return reply.error(fuser::Errno::ENOENT);
         };
         let core = Arc::clone(&self.core);
-        let (uid, gid, mt, ttl) = (self.uid, self.gid, self.mount_time, self.config.ttl);
+        let (uid, gid, fm, dm, mt, ttl) = (
+            self.uid,
+            self.gid,
+            self.config.file_mode,
+            self.config.dir_mode,
+            self.mount_time,
+            self.config.ttl,
+        );
         self.pool.execute(move || match core.getattr(child) {
-            Ok(attr) => reply.entry(&ttl, &to_file_attr(&attr, uid, gid, mt), Generation(0)),
+            Ok(attr) => reply.entry(
+                &ttl,
+                &to_file_attr(&attr, uid, gid, fm, dm, mt),
+                Generation(0),
+            ),
             Err(e) => reply.error(reply_errno("lookup", child, &e)),
         });
     }
@@ -274,13 +304,25 @@ impl Filesystem for MusefsFs {
     fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         self.fire_poll_refresh();
         if platform::spotlight::is_marker(ino.0) {
-            let attr = platform::spotlight::marker_attr(self.uid, self.gid, self.mount_time);
+            let attr = platform::spotlight::marker_attr(
+                self.uid,
+                self.gid,
+                self.config.file_mode,
+                self.mount_time,
+            );
             return reply.attr(&self.config.ttl, &attr);
         }
         let core = Arc::clone(&self.core);
-        let (uid, gid, mt, ttl) = (self.uid, self.gid, self.mount_time, self.config.ttl);
+        let (uid, gid, fm, dm, mt, ttl) = (
+            self.uid,
+            self.gid,
+            self.config.file_mode,
+            self.config.dir_mode,
+            self.mount_time,
+            self.config.ttl,
+        );
         self.pool.execute(move || match core.getattr(ino.0) {
-            Ok(attr) => reply.attr(&ttl, &to_file_attr(&attr, uid, gid, mt)),
+            Ok(attr) => reply.attr(&ttl, &to_file_attr(&attr, uid, gid, fm, dm, mt)),
             Err(e) => reply.error(reply_errno("getattr", ino.0, &e)),
         });
     }
@@ -559,6 +601,10 @@ mod tests {
         assert_eq!(c.max_readahead, 512 * 1024);
         assert_eq!(c.max_background, 64);
         assert!(!c.keep_cache);
+        assert_eq!(c.file_mode, 0o444);
+        assert_eq!(c.dir_mode, 0o555);
+        assert_eq!(c.uid, rustix::process::getuid().as_raw());
+        assert_eq!(c.gid, rustix::process::getgid().as_raw());
     }
 
     #[test]

--- a/musefs-fuse/src/platform/spotlight.rs
+++ b/musefs-fuse/src/platform/spotlight.rs
@@ -22,7 +22,7 @@ pub const MARKER_INO: u64 = u64::MAX;
 
 /// The marker's attributes: a zero-byte, read-only regular file owned by the
 /// mount, all timestamps set to `mtime` (matching synthetic-node stamping).
-pub fn marker_attr(uid: u32, gid: u32, mtime: SystemTime) -> FileAttr {
+pub fn marker_attr(uid: u32, gid: u32, file_mode: u16, mtime: SystemTime) -> FileAttr {
     FileAttr {
         ino: INodeNo(MARKER_INO),
         size: 0,
@@ -32,7 +32,7 @@ pub fn marker_attr(uid: u32, gid: u32, mtime: SystemTime) -> FileAttr {
         ctime: mtime,
         crtime: mtime,
         kind: FileType::RegularFile,
-        perm: 0o444,
+        perm: file_mode,
         nlink: 1,
         uid,
         gid,
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn marker_attr_is_zero_byte_read_only_file() {
         let mt = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
-        let a = marker_attr(501, 20, mt);
+        let a = marker_attr(501, 20, 0o444, mt);
         assert_eq!(a.ino, INodeNo(u64::MAX));
         assert_eq!(a.kind, FileType::RegularFile);
         assert_eq!(a.perm, 0o444);


### PR DESCRIPTION
## Summary

Adds four optional flags to `musefs mount` for controlling the ownership and permission bits the mount presents, and changes the default path template to an album-oriented layout.

- `--owner <NAME|UID>` / `--group <NAME|GID>` — present a chosen owner instead of the launching process's uid/gid. Accepts a username/groupname (resolved via `uzers`) or a numeric id; all-numeric strings are treated as ids, matching `chown`.
- `--file-mode <OCTAL>` / `--dir-mode <OCTAL>` — permission bits for files/dirs (default `444`/`555`). Parsed as octal (not decimal); the read-only mount makes write bits inert, so supplying them prints a one-line stderr warning.
- **Default template** changed from `$artist/$title` to `$albumartist/$album/$title`, matching the documented Mount example and common library structure.

All four flags are optional and default to today's behavior, so this is non-breaking apart from the template default.

## Design

`FuseConfig` now carries the presented `uid`/`gid`/`file_mode`/`dir_mode`; `FuseConfig::default()` resolves the process identity and the existing `0o555`/`0o444` defaults, so the `mount`/`spawn` helpers are unchanged. Name resolution and octal parsing live entirely in the CLI layer (clap `value_parser`s), so `musefs-fuse` only ever receives numeric ids and stays free of user-database lookups — preserving the crate layering.

Spec and implementation plan are included under `docs/superpowers/`; both went through two `spec-plan-reviewer` passes.

## Testing

- `cargo test --workspace` — 833 passed, 0 failed.
- New unit tests: owner/group numeric + name + empty/unknown-name errors; octal-not-decimal parsing + range rejection; write-bit warning fires/silent; flags flow into `FuseConfig`; no-flags matches `default()`; a dir/file mode **swap-mutant** test for the (mutation-gated) `to_file_attr`.
- FreeBSD portability of `uzers` verified by cross-build (`cargo build --target x86_64-unknown-freebsd -p musefs-cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mount flags `--owner`, `--group`, `--file-mode`, and `--dir-mode` to control UID/GID and file/directory permission bits on the mounted view.
  * Changed default path template from `$artist/$title` to `$albumartist/$album/$title`.

* **Documentation**
  * Added "Ownership and permissions" section to README documenting the new mount flags and their usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->