### PR TITLE
feat: MUSEFS_* env vars + systemd user units for host deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,29 @@ user.
 | `--file-mode <OCTAL>` | `444` | Permission bits for regular files, in octal. The mount is read-only, so write bits are advertised but writes still fail with `EROFS`. |
 | `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |
 
+### Configuring with environment variables
+
+Every scalar `mount` and `scan` flag can also be set with a `MUSEFS_*`
+environment variable — uppercase the long flag and turn dashes into
+underscores (e.g. `--poll-interval-ms` → `MUSEFS_POLL_INTERVAL_MS`, the
+`mount` mountpoint → `MUSEFS_MOUNTPOINT`). An explicit flag always overrides
+its env var, which overrides the default. The repeatable `--fallback` and the
+`scan` targets are command-line only. See
+[`contrib/systemd/musefs.conf.example`](contrib/systemd/musefs.conf.example)
+for the full, canonical list.
+
+### Running as a systemd user service
+
+To run musefs on the host at login, drop-in units live in
+[`contrib/systemd/`](contrib/systemd/): a `musefs.service` mount daemon, an
+optional `musefs-scan.timer` for periodic re-scans, and a commented
+`musefs.conf.example` holding every `MUSEFS_*` setting. Copy the units to
+`~/.config/systemd/user/`, copy the config to `~/.config/musefs/musefs.conf`,
+edit `MUSEFS_MOUNTPOINT` and `MUSEFS_DB`, then
+`systemctl --user enable --now musefs.service`. See
+[`contrib/systemd/README.md`](contrib/systemd/README.md) for the full walkthrough
+and the `PATH` / linger gotchas.
+
 ## Supported formats
 
 | Format | Extensions | What synthesis does | Details |

--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -1,0 +1,49 @@
+# Running musefs as a systemd user service
+
+These units run musefs on the host (the recommended deployment) under your own
+user account — no root, no `CAP_SYS_ADMIN`.
+
+## Files
+
+- `musefs.service` — the mount daemon (`musefs mount`); blocks until stopped.
+- `musefs-scan.service` + `musefs-scan.timer` — optional periodic
+  `musefs scan --revalidate`.
+- `musefs.conf.example` — every `MUSEFS_*` setting, commented with defaults.
+
+## Install
+
+```bash
+mkdir -p ~/.config/systemd/user ~/.config/musefs
+cp musefs.service musefs-scan.service musefs-scan.timer ~/.config/systemd/user/
+cp musefs.conf.example ~/.config/musefs/musefs.conf
+$EDITOR ~/.config/musefs/musefs.conf   # set MUSEFS_MOUNTPOINT and MUSEFS_DB
+systemctl --user daemon-reload
+systemctl --user enable --now musefs.service
+```
+
+Enable the periodic re-scan too (edit the library path in
+`musefs-scan.service` first):
+
+```bash
+systemctl --user enable --now musefs-scan.timer
+```
+
+## Notes
+
+- **Binary location.** The `--user` manager does not inherit your shell's
+  `PATH`. The units set `PATH` for a `cargo install` binary in `~/.cargo/bin`;
+  if musefs is elsewhere, edit the `Environment=PATH=` line (or make
+  `ExecStart` an absolute path).
+- **`%h` vs `~`.** Unit files expand `%h` to your home directory; the
+  `musefs.conf` EnvironmentFile does **not** expand `%h` or `~` — use absolute
+  paths there, and never paste `~/...` into a unit directive (it is taken
+  literally).
+- **Settings.** `musefs.conf.example` is the full, canonical list of
+  `MUSEFS_*` variables. Explicit flags override env vars; `--fallback` and scan
+  targets are command-line only (set them in `ExecStart`).
+- **Inline overrides.** Prefer `systemctl --user edit musefs` to add
+  `Environment=` lines in a drop-in; it survives reinstalls.
+- **Headless servers.** A `--user` timer only fires while your user manager
+  runs. For a daily scan when you are not logged in:
+  `loginctl enable-linger <user>`.
+- **Logs.** `journalctl --user -u musefs -f`.

--- a/contrib/systemd/musefs-scan.service
+++ b/contrib/systemd/musefs-scan.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=musefs library re-scan
+Documentation=https://github.com/Sohex/musefs
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/musefs/musefs.conf
+Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
+# Scan target(s) are not env-configurable; set your library path here.
+ExecStart=musefs scan %h/Music --revalidate

--- a/contrib/systemd/musefs-scan.timer
+++ b/contrib/systemd/musefs-scan.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodic musefs library re-scan
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -1,0 +1,71 @@
+# musefs configuration — sourced by the systemd user units as an EnvironmentFile.
+#
+# Copy to ~/.config/musefs/musefs.conf and edit. This is systemd
+# EnvironmentFile syntax, NOT shell:
+#   - one KEY=value per line; the value is literal to end of line
+#   - no quote stripping, no $VAR expansion, no command substitution
+#   - systemd specifiers like %h are NOT expanded here (only in unit files);
+#     write real absolute paths
+#   - leave optional settings COMMENTED. A bare `KEY=` means "set to empty",
+#     which is treated as a value and breaks path/boolean settings.
+#
+# Booleans accept (case-insensitive): true/false, yes/no, on/off, 1/0.
+# Any other value is a hard error that stops the unit from starting.
+
+# --- Required ---------------------------------------------------------------
+
+# Directory to mount at (must exist and be empty). Replace /home/youruser.
+MUSEFS_MOUNTPOINT=/home/youruser/Music
+# Path to the SQLite store (shared by `mount` and `scan`).
+MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
+
+# --- Mount: layout ----------------------------------------------------------
+
+# Path template. Supports ${a|b} fallback chains, [ ... ] conditionals
+# ($[ / $] for literal brackets), and $!{field} path fields.
+#MUSEFS_TEMPLATE=$albumartist/$album/$title
+# Value substituted for any missing template field.
+#MUSEFS_DEFAULT_FALLBACK=Unknown
+# How file contents are served: synthesis or structure-only.
+#MUSEFS_MODE=synthesis
+# Compare filenames case-insensitively. Default: false on Linux/FreeBSD,
+# true on macOS.
+#MUSEFS_CASE_INSENSITIVE=false
+
+# --- Mount: tuning ----------------------------------------------------------
+
+# Debounce window (ms) for picking up external DB edits.
+#MUSEFS_POLL_INTERVAL_MS=1000
+# Entry/attr cache TTL (ms) the kernel may trust before re-validating.
+#MUSEFS_ATTR_TTL_MS=1000
+# Kernel read-ahead window (KiB); clamped to the kernel maximum at mount.
+#MUSEFS_MAX_READAHEAD_KIB=512
+# Max outstanding background (readahead/async) requests the kernel queues.
+#MUSEFS_MAX_BACKGROUND=64
+# Keep the kernel page cache across opens.
+#MUSEFS_KEEP_CACHE=false
+
+# --- Mount: ownership & permissions ----------------------------------------
+
+# Owner presented for every entry: a username or numeric uid.
+# Default: the launching process's uid.
+#MUSEFS_OWNER=media
+# Group presented for every entry: a group name or numeric gid.
+# Default: the launching process's gid.
+#MUSEFS_GROUP=media
+# Permission bits for regular files, octal. Default: 444.
+#MUSEFS_FILE_MODE=444
+# Permission bits for directories, octal. Default: 555.
+#MUSEFS_DIR_MODE=555
+
+# --- Scan -------------------------------------------------------------------
+# (scan targets are set in musefs-scan.service, not here.)
+
+# Probe worker threads (0 = available parallelism).
+#MUSEFS_JOBS=0
+# Re-validate on scan: skip unchanged, prune missing, GC orphaned art.
+#MUSEFS_REVALIDATE=false
+# Follow symlinks while walking.
+#MUSEFS_FOLLOW_SYMLINKS=false
+# Suppress the per-target scan summary.
+#MUSEFS_QUIET=false

--- a/contrib/systemd/musefs.service
+++ b/contrib/systemd/musefs.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=musefs read-only re-tagging FUSE mount
+Documentation=https://github.com/Sohex/musefs
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.config/musefs/musefs.conf
+# The --user manager does not inherit a login shell's PATH, so a cargo-installed
+# binary in ~/.cargo/bin is not found by a bare `musefs`. Adjust this PATH (or
+# replace ExecStart with an absolute path) to match where musefs is installed.
+Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
+ExecStart=musefs mount
+# musefs unmounts cleanly on SIGTERM (systemd's default stop signal), so no
+# ExecStop is required. Uncomment as a fallback if a mount is ever left behind:
+#ExecStop=-fusermount3 -u ${MUSEFS_MOUNTPOINT}
+Restart=on-failure
+RestartSec=5
+# NoNewPrivileges is safe for a FUSE mount. Do NOT add ProtectHome=,
+# PrivateMounts=, or MountFlags=private: they place the mount in a private
+# namespace and hide it from the rest of your session.
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target

--- a/docs/superpowers/plans/2026-06-10-systemd-and-env-config.md
+++ b/docs/superpowers/plans/2026-06-10-systemd-and-env-config.md
@@ -1,0 +1,678 @@
+# systemd user units + env-var configuration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let every scalar `musefs mount`/`scan` flag be set via a `MUSEFS_*` environment variable, and ship drop-in systemd **user** units plus a commented config file so musefs runs on the host without long argument lists.
+
+**Architecture:** Enable clap's `env` feature and annotate each scalar arg in `musefs-cli/src/lib.rs` with `env = "MUSEFS_<NAME>"`; clap then resolves flag > env > default and lets env satisfy required args, with no custom code. Behavior is locked down by integration tests in `musefs/tests/` that spawn the real binary with a controlled, per-process environment (parallel-safe, no `/dev/fuse`: the children fail fast at arg-parse or DB-open). The systemd units are static example files under `contrib/systemd/` that source a `MUSEFS_*` `EnvironmentFile`.
+
+**Tech Stack:** Rust 2024, clap 4 (derive + env), systemd user units, `std::process::Command` for tests, `tempfile` (already a dev-dependency of `musefs`).
+
+---
+
+## Spec
+
+Source spec: `docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md`. Read it before starting.
+
+## Background the implementer needs
+
+- The CLI is defined in `musefs-cli/src/lib.rs`: `MountArgs` (struct, the `mount` flags) and `Command::Scan { .. }` (the `scan` flags). The binary entry point is `musefs/src/main.rs`, which calls `Cli::parse()` then `run(...)`.
+- `Cli::parse()` exits with **code 2** on a usage/parse error (clap's default). On a runtime error, `main` prints `musefs: <err>` and exits **code 1**.
+- `run_mount` (`musefs-cli/src/lib.rs:270`) opens the DB first with `Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?` — so a bad `--db` produces stderr containing `opening database at <path>`. Opening a path whose **parent directory does not exist** fails deterministically; tests use that to prove parsing succeeded.
+- `scan` over a directory with no audio files exits 0 and creates the DB file if absent — tests use that to prove `scan` read `MUSEFS_DB`.
+- Integration tests in `musefs/tests/` get `env!("CARGO_BIN_EXE_musefs")` (the built binary path). These tests are **not** `#[ignore]`d: they never mount, so they need no `/dev/fuse`.
+- **Commit discipline:** the pre-commit hook runs the full workspace test suite and rejects any commit with red tests. So within each task you write the test, watch it fail, implement, watch it pass, and only then commit (test + implementation in one commit). Never run the commit step while a test is red.
+- clap's `env` feature: an env var satisfies a `required` arg; precedence is explicit flag > env var > default. For boolean (`ArgAction::SetTrue`) and `--case-insensitive` (`ArgAction::Set`) flags, the env value is parsed by clap's `BoolishValueParser`: case-insensitive `true/false`, `t/f`, `yes/no`, `y/n`, `on/off`, `1/0`; anything else (including empty) is a hard parse error.
+
+## File structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `musefs-cli/Cargo.toml` | enable clap `env` feature | modify |
+| `musefs-cli/src/lib.rs` | `env = "MUSEFS_*"` on `MountArgs` + `Command::Scan` scalar args | modify |
+| `musefs/tests/env_config.rs` | spawn-the-binary env-precedence integration tests | create |
+| `contrib/systemd/musefs.service` | mount daemon unit | create |
+| `contrib/systemd/musefs-scan.service` | oneshot re-scan unit | create |
+| `contrib/systemd/musefs-scan.timer` | timer for the re-scan | create |
+| `contrib/systemd/musefs.conf.example` | every `MUSEFS_*` var, commented with defaults | create |
+| `contrib/systemd/README.md` | install + gotcha docs | create |
+| `README.md` | "Running as a systemd user service" subsection + env-var note | modify |
+
+---
+
+## Task 1: env support for `mount` (clap feature + `MountArgs`)
+
+**Files:**
+- Create: `musefs/tests/env_config.rs`
+- Modify: `musefs-cli/Cargo.toml:11`
+- Modify: `musefs-cli/src/lib.rs` (`MountArgs`, currently lines 40–105)
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `musefs/tests/env_config.rs` with the shared helpers and the first three tests:
+
+```rust
+//! The `musefs` binary reads MUSEFS_* environment variables for scalar mount
+//! and scan flags (clap's `env` feature). Each test spawns the real binary with
+//! an isolated environment, so they are parallel-safe and need no /dev/fuse:
+//! the children fail fast at arg-parse (exit 2) or DB-open (exit 1), never
+//! reaching a mount.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn musefs() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_musefs"));
+    cmd.env_clear();
+    cmd
+}
+
+/// A DB path whose parent directory does not exist, so opening it fails
+/// deterministically — proving we got *past* arg parsing to the DB-open step.
+fn unopenable_db(dir: &Path, name: &str) -> PathBuf {
+    dir.join("missing").join(name)
+}
+
+#[test]
+fn env_satisfies_required_mount_args() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    let out: Output = musefs()
+        .arg("mount")
+        .env("MUSEFS_MOUNTPOINT", dir.path())
+        .env("MUSEFS_DB", &db)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Not a usage error: env satisfied the required mountpoint and --db.
+    assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
+    // We reached DB-open, which fails on the missing parent directory.
+    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&db.display().to_string()),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn missing_required_mount_args_is_usage_error() {
+    let out = musefs().arg("mount").output().unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("--db") || stderr.contains("required"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn explicit_db_flag_overrides_env_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let env_db = unopenable_db(dir.path(), "env.db");
+    let flag_db = unopenable_db(dir.path(), "flag.db");
+    let out = musefs()
+        .arg("mount")
+        .arg(dir.path()) // positional mountpoint
+        .arg("--db")
+        .arg(&flag_db)
+        .env("MUSEFS_DB", &env_db)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&flag_db.display().to_string()),
+        "expected flag db to win, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains(&env_db.display().to_string()),
+        "env db should have been overridden, stderr: {stderr}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs --test env_config`
+Expected: `missing_required_mount_args_is_usage_error` PASSES (db is already required), but `env_satisfies_required_mount_args` and `explicit_db_flag_overrides_env_db` FAIL — without the `env` wiring, `MUSEFS_MOUNTPOINT`/`MUSEFS_DB` are ignored, so the binary exits 2 with a "required" error instead of reaching DB-open.
+
+- [ ] **Step 3: Enable the clap `env` feature**
+
+In `musefs-cli/Cargo.toml`, change line 11 from:
+
+```toml
+clap = { version = "4", features = ["derive"] }
+```
+
+to:
+
+```toml
+clap = { version = "4", features = ["derive", "env"] }
+```
+
+- [ ] **Step 4: Add `env` attributes to every scalar `MountArgs` field**
+
+Replace the whole `MountArgs` struct in `musefs-cli/src/lib.rs` with the version below. Only `#[arg(...)]` lines change — an `env = "MUSEFS_*"` is added to each scalar field; the two list-valued fields (`fallbacks`, plus `mountpoint` keeps its env) are handled as noted. Doc comments are preserved verbatim.
+
+```rust
+/// Flags for `musefs mount`, grouped so the mount plumbing passes one value
+/// instead of ten ordering-fragile positional parameters.
+#[derive(clap::Args, Debug)]
+pub struct MountArgs {
+    /// Empty directory to mount at.
+    #[arg(env = "MUSEFS_MOUNTPOINT")]
+    pub mountpoint: PathBuf,
+    /// Path to the SQLite database.
+    #[arg(long, env = "MUSEFS_DB")]
+    pub db: PathBuf,
+    /// Path template, e.g. "$albumartist/$album/$title". Supports ${a|b}
+    /// fallback chains, [...] conditional sections ($[/$] for literal
+    /// brackets), and $!{field} path fields that keep '/' as separators.
+    #[arg(long, env = "MUSEFS_TEMPLATE", default_value = "$albumartist/$album/$title")]
+    pub template: String,
+    /// Fallback value substituted for any missing template field.
+    #[arg(long, env = "MUSEFS_DEFAULT_FALLBACK", default_value = "Unknown")]
+    pub default_fallback: String,
+    /// Per-field fallback `FIELD=VALUE`, overriding `--default-fallback` for
+    /// just that field when it is missing. Repeatable, e.g. `--fallback
+    /// albumartist="Unknown Artist" --fallback genre=Misc`.
+    #[arg(long = "fallback", value_name = "FIELD=VALUE", value_parser = parse_fallback)]
+    pub fallbacks: Vec<(String, String)>,
+    /// How file contents are served.
+    #[arg(long, value_enum, env = "MUSEFS_MODE", default_value_t = CliMode::Synthesis)]
+    pub mode: CliMode,
+    /// Debounce window (ms) for picking up external DB edits.
+    #[arg(long, env = "MUSEFS_POLL_INTERVAL_MS", default_value_t = 1000)]
+    pub poll_interval_ms: u64,
+    /// Entry/attr cache TTL (ms) the kernel may trust before re-validating.
+    /// Higher cuts lookup/getattr traffic but slows visibility of DB edits.
+    #[arg(long, env = "MUSEFS_ATTR_TTL_MS", default_value_t = 1000)]
+    pub attr_ttl_ms: u64,
+    /// Kernel read-ahead window (KiB). Larger hides HDD/NFS latency while
+    /// streaming; clamped to the kernel maximum at mount.
+    #[arg(long, env = "MUSEFS_MAX_READAHEAD_KIB", default_value_t = 512)]
+    pub max_readahead_kib: u32,
+    /// Max outstanding background (readahead/async) requests the kernel queues.
+    #[arg(long, env = "MUSEFS_MAX_BACKGROUND", default_value_t = 64)]
+    pub max_background: u16,
+    /// Keep the kernel page cache across opens. External re-tags auto-invalidate
+    /// the affected inodes on refresh, so cached bytes are dropped when content
+    /// changes.
+    #[arg(long, env = "MUSEFS_KEEP_CACHE")]
+    pub keep_cache: bool,
+    /// Compare filenames case-insensitively: case-variant directories merge and
+    /// case-variant files are disambiguated. Defaults to true on macOS (whose
+    /// volumes are usually case-insensitive), false on Linux/FreeBSD. Override
+    /// with `--case-insensitive false` (e.g. a case-sensitive APFS volume).
+    #[arg(long, env = "MUSEFS_CASE_INSENSITIVE", default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set)]
+    pub case_insensitive: bool,
+    /// Owning user for every entry: a username or numeric uid. Defaults to the
+    /// launching process's uid.
+    #[arg(long, env = "MUSEFS_OWNER", value_name = "NAME|UID", value_parser = parse_owner)]
+    pub owner: Option<u32>,
+    /// Owning group for every entry: a group name or numeric gid. Defaults to
+    /// the launching process's gid.
+    #[arg(long, env = "MUSEFS_GROUP", value_name = "NAME|GID", value_parser = parse_group)]
+    pub group: Option<u32>,
+    /// Permission bits for regular files, octal (e.g. 444). Defaults to 444.
+    /// The mount is read-only, so write bits are advertised but inert.
+    #[arg(long, env = "MUSEFS_FILE_MODE", value_name = "OCTAL", value_parser = parse_octal_mode)]
+    pub file_mode: Option<u16>,
+    /// Permission bits for directories, octal (e.g. 555). Defaults to 555.
+    #[arg(long, env = "MUSEFS_DIR_MODE", value_name = "OCTAL", value_parser = parse_octal_mode)]
+    pub dir_mode: Option<u16>,
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs --test env_config`
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Lint**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean (no warnings).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-cli/Cargo.toml musefs-cli/src/lib.rs musefs/tests/env_config.rs Cargo.lock
+git commit -m "feat(cli): MUSEFS_* env vars for mount flags
+
+Enable clap's env feature and annotate every scalar MountArgs field with
+env = \"MUSEFS_*\". Integration tests spawn the binary with a controlled
+environment to verify env satisfies required args and that explicit flags
+win over env."
+```
+
+---
+
+## Task 2: boolean-from-env semantics (regression guard)
+
+**Files:**
+- Modify: `musefs/tests/env_config.rs`
+
+This task adds tests only — the behavior already works after Task 1. It pins the hard-error semantics the systemd conf relies on.
+
+- [ ] **Step 1: Add the boolean env tests**
+
+Append to `musefs/tests/env_config.rs`:
+
+```rust
+#[test]
+fn invalid_boolean_env_is_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    let out = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .env("MUSEFS_KEEP_CACHE", "enabled") // not a boolish value
+        .output()
+        .unwrap();
+    // Hard error at parse time, not a silent false.
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn valid_boolean_env_is_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    let out = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .env("MUSEFS_KEEP_CACHE", "true")
+        .output()
+        .unwrap();
+    // Parsed fine; failed later at DB-open (exit 1), not a usage error (exit 2).
+    assert_ne!(
+        out.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs --test env_config`
+Expected: all five tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs/tests/env_config.rs
+git commit -m "test(cli): pin boolean-from-env hard-error semantics"
+```
+
+---
+
+## Task 3: env support for `scan`
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs` (`Command` enum, currently lines 107–136)
+- Modify: `musefs/tests/env_config.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `musefs/tests/env_config.rs`:
+
+```rust
+#[test]
+fn scan_reads_db_from_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("library");
+    std::fs::create_dir(&target).unwrap();
+    let db = dir.path().join("scan-env.db");
+    let out = musefs()
+        .arg("scan")
+        .arg(&target) // targets stay command-line only
+        .env("MUSEFS_DB", &db)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(db.exists(), "scan should create the DB at the MUSEFS_DB path");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs --test env_config scan_reads_db_from_env`
+Expected: FAIL — without env on `scan`, `--db` is unset, so the binary exits 2 with a "required" error and `out.status.success()` is false.
+
+- [ ] **Step 3: Add `env` attributes to the `Scan` variant**
+
+Replace the whole `Command` enum in `musefs-cli/src/lib.rs` with the version below. Only `#[arg(...)]` lines change on the scalar `Scan` fields (`db`, `revalidate`, `jobs`, `follow_symlinks`, `quiet`); `targets` stays flag-only. Doc comments are preserved verbatim.
+
+```rust
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Walk backing files or directories, ingesting supported audio
+    /// (FLAC, MP3, M4A, Ogg, WAV) into the SQLite store.
+    Scan {
+        /// One or more files or directories to scan (directories recurse).
+        #[arg(required = true, num_args = 1..)]
+        targets: Vec<PathBuf>,
+        /// Path to the SQLite database (created if absent).
+        #[arg(long, env = "MUSEFS_DB")]
+        db: PathBuf,
+        /// Re-validate: skip unchanged files, prune tracks whose backing file is
+        /// gone, and garbage-collect orphaned art.
+        #[arg(long, env = "MUSEFS_REVALIDATE")]
+        revalidate: bool,
+        /// Probe worker threads (0 = available parallelism). 1 = sequential.
+        #[arg(long, env = "MUSEFS_JOBS", default_value_t = 0)]
+        jobs: usize,
+        /// Follow symlinks while walking directories. Off by default: symlinked
+        /// files and directories are logged and skipped.
+        #[arg(long, env = "MUSEFS_FOLLOW_SYMLINKS")]
+        follow_symlinks: bool,
+        /// Suppress the per-target summary on stdout (failures still surface via
+        /// the `log` facade on stderr; raise detail with `RUST_LOG=info`).
+        #[arg(long, short, env = "MUSEFS_QUIET")]
+        quiet: bool,
+    },
+    /// Mount a read-only FUSE view of the store.
+    Mount(MountArgs),
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs --test env_config`
+Expected: all six tests PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-cli/src/lib.rs musefs/tests/env_config.rs
+git commit -m "feat(cli): MUSEFS_* env vars for scan flags"
+```
+
+---
+
+## Task 4: systemd unit files
+
+**Files:**
+- Create: `contrib/systemd/musefs.service`
+- Create: `contrib/systemd/musefs-scan.service`
+- Create: `contrib/systemd/musefs-scan.timer`
+- Create: `contrib/systemd/musefs.conf.example`
+
+No automated test gate applies (these are not Rust, shell, or YAML, so the pre-commit hook does not lint them). Verification is `systemd-analyze` if available.
+
+- [ ] **Step 1: Create `contrib/systemd/musefs.service`**
+
+```ini
+[Unit]
+Description=musefs read-only re-tagging FUSE mount
+Documentation=https://github.com/Sohex/musefs
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.config/musefs/musefs.conf
+# The --user manager does not inherit a login shell's PATH, so a cargo-installed
+# binary in ~/.cargo/bin is not found by a bare `musefs`. Adjust this PATH (or
+# replace ExecStart with an absolute path) to match where musefs is installed.
+Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
+ExecStart=musefs mount
+# musefs unmounts cleanly on SIGTERM (systemd's default stop signal), so no
+# ExecStop is required. Uncomment as a fallback if a mount is ever left behind:
+#ExecStop=-fusermount3 -u ${MUSEFS_MOUNTPOINT}
+Restart=on-failure
+RestartSec=5
+# NoNewPrivileges is safe for a FUSE mount. Do NOT add ProtectHome=,
+# PrivateMounts=, or MountFlags=private: they place the mount in a private
+# namespace and hide it from the rest of your session.
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target
+```
+
+- [ ] **Step 2: Create `contrib/systemd/musefs-scan.service`**
+
+```ini
+[Unit]
+Description=musefs library re-scan
+Documentation=https://github.com/Sohex/musefs
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/musefs/musefs.conf
+Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
+# Scan target(s) are not env-configurable; set your library path here.
+ExecStart=musefs scan %h/Music --revalidate
+```
+
+- [ ] **Step 3: Create `contrib/systemd/musefs-scan.timer`**
+
+```ini
+[Unit]
+Description=Periodic musefs library re-scan
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 4: Create `contrib/systemd/musefs.conf.example`**
+
+```ini
+# musefs configuration — sourced by the systemd user units as an EnvironmentFile.
+#
+# Copy to ~/.config/musefs/musefs.conf and edit. This is systemd
+# EnvironmentFile syntax, NOT shell:
+#   - one KEY=value per line; the value is literal to end of line
+#   - no quote stripping, no $VAR expansion, no command substitution
+#   - systemd specifiers like %h are NOT expanded here (only in unit files);
+#     write real absolute paths
+#   - leave optional settings COMMENTED. A bare `KEY=` means "set to empty",
+#     which is treated as a value and breaks path/boolean settings.
+#
+# Booleans accept (case-insensitive): true/false, yes/no, on/off, 1/0.
+# Any other value is a hard error that stops the unit from starting.
+
+# --- Required ---------------------------------------------------------------
+
+# Directory to mount at (must exist and be empty). Replace /home/youruser.
+MUSEFS_MOUNTPOINT=/home/youruser/Music
+# Path to the SQLite store (shared by `mount` and `scan`).
+MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
+
+# --- Mount: layout ----------------------------------------------------------
+
+# Path template. Supports ${a|b} fallback chains, [ ... ] conditionals
+# ($[ / $] for literal brackets), and $!{field} path fields.
+#MUSEFS_TEMPLATE=$albumartist/$album/$title
+# Value substituted for any missing template field.
+#MUSEFS_DEFAULT_FALLBACK=Unknown
+# How file contents are served: synthesis or structure-only.
+#MUSEFS_MODE=synthesis
+# Compare filenames case-insensitively. Default: false on Linux/FreeBSD,
+# true on macOS.
+#MUSEFS_CASE_INSENSITIVE=false
+
+# --- Mount: tuning ----------------------------------------------------------
+
+# Debounce window (ms) for picking up external DB edits.
+#MUSEFS_POLL_INTERVAL_MS=1000
+# Entry/attr cache TTL (ms) the kernel may trust before re-validating.
+#MUSEFS_ATTR_TTL_MS=1000
+# Kernel read-ahead window (KiB); clamped to the kernel maximum at mount.
+#MUSEFS_MAX_READAHEAD_KIB=512
+# Max outstanding background (readahead/async) requests the kernel queues.
+#MUSEFS_MAX_BACKGROUND=64
+# Keep the kernel page cache across opens.
+#MUSEFS_KEEP_CACHE=false
+
+# --- Mount: ownership & permissions ----------------------------------------
+
+# Owner presented for every entry: a username or numeric uid.
+# Default: the launching process's uid.
+#MUSEFS_OWNER=media
+# Group presented for every entry: a group name or numeric gid.
+# Default: the launching process's gid.
+#MUSEFS_GROUP=media
+# Permission bits for regular files, octal. Default: 444.
+#MUSEFS_FILE_MODE=444
+# Permission bits for directories, octal. Default: 555.
+#MUSEFS_DIR_MODE=555
+
+# --- Scan -------------------------------------------------------------------
+# (scan targets are set in musefs-scan.service, not here.)
+
+# Probe worker threads (0 = available parallelism).
+#MUSEFS_JOBS=0
+# Re-validate on scan: skip unchanged, prune missing, GC orphaned art.
+#MUSEFS_REVALIDATE=false
+# Follow symlinks while walking.
+#MUSEFS_FOLLOW_SYMLINKS=false
+# Suppress the per-target scan summary.
+#MUSEFS_QUIET=false
+```
+
+- [ ] **Step 5: Verify the units parse (best-effort)**
+
+Run: `command -v systemd-analyze >/dev/null && systemd-analyze --user verify contrib/systemd/musefs.service contrib/systemd/musefs-scan.service contrib/systemd/musefs-scan.timer; echo done`
+Expected: prints `done`. A warning like "Failed to resolve executable musefs" / "Command musefs is not executable" is **expected** (musefs is not installed in this environment) and is not a failure; any *syntax* error must be fixed. If `systemd-analyze` is absent, skip this step.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/systemd/musefs.service contrib/systemd/musefs-scan.service contrib/systemd/musefs-scan.timer contrib/systemd/musefs.conf.example
+git commit -m "feat(contrib): ship systemd user units + example config"
+```
+
+---
+
+## Task 5: documentation
+
+**Files:**
+- Create: `contrib/systemd/README.md`
+- Modify: `README.md` (after the "Ownership and permissions" subsection, which ends at the `--dir-mode` table row, currently line 135)
+
+- [ ] **Step 1: Create `contrib/systemd/README.md`**
+
+````markdown
+# Running musefs as a systemd user service
+
+These units run musefs on the host (the recommended deployment) under your own
+user account — no root, no `CAP_SYS_ADMIN`.
+
+## Files
+
+- `musefs.service` — the mount daemon (`musefs mount`); blocks until stopped.
+- `musefs-scan.service` + `musefs-scan.timer` — optional periodic
+  `musefs scan --revalidate`.
+- `musefs.conf.example` — every `MUSEFS_*` setting, commented with defaults.
+
+## Install
+
+```bash
+mkdir -p ~/.config/systemd/user ~/.config/musefs
+cp musefs.service musefs-scan.service musefs-scan.timer ~/.config/systemd/user/
+cp musefs.conf.example ~/.config/musefs/musefs.conf
+$EDITOR ~/.config/musefs/musefs.conf   # set MUSEFS_MOUNTPOINT and MUSEFS_DB
+systemctl --user daemon-reload
+systemctl --user enable --now musefs.service
+```
+
+Enable the periodic re-scan too (edit the library path in
+`musefs-scan.service` first):
+
+```bash
+systemctl --user enable --now musefs-scan.timer
+```
+
+## Notes
+
+- **Binary location.** The `--user` manager does not inherit your shell's
+  `PATH`. The units set `PATH` for a `cargo install` binary in `~/.cargo/bin`;
+  if musefs is elsewhere, edit the `Environment=PATH=` line (or make
+  `ExecStart` an absolute path).
+- **`%h` vs `~`.** Unit files expand `%h` to your home directory; the
+  `musefs.conf` EnvironmentFile does **not** expand `%h` or `~` — use absolute
+  paths there, and never paste `~/...` into a unit directive (it is taken
+  literally).
+- **Settings.** `musefs.conf.example` is the full, canonical list of
+  `MUSEFS_*` variables. Explicit flags override env vars; `--fallback` and scan
+  targets are command-line only (set them in `ExecStart`).
+- **Inline overrides.** Prefer `systemctl --user edit musefs` to add
+  `Environment=` lines in a drop-in; it survives reinstalls.
+- **Headless servers.** A `--user` timer only fires while your user manager
+  runs. For a daily scan when you are not logged in:
+  `loginctl enable-linger <user>`.
+- **Logs.** `journalctl --user -u musefs -f`.
+````
+
+- [ ] **Step 2: Add the README subsection**
+
+In `README.md`, immediately after the "Ownership and permissions" table (the line `| `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |`) and before `## Supported formats`, insert:
+
+```markdown
+### Configuring with environment variables
+
+Every scalar `mount` and `scan` flag can also be set with a `MUSEFS_*`
+environment variable — uppercase the long flag and turn dashes into
+underscores (e.g. `--poll-interval-ms` → `MUSEFS_POLL_INTERVAL_MS`, the
+`mount` mountpoint → `MUSEFS_MOUNTPOINT`). An explicit flag always overrides
+its env var, which overrides the default. The repeatable `--fallback` and the
+`scan` targets are command-line only. See
+[`contrib/systemd/musefs.conf.example`](contrib/systemd/musefs.conf.example)
+for the full, canonical list.
+
+### Running as a systemd user service
+
+To run musefs on the host at login, drop-in units live in
+[`contrib/systemd/`](contrib/systemd/): a `musefs.service` mount daemon, an
+optional `musefs-scan.timer` for periodic re-scans, and a commented
+`musefs.conf.example` holding every `MUSEFS_*` setting. Copy the units to
+`~/.config/systemd/user/`, copy the config to `~/.config/musefs/musefs.conf`,
+edit `MUSEFS_MOUNTPOINT` and `MUSEFS_DB`, then
+`systemctl --user enable --now musefs.service`. See
+[`contrib/systemd/README.md`](contrib/systemd/README.md) for the full walkthrough
+and the `PATH` / linger gotchas.
+```
+
+- [ ] **Step 3: Verify the doc links resolve**
+
+Run: `ls contrib/systemd/musefs.conf.example contrib/systemd/README.md`
+Expected: both paths listed (no "No such file").
+
+- [ ] **Step 4: Commit (docs-only — cargo gate is skipped)**
+
+```bash
+git add README.md contrib/systemd/README.md
+git commit -m "docs: document MUSEFS_* env vars and systemd user units"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full workspace test suite** — Run: `cargo test`. Expected: passes (this is what the pre-commit hook runs).
+- [ ] **Lint** — Run: `cargo clippy --all-targets -- -D warnings`. Expected: clean.
+- [ ] **Format** — Run: `cargo fmt --all --check`. Expected: no diff.
+- [ ] **Help output sanity** — Run: `cargo run -p musefs -- mount --help`. Expected: each documented flag shows its `[env: MUSEFS_*=]` annotation (clap renders env names in help automatically), and `--fallback` does not.

--- a/docs/superpowers/plans/2026-06-10-systemd-and-env-config.md
+++ b/docs/superpowers/plans/2026-06-10-systemd-and-env-config.md
@@ -57,6 +57,12 @@ Create `musefs/tests/env_config.rs` with the shared helpers and the first three 
 //! an isolated environment, so they are parallel-safe and need no /dev/fuse:
 //! the children fail fast at arg-parse (exit 2) or DB-open (exit 1), never
 //! reaching a mount.
+//!
+//! `env_clear()` is deliberate: it guarantees no ambient MUSEFS_* leaks in from
+//! the developer's shell. It is safe here — the binary is launched by absolute
+//! path (`CARGO_BIN_EXE_musefs`), and the assertions key on the
+//! `opening database at <path>` stderr, which `main` emits via anyhow/eprintln,
+//! not through env_logger — so a cleared `RUST_LOG` does not suppress it.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -128,12 +134,70 @@ fn explicit_db_flag_overrides_env_db() {
         "env db should have been overridden, stderr: {stderr}"
     );
 }
+
+// Precedence on a value-bearing, non-required flag (the spec's --mode example).
+// A bogus MUSEFS_MODE alone is rejected at parse (proves env is read); the same
+// bogus env with an explicit --mode is accepted (proves the flag wins and env is
+// not consulted). Observable purely via exit codes — no mount needed.
+#[test]
+fn invalid_mode_env_is_rejected_but_flag_overrides_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+
+    let env_only = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .env("MUSEFS_MODE", "bogus")
+        .output()
+        .unwrap();
+    assert_eq!(
+        env_only.status.code(),
+        Some(2),
+        "bogus MUSEFS_MODE should be a usage error, stderr: {}",
+        String::from_utf8_lossy(&env_only.stderr)
+    );
+
+    let flag_wins = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .arg("--mode")
+        .arg("synthesis")
+        .env("MUSEFS_MODE", "bogus")
+        .output()
+        .unwrap();
+    // --mode on the CLI wins; the bogus env is never parsed. We fall through to
+    // DB-open (exit 1), not a usage error.
+    let stderr = String::from_utf8_lossy(&flag_wins.stderr);
+    assert_ne!(flag_wins.status.code(), Some(2), "stderr: {stderr}");
+    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+}
+
+// Locks the per-flag env wiring: clap's `env` feature renders `[env: NAME=]` in
+// help for annotated args. Catches a dropped `env=` that the precedence tests
+// might miss, and confirms the list-valued carve-out (--fallback) has no env.
+#[test]
+fn mount_help_lists_env_vars() {
+    let out = musefs().args(["mount", "--help"]).output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("MUSEFS_DB"), "stdout: {stdout}");
+    assert!(stdout.contains("MUSEFS_MODE"), "stdout: {stdout}");
+    assert!(stdout.contains("MUSEFS_MOUNTPOINT"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("MUSEFS_FALLBACK"),
+        "--fallback is flag-only and must not advertise an env var, stdout: {stdout}"
+    );
+}
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cargo test -p musefs --test env_config`
-Expected: `missing_required_mount_args_is_usage_error` PASSES (db is already required), but `env_satisfies_required_mount_args` and `explicit_db_flag_overrides_env_db` FAIL — without the `env` wiring, `MUSEFS_MOUNTPOINT`/`MUSEFS_DB` are ignored, so the binary exits 2 with a "required" error instead of reaching DB-open.
+Expected: `missing_required_mount_args_is_usage_error` PASSES (db is already required). The others FAIL without the `env` wiring: `env_satisfies_required_mount_args` and `explicit_db_flag_overrides_env_db` exit 2 with a "required" error instead of reaching DB-open; `invalid_mode_env_is_rejected_but_flag_overrides_it` sees its bogus `MUSEFS_MODE` ignored (so the env-only case is not a usage error); and `mount_help_lists_env_vars` finds no `[env: ...]` in help.
 
 - [ ] **Step 3: Enable the clap `env` feature**
 
