### PR TITLE
fix(contrib): make store tag/art replace ops savepoint-atomic (#191)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,9 +167,10 @@ the art.
 The shared Python library (`contrib/python-musefs/`) encodes this contract
 for plugin authors, including a generated copy of the schema
 (`musefs_common/schema.py`, regenerated from `schema.rs` by a drift-guarded
-test — see [CONTRIBUTING](CONTRIBUTING.md)). Its tag/art replace operations each wrap their `DELETE`+`INSERT` in a SQLite
-savepoint, so they are individually atomic and the "caller owns the transaction"
-guarantee holds even on an autocommit connection. The [Lidarr integration](contrib/lidarr/README.md)
+test — see [CONTRIBUTING](CONTRIBUTING.md)). Its tag/art replace operations
+each wrap their `DELETE`+`INSERT` in a SQLite savepoint, so they are
+individually atomic and the "caller owns the transaction" guarantee holds even
+on an autocommit connection. The [Lidarr integration](contrib/lidarr/README.md)
 uses the same shared library from a Custom Script workflow. Its Lidarr
 destination tree is only a tracking aid, made of symlinks by default; musefs
 remains the consumer-facing filesystem.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,7 +167,9 @@ the art.
 The shared Python library (`contrib/python-musefs/`) encodes this contract
 for plugin authors, including a generated copy of the schema
 (`musefs_common/schema.py`, regenerated from `schema.rs` by a drift-guarded
-test — see [CONTRIBUTING](CONTRIBUTING.md)). The [Lidarr integration](contrib/lidarr/README.md)
+test — see [CONTRIBUTING](CONTRIBUTING.md)). Its tag/art replace operations each wrap their `DELETE`+`INSERT` in a SQLite
+savepoint, so they are individually atomic and the "caller owns the transaction"
+guarantee holds even on an autocommit connection. The [Lidarr integration](contrib/lidarr/README.md)
 uses the same shared library from a Custom Script workflow. Its Lidarr
 destination tree is only a tracking aid, made of symlinks by default; musefs
 remains the consumer-facing filesystem.

--- a/contrib/picard/musefs/_common/store.py
+++ b/contrib/picard/musefs/_common/store.py
@@ -1,12 +1,71 @@
 # GENERATED from python-musefs/src/musefs_common/store.py — do not edit.
 # Run contrib/python-musefs/vendor_to_picard.py after changing the library.
 #
+import contextlib
 import hashlib
 import os
 import sqlite3
 
 from .constants import EXPECTED_USER_VERSION
 from .errors import SchemaMismatch
+
+# sqlite3.LEGACY_TRANSACTION_CONTROL is 3.12+; it is == -1. Use getattr so this
+# module still imports on the 3.8 floor (where the constant does not exist).
+_LEGACY = getattr(sqlite3, "LEGACY_TRANSACTION_CONTROL", -1)
+
+
+def _is_autocommit(conn):
+    """True if the connection auto-commits each statement (no caller-owned
+    transaction will be committed for us)."""
+    ac = getattr(conn, "autocommit", _LEGACY)  # 3.12+ attribute; _LEGACY on <3.12
+    if ac is True:
+        return True
+    if ac is False:
+        return False
+    return conn.isolation_level is None  # legacy transaction control
+
+
+def _is_legacy(conn):
+    """True if the connection uses legacy transaction control (the <3.12 default
+    and the 3.12+ LEGACY_TRANSACTION_CONTROL mode)."""
+    return getattr(conn, "autocommit", _LEGACY) == _LEGACY
+
+
+@contextlib.contextmanager
+def _savepoint(conn, name):
+    """Make a DELETE+INSERT block atomic regardless of the connection's
+    transaction mode. On a caller-managed connection it nests via SAVEPOINT and
+    never commits the enclosing transaction; on an autocommit connection the
+    outermost call owns a transaction for the block (commit on success, rollback
+    on failure). Nested calls only nest -- they never BEGIN or commit -- so a
+    sync_one savepoint may wrap these per-function savepoints safely.
+
+    ``name`` must be a hardcoded SQL identifier (it is interpolated into the SQL,
+    so never pass caller-controlled text)."""
+    autocommit = _is_autocommit(conn)
+    owns = not conn.in_transaction  # outermost call: it opens & owns the txn
+    # Legacy mode never auto-BEGINs before SAVEPOINT, so a savepoint opened as
+    # the first statement of a batch would become the outermost transaction and
+    # commit durably on RELEASE. Force a nesting BEGIN there. PEP-249 modes
+    # auto-begin before any statement, so they need no nudge.
+    if owns and _is_legacy(conn):
+        conn.execute("BEGIN")
+    conn.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        try:
+            conn.execute(f"ROLLBACK TO {name}")
+            conn.execute(f"RELEASE {name}")
+            if owns and autocommit:
+                conn.rollback()
+        except sqlite3.Error:
+            pass  # never mask the original exception with a cleanup failure
+        raise
+    else:
+        conn.execute(f"RELEASE {name}")
+        if owns and autocommit:
+            conn.commit()
 
 
 def connect(db_path):
@@ -57,20 +116,25 @@ def prune_missing(conn, track_ids=None):
 
 def replace_tags(conn, track_id, pairs):
     """Replace all tags for a track. Duplicate keys get incrementing ordinals
-    (mirroring musefs scan ingest)."""
+    (mirroring musefs scan ingest).
+
+    Atomic via an internal savepoint (see ``_savepoint``), so a crash between the
+    DELETE and the INSERT can never leave the track's text tags wiped -- safe
+    even when called on an autocommit connection."""
     # Scope to the plugin-owned text rows: scanner-written binary tags
     # (value_blob NOT NULL) must survive a sync (#82).
-    conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
-    ordinals = {}
-    rows = []
-    for key, value in pairs:
-        ordinal = ordinals.get(key, 0)
-        ordinals[key] = ordinal + 1
-        rows.append((track_id, key, value, ordinal))
-    conn.executemany(
-        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
-        rows,
-    )
+    with _savepoint(conn, "musefs_replace_tags"):
+        conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
+        ordinals = {}
+        rows = []
+        for key, value in pairs:
+            ordinal = ordinals.get(key, 0)
+            ordinals[key] = ordinal + 1
+            rows.append((track_id, key, value, ordinal))
+        conn.executemany(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+            rows,
+        )
 
 
 def merge_tags(conn, track_id, managed_pairs, delete_keys):

--- a/contrib/picard/musefs/_common/store.py
+++ b/contrib/picard/musefs/_common/store.py
@@ -143,26 +143,31 @@ def merge_tags(conn, track_id, managed_pairs, delete_keys):
     of (key, value); every key it names is cleared and rewritten with contiguous
     ordinals. ``delete_keys`` names keys to clear without rewriting (tags the
     plugin previously managed and the user has now removed). Both deletes are
-    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive."""
-    by_key = {}
-    for key, value in managed_pairs:
-        by_key.setdefault(key, []).append(value)
+    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive.
 
