### PR TITLE
docs: fix doc drift flagged in #259-263

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,8 +296,10 @@ disappears, its stale row is not pruned by revalidating this root.
 External writers live under `contrib/`: `python-musefs` is the shared
 store-contract library (schema-version check, tag/art writes, sha256 art
 content-addressing, the `musefs scan` shell-out); the
-[beets plugin](contrib/beets/README.md) and the
-[Picard plugin](contrib/picard/README.md) build host-specific tag mapping on
-top of it. Each plugin's README covers its own setup and behavior;
+[beets plugin](contrib/beets/README.md), the
+[Picard plugin](contrib/picard/README.md), and the
+[Lidarr integration](contrib/lidarr/README.md) (a Custom Script workflow)
+build host-specific tag mapping on top of it. Each one's README covers its own
+setup and behavior;
 [CONTRIBUTING](CONTRIBUTING.md) covers their test suites and the
 generated-schema/vendoring mechanics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,9 @@ First public release.
 ### Notes
 
 - Read-only mount; tag edits happen out-of-band against the SQLite store and are
-  picked up automatically (`PRAGMA data_version` polling). See the README "Tag
-  handling" section for round-trip limitations.
+  picked up automatically (`PRAGMA data_version` polling). See the README
+  [Supported formats](README.md#supported-formats) section and the per-format
+  docs (`docs/{FLAC,MP3,M4A,OGG,WAV}.md`) for round-trip limitations.
 
 ## [0.1.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,14 @@ git config core.hooksPath .githooks
 
 The hook (`.githooks/pre-commit`) runs, in order: `cargo fmt --all --check`,
 `cargo clippy --all-targets -- -D warnings`, **the full workspace test
-suite** (`cargo test --workspace`), `shellcheck` over every tracked shell
-script, `yamllint` (relaxed [`.yamllint`](.yamllint)) over every tracked YAML
-file, and `ruff check` + `ruff format --check` over `contrib/beets/`,
-`contrib/picard/`, `contrib/lidarr/`, `contrib/python-musefs/`, and
-`tests/interop/`. A few consequences worth internalizing:
+suite** (`cargo test --workspace`), a conditional cargo-mutants anchor-drift
+guard (only when `.cargo/mutants.toml`, `scripts/check_mutant_anchors.py`, or
+a `musefs-core`/`musefs-format` source file is staged), `shellcheck` over
+every tracked shell script, `yamllint` (relaxed [`.yamllint`](.yamllint)) over
+every tracked YAML file, and `ruff check` + `ruff format --check` over
+`contrib/beets/`, `contrib/picard/`, `contrib/lidarr/`,
+`contrib/python-musefs/`, `scripts/`, and `tests/interop/`. A few consequences
+worth internalizing:
 
 - A commit with red tests is always rejected — there is no
   "commit-now-fix-later" workflow here.
@@ -40,6 +43,11 @@ file, and `ruff check` + `ruff format --check` over `contrib/beets/`,
   staged, and skip with a notice when the tool is absent; when they do run they
   lint *all* tracked files of that type, so a sibling file can't drift
   unnoticed.
+- The mutant-anchor guard fires only when the mutants config, its check
+  script, or a `musefs-core`/`musefs-format` source file is staged, and skips
+  with a notice when `cargo-mutants` is absent (CI re-checks it regardless). It
+  re-validates that the `.cargo/mutants.toml` `exclude_re` anchors still point
+  at their intended `file:line:col` after a line-shifting edit.
 
 ## Build & test
 
@@ -348,13 +356,14 @@ RUSTFLAGS="-Zsanitizer=thread" TSAN_OPTIONS="halt_on_error=0" \
 
 ```bash
 cargo install cargo-llvm-cov
-cargo llvm-cov --workspace --exclude musefs-fuse --open
-cargo llvm-cov --workspace --exclude musefs-fuse --lcov --output-path lcov.info
+cargo llvm-cov --workspace --exclude musefs-fuse --exclude musefs-latencyfs --open
+cargo llvm-cov --workspace --exclude musefs-fuse --exclude musefs-latencyfs --lcov --output-path lcov.info
 ```
 
-`musefs-fuse` is excluded because its tests need a real mount; the FUSE
-behavior is covered by the separate `e2e` CI job. CI (`coverage.yml`) runs
-this on every push/PR and uploads to Codecov (`CODECOV_TOKEN` repo secret).
+`musefs-fuse` and `musefs-latencyfs` are excluded because these FUSE crates'
+tests need a real mount; their behavior is covered by the separate `e2e` CI
+job rather than `llvm-cov`. CI (`coverage.yml`) runs this on every push/PR and
+uploads to Codecov (`CODECOV_TOKEN` repo secret).
 
 ## Code conventions
 

--- a/contrib/beets/README.md
+++ b/contrib/beets/README.md
@@ -15,19 +15,22 @@ a re-tagged view of your library without rewriting any audio.
   just the touched file and then sync. musefs's auto-refresh shows changes live —
   no remount, and **no separate scan step**.
 
-## Install (local / development)
+## Install
 
-No install needed — point beets at the plugin's `beetsplug` directory. beets adds
-`pluginpath` entries directly to the `beetsplug` package path, so it must be the
-`beetsplug` dir itself (not its parent). In your beets `config.yaml`:
-
-The plugin depends on the shared `python-musefs` library, which is unpublished
-and lives in this repo. Install it from the working tree **before** the plugin:
+Whichever path you choose below, the plugin needs the shared `python-musefs`
+library as a **runtime dependency**. It's unpublished and lives in this repo,
+so install it from the working tree first:
 
 ```bash
 pip install -e contrib/python-musefs
-pip install -e "contrib/beets[test]"
 ```
+
+### Use via pluginpath (no package install)
+
+The plugin itself doesn't need to be installed — point beets at the plugin's
+`beetsplug` directory and it loads at runtime. beets adds `pluginpath` entries
+directly to the `beetsplug` package path, so it must be the `beetsplug` dir
+itself (not its parent). In your beets `config.yaml`:
 
 ```yaml
 pluginpath: /path/to/musefs/contrib/beets/beetsplug
@@ -40,6 +43,15 @@ musefs:
   #                        # manage scanning yourself (hooks then best-effort).
   # fields:                # optional: map extra beets fields to musefs keys
   #   comments: comment
+```
+
+### Development / test install
+
+To run the test suite — or if you'd rather install the plugin as a package
+than wire up `pluginpath` — install it editable instead:
+
+```bash
+pip install -e "contrib/beets[test]"
 ```
 
 ## Workflow (test drive)


### PR DESCRIPTION
Validates and fixes five documentation-drift issues. Docs-only; no code changes.

- **#259** — CONTRIBUTING pre-commit summary now documents the conditional cargo-mutants anchor-drift guard (config / check script / `musefs-core`/`musefs-format` source triggers, skips when `cargo-mutants` absent) and adds `scripts/` to the ruff coverage list, matching `.githooks/pre-commit`.
- **#260** — Coverage commands and the explanatory sentence now exclude both `musefs-fuse` and `musefs-latencyfs`, matching `coverage.yml`.
- **#261** — ARCHITECTURE "The contrib ecosystem" summary now includes the Lidarr Custom Script integration alongside beets and Picard.
- **#262** — `contrib/beets/README.md` install section split into a shared runtime `python-musefs` step, "Use via pluginpath (no package install)", and "Development / test install", removing the "no install needed / then pip install" contradiction.
- **#263** — CHANGELOG stale README "Tag handling" cross-reference replaced with `README.md#supported-formats` plus the per-format docs.

Closes #259, closes #260, closes #261, closes #262, closes #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture overview to clarify external integrations and supported workflows
  * Improved tag handling documentation references with pointers to format-specific guidance
  * Enhanced plugin installation documentation with clearer setup and development instructions
  * Refined contributor development guidelines for build and testing processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->