@@ -235,8 +299,13 @@ Expected: clean (no warnings).
 
 - [ ] **Step 7: Commit**
 
+`clap`'s `env` lives in `clap_builder`, which is already in the tree, so flipping
+the feature normally leaves `Cargo.lock` unchanged — stage it only if `git status`
+shows it changed.
+
 ```bash
-git add musefs-cli/Cargo.toml musefs-cli/src/lib.rs musefs/tests/env_config.rs Cargo.lock
+git add musefs-cli/Cargo.toml musefs-cli/src/lib.rs musefs/tests/env_config.rs
+git status --short Cargo.lock && git add Cargo.lock   # only if it changed
 git commit -m "feat(cli): MUSEFS_* env vars for mount flags
 
 Enable clap's env feature and annotate every scalar MountArgs field with
@@ -271,12 +340,18 @@ fn invalid_boolean_env_is_usage_error() {
         .env("MUSEFS_KEEP_CACHE", "enabled") // not a boolish value
         .output()
         .unwrap();
-    // Hard error at parse time, not a silent false.
+    // Hard error at parse time, not a silent false — and pinned to the boolean
+    // parse failure, not any exit-2.
     assert_eq!(
         out.status.code(),
         Some(2),
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("keep-cache") || stderr.contains("invalid value"),
+        "expected a keep-cache boolean parse error, stderr: {stderr}"
     );
 }
 
@@ -292,20 +367,19 @@ fn valid_boolean_env_is_accepted() {
         .env("MUSEFS_KEEP_CACHE", "true")
         .output()
         .unwrap();
-    // Parsed fine; failed later at DB-open (exit 1), not a usage error (exit 2).
-    assert_ne!(
-        out.status.code(),
-        Some(2),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    // Got past parse for the right reason (reached DB-open), not merely "not
+    // exit 2". Proves a valid boolish env value is accepted, not silently
+    // dropped.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
+    assert!(stderr.contains("opening database"), "stderr: {stderr}");
 }
 ```
 
 - [ ] **Step 2: Run the tests to verify they pass**
 
 Run: `cargo test -p musefs --test env_config`
