### PR TITLE
docs: rework README, ARCHITECTURE, CONTRIBUTING, and lidarr README

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,30 +141,55 @@ plugins under `contrib/` write tags and art here out-of-band.
 
 ### The external-writer contract
 
-External tools get full read/write on `tags`, `art`, and `track_art`. The
-scanner owns the structural columns of `tracks` (`id`, `backing_path`,
-`format`, `audio_offset`, `audio_length`, `backing_size`, `backing_mtime`,
-`content_version`, `updated_at`) and all of `structural_blocks`: those are
-derived from probing the file, and external tools must run `musefs scan`
-rather than compute them. As of V4, SQLite `CHECK` constraints reject the
-malformed *shapes* at commit — an unknown `format` string, a negative
-length/offset/size/version, an `audio_offset + audio_length` running past the
-stored `backing_size`, a binary tag row whose `value` is non-empty, an
-`art.byte_len` that disagrees with its blob or a `sha256` of the wrong length,
-a `picture_type` outside `0..=20` — so an external writer cannot persist them.
-What CHECKs cannot catch is a scanner-owned field mutated to a *well-formed*
-value that no longer matches the real file on disk: `backing_size` or
-`backing_mtime` that drift from the actual file's stat, or audio bounds that
-fit the stored `backing_size` but overrun the file once it has shrunk. musefs
-re-stats the backing file on every resolve and treats such rows as untrusted
-input, degrading to a controlled `BackingChanged`/layout error, never
-undefined behavior.
-Referential gaps are treated the same way: a `track_art` row whose `art_id`
-has no matching `art` row (an orphan an external writer can produce with FK
-enforcement disabled) fails the serve with `EIO` rather than silently dropping
-the art.
+**Ownership.** External tools get full read/write on `tags`, `art`, and
+`track_art`. The scanner owns the structural columns of `tracks` (`id`,
+`backing_path`, `format`, `audio_offset`, `audio_length`, `backing_size`,
+`backing_mtime`, `content_version`, `updated_at`) and all of
+`structural_blocks`: those are derived from probing the file, and external
+tools must run `musefs scan` rather than compute them.
 
-The shared Python library (`contrib/python-musefs/`) encodes this contract
+**What the store enforces.** As of V4, SQLite `CHECK` constraints reject the
+malformed *shapes* at commit, so an external writer cannot persist them:
+
+- an unknown `format` string, or a negative length/offset/size/version;
+- an `audio_offset + audio_length` running past the stored `backing_size`;
+- a binary tag row whose `value` is non-empty;
+- an `art.byte_len` that disagrees with its blob, or a `sha256` of the wrong
+  length;
+- a `picture_type` outside `0..=20`.
+
+**What musefs defends at serve time.** CHECKs cannot catch a scanner-owned
+field mutated to a *well-formed* value that no longer matches the real file
+on disk: `backing_size` or `backing_mtime` that drift from the actual file's
+stat, or audio bounds that fit the stored `backing_size` but overrun the file
+once it has shrunk. musefs re-stats the backing file on every resolve and
+treats such rows as untrusted input, degrading to a controlled
+`BackingChanged`/layout error, never undefined behavior. Referential gaps are
+treated the same way: a `track_art` row whose `art_id` has no matching `art`
+row (an orphan an external writer can produce with FK enforcement disabled)
+fails the serve with `EIO` rather than silently dropping the art.
+
+**Merge vs. replace.** An external writer may **merge** rather than fully
+replace text tags — overwriting only the keys it manages and leaving the rest
+of the scan-seeded set in place — provided it tracks its own managed-key set
+out of band (the beets plugin uses a beets flexattr; the store is not the
+place for plugin state). musefs renders tags outside its native VOCAB
+(`musefs-format/src/tagmap.rs`) by passthrough (Vorbis uppercased, mp3
+`TXXX`, mp4 freeform), so such tags appear but are not guaranteed
+byte-identical to a given tagger's own per-format encoding.
+
+**Path layout offload.** External tools can also offload path layout
+entirely: a plugin evaluates its own (arbitrarily complex) path logic, writes
+the resulting relative path into a custom text tag — e.g. `INSERT INTO tags
+(track_id, key, value, ordinal) VALUES (?, 'beets_path', 'Pink
+Floyd/Animals/01 Pigs', 0)` — and the user mounts with `--template
+'$!{beets_path}'`. Because the field map is just the (lowercased) tag keys,
+any number of such tags (`beets_path`, `lidarr_path`, …) can back different
+concurrent mounts. The path field keeps embedded `/` as directory separators
+but sanitizes each segment and drops empty/`.`/`..` segments, so a
+misbehaving writer cannot inject traversal or empty components into the tree.
+
+**The shared Python library.** `contrib/python-musefs/` encodes this contract
 for plugin authors, including a generated copy of the schema
 (`musefs_common/schema.py`, regenerated from `schema.rs` by a drift-guarded
 test — see [CONTRIBUTING](CONTRIBUTING.md)). Its tag/art replace operations
