### PR TITLE
feat(beets): full field coverage + stateful merge sync (+ Picard naming)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,6 +172,14 @@ uses the same shared library from a Custom Script workflow. Its Lidarr
 destination tree is only a tracking aid, made of symlinks by default; musefs
 remains the consumer-facing filesystem.
 
+An external writer may **merge** rather than fully replace text tags — overwriting
+only the keys it manages and leaving the rest of the scan-seeded set in place —
+provided it tracks its own managed-key set out of band (the beets plugin uses a
+beets flexattr; the store is not the place for plugin state). musefs renders tags
+outside its native VOCAB (`musefs-format/src/tagmap.rs`) by passthrough (Vorbis
+uppercased, mp3 `TXXX`, mp4 freeform), so such tags appear but are not
+guaranteed byte-identical to a given tagger's own per-format encoding.
+
 External tools can also offload path layout entirely: a plugin evaluates its own
 (arbitrarily complex) path logic, writes the resulting relative path into a
 custom text tag — e.g. `INSERT INTO tags (track_id, key, value, ordinal) VALUES

--- a/contrib/beets/README.md
+++ b/contrib/beets/README.md
@@ -69,6 +69,21 @@ first; the hooks then skip gracefully if the DB is missing.
 
 ## Notes
 
+- **Field coverage:** every tag beets writes to a file (its `_media_tag_fields`)
+  is synced — ReplayGain, MusicBrainz IDs, comment, lyrics, grouping, isrc,
+  multi-valued artists, and any custom field — under canonical musefs keys.
+  Read-only file facts (bitrate, length, …) are never written as tags.
+- **Merge, not replace:** beets' values win for the fields it manages; any other
+  tag already embedded in the file is preserved in the view.
+- **Deletions stick:** the plugin records the keys it manages per track in a
+  `musefs_managed` beets flexattr (stored in the beets DB only — never in your
+  audio files or the musefs store). Remove a tag in beets and it is removed from
+  the view and stays gone across re-scans.
+- **`--restore-backing`** (or `restore_backing: yes`): when you remove a tag in
+  beets, let the file's original embedded value reappear instead of disappearing.
+- **Caveat:** sticky deletion relies on `autoscan: yes` (the default), which
+  re-derives the file's embedded tags before each sync. With `autoscan: no`, a
+  deletion only takes effect after your next manual `musefs scan`.
 - **Cover art:** taken from the album's `artpath` (beets' external cover file).
   beets art wins when present; otherwise any art `musefs scan` ingested from
   embedded pictures is preserved.

--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -9,37 +9,122 @@ import os
 
 from musefs_common import MAX_ART_BYTES, ArtImage, Record, realpath_key, sniff_mime
 
-# beets field name -> musefs (Vorbis-lowercase) tag key, for direct copies.
-# beets 2.x exposes genre/composer as the multi-valued `genres`/`composers`
-# (lists); the singular keys are kept for simpler/older items. List values are
-# expanded into one tag per element by _values().
-DIRECT_FIELDS = {
-    "title": "title",
-    "artist": "artist",
-    "albumartist": "albumartist",
-    "album": "album",
+MANAGED_FLEXATTR = "musefs_managed"
+
+# beets field name -> canonical musefs (Vorbis-lowercase) key, where they differ.
+RENAME = {
+    "track": "tracknumber",
+    "disc": "discnumber",
+    "comments": "comment",
+    "rg_track_gain": "replaygain_track_gain",
+    "rg_album_gain": "replaygain_album_gain",
+    "rg_track_peak": "replaygain_track_peak",
+    "rg_album_peak": "replaygain_album_peak",
+    "mb_trackid": "musicbrainz_trackid",
+    "mb_albumid": "musicbrainz_albumid",
+    "mb_artistid": "musicbrainz_artistid",
+    "mb_albumartistid": "musicbrainz_albumartistid",
+    "mb_releasegroupid": "musicbrainz_releasegroupid",
+    "mb_releasetrackid": "musicbrainz_releasetrackid",
+    "mb_workid": "musicbrainz_workid",
 }
 
-# (list_field, scalar_field, store_key): beets carries some tags as both a list
-# (genres/composers, beets 2.x) and a joined scalar (genre/composer). Emitting
-# both duplicates rows, so prefer the list when present, else the scalar. The
-# per-twin dedup below is scoped to one twin: if a user maps an extra_field onto
-# the "genre"/"composer" store key, that row is emitted in the direct-fields
-# loop and won't be deduped against these — an unlikely config we don't guard.
-TWIN_FIELDS = (
-    ("genres", "genre", "genre"),
-    ("composers", "composer", "composer"),
+# plural beets list field -> the singular beets field it collapses onto. The
+# plural wins when present; both resolve to one output key (via RENAME below) and
+# are emitted once so a value is never written twice.
+TWINS = {
+    "artists": "artist",
+    "albumartists": "albumartist",
+    "genres": "genre",
+    "composers": "composer",
+    "lyricists": "lyricist",
+    "arrangers": "arranger",
+    "remixers": "remixer",
+    "artists_sort": "artist_sort",
+    "albumartists_sort": "albumartist_sort",
+    "artists_credit": "artist_credit",
+    "albumartists_credit": "albumartist_credit",
+}
+
+# Assembled into `date`; never emitted under their own names.
+_DATE_PARTS = ("year", "month", "day")
+
+# Output keys dropped when their numeric value is zero (0 is noise here). `comp`
+# is a 0/1 int in beets, so dropping on zero covers both the int and bool forms
+# of a non-compilation.
+_DROP_IF_ZERO = {"tracknumber", "discnumber", "tracktotal", "disctotal", "comp"}
+
+# Used when an item has no _media_tag_fields (older beets / non-beets test stubs).
+FALLBACK_TAG_FIELDS = (
+    "title",
+    "artist",
+    "artists",
+    "albumartist",
+    "albumartists",
+    "album",
+    "genre",
+    "genres",
+    "composer",
+    "composers",
+    "track",
+    "disc",
+    "year",
+    "month",
+    "day",
 )
 
 
-def _values(value):
-    """Normalize a beets field value to a list of non-empty string values.
-    Multi-valued beets fields (genres, composers) arrive as lists; scalars
-    become a single-element list. Avoids stringifying a list as ``['Rock']``."""
+def _fmt_db(value):
+    return f"{float(value):.2f} dB"
+
+
+def _fmt_peak(value):
+    return f"{float(value):.6f}"
+
+
+# Per-output-key value formatters: the explicit exceptions to default stringify.
+FORMATTERS = {
+    "replaygain_track_gain": _fmt_db,
+    "replaygain_album_gain": _fmt_db,
+    "replaygain_track_peak": _fmt_peak,
+    "replaygain_album_peak": _fmt_peak,
+}
+
+
+def _output_key(field):
+    """beets field name -> canonical musefs store key (collapse twin, then rename)."""
+    base = TWINS.get(field, field)
+    return RENAME.get(base, base.lower())
+
+
+def _stringify(value, output_key):
+    """Render one beets value to a store string. Formatter exceptions first, then
+    the default: bool -> '1'/'0', integral float -> no trailing '.0', int -> str,
+    else str().strip()."""
+    formatter = FORMATTERS.get(output_key)
+    if formatter is not None:
+        return formatter(value)
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else str(value)
+    if isinstance(value, int):
+        return str(value)
+    return str(value).strip()
+
+
+def _iter_values(value):
+    """A beets field value as a list of raw (un-stringified) elements."""
     if value is None:
         return []
-    items = value if isinstance(value, (list, tuple)) else [value]
-    return [text for v in items if (text := str(v).strip())]
+    return list(value) if isinstance(value, (list, tuple)) else [value]
+
+
+def _is_zero(text):
+    try:
+        return float(text) == 0.0
+    except ValueError:
+        return False
 
 
 def _to_int(value):
@@ -63,41 +148,53 @@ def _format_date(item):
 
 
 def map_fields(item, extra_fields=None):
-    """Map a beets item to a list of (musefs_key, value) pairs.
+    """Map a beets item to a list of (musefs_key, value) pairs covering every tag
+    beets writes to a file (``item._media_tag_fields``), renamed to canonical
+    keys, multi-values expanded, file facts excluded automatically. ``extra_fields``
+    (the ``fields:`` config) is a final ``beets_field -> store_key`` override layer."""
+    field_names = list(getattr(item, "_media_tag_fields", FALLBACK_TAG_FIELDS))
+    # Process plural twins before singulars so the plural list wins its key.
+    ordered = sorted(field_names, key=lambda f: (f not in TWINS, f))
 
-    Empty strings and zero numerics are omitted. ``extra_fields`` merges into
-    (and can override) the direct-copy table.
-    """
-    fields = dict(DIRECT_FIELDS)
-    if extra_fields:
-        fields.update(extra_fields)
+    emitted = {}  # output_key -> list[str], insertion-ordered
+    for field in ordered:
+        if field in _DATE_PARTS:
+            continue
+        key = _output_key(field)
+        if key in emitted:
+            continue  # already claimed (plural beat singular, or a duplicate)
+        values = []
+        for raw in _iter_values(getattr(item, field, None)):
+            if raw is None:
+                continue
+            if isinstance(raw, str) and not raw.strip():
+                continue
+            if isinstance(raw, bool) and not raw:
+                continue  # comp=False etc. carry no info -> drop
+            text = _stringify(raw, key)
+            if not text:
+                continue
+            if key in _DROP_IF_ZERO and _is_zero(text):
+                continue
+            values.append(text)
+        if values:
+            emitted[key] = values
 
-    pairs = []
-    for beets_field, key in fields.items():
-        for text in _values(getattr(item, beets_field, None)):
-            pairs.append((key, text))
-
-    for list_field, scalar_field, key in TWIN_FIELDS:
-        values = _values(getattr(item, list_field, None)) or _values(
-            getattr(item, scalar_field, None)
-        )
-        seen = set()
-        for text in values:
-            if text not in seen:
-                seen.add(text)
-                pairs.append((key, text))
-
-    track = _to_int(getattr(item, "track", 0))
-    if track:
-        pairs.append(("tracknumber", str(track)))
-    disc = _to_int(getattr(item, "disc", 0))
-    if disc:
-        pairs.append(("discnumber", str(disc)))
     date = _format_date(item)
     if date:
-        pairs.append(("date", date))
+        emitted.setdefault("date", [date])
 
-    return pairs
+    if extra_fields:
+        for beets_field, store_key in extra_fields.items():
+            values = []
+            for raw in _iter_values(getattr(item, beets_field, None)):
+                if raw is None or (isinstance(raw, str) and not raw.strip()):
+                    continue
+                values.append(_stringify(raw, store_key))
+            if values:
+                emitted[store_key] = values  # override (last wins)
+
+    return [(key, value) for key, values in emitted.items() for value in values]
 
 
 def _album_art_path(item):

--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -72,10 +72,22 @@ TWINS = {
 # Assembled into `date`; never emitted under their own names.
 _DATE_PARTS = ("year", "month", "day")
 
-# Output keys dropped when their numeric value is zero (0 is noise here). `comp`
-# is a 0/1 int in beets, so dropping on zero covers both the int and bool forms
-# of a non-compilation.
-_DROP_IF_ZERO = {"tracknumber", "discnumber", "tracktotal", "disctotal", "comp"}
+# Output keys dropped when their numeric value is zero, because beets uses 0 as
+# the "unset" sentinel for these integer fields, so a stored 0 is noise rather
+# than a real value. `comp` is a 0/1 int, so this covers both its int and bool
+# forms. (ReplayGain is exempt — beets defaults it to None, not 0.0, so a stored
+# 0.00 dB is a real measured value and must survive.)
+_DROP_IF_ZERO = {
+    "tracknumber",
+    "discnumber",
+    "tracktotal",
+    "disctotal",
+    "comp",
+    "bpm",
+    "original_year",
+    "original_month",
+    "original_day",
+}
 
 # Used when an item has no _media_tag_fields (older beets / non-beets test stubs).
 FALLBACK_TAG_FIELDS = (

--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -11,6 +11,29 @@ from musefs_common import MAX_ART_BYTES, ArtImage, Record, realpath_key, sniff_m
 
 MANAGED_FLEXATTR = "musefs_managed"
 
+
+def read_managed(item):
+    """Parse the per-item ``musefs_managed`` flexattr into a list of keys."""
+    raw = getattr(item, MANAGED_FLEXATTR, None)
+    if not raw:
+        return []
+    return [k for k in str(raw).split(",") if k]
+
+
+def format_managed(keys):
+    """Serialize a managed key set: sorted, de-duplicated, comma-joined."""
+    return ",".join(sorted(set(keys)))
+
+
+def persist_managed(writes):
+    """Persist each ``(item, managed_keys)`` pair into the beets DB via
+    ``item.store()``. Never calls ``item.write()`` — that writes the audio file and
+    fires ``after_write``, which would re-enter the plugin's reconcile loop."""
+    for item, keys in writes:
+        item[MANAGED_FLEXATTR] = format_managed(keys)
+        item.store()
+
+
 # beets field name -> canonical musefs (Vorbis-lowercase) key, where they differ.
 RENAME = {
     "track": "tracknumber",
@@ -269,14 +292,21 @@ def _computed_path_or_skip(item, log):
         return ""
 
 
-def build_records(items, *, fields=None, stats, write_path=True, log=None):
-    """Build ``Record``s for beets items: map tags and resolve album art (with a
-    per-run cache; unreadable/over-cap covers counted into ``stats.skipped_art``).
-    When ``write_path`` is set, also emit a ``beets_path`` tag with the track's
-    beets library-relative path (extension stripped); a failed computation is
-    skipped and warned through ``log``. ``stats`` is mutated and must be the same
-    instance passed to ``sync_files``."""
+def build_records(items, *, fields=None, stats, write_path=True, restore_backing=False, log=None):
+    """Build ``Record``s for beets items and the parallel managed-key writes.
+
+    Returns ``(records, managed_writes)`` where ``managed_writes`` is a list of
+    ``(item, managed_keys)`` the caller persists *after a successful commit* via
+    ``persist_managed``.
+
+    ``musefs_managed`` is an *accumulating* set (keys ever managed): each record's
+    ``delete_keys`` is ``prev - keys(M)`` and the persisted set is the union
+    ``prev | keys(M)``, so a key dropped from M stays a tombstone and keeps getting
+    re-deleted on every sync until it re-enters M or ``restore_backing`` clears it.
+    Under ``restore_backing`` no keys are deleted and the set is reset to ``keys(M)``
+    (tombstones forgotten), so restored backing values stay visible."""
     records = []
+    managed_writes = []
     art_cache = {}
     for item in items:
         cover = _read_album_art(item, art_cache, stats)
@@ -285,11 +315,21 @@ def build_records(items, *, fields=None, stats, write_path=True, log=None):
             path = _computed_path_or_skip(item, log)
             if path:
                 pairs.append(("beets_path", path))
+        keys_now = {key for key, _ in pairs}
+        prev = set(read_managed(item))
+        if restore_backing:
+            delete_keys = []
+            managed = sorted(keys_now)
+        else:
+            delete_keys = sorted(prev - keys_now)
+            managed = sorted(prev | keys_now)
         records.append(
             Record(
                 key=realpath_key(item.path),
                 pairs=pairs,
                 art=[ArtImage(*cover)] if cover else None,
+                delete_keys=delete_keys,
             )
         )
-    return records
+        managed_writes.append((item, managed))
+    return records, managed_writes

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -32,6 +32,7 @@ class MusefsPlugin(BeetsPlugin):
             "bin": "musefs",  # musefs executable (PATH name or full path)
             "autoscan": True,  # run `musefs scan` automatically before syncing
             "write_path": True,  # emit a beets_path tag for $!{beets_path} mounts
+            "restore_backing": False,  # on delete, let the backing tag value reappear
         })
         # beets has no file-move event, and `after_write` fires *before* a move
         # (at the old path). So imports/writes are recorded and reconciled once
@@ -61,6 +62,13 @@ class MusefsPlugin(BeetsPlugin):
             default=False,
             help="report what would change without writing",
         )
+        cmd.parser.add_option(
+            "--restore-backing",
+            dest="restore_backing",
+            action="store_true",
+            default=False,
+            help="when a tag is removed in beets, let the backing file's value reappear",
+        )
         cmd.func = self._command
         return [cmd]
 
@@ -86,7 +94,8 @@ class MusefsPlugin(BeetsPlugin):
                 [os.fsdecode(i.path) for i in items] if query else [os.fsdecode(lib.directory)]
             )
             self._run_scan(db_path, targets)
-        stats = self._sync(db_path, items, dry_run=opts.dry_run)
+        restore_backing = bool(opts.restore_backing) or self._restore_backing()
+        stats = self._sync(db_path, items, dry_run=opts.dry_run, restore_backing=restore_backing)
         if opts.dry_run:
             pruned = 0
         else:
@@ -121,7 +130,7 @@ class MusefsPlugin(BeetsPlugin):
         try:
             if self._autoscan():
                 self._run_scan(db_path, [os.fsdecode(i.path) for i in items])
-            self._sync(db_path, items)
+            self._sync(db_path, items, restore_backing=self._restore_backing())
             self._prune_missing(db_path)
         except (ui.UserError, sqlite3.Error, OSError, subprocess.SubprocessError) as exc:
             # A passive cli_exit hook must never abort the beets operation for an
@@ -147,6 +156,9 @@ class MusefsPlugin(BeetsPlugin):
 
     def _write_path(self):
         return bool(self.config["write_path"].get(bool))
+
+    def _restore_backing(self):
+        return bool(self.config["restore_backing"].get(bool))
 
     def _bin(self):
         return self.config["bin"].get(str) or "musefs"

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -200,7 +200,7 @@ class MusefsPlugin(BeetsPlugin):
         finally:
             conn.close()
 
-    def _sync(self, db_path, items, dry_run=False):
+    def _sync(self, db_path, items, dry_run=False, restore_backing=False):
         if not os.path.exists(db_path):
             raise ui.UserError(
                 f"musefs: DB not found at {db_path}; enable `musefs.autoscan` "
@@ -210,18 +210,20 @@ class MusefsPlugin(BeetsPlugin):
         try:
             check_schema_version(conn)
             stats = SyncStats()
-            records = _core.build_records(
+            records, managed_writes = _core.build_records(
                 items,
                 fields=self._fields(),
                 stats=stats,
                 write_path=self._write_path(),
+                restore_backing=restore_backing,
                 log=self._log,
             )
-            sync_files(conn, records, dry_run=dry_run, stats=stats)
+            sync_files(conn, records, dry_run=dry_run, stats=stats, merge=True)
             if dry_run:
                 conn.rollback()
             else:
                 conn.commit()
+                _core.persist_managed(managed_writes)
             return stats
         except SchemaMismatch as exc:
             conn.rollback()

--- a/contrib/beets/tests/conftest.py
+++ b/contrib/beets/tests/conftest.py
@@ -73,6 +73,13 @@ class FakeItem:
     def get_album(self):
         return self._album
 
+    def __setitem__(self, key, value):
+        # beets flexattr write; readable back via getattr (used by read_managed).
+        setattr(self, key, value)
+
+    def store(self):
+        self.stored = getattr(self, "stored", 0) + 1
+
 
 @pytest.fixture
 def fake_item():

--- a/contrib/beets/tests/test_build_records.py
+++ b/contrib/beets/tests/test_build_records.py
@@ -6,7 +6,7 @@ from beetsplug import _core
 def test_build_records_maps_fields(fake_item):
     item = fake_item(b"/m/a.flac", title="T", artist="A", genre=["Rock", "Pop"])
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats)
+    records, _ = _core.build_records([item], fields=None, stats=stats)
     assert len(records) == 1
     pairs = records[0].pairs
     assert ("title", "T") in pairs
@@ -21,7 +21,7 @@ def test_build_records_reads_album_art(fake_item, fake_album, tmp_path):
     album = fake_album(artpath=str(cover).encode())
     item = fake_item(b"/m/a.flac", album=album, title="T")
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats)
+    records, _ = _core.build_records([item], fields=None, stats=stats)
     assert records[0].art is not None
     (img,) = records[0].art
     assert img.mime == "image/jpeg"
@@ -34,7 +34,7 @@ def test_build_records_counts_unreadable_art_once(fake_item, fake_album):
     album = fake_album(artpath=b"/does/not/exist.jpg")
     items = [fake_item(b"/m/a.flac", album=album), fake_item(b"/m/b.flac", album=album)]
     stats = SyncStats()
-    records = _core.build_records(items, fields=None, stats=stats)
+    records, _ = _core.build_records(items, fields=None, stats=stats)
     assert all(r.art is None for r in records)
     # Cached per realpath, so a shared missing cover counts once (legacy behavior).
     assert stats.skipped_art == 1
@@ -48,7 +48,7 @@ def test_build_records_counts_oversized_art_once(fake_item, fake_album, tmp_path
     album = fake_album(artpath=str(cover).encode())
     items = [fake_item(b"/m/a.flac", album=album), fake_item(b"/m/b.flac", album=album)]
     stats = SyncStats()
-    records = _core.build_records(items, fields=None, stats=stats)
+    records, _ = _core.build_records(items, fields=None, stats=stats)
     assert all(r.art is None for r in records)
     assert stats.skipped_art == 1
 
@@ -66,14 +66,14 @@ class _RecordingLog:
 def test_build_records_writes_beets_path_stripping_extension(fake_item):
     item = fake_item(b"/m/a.flac", title="T", destination=b"Artist/Album/01 Song.flac")
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats)
+    records, _ = _core.build_records([item], fields=None, stats=stats)
     assert ("beets_path", "Artist/Album/01 Song") in records[0].pairs
 
 
 def test_build_records_omits_beets_path_when_write_path_false(fake_item):
     item = fake_item(b"/m/a.flac", title="T", destination=b"Artist/Album/01 Song.flac")
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats, write_path=False)
+    records, _ = _core.build_records([item], fields=None, stats=stats, write_path=False)
     assert all(k != "beets_path" for k, _ in records[0].pairs)
 
 
@@ -81,7 +81,7 @@ def test_build_records_skips_beets_path_on_error_and_warns(fake_item):
     item = fake_item(b"/m/a.flac", title="T", destination_raises=True)
     log = _RecordingLog()
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats, log=log)
+    records, _ = _core.build_records([item], fields=None, stats=stats, log=log)
     assert all(k != "beets_path" for k, _ in records[0].pairs)
     assert ("title", "T") in records[0].pairs  # other tags still sync
     assert log.warnings  # a warning was emitted
@@ -92,7 +92,7 @@ def test_build_records_beets_path_is_utf8_safe_for_non_unicode_paths(fake_item):
     # surrogate that SQLite's TEXT encoder would reject.
     item = fake_item(b"/m/a.flac", destination=b"Art\xffist/Album/01 Song.flac")
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats)
+    records, _ = _core.build_records([item], fields=None, stats=stats)
     value = dict(records[0].pairs)["beets_path"]
     value.encode("utf-8")  # must not raise
     assert value.startswith("Art")
@@ -113,6 +113,6 @@ def test_build_records_uses_real_beets_destination(tmp_path):
     item.path = b"/music/x.flac"  # supplies the .flac extension
     lib.add(item)  # assigns an id and binds the library, required by destination()
     stats = SyncStats()
-    records = _core.build_records([item], fields=None, stats=stats)
+    records, _ = _core.build_records([item], fields=None, stats=stats)
     # beets sanitizes "AC/DC" -> "AC_DC" and zero-pads $track; we strip ".flac".
     assert ("beets_path", "AC_DC/Back in Black/01 Hells Bells") in records[0].pairs

--- a/contrib/beets/tests/test_e2e.py
+++ b/contrib/beets/tests/test_e2e.py
@@ -602,3 +602,40 @@ def test_e2e_art_precedence_beets_wins(tmp_path):
     with _mounted(mnt, db, "$albumartist/$album/$title"):
         # beets art (external B) wins; the embedded A must not survive.
         _check_mount_art(cfg, env, mnt, external_sha)
+
+
+def test_e2e_full_fields_sticky_delete_and_restore(tmp_path):
+    """Rich fields reach the mount; a deleted file-embedded tag stays gone across
+    re-scans; --restore-backing brings the backing value back."""
+    cfg, env, db, mnt, library = _imported_library(tmp_path)
+    template = "$albumartist/$album/$title"
+
+    _beet(
+        cfg,
+        env,
+        "modify",
+        "-M",
+        "-y",
+        "format:FLAC",
+        "comments=from file",
+        "rg_track_gain=-7.5",
+        "mb_albumid=11111111-1111-1111-1111-111111111111",
+    )
+    _beet(cfg, env, "musefs")
+    with _mounted(mnt, db, template):
+        ft = FLAC(str(next(mnt.rglob("*.flac"))))
+        assert ft["replaygain_track_gain"][0].endswith("dB")
+        assert ft["musicbrainz_albumid"][0].startswith("11111111")
+        assert ft["comment"][0] == "from file"
+
+    _beet(cfg, env, "modify", "-W", "-M", "-y", "format:FLAC", "comments!")
+    _beet(cfg, env, "musefs")
+    _beet(cfg, env, "musefs")
+    with _mounted(mnt, db, template):
+        ft = FLAC(str(next(mnt.rglob("*.flac"))))
+        assert "comment" not in ft
+
+    _beet(cfg, env, "musefs", "--restore-backing")
+    with _mounted(mnt, db, template):
+        ft = FLAC(str(next(mnt.rglob("*.flac"))))
+        assert ft["comment"][0] == "from file"

--- a/contrib/beets/tests/test_managed_state.py
+++ b/contrib/beets/tests/test_managed_state.py
@@ -1,0 +1,60 @@
+from conftest import FakeItem
+from musefs_common import SyncStats
+
+from beetsplug import _core
+
+
+def _item(**kw):
+    return FakeItem(b"/m/a.flac", **kw)
+
+
+def test_read_managed_empty_and_parsed():
+    it = _item()
+    assert _core.read_managed(it) == []
+    it["musefs_managed"] = "artist,comment,title"
+    assert _core.read_managed(it) == ["artist", "comment", "title"]
+
+
+def test_format_managed_sorts_and_dedupes():
+    assert _core.format_managed(["title", "artist", "artist"]) == "artist,title"
+
+
+def test_persist_managed_writes_flexattr_via_store():
+    it = _item()
+    _core.persist_managed([(it, ["artist", "title"])])
+    assert it.musefs_managed == "artist,title"
+    assert it.stored == 1
+
+
+def test_build_records_delete_keys_and_union_persist():
+    it = _item(title="T", artist="A")
+    it["musefs_managed"] = "artist,title,grouping"  # grouping was managed before
+    records, writes = _core.build_records(
+        [it], fields={}, stats=SyncStats(), write_path=False, restore_backing=False
+    )
+    rec = records[0]
+    assert rec.delete_keys == ["grouping"]  # dropped from M -> delete
+    assert ("title", "T") in rec.pairs and ("artist", "A") in rec.pairs
+    item, managed = writes[0]
+    assert item is it
+    # UNION: grouping stays in musefs_managed as a tombstone so the delete sticks
+    assert set(managed) == {"title", "artist", "grouping"}
+
+
+def test_build_records_restore_backing_clears_deletes_and_tombstones():
+    it = _item(title="T")
+    it["musefs_managed"] = "title,grouping"
+    records, writes = _core.build_records(
+        [it], fields={}, stats=SyncStats(), write_path=False, restore_backing=True
+    )
+    assert records[0].delete_keys == []
+    assert set(writes[0][1]) == {"title"}
+
+
+def test_build_records_beets_path_is_managed():
+    it = _item(title="T", destination=b"Artist/Album/01 T.flac")
+    records, writes = _core.build_records(
+        [it], fields={}, stats=SyncStats(), write_path=True, restore_backing=False
+    )
+    assert "beets_path" in {k for k, _ in records[0].pairs}
+    assert "beets_path" in writes[0][1]

--- a/contrib/beets/tests/test_map_fields.py
+++ b/contrib/beets/tests/test_map_fields.py
@@ -139,3 +139,24 @@ def test_extra_fields_override_wins():
 
 def test_bpm_int_no_trailing_dot_zero():
     assert dict(map_fields(item(bpm=120)))["bpm"] == "120"
+
+
+def test_real_item_bare_emits_no_zero_sentinel_fields():
+    """Against a REAL beets Item (not a stub), the integer fields beets defaults to
+    0 as an 'unset' sentinel must not leak as "0" tags. This exercises the real
+    `_media_tag_fields` boundary that the SimpleNamespace tests above do not."""
+    import pytest
+
+    beets_library = pytest.importorskip("beets.library")
+    it = beets_library.Item()
+    it.title = "Bare"
+    it.artist = "X"
+    d = dict(map_fields(it))
+    for noise in ("bpm", "original_year", "original_month", "original_day"):
+        assert noise not in d, f"{noise} leaked as {d.get(noise)!r}"
+    # A real value still comes through (we drop the zero sentinel, not the field).
+    it.original_year = 1999
+    it.bpm = 128
+    d = dict(map_fields(it))
+    assert d["original_year"] == "1999"
+    assert d["bpm"] == "128"

--- a/contrib/beets/tests/test_map_fields.py
+++ b/contrib/beets/tests/test_map_fields.py
@@ -2,100 +2,140 @@ from types import SimpleNamespace
 
 from beetsplug._core import map_fields
 
+# Fields a real beets Item exposes via Item._media_tag_fields. Tests attach this
+# so map_fields iterates the same boundary it will in production.
+_TAG_FIELDS = (
+    "title",
+    "artist",
+    "artists",
+    "albumartist",
+    "albumartists",
+    "album",
+    "genre",
+    "genres",
+    "composer",
+    "composers",
+    "comments",
+    "grouping",
+    "isrc",
+    "lyrics",
+    "bpm",
+    "comp",
+    "track",
+    "tracktotal",
+    "disc",
+    "disctotal",
+    "year",
+    "month",
+    "day",
+    "rg_track_gain",
+    "rg_album_gain",
+    "rg_track_peak",
+    "rg_album_peak",
+    "mb_albumid",
+    "mb_artistid",
+    "mb_trackid",
+    "artist_sort",
+    "artists_sort",
+    "bitrate",
+    "length",
+    "format",  # file facts: present on item, NOT tag fields
+)
+_FILE_FACTS = {"bitrate", "length", "format"}
+_TAG_ONLY = tuple(f for f in _TAG_FIELDS if f not in _FILE_FACTS)
+
 
 def item(**kw):
-    base = dict(
-        title="",
-        artist="",
-        albumartist="",
-        album="",
-        genre="",
-        composer="",
-        track=0,
-        disc=0,
-        year=0,
-        month=0,
-        day=0,
-    )
+    base = {f: "" for f in _TAG_FIELDS}
+    base.update({
+        f: 0 for f in ("track", "tracktotal", "disc", "disctotal", "year", "month", "day", "bpm")
+    })
+    base.update({"comp": False, "bitrate": 320000, "length": 210.0, "format": "FLAC"})
     base.update(kw)
-    return SimpleNamespace(**base)
+    ns = SimpleNamespace(**base)
+    ns._media_tag_fields = _TAG_ONLY  # boundary excludes the file facts
+    return ns
 
 
-def test_direct_fields_copied():
-    pairs = map_fields(item(title="Song", artist="Band", album="Disc"))
-    d = dict(pairs)
-    assert d["title"] == "Song"
-    assert d["artist"] == "Band"
-    assert d["album"] == "Disc"
+def test_core_fields_copied():
+    d = dict(map_fields(item(title="Song", artist="Band", album="Disc")))
+    assert d["title"] == "Song" and d["artist"] == "Band" and d["album"] == "Disc"
 
 
-def test_track_and_disc_renamed():
-    pairs = dict(map_fields(item(track=7, disc=2)))
-    assert pairs["tracknumber"] == "7"
-    assert pairs["discnumber"] == "2"
+def test_track_disc_renamed_and_zero_dropped():
+    d = dict(map_fields(item(track=7, disc=2)))
+    assert d["tracknumber"] == "7" and d["discnumber"] == "2"
+    assert "tracknumber" not in dict(map_fields(item(track=0)))
 
 
-def test_year_only_date():
-    assert dict(map_fields(item(year=1999)))["date"] == "1999"
+def test_replaygain_renamed_and_formatted():
+    pairs = dict(map_fields(item(rg_track_gain=-7.5, rg_track_peak=0.987654321)))
+    assert pairs["replaygain_track_gain"] == "-7.50 dB"
+    assert pairs["replaygain_track_peak"].startswith("0.98")
+    assert "rg_track_gain" not in pairs
 
 
-def test_full_date_when_month_and_day():
-    assert dict(map_fields(item(year=1999, month=3, day=5)))["date"] == "1999-03-05"
+def test_replaygain_zero_gain_survives():
+    # 0 dB is a real measured value and must NOT be dropped.
+    assert dict(map_fields(item(rg_track_gain=0.0)))["replaygain_track_gain"] == "0.00 dB"
 
 
-def test_partial_date_falls_back_to_year():
-    # month without day -> year only (we only emit a full date when both set)
-    assert dict(map_fields(item(year=1999, month=3)))["date"] == "1999"
+def test_musicbrainz_renamed():
+    d = dict(map_fields(item(mb_albumid="abc", mb_artistid="def", mb_trackid="ghi")))
+    assert d["musicbrainz_albumid"] == "abc"
+    assert d["musicbrainz_artistid"] == "def"
+    assert d["musicbrainz_trackid"] == "ghi"
 
 
-def test_empty_and_zero_omitted():
-    pairs = dict(map_fields(item()))
-    assert pairs == {}
+def test_comments_renamed_to_comment():
+    assert dict(map_fields(item(comments="hi")))["comment"] == "hi"
 
 
-def test_whitespace_only_omitted():
-    assert "title" not in dict(map_fields(item(title="   ")))
+def test_plural_artist_wins_and_expands():
+    pairs = map_fields(item(artist="Joined", artists=["A", "B"]))
+    artists = [v for k, v in pairs if k == "artist"]
+    assert artists == ["A", "B"]  # plural list wins, one row each
 
 
-def test_extra_field_override():
-    it = item(title="Song")
-    it.comments = "hi there"
-    pairs = dict(map_fields(it, extra_fields={"comments": "comment"}))
-    assert pairs["comment"] == "hi there"
-    assert pairs["title"] == "Song"
+def test_singular_artist_used_when_plural_empty():
+    pairs = map_fields(item(artist="Solo", artists=[]))
+    assert [v for k, v in pairs if k == "artist"] == ["Solo"]
 
 
-def test_extra_field_overrides_existing_key():
-    # Overriding an existing beets field remaps its destination key.
-    pairs = dict(map_fields(item(title="Song"), extra_fields={"title": "subtitle"}))
-    assert pairs["subtitle"] == "Song"
-    assert "title" not in pairs
+def test_genre_plural_collapses_to_genre_key():
+    pairs = map_fields(item(genres=["Rock", "Pop"]))
+    assert [v for k, v in pairs if k == "genre"] == ["Rock", "Pop"]
 
 
-def test_non_numeric_track_does_not_crash():
-    # A malformed track like "1/12" must not raise; it is dropped, not emitted.
-    pairs = dict(map_fields(item(track="1/12")))
-    assert "tracknumber" not in pairs
+def test_comp_one_kept_zero_dropped():
+    # beets `comp` is a 0/1 int; bool here too. 1 -> kept "1", 0/False -> dropped.
+    assert dict(map_fields(item(comp=True)))["comp"] == "1"
+    assert dict(map_fields(item(comp=1)))["comp"] == "1"
+    assert "comp" not in dict(map_fields(item(comp=False)))
+    assert "comp" not in dict(map_fields(item(comp=0)))
 
 
-def test_genre_and_genres_deduped_prefer_list():
-    # Both the scalar and list set: prefer the list, dedupe, preserve order.
-    pairs = map_fields(item(genre="Rock", genres=["Rock", "Indie"]))
-    genres = [v for k, v in pairs if k == "genre"]
-    assert genres == ["Rock", "Indie"]  # not ["Rock", "Rock", "Indie"]
+def test_file_facts_excluded():
+    d = dict(map_fields(item()))
+    assert "bitrate" not in d and "length" not in d and "format" not in d
 
 
-def test_composer_and_composers_deduped_prefer_list():
-    pairs = map_fields(item(composer="Bach", composers=["Bach", "Mozart"]))
-    composers = [v for k, v in pairs if k == "composer"]
-    assert composers == ["Bach", "Mozart"]
+def test_date_assembled_and_parts_not_emitted():
+    d = dict(map_fields(item(year=1999, month=3, day=5)))
+    assert d["date"] == "1999-03-05"
+    assert "year" not in d and "month" not in d and "day" not in d
 
 
-def test_genre_scalar_only_when_no_list():
-    pairs = map_fields(item(genre="Jazz"))
-    assert [v for k, v in pairs if k == "genre"] == ["Jazz"]
+def test_arbitrary_passthrough_lowercased():
+    d = dict(map_fields(item(grouping="Set", isrc="US-X", lyrics="la")))
+    assert d["grouping"] == "Set" and d["isrc"] == "US-X" and d["lyrics"] == "la"
 
 
-def test_genres_list_only_when_no_scalar():
-    pairs = map_fields(item(genres=["Folk", "Pop"]))
-    assert [v for k, v in pairs if k == "genre"] == ["Folk", "Pop"]
+def test_extra_fields_override_wins():
+    # `fields:` maps a beets field onto a store key, last-wins.
+    d = dict(map_fields(item(comments="orig", bpm=120), extra_fields={"bpm": "comment"}))
+    assert d["comment"] == "120"  # override beat the comments->comment rename
+
+
+def test_bpm_int_no_trailing_dot_zero():
+    assert dict(map_fields(item(bpm=120)))["bpm"] == "120"

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip("beets")
 
 from beets.library import Item  # noqa: E402
+from conftest import FakeItem, insert_track  # noqa: E402
 from musefs_common import connect  # noqa: E402
 
 from beetsplug._core import map_fields  # noqa: E402
@@ -342,3 +343,109 @@ def test_sync_omits_beets_path_when_disabled(db_path, make_track, fake_item, tmp
         )
     finally:
         conn.close()
+
+
+# --- restore_backing tests ------------------------------------------------
+
+
+def _seed_track_with_tag(db_path, real_path, key, value):
+    conn = connect(db_path)
+    tid = insert_track(conn, real_path)
+    conn.execute(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?,?,?,0)", (tid, key, value)
+    )
+    conn.commit()
+    conn.close()
+    return tid
+
+
+def _text_tags(db_path, tid):
+    conn = connect(db_path)
+    rows = dict(
+        conn.execute("SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL", (tid,))
+    )
+    conn.close()
+    return rows
+
+
+def test_sync_merges_keeps_unmanaged_and_persists(db_path, tmp_path, monkeypatch):
+    """Command path: B persists, M wins, managed flexattr written via store()."""
+    p = tmp_path / "a.flac"
+    p.write_bytes(b"")
+    real = os.path.realpath(str(p))
+    tid = _seed_track_with_tag(db_path, real, "comment", "keep")
+
+    item = FakeItem(str(p).encode(), artist="New")
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({
+            "db": db_path,
+            "fields": {},
+            "write_path": False,
+            "restore_backing": False,
+        }),
+        raising=False,
+    )
+    plugin._sync(db_path, [item], dry_run=False, restore_backing=False)
+
+    tags = _text_tags(db_path, tid)
+    assert tags["artist"] == "New"  # M wins
+    assert tags["comment"] == "keep"  # unmanaged B persists (merge, not replace)
+    assert "artist" in item.musefs_managed  # managed set persisted via store()
+
+
+def test_reconcile_path_merges_and_sticky_deletes(db_path, tmp_path, monkeypatch):
+    """Passive cli_exit path runs the same merge + managed-state cycle, and a key
+    dropped from a prior managed set is deleted (tombstone)."""
+    p = tmp_path / "b.flac"
+    p.write_bytes(b"")
+    real = os.path.realpath(str(p))
+    tid = _seed_track_with_tag(db_path, real, "grouping", "old")
+
+    item = FakeItem(str(p).encode(), title="T")
+    item["musefs_managed"] = "grouping,title"  # grouping managed before; now dropped
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({
+            "db": db_path,
+            "fields": {},
+            "write_path": False,
+            "autoscan": False,
+            "restore_backing": False,
+        }),
+        raising=False,
+    )
+    monkeypatch.setattr(plugin, "_run_scan", lambda db, targets: None)
+    plugin._pending = [item]
+    plugin._reconcile_pending(lib=None)
+
+    tags = _text_tags(db_path, tid)
+    assert tags.get("title") == "T"  # merged on the reconcile path
+    assert "grouping" not in tags  # tombstoned delete applied on the reconcile path
+
+
+def test_restore_backing_skips_deletes(db_path, tmp_path, monkeypatch):
+    """With restore_backing, a previously-managed-now-dropped key is NOT deleted."""
+    p = tmp_path / "c.flac"
+    p.write_bytes(b"")
+    real = os.path.realpath(str(p))
+    tid = _seed_track_with_tag(db_path, real, "grouping", "frombacking")
+
+    item = FakeItem(str(p).encode(), title="T")
+    item["musefs_managed"] = "grouping,title"
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": False, "restore_backing": True}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item], dry_run=False, restore_backing=True)
+
+    tags = _text_tags(db_path, tid)
+    assert tags["grouping"] == "frombacking"  # backing value left in place
+    assert set(item.musefs_managed.split(",")) == {"title"}  # tombstones cleared

--- a/contrib/beets/tests/test_reconcile.py
+++ b/contrib/beets/tests/test_reconcile.py
@@ -24,9 +24,10 @@ def _plugin(monkeypatch, *, sync_raises=None):
     plugin._pending = [SimpleNamespace(path=b"/music/a.flac")]
     plugin._db_path = lambda: "/db.sqlite"
     plugin._autoscan = lambda: False
+    plugin._restore_backing = lambda: False
     plugin._prune_missing = lambda db: None
 
-    def _sync(db, items):
+    def _sync(db, items, **kwargs):
         if sync_raises is not None:
             raise sync_raises
 

--- a/contrib/beets/tests/test_smoke.py
+++ b/contrib/beets/tests/test_smoke.py
@@ -12,7 +12,7 @@ def test_core_imports_without_beets():
     code = (
         "import sys; sys.modules['beets'] = None; "
         "import beetsplug._core as c; "
-        "assert c.DIRECT_FIELDS and c.map_fields and c.build_records"
+        "assert c.RENAME and c.map_fields and c.build_records"
     )
     env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
     subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/contrib/picard/musefs/_common/__init__.py
+++ b/contrib/picard/musefs/_common/__init__.py
@@ -16,6 +16,7 @@ from .scan import run_scan
 from .store import (
     check_schema_version,
     connect,
+    merge_tags,
     prune_missing,
     replace_tags,
     replace_track_art,
@@ -39,6 +40,7 @@ __all__ = [
     "check_schema_version",
     "track_id_for_path",
     "prune_missing",
+    "merge_tags",
     "replace_tags",
     "upsert_art",
     "replace_track_art",

--- a/contrib/picard/musefs/_common/store.py
+++ b/contrib/picard/musefs/_common/store.py
@@ -73,6 +73,34 @@ def replace_tags(conn, track_id, pairs):
     )
 
 
+def merge_tags(conn, track_id, managed_pairs, delete_keys):
+    """Per-key replace of the plugin-managed text tags, leaving unmanaged text
+    rows (the scan-seeded baseline) intact. ``managed_pairs`` is an ordered list
+    of (key, value); every key it names is cleared and rewritten with contiguous
+    ordinals. ``delete_keys`` names keys to clear without rewriting (tags the
+    plugin previously managed and the user has now removed). Both deletes are
+    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive."""
+    by_key = {}
+    for key, value in managed_pairs:
+        by_key.setdefault(key, []).append(value)
+
+    for key in set(by_key) | set(delete_keys or ()):
+        conn.execute(
+            "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+            (track_id, key),
+        )
+
+    rows = [
+        (track_id, key, value, ordinal)
+        for key, values in by_key.items()
+        for ordinal, value in enumerate(values)
+    ]
+    conn.executemany(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+
+
 _EXT_MIME = {
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",

--- a/contrib/picard/musefs/_common/sync.py
+++ b/contrib/picard/musefs/_common/sync.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .constants import MAX_ART_BYTES
-from .store import replace_tags, replace_track_art, track_id_for_path, upsert_art
+from .store import merge_tags, replace_tags, replace_track_art, track_id_for_path, upsert_art
 
 
 @dataclass(frozen=True)
@@ -29,6 +29,7 @@ class Record:
     key: str
     pairs: list = field(default_factory=list)
     art: object = None  # list[ArtImage] | None
+    delete_keys: object = None  # list[str] of keys to clear without rewrite (merge mode)
 
 
 @dataclass
@@ -45,7 +46,7 @@ class SyncStats:
         )
 
 
-def sync_one(conn, record, stats, *, dry_run=False):
+def sync_one(conn, record, stats, *, dry_run=False, merge=False):
     """Sync one ``Record`` into the DB, mutating ``stats``. Caller owns the
     transaction. Tags are always fully replaced (scanner-written binary tags
     survive — see ``replace_tags``). Art is replaced when at least one image is
@@ -66,7 +67,10 @@ def sync_one(conn, record, stats, *, dry_run=False):
     will_link_art = bool(kept)
 
     if not dry_run:
-        replace_tags(conn, track_id, record.pairs)
+        if merge:
+            merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+        else:
+            replace_tags(conn, track_id, record.pairs)
         if will_link_art:
             arts = [
                 (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
@@ -79,7 +83,7 @@ def sync_one(conn, record, stats, *, dry_run=False):
     stats.synced += 1
 
 
-def sync_files(conn, records, *, dry_run=False, stats=None):
+def sync_files(conn, records, *, dry_run=False, stats=None, merge=False):
     """Sync an iterable of ``Record``s, returning the ``SyncStats``. Pass
     ``stats`` to accumulate into a caller-seeded instance (e.g. beets pre-counts
     unreadable art); otherwise a fresh one is created. Caller owns the
@@ -87,5 +91,5 @@ def sync_files(conn, records, *, dry_run=False, stats=None):
     if stats is None:
         stats = SyncStats()
     for record in records:
-        sync_one(conn, record, stats, dry_run=dry_run)
+        sync_one(conn, record, stats, dry_run=dry_run, merge=merge)
     return stats

--- a/contrib/picard/musefs/_common/sync.py
+++ b/contrib/picard/musefs/_common/sync.py
@@ -48,8 +48,10 @@ class SyncStats:
 
 def sync_one(conn, record, stats, *, dry_run=False, merge=False):
     """Sync one ``Record`` into the DB, mutating ``stats``. Caller owns the
-    transaction. Tags are always fully replaced (scanner-written binary tags
-    survive — see ``replace_tags``). Art is replaced when at least one image is
+    transaction. With ``merge=False`` (the default) all plugin-owned text tags are
+    replaced; with ``merge=True`` only the keys in ``record.pairs`` and
+    ``record.delete_keys`` are touched (see ``merge_tags``). Either way,
+    scanner-written binary tags survive. Art is replaced when at least one image is
     within ``MAX_ART_BYTES``; each over-cap image bumps ``skipped_art``, and if
     every provided image is over cap any scan-seeded ``track_art`` is left
     untouched."""

--- a/contrib/picard/musefs/_core.py
+++ b/contrib/picard/musefs/_core.py
@@ -24,6 +24,16 @@ DIRECT_FIELDS = {
     "tracknumber": "tracknumber",
     "discnumber": "discnumber",
     "date": "date",
+    "comment": "comment",
+    "lyrics": "lyrics",
+    "grouping": "grouping",
+    "isrc": "isrc",
+    "replaygain_track_gain": "replaygain_track_gain",
+    "replaygain_album_gain": "replaygain_album_gain",
+    "replaygain_track_peak": "replaygain_track_peak",
+    "replaygain_album_peak": "replaygain_album_peak",
+    "musicbrainz_albumid": "musicbrainz_albumid",
+    "musicbrainz_artistid": "musicbrainz_artistid",
 }
 
 # Keys whose value is dropped when it normalizes to zero (a 0 track/disc is noise).

--- a/contrib/picard/tests/test_map_fields.py
+++ b/contrib/picard/tests/test_map_fields.py
@@ -61,3 +61,19 @@ def test_extra_field_remaps_existing_key(fake_metadata):
     d = dict(map_fields(fake_metadata(title="Song"), extra_fields={"title": "subtitle"}))
     assert d["subtitle"] == "Song"
     assert "title" not in d
+
+
+def test_replaygain_and_musicbrainz_and_comment_mapped(fake_metadata):
+    md = fake_metadata(
+        replaygain_track_gain="-7.50 dB",
+        musicbrainz_albumid="abc",
+        comment="hello",
+        lyrics="la",
+        grouping="set",
+        isrc="US-X",
+    )
+    d = dict(map_fields(md))
+    assert d["replaygain_track_gain"] == "-7.50 dB"
+    assert d["musicbrainz_albumid"] == "abc"
+    assert d["comment"] == "hello"
+    assert d["lyrics"] == "la" and d["grouping"] == "set" and d["isrc"] == "US-X"

--- a/contrib/python-musefs/README.md
+++ b/contrib/python-musefs/README.md
@@ -12,6 +12,11 @@ Field mapping stays in each plugin — beets expands multi-valued
 `genres`/`composers` into one tag each, Picard takes the first value — so this
 library deliberately does not own it.
 
+- `merge_tags(conn, track_id, managed_pairs, delete_keys)` — per-key replacement
+  of plugin-managed text tags. Unlike `replace_tags` (which clears all text rows),
+  `merge_tags` clears only the keys it rewrites plus `delete_keys`, leaving other
+  scan-seeded text tags intact. Scanner-written binary tags survive either way.
+
 ## Consumers
 
 - **beets** depends on this package via pip (`contrib/beets/pyproject.toml`).

--- a/contrib/python-musefs/src/musefs_common/__init__.py
+++ b/contrib/python-musefs/src/musefs_common/__init__.py
@@ -13,6 +13,7 @@ from .scan import run_scan
 from .store import (
     check_schema_version,
     connect,
+    merge_tags,
     prune_missing,
     replace_tags,
     replace_track_art,
@@ -36,6 +37,7 @@ __all__ = [
     "check_schema_version",
     "track_id_for_path",
     "prune_missing",
+    "merge_tags",
     "replace_tags",
     "upsert_art",
     "replace_track_art",

--- a/contrib/python-musefs/src/musefs_common/store.py
+++ b/contrib/python-musefs/src/musefs_common/store.py
@@ -70,6 +70,34 @@ def replace_tags(conn, track_id, pairs):
     )
 
 
+def merge_tags(conn, track_id, managed_pairs, delete_keys):
+    """Per-key replace of the plugin-managed text tags, leaving unmanaged text
+    rows (the scan-seeded baseline) intact. ``managed_pairs`` is an ordered list
+    of (key, value); every key it names is cleared and rewritten with contiguous
+    ordinals. ``delete_keys`` names keys to clear without rewriting (tags the
+    plugin previously managed and the user has now removed). Both deletes are
+    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive."""
+    by_key = {}
+    for key, value in managed_pairs:
+        by_key.setdefault(key, []).append(value)
+
+    for key in set(by_key) | set(delete_keys or ()):
+        conn.execute(
+            "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+            (track_id, key),
+        )
+
+    rows = [
+        (track_id, key, value, ordinal)
+        for key, values in by_key.items()
+        for ordinal, value in enumerate(values)
+    ]
+    conn.executemany(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+
+
 _EXT_MIME = {
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",

--- a/contrib/python-musefs/src/musefs_common/sync.py
+++ b/contrib/python-musefs/src/musefs_common/sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .constants import MAX_ART_BYTES
-from .store import replace_tags, replace_track_art, track_id_for_path, upsert_art
+from .store import merge_tags, replace_tags, replace_track_art, track_id_for_path, upsert_art
 
 
 @dataclass(frozen=True)
@@ -26,6 +26,7 @@ class Record:
     key: str
     pairs: list = field(default_factory=list)
     art: object = None  # list[ArtImage] | None
+    delete_keys: object = None  # list[str] of keys to clear without rewrite (merge mode)
 
 
 @dataclass
@@ -42,7 +43,7 @@ class SyncStats:
         )
 
 
-def sync_one(conn, record, stats, *, dry_run=False):
+def sync_one(conn, record, stats, *, dry_run=False, merge=False):
     """Sync one ``Record`` into the DB, mutating ``stats``. Caller owns the
     transaction. Tags are always fully replaced (scanner-written binary tags
     survive — see ``replace_tags``). Art is replaced when at least one image is
@@ -63,7 +64,10 @@ def sync_one(conn, record, stats, *, dry_run=False):
     will_link_art = bool(kept)
 
     if not dry_run:
-        replace_tags(conn, track_id, record.pairs)
+        if merge:
+            merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+        else:
+            replace_tags(conn, track_id, record.pairs)
         if will_link_art:
             arts = [
                 (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
@@ -76,7 +80,7 @@ def sync_one(conn, record, stats, *, dry_run=False):
     stats.synced += 1
 
 
-def sync_files(conn, records, *, dry_run=False, stats=None):
+def sync_files(conn, records, *, dry_run=False, stats=None, merge=False):
     """Sync an iterable of ``Record``s, returning the ``SyncStats``. Pass
     ``stats`` to accumulate into a caller-seeded instance (e.g. beets pre-counts
     unreadable art); otherwise a fresh one is created. Caller owns the
@@ -84,5 +88,5 @@ def sync_files(conn, records, *, dry_run=False, stats=None):
     if stats is None:
         stats = SyncStats()
     for record in records:
-        sync_one(conn, record, stats, dry_run=dry_run)
+        sync_one(conn, record, stats, dry_run=dry_run, merge=merge)
     return stats

--- a/contrib/python-musefs/src/musefs_common/sync.py
+++ b/contrib/python-musefs/src/musefs_common/sync.py
@@ -45,8 +45,10 @@ class SyncStats:
 
 def sync_one(conn, record, stats, *, dry_run=False, merge=False):
     """Sync one ``Record`` into the DB, mutating ``stats``. Caller owns the
-    transaction. Tags are always fully replaced (scanner-written binary tags
-    survive — see ``replace_tags``). Art is replaced when at least one image is
+    transaction. With ``merge=False`` (the default) all plugin-owned text tags are
+    replaced; with ``merge=True`` only the keys in ``record.pairs`` and
+    ``record.delete_keys`` are touched (see ``merge_tags``). Either way,
+    scanner-written binary tags survive. Art is replaced when at least one image is
     within ``MAX_ART_BYTES``; each over-cap image bumps ``skipped_art``, and if
     every provided image is over cap any scan-seeded ``track_art`` is left
     untouched."""

--- a/contrib/python-musefs/tests/conftest.py
+++ b/contrib/python-musefs/tests/conftest.py
@@ -22,6 +22,19 @@ def db_path(tmp_path):
     return str(path)
 
 
+def text_tags(conn, track_id):
+    """Return {key: [values in ordinal order]} for a track's text rows only
+    (binary tags excluded)."""
+    rows = conn.execute(
+        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL ORDER BY key, ordinal",
+        (track_id,),
+    ).fetchall()
+    out = {}
+    for key, value in rows:
+        out.setdefault(key, []).append(value)
+    return out
+
+
 def insert_track(conn, backing_path, fmt="flac"):
     """Insert a minimal track row (as `musefs scan` would) and return its id."""
     now = int(time.time())

--- a/contrib/python-musefs/tests/test_merge_tags.py
+++ b/contrib/python-musefs/tests/test_merge_tags.py
@@ -1,19 +1,7 @@
-from conftest import insert_track
+from conftest import insert_track, text_tags
 
 from musefs_common import connect
 from musefs_common.store import merge_tags, replace_tags
-
-
-def _text_tags(conn, track_id):
-    """Return {key: [values in ordinal order]} for text rows only."""
-    rows = conn.execute(
-        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL ORDER BY key, ordinal",
-        (track_id,),
-    ).fetchall()
-    out = {}
-    for key, value in rows:
-        out.setdefault(key, []).append(value)
-    return out
 
 
 def test_merge_overwrites_managed_keeps_unmanaged(db_path):
@@ -31,7 +19,7 @@ def test_merge_overwrites_managed_keeps_unmanaged(db_path):
             conn, tid, [("artist", "New"), ("replaygain_track_gain", "-7.50 dB")], delete_keys=[]
         )
         conn.commit()
-        tags = _text_tags(conn, tid)
+        tags = text_tags(conn, tid)
         assert tags["artist"] == ["New"]  # M wins
         assert tags["comment"] == ["keep me"]  # unmanaged B persists
         assert tags["replaygain_track_gain"] == ["-7.50 dB"]
@@ -47,7 +35,7 @@ def test_merge_delete_keys_suppresses_backing(db_path):
         # M keeps artist; comment was managed before and is now dropped.
         merge_tags(conn, tid, [("artist", "Band")], delete_keys=["comment"])
         conn.commit()
-        tags = _text_tags(conn, tid)
+        tags = text_tags(conn, tid)
         assert tags["artist"] == ["Band"]
         assert "comment" not in tags  # suppressed
     finally:
@@ -64,7 +52,7 @@ def test_merge_multivalue_ordinals_contiguous(db_path):
             "SELECT ordinal FROM tags WHERE track_id=? AND key='artist' ORDER BY ordinal", (tid,)
         ).fetchall()
         assert [o[0] for o in ords] == [0, 1]  # 0..n per key
-        assert _text_tags(conn, tid)["artist"] == ["A", "B"]
+        assert text_tags(conn, tid)["artist"] == ["A", "B"]
     finally:
         conn.close()
 
@@ -85,6 +73,6 @@ def test_merge_preserves_binary_tags(db_path):
             "SELECT COUNT(*) FROM tags WHERE track_id=? AND value_blob IS NOT NULL", (tid,)
         ).fetchone()[0]
         assert bin_rows == 1
-        assert _text_tags(conn, tid)["comment"] == ["text"]
+        assert text_tags(conn, tid)["comment"] == ["text"]
     finally:
         conn.close()

--- a/contrib/python-musefs/tests/test_merge_tags.py
+++ b/contrib/python-musefs/tests/test_merge_tags.py
@@ -1,0 +1,90 @@
+from conftest import insert_track
+
+from musefs_common import connect
+from musefs_common.store import merge_tags, replace_tags
+
+
+def _text_tags(conn, track_id):
+    """Return {key: [values in ordinal order]} for text rows only."""
+    rows = conn.execute(
+        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL ORDER BY key, ordinal",
+        (track_id,),
+    ).fetchall()
+    out = {}
+    for key, value in rows:
+        out.setdefault(key, []).append(value)
+    return out
+
+
+def test_merge_overwrites_managed_keeps_unmanaged(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        # Baseline B (as a scan would seed it).
+        replace_tags(
+            conn,
+            tid,
+            [("artist", "Old"), ("comment", "keep me"), ("replaygain_track_gain", "-3.00 dB")],
+        )
+        # M overrides artist + replaygain, does not mention comment.
+        merge_tags(
+            conn, tid, [("artist", "New"), ("replaygain_track_gain", "-7.50 dB")], delete_keys=[]
+        )
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["New"]  # M wins
+        assert tags["comment"] == ["keep me"]  # unmanaged B persists
+        assert tags["replaygain_track_gain"] == ["-7.50 dB"]
+    finally:
+        conn.close()
+
+
+def test_merge_delete_keys_suppresses_backing(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/b.flac")
+        replace_tags(conn, tid, [("artist", "Band"), ("comment", "drop me")])
+        # M keeps artist; comment was managed before and is now dropped.
+        merge_tags(conn, tid, [("artist", "Band")], delete_keys=["comment"])
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["Band"]
+        assert "comment" not in tags  # suppressed
+    finally:
+        conn.close()
+
+
+def test_merge_multivalue_ordinals_contiguous(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/c.flac")
+        merge_tags(conn, tid, [("artist", "A"), ("artist", "B"), ("genre", "Rock")], delete_keys=[])
+        conn.commit()
+        ords = conn.execute(
+            "SELECT ordinal FROM tags WHERE track_id=? AND key='artist' ORDER BY ordinal", (tid,)
+        ).fetchall()
+        assert [o[0] for o in ords] == [0, 1]  # 0..n per key
+        assert _text_tags(conn, tid)["artist"] == ["A", "B"]
+    finally:
+        conn.close()
+
+
+def test_merge_preserves_binary_tags(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/d.flac")
+        # A scanner-written binary tag sharing key 'comment' (value_blob NOT NULL).
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) VALUES (?, ?, '', ?, 1)",
+            (tid, "comment", b"\x00\x01"),
+        )
+        merge_tags(conn, tid, [("comment", "text")], delete_keys=[])
+        conn.commit()
+        # Binary row survives; text row added.
+        bin_rows = conn.execute(
+            "SELECT COUNT(*) FROM tags WHERE track_id=? AND value_blob IS NOT NULL", (tid,)
+        ).fetchone()[0]
+        assert bin_rows == 1
+        assert _text_tags(conn, tid)["comment"] == ["text"]
+    finally:
+        conn.close()

--- a/contrib/python-musefs/tests/test_sync.py
+++ b/contrib/python-musefs/tests/test_sync.py
@@ -2,6 +2,7 @@ from conftest import JPEG, PNG, insert_track
 
 from musefs_common import ArtImage, Record, SyncStats, connect, sync_files, sync_one
 from musefs_common.constants import MAX_ART_BYTES
+from musefs_common.store import replace_tags
 
 
 def _seed(db_path, path="/m/a.flac"):
@@ -277,5 +278,50 @@ def test_sync_one_all_images_over_cap_leaves_existing_art(db_path):
         assert stats.art_linked == 0
         row = conn.execute("SELECT art_id FROM track_art WHERE track_id=?", (tid,)).fetchone()
         assert row == (art_id,)  # scan-seeded art untouched
+    finally:
+        conn.close()
+
+
+def _text_tags(conn, track_id):
+    rows = conn.execute(
+        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL ORDER BY key, ordinal",
+        (track_id,),
+    ).fetchall()
+    out = {}
+    for key, value in rows:
+        out.setdefault(key, []).append(value)
+    return out
+
+
+def test_sync_files_merge_keeps_unmanaged_and_deletes(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        replace_tags(conn, tid, [("artist", "Old"), ("comment", "keep"), ("grouping", "gone")])
+        conn.commit()
+        rec = Record(key="/m/a.flac", pairs=[("artist", "New")], delete_keys=["grouping"])
+        sync_files(conn, [rec], merge=True, stats=SyncStats())
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["New"]  # merged
+        assert tags["comment"] == ["keep"]  # untouched
+        assert "grouping" not in tags  # deleted
+    finally:
+        conn.close()
+
+
+def test_sync_files_default_is_full_replace(db_path):
+    """merge defaults off -> Picard's behavior is unchanged (full replace)."""
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/b.flac")
+        replace_tags(conn, tid, [("artist", "Old"), ("comment", "wiped")])
+        conn.commit()
+        rec = Record(key="/m/b.flac", pairs=[("artist", "New")])
+        sync_files(conn, [rec], stats=SyncStats())  # no merge=
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["New"]
+        assert "comment" not in tags  # full replace wiped it
     finally:
         conn.close()

--- a/contrib/python-musefs/tests/test_sync.py
+++ b/contrib/python-musefs/tests/test_sync.py
@@ -1,4 +1,4 @@
-from conftest import JPEG, PNG, insert_track
+from conftest import JPEG, PNG, insert_track, text_tags
 
 from musefs_common import ArtImage, Record, SyncStats, connect, sync_files, sync_one
 from musefs_common.constants import MAX_ART_BYTES
@@ -282,17 +282,6 @@ def test_sync_one_all_images_over_cap_leaves_existing_art(db_path):
         conn.close()
 
 
-def _text_tags(conn, track_id):
-    rows = conn.execute(
-        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL ORDER BY key, ordinal",
-        (track_id,),
-    ).fetchall()
-    out = {}
-    for key, value in rows:
-        out.setdefault(key, []).append(value)
-    return out
-
-
 def test_sync_files_merge_keeps_unmanaged_and_deletes(db_path):
     conn = connect(db_path)
     try:
@@ -302,7 +291,7 @@ def test_sync_files_merge_keeps_unmanaged_and_deletes(db_path):
         rec = Record(key="/m/a.flac", pairs=[("artist", "New")], delete_keys=["grouping"])
         sync_files(conn, [rec], merge=True, stats=SyncStats())
         conn.commit()
-        tags = _text_tags(conn, tid)
+        tags = text_tags(conn, tid)
         assert tags["artist"] == ["New"]  # merged
         assert tags["comment"] == ["keep"]  # untouched
         assert "grouping" not in tags  # deleted
@@ -320,7 +309,7 @@ def test_sync_files_default_is_full_replace(db_path):
         rec = Record(key="/m/b.flac", pairs=[("artist", "New")])
         sync_files(conn, [rec], stats=SyncStats())  # no merge=
         conn.commit()
-        tags = _text_tags(conn, tid)
+        tags = text_tags(conn, tid)
         assert tags["artist"] == ["New"]
         assert "comment" not in tags  # full replace wiped it
     finally:

--- a/docs/superpowers/plans/2026-06-10-beets-field-coverage.md
+++ b/docs/superpowers/plans/2026-06-10-beets-field-coverage.md
@@ -1,0 +1,1184 @@
+# beets Field Coverage + Stateful Merge Sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a beets sync reflect the user's full library in the musefs mount — every tag beets writes to a file, under recognizable names, with beets winning over embedded values, other embedded tags preserved, and deletions that stick.
+
+**Architecture:** A new `merge_tags` primitive in the shared `python-musefs` library does per-key replacement (M-wins) instead of full text-tag replacement, leaving unmanaged embedded tags (`B`) untouched. The beets plugin derives the managed set `M` from beets' own `_media_tag_fields`, tracks the last-synced key set in a per-item `musefs_managed` beets flexattr, and on each sync deletes keys dropped from `M` (unless `--restore-backing`). Picard keeps full-replace and gains only the naming additions. No Rust or schema changes.
+
+**Tech Stack:** Python 3 (beets plugin + `musefs_common` shared lib), pytest, SQLite. The Rust workspace is untouched.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md`
+
+**Working tree:** git worktree on branch `plugin-field-coverage` at `/home/cfutro/git/musefs-plugin-fields`. All paths below are relative to that root.
+
+**Environment setup (once, before Task 1):** the contrib suites need editable installs.
+```bash
+cd contrib/python-musefs && python -m pytest -q   # sanity: shared lib tests pass today
+cd ../beets && python -m pytest -q                # sanity: beets unit tests pass today
+```
+If imports fail, install per `contrib/beets/README.md` (`pip install -e contrib/python-musefs` then `pip install -e "contrib/beets[test]"`), using the beets venv (`contrib/beets/.venv`) — system Python is PEP-668 managed.
+
+---
+
+## File structure
+
+**Shared library (`contrib/python-musefs/src/musefs_common/`):**
+- `store.py` — add `merge_tags()` beside `replace_tags()`.
+- `sync.py` — `Record` gains `delete_keys`; `sync_one`/`sync_files` gain a `merge` flag.
+- `__init__.py` — export `merge_tags`.
+
+**beets plugin (`contrib/beets/beetsplug/`):**
+- `_core.py` — rewrite `map_fields` (boundary + rename + twins + formatters + drop predicate); add managed-state helpers and `delete_keys`/`musefs_managed` wiring to `build_records`.
+- `musefs.py` — `restore_backing` config + `--restore-backing` option; `_sync` uses merge and persists managed state; `_reconcile_pending` threads `restore_backing`.
+
+**Picard plugin (`contrib/picard/musefs/`):**
+- `_core.py` — extend `DIRECT_FIELDS` + `_MULTI_VALUE_KEYS` (naming additions only).
+
+**Docs:** `contrib/beets/README.md`, `contrib/python-musefs/README.md`, `ARCHITECTURE.md`.
+
+**Tests:** `contrib/python-musefs/tests/test_merge_tags.py` (new), `contrib/beets/tests/test_map_fields.py` (rewrite), `contrib/beets/tests/test_build_records.py` (extend), `contrib/beets/tests/test_managed_state.py` (new), `contrib/beets/tests/test_e2e.py` (extend).
+
+---
+
+## Task 1: `merge_tags` primitive in the shared library
+
+**Files:**
+- Modify: `contrib/python-musefs/src/musefs_common/store.py` (add after `replace_tags`, ~line 70)
+- Modify: `contrib/python-musefs/src/musefs_common/__init__.py` (export)
+- Test: `contrib/python-musefs/tests/test_merge_tags.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `contrib/python-musefs/tests/test_merge_tags.py`:
+
+```python
+from conftest import insert_track
+
+from musefs_common import connect
+from musefs_common.store import merge_tags, replace_tags
+
+
+def _text_tags(conn, track_id):
+    """Return {key: [values in ordinal order]} for text rows only."""
+    rows = conn.execute(
+        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL "
+        "ORDER BY key, ordinal",
+        (track_id,),
+    ).fetchall()
+    out = {}
+    for key, value in rows:
+        out.setdefault(key, []).append(value)
+    return out
+
+
+def test_merge_overwrites_managed_keeps_unmanaged(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        # Baseline B (as a scan would seed it).
+        replace_tags(conn, tid, [("artist", "Old"), ("comment", "keep me"),
+                                  ("replaygain_track_gain", "-3.00 dB")])
+        # M overrides artist + replaygain, does not mention comment.
+        merge_tags(conn, tid,
+                   [("artist", "New"), ("replaygain_track_gain", "-7.50 dB")],
+                   delete_keys=[])
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["New"]                 # M wins
+        assert tags["comment"] == ["keep me"]            # unmanaged B persists
+        assert tags["replaygain_track_gain"] == ["-7.50 dB"]
+    finally:
+        conn.close()
+
+
+def test_merge_delete_keys_suppresses_backing(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/b.flac")
+        replace_tags(conn, tid, [("artist", "Band"), ("comment", "drop me")])
+        # M keeps artist; comment was managed before and is now dropped.
+        merge_tags(conn, tid, [("artist", "Band")], delete_keys=["comment"])
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["Band"]
+        assert "comment" not in tags                     # suppressed
+    finally:
+        conn.close()
+
+
+def test_merge_multivalue_ordinals_contiguous(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/c.flac")
+        merge_tags(conn, tid,
+                   [("artist", "A"), ("artist", "B"), ("genre", "Rock")],
+                   delete_keys=[])
+        conn.commit()
+        ords = conn.execute(
+            "SELECT ordinal FROM tags WHERE track_id=? AND key='artist' "
+            "ORDER BY ordinal", (tid,)).fetchall()
+        assert [o[0] for o in ords] == [0, 1]            # 0..n per key
+        assert _text_tags(conn, tid)["artist"] == ["A", "B"]
+    finally:
+        conn.close()
+
+
+def test_merge_preserves_binary_tags(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/d.flac")
+        # A scanner-written binary tag sharing key 'comment' (value_blob NOT NULL).
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value_blob, ordinal) VALUES (?,?,?,0)",
+            (tid, "comment", b"\x00\x01"))
+        merge_tags(conn, tid, [("comment", "text")], delete_keys=[])
+        conn.commit()
+        # Binary row survives; text row added.
+        bin_rows = conn.execute(
+            "SELECT COUNT(*) FROM tags WHERE track_id=? AND value_blob IS NOT NULL",
+            (tid,)).fetchone()[0]
+        assert bin_rows == 1
+        assert _text_tags(conn, tid)["comment"] == ["text"]
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd contrib/python-musefs && python -m pytest tests/test_merge_tags.py -v`
+Expected: FAIL — `ImportError: cannot import name 'merge_tags'`.
+
+- [ ] **Step 3: Implement `merge_tags`**
+
+In `contrib/python-musefs/src/musefs_common/store.py`, add immediately after `replace_tags`:
+
+```python
+def merge_tags(conn, track_id, managed_pairs, delete_keys):
+    """Per-key replace of the plugin-managed text tags, leaving unmanaged text
+    rows (the scan-seeded baseline) intact. ``managed_pairs`` is an ordered list
+    of (key, value); every key it names is cleared and rewritten with contiguous
+    ordinals. ``delete_keys`` names keys to clear without rewriting (tags the
+    plugin previously managed and the user has now removed). Both deletes are
+    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive."""
+    by_key = {}
+    for key, value in managed_pairs:
+        by_key.setdefault(key, []).append(value)
+
+    for key in set(by_key) | set(delete_keys or ()):
+        conn.execute(
+            "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+            (track_id, key),
+        )
+
+    rows = [
+        (track_id, key, value, ordinal)
+        for key, values in by_key.items()
+        for ordinal, value in enumerate(values)
+    ]
+    conn.executemany(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+```
+
+- [ ] **Step 4: Export it**
+
+In `contrib/python-musefs/src/musefs_common/__init__.py`: add `merge_tags` to the `from .store import (...)` block and to `__all__` (next to `replace_tags`).
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd contrib/python-musefs && python -m pytest tests/test_merge_tags.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/python-musefs/src/musefs_common/store.py \
+        contrib/python-musefs/src/musefs_common/__init__.py \
+        contrib/python-musefs/tests/test_merge_tags.py
+git commit -m "feat(python-musefs): add merge_tags per-key text-tag merge primitive"
+```
+
+---
+
+## Task 2: `Record.delete_keys` and a `merge` flag on sync
+
+**Files:**
+- Modify: `contrib/python-musefs/src/musefs_common/sync.py`
+- Test: `contrib/python-musefs/tests/test_sync.py` (extend; if absent, create)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `contrib/python-musefs/tests/test_sync.py` (create the file with this import header if it does not exist):
+
+```python
+from conftest import insert_track
+
+from musefs_common import connect
+from musefs_common.store import replace_tags
+from musefs_common.sync import Record, SyncStats, sync_files
+
+
+def _text_tags(conn, track_id):
+    rows = conn.execute(
+        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL "
+        "ORDER BY key, ordinal", (track_id,)).fetchall()
+    out = {}
+    for key, value in rows:
+        out.setdefault(key, []).append(value)
+    return out
+
+
+def test_sync_files_merge_keeps_unmanaged_and_deletes(db_path):
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        replace_tags(conn, tid, [("artist", "Old"), ("comment", "keep"),
+                                  ("grouping", "gone")])
+        rec = Record(key="/m/a.flac",
+                     pairs=[("artist", "New")],
+                     delete_keys=["grouping"])
+        sync_files(conn, [rec], merge=True, stats=SyncStats())
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["New"]      # merged
+        assert tags["comment"] == ["keep"]    # untouched
+        assert "grouping" not in tags         # deleted
+    finally:
+        conn.close()
+
+
+def test_sync_files_default_is_full_replace(db_path):
+    """merge defaults off -> Picard's behavior is unchanged (full replace)."""
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/b.flac")
+        replace_tags(conn, tid, [("artist", "Old"), ("comment", "wiped")])
+        rec = Record(key="/m/b.flac", pairs=[("artist", "New")])
+        sync_files(conn, [rec], stats=SyncStats())   # no merge=
+        conn.commit()
+        tags = _text_tags(conn, tid)
+        assert tags["artist"] == ["New"]
+        assert "comment" not in tags                 # full replace wiped it
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd contrib/python-musefs && python -m pytest tests/test_sync.py -v -k merge`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'delete_keys'` (and `sync_files` has no `merge`).
+
+- [ ] **Step 3: Add `delete_keys` to `Record`**
+
+In `contrib/python-musefs/src/musefs_common/sync.py`, in the `Record` dataclass, add a field after `art`:
+
+```python
+    delete_keys: object = None  # list[str] of keys to clear without rewrite (merge mode)
+```
+
+- [ ] **Step 4: Thread `merge` through `sync_one`/`sync_files`**
+
+In the same file, update the import and the two functions. Change the import line to:
+
+```python
+from .store import merge_tags, replace_tags, replace_track_art, track_id_for_path, upsert_art
+```
+
+Replace the tag-writing line in `sync_one` and add the `merge` parameter. The `sync_one` signature becomes `def sync_one(conn, record, stats, *, dry_run=False, merge=False):` and the write block becomes:
+
+```python
+    if not dry_run:
+        if merge:
+            merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+        else:
+            replace_tags(conn, track_id, record.pairs)
+        if will_link_art:
+            arts = [
+                (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
+                for img in kept
+            ]
+            replace_track_art(conn, track_id, arts)
+```
+
+`sync_files` signature becomes `def sync_files(conn, records, *, dry_run=False, stats=None, merge=False):` and its loop passes the flag:
+
+```python
+    for record in records:
+        sync_one(conn, record, stats, dry_run=dry_run, merge=merge)
+    return stats
+```
+
+- [ ] **Step 5: Run the full shared-lib suite**
+
+Run: `cd contrib/python-musefs && python -m pytest -q`
+Expected: PASS (new sync tests pass; all prior tests still pass — `merge` defaults off, so existing Picard/beets behavior is untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/python-musefs/src/musefs_common/sync.py \
+        contrib/python-musefs/tests/test_sync.py
+git commit -m "feat(python-musefs): Record.delete_keys and merge flag on sync_one/sync_files"
+```
+
+---
+
+## Task 3: Rewrite beets `map_fields` (boundary, rename, twins, formatters, drops)
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/_core.py` (replace `DIRECT_FIELDS`, `TWIN_FIELDS`, `map_fields`, `_values`; keep `_to_int`, `_format_date`, art + path helpers)
+- Test: `contrib/beets/tests/test_map_fields.py` (rewrite)
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire contents of `contrib/beets/tests/test_map_fields.py`:
+
+```python
+from types import SimpleNamespace
+
+from beetsplug._core import map_fields
+
+# Fields a real beets Item exposes via Item._media_tag_fields. Tests attach this
+# so map_fields iterates the same boundary it will in production.
+_TAG_FIELDS = (
+    "title", "artist", "artists", "albumartist", "albumartists", "album",
+    "genre", "genres", "composer", "composers", "comments", "grouping",
+    "isrc", "lyrics", "bpm", "comp", "track", "tracktotal", "disc", "disctotal",
+    "year", "month", "day",
+    "rg_track_gain", "rg_album_gain", "rg_track_peak", "rg_album_peak",
+    "mb_albumid", "mb_artistid", "mb_trackid",
+    "artist_sort", "artists_sort",
+    "bitrate", "length", "format",   # file facts: present on item, NOT tag fields
+)
+_FILE_FACTS = {"bitrate", "length", "format"}
+_TAG_ONLY = tuple(f for f in _TAG_FIELDS if f not in _FILE_FACTS)
+
+
+def item(**kw):
+    base = {f: "" for f in _TAG_FIELDS}
+    base.update({f: 0 for f in ("track", "tracktotal", "disc", "disctotal",
+                                 "year", "month", "day", "bpm")})
+    base.update({"comp": False, "bitrate": 320000, "length": 210.0, "format": "FLAC"})
+    base.update(kw)
+    ns = SimpleNamespace(**base)
+    ns._media_tag_fields = _TAG_ONLY   # boundary excludes the file facts
+    return ns
+
+
+def test_core_fields_copied():
+    d = dict(map_fields(item(title="Song", artist="Band", album="Disc")))
+    assert d["title"] == "Song" and d["artist"] == "Band" and d["album"] == "Disc"
+
+
+def test_track_disc_renamed_and_zero_dropped():
+    d = dict(map_fields(item(track=7, disc=2)))
+    assert d["tracknumber"] == "7" and d["discnumber"] == "2"
+    assert "tracknumber" not in dict(map_fields(item(track=0)))
+
+
+def test_replaygain_renamed_and_formatted():
+    pairs = dict(map_fields(item(rg_track_gain=-7.5, rg_track_peak=0.987654321)))
+    assert pairs["replaygain_track_gain"] == "-7.50 dB"
+    assert pairs["replaygain_track_peak"].startswith("0.98")
+    assert "rg_track_gain" not in pairs
+
+
+def test_replaygain_zero_gain_survives():
+    # 0 dB is a real measured value and must NOT be dropped.
+    assert dict(map_fields(item(rg_track_gain=0.0)))["replaygain_track_gain"] == "0.00 dB"
+
+
+def test_musicbrainz_renamed():
+    d = dict(map_fields(item(mb_albumid="abc", mb_artistid="def", mb_trackid="ghi")))
+    assert d["musicbrainz_albumid"] == "abc"
+    assert d["musicbrainz_artistid"] == "def"
+    assert d["musicbrainz_trackid"] == "ghi"
+
+
+def test_comments_renamed_to_comment():
+    assert dict(map_fields(item(comments="hi")))["comment"] == "hi"
+
+
+def test_plural_artist_wins_and_expands():
+    pairs = map_fields(item(artist="Joined", artists=["A", "B"]))
+    artists = [v for k, v in pairs if k == "artist"]
+    assert artists == ["A", "B"]              # plural list wins, one row each
+
+
+def test_singular_artist_used_when_plural_empty():
+    pairs = map_fields(item(artist="Solo", artists=[]))
+    assert [v for k, v in pairs if k == "artist"] == ["Solo"]
+
+
+def test_genre_plural_collapses_to_genre_key():
+    pairs = map_fields(item(genres=["Rock", "Pop"]))
+    assert [v for k, v in pairs if k == "genre"] == ["Rock", "Pop"]
+
+
+def test_comp_one_kept_zero_dropped():
+    # beets `comp` is a 0/1 int; bool here too. 1 -> kept "1", 0/False -> dropped.
+    assert dict(map_fields(item(comp=True)))["comp"] == "1"
+    assert dict(map_fields(item(comp=1)))["comp"] == "1"
+    assert "comp" not in dict(map_fields(item(comp=False)))
+    assert "comp" not in dict(map_fields(item(comp=0)))
+
+
+def test_file_facts_excluded():
+    d = dict(map_fields(item()))
+    assert "bitrate" not in d and "length" not in d and "format" not in d
+
+
+def test_date_assembled_and_parts_not_emitted():
+    d = dict(map_fields(item(year=1999, month=3, day=5)))
+    assert d["date"] == "1999-03-05"
+    assert "year" not in d and "month" not in d and "day" not in d
+
+
+def test_arbitrary_passthrough_lowercased():
+    d = dict(map_fields(item(grouping="Set", isrc="US-X", lyrics="la")))
+    assert d["grouping"] == "Set" and d["isrc"] == "US-X" and d["lyrics"] == "la"
+
+
+def test_extra_fields_override_wins():
+    # `fields:` maps a beets field onto a store key, last-wins.
+    d = dict(map_fields(item(comments="orig", bpm=120), extra_fields={"bpm": "comment"}))
+    assert d["comment"] == "120"   # override beat the comments->comment rename
+
+
+def test_bpm_int_no_trailing_dot_zero():
+    assert dict(map_fields(item(bpm=120)))["bpm"] == "120"
+```
+
+Note on `comp`: beets stores compilation as a `0`/`1` int (some stubs use a bool). A non-compilation carries no information, so this plan **drops `comp` when zero/False** (via `_DROP_IF_ZERO`) and emits `"1"` for a compilation. The test above encodes both the int and bool forms.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd contrib/beets && python -m pytest tests/test_map_fields.py -v`
+Expected: FAIL (old `map_fields` ignores `_media_tag_fields`, has no rename/twin/formatter logic).
+
+- [ ] **Step 3: Rewrite the mapping in `_core.py`**
+
+In `contrib/beets/beetsplug/_core.py`, replace the `DIRECT_FIELDS` and `TWIN_FIELDS` constants and the `_values`/`map_fields` functions with the following. Keep `_to_int`, `_format_date`, `_album_art_path`, `_read_album_art`, `_computed_path`, `_computed_path_or_skip`, and the existing imports (add nothing new beyond what is shown):
+
+```python
+MANAGED_FLEXATTR = "musefs_managed"
+
+# beets field name -> canonical musefs (Vorbis-lowercase) key, where they differ.
+RENAME = {
+    "track": "tracknumber",
+    "disc": "discnumber",
+    "comments": "comment",
+    "rg_track_gain": "replaygain_track_gain",
+    "rg_album_gain": "replaygain_album_gain",
+    "rg_track_peak": "replaygain_track_peak",
+    "rg_album_peak": "replaygain_album_peak",
+    "mb_trackid": "musicbrainz_trackid",
+    "mb_albumid": "musicbrainz_albumid",
+    "mb_artistid": "musicbrainz_artistid",
+    "mb_albumartistid": "musicbrainz_albumartistid",
+    "mb_releasegroupid": "musicbrainz_releasegroupid",
+    "mb_releasetrackid": "musicbrainz_releasetrackid",
+    "mb_workid": "musicbrainz_workid",
+}
+
+# plural beets list field -> the singular beets field it collapses onto. The
+# plural wins when present; both resolve to one output key (via RENAME below) and
+# are emitted once so a value is never written twice.
+TWINS = {
+    "artists": "artist",
+    "albumartists": "albumartist",
+    "genres": "genre",
+    "composers": "composer",
+    "lyricists": "lyricist",
+    "arrangers": "arranger",
+    "remixers": "remixer",
+    "artists_sort": "artist_sort",
+    "albumartists_sort": "albumartist_sort",
+    "artists_credit": "artist_credit",
+    "albumartists_credit": "albumartist_credit",
+}
+
+# Assembled into `date`; never emitted under their own names.
+_DATE_PARTS = ("year", "month", "day")
+
+# Output keys dropped when their numeric value is zero (0 is noise here). `comp`
+# is a 0/1 int in beets, so dropping on zero covers both the int and bool forms
+# of a non-compilation.
+_DROP_IF_ZERO = {"tracknumber", "discnumber", "tracktotal", "disctotal", "comp"}
+
+# Used when an item has no _media_tag_fields (older beets / non-beets test stubs).
+FALLBACK_TAG_FIELDS = (
+    "title", "artist", "artists", "albumartist", "albumartists", "album",
+    "genre", "genres", "composer", "composers",
+    "track", "disc", "year", "month", "day",
+)
+
+
+def _fmt_db(value):
+    return f"{float(value):.2f} dB"
+
+
+def _fmt_peak(value):
+    return f"{float(value):.6f}"
+
+
+# Per-output-key value formatters: the explicit exceptions to default stringify.
+FORMATTERS = {
+    "replaygain_track_gain": _fmt_db,
+    "replaygain_album_gain": _fmt_db,
+    "replaygain_track_peak": _fmt_peak,
+    "replaygain_album_peak": _fmt_peak,
+}
+
+
+def _output_key(field):
+    """beets field name -> canonical musefs store key (collapse twin, then rename)."""
+    base = TWINS.get(field, field)
+    return RENAME.get(base, base.lower())
+
+
+def _stringify(value, output_key):
+    """Render one beets value to a store string. Formatter exceptions first, then
+    the default: bool -> '1'/'0', integral float -> no trailing '.0', int -> str,
+    else str().strip()."""
+    formatter = FORMATTERS.get(output_key)
+    if formatter is not None:
+        return formatter(value)
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else str(value)
+    if isinstance(value, int):
+        return str(value)
+    return str(value).strip()
+
+
+def _iter_values(value):
+    """A beets field value as a list of raw (un-stringified) elements."""
+    if value is None:
+        return []
+    return list(value) if isinstance(value, (list, tuple)) else [value]
+
+
+def _is_zero(text):
+    try:
+        return float(text) == 0.0
+    except ValueError:
+        return False
+
+
+def map_fields(item, extra_fields=None):
+    """Map a beets item to a list of (musefs_key, value) pairs covering every tag
+    beets writes to a file (``item._media_tag_fields``), renamed to canonical
+    keys, multi-values expanded, file facts excluded automatically. ``extra_fields``
+    (the ``fields:`` config) is a final ``beets_field -> store_key`` override layer."""
+    field_names = list(getattr(item, "_media_tag_fields", FALLBACK_TAG_FIELDS))
+    # Process plural twins before singulars so the plural list wins its key.
+    ordered = sorted(field_names, key=lambda f: (f not in TWINS, f))
+
+    emitted = {}  # output_key -> list[str], insertion-ordered
+    for field in ordered:
+        if field in _DATE_PARTS:
+            continue
+        key = _output_key(field)
+        if key in emitted:
+            continue  # already claimed (plural beat singular, or a duplicate)
+        values = []
+        for raw in _iter_values(getattr(item, field, None)):
+            if raw is None:
+                continue
+            if isinstance(raw, str) and not raw.strip():
+                continue
+            if isinstance(raw, bool) and not raw:
+                continue  # comp=False etc. carry no info -> drop
+            text = _stringify(raw, key)
+            if not text:
+                continue
+            if key in _DROP_IF_ZERO and _is_zero(text):
+                continue
+            values.append(text)
+        if values:
+            emitted[key] = values
+
+    date = _format_date(item)
+    if date:
+        emitted.setdefault("date", [date])
+
+    if extra_fields:
+        for beets_field, store_key in extra_fields.items():
+            values = []
+            for raw in _iter_values(getattr(item, beets_field, None)):
+                if raw is None or (isinstance(raw, str) and not raw.strip()):
+                    continue
+                values.append(_stringify(raw, store_key))
+            if values:
+                emitted[store_key] = values  # override (last wins)
+
+    return [(key, value) for key, values in emitted.items() for value in values]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd contrib/beets && python -m pytest tests/test_map_fields.py -v`
+Expected: PASS (all tests in the rewritten file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add contrib/beets/beetsplug/_core.py contrib/beets/tests/test_map_fields.py
+git commit -m "feat(beets): map full _media_tag_fields with rename, twins, formatters"
+```
+
+---
+
+## Task 4: Managed-state helpers + `build_records` delete-keys wiring
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/_core.py` (add helpers; change `build_records` signature/return)
+- Test: `contrib/beets/tests/test_build_records.py` (extend) and `contrib/beets/tests/test_managed_state.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `contrib/beets/tests/test_managed_state.py`:
+
+```python
+from musefs_common import SyncStats
+
+from beetsplug import _core
+
+
+class FakeStoreItem:
+    """Item stub that supports flexattr read (getattr), write (item[k]=v) and
+    store(); records whether write() (the file-writing method) was called."""
+
+    def __init__(self, path=b"/m/a.flac", **fields):
+        self.path = path
+        self._flex = {}
+        self.stored = 0
+        self.wrote_file = False
+        self._media_tag_fields = _core.FALLBACK_TAG_FIELDS
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+    # flexattr read path used by read_managed
+    def __getattr__(self, name):
+        flex = self.__dict__.get("_flex", {})
+        if name in flex:
+            return flex[name]
+        raise AttributeError(name)
+
+    def __setitem__(self, key, value):
+        self._flex[key] = value
+
+    def store(self):
+        self.stored += 1
+
+    def write(self):
+        self.wrote_file = True
+
+    def destination(self, relative_to_libdir=False):
+        return self.path
+
+    def get_album(self):
+        return None
+
+
+def test_read_managed_empty_and_parsed():
+    it = FakeStoreItem()
+    assert _core.read_managed(it) == []
+    it["musefs_managed"] = "artist,comment,title"
+    assert _core.read_managed(it) == ["artist", "comment", "title"]
+
+
+def test_format_managed_sorts_and_dedupes():
+    assert _core.format_managed(["title", "artist", "artist"]) == "artist,title"
+
+
+def test_persist_managed_uses_store_not_write():
+    it = FakeStoreItem()
+    _core.persist_managed([(it, ["artist", "title"])])
+    assert it._flex["musefs_managed"] == "artist,title"
+    assert it.stored == 1
+    assert it.wrote_file is False   # must not call write() (would fire after_write)
+
+
+def test_build_records_computes_delete_keys_from_prev_managed():
+    it = FakeStoreItem(title="T", artist="A")
+    it["musefs_managed"] = "artist,title,grouping"   # grouping managed last time
+    records, writes = _core.build_records(
+        [it], fields={}, stats=SyncStats(), write_path=False, restore_backing=False)
+    rec = records[0]
+    # grouping no longer in M -> queued for deletion; title/artist not deleted.
+    assert rec.delete_keys == ["grouping"]
+    assert ("title", "T") in rec.pairs and ("artist", "A") in rec.pairs
+    # managed_writes carries the new key set for persistence.
+    item, managed = writes[0]
+    assert item is it
+    assert set(managed) == {"title", "artist"}
+
+
+def test_build_records_restore_backing_disables_deletes():
+    it = FakeStoreItem(title="T")
+    it["musefs_managed"] = "title,grouping"
+    records, _ = _core.build_records(
+        [it], fields={}, stats=SyncStats(), write_path=False, restore_backing=True)
+    assert records[0].delete_keys == []   # restore-backing -> never delete
+
+
+def test_build_records_beets_path_is_managed():
+    it = FakeStoreItem(title="T", destination=b"Artist/Album/01 T.flac")
+    records, writes = _core.build_records(
+        [it], fields={}, stats=SyncStats(), write_path=True, restore_backing=False)
+    keys = {k for k, _ in records[0].pairs}
+    assert "beets_path" in keys
+    assert "beets_path" in writes[0][1]   # included in managed set
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd contrib/beets && python -m pytest tests/test_managed_state.py -v`
+Expected: FAIL — `AttributeError: module 'beetsplug._core' has no attribute 'read_managed'` (and `build_records` returns a list, not a tuple).
+
+- [ ] **Step 3: Add the helpers and rewrite `build_records`**
+
+In `contrib/beets/beetsplug/_core.py`, add the three helpers (anywhere after `MANAGED_FLEXATTR`):
+
+```python
+def read_managed(item):
+    """Parse the per-item ``musefs_managed`` flexattr into a list of keys."""
+    raw = getattr(item, MANAGED_FLEXATTR, None)
+    if not raw:
+        return []
+    return [k for k in str(raw).split(",") if k]
+
+
+def format_managed(keys):
+    """Serialize a managed key set: sorted, de-duplicated, comma-joined."""
+    return ",".join(sorted(set(keys)))
+
+
+def persist_managed(writes):
+    """Persist each ``(item, managed_keys)`` pair's key set into the beets DB via
+    ``item.store()``. Never calls ``item.write()`` — that writes the audio file and
+    fires ``after_write``, which would re-enter the plugin's reconcile loop."""
+    for item, keys in writes:
+        item[MANAGED_FLEXATTR] = format_managed(keys)
+        item.store()
+```
+
+Then replace the existing `build_records` with:
+
+```python
+def build_records(items, *, fields=None, stats, write_path=True, restore_backing=False, log=None):
+    """Build ``Record``s for beets items and the parallel managed-key writes.
+
+    Returns ``(records, managed_writes)`` where ``managed_writes`` is a list of
+    ``(item, managed_keys)`` for the caller to persist *after a successful commit*
+    via ``persist_managed``. Each record's ``delete_keys`` is the set of keys the
+    item managed last sync but no longer does (empty when ``restore_backing``)."""
+    records = []
+    managed_writes = []
+    art_cache = {}
+    for item in items:
+        cover = _read_album_art(item, art_cache, stats)
+        pairs = map_fields(item, fields)
+        if write_path:
+            path = _computed_path_or_skip(item, log)
+            if path:
+                pairs.append(("beets_path", path))
+        managed = sorted({key for key, _ in pairs})
+        prev = read_managed(item)
+        delete_keys = [] if restore_backing else sorted(set(prev) - set(managed))
+        records.append(
+            Record(
+                key=realpath_key(item.path),
+                pairs=pairs,
+                art=[ArtImage(*cover)] if cover else None,
+                delete_keys=delete_keys,
+            )
+        )
+        managed_writes.append((item, managed))
+    return records, managed_writes
+```
+
+- [ ] **Step 4: Fix the existing `build_records` test for the new return shape**
+
+`contrib/beets/tests/test_build_records.py` currently unpacks a single list. Update each `build_records(...)` call site to `records, _ = build_records(...)` (and add a focused assertion if the test inspects records). Run the file to find call sites:
+
+Run: `cd contrib/beets && python -m pytest tests/test_build_records.py -v`
+Fix each failure by destructuring the tuple. Re-run until green.
+
+- [ ] **Step 5: Run both test files**
+
+Run: `cd contrib/beets && python -m pytest tests/test_build_records.py tests/test_managed_state.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/beets/beetsplug/_core.py \
+        contrib/beets/tests/test_managed_state.py \
+        contrib/beets/tests/test_build_records.py
+git commit -m "feat(beets): managed-key flexattr state and delete-key computation"
+```
+
+---
+
+## Task 5: Wire the adapter — merge sync, persist, `--restore-backing`, both paths
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/musefs.py`
+- Test: `contrib/beets/tests/test_plugin.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `contrib/beets/tests/test_plugin.py` (mirror the file's existing plugin-construction pattern; if it builds a plugin via a fixture, reuse it). Minimal direct-call tests:
+
+```python
+def test_sync_uses_merge_and_persists_managed(tmp_path, monkeypatch):
+    """A real DB round-trip: B persists, M wins, managed flexattr written."""
+    import sqlite3
+    from musefs_common.schema import SCHEMA_SQL
+    from musefs_common import connect
+    from beetsplug.musefs import MusefsPlugin
+    from beetsplug import _core
+
+    db = tmp_path / "musefs.db"
+    raw = sqlite3.connect(str(db)); raw.executescript(SCHEMA_SQL); raw.commit()
+    raw.execute("INSERT INTO tracks (backing_path, format, audio_offset, "
+                "audio_length, backing_size, backing_mtime, updated_at) "
+                "VALUES ('/m/a.flac','flac',0,0,0,0,0)")
+    tid = raw.execute("SELECT id FROM tracks").fetchone()[0]
+    raw.execute("INSERT INTO tags (track_id,key,value,ordinal) VALUES (?,?,?,0)",
+                (tid, "comment", "keep"))
+    raw.commit(); raw.close()
+
+    # Item stub: real path on disk so realpath_key matches the inserted row.
+    p = tmp_path / "a.flac"; p.write_bytes(b"")
+    from tests.test_managed_state import FakeStoreItem  # reuse stub
+    item = FakeStoreItem(path=str(p).encode())
+    item._media_tag_fields = _core.FALLBACK_TAG_FIELDS
+    item.artist = "New"
+
+    # Point the inserted track at the real temp path.
+    conn = connect(str(db))
+    conn.execute("UPDATE tracks SET backing_path=? WHERE id=?",
+                 (__import__("os").path.realpath(str(p)), tid))
+    conn.commit(); conn.close()
+
+    plugin = MusefsPlugin()
+    plugin.config["db"] = str(db)
+    plugin._sync(str(db), [item], dry_run=False, restore_backing=False)
+
+    conn = connect(str(db))
+    tags = dict((k, v) for k, v in conn.execute(
+        "SELECT key,value FROM tags WHERE track_id=? AND value_blob IS NULL", (tid,)))
+    conn.close()
+    assert tags["artist"] == "New"      # M wins
+    assert tags["comment"] == "keep"    # unmanaged B persists (merge, not replace)
+    assert item._flex.get("musefs_managed")   # managed set persisted
+    assert item.wrote_file is False           # store(), not write()
+```
+
+(If `MusefsPlugin()` cannot be constructed bare in the test env, gate this test behind the same marker the existing plugin tests use, or construct via the project's existing plugin fixture.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd contrib/beets && python -m pytest tests/test_plugin.py -v -k merge_and_persists`
+Expected: FAIL — `_sync()` has no `restore_backing` parameter and still full-replaces (comment wiped).
+
+- [ ] **Step 3: Update the adapter**
+
+In `contrib/beets/beetsplug/musefs.py`:
+
+(a) Add the config default in `__init__`'s `self.config.add({...})`:
+```python
+            "restore_backing": False,  # on delete, let the backing tag value reappear
+```
+
+(b) Add the command option in `commands()` (after the `--dry-run` option):
+```python
+        cmd.parser.add_option(
+            "--restore-backing",
+            dest="restore_backing",
+            action="store_true",
+            default=False,
+            help="when a tag is removed in beets, let the backing file's value reappear",
+        )
+```
+
+(c) Add a config helper near `_write_path`:
+```python
+    def _restore_backing(self):
+        return bool(self.config["restore_backing"].get(bool))
+```
+
+(d) In `_command`, resolve the effective flag and pass it through:
+```python
+        restore_backing = bool(opts.restore_backing) or self._restore_backing()
+        stats = self._sync(db_path, items, dry_run=opts.dry_run, restore_backing=restore_backing)
+```
+
+(e) Replace `_sync` with the merge + persist version:
+```python
+    def _sync(self, db_path, items, dry_run=False, restore_backing=False):
+        if not os.path.exists(db_path):
+            raise ui.UserError(
+                f"musefs: DB not found at {db_path}; enable `musefs.autoscan` "
+                f"or run `musefs scan` first"
+            )
+        conn = connect(db_path)
+        try:
+            check_schema_version(conn)
+            stats = SyncStats()
+            records, managed_writes = _core.build_records(
+                items,
+                fields=self._fields(),
+                stats=stats,
+                write_path=self._write_path(),
+                restore_backing=restore_backing,
+                log=self._log,
+            )
+            sync_files(conn, records, dry_run=dry_run, stats=stats, merge=True)
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+                _core.persist_managed(managed_writes)
+            return stats
+        except SchemaMismatch as exc:
+            conn.rollback()
+            raise ui.UserError(f"musefs: {exc}")
+        finally:
+            conn.close()
+```
+
+(f) In `_reconcile_pending`, thread the config default into the sync call. Change the `self._sync(db_path, items)` call to:
+```python
+            self._sync(db_path, items, restore_backing=self._restore_backing())
+```
+
+- [ ] **Step 4: Run the test + full beets unit suite**
+
+Run: `cd contrib/beets && python -m pytest -q`
+Expected: PASS. (If the new plugin test must be marker-gated for env reasons, the rest of the suite must still be green.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add contrib/beets/beetsplug/musefs.py contrib/beets/tests/test_plugin.py
+git commit -m "feat(beets): merge sync with managed-state persistence and --restore-backing"
+```
+
+---
+
+## Task 6: Picard naming additions (no merge)
+
+**Files:**
+- Modify: `contrib/picard/musefs/_core.py` (`DIRECT_FIELDS`, `_MULTI_VALUE_KEYS`)
+- Test: `contrib/picard/tests/test_map_fields.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `contrib/picard/tests/test_map_fields.py` (reuse the file's existing fake-`Metadata` helper):
+
+```python
+def test_replaygain_and_musicbrainz_and_comment_mapped():
+    md = metadata(  # the file's existing dict-like Metadata stub
+        replaygain_track_gain="-7.50 dB",
+        musicbrainz_albumid="abc",
+        comment="hello",
+        lyrics="la",
+        grouping="set",
+        isrc="US-X",
+    )
+    d = dict(map_fields(md))
+    assert d["replaygain_track_gain"] == "-7.50 dB"
+    assert d["musicbrainz_albumid"] == "abc"
+    assert d["comment"] == "hello"
+    assert d["lyrics"] == "la" and d["grouping"] == "set" and d["isrc"] == "US-X"
+```
+
+If the existing test file has no `metadata()` helper, construct the stub the same way the neighboring tests in that file do (Picard `Metadata` is dict-like with `getall`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd contrib/picard && python -m pytest tests/test_map_fields.py -v -k replaygain_and_musicbrainz`
+Expected: FAIL — keys absent (not in `DIRECT_FIELDS`).
+
+- [ ] **Step 3: Extend Picard's `DIRECT_FIELDS`**
+
+In `contrib/picard/musefs/_core.py`, extend `DIRECT_FIELDS` (Picard's internal tag names already equal musefs keys, so these are identity entries):
+
+```python
+DIRECT_FIELDS = {
+    "title": "title",
+    "artist": "artist",
+    "albumartist": "albumartist",
+    "album": "album",
+    "genre": "genre",
+    "composer": "composer",
+    "tracknumber": "tracknumber",
+    "discnumber": "discnumber",
+    "date": "date",
+    "comment": "comment",
+    "lyrics": "lyrics",
+    "grouping": "grouping",
+    "isrc": "isrc",
+    "replaygain_track_gain": "replaygain_track_gain",
+    "replaygain_album_gain": "replaygain_album_gain",
+    "replaygain_track_peak": "replaygain_track_peak",
+    "replaygain_album_peak": "replaygain_album_peak",
+    "musicbrainz_albumid": "musicbrainz_albumid",
+    "musicbrainz_artistid": "musicbrainz_artistid",
+}
+```
+
+(Picard already formats ReplayGain with the `dB` suffix and the MusicBrainz IDs under these exact keys, so no value formatting is needed here.)
+
+- [ ] **Step 4: Run to verify pass + full Picard unit suite**
+
+Run: `cd contrib/picard && python -m pytest -q`
+Expected: PASS. (Per repo notes, the real-Picard/Qt tests skip without an importable Picard; the pure-mapping tests here run regardless.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add contrib/picard/musefs/_core.py contrib/picard/tests/test_map_fields.py
+git commit -m "feat(picard): map ReplayGain, MusicBrainz, comment, lyrics, grouping, isrc"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+- Modify: `contrib/beets/README.md`
+- Modify: `contrib/python-musefs/README.md`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: beets README**
+
+In `contrib/beets/README.md`, under "Notes", replace the field-coverage description with the new behavior. Add bullets covering: (a) the plugin now syncs everything beets writes to a file (`_media_tag_fields`) — ReplayGain, MusicBrainz IDs, comment, lyrics, grouping, isrc, multi-valued artists — under canonical names; (b) **merge semantics**: beets values win, the file's other embedded tags are preserved; (c) the `musefs_managed` beets flexattr records what the plugin manages, so deleting a tag in beets removes it from the view and it **stays** removed; (d) `--restore-backing` / `restore_backing: no` brings the backing value back for a removed tag; (e) the caveat that sticky deletion depends on `autoscan: yes` — with `autoscan: no`, a deletion reconciles only on the next manual `musefs scan`.
+
+Use this block (insert under Notes):
+```markdown
+- **Field coverage:** every tag beets writes to a file (its `_media_tag_fields`)
+  is synced — ReplayGain, MusicBrainz IDs, comment, lyrics, grouping, isrc,
+  multi-valued artists, and any custom field — under canonical musefs keys.
+  Read-only file facts (bitrate, length, …) are never written as tags.
+- **Merge, not replace:** beets' values win for the fields it manages; any other
+  tag already embedded in the file is preserved in the view.
+- **Deletions stick:** the plugin records the keys it manages per track in a
+  `musefs_managed` beets flexattr (stored in the beets DB only — never in your
+  audio files or the musefs store). Remove a tag in beets and it is removed from
+  the view and stays gone across re-scans.
+- **`--restore-backing`** (or `restore_backing: yes`): when you remove a tag in
+  beets, let the file's original embedded value reappear instead of disappearing.
+- **Caveat:** sticky deletion relies on `autoscan: yes` (the default), which
+  re-derives the file's embedded tags before each sync. With `autoscan: no`, a
+  deletion only takes effect after your next manual `musefs scan`.
+```
+
+- [ ] **Step 2: python-musefs README**
+
+In `contrib/python-musefs/README.md`, document `merge_tags` next to `replace_tags`:
+```markdown
+- `merge_tags(conn, track_id, managed_pairs, delete_keys)` — per-key replacement
+  of plugin-managed text tags. Unlike `replace_tags` (which clears all text rows),
+  `merge_tags` clears only the keys it rewrites plus `delete_keys`, leaving other
+  scan-seeded text tags intact. Scanner-written binary tags survive either way.
+```
+
+- [ ] **Step 3: ARCHITECTURE.md external-writer contract**
+
+In `ARCHITECTURE.md`, in the external-writer-contract section, add a paragraph: an external writer may **merge** rather than fully replace text tags — overwriting only the keys it manages and leaving the rest of the scan-seeded set in place — provided it tracks its own managed-key set out of band (the beets plugin uses a beets flexattr; the store is not the place for plugin state). Note that musefs renders tags outside its native VOCAB (`musefs-format/src/tagmap.rs`) by passthrough (Vorbis uppercased, mp3 `TXXX`, mp4 freeform), so such tags appear but are not guaranteed byte-identical to a given tagger's own per-format encoding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add contrib/beets/README.md contrib/python-musefs/README.md ARCHITECTURE.md
+git commit -m "docs: document beets merge sync, musefs_managed, merge_tags contract"
+```
+
+---
+
+## Task 8: End-to-end coverage
+
+**Files:**
+- Modify: `contrib/beets/tests/test_e2e.py`
+
+- [ ] **Step 1: Add the e2e assertions**
+
+The `e2e` tier (marker `e2e`, gated on `ffmpeg` + `/dev/fuse` + `fusermount`) already imports audio, retags, syncs, mounts, and verifies tags + byte-identical audio. Extend it (or add a sibling `@pytest.mark.e2e` test mirroring the existing one's setup/mount helpers) to assert the new behavior:
+
+```python
+# After the existing import + `beet musefs` sync + mount, with the item carrying
+# ReplayGain, a MusicBrainz album id, and a custom field:
+mounted = read_tags_from_mount(mount_dir, rel_path)   # reuse the file's helper
+assert mounted["replaygain_track_gain"].endswith("dB")
+assert mounted["musicbrainz_albumid"]
+assert mounted["comment"]                              # an arbitrary mapped field
+
+# Deletion sticks: clear the comment in beets, re-sync, remount, assert absent.
+clear_tag_in_beets(item, "comments"); run_beet_musefs()
+mounted = read_tags_from_mount(mount_dir, rel_path)
+assert "comment" not in mounted
+
+# With --restore-backing, the embedded value returns.
+run_beet_musefs(extra_args=["--restore-backing"])
+mounted = read_tags_from_mount(mount_dir, rel_path)
+assert mounted.get("comment")                          # backing value reappeared
+```
+
+Use the test file's existing helpers for mounting and reading; the pseudo-calls above (`read_tags_from_mount`, `run_beet_musefs`, `clear_tag_in_beets`) name the operations the existing e2e already performs — wire them to the real helpers in that file.
+
+- [ ] **Step 2: Run the e2e tier (requires tools)**
+
+Run: `cd contrib/beets && python -m pytest -m e2e -v`
+Expected: PASS if `ffmpeg` + `/dev/fuse` + `fusermount` are present; otherwise the tier skips cleanly (acceptable — note the skip).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add contrib/beets/tests/test_e2e.py
+git commit -m "test(beets): e2e coverage for full-field merge, sticky delete, restore-backing"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run every Python suite green:**
+
+```bash
+cd contrib/python-musefs && python -m pytest -q
+cd ../beets && python -m pytest -q          # default tier (no Rust binary)
+cd ../picard && python -m pytest -q
+```
+
+- [ ] **Optional, with tools:** `cd contrib/beets && python -m pytest -m musefs_bin -q` (path gate vs the real `musefs` binary — build it first from repo root with `cargo build`), then `python -m pytest -m e2e -q`.
+
+- [ ] **No Rust/schema touched:** confirm `git diff --name-only main...HEAD` lists only files under `contrib/`, `ARCHITECTURE.md`, and `docs/superpowers/`. No `*.rs`, no `schema.py`/`schema.rs` — so the Rust workspace build and the schema-mirror gate are unaffected.
+
+---
+
+## Spec-coverage self-check (done while writing — recorded for the executor)
+
+- Field boundary `_media_tag_fields` + auto file-fact exclusion → Task 3 (`map_fields`, `FALLBACK_TAG_FIELDS`, `test_file_facts_excluded`).
+- Drop predicate, numeric-zero kept, ReplayGain 0 dB survives → Task 3 (`_DROP_IF_ZERO`, `test_replaygain_zero_gain_survives`).
+- `fields:` override precedence (last-wins; may re-introduce a fact) → Task 3 (`extra_fields` block, `test_extra_fields_override_wins`).
+- Rename table (`rg_*`, `mb_*`, `comments`) → Task 3 (`RENAME`).
+- Twin pre-pass, plural-wins, multi-artist fix → Task 3 (`TWINS`, ordered loop, `test_plural_artist_wins_and_expands`).
+- Stringification (bool `1`/`0`, int no `.0`) + formatter exceptions → Task 3 (`_stringify`, `FORMATTERS`).
+- `beets_path` is a managed key → Task 4 (`build_records`, `test_build_records_beets_path_is_managed`).
+- `merge_tags` with `value_blob IS NULL` scoping + per-key ordinals → Task 1.
+- `Record.delete_keys` + `merge` flag (Picard unaffected by default) → Task 2 (`test_sync_files_default_is_full_replace`).
+- `musefs_managed` flexattr read/compute/write; `item.store()` not `write()` → Task 4 (`persist_managed`, `test_persist_managed_uses_store_not_write`).
+- Both sync paths (command + `_reconcile_pending`) → Task 5 (`_sync` shared by both; `_reconcile_pending` threads `restore_backing`).
+- `--restore-backing` / `restore_backing` default off → Task 5.
+- Picard naming-only → Task 6.
+- Docs (beets, python-musefs, ARCHITECTURE) → Task 7.
+- e2e + autoscan-off caveat documented → Task 8 + Task 7.

--- a/docs/superpowers/plans/2026-06-10-beets-field-coverage.md
+++ b/docs/superpowers/plans/2026-06-10-beets-field-coverage.md
@@ -619,10 +619,17 @@ def map_fields(item, extra_fields=None):
     return [(key, value) for key, values in emitted.items() for value in values]
 ```
 
-- [ ] **Step 4: Run to verify pass**
+- [ ] **Step 4: Run the rewritten file, then the WHOLE beets suite**
 
 Run: `cd contrib/beets && python -m pytest tests/test_map_fields.py -v`
 Expected: PASS (all tests in the rewritten file).
+
+Then run the full suite — the new `map_fields` must not regress `test_build_records.py`
+or `test_plugin.py`, which exercise it via `build_records` with conftest `FakeItem`
+stubs that expose **no** `_media_tag_fields` (so `map_fields` uses `FALLBACK_TAG_FIELDS`):
+
+Run: `cd contrib/beets && python -m pytest -q`
+Expected: PASS (whole suite green at this commit).
 
 - [ ] **Step 5: Commit**
 
@@ -633,60 +640,56 @@ git commit -m "feat(beets): map full _media_tag_fields with rename, twins, forma
 
 ---
 
-## Task 4: Managed-state helpers + `build_records` delete-keys wiring
+## Task 4: Managed-state helpers, accumulating delete-keys, and merge-wired `_sync`
+
+This task adds the managed-state helpers, rewrites `build_records` to use the
+**accumulating-union** model (a deleted tag stays deleted across re-scans), and —
+critically — updates `_sync` in the same commit, because `build_records`'s return
+shape changes from a list to a `(records, managed_writes)` tuple and `_sync` is its
+only production caller. Splitting these would leave the suite red at the commit.
 
 **Files:**
-- Modify: `contrib/beets/beetsplug/_core.py` (add helpers; change `build_records` signature/return)
-- Test: `contrib/beets/tests/test_build_records.py` (extend) and `contrib/beets/tests/test_managed_state.py` (create)
+- Modify: `contrib/beets/beetsplug/_core.py` (add helpers; rewrite `build_records`)
+- Modify: `contrib/beets/beetsplug/musefs.py` (`_sync` → tuple unpack + merge + persist)
+- Modify: `contrib/beets/tests/conftest.py` (`FakeItem` gains flexattr write + `store()`)
+- Test: `contrib/beets/tests/test_build_records.py` (fix call sites), `contrib/beets/tests/test_managed_state.py` (create)
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Teach the conftest `FakeItem` to persist a flexattr**
 
-Create `contrib/beets/tests/test_managed_state.py`:
+`build_records` reads the `musefs_managed` flexattr (via `getattr`, already works)
+and `_sync` writes it via `persist_managed` → `item[key] = value` + `item.store()`.
+The real beets Item supports both; the conftest stub does not yet. In
+`contrib/beets/tests/conftest.py`, add these two methods to `FakeItem` (right after
+its `get_album` method):
 
 ```python
+    def __setitem__(self, key, value):
+        # beets flexattr write; readable back via getattr (used by read_managed).
+        setattr(self, key, value)
+
+    def store(self):
+        self.stored = getattr(self, "stored", 0) + 1
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `contrib/beets/tests/test_managed_state.py` (reuses the conftest `FakeItem`,
+now flexattr-capable):
+
+```python
+from conftest import FakeItem
+
 from musefs_common import SyncStats
 
 from beetsplug import _core
 
 
-class FakeStoreItem:
-    """Item stub that supports flexattr read (getattr), write (item[k]=v) and
-    store(); records whether write() (the file-writing method) was called."""
-
-    def __init__(self, path=b"/m/a.flac", **fields):
-        self.path = path
-        self._flex = {}
-        self.stored = 0
-        self.wrote_file = False
-        self._media_tag_fields = _core.FALLBACK_TAG_FIELDS
-        for k, v in fields.items():
-            setattr(self, k, v)
-
-    # flexattr read path used by read_managed
-    def __getattr__(self, name):
-        flex = self.__dict__.get("_flex", {})
-        if name in flex:
-            return flex[name]
-        raise AttributeError(name)
-
-    def __setitem__(self, key, value):
-        self._flex[key] = value
-
-    def store(self):
-        self.stored += 1
-
-    def write(self):
-        self.wrote_file = True
-
-    def destination(self, relative_to_libdir=False):
-        return self.path
-
-    def get_album(self):
-        return None
+def _item(**kw):
+    return FakeItem(b"/m/a.flac", **kw)
 
 
 def test_read_managed_empty_and_parsed():
-    it = FakeStoreItem()
+    it = _item()
     assert _core.read_managed(it) == []
     it["musefs_managed"] = "artist,comment,title"
     assert _core.read_managed(it) == ["artist", "comment", "title"]
@@ -696,52 +699,55 @@ def test_format_managed_sorts_and_dedupes():
     assert _core.format_managed(["title", "artist", "artist"]) == "artist,title"
 
 
-def test_persist_managed_uses_store_not_write():
-    it = FakeStoreItem()
+def test_persist_managed_writes_flexattr_via_store():
+    # store() persists to the beets DB; it does NOT call write() (which writes the
+    # audio file and fires after_write). The stub has no write() at all, so a
+    # regression to write() would raise here. The real guarantee is beets' event
+    # model (store != after_write) plus the e2e reconcile path (Task 8).
+    it = _item()
     _core.persist_managed([(it, ["artist", "title"])])
-    assert it._flex["musefs_managed"] == "artist,title"
+    assert it.musefs_managed == "artist,title"
     assert it.stored == 1
-    assert it.wrote_file is False   # must not call write() (would fire after_write)
 
 
-def test_build_records_computes_delete_keys_from_prev_managed():
-    it = FakeStoreItem(title="T", artist="A")
-    it["musefs_managed"] = "artist,title,grouping"   # grouping managed last time
+def test_build_records_delete_keys_and_union_persist():
+    it = _item(title="T", artist="A")
+    it["musefs_managed"] = "artist,title,grouping"   # grouping was managed before
     records, writes = _core.build_records(
         [it], fields={}, stats=SyncStats(), write_path=False, restore_backing=False)
     rec = records[0]
-    # grouping no longer in M -> queued for deletion; title/artist not deleted.
-    assert rec.delete_keys == ["grouping"]
+    assert rec.delete_keys == ["grouping"]           # dropped from M -> delete
     assert ("title", "T") in rec.pairs and ("artist", "A") in rec.pairs
-    # managed_writes carries the new key set for persistence.
     item, managed = writes[0]
     assert item is it
-    assert set(managed) == {"title", "artist"}
+    # UNION: grouping stays in musefs_managed as a tombstone so the delete sticks
+    # across future re-scans (not just one cycle).
+    assert set(managed) == {"title", "artist", "grouping"}
 
 
-def test_build_records_restore_backing_disables_deletes():
-    it = FakeStoreItem(title="T")
+def test_build_records_restore_backing_clears_deletes_and_tombstones():
+    it = _item(title="T")
     it["musefs_managed"] = "title,grouping"
-    records, _ = _core.build_records(
+    records, writes = _core.build_records(
         [it], fields={}, stats=SyncStats(), write_path=False, restore_backing=True)
-    assert records[0].delete_keys == []   # restore-backing -> never delete
+    assert records[0].delete_keys == []              # no deletes under the flag
+    assert set(writes[0][1]) == {"title"}            # tombstones cleared (reset to M)
 
 
 def test_build_records_beets_path_is_managed():
-    it = FakeStoreItem(title="T", destination=b"Artist/Album/01 T.flac")
+    it = _item(title="T", destination=b"Artist/Album/01 T.flac")
     records, writes = _core.build_records(
         [it], fields={}, stats=SyncStats(), write_path=True, restore_backing=False)
-    keys = {k for k, _ in records[0].pairs}
-    assert "beets_path" in keys
-    assert "beets_path" in writes[0][1]   # included in managed set
+    assert "beets_path" in {k for k, _ in records[0].pairs}
+    assert "beets_path" in writes[0][1]              # included in the managed set
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [ ] **Step 3: Run to verify failure**
 
 Run: `cd contrib/beets && python -m pytest tests/test_managed_state.py -v`
 Expected: FAIL — `AttributeError: module 'beetsplug._core' has no attribute 'read_managed'` (and `build_records` returns a list, not a tuple).
 
-- [ ] **Step 3: Add the helpers and rewrite `build_records`**
+- [ ] **Step 4: Add the helpers and rewrite `build_records`**
 
 In `contrib/beets/beetsplug/_core.py`, add the three helpers (anywhere after `MANAGED_FLEXATTR`):
 
@@ -760,7 +766,7 @@ def format_managed(keys):
 
 
 def persist_managed(writes):
-    """Persist each ``(item, managed_keys)`` pair's key set into the beets DB via
+    """Persist each ``(item, managed_keys)`` pair into the beets DB via
     ``item.store()``. Never calls ``item.write()`` — that writes the audio file and
     fires ``after_write``, which would re-enter the plugin's reconcile loop."""
     for item, keys in writes:
@@ -768,16 +774,22 @@ def persist_managed(writes):
         item.store()
 ```
 
-Then replace the existing `build_records` with:
+Then replace the existing `build_records` with the accumulating-union version:
 
 ```python
 def build_records(items, *, fields=None, stats, write_path=True, restore_backing=False, log=None):
     """Build ``Record``s for beets items and the parallel managed-key writes.
 
     Returns ``(records, managed_writes)`` where ``managed_writes`` is a list of
-    ``(item, managed_keys)`` for the caller to persist *after a successful commit*
-    via ``persist_managed``. Each record's ``delete_keys`` is the set of keys the
-    item managed last sync but no longer does (empty when ``restore_backing``)."""
+    ``(item, managed_keys)`` the caller persists *after a successful commit* via
+    ``persist_managed``.
+
+    ``musefs_managed`` is an *accumulating* set (keys ever managed): each record's
+    ``delete_keys`` is ``prev - keys(M)`` and the persisted set is the union
+    ``prev | keys(M)``, so a key dropped from M stays a tombstone and keeps getting
+    re-deleted on every sync until it re-enters M or ``restore_backing`` clears it.
+    Under ``restore_backing`` no keys are deleted and the set is reset to ``keys(M)``
+    (tombstones forgotten), so restored backing values stay visible."""
     records = []
     managed_writes = []
     art_cache = {}
@@ -788,9 +800,14 @@ def build_records(items, *, fields=None, stats, write_path=True, restore_backing
             path = _computed_path_or_skip(item, log)
             if path:
                 pairs.append(("beets_path", path))
-        managed = sorted({key for key, _ in pairs})
-        prev = read_managed(item)
-        delete_keys = [] if restore_backing else sorted(set(prev) - set(managed))
+        keys_now = {key for key, _ in pairs}
+        prev = set(read_managed(item))
+        if restore_backing:
+            delete_keys = []
+            managed = sorted(keys_now)
+        else:
+            delete_keys = sorted(prev - keys_now)
+            managed = sorted(prev | keys_now)
         records.append(
             Record(
                 key=realpath_key(item.path),
@@ -803,125 +820,13 @@ def build_records(items, *, fields=None, stats, write_path=True, restore_backing
     return records, managed_writes
 ```
 
-- [ ] **Step 4: Fix the existing `build_records` test for the new return shape**
+- [ ] **Step 5: Update `_sync` to the merge + persist version (same commit)**
 
-`contrib/beets/tests/test_build_records.py` currently unpacks a single list. Update each `build_records(...)` call site to `records, _ = build_records(...)` (and add a focused assertion if the test inspects records). Run the file to find call sites:
+In `contrib/beets/beetsplug/musefs.py`, replace `_sync` so it unpacks the new tuple,
+syncs with `merge=True`, and persists managed state after commit. The
+`restore_backing` parameter defaults `False` here; Task 5 wires the config/flag that
+feeds it (until then, callers use the default and behavior is "deletions stick"):
 
-Run: `cd contrib/beets && python -m pytest tests/test_build_records.py -v`
-Fix each failure by destructuring the tuple. Re-run until green.
-
-- [ ] **Step 5: Run both test files**
-
-Run: `cd contrib/beets && python -m pytest tests/test_build_records.py tests/test_managed_state.py -v`
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add contrib/beets/beetsplug/_core.py \
-        contrib/beets/tests/test_managed_state.py \
-        contrib/beets/tests/test_build_records.py
-git commit -m "feat(beets): managed-key flexattr state and delete-key computation"
-```
-
----
-
-## Task 5: Wire the adapter — merge sync, persist, `--restore-backing`, both paths
-
-**Files:**
-- Modify: `contrib/beets/beetsplug/musefs.py`
-- Test: `contrib/beets/tests/test_plugin.py` (extend)
-
-- [ ] **Step 1: Write the failing test**
-
-Append to `contrib/beets/tests/test_plugin.py` (mirror the file's existing plugin-construction pattern; if it builds a plugin via a fixture, reuse it). Minimal direct-call tests:
-
-```python
-def test_sync_uses_merge_and_persists_managed(tmp_path, monkeypatch):
-    """A real DB round-trip: B persists, M wins, managed flexattr written."""
-    import sqlite3
-    from musefs_common.schema import SCHEMA_SQL
-    from musefs_common import connect
-    from beetsplug.musefs import MusefsPlugin
-    from beetsplug import _core
-
-    db = tmp_path / "musefs.db"
-    raw = sqlite3.connect(str(db)); raw.executescript(SCHEMA_SQL); raw.commit()
-    raw.execute("INSERT INTO tracks (backing_path, format, audio_offset, "
-                "audio_length, backing_size, backing_mtime, updated_at) "
-                "VALUES ('/m/a.flac','flac',0,0,0,0,0)")
-    tid = raw.execute("SELECT id FROM tracks").fetchone()[0]
-    raw.execute("INSERT INTO tags (track_id,key,value,ordinal) VALUES (?,?,?,0)",
-                (tid, "comment", "keep"))
-    raw.commit(); raw.close()
-
-    # Item stub: real path on disk so realpath_key matches the inserted row.
-    p = tmp_path / "a.flac"; p.write_bytes(b"")
-    from tests.test_managed_state import FakeStoreItem  # reuse stub
-    item = FakeStoreItem(path=str(p).encode())
-    item._media_tag_fields = _core.FALLBACK_TAG_FIELDS
-    item.artist = "New"
-
-    # Point the inserted track at the real temp path.
-    conn = connect(str(db))
-    conn.execute("UPDATE tracks SET backing_path=? WHERE id=?",
-                 (__import__("os").path.realpath(str(p)), tid))
-    conn.commit(); conn.close()
-
-    plugin = MusefsPlugin()
-    plugin.config["db"] = str(db)
-    plugin._sync(str(db), [item], dry_run=False, restore_backing=False)
-
-    conn = connect(str(db))
-    tags = dict((k, v) for k, v in conn.execute(
-        "SELECT key,value FROM tags WHERE track_id=? AND value_blob IS NULL", (tid,)))
-    conn.close()
-    assert tags["artist"] == "New"      # M wins
-    assert tags["comment"] == "keep"    # unmanaged B persists (merge, not replace)
-    assert item._flex.get("musefs_managed")   # managed set persisted
-    assert item.wrote_file is False           # store(), not write()
-```
-
-(If `MusefsPlugin()` cannot be constructed bare in the test env, gate this test behind the same marker the existing plugin tests use, or construct via the project's existing plugin fixture.)
-
-- [ ] **Step 2: Run to verify failure**
-
-Run: `cd contrib/beets && python -m pytest tests/test_plugin.py -v -k merge_and_persists`
-Expected: FAIL — `_sync()` has no `restore_backing` parameter and still full-replaces (comment wiped).
-
-- [ ] **Step 3: Update the adapter**
-
-In `contrib/beets/beetsplug/musefs.py`:
-
-(a) Add the config default in `__init__`'s `self.config.add({...})`:
-```python
-            "restore_backing": False,  # on delete, let the backing tag value reappear
-```
-
-(b) Add the command option in `commands()` (after the `--dry-run` option):
-```python
-        cmd.parser.add_option(
-            "--restore-backing",
-            dest="restore_backing",
-            action="store_true",
-            default=False,
-            help="when a tag is removed in beets, let the backing file's value reappear",
-        )
-```
-
-(c) Add a config helper near `_write_path`:
-```python
-    def _restore_backing(self):
-        return bool(self.config["restore_backing"].get(bool))
-```
-
-(d) In `_command`, resolve the effective flag and pass it through:
-```python
-        restore_backing = bool(opts.restore_backing) or self._restore_backing()
-        stats = self._sync(db_path, items, dry_run=opts.dry_run, restore_backing=restore_backing)
-```
-
-(e) Replace `_sync` with the merge + persist version:
 ```python
     def _sync(self, db_path, items, dry_run=False, restore_backing=False):
         if not os.path.exists(db_path):
@@ -955,21 +860,212 @@ In `contrib/beets/beetsplug/musefs.py`:
             conn.close()
 ```
 
-(f) In `_reconcile_pending`, thread the config default into the sync call. Change the `self._sync(db_path, items)` call to:
+- [ ] **Step 6: Fix existing `test_build_records.py` call sites**
+
+`test_build_records.py` unpacks `build_records(...)` as a single list. Update each
+call site to `records, _ = build_records(...)`. Run the file and fix every failure:
+
+Run: `cd contrib/beets && python -m pytest tests/test_build_records.py -v`
+Expected after fixes: PASS.
+
+- [ ] **Step 7: Run the WHOLE beets suite (catches the `_sync`/`FakeItem` coupling)**
+
+Run: `cd contrib/beets && python -m pytest -q`
+Expected: PASS. This must include `test_plugin.py` — those tests drive `_command`/
+`_reconcile_pending` → `_sync` → `persist_managed`, which now calls `item.store()` on
+the conftest `FakeItem` (Step 1) and goes through `merge_tags` (Task 2). They use
+`FALLBACK_TAG_FIELDS` because `FakeItem` exposes no `_media_tag_fields`, and the
+`make_track` fixture seeds no text tags, so merge produces the same rows full-replace
+did. If any `test_plugin.py` test is red here, the coupling above is the cause.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add contrib/beets/beetsplug/_core.py contrib/beets/beetsplug/musefs.py \
+        contrib/beets/tests/conftest.py \
+        contrib/beets/tests/test_managed_state.py \
+        contrib/beets/tests/test_build_records.py
+git commit -m "feat(beets): accumulating managed-state flexattr + merge-wired _sync"
+```
+
+---
+
+## Task 5: Config + flag + both-paths wiring (`--restore-backing`)
+
+`_sync` already merges and persists (Task 4). This task adds the `restore_backing`
+config/flag and threads it into both sync paths, then proves the merge + sticky-delete
+behavior end to end through the plugin (including the passive `cli_exit` path).
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/musefs.py` (config key, command option, helper, `_command`, `_reconcile_pending`)
+- Test: `contrib/beets/tests/test_plugin.py` (extend — reuse its `FakeConfigView` + `monkeypatch` pattern)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `contrib/beets/tests/test_plugin.py`. Reuse the module's existing
+`FakeConfigView` (defined at the top of that file) and the `monkeypatch.setattr(plugin,
+"config", FakeConfigView({...}), raising=False)` pattern used by the existing tests —
+do **not** assign `plugin.config[...] = ...` (the real config view is read-only here):
+
+```python
+import os
+import sqlite3
+
+from musefs_common import connect
+from musefs_common.schema import SCHEMA_SQL
+
+from beetsplug.musefs import MusefsPlugin
+from conftest import FakeItem, insert_track
+
+
+def _seed_track_with_tag(db_path, real_path, key, value):
+    conn = connect(db_path)
+    tid = insert_track(conn, real_path)
+    conn.execute("INSERT INTO tags (track_id, key, value, ordinal) VALUES (?,?,?,0)",
+                 (tid, key, value))
+    conn.commit()
+    conn.close()
+    return tid
+
+
+def _text_tags(db_path, tid):
+    conn = connect(db_path)
+    rows = dict(conn.execute(
+        "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL", (tid,)))
+    conn.close()
+    return rows
+
+
+def test_sync_merges_keeps_unmanaged_and_persists(db_path, tmp_path, monkeypatch):
+    """Command path: B persists, M wins, managed flexattr written via store()."""
+    p = tmp_path / "a.flac"; p.write_bytes(b"")
+    real = os.path.realpath(str(p))
+    tid = _seed_track_with_tag(db_path, real, "comment", "keep")
+
+    item = FakeItem(str(p).encode(), artist="New")
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin, "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": False,
+                        "restore_backing": False}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item], dry_run=False, restore_backing=False)
+
+    tags = _text_tags(db_path, tid)
+    assert tags["artist"] == "New"      # M wins
+    assert tags["comment"] == "keep"    # unmanaged B persists (merge, not replace)
+    assert "artist" in item.musefs_managed   # managed set persisted via store()
+
+
+def test_reconcile_path_merges_and_sticky_deletes(db_path, tmp_path, monkeypatch):
+    """Passive cli_exit path runs the same merge + managed-state cycle, and a key
+    dropped from a prior managed set is deleted (tombstone)."""
+    p = tmp_path / "b.flac"; p.write_bytes(b"")
+    real = os.path.realpath(str(p))
+    tid = _seed_track_with_tag(db_path, real, "grouping", "old")
+
+    item = FakeItem(str(p).encode(), title="T")
+    item["musefs_managed"] = "grouping,title"   # grouping managed before; now dropped
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin, "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": False,
+                        "autoscan": False, "restore_backing": False}),
+        raising=False,
+    )
+    monkeypatch.setattr(plugin, "_run_scan", lambda db, targets: None)
+    plugin._pending = [item]
+    plugin._reconcile_pending(lib=None)
+
+    tags = _text_tags(db_path, tid)
+    assert tags.get("title") == "T"     # merged on the reconcile path
+    assert "grouping" not in tags       # tombstoned delete applied on the reconcile path
+
+
+def test_restore_backing_skips_deletes(db_path, tmp_path, monkeypatch):
+    """With restore_backing, a previously-managed-now-dropped key is NOT deleted."""
+    p = tmp_path / "c.flac"; p.write_bytes(b"")
+    real = os.path.realpath(str(p))
+    tid = _seed_track_with_tag(db_path, real, "grouping", "frombacking")
+
+    item = FakeItem(str(p).encode(), title="T")
+    item["musefs_managed"] = "grouping,title"
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin, "config",
+        FakeConfigView({"db": db_path, "fields": {}, "write_path": False,
+                        "restore_backing": True}),
+        raising=False,
+    )
+    plugin._sync(db_path, [item], dry_run=False, restore_backing=True)
+
+    tags = _text_tags(db_path, tid)
+    assert tags["grouping"] == "frombacking"   # backing value left in place
+    assert set(item.musefs_managed.split(",")) == {"title"}  # tombstones cleared
+```
+
+Note: the existing `FakeConfigView` (`test_plugin.py` top) returns raw data and its
+`get(template)` ignores the template, so the existing tests whose config dicts omit
+`restore_backing` still work — `self.config["restore_backing"].get(bool)` degrades to
+`None` → `bool(None)` = `False`. Do **not** edit those existing fixtures.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd contrib/beets && python -m pytest tests/test_plugin.py -v -k "restore_backing or merges"`
+Expected: FAIL — `_restore_backing` / `--restore-backing` not present; `_command`/
+`_reconcile_pending` don't thread `restore_backing`.
+
+- [ ] **Step 3: Update the adapter**
+
+In `contrib/beets/beetsplug/musefs.py`:
+
+(a) Add the config default in `__init__`'s `self.config.add({...})`:
+```python
+            "restore_backing": False,  # on delete, let the backing tag value reappear
+```
+
+(b) Add the command option in `commands()` (after the `--dry-run` option):
+```python
+        cmd.parser.add_option(
+            "--restore-backing",
+            dest="restore_backing",
+            action="store_true",
+            default=False,
+            help="when a tag is removed in beets, let the backing file's value reappear",
+        )
+```
+
+(c) Add a config helper near `_write_path`:
+```python
+    def _restore_backing(self):
+        return bool(self.config["restore_backing"].get(bool))
+```
+
+(d) In `_command`, resolve the effective flag and pass it through (replace the existing
+`stats = self._sync(db_path, items, dry_run=opts.dry_run)` line):
+```python
+        restore_backing = bool(opts.restore_backing) or self._restore_backing()
+        stats = self._sync(db_path, items, dry_run=opts.dry_run, restore_backing=restore_backing)
+```
+
+(e) In `_reconcile_pending`, thread the config default (replace the existing
+`self._sync(db_path, items)` call):
 ```python
             self._sync(db_path, items, restore_backing=self._restore_backing())
 ```
 
-- [ ] **Step 4: Run the test + full beets unit suite**
+- [ ] **Step 4: Run the full beets suite**
 
 Run: `cd contrib/beets && python -m pytest -q`
-Expected: PASS. (If the new plugin test must be marker-gated for env reasons, the rest of the suite must still be green.)
+Expected: PASS (new tests green; existing `FakeConfigView` tests unaffected — see the
+Step 1 note on the benign `restore_backing` default).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add contrib/beets/beetsplug/musefs.py contrib/beets/tests/test_plugin.py
-git commit -m "feat(beets): merge sync with managed-state persistence and --restore-backing"
+git commit -m "feat(beets): restore_backing config + --restore-backing on both sync paths"
 ```
 
 ---
@@ -977,7 +1073,7 @@ git commit -m "feat(beets): merge sync with managed-state persistence and --rest
 ## Task 6: Picard naming additions (no merge)
 
 **Files:**
-- Modify: `contrib/picard/musefs/_core.py` (`DIRECT_FIELDS`, `_MULTI_VALUE_KEYS`)
+- Modify: `contrib/picard/musefs/_core.py` (`DIRECT_FIELDS` only — the additions are all single-valued, so `_MULTI_VALUE_KEYS` is unchanged)
 - Test: `contrib/picard/tests/test_map_fields.py` (extend)
 
 - [ ] **Step 1: Write the failing test**
@@ -1110,35 +1206,65 @@ git commit -m "docs: document beets merge sync, musefs_managed, merge_tags contr
 **Files:**
 - Modify: `contrib/beets/tests/test_e2e.py`
 
-- [ ] **Step 1: Add the e2e assertions**
+This tier is **skip-acceptable**: it is gated on `ffmpeg` + `/dev/fuse` +
+`fusermount` and skips cleanly when absent. The unit/integration tiers (Tasks 1–5)
+carry the correctness load; this is the real-mount confirmation, and notably the
+**multi-cycle** sticky-delete check that would have caught the one-cycle bug.
 
-The `e2e` tier (marker `e2e`, gated on `ffmpeg` + `/dev/fuse` + `fusermount`) already imports audio, retags, syncs, mounts, and verifies tags + byte-identical audio. Extend it (or add a sibling `@pytest.mark.e2e` test mirroring the existing one's setup/mount helpers) to assert the new behavior:
+- [ ] **Step 1: Add a concrete e2e test**
+
+Add a new `@pytest.mark.e2e` test to `contrib/beets/tests/test_e2e.py`, built from the
+file's real helpers (`_imported_library` → `(cfg, env, db, mnt, library)`,
+`_beet(cfg, env, *args)`, the `_mounted(mnt, db, template)` context manager) and
+modeled on `test_e2e_import_retag_mount_playback`. Read tags with `FLAC(str(path))`
+(already imported as `from mutagen.flac import FLAC`) so Vorbis keys like
+`replaygain_track_gain` / `musicbrainz_albumid` are visible — `easy=True` would hide
+them. FLAC-focused so the assertions are format-idiomatic per the spec §2 fidelity note.
 
 ```python
-# After the existing import + `beet musefs` sync + mount, with the item carrying
-# ReplayGain, a MusicBrainz album id, and a custom field:
-mounted = read_tags_from_mount(mount_dir, rel_path)   # reuse the file's helper
-assert mounted["replaygain_track_gain"].endswith("dB")
-assert mounted["musicbrainz_albumid"]
-assert mounted["comment"]                              # an arbitrary mapped field
+def test_e2e_full_fields_sticky_delete_and_restore(tmp_path):
+    """Rich fields reach the mount; a deleted file-embedded tag stays gone across
+    re-scans; --restore-backing brings the backing value back."""
+    cfg, env, db, mnt, library = _imported_library(tmp_path)
+    template = "$albumartist/$album/$title"
 
-# Deletion sticks: clear the comment in beets, re-sync, remount, assert absent.
-clear_tag_in_beets(item, "comments"); run_beet_musefs()
-mounted = read_tags_from_mount(mount_dir, rel_path)
-assert "comment" not in mounted
+    # Embed a comment INTO the FLAC (no -W -> beets writes the file), so the tag
+    # exists in the backing file (B), not just the beets DB.
+    _beet(cfg, env, "modify", "-M", "-y", "format:FLAC",
+          "comments=from file", "rg_track_gain=-7.5",
+          "mb_albumid=11111111-1111-1111-1111-111111111111")
+    _beet(cfg, env, "musefs")
+    with _mounted(mnt, db, template):
+        ft = FLAC(str(next(mnt.rglob("*.flac"))))
+        assert ft["replaygain_track_gain"][0].endswith("dB")
+        assert ft["musicbrainz_albumid"][0].startswith("11111111")
+        assert ft["comment"][0] == "from file"
 
-# With --restore-backing, the embedded value returns.
-run_beet_musefs(extra_args=["--restore-backing"])
-mounted = read_tags_from_mount(mount_dir, rel_path)
-assert mounted.get("comment")                          # backing value reappeared
+    # Delete the comment in beets WITHOUT writing the file (-W): the FLAC on disk
+    # still embeds "from file", so this is the case the union model must handle.
+    _beet(cfg, env, "modify", "-W", "-M", "-y", "format:FLAC", "comments!")
+    _beet(cfg, env, "musefs")                       # cycle 1: delete applied
+    _beet(cfg, env, "musefs")                       # cycle 2: must STAY gone
+    with _mounted(mnt, db, template):
+        ft = FLAC(str(next(mnt.rglob("*.flac"))))
+        assert "comment" not in ft                  # tombstone held across re-scan
+
+    # --restore-backing: the file's embedded "from file" comment returns.
+    _beet(cfg, env, "musefs", "--restore-backing")
+    with _mounted(mnt, db, template):
+        ft = FLAC(str(next(mnt.rglob("*.flac"))))
+        assert ft["comment"][0] == "from file"
 ```
 
-Use the test file's existing helpers for mounting and reading; the pseudo-calls above (`read_tags_from_mount`, `run_beet_musefs`, `clear_tag_in_beets`) name the operations the existing e2e already performs — wire them to the real helpers in that file.
+If beets' field name for a tag differs on your beets version (e.g. it rejects
+`rg_track_gain` as a settable field), set it via the `fields:` config or skip that one
+assertion — the comment sticky-delete cycle is the load-bearing check.
 
 - [ ] **Step 2: Run the e2e tier (requires tools)**
 
 Run: `cd contrib/beets && python -m pytest -m e2e -v`
-Expected: PASS if `ffmpeg` + `/dev/fuse` + `fusermount` are present; otherwise the tier skips cleanly (acceptable — note the skip).
+Expected: PASS if `ffmpeg` + `/dev/fuse` + `fusermount` are present; otherwise the tier
+skips cleanly (acceptable — record the skip rather than treating it as success).
 
 - [ ] **Step 3: Commit**
 
@@ -1176,9 +1302,11 @@ cd ../picard && python -m pytest -q
 - `beets_path` is a managed key → Task 4 (`build_records`, `test_build_records_beets_path_is_managed`).
 - `merge_tags` with `value_blob IS NULL` scoping + per-key ordinals → Task 1.
 - `Record.delete_keys` + `merge` flag (Picard unaffected by default) → Task 2 (`test_sync_files_default_is_full_replace`).
-- `musefs_managed` flexattr read/compute/write; `item.store()` not `write()` → Task 4 (`persist_managed`, `test_persist_managed_uses_store_not_write`).
-- Both sync paths (command + `_reconcile_pending`) → Task 5 (`_sync` shared by both; `_reconcile_pending` threads `restore_backing`).
-- `--restore-backing` / `restore_backing` default off → Task 5.
+- `musefs_managed` flexattr read/compute/write via `item.store()` → Task 4 (`persist_managed`, `test_persist_managed_writes_flexattr_via_store`).
+- **Accumulating-union model — deletions stay deleted across re-scans** (spec §4 union) → Task 4 (`build_records` persists `prev | keys(M)`, `test_build_records_delete_keys_and_union_persist`) + Task 8 multi-cycle e2e.
+- Both sync paths (command + `_reconcile_pending`) → Task 4 (`_sync` shared by both) + Task 5 (`_reconcile_pending` threads `restore_backing`; `test_reconcile_path_merges_and_sticky_deletes`).
+- `--restore-backing` / `restore_backing` default off; resets tombstones → Task 5 (`test_restore_backing_skips_deletes`).
 - Picard naming-only → Task 6.
 - Docs (beets, python-musefs, ARCHITECTURE) → Task 7.
 - e2e + autoscan-off caveat documented → Task 8 + Task 7.
+- Query/partial syncs per-item safe (spec §5) → true by construction (`build_records` iterates only passed `items`; each owns its flexattr); not separately tested — noted as a known minor coverage gap.

--- a/docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md
@@ -27,12 +27,21 @@ Two confirmed facts shape the fix:
    to the file's embedded set. Autoscan runs `musefs scan` before every sync by
    default. This is the baseline the merge model builds on.
 
-## Goal
+## Goals
 
-A `beet musefs` sync should make the mounted view reflect the user's beets
-library: every tag beets would write to the file, under recognizable names,
-with beets' values winning over the file's embedded values, the file's other
-embedded tags preserved, and deletions that *stick*.
+A `beet musefs` sync — and an automatic sync via the import/write hooks — should
+make the mounted view reflect the user's beets library: every tag beets would
+write to the file, under recognizable names, with beets' values winning over the
+file's embedded values, the file's other embedded tags preserved, and deletions
+that *stick*.
+
+## Non-goals
+
+- Any Rust change, including extending `tagmap.rs` VOCAB for long-tail fidelity
+  or adding native `tracktotal`/`disctotal` keys.
+- `musefs-db` schema changes (and therefore the Python schema-mirror regen).
+- Changing `musefs scan`'s tag-ingest behavior.
+- Porting the merge/state model to Picard or Lidarr.
 
 ## Model
 
@@ -58,43 +67,77 @@ encoder_info, encoder_settings`) are **excluded automatically** because beets
 classifies them in `_media_fields` but not `_media_tag_fields` — no
 hand-maintained denylist, and the set tracks beets as it evolves.
 
-The existing `fields:` config still merges into / overrides this set.
-`beets_path` continues to be emitted as today (governed by `write_path`).
-Empty/zero values are dropped; multi-valued fields expand to one row per value.
+**Drop predicate (precise).** Drop a value only when it is `None` or an
+empty-after-strip string. **Numeric zero is kept** — `replaygain_track_gain ==
+0.00 dB`, `bpm == 0` mean different things but are both legitimate, and dropping
+`0 dB` would silently break the ReplayGain guarantee this design exists to
+deliver. The sole drop-on-zero exceptions are `tracknumber` and `discnumber`
+(a 0 track/disc is noise, as today). `tracktotal`/`disctotal` of 0 are dropped
+too (no meaningful "of 0").
 
-### 2. Naming & value formatting
+**`fields:` override.** The existing `fields:` config is applied as a *final
+override layer after* the §2 rename table: last-wins on store-key collision, and
+a `fields:` entry **may re-introduce an auto-excluded file fact** (explicit user
+intent beats the auto-exclusion). This is the one path by which a non-tag field
+can reach the store; it is opt-in and tested.
 
-Mapping from beets field name to canonical musefs key:
+**`beets_path`.** Still emitted when `write_path` is on (as today), but it is now
+a first-class **plugin-synthesized managed key**: it is included in `keys(M)` /
+`musefs_managed` (§4) so that turning `write_path: no` lands it in `delete_keys`
+and removes the stale row. Because it is synthesized (no `B` counterpart), the
+`--restore-backing` flag (§5) does not apply to it — when dropped it is simply
+deleted.
 
-- **Rename table** (only where the conventional musefs key differs):
-  - `rg_track_gain → replaygain_track_gain`, `rg_album_gain →
-    replaygain_album_gain`, `rg_track_peak → replaygain_track_peak`,
-    `rg_album_peak → replaygain_album_peak`
-  - `mb_albumid → musicbrainz_albumid`, `mb_artistid → musicbrainz_artistid`,
-    and the rest of the `mb_* → musicbrainz_*` family
-    (`mb_trackid`, `mb_albumartistid`, `mb_releasegroupid`, `mb_releasetrackid`,
-    `mb_workid`)
-  - `comments → comment`
-- **Plural → singular multi-value twins** (generalizes today's
-  genre/composer logic and **fixes the multi-artist collapse**): `artists →
-  artist`, `albumartists → albumartist`, `genres → genre`, `composers →
-  composer`, `lyricists → lyricist`, etc. Prefer the plural list when present,
-  else the singular scalar; expand to one store row per value.
-- **Everything else** passes through under its (lowercased) beets field name.
-- **Value formatters** (a per-field hook): `rg_*` gains format as `"-7.50 dB"`,
-  peaks as a plain float string, matching beets/MediaFile's on-file form. The
-  existing `date` assembly from `year`/`month`/`day` stays. `r128_*` values
-  pass through as integers (no `replaygain_*` rename — distinct convention).
+Multi-valued fields expand to one store row per value (§2 twin handling).
 
-**Fidelity limitation (explicit non-goal).** musefs renders the ~22 keys in its
-native VOCAB (`musefs-format/src/tagmap.rs`) idiomatically per format. The long
-tail (sort fields, `asin`, `catalognum`, and `tracktotal`/`disctotal` on
-mp3/mp4) passes through and *renders* — Vorbis uppercased, mp3 `TXXX`, mp4
-freeform — but is **not** guaranteed byte-identical to what beets itself would
-write to that format (e.g. mp3 wants `TRCK` "N/M" rather than a `TRACKTOTAL`
-`TXXX`). Full per-format fidelity for the long tail would require extending the
-Rust VOCAB and is out of scope here. FLAC/Ogg (Vorbis) get the closest match
-because the uppercased key *is* the convention.
+### 2. Naming, multi-value, and value formatting
+
+Mapping from beets field name to canonical musefs key, applied in this order:
+
+1. **Twin pre-pass (multi-value).** `_media_tag_fields` contains *both* singular
+   and plural forms for some concepts (`artist`+`artists`,
+   `albumartist`+`albumartists`), and plural-only forms for others (`genres`,
+   `composers`, `lyricists`, `arrangers`), plus `*_sort`/`*_credit` variants
+   (`artist_sort`/`artists_sort`, `artist_credit`/`artists_credit`, …). For each
+   such pair, **prefer the plural list when present and non-empty, else the
+   singular scalar**, and remove the non-chosen form from the iterated set so
+   each canonical store key is produced by exactly one source (no double rows).
+   The chosen plural expands to one row per value. The canonical store keys are
+   the musefs singular forms (`artist`, `albumartist`, `genre`, `composer`,
+   `lyricist`, …). *This fixes today's multi-artist collapse.*
+2. **Rename table** (only where the conventional musefs key differs from the
+   beets field name):
+   - `rg_track_gain → replaygain_track_gain` (+ `album_gain`, `track_peak`,
+     `album_peak`)
+   - `mb_albumid → musicbrainz_albumid`, `mb_artistid → musicbrainz_artistid`,
+     and the rest of the `mb_* → musicbrainz_*` family (`mb_trackid`,
+     `mb_albumartistid`, `mb_releasegroupid`, `mb_releasetrackid`, `mb_workid`)
+   - `comments → comment`
+3. **Everything else** passes through under its lowercased beets field name.
+4. **`fields:` override** (§1) is applied last.
+
+**Stringification.** Default rule: ints render as `str(int)` with no trailing
+`.0`; bools render as `"1"`/`"0"` (matching beets/MediaFile's on-file form for
+`comp`, **not** `"True"`); lists are handled by the twin pre-pass; everything
+else is `str(value).strip()`. The **value-formatter table is the explicit set of
+exceptions** to that default: the four `rg_*` gains format as `"-7.50 dB"`,
+the `rg_*` peaks as a plain float string, and `date` is assembled from
+`year`/`month`/`day` (as today). `r128_*` values pass through as integers (no
+`replaygain_*` rename — a distinct convention). Each formatter exception gets a
+dedicated test.
+
+**Fidelity limitation (explicit non-goal).** musefs renders the keys in its
+native VOCAB (`musefs-format/src/tagmap.rs`, a curated subset of roughly two
+dozen keys) idiomatically per format. Of the renamed family, only
+`musicbrainz_albumid`/`musicbrainz_artistid` and the `replaygain_*` set are in
+VOCAB; the remaining `mb_*`, the sort/credit fields, `asin`, `catalognum`, and
+`tracktotal`/`disctotal` are **long tail** — they pass through and *render*
+(Vorbis uppercased, mp3 `TXXX`, mp4 freeform) but are **not** guaranteed
+byte-identical to what beets itself writes to that format (e.g. mp3 wants `TRCK`
+"N/M" for the track/total rather than a `TRACKTOTAL` `TXXX`). Full per-format
+fidelity for the long tail would require extending the Rust VOCAB and is out of
+scope. FLAC/Ogg (Vorbis) get the closest match because the uppercased key *is*
+the convention.
 
 ### 3. Sync semantics — per-key merge
 
@@ -105,49 +148,83 @@ beside the existing `replace_tags` (which Picard keeps unchanged):
 merge_tags(conn, track_id, managed_pairs, delete_keys)
 ```
 
-- For each key present in `managed_pairs`: delete that key's text rows, then
-  insert the managed values (M-wins, multi-value safe, ordinals per key).
-- For each key in `delete_keys`: delete its text rows (suppress the `B` value).
-- Every other text row (unmanaged `B`) is left untouched.
-- Binary tags (`value_blob NOT NULL`, scanner-written) are untouched, exactly
-  as `replace_tags` already guarantees.
+- For each key present in `managed_pairs`: delete that key's **text** rows, then
+  insert the managed values. The delete is scoped
+  `DELETE FROM tags WHERE track_id=? AND key=? AND value_blob IS NULL` so
+  scanner-written **binary** tags (`value_blob NOT NULL`) sharing a key are never
+  clobbered. Inserted ordinals run `0..n` per key (mirroring `replace_tags`,
+  which the store reads back `ORDER BY key, ordinal`).
+- For each key in `delete_keys`: delete its text rows, scoped the same
+  (`value_blob IS NULL`).
+- Every other text row (unmanaged `B`) is left untouched; binary tags untouched.
 
 beets' `sync_one`/`sync_files` path switches from `replace_tags` to
 `merge_tags`; Picard's path is unchanged.
 
-### 4. Stateful deletion via a beets flexattr
+### 4. Stateful deletion via a beets flexattr — on **both** sync paths
 
-Per item, the plugin stores `musefs_managed` — the sorted list of canonical
-keys written in the last sync — as a beets **flexattr** (lives in the beets DB;
-never written to the audio file, never sent to the musefs store).
+Per item, the plugin stores `musefs_managed` — the sorted list of canonical keys
+written in the last sync, including `beets_path` when emitted — as a beets
+**flexattr** (lives in the beets DB; never written to the audio file, never sent
+to the musefs store).
 
-Each sync:
+Each sync (the explicit `beet musefs` command **and** the passive
+`_reconcile_pending` `cli_exit` hook — see §4a):
 
 1. Autoscan resets the store's text tags to `B`.
 2. Compute `M` (§1–2).
 3. Read `prev` from `musefs_managed`; `delete_keys = prev − keys(M)`.
 4. `merge_tags(conn, track_id, M, delete_keys)` — unless restore-backing is set
-   (see §5), in which case pass `delete_keys = ∅`.
-5. Write `keys(M)` back to `musefs_managed` (skipped on dry-run).
+   (§5), in which case pass `delete_keys = ∅`.
+5. Persist `keys(M)` back to `musefs_managed` via `item.store()` (skipped only on
+   the command path's `-n` dry-run, which writes nothing).
 
 First-ever sync has no `prev` → no deletions, just writes `M`. A key the user
 never managed is never in `prev`, so it is never deleted → `B` persists. A key
-the user managed then dropped is in `prev` but not `M` → deleted and, because
-the plugin re-applies this after every autoscan, stays deleted.
+the user managed then dropped is in `prev` but not `M` → deleted and, because the
+plugin re-applies this after every autoscan, stays deleted.
+
+#### 4a. Both paths, identically — the passive `cli_exit` path is primary
+
+The plugin's *most common* sync is the passive one: `after_write` /
+`item_imported` / `album_imported` listeners record touched items, and
+`_reconcile_pending` (registered on `cli_exit`, `musefs.py`) syncs them at their
+final path. A user who removes ReplayGain via `beet modify -w` or re-imports goes
+through **this** path, not `beet musefs`. Therefore the full §4 cycle (read
+`prev` → compute `delete_keys` → `merge_tags` → persist `musefs_managed`) **must
+run identically in `_reconcile_pending`**, not only in the command. The passive
+path has no dry-run, so step 5 always persists.
+
+**Re-entrancy.** Persisting the flexattr uses `item.store()` (a beets *library
+DB* write), which does **not** emit `after_write` (that event fires only on
+`item.write()`, a file write). So writing `musefs_managed` inside the hook cannot
+re-trigger the record→reconcile loop. The plan must use `item.store()`, never
+`item.write()`, for this state.
+
+**Best-effort contract preserved.** `_reconcile_pending` already swallows
+environmental errors into warnings so a passive hook never aborts the beets
+operation; the added flexattr/merge work stays inside that same guard.
 
 ### 5. The restore-backing flag
 
-`--restore-backing` on the `beet musefs` subcommand, plus
-`restore_backing: no` in config as the default.
+`--restore-backing` on the `beet musefs` subcommand, plus `restore_backing: no`
+in config as the default. (The passive path honors the config default; the flag
+is command-only.)
 
 - **Default (off):** deletions stick — `delete_keys` is applied, suppressing the
   backing value for any key dropped from `M`.
 - **On:** `delete_keys` is skipped, so after the autoscan reset, `B`'s embedded
-  value for a dropped key reappears in the view.
+  value for a dropped key reappears in the view. (Synthesized keys like
+  `beets_path` have no `B` and are deleted regardless — §1.)
 
-**Caveat:** the deletion guarantee depends on autoscan resetting `B` before each
-sync. With `autoscan: no`, a deletion only reconciles on the next manual
-`musefs scan` + sync; this is documented as a limitation of that mode.
+**Caveat — the guarantee is contingent on the store holding `B` at sync time.**
+That is what `autoscan: yes` (the default) guarantees by resetting the store
+before each sync. With `autoscan: no`, step 1 does not run, the store may hold
+stale prior-sync rows rather than fresh `B`, and a deletion only reconciles on
+the next manual `musefs scan` + sync. Docs steer deletion-sensitive users to
+keep autoscan on. Query/partial syncs (`beet musefs QUERY`, which scans only
+matched files) are per-item safe: each item owns its own `musefs_managed`
+flexattr, so syncing a subset never disturbs unmatched items' managed state.
 
 ### 6. Picard
 
@@ -158,38 +235,52 @@ machinery: Picard writes the file's tags directly and is the authority on them,
 so full-replace is the correct semantics there. The `merge_tags` primitive is
 beets-only.
 
-## Out of scope
-
-- Any Rust change, including extending `tagmap.rs` VOCAB for long-tail fidelity
-  or adding native `tracktotal`/`disctotal` keys.
-- `musefs-db` schema changes (and therefore the Python schema-mirror regen).
-- Changing `musefs scan`'s tag-ingest behavior.
-- Porting the merge/state model to Picard or Lidarr.
-
 ## Testing
 
 - **`merge_tags` unit** (python-musefs): M-wins over B; unmanaged B persists;
-  `delete_keys` suppresses; binary tags survive; multi-value ordinals correct.
+  `delete_keys` suppresses; binary tags (`value_blob NOT NULL`) survive a
+  same-key text merge and a same-key delete; multi-value ordinals contiguous
+  per key.
 - **`map_fields` / `build_records`** (beets): boundary derives from
-  `_media_tag_fields`; file-facts excluded; rename table applied; plural→singular
-  multi-value expansion (incl. `artists`/`albumartists`); ReplayGain value
-  formatting; `fields:` override still works.
-- **Stateful deletion integration:** sync → delete a tag in beets → re-sync →
-  tag stays gone across the intervening autoscan; `musefs_managed` flexattr
-  round-trips.
+  `_media_tag_fields`; file-facts excluded; twin pre-pass picks plural-over-
+  singular and emits exactly one source per store key (incl. `artist`/`artists`,
+  `albumartist`/`albumartists`, the `*_sort`/`*_credit` variants); rename table
+  applied; ReplayGain `"x.xx dB"` / peak formatting; bool `comp` → `"1"`/`"0"`;
+  int with no trailing `.0`; **numeric-zero `replaygain_track_gain` survives**;
+  `fields:` override wins on collision and can re-introduce a file fact;
+  `beets_path` present in `keys(M)`.
+- **Stateful deletion integration — both paths:** (a) `beet musefs` → delete a
+  tag in beets → re-sync → tag stays gone across the intervening autoscan; (b)
+  the same via the `cli_exit` reconcile path (simulate `item_imported` /
+  `after_write` → `_reconcile_pending`); `musefs_managed` flexattr round-trips
+  and is written with `item.store()` (assert no `after_write` re-entrancy).
+- **`beets_path` lifecycle:** `write_path: yes` then `no` → the `beets_path` row
+  is removed (it was in the managed set), unaffected by `--restore-backing`.
 - **`--restore-backing`:** dropped key reappears from `B` with the flag, stays
   gone without it.
-- **e2e (`m e2e`):** scan → beets tags incl. ReplayGain + MusicBrainz +
-  an arbitrary field → mount → all visible and correctly named; delete a tag →
-  absent at mount; with flag → present again. Byte-identical audio preserved.
+- **e2e (`python -m pytest -m e2e`):** scan → beets tags incl. ReplayGain +
+  MusicBrainz + an arbitrary field → mount → all visible and correctly named;
+  delete a tag → absent at mount; with flag → present again. Byte-identical
+  audio preserved.
 
 Commit any new harness/fixtures in-tree as runnable scripts per repo convention;
 keep large generated artifacts gitignored.
 
-## Docs to update
+## Documentation
 
 - `contrib/beets/README.md`: field coverage, merge vs replace, the
-  `musefs_managed` flexattr, `--restore-backing` / `restore_backing`, and the
-  autoscan-off caveat.
+  `musefs_managed` flexattr, `--restore-backing` / `restore_backing`, the
+  passive-path behavior, and the autoscan-off caveat.
+- `contrib/python-musefs/README.md`: document `merge_tags` as a new public
+  store-contract primitive alongside `replace_tags`.
 - `ARCHITECTURE.md` external-writer-contract section: a writer may merge rather
   than fully replace text tags; note the §2 long-tail fidelity limitation.
+
+## Open risks the plan must resolve
+
+- Confirm `item.store()` inside a `cli_exit` hook persists a flexattr without
+  firing `after_write` on the running beets version(s) the suite targets (the
+  re-entrancy assumption in §4a). If it does fire, the plan needs a guard.
+- Confirm `_media_tag_fields` is stable across the supported beets versions
+  (1.x vs 2.x) and that the twin pairs (§2) exist in each; fall back gracefully
+  (singular-only) where a plural is absent.

--- a/docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md
@@ -1,0 +1,195 @@
+# beets plugin: full field coverage + stateful merge sync
+
+**Status:** design / approved for planning
+**Date:** 2026-06-10
+**Scope:** `contrib/beets/`, `contrib/python-musefs/` (shared lib), docs. Picard
+gets the naming additions only. No Rust changes, no `musefs-db` schema change.
+
+## Problem
+
+The beets plugin syncs a deliberately minimal 9-field core
+(`title, artist, albumartist, album, genre, composer, tracknumber, discnumber,
+date`) plus album art and `beets_path`. Everything else a user has in beets —
+ReplayGain, MusicBrainz IDs, comment, lyrics, grouping, isrc, multi-valued
+artists, and arbitrary fields — is **lost** in the mounted view, because
+`sync_one` fully replaces a track's text tags with only the mapped set. A
+re-tagged view that drops the user's ReplayGain (breaking player volume
+normalization) and identity tags is not what users want.
+
+Two confirmed facts shape the fix:
+
+1. The Rust format layer already renders **arbitrary** tag keys: Vorbis
+   (FLAC/Ogg) uppercases an unknown key, mp3 wraps it in `TXXX` (or emits a
+   4-byte key like `TBPM` as that text frame), mp4 emits a `----` freeform
+   atom. So nothing on the Rust side blocks broader coverage.
+2. `musefs scan`'s `ingest()` calls `db.replace_tags()` on every (re)scan
+   (`musefs-core/src/scan.rs`), so a re-scan resets a track's stored text tags
+   to the file's embedded set. Autoscan runs `musefs scan` before every sync by
+   default. This is the baseline the merge model builds on.
+
+## Goal
+
+A `beet musefs` sync should make the mounted view reflect the user's beets
+library: every tag beets would write to the file, under recognizable names,
+with beets' values winning over the file's embedded values, the file's other
+embedded tags preserved, and deletions that *stick*.
+
+## Model
+
+Let `B` = the track's embedded tags (seeded into the store by `musefs scan`)
+and `M` = the tags beets manages for that track.
+
+- For any key in both, **M wins**.
+- For a key only in `B`, **B persists** (untouched).
+- `M` may contain **arbitrary** beets fields, returned faithfully on read.
+- Deleting a key from `M` **removes it and keeps it removed** across re-scans;
+  it is not refilled from `B`. An opt-in flag reverts to "let `B` come back".
+
+## Design
+
+### 1. Field boundary — "what beets writes to the file"
+
+`M` is derived from `item._media_tag_fields` — beets' own definition of the
+fields it writes to a file as tags (~70 fields: `title`, `artist`, `rg_*`,
+`mb_*`, `comments`, `bpm`, `isrc`, `lyrics`, `grouping`, `tracktotal`,
+`disctotal`, `comp`, `asin`, `catalognum`, …). Read-only file facts
+(`bitrate, length, samplerate, bitdepth, channels, format, bitrate_mode,
+encoder_info, encoder_settings`) are **excluded automatically** because beets
+classifies them in `_media_fields` but not `_media_tag_fields` — no
+hand-maintained denylist, and the set tracks beets as it evolves.
+
+The existing `fields:` config still merges into / overrides this set.
+`beets_path` continues to be emitted as today (governed by `write_path`).
+Empty/zero values are dropped; multi-valued fields expand to one row per value.
+
+### 2. Naming & value formatting
+
+Mapping from beets field name to canonical musefs key:
+
+- **Rename table** (only where the conventional musefs key differs):
+  - `rg_track_gain → replaygain_track_gain`, `rg_album_gain →
+    replaygain_album_gain`, `rg_track_peak → replaygain_track_peak`,
+    `rg_album_peak → replaygain_album_peak`
+  - `mb_albumid → musicbrainz_albumid`, `mb_artistid → musicbrainz_artistid`,
+    and the rest of the `mb_* → musicbrainz_*` family
+    (`mb_trackid`, `mb_albumartistid`, `mb_releasegroupid`, `mb_releasetrackid`,
+    `mb_workid`)
+  - `comments → comment`
+- **Plural → singular multi-value twins** (generalizes today's
+  genre/composer logic and **fixes the multi-artist collapse**): `artists →
+  artist`, `albumartists → albumartist`, `genres → genre`, `composers →
+  composer`, `lyricists → lyricist`, etc. Prefer the plural list when present,
+  else the singular scalar; expand to one store row per value.
+- **Everything else** passes through under its (lowercased) beets field name.
+- **Value formatters** (a per-field hook): `rg_*` gains format as `"-7.50 dB"`,
+  peaks as a plain float string, matching beets/MediaFile's on-file form. The
+  existing `date` assembly from `year`/`month`/`day` stays. `r128_*` values
+  pass through as integers (no `replaygain_*` rename — distinct convention).
+
+**Fidelity limitation (explicit non-goal).** musefs renders the ~22 keys in its
+native VOCAB (`musefs-format/src/tagmap.rs`) idiomatically per format. The long
+tail (sort fields, `asin`, `catalognum`, and `tracktotal`/`disctotal` on
+mp3/mp4) passes through and *renders* — Vorbis uppercased, mp3 `TXXX`, mp4
+freeform — but is **not** guaranteed byte-identical to what beets itself would
+write to that format (e.g. mp3 wants `TRCK` "N/M" rather than a `TRACKTOTAL`
+`TXXX`). Full per-format fidelity for the long tail would require extending the
+Rust VOCAB and is out of scope here. FLAC/Ogg (Vorbis) get the closest match
+because the uppercased key *is* the convention.
+
+### 3. Sync semantics — per-key merge
+
+A new shared primitive in `contrib/python-musefs/src/musefs_common/store.py`,
+beside the existing `replace_tags` (which Picard keeps unchanged):
+
+```
+merge_tags(conn, track_id, managed_pairs, delete_keys)
+```
+
+- For each key present in `managed_pairs`: delete that key's text rows, then
+  insert the managed values (M-wins, multi-value safe, ordinals per key).
+- For each key in `delete_keys`: delete its text rows (suppress the `B` value).
+- Every other text row (unmanaged `B`) is left untouched.
+- Binary tags (`value_blob NOT NULL`, scanner-written) are untouched, exactly
+  as `replace_tags` already guarantees.
+
+beets' `sync_one`/`sync_files` path switches from `replace_tags` to
+`merge_tags`; Picard's path is unchanged.
+
+### 4. Stateful deletion via a beets flexattr
+
+Per item, the plugin stores `musefs_managed` — the sorted list of canonical
+keys written in the last sync — as a beets **flexattr** (lives in the beets DB;
+never written to the audio file, never sent to the musefs store).
+
+Each sync:
+
+1. Autoscan resets the store's text tags to `B`.
+2. Compute `M` (§1–2).
+3. Read `prev` from `musefs_managed`; `delete_keys = prev − keys(M)`.
+4. `merge_tags(conn, track_id, M, delete_keys)` — unless restore-backing is set
+   (see §5), in which case pass `delete_keys = ∅`.
+5. Write `keys(M)` back to `musefs_managed` (skipped on dry-run).
+
+First-ever sync has no `prev` → no deletions, just writes `M`. A key the user
+never managed is never in `prev`, so it is never deleted → `B` persists. A key
+the user managed then dropped is in `prev` but not `M` → deleted and, because
+the plugin re-applies this after every autoscan, stays deleted.
+
+### 5. The restore-backing flag
+
+`--restore-backing` on the `beet musefs` subcommand, plus
+`restore_backing: no` in config as the default.
+
+- **Default (off):** deletions stick — `delete_keys` is applied, suppressing the
+  backing value for any key dropped from `M`.
+- **On:** `delete_keys` is skipped, so after the autoscan reset, `B`'s embedded
+  value for a dropped key reappears in the view.
+
+**Caveat:** the deletion guarantee depends on autoscan resetting `B` before each
+sync. With `autoscan: no`, a deletion only reconciles on the next manual
+`musefs scan` + sync; this is documented as a limitation of that mode.
+
+### 6. Picard
+
+Picard receives only the §2 naming additions (so a Picard sync also carries
+ReplayGain / MusicBrainz / comment / lyrics / grouping / isrc under canonical
+keys). Picard keeps `replace_tags` and gains **no** merge or flexattr
+machinery: Picard writes the file's tags directly and is the authority on them,
+so full-replace is the correct semantics there. The `merge_tags` primitive is
+beets-only.
+
+## Out of scope
+
+- Any Rust change, including extending `tagmap.rs` VOCAB for long-tail fidelity
+  or adding native `tracktotal`/`disctotal` keys.
+- `musefs-db` schema changes (and therefore the Python schema-mirror regen).
+- Changing `musefs scan`'s tag-ingest behavior.
+- Porting the merge/state model to Picard or Lidarr.
+
+## Testing
+
+- **`merge_tags` unit** (python-musefs): M-wins over B; unmanaged B persists;
+  `delete_keys` suppresses; binary tags survive; multi-value ordinals correct.
+- **`map_fields` / `build_records`** (beets): boundary derives from
+  `_media_tag_fields`; file-facts excluded; rename table applied; plural→singular
+  multi-value expansion (incl. `artists`/`albumartists`); ReplayGain value
+  formatting; `fields:` override still works.
+- **Stateful deletion integration:** sync → delete a tag in beets → re-sync →
+  tag stays gone across the intervening autoscan; `musefs_managed` flexattr
+  round-trips.
+- **`--restore-backing`:** dropped key reappears from `B` with the flag, stays
+  gone without it.
+- **e2e (`m e2e`):** scan → beets tags incl. ReplayGain + MusicBrainz +
+  an arbitrary field → mount → all visible and correctly named; delete a tag →
+  absent at mount; with flag → present again. Byte-identical audio preserved.
+
+Commit any new harness/fixtures in-tree as runnable scripts per repo convention;
+keep large generated artifacts gitignored.
+
+## Docs to update
+
+- `contrib/beets/README.md`: field coverage, merge vs replace, the
+  `musefs_managed` flexattr, `--restore-backing` / `restore_backing`, and the
+  autoscan-off caveat.
+- `ARCHITECTURE.md` external-writer-contract section: a writer may merge rather
+  than fully replace text tags; note the §2 long-tail fidelity limitation.

--- a/docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-10-beets-field-coverage-design.md
@@ -163,10 +163,13 @@ beets' `sync_one`/`sync_files` path switches from `replace_tags` to
 
 ### 4. Stateful deletion via a beets flexattr — on **both** sync paths
 
-Per item, the plugin stores `musefs_managed` — the sorted list of canonical keys
-written in the last sync, including `beets_path` when emitted — as a beets
-**flexattr** (lives in the beets DB; never written to the audio file, never sent
-to the musefs store).
+Per item, the plugin stores `musefs_managed` — the sorted set of canonical keys
+the plugin has **ever** managed for this track (including `beets_path` when
+emitted) — as a beets **flexattr** (lives in the beets DB; never written to the
+audio file, never sent to the musefs store). It is an accumulating set, not just
+"last sync's keys": once a key has been managed, it stays in `musefs_managed` as
+a tombstone until the key is re-managed or `--restore-backing` clears it. This is
+what makes a deletion *stay* deleted across re-scans (see the why below).
 
 Each sync (the explicit `beet musefs` command **and** the passive
 `_reconcile_pending` `cli_exit` hook — see §4a):
@@ -176,13 +179,25 @@ Each sync (the explicit `beet musefs` command **and** the passive
 3. Read `prev` from `musefs_managed`; `delete_keys = prev − keys(M)`.
 4. `merge_tags(conn, track_id, M, delete_keys)` — unless restore-backing is set
    (§5), in which case pass `delete_keys = ∅`.
-5. Persist `keys(M)` back to `musefs_managed` via `item.store()` (skipped only on
-   the command path's `-n` dry-run, which writes nothing).
+5. Persist `prev ∪ keys(M)` back to `musefs_managed` (the **union** — accumulate
+   tombstones) via `item.store()`, skipped only on the command path's `-n`
+   dry-run. `--restore-backing` instead persists just `keys(M)` (clears
+   tombstones — §5).
 
 First-ever sync has no `prev` → no deletions, just writes `M`. A key the user
-never managed is never in `prev`, so it is never deleted → `B` persists. A key
-the user managed then dropped is in `prev` but not `M` → deleted and, because the
-plugin re-applies this after every autoscan, stays deleted.
+never managed is never in `prev`, so it is never deleted → `B` persists.
+
+**Why the union, not just `keys(M)`.** Consider a tag embedded in the file
+(`comment="x"`) that the user deletes in beets with a metadata-only edit (no file
+write). Sync B: autoscan reseeds `B={comment}`, `M` drops it, `delete_keys =
+prev − M = {comment}` → deleted. If we persisted only `keys(M)`, `comment` would
+leave `musefs_managed`, and at Sync C the autoscan would reseed `comment="x"` with
+nothing left in `prev` to suppress it — the deletion would silently undo after one
+cycle. Persisting the union keeps `comment` in `prev` as a tombstone, so
+`delete_keys` re-suppresses it on every sync until the user re-adds it in beets
+(it re-enters `M`, leaving `delete_keys`) or runs `--restore-backing`. Tags that
+only ever lived in beets (never in `B`) are unaffected either way — autoscan never
+reseeds them — so the union costs nothing for them.
 
 #### 4a. Both paths, identically — the passive `cli_exit` path is primary
 
@@ -214,8 +229,11 @@ is command-only.)
 - **Default (off):** deletions stick — `delete_keys` is applied, suppressing the
   backing value for any key dropped from `M`.
 - **On:** `delete_keys` is skipped, so after the autoscan reset, `B`'s embedded
-  value for a dropped key reappears in the view. (Synthesized keys like
-  `beets_path` have no `B` and are deleted regardless — §1.)
+  value for a dropped key reappears in the view. It also persists `musefs_managed`
+  as just `keys(M)` (clearing accumulated tombstones), so the restored backing
+  values *stay* visible on subsequent default-mode syncs rather than being
+  re-suppressed. (Synthesized keys like `beets_path` have no `B` and are deleted
+  regardless — §1.)
 
 **Caveat — the guarantee is contingent on the store holding `B` at sync time.**
 That is what `autoscan: yes` (the default) guarantees by resetting the store


### PR DESCRIPTION
## What & why

The beets plugin synced only a 9-field core, so everything else a user has in beets — ReplayGain, MusicBrainz IDs, comment, lyrics, grouping, isrc, multi-valued artists, arbitrary fields — was **lost** in the mounted view (ReplayGain especially: silently dropping it breaks player volume normalization). This broadens the beets plugin to sync *everything beets writes to a file*, with merge semantics so the user's library is faithfully reflected.

Beets-only behaviour change. **No Rust or `musefs-db` schema changes.** Picard gets the naming additions only (it's the tag authority, so its full-replace stays correct).

## Model

Let `B` = the track's embedded tags (seeded by `musefs scan`) and `M` = what beets manages.

- **M wins** per key; **B persists** for keys M doesn't manage (merge, not full-replace).
- The managed set is derived from beets' own `Item._media_tag_fields` (so file facts like `bitrate`/`length` are excluded automatically — no hand-maintained denylist), renamed to canonical musefs keys (`rg_*→replaygain_*`, `mb_*→musicbrainz_*`, `comments→comment`), multi-values expanded (fixes the multi-artist collapse).
- **Deletions stick**: `musefs_managed` (a beets flexattr, DB-only — never in your files or the musefs store) accumulates keys-ever-managed, so a deleted tag is re-suppressed on every sync until re-added or `--restore-backing` clears it.
- Runs on **both** sync paths — the `beet musefs` command and the passive `cli_exit` reconcile (import/write hooks).

## Key pieces

- New `merge_tags(conn, track_id, managed_pairs, delete_keys)` in `python-musefs` (per-key replace, `value_blob IS NULL`-scoped so scanner binary tags survive); `Record.delete_keys` + a `merge` flag on `sync_one`/`sync_files` (defaults off → Picard unchanged).
- `_core.map_fields` rewrite (boundary + rename + twin pre-pass + value formatters + zero-sentinel drops); accumulating-union managed-state in `build_records`; `--restore-backing` / `restore_backing` config.
- Picard: `DIRECT_FIELDS` extended with the same canonical naming.

## Testing

- python-musefs **56**, beets **60**, picard **34** (+7 expected Qt skips) — all green; full Rust workspace unaffected (verified by the pre-commit gate).
- Covers the merge primitive, the accumulating-union sticky-delete (incl. the passive reconcile path), `--restore-backing`, the `_media_tag_fields` boundary against a **real** beets Item, and an e2e multi-cycle delete + restore (skip-gated on `/dev/fuse`).

## Notes

- Fidelity: musefs renders its ~two-dozen native VOCAB keys idiomatically per format; the long tail passes through (Vorbis uppercased / mp3 `TXXX` / mp4 freeform) — renders, but not guaranteed byte-identical to beets' own per-format encoding. Out of scope here (would need Rust VOCAB work).
- Sticky-delete relies on `autoscan: yes` (the default); documented caveat for `autoscan: no`.
- Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added merge-mode tag sync that updates only plugin-managed text keys (preserving other embedded and binary tags)
  * Added per-item "managed" state and sticky deletions in the beets plugin
  * Added `--restore-backing` option to revert deleted tags from backing files
  * Extended Picard field coverage (ReplayGain, MusicBrainz IDs, comment/lyrics/grouping/isrc)

* **Tests**
  * Added unit and end-to-end tests covering merge behavior, managed-state persistence, and restore-backings

* **Documentation**
  * Added design, plans, and README updates clarifying merge/managed semantics and format fidelity caveats
<!-- end of auto-generated comment: release notes by coderabbit.ai -->