-Expected: all five tests PASS.
+Expected: all seven tests PASS (the five from Task 1 plus these two — they need no new wiring, since Task 1 already enabled env on `--keep-cache`).
 
 - [ ] **Step 3: Commit**
 
@@ -346,12 +420,21 @@ fn scan_reads_db_from_env() {
     );
     assert!(db.exists(), "scan should create the DB at the MUSEFS_DB path");
 }
+
+#[test]
+fn scan_help_lists_env_vars() {
+    let out = musefs().args(["scan", "--help"]).output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("MUSEFS_DB"), "stdout: {stdout}");
+    assert!(stdout.contains("MUSEFS_JOBS"), "stdout: {stdout}");
+}
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `cargo test -p musefs --test env_config scan_reads_db_from_env`
-Expected: FAIL — without env on `scan`, `--db` is unset, so the binary exits 2 with a "required" error and `out.status.success()` is false.
+Run: `cargo test -p musefs --test env_config scan`
+Expected: both FAIL — without env on `scan`, `scan_reads_db_from_env` exits 2 with a "required" error (so `success()` is false), and `scan_help_lists_env_vars` finds no `MUSEFS_*` in the scan help.
 
 - [ ] **Step 3: Add `env` attributes to the `Scan` variant**
 
@@ -390,10 +473,10 @@ pub enum Command {
 }
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `cargo test -p musefs --test env_config`
-Expected: all six tests PASS.
+Expected: all nine tests PASS (seven from Tasks 1-2 plus these two).
 
 - [ ] **Step 5: Lint**
 