-    for key in set(by_key) | set(delete_keys or ()):
-        conn.execute(
-            "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
-            (track_id, key),
+    Atomic via an internal savepoint (see ``_savepoint``): the per-key deletes
+    and the rewrite either all land or none do, even on an autocommit
+    connection."""
+    with _savepoint(conn, "musefs_merge_tags"):
+        by_key = {}
+        for key, value in managed_pairs:
+            by_key.setdefault(key, []).append(value)
+
+        for key in set(by_key) | set(delete_keys or ()):
+            conn.execute(
+                "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+                (track_id, key),
+            )
+
+        rows = [
+            (track_id, key, value, ordinal)
+            for key, values in by_key.items()
+            for ordinal, value in enumerate(values)
+        ]
+        conn.executemany(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+            rows,
         )
-
-    rows = [
-        (track_id, key, value, ordinal)
-        for key, values in by_key.items()
-        for ordinal, value in enumerate(values)
-    ]
-    conn.executemany(
-        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
-        rows,
-    )
 
 
 _EXT_MIME = {

--- a/contrib/picard/musefs/_common/store.py
+++ b/contrib/picard/musefs/_common/store.py
@@ -207,13 +207,18 @@ def upsert_art(conn, data, mime):
 def replace_track_art(conn, track_id, arts):
     """Replace the track's art rows. ``arts`` is an ordered list of
     ``(art_id, picture_type, description)``; each row's ``ordinal`` is its
-    list index."""
-    conn.execute("DELETE FROM track_art WHERE track_id = ?", (track_id,))
-    conn.executemany(
-        "INSERT INTO track_art (track_id, art_id, picture_type, description, "
-        "ordinal) VALUES (?, ?, ?, ?, ?)",
-        [
-            (track_id, art_id, picture_type, description, i)
-            for i, (art_id, picture_type, description) in enumerate(arts)
-        ],
-    )
+    list index.
+
+    Atomic via an internal savepoint (see ``_savepoint``): the DELETE and the
+    re-insert either both land or neither does, even on an autocommit
+    connection."""
+    with _savepoint(conn, "musefs_replace_track_art"):
+        conn.execute("DELETE FROM track_art WHERE track_id = ?", (track_id,))
+        conn.executemany(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, "
+            "ordinal) VALUES (?, ?, ?, ?, ?)",
+            [
+                (track_id, art_id, picture_type, description, i)
+                for i, (art_id, picture_type, description) in enumerate(arts)
+            ],
+        )

--- a/contrib/picard/musefs/_common/sync.py
+++ b/contrib/picard/musefs/_common/sync.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .constants import MAX_ART_BYTES
-from .store import merge_tags, replace_tags, replace_track_art, track_id_for_path, upsert_art
+from .store import (
+    _savepoint,
+    merge_tags,
+    replace_tags,
+    replace_track_art,
+    track_id_for_path,
+    upsert_art,
+)
 
 
 @dataclass(frozen=True)
@@ -69,16 +76,17 @@ def sync_one(conn, record, stats, *, dry_run=False, merge=False):
     will_link_art = bool(kept)
 
     if not dry_run:
-        if merge:
-            merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
-        else:
-            replace_tags(conn, track_id, record.pairs)
-        if will_link_art:
-            arts = [
-                (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
-                for img in kept
-            ]
-            replace_track_art(conn, track_id, arts)
+        with _savepoint(conn, "musefs_sync_one"):
+            if merge:
+                merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+            else:
+                replace_tags(conn, track_id, record.pairs)
+            if will_link_art:
+                arts = [
+                    (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
+                    for img in kept
+                ]
+                replace_track_art(conn, track_id, arts)
 
     if will_link_art:
         stats.art_linked += 1

--- a/contrib/python-musefs/src/musefs_common/store.py
+++ b/contrib/python-musefs/src/musefs_common/store.py
@@ -1,9 +1,68 @@
+import contextlib
 import hashlib
 import os
 import sqlite3
 
 from .constants import EXPECTED_USER_VERSION
 from .errors import SchemaMismatch
+
+# sqlite3.LEGACY_TRANSACTION_CONTROL is 3.12+; it is == -1. Use getattr so this
+# module still imports on the 3.8 floor (where the constant does not exist).
+_LEGACY = getattr(sqlite3, "LEGACY_TRANSACTION_CONTROL", -1)
+
+
+def _is_autocommit(conn):
+    """True if the connection auto-commits each statement (no caller-owned
+    transaction will be committed for us)."""
+    ac = getattr(conn, "autocommit", _LEGACY)  # 3.12+ attribute; _LEGACY on <3.12
+    if ac is True:
+        return True
+    if ac is False:
+        return False
+    return conn.isolation_level is None  # legacy transaction control
+
+
+def _is_legacy(conn):
+    """True if the connection uses legacy transaction control (the <3.12 default
+    and the 3.12+ LEGACY_TRANSACTION_CONTROL mode)."""
+    return getattr(conn, "autocommit", _LEGACY) == _LEGACY
+
+
+@contextlib.contextmanager
+def _savepoint(conn, name):
+    """Make a DELETE+INSERT block atomic regardless of the connection's
+    transaction mode. On a caller-managed connection it nests via SAVEPOINT and
+    never commits the enclosing transaction; on an autocommit connection the
+    outermost call owns a transaction for the block (commit on success, rollback
+    on failure). Nested calls only nest -- they never BEGIN or commit -- so a
+    sync_one savepoint may wrap these per-function savepoints safely.
+
+    ``name`` must be a hardcoded SQL identifier (it is interpolated into the SQL,
+    so never pass caller-controlled text)."""
+    autocommit = _is_autocommit(conn)
+    owns = not conn.in_transaction  # outermost call: it opens & owns the txn
+    # Legacy mode never auto-BEGINs before SAVEPOINT, so a savepoint opened as
+    # the first statement of a batch would become the outermost transaction and
+    # commit durably on RELEASE. Force a nesting BEGIN there. PEP-249 modes
+    # auto-begin before any statement, so they need no nudge.
+    if owns and _is_legacy(conn):
+        conn.execute("BEGIN")
+    conn.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        try:
+            conn.execute(f"ROLLBACK TO {name}")
+            conn.execute(f"RELEASE {name}")
+            if owns and autocommit:
+                conn.rollback()
+        except sqlite3.Error:
+            pass  # never mask the original exception with a cleanup failure
+        raise
+    else:
+        conn.execute(f"RELEASE {name}")
+        if owns and autocommit:
+            conn.commit()
 
 
 def connect(db_path):
@@ -54,20 +113,25 @@ def prune_missing(conn, track_ids=None):
 
 def replace_tags(conn, track_id, pairs):
     """Replace all tags for a track. Duplicate keys get incrementing ordinals
-    (mirroring musefs scan ingest)."""
+    (mirroring musefs scan ingest).
+
+    Atomic via an internal savepoint (see ``_savepoint``), so a crash between the
+    DELETE and the INSERT can never leave the track's text tags wiped -- safe
+    even when called on an autocommit connection."""
     # Scope to the plugin-owned text rows: scanner-written binary tags
     # (value_blob NOT NULL) must survive a sync (#82).
-    conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
-    ordinals = {}
-    rows = []
-    for key, value in pairs:
-        ordinal = ordinals.get(key, 0)
-        ordinals[key] = ordinal + 1
-        rows.append((track_id, key, value, ordinal))
-    conn.executemany(
-        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
-        rows,
-    )
+    with _savepoint(conn, "musefs_replace_tags"):
+        conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
+        ordinals = {}
+        rows = []
+        for key, value in pairs:
+            ordinal = ordinals.get(key, 0)
+            ordinals[key] = ordinal + 1
+            rows.append((track_id, key, value, ordinal))
+        conn.executemany(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+            rows,
+        )
 
 
 def merge_tags(conn, track_id, managed_pairs, delete_keys):

--- a/contrib/python-musefs/src/musefs_common/store.py
+++ b/contrib/python-musefs/src/musefs_common/store.py
@@ -140,26 +140,31 @@ def merge_tags(conn, track_id, managed_pairs, delete_keys):
     of (key, value); every key it names is cleared and rewritten with contiguous
     ordinals. ``delete_keys`` names keys to clear without rewriting (tags the
     plugin previously managed and the user has now removed). Both deletes are
-    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive."""
-    by_key = {}
-    for key, value in managed_pairs:
-        by_key.setdefault(key, []).append(value)
+    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive.
 
-    for key in set(by_key) | set(delete_keys or ()):
-        conn.execute(
-            "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
-            (track_id, key),
+    Atomic via an internal savepoint (see ``_savepoint``): the per-key deletes
+    and the rewrite either all land or none do, even on an autocommit
+    connection."""
+    with _savepoint(conn, "musefs_merge_tags"):
+        by_key = {}
+        for key, value in managed_pairs:
+            by_key.setdefault(key, []).append(value)
+
+        for key in set(by_key) | set(delete_keys or ()):
+            conn.execute(
+                "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+                (track_id, key),
+            )
+
+        rows = [
+            (track_id, key, value, ordinal)
+            for key, values in by_key.items()
+            for ordinal, value in enumerate(values)
+        ]
+        conn.executemany(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+            rows,
         )
-
-    rows = [
-        (track_id, key, value, ordinal)
-        for key, values in by_key.items()
-        for ordinal, value in enumerate(values)
-    ]
-    conn.executemany(
-        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
-        rows,
-    )
 
 
 _EXT_MIME = {

--- a/contrib/python-musefs/src/musefs_common/store.py
+++ b/contrib/python-musefs/src/musefs_common/store.py
@@ -204,13 +204,18 @@ def upsert_art(conn, data, mime):
 def replace_track_art(conn, track_id, arts):
     """Replace the track's art rows. ``arts`` is an ordered list of
     ``(art_id, picture_type, description)``; each row's ``ordinal`` is its
-    list index."""
-    conn.execute("DELETE FROM track_art WHERE track_id = ?", (track_id,))
-    conn.executemany(
-        "INSERT INTO track_art (track_id, art_id, picture_type, description, "
-        "ordinal) VALUES (?, ?, ?, ?, ?)",
-        [
-            (track_id, art_id, picture_type, description, i)
-            for i, (art_id, picture_type, description) in enumerate(arts)
-        ],
-    )
+    list index.
+
+    Atomic via an internal savepoint (see ``_savepoint``): the DELETE and the
+    re-insert either both land or neither does, even on an autocommit
+    connection."""
+    with _savepoint(conn, "musefs_replace_track_art"):
+        conn.execute("DELETE FROM track_art WHERE track_id = ?", (track_id,))
+        conn.executemany(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, "
+            "ordinal) VALUES (?, ?, ?, ?, ?)",
+            [
+                (track_id, art_id, picture_type, description, i)
+                for i, (art_id, picture_type, description) in enumerate(arts)
+            ],
+        )

--- a/contrib/python-musefs/src/musefs_common/sync.py
+++ b/contrib/python-musefs/src/musefs_common/sync.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .constants import MAX_ART_BYTES
-from .store import merge_tags, replace_tags, replace_track_art, track_id_for_path, upsert_art
+from .store import (
+    _savepoint,
+    merge_tags,
+    replace_tags,
+    replace_track_art,
+    track_id_for_path,
+    upsert_art,
+)
 
 
 @dataclass(frozen=True)
@@ -66,16 +73,17 @@ def sync_one(conn, record, stats, *, dry_run=False, merge=False):
     will_link_art = bool(kept)
 
     if not dry_run:
-        if merge:
-            merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
-        else:
-            replace_tags(conn, track_id, record.pairs)
-        if will_link_art:
-            arts = [
-                (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
-                for img in kept
-            ]
-            replace_track_art(conn, track_id, arts)
+        with _savepoint(conn, "musefs_sync_one"):
+            if merge:
+                merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+            else:
+                replace_tags(conn, track_id, record.pairs)
+            if will_link_art:
+                arts = [
+                    (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
+                    for img in kept
+                ]
+                replace_track_art(conn, track_id, arts)
 
     if will_link_art:
         stats.art_linked += 1

--- a/contrib/python-musefs/tests/test_atomicity.py
+++ b/contrib/python-musefs/tests/test_atomicity.py
@@ -1,0 +1,65 @@
+import sqlite3
+
+import pytest
+from conftest import insert_track, text_tags
+
+from musefs_common import connect, replace_tags
+
+
+class _FailInsert(sqlite3.Connection):
+    """Connection that raises on the next INSERT executemany, to enter the
+    DELETE-then-INSERT torn window deterministically."""
+
+    fail = False
+
+    def executemany(self, sql, parameters):
+        if self.fail and sql.lstrip().upper().startswith("INSERT"):
+            raise RuntimeError("boom")
+        return super().executemany(sql, parameters)
+
+
+def _autocommit(db_path, factory=None):
+    """An autocommit connection with foreign keys on (mirrors connect()'s FK
+    pragma), used to exercise the undefended-against-autocommit path."""
+    conn = sqlite3.connect(db_path, factory=factory) if factory else sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.isolation_level = None  # legacy autocommit
+    return conn
+
+
+def test_replace_tags_atomic_on_autocommit_failure(db_path):
+    # Seed a track + one text tag (committed) on an autocommit connection.
+    conn = _autocommit(db_path, factory=_FailInsert)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        replace_tags(conn, tid, [("title", "ORIG")])
+        # Now force the INSERT half of replace_tags to crash after the DELETE.
+        conn.fail = True
+        with pytest.raises(RuntimeError):
+            replace_tags(conn, tid, [("title", "NEW")])
+    finally:
+        conn.close()
+    # The original tag must survive: the savepoint rolled the torn write back.
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {"title": ["ORIG"]}
+    finally:
+        check.close()
+
+
+def test_replace_tags_no_premature_commit_in_deferred_mode(db_path):
+    # The legacy-mode trap guard: in default deferred mode the savepoint must
+    # nest, so a caller rollback still wins. A bare savepoint would commit here.
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        conn.commit()
+        replace_tags(conn, tid, [("title", "X")])
+        conn.rollback()
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {}
+    finally:
+        check.close()

--- a/contrib/python-musefs/tests/test_atomicity.py
+++ b/contrib/python-musefs/tests/test_atomicity.py
@@ -188,14 +188,21 @@ def test_sync_files_deferred_batch_rolls_back_as_unit(db_path):
     # rollback abandons the whole batch.
     conn = connect(db_path)
     try:
-        tid = insert_track(conn, "/m/a.flac")
+        insert_track(conn, "/m/a.flac")
+        insert_track(conn, "/m/b.flac")
         conn.commit()
-        sync_one(conn, Record(key="/m/a.flac", pairs=[("title", "A")]), SyncStats())
+        sync_files(
+            conn,
+            [
+                Record(key="/m/a.flac", pairs=[("title", "A")]),
+                Record(key="/m/b.flac", pairs=[("title", "B")]),
+            ],
+        )
         conn.rollback()  # caller abandons the batch after the write
     finally:
         conn.close()
     check = connect(db_path)
     try:
-        assert text_tags(check, tid) == {}
+        assert check.execute("SELECT COUNT(*) FROM tags").fetchone()[0] == 0
     finally:
         check.close()

--- a/contrib/python-musefs/tests/test_atomicity.py
+++ b/contrib/python-musefs/tests/test_atomicity.py
@@ -133,10 +133,9 @@ def test_sync_one_whole_record_atomic_on_autocommit(db_path):
     conn = _autocommit(db_path, factory=_FailInsert)
     try:
         tid = insert_track(conn, "/m/a.flac")
-        # _FailInsert fails the FIRST insert executemany once fail=True. In
-        # sync_one the tag INSERT runs before the art INSERT, so to target the
-        # art step specifically we let tags write, then fail on the art INSERT.
-        conn.fail = "art"  # sentinel handled below
+        # fail="art" makes _FailInsert raise only on the track_art INSERT, so
+        # tags write first and the failure lands on the later art step.
+        conn.fail = "art"
         with pytest.raises(RuntimeError):
             sync_one(
                 conn,

--- a/contrib/python-musefs/tests/test_atomicity.py
+++ b/contrib/python-musefs/tests/test_atomicity.py
@@ -3,18 +3,32 @@ import sqlite3
 import pytest
 from conftest import JPEG, insert_track, text_tags
 
-from musefs_common import connect, merge_tags, replace_tags, replace_track_art, upsert_art
+from musefs_common import (
+    ArtImage,
+    Record,
+    SyncStats,
+    connect,
+    merge_tags,
+    replace_tags,
+    replace_track_art,
+    sync_files,
+    sync_one,
+    upsert_art,
+)
 
 
 class _FailInsert(sqlite3.Connection):
-    """Connection that raises on the next INSERT executemany, to enter the
-    DELETE-then-INSERT torn window deterministically."""
+    """Connection that raises on a chosen INSERT executemany, to enter a
+    DELETE-then-INSERT torn window deterministically. ``fail`` may be:
+    False (never), True (any INSERT), or "art" (only the track_art INSERT)."""
 
     fail = False
 
     def executemany(self, sql, parameters):
-        if self.fail and sql.lstrip().upper().startswith("INSERT"):
-            raise RuntimeError("boom")
+        upper = sql.lstrip().upper()
+        if upper.startswith("INSERT"):
+            if self.fail is True or (self.fail == "art" and "TRACK_ART" in upper):
+                raise RuntimeError("boom")
         return super().executemany(sql, parameters)
 
 
@@ -111,3 +125,78 @@ def test_replace_track_art_atomic_on_fk_violation(db_path):
     # The DELETE + the content_version trigger bump both rolled back with the FK failure.
     assert rows == [(art_id, 3, 0)]
     assert after_cv == before_cv
+
+
+def test_sync_one_whole_record_atomic_on_autocommit(db_path):
+    # On an autocommit connection, if art linking fails the tags written earlier
+    # in the same record must roll back too (record is all-or-nothing).
+    conn = _autocommit(db_path, factory=_FailInsert)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        # _FailInsert fails the FIRST insert executemany once fail=True. In
+        # sync_one the tag INSERT runs before the art INSERT, so to target the
+        # art step specifically we let tags write, then fail on the art INSERT.
+        conn.fail = "art"  # sentinel handled below
+        with pytest.raises(RuntimeError):
+            sync_one(
+                conn,
+                Record(key="/m/a.flac", pairs=[("title", "T")], art=[ArtImage(JPEG, "image/jpeg")]),
+                SyncStats(),
+            )
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {}
+        assert check.execute("SELECT COUNT(*) FROM track_art").fetchone()[0] == 0
+    finally:
+        check.close()
+
+
+def test_sync_files_deferred_batch_commits_atomically(db_path):
+    # Shipped beets-style path: deferred mode, several records, one final commit.
+    conn = connect(db_path)
+    try:
+        insert_track(conn, "/m/a.flac")
+        insert_track(conn, "/m/b.flac")
+        conn.commit()
+        records = [
+            Record(key="/m/a.flac", pairs=[("title", "A")]),
+            Record(key="/m/b.flac", pairs=[("title", "B")]),
+        ]
+        stats = sync_files(conn, records)
+        assert stats.synced == 2
+        conn.commit()
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        got = {
+            path: check.execute(
+                "SELECT value FROM tags t JOIN tracks tr ON tr.id = t.track_id "
+                "WHERE tr.backing_path = ? AND t.key = 'title'",
+                (path,),
+            ).fetchone()[0]
+            for path in ("/m/a.flac", "/m/b.flac")
+        }
+        assert got == {"/m/a.flac": "A", "/m/b.flac": "B"}
+    finally:
+        check.close()
+
+
+def test_sync_files_deferred_batch_rolls_back_as_unit(db_path):
+    # Deferred mode: per-record savepoints must NOT self-commit, so a caller
+    # rollback abandons the whole batch.
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        conn.commit()
+        sync_one(conn, Record(key="/m/a.flac", pairs=[("title", "A")]), SyncStats())
+        conn.rollback()  # caller abandons the batch after the write
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {}
+    finally:
+        check.close()

--- a/contrib/python-musefs/tests/test_atomicity.py
+++ b/contrib/python-musefs/tests/test_atomicity.py
@@ -1,9 +1,9 @@
 import sqlite3
 
 import pytest
-from conftest import insert_track, text_tags
+from conftest import JPEG, insert_track, text_tags
 
-from musefs_common import connect, merge_tags, replace_tags
+from musefs_common import connect, merge_tags, replace_tags, replace_track_art, upsert_art
 
 
 class _FailInsert(sqlite3.Connection):
@@ -86,3 +86,28 @@ def test_merge_tags_atomic_on_autocommit_failure(db_path):
         assert text_tags(check, tid) == {"artist": ["ORIG"], "genre": ["Jazz"]}
     finally:
         check.close()
+
+
+def test_replace_track_art_atomic_on_fk_violation(db_path):
+    conn = _autocommit(db_path)  # FK on, autocommit; no failure injection needed
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        art_id = upsert_art(conn, JPEG, "image/jpeg")
+        replace_track_art(conn, tid, [(art_id, 3, "")])
+        before_cv = conn.execute(
+            "SELECT content_version FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+        # 999999 has no row in `art`: the INSERT (after the DELETE) trips the FK.
+        with pytest.raises(sqlite3.IntegrityError):
+            replace_track_art(conn, tid, [(999999, 3, "")])
+        rows = conn.execute(
+            "SELECT art_id, picture_type, ordinal FROM track_art WHERE track_id = ?", (tid,)
+        ).fetchall()
+        after_cv = conn.execute(
+            "SELECT content_version FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    # The DELETE + the content_version trigger bump both rolled back with the FK failure.
+    assert rows == [(art_id, 3, 0)]
+    assert after_cv == before_cv

--- a/contrib/python-musefs/tests/test_atomicity.py
+++ b/contrib/python-musefs/tests/test_atomicity.py
@@ -3,7 +3,7 @@ import sqlite3
 import pytest
 from conftest import insert_track, text_tags
 
-from musefs_common import connect, replace_tags
+from musefs_common import connect, merge_tags, replace_tags
 
 
 class _FailInsert(sqlite3.Connection):
@@ -61,5 +61,28 @@ def test_replace_tags_no_premature_commit_in_deferred_mode(db_path):
     check = connect(db_path)
     try:
         assert text_tags(check, tid) == {}
+    finally:
+        check.close()
+
+
+def test_merge_tags_atomic_on_autocommit_failure(db_path):
+    conn = _autocommit(db_path, factory=_FailInsert)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        # Seed both a managed key we'll overwrite and an unmanaged baseline key.
+        merge_tags(conn, tid, [("artist", "ORIG")], [])
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, 'genre', 'Jazz', 0)",
+            (tid,),
+        )
+        conn.fail = True
+        with pytest.raises(RuntimeError):
+            merge_tags(conn, tid, [("artist", "NEW")], [])
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        # The failed merge rolled back: both the managed and baseline rows remain.
+        assert text_tags(check, tid) == {"artist": ["ORIG"], "genre": ["Jazz"]}
     finally:
         check.close()

--- a/docs/superpowers/plans/2026-06-11-contrib-store-savepoint-atomicity.md
+++ b/docs/superpowers/plans/2026-06-11-contrib-store-savepoint-atomicity.md
@@ -1,0 +1,692 @@
+# Contrib Store Savepoint Atomicity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the contrib Python store's destructive tag/art replace operations atomic regardless of the connection's transaction mode, closing the torn `DELETE`+`INSERT` window flagged in issue #191 without weakening the "caller owns the transaction" contract.
+
+**Architecture:** Add one private `_savepoint` context manager (plus two tiny mode-detection helpers) to `store.py`. Wrap each of `replace_tags`, `merge_tags`, `replace_track_art` in it (approach **A**), and wrap the whole per-record write block in `sync_one` in it (approach **C**). The helper nests via `SAVEPOINT` inside a caller-managed transaction (never committing it) and, on an autocommit connection, has the *outermost* call own a transaction for the operation (commit on success, rollback on failure). An `owns`-the-transaction guard makes the C-over-A nesting correct on autocommit connections.
+
+**Tech Stack:** Python 3.8+ (no version bump), stdlib `sqlite3` + `contextlib`, pytest.
+
+**Design spec:** `docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md` (read it before starting; the "Transaction semantics" and "legacy-mode trap" sections explain *why* the helper is shaped the way it is).
+
+---
+
+## Critical context (read before any task)
+
+- **The pre-commit hook runs the FULL workspace test suite + clippy + ruff.** Tasks 1–4 touch `.py` files, so **each of those commits also compiles and runs the entire Rust workspace** (the cargo gate is skipped only for commits whose staged paths are *all* under `docs/` or `*.md`). Expect slow commits and ensure a working Rust toolchain. A commit with any red test is rejected, so **never commit a failing test on its own** — within each task, write the test and the implementation, get green, then commit them together. (The "run the test and watch it fail" step is local verification only; do not commit at that point.)
+- **Ruff must be clean before committing.** The hook runs `ruff check` and `ruff format --check` over `contrib/python-musefs/` (among others). Run them yourself first (commands in each task).
+- **Run the Python suite from the package dir:** `cd contrib/python-musefs` then `python3 -m pytest -q`. The baseline is **56 passed**.
+- **Why `sqlite3.Connection` can't be monkeypatched:** instances disallow attribute assignment, so failure-injection tests use a `Connection` *subclass* via `factory=` (provided in Task 1's test file) rather than `monkeypatch.setattr(conn, "executemany", ...)`.
+- **Autocommit test connections** must enable foreign keys *and* switch to autocommit: open the connection, `PRAGMA foreign_keys = ON`, then set `conn.isolation_level = None`. A bare `sqlite3.connect(path, isolation_level=None)` leaves FKs off and would make the FK-violation test a silent no-op.
+
+## File structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `contrib/python-musefs/src/musefs_common/store.py` | the store contract: connect, schema check, tag/art writes | Add `_savepoint`/`_is_autocommit`/`_is_legacy`; wrap three functions; docstrings |
+| `contrib/python-musefs/src/musefs_common/sync.py` | per-file sync write-loop | Import `_savepoint`; wrap the `sync_one` write block |
+| `contrib/python-musefs/tests/test_atomicity.py` | **new** — atomicity/rollback tests for A and C | Create, grow across Tasks 1–4 |
+| `ARCHITECTURE.md` | external-writer contract docs | One sentence in the contract section |
+
+---
+
+## Task 1: `_savepoint` helper + wrap `replace_tags`
+
+**Files:**
+- Modify: `contrib/python-musefs/src/musefs_common/store.py` (imports near `:1-3`; add helpers before `connect` at `:9`; rewrite `replace_tags` at `:55-70`)
+- Test: `contrib/python-musefs/tests/test_atomicity.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `contrib/python-musefs/tests/test_atomicity.py`:
+
+```python
+import sqlite3
+
+import pytest
+from conftest import insert_track, text_tags
+
+from musefs_common import connect, replace_tags
+
+
+class _FailInsert(sqlite3.Connection):
+    """Connection that raises on the next INSERT executemany, to enter the
+    DELETE-then-INSERT torn window deterministically."""
+
+    fail = False
+
+    def executemany(self, sql, parameters):
+        if self.fail and sql.lstrip().upper().startswith("INSERT"):
+            raise RuntimeError("boom")
+        return super().executemany(sql, parameters)
+
+
+def _autocommit(db_path, factory=None):
+    """An autocommit connection with foreign keys on (mirrors connect()'s FK
+    pragma), used to exercise the undefended-against-autocommit path."""
+    conn = sqlite3.connect(db_path, factory=factory) if factory else sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.isolation_level = None  # legacy autocommit
+    return conn
+
+
+def test_replace_tags_atomic_on_autocommit_failure(db_path):
+    # Seed a track + one text tag (committed) on an autocommit connection.
+    conn = _autocommit(db_path, factory=_FailInsert)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        replace_tags(conn, tid, [("title", "ORIG")])
+        # Now force the INSERT half of replace_tags to crash after the DELETE.
+        conn.fail = True
+        with pytest.raises(RuntimeError):
+            replace_tags(conn, tid, [("title", "NEW")])
+    finally:
+        conn.close()
+    # The original tag must survive: the savepoint rolled the torn write back.
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {"title": ["ORIG"]}
+    finally:
+        check.close()
+
+
+def test_replace_tags_no_premature_commit_in_deferred_mode(db_path):
+    # The legacy-mode trap guard: in default deferred mode the savepoint must
+    # nest, so a caller rollback still wins. A bare savepoint would commit here.
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        conn.commit()
+        replace_tags(conn, tid, [("title", "X")])
+        conn.rollback()
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {}
+    finally:
+        check.close()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py -q`
+Expected: both FAIL — `test_replace_tags_atomic_on_autocommit_failure` because the torn write is *not* rolled back (the new tag/empty state persists), and `test_replace_tags_no_premature_commit_in_deferred_mode` because today nothing wraps the write so `"X"` is never written and... actually it currently passes vacuously; if so, treat the autocommit test as the primary red. (See note.) The autocommit test MUST be red before implementing.
+
+> Note: the deferred trap-guard test only turns red against a *naive* `SAVEPOINT` (no `BEGIN`). Against today's unwrapped code it passes (the write is never committed because nothing commits). It is kept as a permanent guard so a future "simplify the helper to a bare savepoint" regression is caught. The autocommit test is the one that must be red now.
+
+- [ ] **Step 3: Add the helper to `store.py`**
+
+Add `import contextlib` to the import block (keep alphabetical — it goes first):
+
+```python
+import contextlib
+import hashlib
+import os
+import sqlite3
+```
+
+Then insert these definitions immediately before `def connect(` (currently `store.py:9`):
+
+```python
+_LEGACY = sqlite3.LEGACY_TRANSACTION_CONTROL  # == -1; the getattr default for <3.12
+
+
+def _is_autocommit(conn):
+    """True if the connection auto-commits each statement (no caller-owned
+    transaction will be committed for us)."""
+    ac = getattr(conn, "autocommit", _LEGACY)  # 3.12+ attribute; _LEGACY on <3.12
+    if ac is True:
+        return True
+    if ac is False:
+        return False
+    return conn.isolation_level is None  # legacy transaction control
+
+
+def _is_legacy(conn):
+    """True if the connection uses legacy transaction control (the <3.12 default
+    and the 3.12+ LEGACY_TRANSACTION_CONTROL mode)."""
+    return getattr(conn, "autocommit", _LEGACY) == _LEGACY
+
+
+@contextlib.contextmanager
+def _savepoint(conn, name):
+    """Make a DELETE+INSERT block atomic regardless of the connection's
+    transaction mode. On a caller-managed connection it nests via SAVEPOINT and
+    never commits the enclosing transaction; on an autocommit connection the
+    outermost call owns a transaction for the block (commit on success, rollback
+    on failure). Nested calls only nest -- they never BEGIN or commit -- so a
+    sync_one savepoint may wrap these per-function savepoints safely.
+
+    ``name`` must be a hardcoded SQL identifier (it is interpolated into the SQL,
+    so never pass caller-controlled text)."""
+    autocommit = _is_autocommit(conn)
+    owns = not conn.in_transaction  # outermost call: it opens & owns the txn
+    # Legacy mode never auto-BEGINs before SAVEPOINT, so a savepoint opened as
+    # the first statement of a batch would become the outermost transaction and
+    # commit durably on RELEASE. Force a nesting BEGIN there. PEP-249 modes
+    # auto-begin before any statement, so they need no nudge.
+    if owns and _is_legacy(conn):
+        conn.execute("BEGIN")
+    conn.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        try:
+            conn.execute(f"ROLLBACK TO {name}")
+            conn.execute(f"RELEASE {name}")
+            if owns and autocommit:
+                conn.rollback()
+        except sqlite3.Error:
+            pass  # never mask the original exception with a cleanup failure
+        raise
+    else:
+        conn.execute(f"RELEASE {name}")
+        if owns and autocommit:
+            conn.commit()
+```
+
+- [ ] **Step 4: Wrap `replace_tags`**
+
+Replace the body of `replace_tags` (`store.py:55-70`) with:
+
+```python
+def replace_tags(conn, track_id, pairs):
+    """Replace all tags for a track. Duplicate keys get incrementing ordinals
+    (mirroring musefs scan ingest).
+
+    Atomic via an internal savepoint (see ``_savepoint``), so a crash between the
+    DELETE and the INSERT can never leave the track's text tags wiped -- safe
+    even when called on an autocommit connection."""
+    # Scope to the plugin-owned text rows: scanner-written binary tags
+    # (value_blob NOT NULL) must survive a sync (#82).
+    with _savepoint(conn, "musefs_replace_tags"):
+        conn.execute("DELETE FROM tags WHERE track_id = ? AND value_blob IS NULL", (track_id,))
+        ordinals = {}
+        rows = []
+        for key, value in pairs:
+            ordinal = ordinals.get(key, 0)
+            ordinals[key] = ordinal + 1
+            rows.append((track_id, key, value, ordinal))
+        conn.executemany(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+```
+
+- [ ] **Step 5: Run the new tests and the full Python suite**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py -q && python3 -m pytest -q`
+Expected: `test_atomicity.py` both PASS; full suite **58 passed** (56 baseline + 2 new).
+
+- [ ] **Step 6: Lint (auto-fix, then verify)**
+
+The hook enforces ruff's import-sorting (`I`) and formatting, so let ruff arrange them first, then verify clean:
+
+Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
+Expected: the first two commands may rewrite imports/formatting; the final two report no errors. Re-stage any files ruff touched.
+
+- [ ] **Step 7: Commit** (runs the full pre-commit hook incl. the Rust suite)
+
+```bash
+git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py
+git commit -m "fix(contrib): make replace_tags atomic via savepoint (#191)"
+```
+
+---
+
+## Task 2: Wrap `merge_tags`
+
+**Files:**
+- Modify: `contrib/python-musefs/src/musefs_common/store.py` (rewrite `merge_tags` at `:73-98`)
+- Test: `contrib/python-musefs/tests/test_atomicity.py` (add one test + import)
+
+- [ ] **Step 1: Write the failing test**
+
+In `test_atomicity.py`, add `merge_tags` to the import and append the test:
+
+```python
+from musefs_common import connect, merge_tags, replace_tags
+```
+
+```python
+def test_merge_tags_atomic_on_autocommit_failure(db_path):
+    conn = _autocommit(db_path, factory=_FailInsert)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        # Seed both a managed key we'll overwrite and an unmanaged baseline key.
+        merge_tags(conn, tid, [("artist", "ORIG")], [])
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, 'genre', 'Jazz', 0)",
+            (tid,),
+        )
+        conn.fail = True
+        with pytest.raises(RuntimeError):
+            merge_tags(conn, tid, [("artist", "NEW")], [])
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        # The failed merge rolled back: both the managed and baseline rows remain.
+        assert text_tags(check, tid) == {"artist": ["ORIG"], "genre": ["Jazz"]}
+    finally:
+        check.close()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py::test_merge_tags_atomic_on_autocommit_failure -q`
+Expected: FAIL — the per-key DELETE wiped `artist` and the INSERT crashed, so without a savepoint `artist` is gone (result `{"genre": ["Jazz"]}`).
+
+- [ ] **Step 3: Wrap `merge_tags`**
+
+Replace the body of `merge_tags` (`store.py:73-98`) with:
+
+```python
+def merge_tags(conn, track_id, managed_pairs, delete_keys):
+    """Per-key replace of the plugin-managed text tags, leaving unmanaged text
+    rows (the scan-seeded baseline) intact. ``managed_pairs`` is an ordered list
+    of (key, value); every key it names is cleared and rewritten with contiguous
+    ordinals. ``delete_keys`` names keys to clear without rewriting (tags the
+    plugin previously managed and the user has now removed). Both deletes are
+    scoped to ``value_blob IS NULL`` so scanner-written binary tags survive.
+
+    Atomic via an internal savepoint (see ``_savepoint``): the per-key deletes
+    and the rewrite either all land or none do, even on an autocommit
+    connection."""
+    with _savepoint(conn, "musefs_merge_tags"):
+        by_key = {}
+        for key, value in managed_pairs:
+            by_key.setdefault(key, []).append(value)
+
+        for key in set(by_key) | set(delete_keys or ()):
+            conn.execute(
+                "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+                (track_id, key),
+            )
+
+        rows = [
+            (track_id, key, value, ordinal)
+            for key, values in by_key.items()
+            for ordinal, value in enumerate(values)
+        ]
+        conn.executemany(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+```
+
+- [ ] **Step 4: Run the test + full suite**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py -q && python3 -m pytest -q`
+Expected: atomicity tests PASS; full suite **59 passed**.
+
+- [ ] **Step 5: Lint (auto-fix, then verify)**
+
+Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
+Expected: the final two commands report no errors. Re-stage any files ruff touched.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py
+git commit -m "fix(contrib): make merge_tags atomic via savepoint (#191)"
+```
+
+---
+
+## Task 3: Wrap `replace_track_art`
+
+**Files:**
+- Modify: `contrib/python-musefs/src/musefs_common/store.py` (rewrite `replace_track_art` at `:135-147`)
+- Test: `contrib/python-musefs/tests/test_atomicity.py` (add one test + imports)
+
+- [ ] **Step 1: Write the failing test**
+
+In `test_atomicity.py`, extend the import and append the test. This one uses a **natural** failure: an `art_id` with no matching `art` row violates the `track_art.art_id` foreign key on the INSERT-after-DELETE (FK enforcement is on via `_autocommit`).
+
+```python
+from conftest import JPEG, insert_track, text_tags
+from musefs_common import connect, merge_tags, replace_tags, replace_track_art, upsert_art
+```
+
+```python
+def test_replace_track_art_atomic_on_fk_violation(db_path):
+    conn = _autocommit(db_path)  # FK on, autocommit; no failure injection needed
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        art_id = upsert_art(conn, JPEG, "image/jpeg")
+        replace_track_art(conn, tid, [(art_id, 3, "")])
+        before_cv = conn.execute(
+            "SELECT content_version FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+        # 999999 has no row in `art`: the INSERT (after the DELETE) trips the FK.
+        with pytest.raises(sqlite3.IntegrityError):
+            replace_track_art(conn, tid, [(999999, 3, "")])
+        rows = conn.execute(
+            "SELECT art_id, picture_type, ordinal FROM track_art WHERE track_id = ?", (tid,)
+        ).fetchall()
+        after_cv = conn.execute(
+            "SELECT content_version FROM tracks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    # The DELETE + the content_version trigger bump both rolled back with the FK failure.
+    assert rows == [(art_id, 3, 0)]
+    assert after_cv == before_cv
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py::test_replace_track_art_atomic_on_fk_violation -q`
+Expected: FAIL — `pytest.raises(IntegrityError)` is satisfied, but the assertions fail: today the DELETE already committed (autocommit), so `rows == []` and `after_cv != before_cv`.
+
+- [ ] **Step 3: Wrap `replace_track_art`**
+
+Replace the body of `replace_track_art` (`store.py:135-147`) with:
+
+```python
+def replace_track_art(conn, track_id, arts):
+    """Replace the track's art rows. ``arts`` is an ordered list of
+    ``(art_id, picture_type, description)``; each row's ``ordinal`` is its
+    list index.
+
+    Atomic via an internal savepoint (see ``_savepoint``): the DELETE and the
+    re-insert either both land or neither does, even on an autocommit
+    connection."""
+    with _savepoint(conn, "musefs_replace_track_art"):
+        conn.execute("DELETE FROM track_art WHERE track_id = ?", (track_id,))
+        conn.executemany(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, "
+            "ordinal) VALUES (?, ?, ?, ?, ?)",
+            [
+                (track_id, art_id, picture_type, description, i)
+                for i, (art_id, picture_type, description) in enumerate(arts)
+            ],
+        )
+```
+
+- [ ] **Step 4: Run the test + full suite**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py -q && python3 -m pytest -q`
+Expected: atomicity tests PASS; full suite **60 passed**.
+
+- [ ] **Step 5: Lint (auto-fix, then verify)**
+
+Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
+Expected: the final two commands report no errors. Re-stage any files ruff touched.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py
+git commit -m "fix(contrib): make replace_track_art atomic via savepoint (#191)"
+```
+
+---
+
+## Task 4: Whole-record atomicity in `sync_one` (approach C)
+
+**Files:**
+- Modify: `contrib/python-musefs/src/musefs_common/sync.py` (import at `:6`; wrap the `sync_one` write block at `:68-78`)
+- Test: `contrib/python-musefs/tests/test_atomicity.py` (add three tests + imports)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test_atomicity.py`, extend the imports and append the tests. Note `ArtImage`, `Record`, `SyncStats`, `sync_files`, `sync_one` are all exported from `musefs_common`.
+
+```python
+from musefs_common import (
+    ArtImage,
+    Record,
+    SyncStats,
+    connect,
+    merge_tags,
+    replace_tags,
+    replace_track_art,
+    sync_files,
+    sync_one,
+    upsert_art,
+)
+```
+
+```python
+def test_sync_one_whole_record_atomic_on_autocommit(db_path):
+    # On an autocommit connection, if art linking fails the tags written earlier
+    # in the same record must roll back too (record is all-or-nothing).
+    conn = _autocommit(db_path, factory=_FailInsert)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        # _FailInsert fails the FIRST insert executemany once fail=True. In
+        # sync_one the tag INSERT runs before the art INSERT, so to target the
+        # art step specifically we let tags write, then fail on the art INSERT.
+        conn.fail = "art"  # sentinel handled below
+        with pytest.raises(RuntimeError):
+            sync_one(
+                conn,
+                Record(key="/m/a.flac", pairs=[("title", "T")], art=[ArtImage(JPEG, "image/jpeg")]),
+                SyncStats(),
+            )
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {}
+        assert check.execute("SELECT COUNT(*) FROM track_art").fetchone()[0] == 0
+    finally:
+        check.close()
+
+
+def test_sync_files_deferred_batch_commits_atomically(db_path):
+    # Shipped beets-style path: deferred mode, several records, one final commit.
+    conn = connect(db_path)
+    try:
+        insert_track(conn, "/m/a.flac")
+        insert_track(conn, "/m/b.flac")
+        conn.commit()
+        records = [
+            Record(key="/m/a.flac", pairs=[("title", "A")]),
+            Record(key="/m/b.flac", pairs=[("title", "B")]),
+        ]
+        stats = sync_files(conn, records)
+        assert stats.synced == 2
+        conn.commit()
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        got = {
+            path: check.execute(
+                "SELECT value FROM tags t JOIN tracks tr ON tr.id = t.track_id "
+                "WHERE tr.backing_path = ? AND t.key = 'title'",
+                (path,),
+            ).fetchone()[0]
+            for path in ("/m/a.flac", "/m/b.flac")
+        }
+        assert got == {"/m/a.flac": "A", "/m/b.flac": "B"}
+    finally:
+        check.close()
+
+
+def test_sync_files_deferred_batch_rolls_back_as_unit(db_path):
+    # Deferred mode: per-record savepoints must NOT self-commit, so a caller
+    # rollback abandons the whole batch.
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/a.flac")
+        conn.commit()
+        sync_one(conn, Record(key="/m/a.flac", pairs=[("title", "A")]), SyncStats())
+        conn.rollback()  # caller abandons the batch after the write
+    finally:
+        conn.close()
+    check = connect(db_path)
+    try:
+        assert text_tags(check, tid) == {}
+    finally:
+        check.close()
+```
+
+The first test references `conn.fail = "art"`; update `_FailInsert` to honor it so only the **art** INSERT fails (tags still write). Replace the class body with:
+
+```python
+class _FailInsert(sqlite3.Connection):
+    """Connection that raises on a chosen INSERT executemany, to enter a
+    DELETE-then-INSERT torn window deterministically. ``fail`` may be:
+    False (never), True (any INSERT), or "art" (only the track_art INSERT)."""
+
+    fail = False
+
+    def executemany(self, sql, parameters):
+        upper = sql.lstrip().upper()
+        if upper.startswith("INSERT"):
+            if self.fail is True or (self.fail == "art" and "TRACK_ART" in upper):
+                raise RuntimeError("boom")
+        return super().executemany(sql, parameters)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py -q`
+Expected: `test_sync_one_whole_record_atomic_on_autocommit` FAILS — without C, the tag write autocommitted before the art INSERT crashed, so `text_tags` is `{"title": ["T"]}` not `{}`. The two `sync_files` deferred tests pass already (deferred mode never had the leak when the caller commits/rolls back as one unit), but they are kept as permanent guards against a future per-record self-commit regression.
+
+- [ ] **Step 3: Wrap the `sync_one` write block**
+
+In `sync.py`, add `_savepoint` to the store import (`sync.py:6`):
+
+```python
+from .store import (
+    _savepoint,
+    merge_tags,
+    replace_tags,
+    replace_track_art,
+    track_id_for_path,
+    upsert_art,
+)
+```
+
+Then wrap the existing `if not dry_run:` block (`sync.py:68-78`). Replace:
+
+```python
+    if not dry_run:
+        if merge:
+            merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+        else:
+            replace_tags(conn, track_id, record.pairs)
+        if will_link_art:
+            arts = [
+                (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
+                for img in kept
+            ]
+            replace_track_art(conn, track_id, arts)
+```
+
+with:
+
+```python
+    if not dry_run:
+        with _savepoint(conn, "musefs_sync_one"):
+            if merge:
+                merge_tags(conn, track_id, record.pairs, record.delete_keys or [])
+            else:
+                replace_tags(conn, track_id, record.pairs)
+            if will_link_art:
+                arts = [
+                    (upsert_art(conn, img.data, img.mime), img.picture_type, img.description)
+                    for img in kept
+                ]
+                replace_track_art(conn, track_id, arts)
+```
+
+- [ ] **Step 4: Run the tests + full suite**
+
+Run: `cd contrib/python-musefs && python3 -m pytest tests/test_atomicity.py -q && python3 -m pytest -q`
+Expected: all atomicity tests PASS; full suite **63 passed** (60 + 3 new).
+
+- [ ] **Step 5: Lint (auto-fix, then verify)**
+
+Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
+Expected: the final two commands report no errors. Re-stage any files ruff touched. (Importing the underscore-prefixed `_savepoint` across modules is fine; ruff's `F401`/`N` rules don't object to a used private import.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/python-musefs/src/musefs_common/sync.py contrib/python-musefs/tests/test_atomicity.py
+git commit -m "fix(contrib): make sync_one record write atomic via savepoint (#191)"
+```
+
+---
+
+## Task 5: Document the contract guarantee in `ARCHITECTURE.md`
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (the "The external-writer contract" section, the paragraph beginning "The shared Python library", around `:167`)
+
+This is a docs-only commit (the cargo gate is skipped), so no test step.
+
+- [ ] **Step 1: Add the atomicity sentence**
+
+Find this sentence (`ARCHITECTURE.md:167-170`):
+
+```
+The shared Python library (`contrib/python-musefs/`) encodes this contract
+for plugin authors, including a generated copy of the schema
+(`musefs_common/schema.py`, regenerated from `schema.rs` by a drift-guarded
+test — see [CONTRIBUTING](CONTRIBUTING.md)).
+```
+
+Append one sentence to that paragraph, immediately after the `see [CONTRIBUTING](CONTRIBUTING.md)).` clause and before ` The [Lidarr integration]`:
+
+```
+ Its tag/art replace operations each wrap their `DELETE`+`INSERT` in a SQLite
+savepoint, so they are individually atomic and the "caller owns the transaction"
+guarantee holds even on an autocommit connection.
+```
+
+- [ ] **Step 2: Verify the prose reads correctly**
+
+Run: `cd /home/cfutro/git/musefs && git diff ARCHITECTURE.md`
+Expected: the new sentence sits inside the "shared Python library" paragraph; no stray formatting.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md
+git commit -m "docs: note contrib store replace ops are savepoint-atomic (#191)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full Python suite green**
+
+Run: `cd contrib/python-musefs && python3 -m pytest -q`
+Expected: **63 passed**.
+
+- [ ] **Step 2: Lint clean**
+
+Run: `cd /home/cfutro/git/musefs && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
+Expected: no errors.
+
+- [ ] **Step 3: Confirm the fuzz/contract jobs are unaffected**
+
+No Rust signatures changed and no schema change was made, so the `fuzz/` crate and the schema-mirror regen are untouched. No action needed — just confirm `git status` shows only the four files from this plan were modified.
+
+- [ ] **Step 4 (optional): cross-version sanity on the 3.8 floor**
+
+The helper's behavior is mode- and version-sensitive in principle. If a 3.8 interpreter is available, run the suite under it: `cd contrib/python-musefs && python3.8 -m pytest -q`. (Behavior was confirmed stable on CPython 3.8/3.11/3.12/3.14 during design.)
+
+---
+
+## Spec coverage check
+
+- Approach **A** (per-function savepoints): Tasks 1 (`replace_tags`), 2 (`merge_tags`), 3 (`replace_track_art`). ✓
+- Approach **C** (whole-record savepoint in `sync_one`, wrapping the entire `if not dry_run:` body incl. `upsert_art`): Task 4. ✓
+- `_savepoint` helper with `owns`-guard + mode detection: Task 1. ✓
+- Legacy-mode trap guard test: Task 1 (`...no_premature_commit_in_deferred_mode`). ✓
+- FK-on test setup + assert `IntegrityError` fires: Task 3. ✓
+- Whole-record autocommit atomicity + deferred batch atomicity tests: Task 4. ✓
+- Docstring updates on all four functions: Tasks 1–4. ✓
+- `ARCHITECTURE.md` contract sentence: Task 5. ✓
+- Non-goals respected: no Python version bump, no `connect()` enforcement, no cross-record atomicity. ✓

--- a/docs/superpowers/plans/2026-06-11-contrib-store-savepoint-atomicity.md
+++ b/docs/superpowers/plans/2026-06-11-contrib-store-savepoint-atomicity.md
@@ -19,6 +19,7 @@
 - **Run the Python suite from the package dir:** `cd contrib/python-musefs` then `python3 -m pytest -q`. The baseline is **56 passed**.
 - **Why `sqlite3.Connection` can't be monkeypatched:** instances disallow attribute assignment, so failure-injection tests use a `Connection` *subclass* via `factory=` (provided in Task 1's test file) rather than `monkeypatch.setattr(conn, "executemany", ...)`.
 - **Autocommit test connections** must enable foreign keys *and* switch to autocommit: open the connection, `PRAGMA foreign_keys = ON`, then set `conn.isolation_level = None`. A bare `sqlite3.connect(path, isolation_level=None)` leaves FKs off and would make the FK-violation test a silent no-op.
+- **Picard vendors a byte-identical copy of the library.** `contrib/picard/musefs/_common/` holds generated copies of every `musefs_common/*.py` (Picard can't pip-install deps). After changing canonical `store.py`/`sync.py` you MUST re-vendor with `python3 contrib/python-musefs/vendor_to_picard.py` and stage the regenerated `_common/` file(s); otherwise `contrib/picard/tests/test_vendor_sync.py` fails CI **and the #191 fix never reaches the Picard consumer**. The pre-commit hook does NOT run pytest (only cargo + ruff), so it will not catch drift — re-vendoring is on you. The regenerated files are byte-identical to canonical plus a 3-line `# GENERATED …` header, so they stay ruff-clean. Each task below that edits canonical includes a re-vendor step.
 
 ## File structure
 
@@ -27,6 +28,7 @@
 | `contrib/python-musefs/src/musefs_common/store.py` | the store contract: connect, schema check, tag/art writes | Add `_savepoint`/`_is_autocommit`/`_is_legacy`; wrap three functions; docstrings |
 | `contrib/python-musefs/src/musefs_common/sync.py` | per-file sync write-loop | Import `_savepoint`; wrap the `sync_one` write block |
 | `contrib/python-musefs/tests/test_atomicity.py` | **new** — atomicity/rollback tests for A and C | Create, grow across Tasks 1–4 |
+| `contrib/picard/musefs/_common/{store,sync}.py` | vendored byte-identical copy for Picard | Regenerated via `vendor_to_picard.py` in each canonical-changing task |
 | `ARCHITECTURE.md` | external-writer contract docs | One sentence in the contract section |
 
 ---
@@ -130,7 +132,9 @@ import sqlite3
 Then insert these definitions immediately before `def connect(` (currently `store.py:9`):
 
 ```python
-_LEGACY = sqlite3.LEGACY_TRANSACTION_CONTROL  # == -1; the getattr default for <3.12
+# sqlite3.LEGACY_TRANSACTION_CONTROL is 3.12+; it is == -1. Use getattr so this
+# module still imports on the 3.8 floor (where the constant does not exist).
+_LEGACY = getattr(sqlite3, "LEGACY_TRANSACTION_CONTROL", -1)
 
 
 def _is_autocommit(conn):
@@ -227,10 +231,15 @@ The hook enforces ruff's import-sorting (`I`) and formatting, so let ruff arrang
 Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
 Expected: the first two commands may rewrite imports/formatting; the final two report no errors. Re-stage any files ruff touched.
 
-- [ ] **Step 7: Commit** (runs the full pre-commit hook incl. the Rust suite)
+- [ ] **Step 7: Re-vendor to Picard**
+
+Run: `cd /home/cfutro/git/musefs && python3 contrib/python-musefs/vendor_to_picard.py`
+This regenerates `contrib/picard/musefs/_common/store.py` (byte-identical to canonical + a 3-line header). Confirm it changed: `git status --short contrib/picard/musefs/_common/`.
+
+- [ ] **Step 8: Commit** (runs the full pre-commit hook incl. the Rust suite)
 
 ```bash
-git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py
+git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py contrib/picard/musefs/_common/store.py
 git commit -m "fix(contrib): make replace_tags atomic via savepoint (#191)"
 ```
 
@@ -327,10 +336,15 @@ Expected: atomicity tests PASS; full suite **59 passed**.
 Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
 Expected: the final two commands report no errors. Re-stage any files ruff touched.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Re-vendor to Picard**
+
+Run: `cd /home/cfutro/git/musefs && python3 contrib/python-musefs/vendor_to_picard.py`
+Regenerates `contrib/picard/musefs/_common/store.py`. Confirm: `git status --short contrib/picard/musefs/_common/`.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py
+git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py contrib/picard/musefs/_common/store.py
 git commit -m "fix(contrib): make merge_tags atomic via savepoint (#191)"
 ```
 
@@ -417,10 +431,15 @@ Expected: atomicity tests PASS; full suite **60 passed**.
 Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
 Expected: the final two commands report no errors. Re-stage any files ruff touched.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Re-vendor to Picard**
+
+Run: `cd /home/cfutro/git/musefs && python3 contrib/python-musefs/vendor_to_picard.py`
+Regenerates `contrib/picard/musefs/_common/store.py`. Confirm: `git status --short contrib/picard/musefs/_common/`.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py
+git add contrib/python-musefs/src/musefs_common/store.py contrib/python-musefs/tests/test_atomicity.py contrib/picard/musefs/_common/store.py
 git commit -m "fix(contrib): make replace_track_art atomic via savepoint (#191)"
 ```
 
@@ -608,10 +627,15 @@ Expected: all atomicity tests PASS; full suite **63 passed** (60 + 3 new).
 Run: `cd /home/cfutro/git/musefs && ruff check --fix contrib/python-musefs/ && ruff format contrib/python-musefs/ && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
 Expected: the final two commands report no errors. Re-stage any files ruff touched. (Importing the underscore-prefixed `_savepoint` across modules is fine; ruff's `F401`/`N` rules don't object to a used private import.)
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Re-vendor to Picard**
+
+Run: `cd /home/cfutro/git/musefs && python3 contrib/python-musefs/vendor_to_picard.py`
+Regenerates `contrib/picard/musefs/_common/sync.py` (this task changed `sync.py`). Confirm: `git status --short contrib/picard/musefs/_common/`.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add contrib/python-musefs/src/musefs_common/sync.py contrib/python-musefs/tests/test_atomicity.py
+git add contrib/python-musefs/src/musefs_common/sync.py contrib/python-musefs/tests/test_atomicity.py contrib/picard/musefs/_common/sync.py
 git commit -m "fix(contrib): make sync_one record write atomic via savepoint (#191)"
 ```
 
@@ -669,11 +693,16 @@ Expected: **63 passed**.
 Run: `cd /home/cfutro/git/musefs && ruff check contrib/python-musefs/ && ruff format --check contrib/python-musefs/`
 Expected: no errors.
 
-- [ ] **Step 3: Confirm the fuzz/contract jobs are unaffected**
+- [ ] **Step 3: Picard vendored copy is in sync**
 
-No Rust signatures changed and no schema change was made, so the `fuzz/` crate and the schema-mirror regen are untouched. No action needed — just confirm `git status` shows only the four files from this plan were modified.
+Run: `cd /home/cfutro/git/musefs && python3 contrib/python-musefs/vendor_to_picard.py && python3 -m pytest contrib/picard/tests/test_vendor_sync.py -q`
+Expected: the vendor run produces no further `git status` changes under `contrib/picard/musefs/_common/` (already re-vendored per task), and `test_vendor_sync.py` reports **2 passed** (file-set matches + bodies byte-identical). This test only imports `pathlib`, so it runs without the Picard/Qt environment.
 
-- [ ] **Step 4 (optional): cross-version sanity on the 3.8 floor**
+- [ ] **Step 4: Confirm scope of changes**
+
+No Rust signatures changed and no schema change was made, so the `fuzz/` crate and the schema-mirror regen are untouched. Confirm `git status` across the whole feature branch shows exactly: `store.py`, `sync.py`, `tests/test_atomicity.py`, `contrib/picard/musefs/_common/store.py`, `contrib/picard/musefs/_common/sync.py`, and `ARCHITECTURE.md` — six files, nothing else.
+
+- [ ] **Step 5 (optional): cross-version sanity on the 3.8 floor**
 
 The helper's behavior is mode- and version-sensitive in principle. If a 3.8 interpreter is available, run the suite under it: `cd contrib/python-musefs && python3.8 -m pytest -q`. (Behavior was confirmed stable on CPython 3.8/3.11/3.12/3.14 during design.)
 
@@ -688,5 +717,6 @@ The helper's behavior is mode- and version-sensitive in principle. If a 3.8 inte
 - FK-on test setup + assert `IntegrityError` fires: Task 3. ✓
 - Whole-record autocommit atomicity + deferred batch atomicity tests: Task 4. ✓
 - Docstring updates on all four functions: Tasks 1–4. ✓
+- Picard re-vendor (propagates the fix to the vendored consumer + satisfies the drift guard): Tasks 1–4 + final verification. ✓
 - `ARCHITECTURE.md` contract sentence: Task 5. ✓
 - Non-goals respected: no Python version bump, no `connect()` enforcement, no cross-record atomicity. ✓

--- a/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
+++ b/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
@@ -40,36 +40,111 @@ no premature commits, and `sync_one`'s `dry_run` rollback still works.
   defend a consumer who flips autocommit or brings their own connection.
   Out of scope.
 
+## Transaction semantics: the two modes
+
+A single helper must serve two caller classes with *different* desired
+behavior, and the helper picks behavior from the connection's autocommit
+setting:
+
+- **Caller-managed connection** (the shipped contract: deferred legacy mode, or
+  3.12+ `autocommit=False`): the helper must make its block atomic via a nested
+  `SAVEPOINT` and **never** commit or roll back the enclosing transaction. The
+  caller's eventual single `commit()`/`rollback()` governs. This preserves
+  batch atomicity (beets syncs N records then commits once) and `dry_run`
+  rollback.
+- **Autocommit connection** (`isolation_level=None`, or 3.12+
+  `autocommit=True`): no one else will commit, so the helper **owns** a
+  transaction for the operation — `commit()` on success, `rollback()` on
+  failure — making the `DELETE`+`INSERT` atomic and durable.
+
+### The legacy-mode trap (why a bare savepoint is wrong)
+
+Python's `sqlite3` in **legacy mode** (`isolation_level=""`, the default that
+`connect()` at `store.py:11` returns) auto-issues an implicit `BEGIN` *only*
+before `INSERT`/`UPDATE`/`DELETE`/`REPLACE` — **not** before `SAVEPOINT`. So a
+`SAVEPOINT` issued as the *first* write of a batch becomes the **outermost**
+transaction, and its matching `RELEASE` **commits durably**. A later caller
+`rollback()` then no-ops. Verified empirically on CPython 3.8, 3.11, 3.12, and
+3.14.
+
+Concrete impact on the shipped beets path (`musefs.py:221-238`): `connect()`
+(legacy) → `check_schema_version()` (a `PRAGMA` *read*, opens no transaction) →
+`sync_files`. A naive savepoint in the first `sync_one` would be the first
+write, so `RELEASE` commits that record durably; every later record then
+self-commits too. beets' final `conn.commit()` becomes a no-op, **batch
+atomicity is lost**, and records are committed *before* `persist_managed` runs.
+(beets `dry_run` is unaffected either way — it skips the write block at
+`sync.py:68`, so no savepoint is opened.)
+
+The fix: in legacy mode, force an explicit `BEGIN` when no transaction is open,
+so the `SAVEPOINT` *nests* instead of becoming the outermost. PEP-249 modes
+(3.12+ `autocommit` attribute) auto-begin before any statement, so they need no
+such nudge.
+
 ## Core mechanism: a savepoint context manager
 
-A single private helper in `store.py`, used at all sites. `SAVEPOINT` nests
-inside the caller's transaction *without committing it*, and self-commits only
-when there is no enclosing transaction (the direct-autocommit-caller case).
+A single private helper in `store.py`, used at all sites:
 
 ```python
 import contextlib
+import sqlite3
+
+_LEGACY = sqlite3.LEGACY_TRANSACTION_CONTROL  # == -1; absent-attr fallback below
+
+def _is_autocommit(conn):
+    ac = getattr(conn, "autocommit", _LEGACY)  # 3.12+ attribute; _LEGACY on <3.12
+    if ac is True:
+        return True
+    if ac is False:
+        return False
+    return conn.isolation_level is None  # legacy control: None == autocommit
+
+def _is_legacy(conn):
+    return getattr(conn, "autocommit", _LEGACY) == _LEGACY
 
 @contextlib.contextmanager
 def _savepoint(conn, name):
-    """Make a block atomic within the caller's transaction. Nests harmlessly
-    inside a caller-owned transaction (RELEASE merges, does not commit); on an
-    autocommit connection the outermost savepoint provides the atomic unit."""
+    """Make a DELETE+INSERT block atomic regardless of the connection's
+    transaction mode. On a caller-managed connection it nests via SAVEPOINT and
+    never commits the enclosing transaction; on an autocommit connection it owns
+    a transaction for the block (commit on success, rollback on failure)."""
+    autocommit = _is_autocommit(conn)
+    # Legacy mode never auto-BEGINs before SAVEPOINT, so a savepoint opened as
+    # the first statement would become the outermost txn and commit on RELEASE.
+    # Force a nesting BEGIN there. PEP-249 modes auto-begin already.
+    if _is_legacy(conn) and (autocommit or not conn.in_transaction):
+        conn.execute("BEGIN")
     conn.execute(f"SAVEPOINT {name}")
     try:
         yield
     except BaseException:
-        conn.execute(f"ROLLBACK TO {name}")
-        conn.execute(f"RELEASE {name}")
+        try:
+            conn.execute(f"ROLLBACK TO {name}")
+            conn.execute(f"RELEASE {name}")
+            if autocommit:
+                conn.rollback()
+        except sqlite3.Error:
+            pass  # never mask the original exception with a cleanup failure
         raise
     else:
         conn.execute(f"RELEASE {name}")
+        if autocommit:
+            conn.commit()
 ```
 
 - `name` is a fixed, hardcoded identifier per call site (no user input → no
   injection). Distinct names per site keep nested `RELEASE`/`ROLLBACK TO`
   unambiguous.
 - `ROLLBACK TO` does not pop the savepoint from the stack, so the error path
-  must also `RELEASE` it before re-raising.
+  also `RELEASE`s it before re-raising.
+- The error-path cleanup is wrapped so that a secondary `sqlite3.Error` (e.g. a
+  savepoint already discarded by a `SQLITE_BUSY`/`SQLITE_FULL` auto-rollback)
+  cannot mask the original failure.
+
+This is verified across all relevant scenarios (see Testing): legacy
+deferred batch + single commit, legacy deferred first-statement + caller
+rollback (the trap), legacy autocommit success/failure, and 3.12+
+`autocommit=True`/`False`.
 
 ## A — per-function atomicity (`store.py`)
 
@@ -85,21 +160,30 @@ Defends anyone calling these directly on an autocommit connection — exactly
 
 ## C — whole-record atomicity (`sync.py`)
 
-In `sync_one`, wrap the `if not dry_run:` write block — the
-`merge_tags`/`replace_tags` call *plus* the `replace_track_art` call — in
-`_savepoint(conn, "musefs_sync_one")`. This closes the "tags replaced, then
-crash before art" gap *between* the two function calls for an autocommit sync
-caller. It nests cleanly over A's inner savepoints. `dry_run` is unaffected:
-it skips the write block, so no savepoint is opened.
+In `sync_one`, wrap the **entire** `if not dry_run:` write block in
+`_savepoint(conn, "musefs_sync_one")` — that means everything inside it: the
+`merge_tags`/`replace_tags` call, the `upsert_art` blob inserts, *and* the
+`replace_track_art` call (`sync.py:69-78`). This closes the "tags replaced,
+then crash before art" gap *between* those calls for an autocommit sync caller,
+and rolls back any content-addressed art inserted via `upsert_art` if the
+record fails. It nests cleanly over A's inner savepoints. `dry_run` is
+unaffected: it skips the write block, so no savepoint is opened.
 
 `_savepoint` is imported into `sync.py` from `store`.
 
-## Behavior on the shipped paths (unchanged)
+## Behavior on the shipped paths
 
-beets `_sync` and Picard run in default deferred mode with one final `commit()`.
-The new savepoints nest inside their open transaction and `RELEASE` merges into
-it — still one commit, same outcome. No behavior change; only added robustness
-for autocommit/direct callers.
+beets `_sync` and Picard run in default deferred (legacy) mode with one final
+`commit()`. With the corrected helper, the first wrapped call issues an explicit
+`BEGIN` (because no transaction is open yet — `check_schema_version` is only a
+read), and every savepoint thereafter nests inside that one transaction and
+`RELEASE`s without committing. The caller's single `commit()` (or, for beets
+`dry_run`/error, `rollback()`) still governs the whole batch — **batch
+atomicity is preserved** and records are still committed only after
+`persist_managed` is reached. The only observable change is that the
+previously-implicit transaction is now opened by an explicit `BEGIN`; the commit
+boundary is identical. Added robustness accrues only to autocommit/direct
+callers.
 
 ## Docs
 
@@ -115,34 +199,58 @@ for autocommit/direct callers.
 `contrib/python-musefs/tests/`, pytest, using the existing fixtures/helpers
 (`db_path`, `make_track`, `text_tags`, `musefs_connect`). TDD — tests first.
 
-1. **`replace_track_art` atomicity (natural failure):** seed art + `track_art`,
-   then call with an `art_id` absent from `art` → FK violation on the `INSERT`
-   *after* the `DELETE`. On an autocommit connection (`isolation_level=None`),
-   assert the original `track_art` rows survive.
+All test connections that exercise autocommit must be opened via the project's
+`connect()` (which sets `PRAGMA foreign_keys = ON`) and *then* switched to
+autocommit (`conn.isolation_level = None`), **not** via a bare
+`sqlite3.connect(..., isolation_level=None)` — the latter leaves FKs off, which
+silently neuters test 1.
+
+1. **`replace_track_art` atomicity (natural FK failure):** seed art +
+   `track_art`, then call with an `art_id` absent from `art`. With
+   `foreign_keys = ON`, the `INSERT` *after* the `DELETE` raises
+   `sqlite3.IntegrityError`. On an autocommit connection assert (a) the call
+   raised `IntegrityError` (so the torn window was genuinely entered — guards
+   against a future FK-off regression turning this into a no-op) **and** (b) the
+   original `track_art` rows survive.
 2. **`replace_tags` atomicity:** seed tags; force the `executemany` to raise
    (monkeypatch) on an autocommit connection; assert original text tags survive
-   and binary tags are untouched.
+   and binary tags (`value_blob NOT NULL`) are untouched.
 3. **`merge_tags` atomicity:** same shape — failure leaves the pre-existing
    managed + unmanaged rows intact.
 4. **C whole-record atomicity:** `sync_one` on an autocommit connection where
    art linking fails → assert tags *also* rolled back (record is all-or-nothing).
-5. **No premature commit (regression):** in deferred mode, call `replace_tags`
-   then `conn.rollback()`; assert nothing persisted — proves the savepoint did
-   not commit the caller's transaction.
-6. **Happy path unchanged:** existing `test_sync.py`, `test_store_art.py`,
+5. **The legacy-mode trap guard (primary regression test):** in default
+   deferred mode, call `replace_tags`, then `conn.rollback()`; assert nothing
+   persisted (check via a second connection). This is the exact scenario that
+   fails against a *bare* savepoint helper, so it is the guard that proves the
+   nesting `BEGIN` is in place and the caller's rollback still wins.
+6. **Deferred batch atomicity:** in deferred mode, sync several records via
+   `sync_files`, then a single `conn.commit()`; assert all persist — and a
+   variant where a mid-batch record fails and the caller `rollback()`s leaves
+   *nothing* persisted (proves no per-record premature commit).
+7. **Happy path unchanged:** existing `test_sync.py`, `test_store_art.py`,
    `test_merge_tags.py` continue to pass.
+
+The helper's mode-handling is version-sensitive in principle (legacy vs. 3.12+
+PEP-249 attribute), so the implementation plan should note running the suite on
+the 3.8 floor in addition to the dev interpreter. The behavior was confirmed
+stable on CPython 3.8/3.11/3.12/3.14 during design.
 
 ## Scope / non-goals
 
-- No Python version bump (stays `>=3.8`; savepoints are portable).
+- No Python version bump (stays `>=3.8`). The SQL `SAVEPOINT` statement is
+  portable; the Python `sqlite3` *driver's* transaction management around it is
+  **not** uniform across modes, which is exactly why the helper detects the
+  connection mode rather than assuming nesting.
 - No connection-level autocommit enforcement in `connect()`.
 - No batch-level (cross-record) atomicity — that remains the caller's
   transaction to own.
 
 ## Files touched
 
-- `contrib/python-musefs/src/musefs_common/store.py` — `_savepoint` helper +
-  wrap three functions + docstrings.
+- `contrib/python-musefs/src/musefs_common/store.py` — `_savepoint` helper
+  (plus `_is_autocommit`/`_is_legacy` mode detection) + wrap three functions +
+  docstrings.
 - `contrib/python-musefs/src/musefs_common/sync.py` — import `_savepoint`, wrap
   `sync_one` write block.
 - `ARCHITECTURE.md` — one sentence in the external-writer contract section.

--- a/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
+++ b/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
@@ -89,7 +89,7 @@ A single private helper in `store.py`, used at all sites:
 import contextlib
 import sqlite3
 
-_LEGACY = sqlite3.LEGACY_TRANSACTION_CONTROL  # == -1; absent-attr fallback below
+_LEGACY = getattr(sqlite3, "LEGACY_TRANSACTION_CONTROL", -1)  # 3.12+ const; == -1, absent on <3.12
 
 def _is_autocommit(conn):
     ac = getattr(conn, "autocommit", _LEGACY)  # 3.12+ attribute; _LEGACY on <3.12
@@ -264,5 +264,10 @@ stable on CPython 3.8/3.11/3.12/3.14 during design.
   docstrings.
 - `contrib/python-musefs/src/musefs_common/sync.py` — import `_savepoint`, wrap
   `sync_one` write block.
+- `contrib/picard/musefs/_common/{store,sync}.py` — **regenerated** by running
+  `contrib/python-musefs/vendor_to_picard.py`. Picard does not pip-install the
+  library; it vendors a byte-identical copy, and `contrib/picard/tests/
+  test_vendor_sync.py` fails CI if the canonical lib changes without re-vendoring.
+  This is also what propagates the #191 fix to the Picard consumer.
 - `ARCHITECTURE.md` — one sentence in the external-writer contract section.
 - `contrib/python-musefs/tests/` — new atomicity tests.

--- a/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
+++ b/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
@@ -1,0 +1,149 @@
+# Design: Harden contrib store mutations against torn DELETE+INSERT state (#191)
+
+## Problem
+
+`replace_tags`, `merge_tags`, and `replace_track_art` in
+`contrib/python-musefs/src/musefs_common/store.py` each perform a `DELETE`
+followed by an `executemany` `INSERT` with no transaction of their own. They
+rely entirely on the load-bearing **"caller owns the transaction"** contract
+(`sync.py`). The shipped callers (beets `_sync`, Picard) are safe: they run in
+Python's default deferred mode and `commit()` once at the end, so a crash
+before that commit rolls back cleanly.
+
+The torn-state window opens only for a consumer that deliberately uses an
+autocommit connection (`isolation_level=None` / `autocommit=True`) or calls
+these functions directly on one: a crash between the `DELETE` and the `INSERT`
+leaves a track with its tags/art wiped and not replaced until the next sync or
+scan. The contract is undefended against autocommit consumers.
+
+This library is the external-writer contract for plugin authors
+(beets/Picard/Lidarr), so a documented-only footgun is too weak; we defend it.
+
+## Goal & invariant
+
+Make the destructive replace operations atomic regardless of the connection's
+transaction mode, while preserving the "caller owns the transaction" contract:
+no premature commits, and `sync_one`'s `dry_run` rollback still works.
+
+## Why not other approaches
+
+- **Require Python >= 3.12 / use the `autocommit` attribute.** Buys nothing for
+  atomicity (autocommit-mode connections still exist in 3.12) and the correct
+  primitive is still `SAVEPOINT`. Drops 3.8-3.11 — a real adoption cost for a
+  plugin-author library whose consumers (and Picard's bundled runtime) are often
+  on older Pythons. Rejected.
+- **`with conn:` transaction context manager.** Wrong on every version: it
+  *commits* at block exit, which violates "caller owns the transaction" (commits
+  the caller's in-progress batch early) and breaks `dry_run` rollback.
+- **Connection-level enforcement in `connect()`** (e.g. force
+  `autocommit=False`). Doesn't make the functions internally atomic and doesn't
+  defend a consumer who flips autocommit or brings their own connection.
+  Out of scope.
+
+## Core mechanism: a savepoint context manager
+
+A single private helper in `store.py`, used at all sites. `SAVEPOINT` nests
+inside the caller's transaction *without committing it*, and self-commits only
+when there is no enclosing transaction (the direct-autocommit-caller case).
+
+```python
+import contextlib
+
+@contextlib.contextmanager
+def _savepoint(conn, name):
+    """Make a block atomic within the caller's transaction. Nests harmlessly
+    inside a caller-owned transaction (RELEASE merges, does not commit); on an
+    autocommit connection the outermost savepoint provides the atomic unit."""
+    conn.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        conn.execute(f"ROLLBACK TO {name}")
+        conn.execute(f"RELEASE {name}")
+        raise
+    else:
+        conn.execute(f"RELEASE {name}")
+```
+
+- `name` is a fixed, hardcoded identifier per call site (no user input → no
+  injection). Distinct names per site keep nested `RELEASE`/`ROLLBACK TO`
+  unambiguous.
+- `ROLLBACK TO` does not pop the savepoint from the stack, so the error path
+  must also `RELEASE` it before re-raising.
+
+## A — per-function atomicity (`store.py`)
+
+Wrap the `DELETE`+`INSERT` body of each function in `_savepoint`:
+
+- `replace_tags` → `_savepoint(conn, "musefs_replace_tags")`
+- `merge_tags` → `_savepoint(conn, "musefs_merge_tags")` (same pattern; folded
+  in even though #191 names only the other two)
+- `replace_track_art` → `_savepoint(conn, "musefs_replace_track_art")`
+
+Defends anyone calling these directly on an autocommit connection — exactly
+#191's stated exposure.
+
+## C — whole-record atomicity (`sync.py`)
+
+In `sync_one`, wrap the `if not dry_run:` write block — the
+`merge_tags`/`replace_tags` call *plus* the `replace_track_art` call — in
+`_savepoint(conn, "musefs_sync_one")`. This closes the "tags replaced, then
+crash before art" gap *between* the two function calls for an autocommit sync
+caller. It nests cleanly over A's inner savepoints. `dry_run` is unaffected:
+it skips the write block, so no savepoint is opened.
+
+`_savepoint` is imported into `sync.py` from `store`.
+
+## Behavior on the shipped paths (unchanged)
+
+beets `_sync` and Picard run in default deferred mode with one final `commit()`.
+The new savepoints nest inside their open transaction and `RELEASE` merges into
+it — still one commit, same outcome. No behavior change; only added robustness
+for autocommit/direct callers.
+
+## Docs
+
+- Tighten the docstrings of the four functions: they run inside a caller-owned
+  transaction and are now individually atomic via an internal savepoint (so safe
+  on autocommit connections too).
+- Add one sentence to `ARCHITECTURE.md` §"The external-writer contract" noting
+  the library opens nested savepoints within the caller's transaction, so the
+  contract holds regardless of the caller's autocommit setting.
+
+## Testing
+
+`contrib/python-musefs/tests/`, pytest, using the existing fixtures/helpers
+(`db_path`, `make_track`, `text_tags`, `musefs_connect`). TDD — tests first.
+
+1. **`replace_track_art` atomicity (natural failure):** seed art + `track_art`,
+   then call with an `art_id` absent from `art` → FK violation on the `INSERT`
+   *after* the `DELETE`. On an autocommit connection (`isolation_level=None`),
+   assert the original `track_art` rows survive.
+2. **`replace_tags` atomicity:** seed tags; force the `executemany` to raise
+   (monkeypatch) on an autocommit connection; assert original text tags survive
+   and binary tags are untouched.
+3. **`merge_tags` atomicity:** same shape — failure leaves the pre-existing
+   managed + unmanaged rows intact.
+4. **C whole-record atomicity:** `sync_one` on an autocommit connection where
+   art linking fails → assert tags *also* rolled back (record is all-or-nothing).
+5. **No premature commit (regression):** in deferred mode, call `replace_tags`
+   then `conn.rollback()`; assert nothing persisted — proves the savepoint did
+   not commit the caller's transaction.
+6. **Happy path unchanged:** existing `test_sync.py`, `test_store_art.py`,
+   `test_merge_tags.py` continue to pass.
+
+## Scope / non-goals
+
+- No Python version bump (stays `>=3.8`; savepoints are portable).
+- No connection-level autocommit enforcement in `connect()`.
+- No batch-level (cross-record) atomicity — that remains the caller's
+  transaction to own.
+
+## Files touched
+
+- `contrib/python-musefs/src/musefs_common/store.py` — `_savepoint` helper +
+  wrap three functions + docstrings.
+- `contrib/python-musefs/src/musefs_common/sync.py` — import `_savepoint`, wrap
+  `sync_one` write block.
+- `ARCHITECTURE.md` — one sentence in the external-writer contract section.
+- `contrib/python-musefs/tests/` — new atomicity tests.

--- a/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
+++ b/docs/superpowers/specs/2026-06-11-contrib-store-savepoint-atomicity-design.md
@@ -106,13 +106,16 @@ def _is_legacy(conn):
 def _savepoint(conn, name):
     """Make a DELETE+INSERT block atomic regardless of the connection's
     transaction mode. On a caller-managed connection it nests via SAVEPOINT and
-    never commits the enclosing transaction; on an autocommit connection it owns
-    a transaction for the block (commit on success, rollback on failure)."""
+    never commits the enclosing transaction; on an autocommit connection the
+    *outermost* call owns a transaction for the block (commit on success,
+    rollback on failure). Nested calls (e.g. C's sync_one savepoint wrapping A's
+    per-function savepoints) only nest — they never BEGIN or commit."""
     autocommit = _is_autocommit(conn)
+    owns = not conn.in_transaction  # outermost call: it opens & owns the txn
     # Legacy mode never auto-BEGINs before SAVEPOINT, so a savepoint opened as
     # the first statement would become the outermost txn and commit on RELEASE.
     # Force a nesting BEGIN there. PEP-249 modes auto-begin already.
-    if _is_legacy(conn) and (autocommit or not conn.in_transaction):
+    if owns and _is_legacy(conn):
         conn.execute("BEGIN")
     conn.execute(f"SAVEPOINT {name}")
     try:
@@ -121,20 +124,27 @@ def _savepoint(conn, name):
         try:
             conn.execute(f"ROLLBACK TO {name}")
             conn.execute(f"RELEASE {name}")
-            if autocommit:
+            if owns and autocommit:
                 conn.rollback()
         except sqlite3.Error:
             pass  # never mask the original exception with a cleanup failure
         raise
     else:
         conn.execute(f"RELEASE {name}")
-        if autocommit:
+        if owns and autocommit:
             conn.commit()
 ```
 
 - `name` is a fixed, hardcoded identifier per call site (no user input → no
   injection). Distinct names per site keep nested `RELEASE`/`ROLLBACK TO`
   unambiguous.
+- **`owns` guard is load-bearing.** Only the outermost `_savepoint` (the one
+  that found no transaction open on entry) issues `BEGIN` and, in autocommit
+  mode, the final `commit()`/`rollback()`. Without it, C's `sync_one` savepoint
+  wrapping A's `replace_tags` savepoint on an autocommit connection would (a)
+  attempt a second `BEGIN` inside the open transaction and (b) let the inner
+  call `commit()` early — committing tags before art and destroying whole-record
+  atomicity. The inner calls must only nest.
 - `ROLLBACK TO` does not pop the savepoint from the stack, so the error path
   also `RELEASE`s it before re-raising.
 - The error-path cleanup is wrapped so that a secondary `sqlite3.Error` (e.g. a
@@ -143,8 +153,9 @@ def _savepoint(conn, name):
 
 This is verified across all relevant scenarios (see Testing): legacy
 deferred batch + single commit, legacy deferred first-statement + caller
-rollback (the trap), legacy autocommit success/failure, and 3.12+
-`autocommit=True`/`False`.
+rollback (the trap), legacy autocommit success/failure, **nested C-over-A on an
+autocommit connection (success and inner-failure)**, and the 3.12+
+`autocommit=True`/`False` equivalents.
 
 ## A — per-function atomicity (`store.py`)
 


### PR DESCRIPTION
## What

Closes #191. The contrib Python store's destructive replace operations
(`replace_tags`, `merge_tags`, `replace_track_art`) did `DELETE` + `executemany
INSERT` with no transaction of their own, relying on the "caller owns the
transaction" contract. On an autocommit connection a crash between the `DELETE`
and the `INSERT` left a track with its tags/art **wiped but not replaced**.

This wraps each operation — and the whole per-record write in `sync_one` — in a
SQLite savepoint, so they are atomic regardless of the connection's transaction
mode, without weakening the caller-owns-the-transaction contract.

## How

A single `_savepoint` context manager in `store.py`:

- **Caller-managed connection** (the shipped beets/Picard path, deferred mode):
  nests via `SAVEPOINT` and never commits the enclosing transaction — the
  caller's single `commit()`/`rollback()` still governs the whole batch.
- **Autocommit connection**: the *outermost* call owns a transaction for the
  operation (commit on success, rollback on failure).

Two subtleties the helper handles explicitly:

1. **The legacy-mode trap.** Python's `sqlite3` in legacy mode does not
   auto-`BEGIN` before `SAVEPOINT`, so a savepoint opened as the first statement
   of a batch becomes the *outermost* transaction and **commits durably on
   `RELEASE`** — which would silently break beets' single-commit batch
   atomicity. The helper forces a nesting `BEGIN` in legacy mode when no
   transaction is open. Verified across CPython 3.8/3.11/3.12/3.14.
2. **Nested C-over-A on autocommit.** An `owns`-the-transaction guard ensures
   only the outermost call `BEGIN`s/commits, so `sync_one`'s savepoint can wrap
   the per-function savepoints without double-`BEGIN` or early commit.

Stays on the 3.8 floor (no version bump); `sqlite3.LEGACY_TRANSACTION_CONTROL`
is read via `getattr(..., -1)` since it is 3.12+.

## Tests

New `tests/test_atomicity.py` (7 tests): per-function autocommit-failure
rollback (incl. a natural FK violation for `replace_track_art`, asserting
`content_version` rolls back too), the legacy-mode trap guard, whole-record
atomicity, and deferred-batch atomicity. Full `python-musefs` suite: 63 passed.

## Picard

Picard vendors a byte-identical copy of the library, so
`contrib/picard/musefs/_common/{store,sync}.py` were regenerated via
`vendor_to_picard.py` (drift-guarded by `test_vendor_sync.py`). This is also how
the fix reaches the Picard consumer.

## Design docs

Spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tag and artwork replacement now behave atomically, preventing partial deletes/inserts and ensuring per-record syncs are all-or-nothing.

* **New Features**
  * Per-record synchronization updates are executed with explicit atomic boundaries so tag and art changes roll back together on failure.

* **Documentation**
  * Architecture and design docs updated with the new atomicity guarantees and implementation plan.

* **Tests**
  * Added comprehensive tests validating atomic behavior across failure and transaction-mode scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->