@@ -175,23 +200,6 @@ uses the same shared library from a Custom Script workflow. Its Lidarr
 destination tree is only a tracking aid, made of symlinks by default; musefs
 remains the consumer-facing filesystem.
 
-An external writer may **merge** rather than fully replace text tags — overwriting
-only the keys it manages and leaving the rest of the scan-seeded set in place —
-provided it tracks its own managed-key set out of band (the beets plugin uses a
-beets flexattr; the store is not the place for plugin state). musefs renders tags
-outside its native VOCAB (`musefs-format/src/tagmap.rs`) by passthrough (Vorbis
-uppercased, mp3 `TXXX`, mp4 freeform), so such tags appear but are not
-guaranteed byte-identical to a given tagger's own per-format encoding.
-
-External tools can also offload path layout entirely: a plugin evaluates its own
-(arbitrarily complex) path logic, writes the resulting relative path into a
-custom text tag — e.g. `INSERT INTO tags (track_id, key, value, ordinal) VALUES
-(?, 'beets_path', 'Pink Floyd/Animals/01 Pigs', 0)` — and the user mounts with
-`--template '$!{beets_path}'`. Because the field map is just the (lowercased) tag
-keys, any number of such tags (`beets_path`, `lidarr_path`, …) can back
-different concurrent mounts. The path field keeps embedded `/` as directory
-separators but sanitizes each segment and drops empty/`.`/`..` segments, so a
-misbehaving writer cannot inject traversal or empty components into the tree.
 CI proves this contract end to end in the `contract` job (see
 [CONTRIBUTING](CONTRIBUTING.md)): a Python writer's tags/art, layered on a
 scanned track, are synthesized by the Rust serve path and read back by an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,36 @@ The working manual for building, testing, and landing a change. For what the
 pieces *are*, read [ARCHITECTURE.md](ARCHITECTURE.md) first; for per-format
 behavior, the docs under [`docs/`](docs/).
 