@@ -417,7 +500,7 @@ git commit -m "feat(cli): MUSEFS_* env vars for scan flags"
 - Create: `contrib/systemd/musefs-scan.timer`
 - Create: `contrib/systemd/musefs.conf.example`
 
-No automated test gate applies (these are not Rust, shell, or YAML, so the pre-commit hook does not lint them). Verification is `systemd-analyze` if available.
+No *linter* gate applies to these files (they are not Rust, shell, or YAML, so the pre-commit hook does not lint them). Note this does **not** mean the Task 4 commit skips the cargo gate: it adds `contrib/systemd/*.service`/`.timer`/`.conf.example` (none under `docs/` or a `*.md`), so the hook still runs the full fmt/clippy/test suite on this commit — it passes because the tree is already green from Task 3. Unit-syntax verification is `systemd-analyze` if available.
 
 - [ ] **Step 1: Create `contrib/systemd/musefs.service`**
 
@@ -556,7 +639,7 @@ MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
 - [ ] **Step 5: Verify the units parse (best-effort)**
 
 Run: `command -v systemd-analyze >/dev/null && systemd-analyze --user verify contrib/systemd/musefs.service contrib/systemd/musefs-scan.service contrib/systemd/musefs-scan.timer; echo done`
-Expected: prints `done`. A warning like "Failed to resolve executable musefs" / "Command musefs is not executable" is **expected** (musefs is not installed in this environment) and is not a failure; any *syntax* error must be fixed. If `systemd-analyze` is absent, skip this step.
+Expected: prints `done`. Treat only genuine syntax errors as failures — lines containing `Failed to parse`, `Invalid`, or `Unknown lvalue`. The following are **expected and harmless**: `Failed to resolve executable musefs` / `... is not executable` (musefs is not installed here), and any advisory `Notice:`/hint lines (e.g. about `NoNewPrivileges` or an inactive bound unit). If `systemd-analyze` is absent, skip this step.
 
 - [ ] **Step 6: Commit**
 
