### PR TITLE
docs: investigate per-medium storage tunables; defaults confirmed

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -641,3 +641,104 @@ ogg cold/seek collapse.
 _Criterion's own `change:` lines compare against the previous on-machine baseline
 (itself already optimized); the absolutes above are the reliable end-to-end
 signal._
+
+---
+
+## Storage tunables
+
+A proposed `--storage-profile {ssd,hdd,nfs}` preset would have bumped
+`--max-readahead-kib` and `--max-background` (and enabled `--keep-cache`) per medium,
+on the premise that "larger read-ahead hides HDD/NFS latency." Measured against real
+storage, **that premise does not hold** — only `--keep-cache` shows a benefit — so the
+preset was dropped and these flags keep their defaults. This section records the
+evidence.
+
+### Methodology
+
+Unlike the optimization passes above (tmpfs, in-process Criterion), these run through a
+**real kernel mount with a real reader**, because the tunables are kernel↔FUSE
+negotiation parameters invisible to an in-process driver:
+
+- **Backing:** real RAID-1 HDD (`/home`, `/dev/md127`) and a btrfs HDD span (`/data`,
+  `/dev/sda3`); for NFS, a loopback **NFSv4.2** export (`exportfs` + `mount -t nfs
+  localhost:…`) whose backing is tmpfs (isolates the RPC tax) or HDD (RPC + seeks).
+- **Latency:** `tc qdisc add dev lo root netem delay <X>ms` adds `X` per packet
+  → ≈`2X` RTT per NFS RPC. Tested at 8 ms, 50 ms, and 200 ms RTT (the last ≈ a
+  trans-Pacific server).
+- **Cold reads:** `sync; echo 3 > /proc/sys/vm/drop_caches` before each measured read —
+  without it the page cache serves repeats and hides all backing latency.
+- **Mode: `synthesis`, not `structure-only`.** Structure-only triggers kernel FUSE
+  passthrough when the process is privileged (these run as root), which serves the
+  backing fd directly and **bypasses the daemon read path** — and with it every tunable
+  that acts on that path. Synthesis splices `BackingAudio` reads through the daemon,
+  the real serving path.
+- **Why not the injected `MUSEFS_FAULT_*_US` model:** it cannot show a read-ahead
+  effect. FUSE delivers reads to the daemon in fixed ≤256 KiB chunks (`max_pages`,
+  already pinned at the kernel's 1 MiB ceiling by `fuser`'s 16 MiB default
+  `max_write`), so the per-`pread` count — and thus any per-`pread` injected latency
+  total — is independent of `max_readahead`.
+
+Reproduce: `benches/storage_tunables_bench.sh` (needs `/dev/fuse`, root, and for the
+NFS rows `nfs-kernel-server` + `tc`). HDD numbers are noisy (±10–15%); the trends, not
+the digits, are the signal.
+
+### `--max-readahead-kib` — no benefit anywhere; hurts on HDD
+
+Cold single-stream sequential throughput (MB/s), `synthesis`:
+
+| readahead KiB | HDD /home (RAID1) | HDD /data (btrfs) | NFS 8 ms | NFS-on-HDD 50 ms | NFS-on-HDD 200 ms |
+|--------------:|------------------:|------------------:|---------:|-----------------:|------------------:|
+| 512 (default) | 248 | 127 | 30.8 | 4.7 | 1.3 |
+| 2048          | 191 | 72  | 30.6 | 4.9 | 1.3 |
+| 4096          | 153 | 84  | 30.5 | 4.9 | 1.3 |
+| 32 (probe)    | 237 | 75  | —    | —   | —   |
+
+(File sizes differ per column — 512 MiB local, 96 MiB at 50 ms, 48 MiB at 200 ms — so
+compare *within* a column, not across. The 200 ms column ≈ a trans-Pacific server:
+flat to the last digit.)
+
+The window size barely moves throughput, and on HDD values ≥2048 KiB are among the
+**slowest** (peak is ~128–512 KiB). The reason is visible on NFS: 512 MiB ÷ 256 KiB ×
+8 ms ≈ 16 s ≈ the observed 31 MB/s — a single stream is served **serially**, one
+≤256 KiB read at a time, each paying the full RTT, with no prefetch overlap that a
+larger window could exploit.
+
+### `--max-background` — no effect on read throughput
+
+Wall time (s) for N concurrent cold streams over distinct tracks:
+
+| max_background | HDD /home (16 streams) | NFS 8 ms (16) | NFS-on-HDD 50 ms (80) | NFS-on-HDD 200 ms (24) |
+|---------------:|-----------------------:|--------------:|----------------------:|-----------------------:|
+| 64 (default)   | 4.55 | 5.16 | 177.8 | 238.5 |
+| 128            | 5.05 | 5.18 | 175.7 | 237.4 |
+
+64 ≈ 128 even with 80 > 64 streams. Expected: musefs's `FuseConfig` notes
+`max_background` caps *background* work and that "foreground reads are bounded only by
+client concurrency, not by this." The concurrent reads here are foreground.
+(Concurrency *does* hide latency — 16 NFS streams reach ~10× single-stream aggregate —
+but that is client parallelism, which `max_background` does not gate.)
+
+### `--keep-cache` — the one real win (~3×)
+
+Cold read then immediate reopen (no cache drop between); `reopen_s` is the signal:
+
+| keep_cache | HDD reopen (s) | NFS 8 ms reopen (s) | NFS-on-HDD 50 ms reopen (s) |
+|-----------:|---------------:|--------------------:|----------------------------:|
+| false      | 0.224 | 0.207 | 0.039 |
+| true       | 0.062 | 0.060 | 0.014 |
+
+With `--keep-cache` the kernel retains the page cache across opens, so a re-opened file
+is served from RAM instead of re-fetched over slow storage — **~3× faster reopen**,
+consistent across HDD and NFS. This is the only tunable worth changing for slow backing
+(relevant for players/scanners that re-open files), and it needs no preset.
+
+### Conclusions
+
+- **Drop the `--storage-profile` preset.** Of the four knobs it would have set, three
+  (`max_readahead`, `max_background`, and by extension a per-medium combination of them)
+  show no benefit; `max_readahead` ≥2048 KiB actively hurts on HDD. The only justified
+  change — enable `--keep-cache` on HDD/NFS — does not need an abstraction.
+- **Latent finding (future work):** single-stream reads are serialized, so per-read
+  latency is never hidden by prefetch. The real lever for slow backing would be a
+  **concurrent backing-prefetch pipeline in the daemon** (issue several `BackingAudio`
+  reads ahead in parallel), an architectural change tracked separately.

--- a/README.md
+++ b/README.md
@@ -109,15 +109,18 @@ Run `musefs <command> --help` for the full flag list.
 
 ### Tuning
 