+Map of this document:
+
+- [Getting set up](#getting-set-up) — prerequisites and the pre-commit hook.
+- [Build & test](#build--test) — everyday commands, the FUSE e2e suite, the
+  [FreeBSD VM harness](#freebsd-e2e).
+- [Test tiers beyond `cargo test`](#test-tiers-beyond-cargo-test) — property
+  tests, fuzzing, interop, the contract round trip, fault injection, mutation
+  testing, sanitizers, coverage.
+- [Code conventions](#code-conventions) — errors, integer casts, lints,
+  `unsafe`, layering.
+- [Adding a format](#adding-a-format) — the four-step recipe.
+- [Python plugins (contrib)](#python-plugins-contrib) — per-suite commands and
+  the gotchas.
+- [Releasing](#releasing-the-python-packages) — the Python (`py-v*`) and
+  [Rust (`v*`)](#releasing-the-rust-crates-and-binaries) release flows.
+- [PRs & commits](#prs--commits) — conventions and the
+  [before-you-push checklist](#before-you-push).
+
 ## Getting set up
 
-You need stable Rust (edition 2024) with `rustfmt` and `clippy`. To mount or run
-the FUSE end-to-end tests you need a FUSE-capable OS: Linux with `/dev/fuse` and
-libfuse (`libfuse3-dev` / `libfuse3` plus `pkg-config`), or FreeBSD with
-`/dev/fuse` and the `fusefs` kernel module (no libfuse — see [FreeBSD
-e2e](#freebsd-e2e) for the in-tree VM harness). The Python plugin suites
-additionally want Python 3 with `ruff` and `pytest`. The pre-commit hook's
-shell and YAML lint legs use `shellcheck` and `yamllint` — both optional, each
-skips with a notice if not installed.
+Prerequisites:
+
+- **Rust** — stable (edition 2024) with `rustfmt` and `clippy`.
+- **FUSE** (to mount, or to run the FUSE end-to-end tests) — Linux with
+  `/dev/fuse` and libfuse (`libfuse3-dev` / `libfuse3` plus `pkg-config`), or
+  FreeBSD with `/dev/fuse` and the `fusefs` kernel module (no libfuse — see
+  [FreeBSD e2e](#freebsd-e2e) for the in-tree VM harness).
+- **Python 3** with `ruff` and `pytest` — only for the Python plugin suites.
+- **`shellcheck` and `yamllint`** — optional; the pre-commit hook's shell and
+  YAML lint legs each skip with a notice if not installed.
 
 Enable the repo's pre-commit hook once per clone:
 
@@ -600,5 +620,22 @@ Lidarr e2e gate) is also run.
   report.
 - Benchmark results, when a change warrants them, are recorded in
   [BENCHMARKS.md](BENCHMARKS.md).
-- Run the in-diff mutation gate (above) for logic changes — it is CI parity,
-  not optional polish.
+
+### Before you push
+
+The pre-commit hook already gates fmt, clippy, the workspace tests, and the
+Python/shell/YAML lints on every commit. What it does **not** run — check the
+ones your change triggers:
+
+- **Logic changes** → the [in-diff mutation gate](#mutation-testing). It is CI
+  parity, not optional polish.
+- **Format-layer API changes** → `cargo +nightly fuzz build`; the `fuzz/`
+  crate is outside the workspace, so nothing else compiles it
+  ([coverage-guided fuzzing](#coverage-guided-fuzzing)).
+- **`musefs-db` schema changes** → regenerate and re-vendor the Python schema
+  mirror ([Python plugins](#python-plugins-contrib)).
+- **Picard plugin changes** → make sure the real-Picard tests actually ran
+  rather than silently skipped ([gotchas](#python-plugins-contrib)).
+- **FUSE/mount-surface changes** → run the `--ignored` e2e suite locally
+  ([Build & test](#build--test)); the FreeBSD CI leg only runs on PRs that
+  touch that surface.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ mount shows a clean library while your files stay exactly as they are.
 ## Quick start
 
 ```bash
-cargo install musefs    # compiles from source: needs a Rust toolchain,
-                        # libfuse3-dev and pkg-config — see Requirements
+cargo install musefs    # compiles from source — needs a Rust toolchain,
+                        # libfuse3-dev and pkg-config; prebuilt binaries
+                        # and container images: see Installing
 
 musefs scan ~/Music --db library.db        # ingest your library
 mkdir -p ~/mnt/music
@@ -37,6 +38,134 @@ from the database, spliced in front of your original, untouched audio.
 - **Lossless-by-construction experimentation.** Try a retag, a different
   organization scheme, new cover art — the originals are physically
   read-only to the mount.
+
+## Installing
+
+Three ways to get musefs: a [prebuilt binary](#prebuilt-binaries) (no
+toolchain needed), [building from source](#building-from-source), or a
+[container image](#container-images).
+Whichever you pick, mounting needs a FUSE-capable OS — see
+[Platform support](#platform-support).
+
+### Prebuilt binaries
+
+Each tagged release attaches static/portable Linux binaries for four targets:
+
+| Target | libc | Notes |
+| --- | --- | --- |
+| `x86_64-unknown-linux-gnu`  | glibc | Pinned to glibc 2.17 — runs on essentially any current distro. |
+| `aarch64-unknown-linux-gnu` | glibc | glibc 2.17 floor, ARM64. |
+| `x86_64-unknown-linux-musl`  | musl | Fully static — runs on Alpine / scratch containers. |
+| `aarch64-unknown-linux-musl` | musl | Fully static, ARM64. |
+
+Download the tarball for your target from the
+[latest release](https://github.com/Sohex/musefs/releases/latest), verify it,
+and extract:
+
+```bash
+sha256sum -c musefs-<version>-<target>.tar.gz.sha256
+tar -xzf musefs-<version>-<target>.tar.gz   # yields ./musefs
+```
+
+**Runtime requirements:** the binaries mount via FUSE's `fusermount3` helper, so
+the target needs the FUSE userspace tools and `/dev/fuse`:
+
+- Debian/Ubuntu: `apt-get install fuse3`
+- Alpine: `apk add fuse3`
+
+No glibc/libfuse install is needed for the musl binaries beyond `fuse3`.
+
+### Building from source
+
+`cargo install musefs` compiles the latest release; building needs a stable
+Rust toolchain (2024 edition) plus the FUSE headers (`libfuse3-dev`) and
+`pkg-config`. To install the latest development version instead:
+
+```bash
+cargo install --git https://github.com/Sohex/musefs musefs
+```
+
+The same `fuse3` runtime requirement as the prebuilt binaries applies.
+
+### Container images
+
+Each tagged release also publishes multi-arch images to the GitHub Container
+Registry:
+
+| Image | libc | Platforms |
+| --- | --- | --- |
+| `ghcr.io/sohex/musefs:<version>`, `ghcr.io/sohex/musefs:latest` | glibc | amd64, arm64 |
+| `ghcr.io/sohex/musefs:<version>-musl`, `ghcr.io/sohex/musefs:musl` | musl | amd64, arm64 |
+
+`docker pull` selects the CPU architecture automatically. Use the `-musl` /
+`:musl` tags when slotting musefs into an Alpine-based stack; the default
+(glibc) tags suit everything else. Floating `:latest` / `:musl` track the most
+recent stable release only — prereleases publish only version-pinned tags.
+
+**Running musefs on the host is the simplest, best-supported option** — it is an
+ordinary FUSE daemon and the image exists mainly to colocate musefs with
+containerized media managers (e.g. Lidarr). If you do containerize, mind the
+gotchas below.
+
+#### Required flags
+
+musefs mounts via FUSE, so the container needs `/dev/fuse` and the matching
+capability:
+
+```bash
+docker run --rm \
+  --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+  -v /path/to/library:/library:ro \
+  -v /path/to/store:/store \
+  ghcr.io/sohex/musefs:latest scan /library --db /store/musefs.db
+```
+
+Without `--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined`
+the mount cannot be established.
+
+Note that `CAP_SYS_ADMIN` is a broadly privileged capability — it grants far more
+than FUSE mounting (mounting arbitrary filesystems, and more). It is unavoidable
+for an in-container FUSE mount, but it is another reason to prefer running musefs
+on the host, which needs no such capability.
+
+#### The mount-visibility gotcha (read this before sharing the mount)
+
+A FUSE mount made **inside** a container lives in that container's mount
+namespace. By default neither the host nor other containers can see it, so
+pointing a second container (your media manager) at musefs's output does not
+work out of the box. Two ways to share it:
+
+- **Prefer Podman in a shared pod** — Docker has no first-class pod primitive,
+  but Podman does, so this is the cleanest path: put musefs and the consumer in
+  the same pod so they share namespaces and the mount is directly reachable:
+
+  ```bash
+  podman pod create --name media
+  podman run -d --pod media \
+    --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+    -v /path/to/library:/library:ro -v /path/to/store:/store \
+    ghcr.io/sohex/musefs:latest mount /mnt/musefs --db /store/musefs.db
+  # the consumer container, in the same pod, reads /mnt/musefs
+  ```
+
+- Or bind-mount the mount point with **`rshared` propagation** so the mount
+  escapes the container's namespace to the host (`--mount type=bind,...,bind-propagation=rshared`).
+  This is fiddlier than a shared pod, which is why the pod approach is
+  recommended.
+
+Both the glibc and musl images carry the `fuse3` userspace tools; pick `:musl`
+if your other containers are Alpine-based, otherwise the default tags are fine.
+
+### Platform support
+
+| Platform | FUSE | Kernel passthrough (StructureOnly) | Notes |
+| --- | --- | --- | --- |
+| Linux | Yes (`/dev/fuse` + `fusermount3`, from the `fuse3` package) | Yes (6.9+, falls back to daemon serving otherwise) | Full support. |
+| FreeBSD | Yes (pure-rust `/dev/fuse` backend; `fusefs` kernel module, no libfuse) | No | Full FUSE support. |
+| macOS (FUSE-T) | Best-effort | No | Compiles and runs unit tests with `macos-no-mount`; mounted e2e is not yet validated. |
+
+On platforms without kernel passthrough, `--mode structure-only` still serves
+the original bytes, just through the daemon instead of the kernel.
 
 ## Usage
 
@@ -69,7 +198,23 @@ musefs mount /path/to/mountpoint --db library.db \
 ```
 
 `mount` blocks until the filesystem is unmounted (`fusermount -u`, or
-Ctrl-C). Paths come from a beets-style template (matched case-insensitively;
+Ctrl-C).
+
+Two modes:
+
+- **`synthesis`** (default) — files carry metadata freshly generated from
+  the store, spliced ahead of the original audio bytes.
+- **`structure-only`** — files are served byte-for-byte as they are on disk;
+  only the directory tree is virtual.
+
+Edit tags or art in the database while mounted (another `scan`, a
+beets/Picard/Lidarr sync, raw SQL) and the view refreshes automatically.
+
+Run `musefs <command> --help` for the full flag list.
+
+#### Path templates
+
+Paths come from a beets-style template (matched case-insensitively;
 any tag key in the store works):
 
 - `$field` / `${field}` — substitute a tag field (e.g. `$artist`, `$album`,
@@ -94,18 +239,6 @@ suffix. Every rendered component is capped at 255 bytes (NAME_MAX, truncated on
 a UTF-8 boundary, extension preserved), and a plain field whose value is
 exactly `.` or `..` is dropped rather than creating an unusable directory. The
 default template is `$albumartist/$album/$title`.
-
-Two modes:
-
-- **`synthesis`** (default) — files carry metadata freshly generated from
-  the store, spliced ahead of the original audio bytes.
-- **`structure-only`** — files are served byte-for-byte as they are on disk;
-  only the directory tree is virtual.
-
-Edit tags or art in the database while mounted (another `scan`, a
-beets/Picard/Lidarr sync, raw SQL) and the view refreshes automatically.
-
-Run `musefs <command> --help` for the full flag list.
 
 ### Tuning
 
@@ -206,9 +339,6 @@ keep working.
 No — and it's not planned. Out-of-band editing against the store *is* the
 design: it's what guarantees your originals can never be corrupted.
 
-**What platforms?**
-See [Platform support](#platform-support).
-
 **Is it fast enough for a big library on a NAS?**
 That's the design target: synthesized headers are cached, blocking reads run
 on a worker pool so a slow disk never stalls the filesystem, and read-ahead,
@@ -220,130 +350,6 @@ via FUSE passthrough (needs `CAP_SYS_ADMIN`).
 The most common cause is a backing file that changed since its last scan
 (musefs refuses to serve a file whose size or mtime drifted, rather than
 splice at stale offsets). Run `musefs scan --revalidate` to re-probe it.
-
-## Prebuilt binaries
-
-Each tagged release attaches static/portable Linux binaries for four targets:
-
-| Target | libc | Notes |
-| --- | --- | --- |
-| `x86_64-unknown-linux-gnu`  | glibc | Pinned to glibc 2.17 — runs on essentially any current distro. |
-| `aarch64-unknown-linux-gnu` | glibc | glibc 2.17 floor, ARM64. |
-| `x86_64-unknown-linux-musl`  | musl | Fully static — runs on Alpine / scratch containers. |
-| `aarch64-unknown-linux-musl` | musl | Fully static, ARM64. |
-
-Download the tarball for your target from the
-[latest release](https://github.com/Sohex/musefs/releases/latest), verify it,
-and extract:
-
-```bash
-sha256sum -c musefs-<version>-<target>.tar.gz.sha256
-tar -xzf musefs-<version>-<target>.tar.gz   # yields ./musefs
-```
-
-**Runtime requirements:** the binaries mount via FUSE's `fusermount3` helper, so
-the target needs the FUSE userspace tools and `/dev/fuse`:
-
-- Debian/Ubuntu: `apt-get install fuse3`
-- Alpine: `apk add fuse3`
-
-No glibc/libfuse install is needed for the musl binaries beyond `fuse3`.
-
-## Container images
-
-Each tagged release also publishes multi-arch images to the GitHub Container
-Registry:
-
-| Image | libc | Platforms |
-| --- | --- | --- |
-| `ghcr.io/sohex/musefs:<version>`, `ghcr.io/sohex/musefs:latest` | glibc | amd64, arm64 |
-| `ghcr.io/sohex/musefs:<version>-musl`, `ghcr.io/sohex/musefs:musl` | musl | amd64, arm64 |
-
-`docker pull` selects the CPU architecture automatically. Use the `-musl` /
-`:musl` tags when slotting musefs into an Alpine-based stack; the default
-(glibc) tags suit everything else. Floating `:latest` / `:musl` track the most
-recent stable release only — prereleases publish only version-pinned tags.
-
-**Running musefs on the host is the simplest, best-supported option** — it is an
-ordinary FUSE daemon and the image exists mainly to colocate musefs with
-containerized media managers (e.g. Lidarr). If you do containerize, mind the
-gotchas below.
-
-### Required flags
-
-musefs mounts via FUSE, so the container needs `/dev/fuse` and the matching
-capability:
-
-```bash
-docker run --rm \
-  --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
-  -v /path/to/library:/library:ro \
-  -v /path/to/store:/store \
-  ghcr.io/sohex/musefs:latest scan /library --db /store/musefs.db
-```
-
-Without `--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined`
-the mount cannot be established.
-
-Note that `CAP_SYS_ADMIN` is a broadly privileged capability — it grants far more
-than FUSE mounting (mounting arbitrary filesystems, and more). It is unavoidable
-for an in-container FUSE mount, but it is another reason to prefer running musefs
-on the host, which needs no such capability.
-
-### The mount-visibility gotcha (read this before sharing the mount)
-
-A FUSE mount made **inside** a container lives in that container's mount
-namespace. By default neither the host nor other containers can see it, so
-pointing a second container (your media manager) at musefs's output does not
-work out of the box. Two ways to share it:
-
-- **Prefer Podman in a shared pod** — Docker has no first-class pod primitive,
-  but Podman does, so this is the cleanest path: put musefs and the consumer in
-  the same pod so they share namespaces and the mount is directly reachable:
-
-  ```bash
-  podman pod create --name media
-  podman run -d --pod media \
-    --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
-    -v /path/to/library:/library:ro -v /path/to/store:/store \
-    ghcr.io/sohex/musefs:latest mount /mnt/musefs --db /store/musefs.db
-  # the consumer container, in the same pod, reads /mnt/musefs
-  ```
-
-- Or bind-mount the mount point with **`rshared` propagation** so the mount
-  escapes the container's namespace to the host (`--mount type=bind,...,bind-propagation=rshared`).
-  This is fiddlier than a shared pod, which is why the pod approach is
-  recommended.
-
-Both the glibc and musl images carry the `fuse3` userspace tools; pick `:musl`
-if your other containers are Alpine-based, otherwise the default tags are fine.
-
-## Requirements
-
-- Rust (2024 edition) and Cargo to build/install.
-- A supported OS with FUSE to mount — Linux (`/dev/fuse` + `fusermount3`, from
-  the `fuse3` package) or FreeBSD
-  (`/dev/fuse` + the `fusefs` kernel module; no libfuse). macOS (FUSE-T) is
-  best-effort. See [Platform support](#platform-support) for details.
-
-## Platform support
-
-| Platform | FUSE | Kernel passthrough (StructureOnly) | Notes |
-| --- | --- | --- | --- |
-| Linux | Yes | Yes (6.9+, falls back to daemon serving otherwise) | Full support. |
-| FreeBSD | Yes (pure-rust `/dev/fuse` backend; `fusefs` kernel module) | No | Full FUSE support. |
-| macOS (FUSE-T) | Best-effort | No | Compiles and runs unit tests with `macos-no-mount`; mounted e2e is not yet validated. |
-
-On platforms without kernel passthrough, `--mode structure-only` still serves
-the original bytes, just through the daemon instead of the kernel.
-
-`cargo install` compiles from source, so the same prerequisites as a local
-build apply: a Rust toolchain plus FUSE headers (`libfuse3-dev`) and
-`pkg-config`. To install the latest development version:
-
-```bash
-cargo install --git https://github.com/Sohex/musefs musefs
-```
 
 ## Status
 

--- a/contrib/lidarr/README.md
+++ b/contrib/lidarr/README.md
@@ -1,12 +1,55 @@
 # lidarr-musefs
 
-A Lidarr integration that lets Lidarr import into a placeholder library tree
-while musefs serves the real consumer-facing, re-tagged FUSE view.
+A [Lidarr](https://lidarr.audio/) integration that syncs Lidarr's metadata
+into a [musefs](../../README.md) SQLite store, so a live musefs mount shows a
+re-tagged view of your library without Lidarr ever copying, moving, or
+rewriting backing audio bytes.
 
-The supported workflow keeps Lidarr as the downloader, matcher, and metadata
-source, but prevents Lidarr from copying, moving, or rewriting backing audio
-bytes. Lidarr's destination tree exists so Lidarr can track files. Point
-Navidrome, Plex, Jellyfin, or other consumers at the musefs mount instead.
+Lidarr stays the downloader, matcher, and metadata source; its destination
+tree becomes a placeholder of symlinks that exists only so Lidarr can track
+files. Point Navidrome, Plex, Jellyfin, or other consumers at the musefs
+mount instead.
+
+## How it fits together
+
+The package installs two console scripts that plug into Lidarr's hooks:
+
+- **`musefs-lidarr-import`** (Import Using Script) — replaces Lidarr's own
+  copy/move when it imports a download: it creates the destination entry as a
+  **symlink** (or hardlink) to the downloaded file and **fails closed** — it
+  never falls back to copying bytes.
+- **`musefs-lidarr-sync`** (Custom Script notification) — fires after an
+  import or rename: it queries Lidarr's API for the affected tracks' metadata
+  (title, artist/albumartist, album, track/disc numbers, release date,
+  MusicBrainz ids, genres), runs `musefs scan` on the files to create/refresh
+  their track rows (the structural columns only musefs can compute), and
+  writes the tags into the store.
+
+musefs's auto-refresh surfaces each sync at the mount with no remount. Both
+scripts build on the shared [`python-musefs`](../python-musefs/README.md)
+store-contract library.
+
+## Install
+
+Install the package — with its `python-musefs` dependency — into the
+environment Lidarr uses to run custom scripts, so both scripts are on
+Lidarr's `PATH`:
+
+```bash
+pip install lidarr-musefs
+```
+
+Or, from this repository (the working-tree library first — it is the local
+source of the `python-musefs` dependency):
+
+```bash
+pip install -e contrib/python-musefs
+pip install -e contrib/lidarr
+```
+
+You also need the `musefs` binary reachable by the sync script (see
+`MUSEFS_BIN` below) and a musefs store/mount of your own — see the
+[main README](../../README.md).
 
 ## Required Lidarr settings
 
@@ -21,7 +64,25 @@ workflow. Lidarr uses a hardlink-or-copy transfer mode internally, so a hardlink
 failure can copy bytes. `musefs-lidarr-import` creates the destination entry
 itself and fails closed.
 
+`musefs-lidarr-sync --doctor` verifies these settings over the API (see
+[Doctor](#doctor)).
+
+## Lidarr Custom Script
+
+Configure a Custom Script notification (Settings -> Connect):
+
+- On Release Import: enabled.
+- On Rename: enabled.
+- Path: `musefs-lidarr-sync`.
+
+Test events exit successfully without touching files or the database.
+`TrackRetag` events are skipped with a warning because they fire after Lidarr
+writes tags.
+
 ## Environment
+
+Both scripts are configured through environment variables, set in the
+environment Lidarr launches scripts with.
 
 Import script:
 
@@ -32,41 +93,31 @@ MUSEFS_LIDARR_LINK_MODE=symlink   # default; use hardlink only if symlinks are u
 Sync script:
 
 ```bash
-MUSEFS_DB=/path/to/musefs.db
-MUSEFS_BIN=musefs
+MUSEFS_DB=/path/to/musefs.db      # the musefs SQLite store (required)
+MUSEFS_BIN=musefs                 # musefs executable; full path if not on PATH
 MUSEFS_LIDARR_URL=http://localhost:8686
 MUSEFS_LIDARR_API_KEY=your-api-key
-MUSEFS_LIDARR_AUTOSCAN=1
+MUSEFS_LIDARR_AUTOSCAN=1          # default; runs `musefs scan` before each sync
 ```
 
 API keys are redacted from logs and errors.
 
-## Lidarr Custom Script
-
-Configure a Custom Script notification:
-
-- On Release Import: enabled.
-- On Rename: enabled.
-- Path: `musefs-lidarr-sync`.
-
-Test events exit successfully without touching files or the database.
-`TrackRetag` events are skipped with a warning because they fire after Lidarr
-writes tags.
-
 ## Manual backfill
 
-Run:
+To sync every track file Lidarr already knows about (e.g. on first setup):
 
 ```bash
 musefs-lidarr-sync --all
 ```
 
 Manual backfill requires `MUSEFS_LIDARR_URL` and `MUSEFS_LIDARR_API_KEY`. It
-queries all Lidarr artists and syncs their known track files into the musefs DB.
+runs the doctor preflight first (skip with `--skip-lidarr-preflight`), then
+queries all Lidarr artists and syncs their known track files into the musefs
+DB.
 
 ## Doctor
 
-Run:
+To verify your Lidarr settings are musefs-safe:
 
 ```bash
 musefs-lidarr-sync --doctor
@@ -93,3 +144,34 @@ complete per-track metadata.
 6. Run `musefs mount /tmp/mnt --db "$MUSEFS_DB"`.
 7. Confirm the mount shows Lidarr metadata.
 8. Confirm the source file's bytes and mtime did not change.
+
+## Notes
+
+- **Tags are fully replaced** with Lidarr's view on every sync (scanner-written
+  binary tags always survive — see the
+  [external-writer contract](../../ARCHITECTURE.md#the-external-writer-contract)).
+- **No art sync:** the integration writes text tags only; any art `musefs scan`
+  ingested from embedded pictures is preserved.
+- **Schema version:** the sync refuses to run if the DB's `user_version`
+  differs from the version it targets — rebuild the store after upgrading
+  musefs.
+- **CI coverage:** a fast smoke (real Lidarr exec path + mocked API) gates PRs,
+  and a full real-instance download-client import e2e gates the Python
+  releases — see
+  [CONTRIBUTING.md](../../CONTRIBUTING.md#python-plugins-contrib).
+
+## Tests
+
+```bash
+cd contrib/lidarr
+python -m venv .venv && source .venv/bin/activate
+pip install -e ../python-musefs    # shared library (unpublished in-tree; install first)
+pip install -e ".[test]"
+
+python -m pytest                   # unit + integration (no Rust binary)
+python -m pytest -m musefs_bin     # path-matching gate vs the real `musefs` binary
+```
+
+The `musefs_bin` gate shells out to the real `musefs` binary, so build it first
+from the repo root (`cargo build`). It is deselected from the default run and
+skips cleanly if the binary is absent.


### PR DESCRIPTION
Quality/clarity pass over the user- and contributor-facing docs (everything outside `docs/superpowers` was reviewed; only the four files with real structural or audience problems were changed).

## What changed

- **README.md** (user-facing): installation was scattered across five sections (Quick start, Prebuilt binaries, Container images, Requirements, Platform support). It is now a single `## Installing` section ordered prebuilt → source → containers → platform support, placed before Usage so a new user hits it in reading order. The template mini-language gets its own `#### Path templates` heading inside Mount, and the filler FAQ entry ("What platforms? See Platform support.") is dropped. Externally referenced anchors (`#supported-formats`, `#platform-support`, `#tuning`) are preserved.
- **ARCHITECTURE.md** (contributor-facing): "The external-writer contract" was three unbroken prose walls; it is now bold-led paragraphs (Ownership / What the store enforces / What musefs defends at serve time / Merge vs. replace / Path layout offload / The shared Python library) with the CHECK-constraint list as bullets. Content and heading anchor unchanged.
- **CONTRIBUTING.md**: adds a "Map of this document" TOC (600+ lines, previously no navigation), bulletizes the setup prerequisites, and adds a "Before you push" checklist of exactly the gates the pre-commit hook does *not* run (in-diff mutants, fuzz build, schema regen, real-Picard tests, FUSE e2e), each linked to its section.
- **contrib/lidarr/README.md**: fully rewritten to match the beets/Picard READMEs' depth. Now opens with how the two scripts divide the work (`musefs-lidarr-import` symlinks fail-closed; `musefs-lidarr-sync` pulls metadata from Lidarr's API), and gains the missing Install section, a Notes section (replace-mode tags, no art sync, schema-version guard, CI coverage), and a Tests section. All behavioral claims verified against `musefs_lidarr`'s source.

## Deliberately untouched

BENCHMARKS.md (a measurement record — rewriting numbers only risks errors), SECURITY.md, the five format docs, and the systemd/python-musefs/beets/Picard READMEs (already strong; the lidarr README was the outlier).

## Verification

- All relative links and heading anchors across the repo's markdown resolve (scripted check).
- An independent fact-check pass verified the moved/new claims against the code (lidarr script names, env vars and defaults, tag fields, replace-vs-merge, event handling, test markers; ARCHITECTURE restructure is content-faithful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Restructured architecture documentation for clearer external-writer contract, validation, and path-layout details
* Enhanced contribution guide with prerequisite checklist and pre-push CI check guidance
* Expanded README with dedicated installation section, platform support table, and container/FUSE guidance
* Added comprehensive Lidarr integration documentation with setup, environment variables, and tag behavior notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->