@@ -629,7 +712,11 @@ systemctl --user enable --now musefs-scan.timer
 
 - [ ] **Step 2: Add the README subsection**
 
-In `README.md`, immediately after the "Ownership and permissions" table (the line `| `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |`) and before `## Supported formats`, insert:
+The spec floated an optional per-flag "Env var" column on the flag tables; we
+deliberately use a short prose note plus a pointer to the canonical
+`musefs.conf.example` instead, to avoid maintaining the mapping in a third place
+(the README has a mount table and an ownership table but no scan table). In
+`README.md`, immediately after the "Ownership and permissions" table (the line `| `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |`) and before `## Supported formats`, insert:
 
 ```markdown
 ### Configuring with environment variables
@@ -675,4 +762,4 @@ git commit -m "docs: document MUSEFS_* env vars and systemd user units"
 - [ ] **Full workspace test suite** — Run: `cargo test`. Expected: passes (this is what the pre-commit hook runs).
 - [ ] **Lint** — Run: `cargo clippy --all-targets -- -D warnings`. Expected: clean.
 - [ ] **Format** — Run: `cargo fmt --all --check`. Expected: no diff.
-- [ ] **Help output sanity** — Run: `cargo run -p musefs -- mount --help`. Expected: each documented flag shows its `[env: MUSEFS_*=]` annotation (clap renders env names in help automatically), and `--fallback` does not.
+- [ ] **Help output sanity** — Run: `cargo run -p musefs -- mount --help`. Expected: each annotated flag shows its `[env: MUSEFS_*=]` (clap renders env names in help automatically), and `--fallback` does not. This is now also enforced by the `mount_help_lists_env_vars` / `scan_help_lists_env_vars` tests; the manual run is just a final eyeball.

--- a/docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md
+++ b/docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md
@@ -274,9 +274,12 @@ default below. Specific requirements:
 - Boolean vars list the exact accepted spellings inline
   (`true`/`false`/`yes`/`no`/`on`/`off`/`1`/`0`, case-insensitive), since an
   unrecognized value is a hard error, not a silent false.
-- Use **absolute paths** (or none): under a `--user` unit the working directory
-  defaults to `%h`, so a relative `MUSEFS_DB` resolves against home, which is
-  surprising.
+- Use **absolute paths**. Two reasons: under a `--user` unit the working
+  directory defaults to home, so a relative `MUSEFS_DB` resolves there; and
+  `%h` (and other systemd specifiers) are **not** expanded inside an
+  `EnvironmentFile` — only in unit directives — so `MUSEFS_DB=%h/...` would
+  pass the literal string `%h/...` to musefs. The example uses a
+  `/home/youruser/...` placeholder and tells the user to edit it.
 
 systemd's `EnvironmentFile` parses `KEY=value` lines (no shell quoting, values
 are literal to end of line — no `$VAR` expansion, no quote stripping); the

--- a/docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md
+++ b/docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md
@@ -1,0 +1,280 @@
+# Host-run systemd units + env-var configuration
+
+**Date:** 2026-06-10
+**Status:** Approved (design)
+
+## Problem
+
+musefs ships binaries (`cargo install`) and glibc/musl containers, and the
+README explicitly recommends running on the host as the simplest,
+best-supported option. But it provides no scaffolding to actually do that: a
+user who wants musefs to mount at boot and stay running has to hand-write a
+service unit. There is also no way to configure musefs other than by spelling
+out every flag on the command line, which makes a service file verbose and
+awkward to maintain.
+
+Two coupled gaps:
+
+1. **No host-run scaffolding.** Ship an example/default systemd **user**
+   service file a user can drop into the appropriate directory and tweak.
+2. **No env-var configuration.** Every reasonably settable CLI flag should also
+   be settable via an environment variable, so the service file (and anything
+   else) can configure musefs without long argument lists.
+
+These are coupled: env-var support is what lets the systemd unit stay generic
+while the user configures everything in one place.
+
+## Goals
+
+- Every scalar `mount` and `scan` flag is settable via a `MUSEFS_*` environment
+  variable, with explicit flags taking precedence over env vars.
+- Required arguments (`--db`, the `mountpoint` positional) can be satisfied
+  entirely from the environment.
+- A drop-in-ready systemd **user** unit set under `contrib/systemd/`, plus a
+  fully commented config file listing every variable with its default.
+- Documentation in the README covering host-run-as-a-service and the env-var
+  surface.
+
+## Non-goals
+
+- System-wide (`/etc/systemd/system`) units. We ship **user** units
+  (`systemctl --user`); the README can note that adapting to a system unit is
+  straightforward but we do not ship one.
+- Env-var support for list-valued / repeatable arguments (`--fallback`, scan
+  `targets`). See "List-valued arguments" below.
+- Packaging for distro repositories (deb/rpm), AUR, Homebrew, etc.
+- A bespoke config-file format. systemd's `EnvironmentFile` is the config file.
+
+## Part A — env-var support
+
+### Mechanism
+
+Enable clap's `env` feature:
+
+```toml
+clap = { version = "4", features = ["derive", "env"] }
+```
+
+Add `env = "MUSEFS_<NAME>"` to each scalar arg in `MountArgs` and the `Scan`
+variant in `musefs-cli/src/lib.rs`.
+
+clap's resolution order is exactly what we want and needs no custom code:
+
+1. Explicit command-line flag (highest precedence)
+2. `MUSEFS_*` environment variable
+3. The arg's `default_value` / `default_value_t`
+
+An env var also satisfies a `required` argument, so `--db` and the `mountpoint`
+positional can come entirely from the environment.
+
+### Naming convention
+
+`MUSEFS_` + the long flag name in `SCREAMING_SNAKE_CASE`. The `mountpoint`
+positional has no flag, so it is named `MUSEFS_MOUNTPOINT`.
+
+### Variable mapping
+
+mount (`MountArgs`):
+
+| Env var | Arg |
+| --- | --- |
+| `MUSEFS_MOUNTPOINT` | `mountpoint` (positional) |
+| `MUSEFS_DB` | `--db` |
+| `MUSEFS_TEMPLATE` | `--template` |
+| `MUSEFS_DEFAULT_FALLBACK` | `--default-fallback` |
+| `MUSEFS_MODE` | `--mode` |
+| `MUSEFS_POLL_INTERVAL_MS` | `--poll-interval-ms` |
+| `MUSEFS_ATTR_TTL_MS` | `--attr-ttl-ms` |
+| `MUSEFS_MAX_READAHEAD_KIB` | `--max-readahead-kib` |
+| `MUSEFS_MAX_BACKGROUND` | `--max-background` |
+| `MUSEFS_KEEP_CACHE` | `--keep-cache` |
+| `MUSEFS_CASE_INSENSITIVE` | `--case-insensitive` |
+| `MUSEFS_OWNER` | `--owner` |
+| `MUSEFS_GROUP` | `--group` |
+| `MUSEFS_FILE_MODE` | `--file-mode` |
+| `MUSEFS_DIR_MODE` | `--dir-mode` |
+
+scan (`Command::Scan`):
+
+| Env var | Arg |
+| --- | --- |
+| `MUSEFS_DB` | `--db` (intentionally the same name as mount's `--db`) |
+| `MUSEFS_JOBS` | `--jobs` |
+| `MUSEFS_REVALIDATE` | `--revalidate` |
+| `MUSEFS_FOLLOW_SYMLINKS` | `--follow-symlinks` |
+| `MUSEFS_QUIET` | `--quiet` |
+
+`MUSEFS_DB` is deliberately shared between `mount` and `scan`: a single
+`EnvironmentFile` can point both subcommands at the same store.
+
+### Boolean flags
+
+`--keep-cache`, `--revalidate`, `--follow-symlinks`, `--quiet` are
+`ArgAction::SetTrue` flags. With clap's `env`, their env var is truthy on the
+usual values; the env value is parsed as a bool. `--case-insensitive` already
+uses `ArgAction::Set` with an explicit `true`/`false` value and a
+`cfg!(target_os = "macos")` default — its env var takes `true`/`false`.
+
+The conf example documents the accepted boolean spellings so users are not left
+guessing.
+
+### List-valued arguments (flag-only, by design)
+
+`--fallback FIELD=VALUE` (repeatable `Vec<(String, String)>` with a custom
+`value_parser`) and scan `targets` (positional `Vec<PathBuf>`) do **not** get
+env vars. Mapping a repeatable argument onto a single env var forces a
+delimiter that collides with legitimate values — commas appear in fallback
+strings, `:` appears in paths. Rather than introduce a surprising
+delimiter-splitting behavior, these stay command-line only.
+
+Under systemd this is not a limitation in practice:
+
+- scan `targets` is the library path, which is inherently per-instance, so the
+  scan unit names it directly in `ExecStart`.
+- `--fallback` is an advanced knob; a user who needs it appends it to
+  `ExecStart` (in the shipped unit or a `systemctl --user edit` drop-in).
+
+## Part B — systemd units
+
+Shipped under `contrib/systemd/`, matching the existing `contrib/` convention
+(beets, picard, lidarr). All units are **user** units, intended for
+`~/.config/systemd/user/`.
+
+### `musefs.service` (the mount daemon)
+
+```ini
+[Unit]
+Description=musefs read-only re-tagging FUSE mount
+Documentation=https://github.com/Sohex/musefs
+After=default.target
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.config/musefs/musefs.conf
+ExecStart=musefs mount
+# musefs unmounts cleanly on SIGTERM (systemd's default stop signal), so no
+# ExecStop is required. Uncomment as a fallback if a mount is ever left behind:
+#ExecStop=-fusermount3 -u ${MUSEFS_MOUNTPOINT}
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+Notes:
+
+- `EnvironmentFile=-...` — the leading `-` makes the file optional, so the unit
+  still starts if the user has not created the conf yet (and is relying on a
+  drop-in or inline `Environment=`).
+- `ExecStart=musefs mount` carries no arguments; everything comes from the
+  environment. Required values (`MUSEFS_MOUNTPOINT`, `MUSEFS_DB`) must therefore
+  be present in the conf or a drop-in, or the unit fails fast with clap's
+  "required argument not provided" error.
+- We do **not** embed commented `Environment=` example lines in the unit.
+  Inline overrides are supported the systemd-native way via
+  `systemctl --user edit musefs`, which writes an upgrade-safe drop-in. The conf
+  file is the documented place for the full variable list.
+- `musefs` must be on the unit's `PATH`. The README instructions note that a
+  `cargo install` binary in `~/.cargo/bin` may need either an absolute
+  `ExecStart` path or `Environment=PATH=...`; this is called out rather than
+  guessed at in the unit.
+
+### `musefs-scan.service` + `musefs-scan.timer` (optional periodic re-scan)
+
+A oneshot service plus timer for periodic `scan --revalidate`, useful now that
+env covers scan. The scan target is explicit per the list-valued carve-out.
+
+`musefs-scan.service`:
+
+```ini
+[Unit]
+Description=musefs library re-scan
+Documentation=https://github.com/Sohex/musefs
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/musefs/musefs.conf
+# Set the library path(s) here; targets are not env-configurable.
+ExecStart=musefs scan %h/Music --revalidate
+```
+
+`musefs-scan.timer`:
+
+```ini
+[Unit]
+Description=Periodic musefs library re-scan
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+`MUSEFS_DB` and other scan knobs come from the shared conf; only the target
+path is inlined.
+
+### `musefs.conf.example`
+
+A fully commented file listing every scalar `MUSEFS_*` variable with its
+default value, shipped for the user to copy to `~/.config/musefs/musefs.conf`.
+Structure: required vars uncommented with placeholder values at the top
+(`MUSEFS_MOUNTPOINT`, `MUSEFS_DB`), every optional var commented with its
+default below. Documents accepted boolean spellings.
+
+systemd's `EnvironmentFile` parses `KEY=value` lines (no shell quoting, values
+are literal to end of line); the example is written within those constraints
+and notes them.
+
+## Documentation
+
+- **README** — add a "Running as a systemd user service" subsection in the
+  host-run discussion: how to install the binary, where to put the unit and
+  conf, and the `systemctl --user enable --now musefs` flow, including the
+  `PATH`/absolute-`ExecStart` note. Add an env-var note (and/or an "Env var"
+  column) to the existing mount/scan flag tables so the mapping is discoverable.
+- **contrib/systemd/** — a short `README.md` is acceptable here (the other
+  `contrib/` integrations each have one) describing the three files and install
+  steps. This is the one place a new doc file is warranted.
+
+## Testing
+
+Existing CLI tests in `musefs-cli/tests/cli.rs` use in-process
+`Cli::parse_from(...)`. Reading process env in-process is global state and races
+under parallel test execution, so env-precedence tests instead **spawn the real
+binary** with a controlled environment:
+
+- Location: `musefs/tests/` (the binary crate), where Cargo sets
+  `CARGO_BIN_EXE_musefs`. No new dependency — `std::process::Command` with
+  `.env(...)` / `.env_clear()` suffices, and each spawned process gets an
+  isolated environment so the tests stay parallel-safe.
+- Cases:
+  - Required args supplied via `MUSEFS_MOUNTPOINT` + `MUSEFS_DB` get **past**
+    clap parsing (the process fails later at runtime — e.g. nonexistent db /
+    mountpoint — rather than with clap's "required arguments were not
+    provided"). This proves env satisfies required args.
+  - With no flags and no env, `musefs mount` fails with clap's required-arg
+    error (baseline).
+  - An explicit flag overrides the corresponding env var (e.g.
+    `MUSEFS_MODE=structure-only` on the env but `--mode synthesis` on the
+    command line resolves to synthesis) — asserted via an observable difference.
+- Scalar-arg parse coverage that does not need real env (e.g. confirming the
+  `env` attribute is present and named correctly) can also be asserted by
+  reading the generated clap help/`--help` output where convenient.
+
+systemd unit files and the `.conf` are neither shell nor YAML, so the
+pre-commit shellcheck/yamllint legs do not apply to them.
+
+## Affected files
+
+- `musefs-cli/Cargo.toml` — add clap `env` feature.
+- `musefs-cli/src/lib.rs` — `env = "MUSEFS_*"` on `MountArgs` fields and `Scan`
+  variant fields.
+- `contrib/systemd/musefs.service` — new.
+- `contrib/systemd/musefs-scan.service` — new.
+- `contrib/systemd/musefs-scan.timer` — new.
+- `contrib/systemd/musefs.conf.example` — new.
+- `contrib/systemd/README.md` — new.
+- `README.md` — host-run-as-a-service section + env-var documentation.
+- `musefs/tests/` — env-precedence integration tests.

--- a/docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md
+++ b/docs/superpowers/specs/2026-06-10-systemd-and-env-config-design.md
@@ -44,6 +44,9 @@ while the user configures everything in one place.
   `targets`). See "List-valued arguments" below.
 - Packaging for distro repositories (deb/rpm), AUR, Homebrew, etc.
 - A bespoke config-file format. systemd's `EnvironmentFile` is the config file.
+- `Type=notify` mount-readiness signalling (an sd_notify call so consumer units
+  can order after the mount is live). The shipped unit is `Type=simple`; see the
+  readiness caveat under `musefs.service`.
 
 ## Part A — env-var support
 
@@ -66,6 +69,14 @@ clap's resolution order is exactly what we want and needs no custom code:
 
 An env var also satisfies a `required` argument, so `--db` and the `mountpoint`
 positional can come entirely from the environment.
+
+**Present-but-empty is a value, not "unset".** systemd's `EnvironmentFile`
+distinguishes an unset key from `KEY=` (set to the empty string). clap sees a
+present env var and uses `""` as the value: for `--db` that yields
+`PathBuf::from("")`, which passes clap's required check and fails later at
+store-open; for a boolean it is an invalid bool and hard-errors (see below).
+The conf example therefore comments out optional keys rather than leaving them
+empty, and the README warns against bare `KEY=` lines.
 
 ### Naming convention
 
@@ -105,18 +116,28 @@ scan (`Command::Scan`):
 | `MUSEFS_QUIET` | `--quiet` |
 
 `MUSEFS_DB` is deliberately shared between `mount` and `scan`: a single
-`EnvironmentFile` can point both subcommands at the same store.
+`EnvironmentFile` can point both subcommands at the same store. A shared conf
+also means mount-only vars (e.g. `MUSEFS_MODE`) are in the environment when
+`scan` runs; this is harmless — clap only consults the env vars declared on the
+subcommand being parsed and ignores the rest.
 
 ### Boolean flags
 
 `--keep-cache`, `--revalidate`, `--follow-symlinks`, `--quiet` are
-`ArgAction::SetTrue` flags. With clap's `env`, their env var is truthy on the
-usual values; the env value is parsed as a bool. `--case-insensitive` already
-uses `ArgAction::Set` with an explicit `true`/`false` value and a
-`cfg!(target_os = "macos")` default — its env var takes `true`/`false`.
+`ArgAction::SetTrue` flags. With clap's `env`, the env var is parsed by clap's
+`BoolishValueParser`, which accepts a **fixed, case-insensitive set** —
+`true`/`false`, `t`/`f`, `yes`/`no`, `y`/`n`, `on`/`off`, `1`/`0` — and
+**hard-errors on anything else** (including an empty string). It does not
+silently fall back to false: `MUSEFS_QUIET=enabled` or a typo is a clap parse
+error. `--case-insensitive` already uses `ArgAction::Set` with an explicit
+`true`/`false` value and a `cfg!(target_os = "macos")` default; its env var
+takes the same boolish set.
 
-The conf example documents the accepted boolean spellings so users are not left
-guessing.
+Consequence under systemd: with `Type=simple` a bad boolean spelling in the
+conf makes the unit fail to start (fast and loud — arguably desirable, but it is
+not a silent no-op). The conf example therefore enumerates the **exact** accepted
+spellings rather than saying "the usual values," and the implementation must
+verify the hard-error behavior in tests (see Testing).
 
 ### List-valued arguments (flag-only, by design)
 
@@ -146,16 +167,27 @@ Shipped under `contrib/systemd/`, matching the existing `contrib/` convention
 [Unit]
 Description=musefs read-only re-tagging FUSE mount
 Documentation=https://github.com/Sohex/musefs
-After=default.target
 
 [Service]
 Type=simple
 EnvironmentFile=-%h/.config/musefs/musefs.conf
+# The --user manager does not inherit a login shell's PATH, so a cargo-installed
+# binary in ~/.cargo/bin is not found by a bare `musefs`. Adjust this PATH (or
+# use an absolute ExecStart) to match where musefs is installed.
+Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
 ExecStart=musefs mount
 # musefs unmounts cleanly on SIGTERM (systemd's default stop signal), so no
 # ExecStop is required. Uncomment as a fallback if a mount is ever left behind:
 #ExecStop=-fusermount3 -u ${MUSEFS_MOUNTPOINT}
 Restart=on-failure
+RestartSec=5
+# A misconfigured unit (missing/invalid MUSEFS_* value) exits non-zero on every
+# start; the default start-limiter eventually stops retrying.
+
+# NoNewPrivileges is safe for a FUSE mount. Do NOT add ProtectHome=,
+# PrivateMounts=, or MountFlags=private: they put the mount in a private
+# namespace, hiding it from the rest of your session.
+NoNewPrivileges=true
 
 [Install]
 WantedBy=default.target
@@ -166,18 +198,27 @@ Notes:
 - `EnvironmentFile=-...` — the leading `-` makes the file optional, so the unit
   still starts if the user has not created the conf yet (and is relying on a
   drop-in or inline `Environment=`).
+- No `After=` ordering. For a `--user` unit `WantedBy=default.target` already
+  starts it once the user session is up; ordering `After=default.target` (the
+  top of the user boot) is both unnecessary and self-referential, so it is
+  omitted.
 - `ExecStart=musefs mount` carries no arguments; everything comes from the
   environment. Required values (`MUSEFS_MOUNTPOINT`, `MUSEFS_DB`) must therefore
   be present in the conf or a drop-in, or the unit fails fast with clap's
   "required argument not provided" error.
-- We do **not** embed commented `Environment=` example lines in the unit.
-  Inline overrides are supported the systemd-native way via
+- **`Type=simple` readiness caveat.** `run_mount` blocks (it calls
+  `musefs_fuse::mount_with`), so `Type=simple` is the correct type. But systemd
+  marks the unit "active" the instant it forks — *before* the FUSE mount is
+  actually established. Nothing should assume the mount is live merely because
+  the service is active; mount-ready ordering for a consumer unit is out of
+  scope (would require `Type=notify` + an sd_notify call, see Non-goals).
+- We do **not** embed commented `Environment=` example lines for `MUSEFS_*` in
+  the unit. Inline overrides are supported the systemd-native way via
   `systemctl --user edit musefs`, which writes an upgrade-safe drop-in. The conf
   file is the documented place for the full variable list.
-- `musefs` must be on the unit's `PATH`. The README instructions note that a
-  `cargo install` binary in `~/.cargo/bin` may need either an absolute
-  `ExecStart` path or `Environment=PATH=...`; this is called out rather than
-  guessed at in the unit.
+- `%h` is the unit-file home expansion; `~` only expands in a shell. The README
+  uses `~/...` for human readability — warn against pasting those `~` paths
+  verbatim into unit directives, where they would be taken literally.
 
 ### `musefs-scan.service` + `musefs-scan.timer` (optional periodic re-scan)
 
@@ -194,6 +235,7 @@ Documentation=https://github.com/Sohex/musefs
 [Service]
 Type=oneshot
 EnvironmentFile=-%h/.config/musefs/musefs.conf
+Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
 # Set the library path(s) here; targets are not env-configurable.
 ExecStart=musefs scan %h/Music --revalidate
 ```
@@ -213,30 +255,48 @@ WantedBy=timers.target
 ```
 
 `MUSEFS_DB` and other scan knobs come from the shared conf; only the target
-path is inlined.
+path is inlined. A `--user` timer only fires while the user manager is running;
+on a headless server where the user is not logged in, the contrib README must
+tell users to run `loginctl enable-linger <user>` so the timer fires when
+logged out.
 
 ### `musefs.conf.example`
 
 A fully commented file listing every scalar `MUSEFS_*` variable with its
 default value, shipped for the user to copy to `~/.config/musefs/musefs.conf`.
 Structure: required vars uncommented with placeholder values at the top
-(`MUSEFS_MOUNTPOINT`, `MUSEFS_DB`), every optional var commented with its
-default below. Documents accepted boolean spellings.
+(`MUSEFS_MOUNTPOINT`, `MUSEFS_DB`), every optional var **commented** with its
+default below. Specific requirements:
+
+- Optional vars are left commented (`#MUSEFS_MODE=synthesis`), never set to an
+  empty value — `KEY=` is "present and empty", which clap treats as a value and
+  which breaks required-path and boolean args (see "Present-but-empty" above).
+- Boolean vars list the exact accepted spellings inline
+  (`true`/`false`/`yes`/`no`/`on`/`off`/`1`/`0`, case-insensitive), since an
+  unrecognized value is a hard error, not a silent false.
+- Use **absolute paths** (or none): under a `--user` unit the working directory
+  defaults to `%h`, so a relative `MUSEFS_DB` resolves against home, which is
+  surprising.
 
 systemd's `EnvironmentFile` parses `KEY=value` lines (no shell quoting, values
-are literal to end of line); the example is written within those constraints
-and notes them.
+are literal to end of line — no `$VAR` expansion, no quote stripping); the
+example is written within those constraints and notes them.
 
 ## Documentation
 
 - **README** — add a "Running as a systemd user service" subsection in the
   host-run discussion: how to install the binary, where to put the unit and
   conf, and the `systemctl --user enable --now musefs` flow, including the