-All tuning flags have sensible defaults; adjust them to your backing store:
+The defaults are sensible for most setups. On slow backing storage (HDD, NFS) the one
+flag worth changing is `--keep-cache`; the read-ahead / background knobs have little
+measurable effect on musefs (see [BENCHMARKS.md](BENCHMARKS.md#storage-tunables)
+for the methodology and numbers).
 
 | Flag | Default | What it does |
 | ---- | ------- | ------------ |
 | `--poll-interval-ms` | `1000` | Debounce window for detecting external DB edits. |
-| `--attr-ttl-ms` | `1000` | How long the kernel may trust cached entry/attr lookups. Higher cuts `lookup`/`getattr` traffic; bounds how fast external edits become visible. |
-| `--max-readahead-kib` | `512` | Kernel read-ahead window. Larger hides HDD/NFS latency during sequential playback (clamped to the kernel maximum). |
-| `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. |
-| `--keep-cache` | disabled | Keep the kernel page cache across opens. External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
+| `--keep-cache` | disabled | Keep the kernel page cache across opens. **Worth enabling on HDD/NFS:** repeat opens of a file are then served from cache instead of re-read over slow storage (~3× faster reopen in our benches). External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
+| `--attr-ttl-ms` | `1000` | How long the kernel may trust cached entry/attr lookups. Higher cuts `lookup`/`getattr` traffic — useful for metadata-heavy clients (library scanners) over high-latency backing — but bounds how fast external edits become visible. |
+| `--max-readahead-kib` | `512` | Kernel read-ahead window (clamped to the kernel maximum). In practice this does **not** speed up musefs streaming: reads reach the daemon in fixed FUSE-sized chunks and a single stream is served serially, so a larger window doesn't reduce per-read latency. On HDD, values well above the default can even hurt. Leave at the default unless your own profiling shows otherwise. |
+| `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. Does **not** bound foreground reads (those scale with client concurrency), so it has little effect on read throughput; left for completeness. |
 | `--case-insensitive <true\|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files get a numeric suffix (e.g. `Song (2)`). Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
 
 ### Ownership and permissions

--- a/benches/storage_tunables_bench.sh
+++ b/benches/storage_tunables_bench.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Storage-tunables bench: measures whether --max-readahead-kib / --max-background /
+# --keep-cache actually help musefs on slow backing storage. Backs the discussion in
+# BENCHMARKS.md (#storage-tunables). Negative result: only --keep-cache helps.
+#
+# These knobs are kernel<->FUSE parameters, so they only matter through a REAL kernel
+# mount with a real reader (not the in-process Criterion benches). Mode MUST be
+# synthesis: structure-only triggers kernel passthrough when privileged and bypasses
+# the daemon read path entirely.
+#
+# Usage (run as root; reads drop the page cache between samples):
+#   storage_tunables_bench.sh local <backing-dir> [size_mib] [streams]
+#   storage_tunables_bench.sh nfs   <export-dir>  <netem_ms_per_way> [size_mib] [streams]
+#
+#   local: <backing-dir> is a real disk (e.g. an HDD) holding the corpus.
+#   nfs:   <export-dir> is exported via loopback NFSv4 and `tc netem` adds
+#          <netem_ms_per_way> per packet (~2x that as RPC RTT). Backing it on tmpfs
+#          isolates the RPC tax; on HDD adds real seeks. Needs nfs-kernel-server + tc.
+set -euo pipefail
+
+MODE="${1:?usage: $0 local|nfs <dir> ...}"
+BIN="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)/target/release/musefs"
+[ -x "$BIN" ] || { echo "build first: cargo build --release -p musefs" >&2; exit 1; }
+
+NFSMNT=/tmp/sp-nfsmnt
+MMNT=/tmp/sp-musefs-mnt
+DB=/tmp/sp-tunables.db
+MP=""; NETEM=0; NFS_EXP=""
+
+cleanup() {
+  [ -n "$MP" ] && kill "$MP" 2>/dev/null || true
+  sleep 0.5
+  [ "$NETEM" = 1 ] && tc qdisc del dev lo root 2>/dev/null || true
+  mountpoint -q "$MMNT" && { fusermount3 -u "$MMNT" 2>/dev/null || umount -l "$MMNT" 2>/dev/null; } || true
+  if [ -n "$NFS_EXP" ]; then
+    mountpoint -q "$NFSMNT" && umount -l "$NFSMNT" 2>/dev/null || true
+    exportfs -u localhost:"$NFS_EXP" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+make_wav() { local p="$1" m="$2" d r; [ -f "$p" ] && return 0
+  d=$(( m*1024*1024 )); r=$(( d+36 ))
+  # shellcheck disable=SC2059  # generated hex-escape format string, by design
+  { printf 'RIFF'; printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((r&255)) $((r>>8&255)) $((r>>16&255)) $((r>>24&255)))"
+    printf 'WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x44\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00data'
+    printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((d&255)) $((d>>8&255)) $((d>>16&255)) $((d>>24&255)))"
+    dd if=/dev/zero bs=1M count="$m" 2>/dev/null; } >> "$p"; }
+
+gen_corpus() { # $1=backing-dir $2=size_mib $3=streams
+  mkdir -p "$1"
+  make_wav "$1/big.wav" "$2"
+  local i; for i in $(seq 1 "$3"); do make_wav "$1/t$i.wav" 32; done
+}
+
+case "$MODE" in
+  local)
+    BACKING="${2:?need backing dir}"; SIZE="${3:-512}"; STREAMS="${4:-16}"
+    gen_corpus "$BACKING/backing" "$SIZE" "$STREAMS"
+    SCANDIR="$BACKING/backing"
+    echo "local backing=$BACKING ($(stat -f -c %T "$BACKING"))  size=${SIZE}MiB  streams=$STREAMS" ;;
+  nfs)
+    NFS_EXP="${2:?need export dir}"; NETEM_MS="${3:?need netem ms/way}"; SIZE="${4:-96}"; STREAMS="${5:-16}"
+    gen_corpus "$NFS_EXP/backing" "$SIZE" "$STREAMS"
+    mkdir -p "$NFSMNT"
+    systemctl start nfs-server 2>/dev/null || true
+    exportfs -o rw,sync,no_subtree_check,insecure,no_root_squash localhost:"$NFS_EXP"
+    mount -t nfs -o vers=4.2 localhost:"$NFS_EXP" "$NFSMNT"
+    SCANDIR="$NFSMNT/backing"
+    echo "nfs export=$NFS_EXP ($(stat -f -c %T "$NFS_EXP"))  netem=${NETEM_MS}ms/way  size=${SIZE}MiB  streams=$STREAMS" ;;
+  *) echo "unknown mode: $MODE" >&2; exit 2 ;;
+esac
+
+mkdir -p "$MMNT"
+rm -f "$DB"; "$BIN" scan "$SCANDIR" --db "$DB" >/dev/null   # scan before adding netem
+if [ "$MODE" = nfs ]; then tc qdisc add dev lo root netem delay "${NETEM_MS}ms"; NETEM=1; fi
+
+# shellcheck disable=SC2016  # '$title' is a musefs output-template literal, not a shell var
+mount_m() { "$BIN" mount "$MMNT" --db "$DB" --mode synthesis --template '$title' "$@" >/dev/null 2>&1 & MP=$!
+  local f=""; for _ in $(seq 1 60); do f=$(find "$MMNT" -type f 2>/dev/null|head -1); [ -n "$f" ] && break; sleep 0.25; done; }
+umount_m() { kill "$MP" 2>/dev/null||true; for _ in $(seq 1 20); do kill -0 "$MP" 2>/dev/null||break; sleep 0.25; done; MP=""; }
+drop() { sync; echo 3 > /proc/sys/vm/drop_caches; }
+biggest() { find "$MMNT" -type f -printf '%s\t%p\n'|sort -rn|head -1|cut -f2-; }
+secs() { dd if="$1" of=/dev/null bs=1M 2>&1|tail -1|awk '{for(i=1;i<=NF;i++) if($i=="copied,") print $(i+1)}'; }
+cold_mbps() { local v; v="$(biggest)"; local o
+  o=$(for _ in 1 2 3; do drop
+    dd if="$v" of=/dev/null bs=1M 2>&1|tail -1|awk '{b=$1}{for(i=1;i<=NF;i++) if($i=="copied,")s=$(i+1)}END{if(s>0)printf "%.1f\n",b/1e6/s}'
+  done|sort -n|sed -n 2p); echo "${o:-0}"; }
+
+echo "## max_readahead-kib (cold single-stream MB/s)"
+printf '%-16s %10s\n' readahead MBps
+for ra in 512 2048 4096; do mount_m --max-readahead-kib "$ra"; printf '%-16s %10s\n' "$ra" "$(cold_mbps)"; umount_m; done
+
+echo "## max_background ($STREAMS concurrent cold streams, wall s)"
+printf '%-16s %10s\n' max_background wall_s
+for mb in 64 128; do
+  mount_m --max-background "$mb"
+  mapfile -t files < <(find "$MMNT" -type f ! -path "$(biggest)")
+  drop; t0=$(date +%s.%N); pids=()
+  for f in "${files[@]:0:$STREAMS}"; do dd if="$f" of=/dev/null bs=1M 2>/dev/null & pids+=("$!"); done
+  wait "${pids[@]}"; t1=$(date +%s.%N); umount_m
+  printf '%-16s %10s\n' "$mb" "$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.2f",b-a}')"
+done
+
+echo "## keep_cache (cold then reopen, s)"
+printf '%-16s %10s %10s\n' keep_cache cold_s reopen_s
+for kc in false true; do
+  mount_m --keep-cache "$kc"; v="$(biggest)"; drop
+  c=$(secs "$v"); r=$(secs "$v"); umount_m
+  printf '%-16s %10s %10s\n' "$kc" "$c" "$r"
+done

--- a/docs/superpowers/plans/2026-06-10-storage-profiles.md
+++ b/docs/superpowers/plans/2026-06-10-storage-profiles.md
@@ -1,0 +1,891 @@
+# Storage-aware mount profiles (`--storage-profile`) Implementation Plan
+
+> **Outcome: reverted.** Tasks 1–3 were implemented, but Task 4 (bench validation)
+> disproved the premise: only `--keep-cache` helps on slow backing; the
+> `max_readahead`/`max_background` bumps give no benefit (read-ahead even hurts on HDD).
+> The CLI feature was reverted and the preset dropped. Evidence:
+> [BENCHMARKS.md §Storage tunables](../../../BENCHMARKS.md#storage-tunables). Retained
+> for historical context.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--storage-profile {ssd,hdd,nfs}` mount preset that sets the four backing-media tunables (`max-readahead-kib`, `max-background`, `attr-ttl-ms`, `keep-cache`) to bench-validated values, with explicit flags overriding the profile.
+
+**Architecture:** Additive CLI layer in `musefs-cli`. The four media flags become `Option<…>` (unset = "take from profile or built-in default"); a pure `resolve_tunables` step folds `(explicit flag, profile, default)` into the effective values that feed the existing `FuseConfig`. No changes to `musefs-fuse`/`musefs-core` serving code. Profile values are first implemented as a hypothesis, then confirmed/adjusted by a kernel-mount latency bench before they ship.
+
+**Tech Stack:** Rust, `clap` v4 derive, the existing `musefs-core::metrics` fault-injection hooks, a shell bench harness modeled on `benches/passthrough_dd.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-storage-profiles-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs/Cargo.toml` | binary crate manifest | add `[features] metrics` passthrough |
+| `musefs-cli/Cargo.toml` | cli crate manifest | add `[features] metrics` passthrough |
+| `musefs-cli/src/lib.rs` | CLI parsing + `parse_mount_config` | add `StorageProfile`, constants, `resolve_tunables`; `Option`-ize four fields; wire resolution |
+| `musefs-cli/tests/cli.rs` | CLI integration tests | update 4 construction sites + default assertions; add profile/override/keep-cache tests |
+| `benches/storage_profile_bench.sh` | kernel-mount latency bench harness | new file |
+| `BENCHMARKS.md` (repo root) | bench results log | append the storage-profile before/after table |
+| `README.md` | user docs | update Tuning table; add "pick by backing store" subsection |
+
+---
+
+## Task 1: `metrics` feature passthrough (binary + cli crate)
+
+The bench harness in Task 3 injects latency via `MUSEFS_FAULT_*_US`, but those hooks
+compile to no-op stubs (`musefs-core/src/metrics.rs:242-246`) unless the `metrics`
+feature is on, and the shipped binary leaves it off. The binary depends on
+`musefs-cli` (not `musefs-fuse` directly), so the feature must chain
+`musefs` → `musefs-cli` → `musefs-fuse` → `musefs-core` (the last two links already
+exist in their manifests).
+
+**Files:**
+- Modify: `musefs-cli/Cargo.toml`
+- Modify: `musefs/Cargo.toml`
+
+- [ ] **Step 1: Add the `metrics` feature to `musefs-cli/Cargo.toml`**
+
+Insert after the `[dependencies]` block (after line 17, before `[dev-dependencies]`):
+
+```toml
+[features]
+# Forwards to musefs-fuse/metrics (which forwards to musefs-core/metrics), enabling
+# the serve-path counters and MUSEFS_FAULT_*_US latency injection. Off by default.
+metrics = ["musefs-fuse/metrics"]
+```
+
+- [ ] **Step 2: Add the `metrics` feature to `musefs/Cargo.toml`**
+
+Insert after the `[dependencies]` block (after line 19, before `[dev-dependencies]`):
+
+```toml
+[features]
+# Build with `--features metrics` to enable serve-path latency injection
+# (used by benches/storage_profile_bench.sh). Off in release builds.
+metrics = ["musefs-cli/metrics"]
+```
+
+- [ ] **Step 3: Verify the default build is unchanged and the feature build compiles**
+
+Run: `cargo build -p musefs && cargo build -p musefs --features metrics`
+Expected: both succeed.
+
+- [ ] **Step 4: Verify the feature actually reaches `musefs-core`**
+
+Run: `cargo tree -p musefs --features metrics -e features -i musefs-core | grep -i metrics`
+Expected: output shows `musefs-core` is built with its `metrics` feature (a line containing `feature "metrics"`). If empty, the chain is broken — recheck Steps 1-2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-cli/Cargo.toml musefs/Cargo.toml
+git commit -m "build: add metrics feature passthrough for the latency bench
+
+The musefs-core fault-injection hooks (MUSEFS_FAULT_*_US) are no-op stubs
+unless the metrics feature is on. Chain it musefs -> musefs-cli ->
+musefs-fuse -> musefs-core so benches/storage_profile_bench.sh can build a
+latency-injecting binary. Release builds are unaffected (feature off)."
+```
+
+---
+
+## Task 2: CLI wiring — profile enum, `Option` fields, and `resolve_tunables`
+
+This is the feature's core and must land as **one green commit** (the field type
+change breaks compilation of `parse_mount_config` and the tests until all are updated;
+the pre-commit hook runs the full test suite + `clippy -D warnings`, so an unused enum
+would also fail). Write the tests first, then implement, then make it all green.
+
+Profile values below are the **hypothesis** from the spec — Task 4 confirms or adjusts
+them.
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs` (the `MountArgs` struct lines 43-91; `parse_mount_config` lines 190-206; add a `#[cfg(test)]` unit-test module)
+- Test: `musefs-cli/tests/cli.rs`
+
+- [ ] **Step 1: Add the profile types, constants, and resolver to `musefs-cli/src/lib.rs`**
+
+Add this block immediately **above** the `MountArgs` struct definition (currently the
+doc comment `/// Flags for \`musefs mount\`…` at line 43). It defines the enum (must be
+`pub` — it appears in a `pub` struct field), the default constants, the per-profile
+table, and the pure resolver:
+
+```rust
+/// Built-in tunable defaults — used when neither `--storage-profile` nor the
+/// explicit flag is given. The `ssd` profile is intentionally identical to these.
+const DEFAULT_MAX_READAHEAD_KIB: u32 = 512;
+const DEFAULT_MAX_BACKGROUND: u16 = 64;
+const DEFAULT_ATTR_TTL_MS: u64 = 1000;
+const DEFAULT_KEEP_CACHE: bool = false;
+
+/// The four backing-media tunables, resolved to concrete values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ProfileTunables {
+    max_readahead_kib: u32,
+    max_background: u16,
+    attr_ttl_ms: u64,
+    keep_cache: bool,
+}
+
+impl ProfileTunables {
+    /// The built-in defaults (== the `ssd` profile).
+    const DEFAULTS: ProfileTunables = ProfileTunables {
+        max_readahead_kib: DEFAULT_MAX_READAHEAD_KIB,
+        max_background: DEFAULT_MAX_BACKGROUND,
+        attr_ttl_ms: DEFAULT_ATTR_TTL_MS,
+        keep_cache: DEFAULT_KEEP_CACHE,
+    };
+}
+
+/// Recommended tunable preset for a backing medium. Sets all four media flags at
+/// once; an explicitly-passed flag still overrides the profile for that one knob.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum StorageProfile {
+    /// Local SSD/NVMe — seek-free. Equivalent to the built-in defaults.
+    Ssd,
+    /// Local spinning disk — large read-ahead amortizes the ~8 ms seek; page cache
+    /// kept to avoid re-seeking on repeat opens.
+    Hdd,
+    /// Network filesystem (NFS/SMB) — large read-ahead and a deeper background queue
+    /// hide the per-RPC tax; a longer attr TTL cuts metadata RPCs.
+    Nfs,
+}
+
+impl StorageProfile {
+    fn tunables(self) -> ProfileTunables {
+        match self {
+            // ssd MUST equal DEFAULTS (see the unit test that pins this).
+            StorageProfile::Ssd => ProfileTunables::DEFAULTS,
+            StorageProfile::Hdd => ProfileTunables {
+                max_readahead_kib: 2048,
+                max_background: 64,
+                attr_ttl_ms: 2000,
+                keep_cache: true,
+            },
+            StorageProfile::Nfs => ProfileTunables {
+                max_readahead_kib: 2048,
+                max_background: 128,
+                attr_ttl_ms: 5000,
+                keep_cache: true,
+            },
+        }
+    }
+}
+
+/// Fold `(explicit flag, profile, built-in default)` into the effective tunables.
+/// Precedence: explicit flag > profile > default.
+fn resolve_tunables(args: &MountArgs) -> ProfileTunables {
+    let base = args
+        .storage_profile
+        .map_or(ProfileTunables::DEFAULTS, StorageProfile::tunables);
+    ProfileTunables {
+        max_readahead_kib: args.max_readahead_kib.unwrap_or(base.max_readahead_kib),
+        max_background: args.max_background.unwrap_or(base.max_background),
+        attr_ttl_ms: args.attr_ttl_ms.unwrap_or(base.attr_ttl_ms),
+        keep_cache: args.keep_cache.unwrap_or(base.keep_cache),
+    }
+}
+```
+
+- [ ] **Step 2: Change the four `MountArgs` fields to `Option` and add `storage_profile`**
+
+In `MountArgs`, replace the four media-flag fields (currently lines ~73-89: the
+`max_readahead_kib`, `max_background`, `attr_ttl_ms`, and `keep_cache` fields with
+their `default_value_t` / bare `#[arg(long)]` forms) with the versions below, and add
+the new `storage_profile` field. Leave `poll_interval_ms` and `case_insensitive`
+untouched.
+
+```rust
+    /// Preset tunables for the backing medium. Sets read-ahead, background queue,
+    /// attr TTL, and page-cache retention at once. An explicitly-passed flag below
+    /// overrides the profile for that knob. Unset = built-in defaults.
+    #[arg(long, value_enum)]
+    pub storage_profile: Option<StorageProfile>,
+    /// Entry/attr cache TTL (ms) the kernel may trust before re-validating. Higher
+    /// cuts lookup/getattr traffic but slows visibility of DB edits. Unset = profile
+    /// value, else 1000.
+    #[arg(long)]
+    pub attr_ttl_ms: Option<u64>,
+    /// Kernel read-ahead window (KiB). Larger hides HDD/NFS latency while streaming;
+    /// clamped to the kernel maximum at mount. Unset = profile value, else 512.
+    #[arg(long)]
+    pub max_readahead_kib: Option<u32>,
+    /// Max outstanding background (readahead/async) requests the kernel queues.
+    /// Unset = profile value, else 64.
+    #[arg(long)]
+    pub max_background: Option<u16>,
+    /// Keep the kernel page cache across opens. External re-tags auto-invalidate the
+    /// affected inodes on refresh, so cached bytes are dropped when content changes.
+    /// Takes a value (`--keep-cache true|false`); unset = profile value, else false.
+    #[arg(long, action = clap::ArgAction::Set)]
+    pub keep_cache: Option<bool>,
+```
+
+- [ ] **Step 3: Rewrite `parse_mount_config` to use the resolver**
+
+Replace the `fuse_config` construction inside `parse_mount_config`
+(`musefs-cli/src/lib.rs:199-204`) so it folds through `resolve_tunables`. The
+`config` (MountConfig) block above it is unchanged.
+
+```rust
+    let t = resolve_tunables(args);
+    let fuse_config = musefs_fuse::FuseConfig {
+        ttl: std::time::Duration::from_millis(t.attr_ttl_ms),
+        max_readahead: t.max_readahead_kib.saturating_mul(1024),
+        max_background: t.max_background,
+        keep_cache: t.keep_cache,
+    };
+```
+
+- [ ] **Step 4: Add the `tunables` table unit test (pins "ssd == defaults")**
+
+Append a `#[cfg(test)]` module at the end of `musefs-cli/src/lib.rs` (this lives in the
+crate, so it can see the private `ProfileTunables`/`tunables`):
+
+```rust
+#[cfg(test)]
+mod profile_tests {
+    use super::*;
+
+    #[test]
+    fn ssd_profile_equals_builtin_defaults() {
+        assert_eq!(StorageProfile::Ssd.tunables(), ProfileTunables::DEFAULTS);
+    }
+
+    #[test]
+    fn hdd_and_nfs_tunables_are_as_specified() {
+        let hdd = StorageProfile::Hdd.tunables();
+        assert_eq!(hdd.max_readahead_kib, 2048);
+        assert_eq!(hdd.max_background, 64);
+        assert_eq!(hdd.attr_ttl_ms, 2000);
+        assert!(hdd.keep_cache);
+
+        let nfs = StorageProfile::Nfs.tunables();
+        assert_eq!(nfs.max_readahead_kib, 2048);
+        assert_eq!(nfs.max_background, 128);
+        assert_eq!(nfs.attr_ttl_ms, 5000);
+        assert!(nfs.keep_cache);
+    }
+}
+```
+
+- [ ] **Step 5: Update the default-and-explicit parse assertions in `cli.rs`**
+
+In `musefs-cli/tests/cli.rs`, the `parses_mode_and_revalidate_flags` test asserts the
+old literal defaults and uses bare `--keep-cache`. Replace its "defaults" block
+(currently lines 54-65) so unset flags are `None`:
+
+```rust
+    // Mode defaults to synthesis; media tuning flags are unset (resolved later).
+    let cli = Cli::parse_from(["musefs", "mount", "/mnt/x", "--db", "/tmp/m.db"]);
+    match cli.command {
+        Command::Mount(args) => {
+            assert_eq!(args.mode, CliMode::Synthesis);
+            assert_eq!(args.poll_interval_ms, 1000); // default (unchanged)
+            assert_eq!(args.storage_profile, None);
+            assert_eq!(args.attr_ttl_ms, None);
+            assert_eq!(args.max_readahead_kib, None);
+            assert_eq!(args.max_background, None);
+            assert_eq!(args.keep_cache, None);
+        }
+        Command::Scan { .. } => panic!("expected mount"),
+    }
+```
+
+Replace its "explicit values" block (currently lines 67-93) — note `--keep-cache` now
+takes a value:
+
+```rust
+    // Tuning flags parse to their given values.
+    let cli = Cli::parse_from([
+        "musefs",
+        "mount",
+        "/mnt/x",
+        "--db",
+        "/tmp/m.db",
+        "--poll-interval-ms",
+        "500",
+        "--attr-ttl-ms",
+        "2000",
+        "--max-readahead-kib",
+        "1024",
+        "--max-background",
+        "128",
+        "--keep-cache",
+        "true",
+    ]);
+    match cli.command {
+        Command::Mount(args) => {
+            assert_eq!(args.poll_interval_ms, 500);
+            assert_eq!(args.attr_ttl_ms, Some(2000));
+            assert_eq!(args.max_readahead_kib, Some(1024));
+            assert_eq!(args.max_background, Some(128));
+            assert_eq!(args.keep_cache, Some(true));
+        }
+        Command::Scan { .. } => panic!("expected mount"),
+    }
+```
+
+- [ ] **Step 6: Update the four `MountArgs` struct-literal construction sites in `cli.rs`**
+
+Four tests build `MountArgs` directly and must set the new field shapes. Apply each
+replacement (the surrounding `let (config, fuse_config) = parse_mount_config(&args);`
+and assertions below them stay as-is unless noted).
+
+`parse_mount_config_defaults_are_sensible` (lines 121-134) — all media flags `None`,
+asserting the resolver produces the defaults:
+
+```rust
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$artist/$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        fallbacks: vec![],
+        mode: musefs_cli::CliMode::Synthesis,
+        poll_interval_ms: 1000,
+        storage_profile: None,
+        attr_ttl_ms: None,
+        max_readahead_kib: None,
+        max_background: None,
+        keep_cache: None,
+        case_insensitive: false,
+    };
+```
+
+`parse_mount_config_keep_cache_sets_flag` (lines 149-162):
+
+```rust
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        fallbacks: vec![],
+        mode: musefs_cli::CliMode::StructureOnly,
+        poll_interval_ms: 250,
+        storage_profile: None,
+        attr_ttl_ms: Some(5000),
+        max_readahead_kib: Some(256),
+        max_background: Some(32),
+        keep_cache: Some(true),
+        case_insensitive: false,
+    };
+```
+
+`parse_mount_config_saturating_readahead` (lines 173-186):
+
+```rust
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        fallbacks: vec![],
+        mode: musefs_cli::CliMode::Synthesis,
+        poll_interval_ms: 1000,
+        storage_profile: None,
+        attr_ttl_ms: None,
+        max_readahead_kib: Some(u32::MAX),
+        max_background: None,
+        keep_cache: None,
+        case_insensitive: false,
+    };
+```
+
+`parse_mount_config_populates_per_field_fallbacks` (lines 218-234):
+
+```rust
+    let args = MountArgs {
+        mountpoint: "/mnt/x".into(),
+        db: "/tmp/x.db".into(),
+        template: "$albumartist/$title".to_string(),
+        default_fallback: "Unknown".to_string(),
+        fallbacks: vec![
+            ("albumartist".to_string(), "Unknown Artist".to_string()),
+            ("genre".to_string(), "Misc".to_string()),
+        ],
+        mode: musefs_cli::CliMode::Synthesis,
+        poll_interval_ms: 1000,
+        storage_profile: None,
+        attr_ttl_ms: None,
+        max_readahead_kib: None,
+        max_background: None,
+        keep_cache: None,
+        case_insensitive: false,
+    };
+```
+
+- [ ] **Step 7: Add the profile / override / keep-cache tests to `cli.rs`**
+
+Append these four tests at the end of `musefs-cli/tests/cli.rs` (they reuse the
+existing `use musefs_cli::parse_mount_config;` and `use std::time::Duration;` imports
+at lines 115-117):
+
+```rust
+#[test]
+fn storage_profile_hdd_sets_tunables() {
+    let cli = Cli::parse_from([
+        "musefs", "mount", "/mnt/x", "--db", "/tmp/m.db",
+        "--storage-profile", "hdd",
+    ]);
+    let args = match cli.command {
+        Command::Mount(args) => args,
+        Command::Scan { .. } => panic!("expected mount"),
+    };
+    let (_, fuse_config) = parse_mount_config(&args);
+    assert_eq!(fuse_config.max_readahead, 2048 * 1024);
+    assert_eq!(fuse_config.max_background, 64);
+    assert_eq!(fuse_config.ttl, Duration::from_millis(2000));
+    assert!(fuse_config.keep_cache);
+}
+
+#[test]
+fn explicit_flag_overrides_profile() {
+    let cli = Cli::parse_from([
+        "musefs", "mount", "/mnt/x", "--db", "/tmp/m.db",
+        "--storage-profile", "nfs",
+        "--max-readahead-kib", "4096",
+        "--keep-cache", "false",
+    ]);
+    let args = match cli.command {
+        Command::Mount(args) => args,
+        Command::Scan { .. } => panic!("expected mount"),
+    };
+    let (_, fuse_config) = parse_mount_config(&args);
+    // Explicit flags win:
+    assert_eq!(fuse_config.max_readahead, 4096 * 1024);
+    assert!(!fuse_config.keep_cache);
+    // Untouched nfs-profile values remain:
+    assert_eq!(fuse_config.max_background, 128);
+    assert_eq!(fuse_config.ttl, Duration::from_millis(5000));
+}
+
+#[test]
+fn no_profile_keeps_defaults() {
+    let cli = Cli::parse_from(["musefs", "mount", "/mnt/x", "--db", "/tmp/m.db"]);
+    let args = match cli.command {
+        Command::Mount(args) => args,
+        Command::Scan { .. } => panic!("expected mount"),
+    };
+    let (_, fuse_config) = parse_mount_config(&args);
+    assert_eq!(fuse_config.max_readahead, 512 * 1024);
+    assert_eq!(fuse_config.max_background, 64);
+    assert_eq!(fuse_config.ttl, Duration::from_secs(1));
+    assert!(!fuse_config.keep_cache);
+}
+
+#[test]
+fn keep_cache_flag_requires_value() {
+    // Bare `--keep-cache` no longer parses (UX change from presence to value flag).
+    let err = Cli::try_parse_from([
+        "musefs", "mount", "/mnt/x", "--db", "/tmp/m.db", "--keep-cache",
+    ])
+    .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("value"),
+        "expected a missing-value error, got: {err}"
+    );
+
+    for (arg, want) in [("true", true), ("false", false)] {
+        let cli = Cli::parse_from([
+            "musefs", "mount", "/mnt/x", "--db", "/tmp/m.db", "--keep-cache", arg,
+        ]);
+        match cli.command {
+            Command::Mount(args) => assert_eq!(args.keep_cache, Some(want)),
+            Command::Scan { .. } => panic!("expected mount"),
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Build, lint, and run the full cli test suite**
+
+Run: `cargo test -p musefs-cli && cargo clippy -p musefs-cli --all-targets -- -D warnings`
+Expected: all tests pass; clippy clean (no `dead_code` on the new enum/resolver because
+`parse_mount_config` and the tests use them).
+
+- [ ] **Step 9: Run the full workspace test suite (pre-commit parity)**
+
+Run: `cargo test`
+Expected: PASS (the pre-commit hook runs this; a red commit is rejected).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add musefs-cli/src/lib.rs musefs-cli/tests/cli.rs
+git commit -m "feat(cli): add --storage-profile {ssd,hdd,nfs} preset
+
+Preset the four backing-media tunables per medium. The flags become
+Option (unset = take from profile, else built-in default); an explicit
+flag overrides the profile. --keep-cache becomes a value flag
+(--keep-cache true|false) so a profile's keep_cache can be overridden
+off, matching the existing --case-insensitive style. Profile values are
+the spec hypothesis; Task 4 confirms them via bench."
+```
+
+---
+
+## Task 3: Kernel-mount latency bench harness
+
+A committed, runnable shell harness (per the in-tree-harness convention). It must pass
+`shellcheck` (the pre-commit hook lints tracked shell files). It mounts a
+`--features metrics` binary, injects per-syscall latency, and compares the candidate
+profile against current defaults under each latency profile. Measurement is
+**wall-clock from outside the daemon** — the `metrics::snapshot` counters live inside
+the mounted process and a shell can't read them.
+
+**Files:**
+- Create: `benches/storage_profile_bench.sh`
+
+- [ ] **Step 1: Write the harness script**
+
+Create `benches/storage_profile_bench.sh` with exactly this content:
+
+```bash
+#!/usr/bin/env bash
+# Storage-profile validation bench.
+# Mounts musefs (built --features metrics) over a corpus with per-syscall storage
+# latency injected via MUSEFS_FAULT_*_US, and compares each candidate --storage-profile
+# against the current built-in defaults under each latency profile. Wall-clock only:
+# the metrics::snapshot counters live inside the daemon and are not readable here.
+#
+# Usage: sudo benches/storage_profile_bench.sh <work-dir> [size-mib] [streams]
+set -euo pipefail
+WORK="${1:?usage: sudo $0 <work-dir> [size-mib] [streams]}"
+SIZE_MIB="${2:-512}"
+# Concurrent streams for the max_background driver. A 64-vs-128 background-queue
+# difference only separates with many in-flight requests, so default high; even so it
+# may register as a tie (see the bench task — nfs max_background is then kept-as-reasoned).
+STREAMS="${3:-32}"
+ROOT="$(git rev-parse --show-toplevel)"
+BIN="$ROOT/target/release/musefs"
+
+if [ ! -x "$BIN" ]; then
+  echo "ERROR: $BIN not found. Build it first:" >&2
+  echo "  cargo build --release -p musefs --features metrics" >&2
+  exit 1
+fi
+
+mkdir -p "$WORK/backing" "$WORK/mnt"
+
+# The injected MUSEFS_FAULT_*_US latency must be the ONLY latency in the read path, so
+# the backing corpus must live on a RAM-backed filesystem (tmpfs/ramfs). On real disk,
+# the disk's own seek latency stacks on top of the injection, and the ssd row (which
+# injects ZERO latency) would measure the disk instead of RAM — destroying the
+# "ssd must not regress" baseline. Refuse to run on anything else.
+fstype="$(stat -f -c %T "$WORK")"
+case "$fstype" in
+  tmpfs|ramfs) ;;
+  *)
+    echo "ERROR: work-dir '$WORK' is on '$fstype', not tmpfs/ramfs." >&2
+    echo "       Use a RAM-backed dir (e.g. /dev/shm/musefs-spbench or /tmp/musefs-spbench)" >&2
+    echo "       so only the injected latency is measured. On this box /home and /data are HDD." >&2
+    exit 1
+    ;;
+esac
+
+# One large WAV (sequential-throughput driver) + a few smaller tracks
+# (concurrent-stream and metadata-walk drivers). Reuses passthrough_dd.sh's header.
+make_wav() {
+  local path="$1" mib="$2" data riff
+  [ -f "$path" ] && return 0
+  data=$(( mib * 1024 * 1024 )); riff=$(( data + 36 ))
+  # shellcheck disable=SC2059  # generated hex-escape format string, by design
+  {
+    printf 'RIFF'
+    printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((riff&255)) $((riff>>8&255)) $((riff>>16&255)) $((riff>>24&255)))"
+    printf 'WAVEfmt '
+    printf '\x10\x00\x00\x00\x01\x00\x02\x00\x44\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00'
+    printf 'data'
+    printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((data&255)) $((data>>8&255)) $((data>>16&255)) $((data>>24&255)))"
+    dd if=/dev/zero bs=1M count="$mib" 2>/dev/null
+  } >> "$path"
+}
+
+make_wav "$WORK/backing/big.wav" "$SIZE_MIB"
+for i in $(seq 1 "$STREAMS"); do make_wav "$WORK/backing/t$i.wav" 64; done
+
+DB="$WORK/m.db"; rm -f "$DB"
+"$BIN" scan "$WORK/backing" --db "$DB" >/dev/null
+
+# Latency rows (microseconds) mirroring musefs-latencyfs Latency::profile:
+#   name      pread  open  stat   matching-candidate-profile
+ROWS=(
+  "ssd      0     0     0     ssd"
+  "hdd      8000  8000  8000  hdd"
+  "nfs-ssd  600   600   400   nfs"
+  "nfs-hdd  8600  8600  8400  nfs"
+)
+
+mount_musefs() {
+  # $1=pread_us $2=open_us $3=stat_us ; remaining args = extra musefs flags
+  local pread="$1" open="$2" stat="$3"; shift 3
+  # shellcheck disable=SC2016  # '$title' is a musefs output-template literal, not a shell var
+  MUSEFS_FAULT_PREAD_US="$pread" MUSEFS_FAULT_OPEN_US="$open" MUSEFS_FAULT_STAT_US="$stat" \
+    "$BIN" mount "$WORK/mnt" --db "$DB" --mode structure-only --template '$title' "$@" &
+  MPID=$!
+  local virt=""
+  for _ in $(seq 1 60); do
+    virt=$(find "$WORK/mnt" -type f 2>/dev/null | head -1 || true)
+    [ -n "$virt" ] && break
+    sleep 0.5
+  done
+  if [ -z "$virt" ]; then echo "ERROR: mount never exposed a file" >&2; kill "$MPID" 2>/dev/null || true; exit 1; fi
+}
+
+unmount_musefs() {
+  fusermount3 -u "$WORK/mnt" 2>/dev/null || umount "$WORK/mnt" 2>/dev/null || true
+  kill "$MPID" 2>/dev/null || true
+  wait "$MPID" 2>/dev/null || true
+}
+
+# Virtual filenames are tag-based (untagged WAVs collide and get disambiguated by
+# musefs), so identify tracks by SIZE, not name. The big track is the largest file.
+biggest_virt() { find "$WORK/mnt" -type f -printf '%s\t%p\n' | sort -rn | head -1 | cut -f2-; }
+small_virts()  { find "$WORK/mnt" -type f -printf '%s\t%p\n' | sort -rn | tail -n +2 | cut -f2-; }
+
+# Median of 3 `dd` runs (MB/s) reading the big track sequentially.
+seq_mbps() {
+  local virt; virt="$(biggest_virt)"
+  local out
+  out=$(for _ in 1 2 3; do dd if="$virt" of=/dev/null bs=1M 2>&1 | tail -1 | grep -oE '[0-9.]+ MB/s' | grep -oE '[0-9.]+'; done | sort -n | sed -n 2p)
+  echo "${out:-0}"
+}
+
+# Wall-clock seconds for parallel reads over the distinct smaller tracks.
+concurrent_secs() {
+  local files; mapfile -t files < <(small_virts)
+  local t0 t1
+  t0=$(date +%s.%N)
+  for f in "${files[@]}"; do cat "$f" > /dev/null & done
+  wait
+  t1=$(date +%s.%N)
+  awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.2f", b-a}'
+}
+
+# Self-check: with a large PREAD fault, a sequential read must be visibly slow.
+# If not, the binary was built WITHOUT --features metrics and every number is bogus.
+echo "== fault-injection self-check =="
+mount_musefs 50000 0 0
+SLOW=$(seq_mbps)
+unmount_musefs
+mount_musefs 0 0 0
+FAST=$(seq_mbps)
+unmount_musefs
+echo "  50ms-pread: ${SLOW} MB/s   0-pread: ${FAST} MB/s"
+awk -v s="$SLOW" -v f="$FAST" 'BEGIN{ if (s+0 >= f+0) { print "ERROR: fault not active — rebuild with: cargo build --release -p musefs --features metrics" > "/dev/stderr"; exit 1 } }'
+
+printf '\n%-9s %-9s %12s %12s %14s %14s\n' profile latency def_MBps prof_MBps def_conc_s prof_conc_s
+for row in "${ROWS[@]}"; do
+  read -r name pread open stat cand <<<"$row"
+  # candidate profile tunables come from --storage-profile; defaults from no profile
+  mount_musefs "$pread" "$open" "$stat"
+  d_mbps=$(seq_mbps); d_conc=$(concurrent_secs)
+  unmount_musefs
+  mount_musefs "$pread" "$open" "$stat" --storage-profile "$cand"
+  p_mbps=$(seq_mbps); p_conc=$(concurrent_secs)
+  unmount_musefs
+  printf '%-9s %-9s %12s %12s %14s %14s\n' "$cand" "$name" "$d_mbps" "$p_mbps" "$d_conc" "$p_conc"
+done
+echo
+echo "Higher MB/s and lower concurrent-seconds are better. Record the table in BENCHMARKS.md."
+```
+
+- [ ] **Step 2: Make it executable and shellcheck-clean**
+
+Run: `chmod +x benches/storage_profile_bench.sh && shellcheck benches/storage_profile_bench.sh`
+Expected: **exit 0, no output.** Two `# shellcheck disable=` lines are intentional and
+match `passthrough_dd.sh`: `SC2059` (the generated hex-escape `printf` in the WAV
+header) and `SC2016` (the single-quoted `--template '$title'` literal). Note the
+pre-commit hook treats *any* non-zero shellcheck exit — including info-level findings
+like SC2016 — as a failure, so both disables must be present. Fix any other finding
+before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benches/storage_profile_bench.sh
+git commit -m "test(bench): add storage-profile latency validation harness
+
+Mounts a --features metrics binary, injects per-syscall latency via
+MUSEFS_FAULT_*_US, and compares each --storage-profile against defaults
+under ssd/hdd/nfs-ssd/nfs-hdd latency. Includes a self-check that aborts
+if the binary lacks the metrics feature (else it measures zero latency)."
+```
+
+---
+
+## Task 4: Run the bench, record results, reconcile the profile values
+
+This task has a **manual sudo run** (needs `/dev/fuse` + CAP_SYS_ADMIN; see the
+`fuse-passthrough-cap-sys-admin` memory) and may edit the Task 2 constants if the data
+moves them.
+
+**Files:**
+- Modify (maybe): `musefs-cli/src/lib.rs` (`StorageProfile::tunables` values + the unit test, if the bench moves them)
+- Modify: `BENCHMARKS.md` (repo root)
+
+- [ ] **Step 1: Build the metrics binary**
+
+Run: `cargo build --release -p musefs --features metrics`
+Expected: produces `target/release/musefs` with fault injection active.
+
+- [ ] **Step 2: Run the bench (work-dir MUST be on tmpfs)**
+
+The work-dir has to be RAM-backed so the injected latency is the only latency measured;
+the script refuses to run elsewhere. On this box `/tmp` and `/dev/shm` are tmpfs while
+`/home` (the worktree, RAID-1 HDD) and `/data` (HDD) are not — so do **not** point the
+work-dir at the worktree. The corpus is ~2.5 GiB (512 MiB big track + 32×64 MiB
+streams), which fits `/tmp` comfortably.
+
+Run: `sudo benches/storage_profile_bench.sh /dev/shm/musefs-spbench 512 32`
+Expected: the self-check passes (50ms-pread row is much slower than 0-pread), then a
+table with `def_MBps`/`prof_MBps`/`def_conc_s`/`prof_conc_s` per latency profile. (The
+build artifacts under the worktree's `target/` stay on HDD — that only affects build
+time, not the measurement, since the binary is loaded into RAM once.)
+
+- [ ] **Step 3: Evaluate against the pass criterion**
+
+For each latency profile, check the candidate profile vs defaults on its decisive
+metric (from the spec):
+- **hdd / nfs-ssd / nfs-hdd:** `prof_MBps` should beat `def_MBps` — this is the
+  read-ahead win and the primary, reliably-observable signal of this harness.
+- **ssd:** must not regress on either metric.
+- If a knob shows only a tie (candidate within the defaults' own run-to-run spread),
+  keep the default value for that knob and note it as *reasoned, not bench-proven*.
+  **Expect this for two knobs:** `attr_ttl_ms` (weak attr-cache signal under one mount)
+  and the nfs `max_background` 64→128 bump (a 64-deep queue only separates with far
+  more than 32 in-flight requests, which this single-host harness won't reliably
+  generate). If `prof_conc_s` does not clearly beat `def_conc_s`, keep `max_background`
+  at 128 on the strength of the latency-model reasoning and record it as reasoned —
+  do not lower it to 64 just because the harness can't separate it.
+
+- [ ] **Step 4: Reconcile the code if the data moved any value**
+
+If the bench shows a different value wins (e.g. hdd readahead 4096 beats 2048), update
+**all three** places that hardcode the value, keeping them in sync:
+1. the corresponding arm of `StorageProfile::tunables` in `musefs-cli/src/lib.rs`;
+2. the `hdd_and_nfs_tunables_are_as_specified` unit test in `musefs-cli/src/lib.rs`;
+3. the matching assertions in the `cli.rs` integration tests —
+   `storage_profile_hdd_sets_tunables` (hdd `max_readahead`/`max_background`/`ttl`/
+   `keep_cache`) and `explicit_flag_overrides_profile` (the nfs `max_background == 128`
+   and `ttl == 5000ms` it leaves untouched).
+
+Then run: `cargo test -p musefs-cli`
+Expected: PASS with the updated values.
+
+If no value changed, skip the code edit.
+
+- [ ] **Step 5: Record the results in `BENCHMARKS.md`**
+
+Append a `## Storage profiles (2026-06-10)` section to the repo-root `BENCHMARKS.md`
+containing: the machine/run context, the raw table from Step 2, and a one-line verdict
+per profile (which knobs were bench-confirmed vs kept-as-reasoned). Match the existing
+section formatting in that file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+# If Step 4 changed code, include the src + test files; always include BENCHMARKS.md.
+git add BENCHMARKS.md musefs-cli/src/lib.rs musefs-cli/tests/cli.rs 2>/dev/null || git add BENCHMARKS.md
+git commit -m "test(bench): record storage-profile validation results
+
+Run the latency bench across ssd/hdd/nfs-ssd/nfs-hdd and record the
+before/after table in BENCHMARKS.md. Profile values reconciled to the
+confirmed numbers (knobs that only tied keep the default, noted as
+reasoned)."
+```
+
+---
+
+## Task 5: Documentation (README)
+
+Docs-only commit (the cargo gate is skipped for `*.md` / `docs/` paths). Use the
+**confirmed** values from Task 4 — if Task 4 changed any number, use that number here.
+
+**Files:**
+- Modify: `README.md` (Tuning section, lines 110-121)
+- Modify (only if the sweep finds bare-invocation examples): other `docs/` / `*.md`
+
+- [ ] **Step 0: Sweep for bare `--keep-cache` invocation examples**
+
+The spec requires updating any docs/examples that *invoke* bare `--keep-cache` (now a
+value flag).
+
+Run: `grep -rn -- "--keep-cache" README.md docs/ ARCHITECTURE.md CHANGELOG.md`
+Expected: prose mentions are fine; any line showing a bare `--keep-cache` in a command
+(no following `true`/`false`) must be changed to `--keep-cache true`. As of this plan
+only `README.md:120` is an invocation context; if the sweep surfaces others, fix them
+in this commit.
+
+- [ ] **Step 1: Add the `--storage-profile` row and update `--keep-cache` in the Tuning table**
+
+In `README.md`, replace the `--keep-cache` table row (line 119) and insert a
+`--storage-profile` row directly above the `--attr-ttl-ms` row (line 116). The
+`--keep-cache` row becomes the value form:
+
+```markdown
+| `--storage-profile <ssd\|hdd\|nfs>` | unset | Preset all four tunables below for your backing medium. An explicitly-passed flag overrides the profile for that knob. See "Pick by backing store". |
+```
+
+```markdown
+| `--keep-cache <true\|false>` | `false` | Keep the kernel page cache across opens. External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
+```
+
+- [ ] **Step 2: Add the "Pick by backing store" subsection**
+
+Insert immediately after the Tuning table (after line 121), using the **confirmed**
+values from Task 4 (the table below shows the hypothesis values — replace any the bench
+changed):
+
+```markdown
+#### Pick by backing store
+
+`--storage-profile` sets all four tunables at once. Override any individual knob by
+passing its flag explicitly (e.g. `--storage-profile nfs --max-readahead-kib 4096`).
+
+| Profile | `max-readahead-kib` | `max-background` | `attr-ttl-ms` | `keep-cache` |
+| ------- | ------------------- | ---------------- | ------------- | ------------ |
+| `ssd` (= defaults) | 512 | 64 | 1000 | false |
+| `hdd` | 2048 | 64 | 2000 | true |
+| `nfs` | 2048 | 128 | 5000 | true |
+
+- **ssd** — local SSD/NVMe is seek-free; the defaults are already tuned for it.
+- **hdd** — larger read-ahead amortizes the ~8 ms seek over each sequential read; the
+  page cache is kept so repeat opens don't re-seek.
+- **nfs** — larger read-ahead and a deeper background queue hide the per-RPC network
+  latency; a longer attr TTL cuts `lookup`/`getattr` round-trips (the trade-off:
+  external DB edits take longer to become visible).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document --storage-profile presets and the --keep-cache value form"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** preset flag (Task 2), docs table (Task 5), `Option`/`resolve_tunables`
+  precedence incl. `--keep-cache` value form (Task 2), metrics feature passthrough +
+  bench harness + wall-clock measurement + StructureOnly + concurrent driver +
+  attr_ttl weak-signal handling (Tasks 1, 3, 4), confirmed-values reconciliation
+  (Task 4) — all mapped.
+- **Green-commit ordering:** Task 1 (manifest), Task 2 (atomic type change + all
+  consumers + tests), Task 3 (shellcheck-clean script), Task 4 (bench + optional value
+  edit), Task 5 (docs-only). Each is independently green for the pre-commit hook.
+- **Type consistency:** `ProfileTunables` fields (`max_readahead_kib: u32`,
+  `max_background: u16`, `attr_ttl_ms: u64`, `keep_cache: bool`) match the `MountArgs`
+  `Option<…>` fields and `FuseConfig` (`max_readahead: u32`, `max_background: u16`,
+  `ttl: Duration`, `keep_cache: bool`); `max_readahead_kib.saturating_mul(1024)` feeds
+  `max_readahead` exactly as the original code did.
+- **Known UX break:** bare `--keep-cache` stops parsing (now `--keep-cache true|false`).
+  Pinned by `keep_cache_flag_requires_value` and documented in README + the Task 2
+  commit message.

--- a/docs/superpowers/specs/2026-06-10-storage-profiles-design.md
+++ b/docs/superpowers/specs/2026-06-10-storage-profiles-design.md
@@ -1,0 +1,301 @@
+# Storage-aware mount profiles (`--storage-profile`) — design
+
+*Date: 2026-06-10*
+
+> **Outcome: NOT shipped.** Bench validation on real HDD and (loopback + `netem`) NFS
+> disproved this spec's core premise — larger `max_readahead`/`max_background` give no
+> benefit (and large read-ahead *hurts* on HDD); only `--keep-cache` helps. The preset
+> was dropped; the four flags keep their defaults. See
+> [BENCHMARKS.md §Storage tunables](../../../BENCHMARKS.md#storage-tunables). This
+> document is retained for historical context only.
+
+## Goal
+
+musefs exposes four backing-media-sensitive mount tunables — `--max-readahead-kib`,
+`--max-background`, `--attr-ttl-ms`, `--keep-cache` — but ships a single set of
+hardcoded defaults and no guidance on what to set them to for a given backing store.
+A user on a spinning disk or an NFS export is left to guess.
+
+Add a `--storage-profile {ssd,hdd,nfs}` preset that sets all four tunables to
+recommended values for that medium, and document in the README what each profile
+sets and why. The values are derived from the in-tree latency model and **confirmed
+empirically** with a kernel-mount latency bench before they ship.
+
+## Non-goals
+
+- No new tunables. This wires up presets over the four flags that already exist.
+- No auto-detection of the backing medium. The user names their storage.
+- NFS is a single conservative profile. We do **not** split `nfs-ssd` / `nfs-hdd`
+  at the CLI: the per-RPC network tax dominates and the operator usually cannot
+  tell (or control) the server's backing disk, so the profile targets the safe
+  case. The bench still measures against both `nfs-ssd` and `nfs-hdd` latency
+  settings to confirm the single profile is sane across that range.
+
+## The four tunables (current state)
+
+From `MountArgs` (`musefs-cli/src/lib.rs`), flowing into `FuseConfig`
+(`musefs-fuse/src/lib.rs`) and applied at FUSE init via `set_max_readahead` /
+`set_max_background` and the per-op cache TTLs:
+
+| flag | current default | effect |
+|---|---|---|
+| `--max-readahead-kib` | 512 | kernel read-ahead window; bigger reads amortize seeks/RPCs over more bytes (clamped to the kernel max at mount) |
+| `--max-background` | 64 | max outstanding background (read-ahead/async) requests the kernel keeps in flight |
+| `--attr-ttl-ms` | 1000 | entry/attr cache TTL the kernel trusts before re-validating; bounds how fast external DB edits become visible |
+| `--keep-cache` | off | keep the kernel page cache across opens (external re-tags auto-invalidate affected inodes) |
+
+All four are **kernel↔FUSE negotiation / kernel-cache parameters**. They have no
+effect on the in-process `read_at` path — see Validation.
+
+## Latency model (the empirical basis)
+
+`musefs-latencyfs` (`musefs-latencyfs/src/lib.rs::Latency::profile`) already encodes
+the team's per-medium per-syscall latency model. The read-relevant rows (musefs is
+read-only; `write`/`fsync` do not affect serving):
+
+| op | ssd | hdd | nfs-ssd | nfs-hdd |
+|---|---|---|---|---|
+| read | ~0 | 8 ms | 600 µs | 8.6 ms |
+| open | ~0 | 8 ms | 600 µs | 8.6 ms |
+| stat | ~0 | 8 ms | 400 µs | 8.4 ms |
+
+The gradient: SSD is seek-free; HDD pays an ~8 ms seek per cold read; NFS adds a
+per-RPC network tax (sub-millisecond on an SSD backend, stacked on the HDD seek for
+nfs-hdd). This maps directly onto the tunables — amortize seeks/RPCs with larger
+read-ahead, hide latency with more in-flight requests, and cut metadata RPCs with a
+longer attr TTL.
+
+## Proposed values (bench hypothesis)
+
+These are the starting point. The Validation run confirms or adjusts each number
+before it is committed as the profile default; the final committed table is whatever
+the bench supports.
+
+| knob | ssd | hdd | nfs | rationale |
+|---|---|---|---|---|
+| `max_readahead_kib` | 512 | 2048 | 2048 | bigger reads amortize the 8 ms HDD seek / NFS RPC over more bytes |
+| `max_background` | 64 | 64 | 128 | NFS hides network latency with more in-flight RPCs; HDD is seek-bound, gains nothing from more |
+| `attr_ttl_ms` | 1000 | 2000 | 5000 | metadata ops are RPCs on NFS — a longer TTL is the biggest NFS win; tradeoff is slower visibility of external DB edits |
+| `keep_cache` | off | on | on | avoid re-seeking a slow disk / re-fetching over the network on repeat opens |
+
+`ssd` is the baseline and is intentionally ≈ today's hardcoded defaults.
+
+## Flag semantics and precedence
+
+Additive and backwards-compatible:
+
+1. **No `--storage-profile`** → today's hardcoded defaults, unchanged. Existing
+   command lines and their behavior are untouched.
+2. **`--storage-profile X`** → the four tunables take profile X's values.
+3. **An explicitly-passed knob overrides the profile** for that one knob, e.g.
+   `--storage-profile nfs --max-readahead-kib 4096` keeps every nfs value except
+   read-ahead.
+
+### The clap subtlety (the one real code change beyond a lookup table)
+
+`clap`'s `default_value_t` makes "user passed `--max-readahead-kib 512`"
+indistinguishable from "defaulted to 512", so precedence rule 3 cannot be
+implemented while those four fields carry literal defaults.
+
+**Resolution:** change the four media-sensitive fields on `MountArgs` to `Option<…>`
+(no `default_value_t`), meaning "unset on the command line". After parsing, a
+`resolve_tunables(profile, args)` step folds them down:
+
+```
+effective = match (explicit_flag, profile) {
+    (Some(v), _)        => v,                  // explicit always wins
+    (None, Some(prof))  => prof.value(),       // else profile
+    (None, None)        => HARDCODED_DEFAULT,  // else today's default
+}
+```
+
+The hardcoded defaults move from `#[arg(default_value_t = …)]` into named constants
+(`DEFAULT_MAX_READAHEAD_KIB`, etc.) reused by both `resolve_tunables` and the `ssd`
+profile so the "ssd ≈ defaults" property is enforced in one place. `--help` text for
+each flag gains a line noting it falls back to the profile / built-in default when
+unset (so the disappearance of the literal default value stays self-documenting).
+
+**`--keep-cache` is the exception** and needs care. It is currently a `store_true`
+*presence* flag (`#[arg(long)] pub keep_cache: bool`) — presence means on, absence
+means off, with no way to express "explicitly off". That two-state encoding cannot
+support precedence rule 3: under `--storage-profile hdd` (which sets keep_cache on) a
+user must be able to force it back *off*, which a presence flag cannot say. So
+`keep_cache` becomes `Option<bool>` with `#[arg(long, action = clap::ArgAction::Set)]`
+(no default) — the same value-taking form `case_insensitive` already uses
+(`lib.rs`). This is a **UX change**: `--keep-cache` (bare) stops working; it becomes
+`--keep-cache true|false`. Absent → `None` → profile/default. The README and the
+flag's doc comment must call this out, and any docs/examples using bare
+`--keep-cache` are updated.
+
+*(Alternative considered and rejected: keep the existing flag types and detect
+explicit settings via `ArgMatches::value_source`. It threads `ArgMatches` into
+`parse_mount_config`, which the `cli.rs` tests bypass by constructing `MountArgs`
+directly — so it is less testable — and, decisively, `value_source` still cannot
+express "override keep_cache back to off" for a `store_true` flag. The `Option<…>`
+approach keeps resolution a pure function of the parsed struct and handles all four
+knobs uniformly.)*
+
+`StorageProfile` is a `clap::ValueEnum` (`Ssd`/`Hdd`/`Nfs`) with a
+`fn tunables(self) -> ProfileTunables` lookup returning the four values. `MountArgs`
+construction in tests that build the struct directly (e.g. `cli.rs`) sets the new
+`Option` fields to `None` unless exercising a specific value.
+
+## Code changes
+
+- **`musefs-cli/src/lib.rs`**
+  - Add `pub enum StorageProfile { Ssd, Hdd, Nfs }` (`clap::ValueEnum`) and
+    `struct ProfileTunables { max_readahead_kib, max_background, attr_ttl_ms,
+    keep_cache }` with `StorageProfile::tunables(self)`.
+  - Add named default constants; the `ssd` profile is built from them.
+  - Add `#[arg(long, value_enum)] pub storage_profile: Option<StorageProfile>` to
+    `MountArgs`.
+  - Change `max_readahead_kib: u32`, `max_background: u16`, `attr_ttl_ms: u64` to
+    `Option<…>` (drop their `default_value_t`); change `keep_cache: bool` to
+    `Option<bool>` with `action = clap::ArgAction::Set` (drop the `store_true`
+    presence form — see the keep-cache exception above).
+  - Add `resolve_tunables` and call it where `MountConfig` / `FuseConfig` are built
+    (the existing `max_readahead: args.max_readahead_kib.saturating_mul(1024)` site
+    consumes the resolved value).
+
+- **`musefs/Cargo.toml`** (binary crate) — add a `metrics` feature that forwards to
+  `musefs-fuse/metrics` (which already forwards to `musefs-core/metrics`). This is
+  **required by the validation harness**: the per-syscall fault hooks in
+  `musefs-core/src/metrics.rs` compile to no-op stubs unless the `metrics` feature is
+  on (`metrics.rs:242-246`), and the shipped binary does not enable it — so the
+  harness must build the served binary with `cargo build -p musefs --features metrics`
+  for `MUSEFS_FAULT_*_US` to take effect. The default release binary is unchanged
+  (feature off, zero overhead).
+
+No changes to `musefs-fuse`/`musefs-core` source or the DB layer — the resolved
+values feed the existing `FuseConfig` fields unchanged, and the `metrics` feature
+plumbing already exists in those crates' manifests.
+
+## Validation methodology
+
+**Why the existing benches can't measure this.** `read_throughput` (the Criterion
+bench) and `bench_read_under_latency` both call `Musefs::read` / `read_at`
+**in-process**, bypassing the kernel. The four tunables are kernel↔FUSE parameters
+(read-ahead batching, background-queue depth, attr-cache TTL, page-cache retention),
+so they are invisible to an in-process driver. Validation needs a **real kernel mount
+with a real reader**, modeled on `benches/passthrough_dd.sh`.
+
+**Latency injection — single FUSE layer, faults live in the mounted daemon.** Rather
+than stack `musefs-latencyfs` under musefs (two real FUSE mounts, two CAP_SYS_ADMIN
+setups), inject per-syscall storage latency into musefs's own serve path via the
+existing env hooks in `musefs-core/src/metrics.rs`: `MUSEFS_FAULT_PREAD_US`,
+`MUSEFS_FAULT_OPEN_US`, `MUSEFS_FAULT_STAT_US`, set to each medium's row from the
+latency table.
+
+**Critical prerequisite — the binary must be built `--features metrics`.** Those fault
+hooks are no-op stubs (`metrics.rs:242-246`) unless the `metrics` feature is enabled,
+and the shipped binary does **not** enable it. So the harness builds and mounts
+`cargo build -p musefs --features metrics` (the new feature passthrough above); a
+default-built binary would silently inject zero latency and the whole run would be
+meaningless. The harness asserts the feature is on by sanity-checking that a known
+fault actually slows a read before trusting any numbers.
+
+With faults live, larger read-ahead batches the kernel's reads into fewer, larger
+`pread`s to the daemon — each delayed once by the injected `PREAD` fault — so the
+throughput delta isolates the read-ahead effect with one mount.
+
+**Measurement is wall-clock, from outside the daemon.** The `metrics::snapshot`
+counters (`preads`/`opens`) live *inside the mounted daemon process*; the harness is a
+separate shell process driving the mount and cannot read them (the in-process
+`RunReport`/`snapshot` mechanism in `bench_ingest.rs` only works because that bench
+runs the FS in-process). The harness therefore measures **wall-clock only**: `dd`'s
+own throughput line and `time` on the metadata walk. (Optional, deferred: have the
+daemon log its `snapshot` on SIGTERM so counters can corroborate wall-clock; not
+required for the pass criterion.)
+
+**Serving mode.** Mount **StructureOnly** for the throughput driver (raw backing-byte
+passthrough, like `passthrough_dd.sh`): format-independent, and it isolates the
+backing-read path that read-ahead governs. Synthesis mode only prepends a small
+synthesized header before the same `BackingAudio` reads, so it would not change the
+read-ahead conclusion while adding a format/encoder dependency.
+
+**Harness** — a new committed script `benches/storage_profile_bench.sh` (runnable,
+in-tree, per project convention; large corpora stay gitignored):
+
+1. Build the binary `--features metrics`; build the corpus + a large backing track
+   (reuse the WAV generator from `passthrough_dd.sh`); scan into a DB.
+2. For each latency setting in {ssd, hdd, nfs-ssd, nfs-hdd} (the four `Latency`
+   rows), and for each config in {current-defaults, candidate-profile}:
+   - mount musefs (StructureOnly) with `MUSEFS_FAULT_{PREAD,OPEN,STAT}_US` set from
+     the row and the config's resolved tunables;
+   - **sequential throughput** (exercises `max_readahead` / `keep_cache`):
+     `dd if=<virt> of=/dev/null bs=1M`, cold then warm, 3 reps; record the dd
+     throughput line. `keep_cache` shows up as the warm-rep delta (page cache retained
+     across the re-open vs re-fetched under the `PREAD` fault).
+   - **concurrent throughput** (exercises `max_background`): N parallel
+     `dd`/`cat` streams over **distinct** tracks (a single sequential stream will not
+     fill the background queue, so `max_background` is invisible to the
+     single-stream driver); record aggregate wall time. This needs a multi-track
+     corpus, not the single large track.
+   - **metadata walk** (exercises `attr_ttl_ms`): `time` a `find <mnt> -type f`
+     + `stat` pass, repeated twice with `MUSEFS_FAULT_STAT_US`/`_OPEN_US` set high;
+     the second pass should hit the attr cache when TTL is high. **Caveat:** under a
+     single mount the attr-cache signal is weak and noisy; if it does not separate
+     cleanly, `attr_ttl_ms` is documented as *reasoned, not bench-proven*, and the
+     run says so rather than reporting a spurious win.
+3. **Pass criterion.** "Tie within noise" = the candidate's median is within the
+   run-to-run spread of the defaults (report min/median/max of the 3 reps; treat a
+   difference smaller than the defaults' own max−min as a tie). For each medium the
+   candidate profile must **beat** the defaults on that medium's decisive metric
+   (sequential throughput for hdd/nfs read-ahead; concurrent throughput for nfs
+   `max_background`) or, where the signal is a tie, fall back toward the default and
+   record the value as reasoned. ssd must not regress on any metric.
+4. Record the before/after table in `BENCHMARKS.md` (per the
+   [SP validation convention](../../../BENCHMARKS.md)); the values that land in the
+   README/code table are exactly the confirmed ones.
+
+The script needs `/dev/fuse` and a metrics-built binary; it is a sudo/local run, not
+CI — same tier as the existing `--ignored` latency benches.
+
+## Testing
+
+- **`musefs-cli/tests/cli.rs`** (mirrors the existing `parse_mount_config_*` tests).
+  Every `MountArgs` struct-literal construction site in this file (the existing
+  `parse_mount_config_*` / `saturating_readahead` tests build the struct directly,
+  ~4 sites) must be updated for the new field shapes: `storage_profile: None`, the
+  three numeric knobs as `None`, and `keep_cache: None`. New/updated cases:
+  - `storage_profile_hdd_sets_tunables` — `--storage-profile hdd` yields the hdd
+    `FuseConfig` values.
+  - `explicit_flag_overrides_profile` — `--storage-profile nfs --max-readahead-kib
+    4096 --keep-cache false` keeps nfs `max_background`/`attr_ttl` but uses the
+    explicit read-ahead and the explicit `keep_cache=false` (proves the
+    override-back-to-off path the value-form flag exists for).
+  - `no_profile_keeps_defaults` — bare `mount` still yields today's defaults
+    (regression guard for backwards compatibility).
+  - `keep_cache_flag_requires_value` — bare `--keep-cache` now errors (UX-change
+    guard); `--keep-cache true`/`false` parse to `Some(true)`/`Some(false)`.
+  - `saturating_readahead` and the existing default assertions updated for the new
+    `Option` fields / resolution path.
+- Unit test for `StorageProfile::tunables` covering all three variants (cheap table
+  guard so a typo in a value is caught without a mount).
+
+## Documentation
+
+- **README** mount-options table: add a `--storage-profile` row and a short
+  "pick by backing store" subsection containing the confirmed values table and the
+  one-line rationale per knob. Note the precedence rule (explicit flag wins) and the
+  attr-ttl visibility tradeoff. Update the `--keep-cache` row and any examples to the
+  value form (`--keep-cache true|false`); bare `--keep-cache` no longer parses.
+- Doc comment on the new `storage_profile` field and a one-line note on each of the
+  four flags that they fall back to the profile / built-in default when unset.
+
+## Migration note (the one user-visible breaking change)
+
+The `--keep-cache` change from presence-flag to value-flag is a breaking CLI change
+for anyone passing bare `--keep-cache`. It is called out here, in the README, and in
+the commit message; the implementation plan's first code commit carries the test
+(`keep_cache_flag_requires_value`) that pins the new behavior. No other existing
+command line changes meaning.
+
+## Out of scope
+
+- Auto-detecting the backing filesystem type (`statfs` f_type) to pick a profile —
+  possible future ergonomic win, but it guesses where the user knows, and NFS-over-X
+  ambiguity remains. Deferred.
+- Per-format or per-track profiles. The medium is a mount-wide property.
+- Tuning `--poll-interval-ms` per medium; it governs the DB-watch debounce, not the
+  backing read path, so it is out of the media-profile scope.


### PR DESCRIPTION
## Summary

Prototyped a `--storage-profile {ssd,hdd,nfs}` preset over the backing-media mount
tunables, then **bench-validated the premise against real storage** — and it didn't
hold. The preset was dropped; the existing flags keep their defaults, so **there is no
code change**. What lands is documentation + a reproducible harness.

## What the benches showed

Real RAID-1 + btrfs HDD spans, and loopback NFSv4 with `tc netem` latency at 8 / 50 /
200 ms RTT (the last ≈ a trans-Pacific server):

- `--max-readahead-kib`: **no benefit anywhere**; single-stream reads serialize at the
  fixed ~256 KiB FUSE chunk, and ≥2048 KiB *hurts* on HDD.
- `--max-background`: **no effect** — it doesn't bound foreground reads.
- `--keep-cache`: **the one real win** (~3× faster repeat-open on HDD/NFS); needs no
  preset.

Full methodology + numbers: `BENCHMARKS.md` §Storage tunables.

## Changes

- `BENCHMARKS.md` — new §Storage tunables (methodology + data)
- `README.md` — corrected tunables guidance (the old "larger read-ahead hides HDD/NFS
  latency" claim was wrong)
- `benches/storage_tunables_bench.sh` — the reproducible harness behind the numbers
- design + plan docs, retained with "not shipped" outcome banners

## Follow-up

The real lever — single-stream reads don't overlap, so backing latency isn't hidden by
prefetch — is tracked in #255 (a concurrent backing-prefetch pipeline). Not addressed
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance benchmarking documentation with real-world storage tuning recommendations.
  * Updated tuning guidance to highlight `--keep-cache` for significant performance improvements on slow storage.
  * Introduced automated benchmarking tools to measure storage configuration effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->