-  `PATH`/absolute-`ExecStart` note. Add an env-var note (and/or an "Env var"
-  column) to the existing mount/scan flag tables so the mapping is discoverable.
+  `PATH` note (the shipped unit sets `PATH` for the `~/.cargo/bin` case; users
+  with a different install location adjust it) and the `%h`-vs-`~` warning. Add
+  an env-var note (and/or an "Env var" column) to the existing mount/scan flag
+  tables so the mapping is discoverable. To bound drift across the three places
+  the mapping lives (code attributes, conf example, README), treat
+  `musefs.conf.example` as the canonical list and have the README point to it.
 - **contrib/systemd/** — a short `README.md` is acceptable here (the other
-  `contrib/` integrations each have one) describing the three files and install
-  steps. This is the one place a new doc file is warranted.
+  `contrib/` integrations each have one) describing the three files, the install
+  steps, and `loginctl enable-linger` for the timer on headless servers. This is
+  the one place a new doc file is warranted.
 
 ## Testing
 
@@ -259,6 +319,10 @@ binary** with a controlled environment:
   - An explicit flag overrides the corresponding env var (e.g.
     `MUSEFS_MODE=structure-only` on the env but `--mode synthesis` on the
     command line resolves to synthesis) — asserted via an observable difference.
+  - Boolean-from-env behavior on a `SetTrue` flag (e.g. `MUSEFS_KEEP_CACHE`): a
+    valid truthy value is accepted, and an invalid spelling (e.g.
+    `MUSEFS_KEEP_CACHE=enabled`) is a clap parse error — guarding the hard-error
+    semantics the conf relies on.
 - Scalar-arg parse coverage that does not need real env (e.g. confirming the
   `env` attribute is present and named correctly) can also be asserted by
   reading the generated clap help/`--help` output where convenient.

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["fuse", "music", "metadata", "filesystem", "audio"]
 categories = ["filesystem", "multimedia::audio", "command-line-utilities"]
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 musefs-db = { path = "../musefs-db", version = "0.2.0" }
 musefs-core = { path = "../musefs-core", version = "0.2.0" }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -43,17 +43,22 @@ pub struct Cli {
 #[derive(clap::Args, Debug)]
 pub struct MountArgs {
     /// Empty directory to mount at.
+    #[arg(env = "MUSEFS_MOUNTPOINT")]
     pub mountpoint: PathBuf,
     /// Path to the SQLite database.
-    #[arg(long)]
+    #[arg(long, env = "MUSEFS_DB")]
     pub db: PathBuf,
     /// Path template, e.g. "$albumartist/$album/$title". Supports ${a|b}
     /// fallback chains, [...] conditional sections ($[/$] for literal
     /// brackets), and $!{field} path fields that keep '/' as separators.
-    #[arg(long, default_value = "$albumartist/$album/$title")]
+    #[arg(
+        long,
+        env = "MUSEFS_TEMPLATE",
+        default_value = "$albumartist/$album/$title"
+    )]
     pub template: String,
     /// Fallback value substituted for any missing template field.
-    #[arg(long, default_value = "Unknown")]
+    #[arg(long, env = "MUSEFS_DEFAULT_FALLBACK", default_value = "Unknown")]
     pub default_fallback: String,
     /// Per-field fallback `FIELD=VALUE`, overriding `--default-fallback` for
     /// just that field when it is missing. Repeatable, e.g. `--fallback
@@ -61,47 +66,47 @@ pub struct MountArgs {
     #[arg(long = "fallback", value_name = "FIELD=VALUE", value_parser = parse_fallback)]
     pub fallbacks: Vec<(String, String)>,
     /// How file contents are served.
-    #[arg(long, value_enum, default_value_t = CliMode::Synthesis)]
+    #[arg(long, value_enum, env = "MUSEFS_MODE", default_value_t = CliMode::Synthesis)]
     pub mode: CliMode,
     /// Debounce window (ms) for picking up external DB edits.
-    #[arg(long, default_value_t = 1000)]
+    #[arg(long, env = "MUSEFS_POLL_INTERVAL_MS", default_value_t = 1000)]
     pub poll_interval_ms: u64,
     /// Entry/attr cache TTL (ms) the kernel may trust before re-validating.
     /// Higher cuts lookup/getattr traffic but slows visibility of DB edits.
-    #[arg(long, default_value_t = 1000)]
+    #[arg(long, env = "MUSEFS_ATTR_TTL_MS", default_value_t = 1000)]
     pub attr_ttl_ms: u64,
     /// Kernel read-ahead window (KiB). Larger hides HDD/NFS latency while
     /// streaming; clamped to the kernel maximum at mount.
-    #[arg(long, default_value_t = 512)]
+    #[arg(long, env = "MUSEFS_MAX_READAHEAD_KIB", default_value_t = 512)]
     pub max_readahead_kib: u32,
     /// Max outstanding background (readahead/async) requests the kernel queues.
-    #[arg(long, default_value_t = 64)]
+    #[arg(long, env = "MUSEFS_MAX_BACKGROUND", default_value_t = 64)]
     pub max_background: u16,
     /// Keep the kernel page cache across opens. External re-tags auto-invalidate
     /// the affected inodes on refresh, so cached bytes are dropped when content
     /// changes.
-    #[arg(long)]
+    #[arg(long, env = "MUSEFS_KEEP_CACHE")]
     pub keep_cache: bool,
     /// Compare filenames case-insensitively: case-variant directories merge and
     /// case-variant files are disambiguated. Defaults to true on macOS (whose
     /// volumes are usually case-insensitive), false on Linux/FreeBSD. Override
     /// with `--case-insensitive false` (e.g. a case-sensitive APFS volume).
-    #[arg(long, default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set)]
+    #[arg(long, env = "MUSEFS_CASE_INSENSITIVE", default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set)]
     pub case_insensitive: bool,
     /// Owning user for every entry: a username or numeric uid. Defaults to the
     /// launching process's uid.
-    #[arg(long, value_name = "NAME|UID", value_parser = parse_owner)]
+    #[arg(long, env = "MUSEFS_OWNER", value_name = "NAME|UID", value_parser = parse_owner)]
     pub owner: Option<u32>,
     /// Owning group for every entry: a group name or numeric gid. Defaults to
     /// the launching process's gid.
-    #[arg(long, value_name = "NAME|GID", value_parser = parse_group)]
+    #[arg(long, env = "MUSEFS_GROUP", value_name = "NAME|GID", value_parser = parse_group)]
     pub group: Option<u32>,
     /// Permission bits for regular files, octal (e.g. 444). Defaults to 444.
     /// The mount is read-only, so write bits are advertised but inert.
-    #[arg(long, value_name = "OCTAL", value_parser = parse_octal_mode)]
+    #[arg(long, env = "MUSEFS_FILE_MODE", value_name = "OCTAL", value_parser = parse_octal_mode)]
     pub file_mode: Option<u16>,
     /// Permission bits for directories, octal (e.g. 555). Defaults to 555.
-    #[arg(long, value_name = "OCTAL", value_parser = parse_octal_mode)]
+    #[arg(long, env = "MUSEFS_DIR_MODE", value_name = "OCTAL", value_parser = parse_octal_mode)]
     pub dir_mode: Option<u16>,
 }
 

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -119,22 +119,22 @@ pub enum Command {
         #[arg(required = true, num_args = 1..)]
         targets: Vec<PathBuf>,
         /// Path to the SQLite database (created if absent).
-        #[arg(long)]
+        #[arg(long, env = "MUSEFS_DB")]
         db: PathBuf,
         /// Re-validate: skip unchanged files, prune tracks whose backing file is
         /// gone, and garbage-collect orphaned art.
-        #[arg(long)]
+        #[arg(long, env = "MUSEFS_REVALIDATE")]
         revalidate: bool,
         /// Probe worker threads (0 = available parallelism). 1 = sequential.
-        #[arg(long, default_value_t = 0)]
+        #[arg(long, env = "MUSEFS_JOBS", default_value_t = 0)]
         jobs: usize,
         /// Follow symlinks while walking directories. Off by default: symlinked
         /// files and directories are logged and skipped.
-        #[arg(long)]
+        #[arg(long, env = "MUSEFS_FOLLOW_SYMLINKS")]
         follow_symlinks: bool,
         /// Suppress the per-target summary on stdout (failures still surface via
         /// the `log` facade on stderr; raise detail with `RUST_LOG=info`).
-        #[arg(long, short)]
+        #[arg(long, short, env = "MUSEFS_QUIET")]
         quiet: bool,
     },
     /// Mount a read-only FUSE view of the store.

--- a/musefs/tests/env_config.rs
+++ b/musefs/tests/env_config.rs
@@ -185,3 +185,35 @@ fn valid_boolean_env_is_accepted() {
     assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
     assert!(stderr.contains("opening database"), "stderr: {stderr}");
 }
+
+#[test]
+fn scan_reads_db_from_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("library");
+    std::fs::create_dir(&target).unwrap();
+    let db = dir.path().join("scan-env.db");
+    let out = musefs()
+        .arg("scan")
+        .arg(&target) // targets stay command-line only
+        .env("MUSEFS_DB", &db)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        db.exists(),
+        "scan should create the DB at the MUSEFS_DB path"
+    );
+}
+
+#[test]
+fn scan_help_lists_env_vars() {
+    let out = musefs().args(["scan", "--help"]).output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("MUSEFS_DB"), "stdout: {stdout}");
+    assert!(stdout.contains("MUSEFS_JOBS"), "stdout: {stdout}");
+}

--- a/musefs/tests/env_config.rs
+++ b/musefs/tests/env_config.rs
@@ -1,0 +1,140 @@
+//! The `musefs` binary reads MUSEFS_* environment variables for scalar mount
+//! and scan flags (clap's `env` feature). Each test spawns the real binary with
+//! an isolated environment, so they are parallel-safe and need no /dev/fuse:
+//! the children fail fast at arg-parse (exit 2) or DB-open (exit 1), never
+//! reaching a mount.
+//!
+//! `env_clear()` is deliberate: it guarantees no ambient MUSEFS_* leaks in from
+//! the developer's shell. It is safe here — the binary is launched by absolute
+//! path (`CARGO_BIN_EXE_musefs`), and the assertions key on the
+//! `opening database at <path>` stderr, which `main` emits via anyhow/eprintln,
+//! not through env_logger — so a cleared `RUST_LOG` does not suppress it.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn musefs() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_musefs"));
+    cmd.env_clear();
+    cmd
+}
+
+/// A DB path whose parent directory does not exist, so opening it fails
+/// deterministically — proving we got *past* arg parsing to the DB-open step.
+fn unopenable_db(dir: &Path, name: &str) -> PathBuf {
+    dir.join("missing").join(name)
+}
+
+#[test]
+fn env_satisfies_required_mount_args() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    let out: Output = musefs()
+        .arg("mount")
+        .env("MUSEFS_MOUNTPOINT", dir.path())
+        .env("MUSEFS_DB", &db)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Not a usage error: env satisfied the required mountpoint and --db.
+    assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
+    // We reached DB-open, which fails on the missing parent directory.
+    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&db.display().to_string()),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn missing_required_mount_args_is_usage_error() {
+    let out = musefs().arg("mount").output().unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("--db") || stderr.contains("required"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn explicit_db_flag_overrides_env_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let env_db = unopenable_db(dir.path(), "env.db");
+    let flag_db = unopenable_db(dir.path(), "flag.db");
+    let out = musefs()
+        .arg("mount")
+        .arg(dir.path()) // positional mountpoint
+        .arg("--db")
+        .arg(&flag_db)
+        .env("MUSEFS_DB", &env_db)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&flag_db.display().to_string()),
+        "expected flag db to win, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains(&env_db.display().to_string()),
+        "env db should have been overridden, stderr: {stderr}"
+    );
+}
+
+// Precedence on a value-bearing, non-required flag (the spec's --mode example).
+// A bogus MUSEFS_MODE alone is rejected at parse (proves env is read); the same
+// bogus env with an explicit --mode is accepted (proves the flag wins and env is
+// not consulted). Observable purely via exit codes — no mount needed.
+#[test]
+fn invalid_mode_env_is_rejected_but_flag_overrides_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+
+    let env_only = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .env("MUSEFS_MODE", "bogus")
+        .output()
+        .unwrap();
+    assert_eq!(
+        env_only.status.code(),
+        Some(2),
+        "bogus MUSEFS_MODE should be a usage error, stderr: {}",
+        String::from_utf8_lossy(&env_only.stderr)
+    );
+
+    let flag_wins = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .arg("--mode")
+        .arg("synthesis")
+        .env("MUSEFS_MODE", "bogus")
+        .output()
+        .unwrap();
+    // --mode on the CLI wins; the bogus env is never parsed. We fall through to
+    // DB-open (exit 1), not a usage error.
+    let stderr = String::from_utf8_lossy(&flag_wins.stderr);
+    assert_ne!(flag_wins.status.code(), Some(2), "stderr: {stderr}");
+    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+}
+
+// Locks the per-flag env wiring: clap's `env` feature renders `[env: NAME=]` in
+// help for annotated args. Catches a dropped `env=` that the precedence tests
+// might miss, and confirms the list-valued carve-out (--fallback) has no env.
+#[test]
+fn mount_help_lists_env_vars() {
+    let out = musefs().args(["mount", "--help"]).output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("MUSEFS_DB"), "stdout: {stdout}");
+    assert!(stdout.contains("MUSEFS_MODE"), "stdout: {stdout}");
+    assert!(stdout.contains("MUSEFS_MOUNTPOINT"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("MUSEFS_FALLBACK"),
+        "--fallback is flag-only and must not advertise an env var, stdout: {stdout}"
+    );
+}

--- a/musefs/tests/env_config.rs
+++ b/musefs/tests/env_config.rs
@@ -138,3 +138,50 @@ fn mount_help_lists_env_vars() {
         "--fallback is flag-only and must not advertise an env var, stdout: {stdout}"
     );
 }
+
+#[test]
+fn invalid_boolean_env_is_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    let out = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .env("MUSEFS_KEEP_CACHE", "enabled") // not a boolish value
+        .output()
+        .unwrap();
+    // Hard error at parse time, not a silent false — and pinned to the boolean
+    // parse failure, not any exit-2.
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("keep-cache") || stderr.contains("invalid value"),
+        "expected a keep-cache boolean parse error, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn valid_boolean_env_is_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    let out = musefs()
+        .arg("mount")
+        .arg(dir.path())
+        .arg("--db")
+        .arg(&db)
+        .env("MUSEFS_KEEP_CACHE", "true")
+        .output()
+        .unwrap();
+    // Got past parse for the right reason (reached DB-open), not merely "not
+    // exit 2". Proves a valid boolish env value is accepted, not silently
+    // dropped.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
+    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+}


### PR DESCRIPTION
## What

Two coupled additions that make running musefs on the host (the recommended deployment) turnkey:

1. **`MUSEFS_*` environment variables** for every scalar `mount` and `scan` flag, via clap's `env` feature. Precedence is explicit flag > env var > default, and env satisfies required args (`--db`, the mountpoint). The repeatable `--fallback` and `scan` targets stay command-line only (a single env var can't represent a list without a delimiter that collides with real values).

2. **Drop-in systemd user units** under `contrib/systemd/`: a `musefs.service` mount daemon, an optional `musefs-scan.service`/`.timer` for periodic re-scans, a fully commented `musefs.conf.example`, and a contrib README. All user units (`systemctl --user`) — no root, no `CAP_SYS_ADMIN`.

## Notable details

- The unit ships `Environment=PATH=%h/.cargo/bin:...` so a `cargo install` binary is found (the `--user` manager doesn't inherit a login shell PATH).
- `NoNewPrivileges=true` with an explicit comment warning that `ProtectHome=`/`PrivateMounts=`/`MountFlags=private` must **not** be added — they'd hide the FUSE mount from the session.
- `%h` is **not** expanded inside an `EnvironmentFile` (only in unit directives), so `musefs.conf.example` uses literal absolute paths.
- Booleans from env use clap's `BoolishValueParser` (`true/false`, `yes/no`, `on/off`, `1/0`); an unrecognized value is a hard parse error, documented in the conf.

## Tests

New `musefs/tests/env_config.rs` spawns the real binary with a controlled, per-process environment (parallel-safe, no `/dev/fuse` — children fail fast at arg-parse or DB-open). 9 tests cover: env satisfies required args, flag-beats-env precedence (paths and `--mode`), boolean hard-error semantics, and `--help` advertising the env vars (and `--fallback` not).

Docs updated: README gains an env-var note and a systemd subsection; design spec and implementation plan included under `docs/superpowers/`.

## Verification

- `cargo test -p musefs --test env_config` — 9 passed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `systemd-analyze --user verify` — units valid (only the expected "musefs not installed here" notice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring mount and scan settings via `MUSEFS_*` environment variables (CLI flags take precedence).
  * Added systemd user service integration with optional periodic library rescanning via timer.

* **Documentation**
  * Added systemd user service setup guide with step-by-step installation instructions.
  * Added environment variable configuration reference and example configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->