### PR TITLE
Stream Ogg artwork during synthesis; enforce a shared resolve-time art cap (#266)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,9 @@ sum to the served file size. Six variants:
   metadata blocks, a RIFF front), fully materialized at resolve time.
 - `ArtImage { art_id, len }` — embedded cover art; only the length lives in
   the layout. Image bytes stream from the DB blob in chunks at read time and
-  are never buffered whole.
+  are never buffered whole. This invariant also holds for Ogg synthesis,
+  where page CRCs are computed from page-bounded `ArtSource` windows
+  (previously the documented exception).
 - `BackingAudio { offset, len }` — a run of the original file's audio frames,
   served by positioned reads (`read_exact_at`) against the backing file.
 - `OggAudio { offset, len, seq_delta }` — original Ogg audio pages served
@@ -175,10 +177,13 @@ on disk: `backing_size` or `backing_mtime` that drift from the actual file's
 stat, or audio bounds that fit the stored `backing_size` but overrun the file
 once it has shrunk. musefs re-stats the backing file on every resolve and
 treats such rows as untrusted input, degrading to a controlled
-`BackingChanged`/layout error, never undefined behavior. Referential gaps are
-treated the same way: a `track_art` row whose `art_id` has no matching `art`
-row (an orphan an external writer can produce with FK enforcement disabled)
-fails the serve with `EIO` rather than silently dropping the art.
+`BackingChanged`/layout error, never undefined behavior. Art exceeding
+`MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected at resolve with `ArtTooLarge`
+for all formats; the scanner's ingest-time drop is tracked in #284.
+Referential gaps are treated the same way: a `track_art` row whose `art_id`
+has no matching `art` row (an orphan an external writer can produce with FK
+enforcement disabled) fails the serve with `EIO` rather than silently dropping
+the art.
 
 **Merge vs. replace.** An external writer may **merge** rather than fully
 replace text tags — overwriting only the keys it manages and leaving the rest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,9 +177,11 @@ on disk: `backing_size` or `backing_mtime` that drift from the actual file's
 stat, or audio bounds that fit the stored `backing_size` but overrun the file
 once it has shrunk. musefs re-stats the backing file on every resolve and
 treats such rows as untrusted input, degrading to a controlled
-`BackingChanged`/layout error, never undefined behavior. Art exceeding
-`MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected at resolve with `ArtTooLarge`
-for all formats; the scanner's ingest-time drop is tracked in #284.
+`BackingChanged`/layout error, never undefined behavior. The store's V4
+`CHECK` rejects art over `MAX_ART_BYTES` (16 MiB − 64 KiB) at write time;
+resolve also re-checks it (`ArtTooLarge`, all formats) to backstop a writer
+that disables check enforcement, and the scanner's ingest-time drop is
+tracked in #284.
 Referential gaps are treated the same way: a `track_art` row whose `art_id`
 has no matching `art` row (an orphan an external writer can produce with FK
 enforcement disabled) fails the serve with `EIO` rather than silently dropping

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -72,10 +72,14 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
    `METADATA_BLOCK_PICTURE` comments (the decoded bytes are a FLAC PICTURE
    block body): each image is an `OggArtSlice` run — a window of
    `base64(image)` encoded **incrementally at read time** from the blob
-   store, never materialized whole. FLAC-in-Ogg instead carries one native
-   FLAC `PICTURE` block packet per image (raw `OggArtSlice` runs, no
-   base64); the last metadata packet's last-block flag and packet 0's
-   16-bit following-packet count are recomputed to match.
+   store, never materialized whole. Artwork is streamed at synthesis time:
+   page CRCs are computed from page-bounded `ArtSource` windows, and the
+   full image and its base64 copy are never materialized. FLAC-in-Ogg
+   instead carries one native FLAC `PICTURE` block packet per image (raw
+   `OggArtSlice` runs, no base64); the last metadata packet's last-block
+   flag and packet 0's 16-bit following-packet count are recomputed to
+   match. Art exceeding `MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected at
+   resolve time.
 3. `OggAudio` — one compact segment covering all original audio pages, with
    the page-count delta to apply to every sequence number.
 

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -78,8 +78,9 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
    instead carries one native FLAC `PICTURE` block packet per image (raw
    `OggArtSlice` runs, no base64); the last metadata packet's last-block
    flag and packet 0's 16-bit following-packet count are recomputed to
-   match. Art exceeding `MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected at
-   resolve time.
+   match. Art exceeding `MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected by the
+   store's V4 `CHECK`, with a resolve-time cap backstopping a writer that
+   disables check enforcement.
 3. `OggAudio` — one compact segment covering all original audio pages, with
    the page-count delta to apply to every sequence number.
 

--- a/docs/superpowers/plans/2026-06-11-ogg-art-streaming.md
+++ b/docs/superpowers/plans/2026-06-11-ogg-art-streaming.md
@@ -84,7 +84,11 @@ In `musefs-core/src/mapping.rs`, inside `mod tests`, add this test. It inserts a
 ```rust
     #[test]
     fn track_art_to_inputs_enforces_art_cap() {
-        use musefs_db::{NewArt, TrackArt};
+        use crate::CoreError;
+        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
+        // The boundary uses the real MAX_ART_BYTES (not a smaller test value) so the
+        // mutation gate catches a `>`→`>=` flip; this hashes ~32 MiB across the two
+        // blobs, which is fine here — do not "optimize" the boundary away.
         let cap = crate::scan::MAX_ART_BYTES;
         let dir = tempfile::tempdir().unwrap();
         let db = Db::open(dir.path().join("cap.db")).unwrap();
@@ -511,7 +515,7 @@ pub(crate) fn lace_chunks_to_segments(
 }
 ```
 
-(`emit_segments` is unchanged — it already reads only `art_id`/`base64`/`art_total`, never bytes.)
+(`emit_segments` keeps its logic — it already reads only `art_id`/`base64`/`art_total`, never bytes. One tidy-up: its `PayloadChunk::Art { art_id, base64, art_total, .. }` destructure (`page.rs:392`) now binds every field, so drop the trailing `..`.)
 
 - [ ] **Step 7: Stop materializing art in the packet producers**
 
@@ -633,7 +637,7 @@ In `musefs-core/src/reader.rs`, in `HeaderCache::build`, replace the `Format::Op
             .unwrap();
 ```
 
-(Confirm the import path of `synthesize_layout` in that file; if it is `use musefs_format::ogg::synthesize_layout`, the `MapArtSource` path above is correct.)
+(`ogg_index.rs:335` already has `use musefs_format::ogg::{locate_audio, read_header, synthesize_layout};`; the fully-qualified `MapArtSource` path above resolves regardless.)
 
 `musefs-format/tests/proptest_ogg.rs:18` — pass an empty source:
 
@@ -666,7 +670,9 @@ For each test that calls `synthesize_layout(...)` with non-empty `arts`, add a t
 
 (Inside the `ogg` module use `MapArtSource` directly, not the `musefs_format::ogg::` prefix.)
 
-Sites to update (verified by grep; `synthesize_layout` callers in `ogg/mod.rs` tests at approx. lines 618, 725, 857, 913, 1022, 1053, 1085 and the `OggArt` constructions at 918, 1027, 1058, 1091, 1095, 1123, 1151, 1186, 1320, 1327). Tests calling `build_packets_with_art` directly (the `oversized_full_art_value_rejected_by_build_packets`, `sum_overflow_art_value_rejected_by_build_packets`, `art_value_at_u32_max_boundary_is_accepted_by_build_packets` at ~1110-1200, and ~1320) only need the `image` field dropped — `build_packets_with_art` takes no source and reads no bytes.
+**Every** `synthesize_layout` call in `ogg/mod.rs` tests needs the trailing source argument — the ones with non-empty `arts` get a `MapArtSource` built from their images (as above); the **zero-art** ones (`synthesize_layout(&header, …, &[], &[])`) get `&MapArtSource::default()`. Do not rely on the line numbers below as a complete list — they drift; treat `cargo build --all-targets` (Step 15) as the authoritative finder and migrate every site the compiler flags.
+
+Sites to update (verified via `find_referencing_symbols`): `synthesize_layout` callers in `ogg/mod.rs` tests at approx. lines 617, **663, 676** (these two are zero-art → `&MapArtSource::default()`), 724, 856, 912, 1021, 1052, 1084; and the `OggArt` constructions at ~918, 1027, 1058, 1091, 1095, 1123, 1151, 1186, 1320, 1327. Tests calling `build_packets_with_art` directly (`oversized_full_art_value_rejected_by_build_packets`, `sum_overflow_art_value_rejected_by_build_packets`, `art_value_at_u32_max_boundary_is_accepted_by_build_packets` at ~1110-1200, and the test at ~1320) only need the `image` field dropped — `build_packets_with_art` takes no source and reads no bytes.
 
 Then rewrite the lacer test in `page.rs` (`chunk_lacer_splits_art_across_pages_and_crcs_validate`, ~line 585) so the art is byte-consistent (image length == `art_total`) and base64 output spans pages. Replace its `chunks`/setup and the `lace_chunks_to_segments` call:
 
@@ -707,7 +713,17 @@ In `musefs-format/src/ogg/mod.rs` `mod tests`, add a counting source asserting n
             }
         }
 
-        let (header, scan) = opus_header_and_scan(); // existing test helper that yields an Opus header
+        // Inline Opus fixture, mirroring synthesize_opus_emits_valid_header_and_audio_segment.
+        let mut data = opus_headers();
+        let scan = locate_audio({
+            let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 80]);
+            data.extend_from_slice(&audio);
+            &data
+        })
+        .unwrap();
+        let header =
+            read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
+
         let image: Vec<u8> = (0..500_000u32).map(|i| (i % 251) as u8).collect();
         let meta = crate::input::ArtInput {
             art_id: 7,

--- a/docs/superpowers/plans/2026-06-11-ogg-art-streaming.md
+++ b/docs/superpowers/plans/2026-06-11-ogg-art-streaming.md
@@ -1,0 +1,825 @@
+# Ogg Artwork Streaming + Shared Art Cap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Ogg synthesis from materializing whole artwork images (and their base64 copies) when building header pages, and enforce one artwork-size ceiling at resolve time for every format.
+
+**Architecture:** Two independent components. (A) Promote the scanner's `MAX_ART_BYTES` to a resolve-time invariant enforced in `track_art_to_inputs`, with a diagnosable log. (B) Stream Ogg art end-to-end: a format-layer `ArtSource` trait (DB-backed in core, in-memory for tests/fuzz), an incremental page-CRC fed in page-bounded windows, and `PayloadChunk::Art`/`OggArt` carrying metadata only. Served bytes are byte-identical to today; only synthesis-time memory changes (from ~2.3× the image to O(one Ogg page)).
+
+**Tech Stack:** Rust workspace (`musefs-db` → `musefs-format` → `musefs-core`), SQLite incremental blob I/O, the `log` crate, `thiserror`, libFuzzer (`fuzz/`, out of workspace).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md`
+
+**Tooling note:** This repo uses the Serena MCP semantic tools as the primary way to read/edit Rust. Prefer `get_symbols_overview`/`find_symbol`/`replace_symbol_body`/`insert_after_symbol` over plain Read/Edit on `.rs` files. The pre-commit hook runs fmt + clippy (`-D warnings`) + the **full workspace test suite**, so every commit must compile and pass green. The `fuzz/` crate is outside the workspace; verify it separately with `cargo +nightly fuzz build ogg`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+| ---- | ------ | -------------- |
+| `musefs-core/src/scan.rs` | modify | make `MAX_ART_BYTES` `pub(crate)` (shared ceiling) |
+| `musefs-core/src/error.rs` | modify | add `CoreError::ArtTooLarge` |
+| `musefs-core/src/mapping.rs` | modify | enforce cap in `track_art_to_inputs`; add `DbArtSource`; delete `track_art_images` |
+| `musefs-format/src/ogg/crc.rs` | modify | add `crc32_update` (incremental CRC) |
+| `musefs-format/src/error.rs` | modify | add `FormatError::ArtRead { art_id }` |
+| `musefs-format/src/ogg/art_source.rs` | create | `ArtSource` trait + in-memory `MapArtSource` |
+| `musefs-format/src/ogg/mod.rs` | modify | `OggArt` loses `image`; producers stop materializing; `synthesize_layout` takes `&dyn ArtSource` |
+| `musefs-format/src/ogg/page.rs` | modify | `PayloadChunk::Art` loses `out`; CRC pass streams from `ArtSource` |
+| `musefs-core/src/reader.rs` | modify | Ogg branch builds metadata-only `OggArt` + `DbArtSource`; drop blob pre-read |
+| `musefs-core/src/ogg_index.rs` | modify | zero-art `synthesize_layout` call gets a source arg |
+| `musefs-format/tests/proptest_ogg.rs` | modify | zero-art `synthesize_layout` call gets a source arg |
+| `fuzz/fuzz_targets/ogg.rs` | modify | feed art through `MapArtSource`; couple image length to `data_len` |
+| `docs/OGG.md`, `ARCHITECTURE.md` | modify | document the streamed invariant + shared cap |
+
+---
+
+## Component A — Shared resolve-time art cap
+
+### Task 1: Enforce `MAX_ART_BYTES` at resolve for all formats
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs:31` (visibility)
+- Modify: `musefs-core/src/error.rs:4-47` (new variant)
+- Modify: `musefs-core/src/mapping.rs` (`track_art_to_inputs`, new test)
+
+- [ ] **Step 1: Make the cap constant shareable**
+
+In `musefs-core/src/scan.rs`, change the constant at line 31 from private to crate-visible. Current:
+
+```rust
+const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
+```
+
+New (add a doc line noting it is now the shared ceiling):
+
+```rust
+/// The artwork-size ceiling. Enforced here at ingest (oversize scanned art is
+/// dropped) and at resolve in `mapping::track_art_to_inputs` (oversize art from
+/// any writer is rejected). Sized to clear FLAC's 24-bit block length with
+/// headroom for the picture-block framing.
+pub(crate) const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
+```
+
+- [ ] **Step 2: Add the `ArtTooLarge` error variant**
+
+In `musefs-core/src/error.rs`, add a variant to `CoreError` (after `InvalidPictureType`, before `TrackNotFound`):
+
+```rust
+    #[error(
+        "track {track_id} art {art_id} is {byte_len} bytes, exceeds the {cap}-byte art cap"
+    )]
+    ArtTooLarge {
+        track_id: i64,
+        art_id: i64,
+        byte_len: u64,
+        cap: u64,
+    },
+```
+
+- [ ] **Step 3: Write the failing boundary test**
+
+In `musefs-core/src/mapping.rs`, inside `mod tests`, add this test. It inserts art blobs at exactly the cap (accepted) and one byte over (rejected). `upsert_art` derives `byte_len` from the blob length, and the schema enforces `byte_len = length(data)`, so the blob size *is* the tested `data_len`.
+
+```rust
+    #[test]
+    fn track_art_to_inputs_enforces_art_cap() {
+        use musefs_db::{NewArt, TrackArt};
+        let cap = crate::scan::MAX_ART_BYTES;
+        let dir = tempfile::tempdir().unwrap();
+        let db = Db::open(dir.path().join("cap.db")).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.opus".into(),
+                format: Format::Opus,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+
+        // Exactly at the cap: accepted.
+        let at_cap = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![0u8; cap],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[TrackArt { art_id: at_cap, picture_type: 3, description: String::new(), ordinal: 0 }],
+        )
+        .unwrap();
+        let ok = super::track_art_to_inputs(&db, tid).unwrap();
+        assert_eq!(ok.len(), 1, "art exactly at the cap must be accepted");
+
+        // One byte over the cap: rejected with ArtTooLarge naming the offending ids.
+        let over = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![0u8; cap + 1],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[TrackArt { art_id: over, picture_type: 3, description: String::new(), ordinal: 0 }],
+        )
+        .unwrap();
+        let err = super::track_art_to_inputs(&db, tid).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CoreError::ArtTooLarge { track_id, art_id, byte_len, cap: c }
+                    if track_id == tid && art_id == over
+                        && byte_len == (cap as u64) + 1 && c == cap as u64
+            ),
+            "oversize art must yield ArtTooLarge with the offending ids, got {err:?}"
+        );
+    }
+```
+
+- [ ] **Step 4: Run the test, verify it fails to compile / fail**
+
+Run: `cargo test -p musefs-core track_art_to_inputs_enforces_art_cap`
+Expected: FAIL — `MAX_ART_BYTES` not visible and/or `ArtTooLarge` unknown, then (once those compile) the rejection assertion fails because no cap is enforced yet.
+
+- [ ] **Step 5: Enforce the cap in `track_art_to_inputs`**
+
+In `musefs-core/src/mapping.rs`, in `track_art_to_inputs`, after the `data_len` is derived (the `let Some(data_len) = ... else { continue; }` block) and before `inputs.push(ArtInput { ... })`, insert the cap check:
+
+```rust
+        if data_len.get() > crate::scan::MAX_ART_BYTES as u64 {
+            log::warn!(
+                "track {track_id} art {} is {} bytes, exceeds the {}-byte art cap; refusing to serve",
+                ta.art_id,
+                data_len.get(),
+                crate::scan::MAX_ART_BYTES,
+            );
+            return Err(crate::error::CoreError::ArtTooLarge {
+                track_id,
+                art_id: ta.art_id,
+                byte_len: data_len.get(),
+                cap: crate::scan::MAX_ART_BYTES as u64,
+            });
+        }
+```
+
+- [ ] **Step 6: Run the test, verify it passes**
+
+Run: `cargo test -p musefs-core track_art_to_inputs_enforces_art_cap`
+Expected: PASS
+
+- [ ] **Step 7: Run the full crate suite + clippy**
+
+Run: `cargo test -p musefs-core && cargo clippy --all-targets -- -D warnings`
+Expected: PASS (no warnings). The `as u64`/`as i64` casts mirror the existing style; if clippy flags a cast, use the crate's `convert` helper as neighboring code does.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/src/error.rs musefs-core/src/mapping.rs
+git commit -m "$(cat <<'EOF'
+feat(core): enforce MAX_ART_BYTES at resolve for all formats (#266)
+
+Promote the scanner's art ceiling to a resolve-time invariant in
+track_art_to_inputs, rejecting oversize art (from any writer, not just the
+scanner) with a logged CoreError::ArtTooLarge. Closes the external-writer
+bypass uniformly; Ogg streaming follows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Component B — Stream Ogg art end-to-end
+
+### Task 2: Incremental CRC (`crc32_update`)
+
+**Files:**
+- Modify: `musefs-format/src/ogg/crc.rs` (`crc32`, new `crc32_update`, new test)
+
+- [ ] **Step 1: Write the failing test**
+
+In `musefs-format/src/ogg/crc.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn crc32_update_matches_oneshot_across_a_split() {
+        let data: Vec<u8> = (0..1000u32).map(|i| (i % 251) as u8).collect();
+        for split in [0usize, 1, 3, 255, 256, 700, 1000] {
+            let (a, b) = data.split_at(split);
+            let streamed = super::crc32_update(super::crc32_update(0, a), b);
+            assert_eq!(streamed, super::crc32(&data), "split at {split}");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cargo test -p musefs-format crc32_update_matches_oneshot_across_a_split`
+Expected: FAIL — `crc32_update` not defined.
+
+- [ ] **Step 3: Add `crc32_update` and refactor `crc32` to use it**
+
+In `musefs-format/src/ogg/crc.rs`, replace the body of `crc32` and add `crc32_update`. The Ogg CRC starts at state 0 with no input/output inversion, so feeding `0` as the initial state reproduces a one-shot CRC and the split identity holds.
+
+```rust
+/// Fold `buf` into a running CRC `state`. `crc32(x) == crc32_update(0, x)` and
+/// `crc32(a ++ b) == crc32_update(crc32_update(0, &a), &b)`, so a page CRC can be
+/// computed in bounded windows without assembling the whole page.
+pub(crate) fn crc32_update(mut state: u32, buf: &[u8]) -> u32 {
+    for &b in buf {
+        state = (state << 8) ^ TABLE[(((state >> 24) as u8) ^ b) as usize];
+    }
+    state
+}
+
+pub fn crc32(buf: &[u8]) -> u32 {
+    crc32_update(0, buf)
+}
+```
+
+- [ ] **Step 4: Run the test + existing CRC tests, verify they pass**
+
+Run: `cargo test -p musefs-format ogg::crc`
+Expected: PASS (the existing `crc32` reference tests and the new split test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/ogg/crc.rs
+git commit -m "$(cat <<'EOF'
+feat(ogg): add incremental crc32_update for streamed page CRCs (#266)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3: The streaming refactor (single atomic commit)
+
+This task changes `PayloadChunk::Art` and `OggArt` to drop their byte buffers, so producers, consumers, and all callers must change together — Rust will not compile an intermediate state. Build it up in the ordered steps below, then compile, lint, test, and fuzz-build once, then commit once. Do **not** commit between sub-steps; the tree does not compile until Step 13.
+
+**Files:** `musefs-format/src/error.rs`, `musefs-format/src/ogg/art_source.rs` (new), `musefs-format/src/ogg/mod.rs`, `musefs-format/src/ogg/page.rs`, `musefs-core/src/mapping.rs`, `musefs-core/src/reader.rs`, `musefs-core/src/ogg_index.rs`, `musefs-format/tests/proptest_ogg.rs`, `fuzz/fuzz_targets/ogg.rs`.
+
+- [ ] **Step 1: Add the `FormatError::ArtRead` variant**
+
+In `musefs-format/src/error.rs`, add to `FormatError` (it derives `PartialEq, Eq`; the `i64` payload keeps the derive valid):
+
+```rust
+    #[error("failed to read art {art_id} bytes for synthesis")]
+    ArtRead { art_id: i64 },
+```
+
+- [ ] **Step 2: Create the `ArtSource` trait + in-memory `MapArtSource`**
+
+Create `musefs-format/src/ogg/art_source.rs`:
+
+```rust
+use crate::error::{FormatError, Result};
+use std::collections::HashMap;
+
+/// A source of raw art bytes used during synthesis to compute page CRCs. The
+/// production implementation (in `musefs-core`) streams from the SQLite blob
+/// store; tests and fuzzing use [`MapArtSource`]. `offset` and `buf.len()` are in
+/// raw-image coordinates; a read past the stored image is an error (mirrors the
+/// short-read semantics of the DB blob path), surfaced as `FormatError::ArtRead`.
+pub trait ArtSource {
+    fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()>;
+}
+
+/// In-memory `ArtSource` over an `art_id -> image bytes` map. For tests/fuzz.
+#[derive(Default)]
+pub struct MapArtSource {
+    images: HashMap<i64, Vec<u8>>,
+}
+
+impl MapArtSource {
+    pub fn new(images: impl IntoIterator<Item = (i64, Vec<u8>)>) -> Self {
+        Self { images: images.into_iter().collect() }
+    }
+}
+
+impl ArtSource for MapArtSource {
+    fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()> {
+        let img = self.images.get(&art_id).ok_or(FormatError::ArtRead { art_id })?;
+        let start = crate::convert::usize_from(offset);
+        let end = start
+            .checked_add(buf.len())
+            .filter(|&e| e <= img.len())
+            .ok_or(FormatError::ArtRead { art_id })?;
+        buf.copy_from_slice(&img[start..end]);
+        Ok(())
+    }
+}
+```
+
+In `musefs-format/src/ogg/mod.rs`, register the module and re-export the public items. Add near the other `mod` declarations at the top of the file:
+
+```rust
+mod art_source;
+pub use art_source::{ArtSource, MapArtSource};
+```
+
+- [ ] **Step 3: Shrink `OggArt` to metadata only**
+
+In `musefs-format/src/ogg/mod.rs`, replace the `OggArt` struct (currently `{ meta, image }`):
+
+```rust
+/// One image to embed: its metadata. Bytes are read from an `ArtSource` only to
+/// compute page CRCs at synthesis time; they are never retained in the layout.
+#[derive(Clone, Copy)]
+pub struct OggArt<'a> {
+    pub meta: &'a crate::input::ArtInput,
+}
+```
+
+- [ ] **Step 4: Shrink `PayloadChunk::Art` and compute `out_len` from metadata**
+
+In `musefs-format/src/ogg/page.rs`, replace the `PayloadChunk` enum's `Art` variant and the `out_len` method:
+
+```rust
+/// One span of a packet's payload during chunk-aware lacing.
+pub(crate) enum PayloadChunk {
+    /// Literal bytes copied verbatim into the layout as `Inline`.
+    Bytes(Vec<u8>),
+    /// An art run. Carries no bytes: its OUTPUT length is derived from `art_total`
+    /// (base64-expanded when `base64`), and its bytes are streamed from an
+    /// `ArtSource` to compute page CRCs, then never stored — the layout keeps an
+    /// `OggArtSlice` referencing `art_id`. `art_total` is the raw image length.
+    Art { art_id: i64, base64: bool, art_total: u64 },
+}
+
+impl PayloadChunk {
+    fn out_len(&self) -> usize {
+        match self {
+            PayloadChunk::Bytes(b) => b.len(),
+            PayloadChunk::Art { base64, art_total, .. } => {
+                let n = if *base64 {
+                    crate::ogg::b64::b64_len(*art_total)
+                } else {
+                    *art_total
+                };
+                crate::convert::usize_from(n)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Replace `copy_payload` with a streaming CRC feeder**
+
+In `musefs-format/src/ogg/page.rs`, delete `copy_payload` and add these two functions. They feed page bytes into a running CRC, reading art from the `ArtSource` in page-bounded windows (output span per page ≤ 255×255, so each buffer is ≤ ~64 KiB).
+
+First update the imports at the top of `page.rs`. The file already has `use super::crc::{crc_shift_zeros, crc32};` — add `crc32_update` to it and import the trait:
+
+```rust
+use super::art_source::ArtSource;
+use super::crc::{crc_shift_zeros, crc32, crc32_update};
+```
+
+Then add the two functions:
+
+```rust
+/// Fold payload bytes `[p0, p0+plen)` (packet-payload coordinates) into `crc`,
+/// reading art runs from `src` instead of materializing them.
+fn crc_feed_payload(
+    crc: &mut u32,
+    chunks: &[PayloadChunk],
+    src: &dyn ArtSource,
+    p0: usize,
+    plen: usize,
+) -> crate::error::Result<()> {
+    let end = p0 + plen;
+    let mut cs = 0usize;
+    for c in chunks {
+        let ce = cs + c.out_len();
+        let os = p0.max(cs);
+        let oe = end.min(ce);
+        if os < oe {
+            match c {
+                PayloadChunk::Bytes(b) => {
+                    *crc = crc32_update(*crc, &b[os - cs..oe - cs]);
+                }
+                PayloadChunk::Art { art_id, base64, art_total } => {
+                    crc_feed_art(crc, src, *art_id, *base64, *art_total, (os - cs) as u64, oe - os)?;
+                }
+            }
+        }
+        cs = ce;
+    }
+    Ok(())
+}
+
+/// Fold one art window — output bytes `[out_off, out_off+out_len)` of the run —
+/// into `crc`, base64-encoding on the fly when `base64`. `out_len` is page-bounded.
+fn crc_feed_art(
+    crc: &mut u32,
+    src: &dyn ArtSource,
+    art_id: i64,
+    base64: bool,
+    art_total: u64,
+    out_off: u64,
+    out_len: usize,
+) -> crate::error::Result<()> {
+    if base64 {
+        let w = crate::ogg::b64::b64_window(out_off, out_len as u64, art_total);
+        let mut raw = vec![0u8; crate::convert::usize_from(w.in_len)];
+        src.read_window(art_id, w.in_start, &mut raw)?;
+        let enc = crate::ogg::b64::encode_b64_slice(&raw, w.skip, out_len);
+        *crc = crc32_update(*crc, &enc);
+    } else {
+        let mut raw = vec![0u8; out_len];
+        src.read_window(art_id, out_off, &mut raw)?;
+        *crc = crc32_update(*crc, &raw);
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Thread `ArtSource` through `lace_chunks_to_segments` and stream the page CRC**
+
+In `musefs-format/src/ogg/page.rs`, replace `lace_chunks_to_segments`. It now takes `src`, returns a `Result`, and builds only the page header+table (not the payload) before streaming the CRC:
+
+```rust
+/// Lace one packet (a chunk list) into pages from sequence `seq_start`, emitting
+/// layout segments: page headers + literal payload as `Inline` (CRCs baked in),
+/// art runs as `OggArtSlice` (no bytes stored). Art bytes are streamed from `src`
+/// only to compute page CRCs. Returns `(segments, pages_used)`.
+pub(crate) fn lace_chunks_to_segments(
+    serial: u32,
+    seq_start: u32,
+    bos: bool,
+    chunks: &[PayloadChunk],
+    src: &dyn ArtSource,
+) -> crate::error::Result<(Vec<Segment>, u32)> {
+    let total: usize = chunks.iter().map(PayloadChunk::out_len).sum();
+    let laces = lacing_values(total);
+
+    let mut segments: Vec<Segment> = Vec::new();
+    let mut seq = seq_start;
+    let mut lace_pos = 0usize;
+    let mut payload_pos = 0usize;
+    let mut first = true;
+
+    while first || lace_pos < laces.len() {
+        let seg_count = (laces.len() - lace_pos).min(255);
+        let table = &laces[lace_pos..lace_pos + seg_count];
+        let page_payload: usize = table.iter().map(|&b| b as usize).sum();
+
+        let mut header_type = 0u8;
+        if bos && first {
+            header_type |= FLAG_BOS;
+        }
+        if !first {
+            header_type |= FLAG_CONTINUED;
+        }
+
+        // Build the page header + lacing table only (CRC field zeroed), then stream
+        // the page CRC over header+payload without materializing the payload.
+        let header_len = 27 + seg_count;
+        let mut header = Vec::with_capacity(header_len);
+        header.extend_from_slice(CAPTURE);
+        header.push(0);
+        header.push(header_type);
+        header.extend_from_slice(&0u64.to_le_bytes()); // granule 0 (header page)
+        header.extend_from_slice(&serial.to_le_bytes());
+        header.extend_from_slice(&seq.to_le_bytes());
+        header.extend_from_slice(&0u32.to_le_bytes()); // CRC placeholder
+        header.push(u8::try_from(seg_count).expect("seg_count is .min(255) so fits in u8"));
+        header.extend_from_slice(table);
+
+        let mut crc = crc32_update(0, &header);
+        crc_feed_payload(&mut crc, chunks, src, payload_pos, page_payload)?;
+        header[22..26].copy_from_slice(&crc.to_le_bytes());
+
+        emit_segments(&mut segments, &header, chunks, payload_pos, page_payload);
+
+        payload_pos += page_payload;
+        lace_pos += seg_count;
+        seq += 1;
+        first = false;
+    }
+    Ok((segments, seq - seq_start))
+}
+```
+
+(`emit_segments` is unchanged — it already reads only `art_id`/`base64`/`art_total`, never bytes.)
+
+- [ ] **Step 7: Stop materializing art in the packet producers**
+
+In `musefs-format/src/ogg/mod.rs`, in `comment_packet_chunks`, replace the `PayloadChunk::Art` it pushes (the `out: b64_encode(art.image)` form):
+
+```rust
+        chunks.push(PayloadChunk::Art {
+            art_id: art.meta.art_id,
+            base64: true,
+            art_total: art.meta.data_len.get(),
+        });
+```
+
+In `oggflac_packets_with_art`, replace its `PayloadChunk::Art` (the `out: art.image.to_vec()` form):
+
+```rust
+            PayloadChunk::Art {
+                art_id: art.meta.art_id,
+                base64: false,
+                art_total: art.meta.data_len.get(),
+            },
+```
+
+- [ ] **Step 8: Thread `ArtSource` through `synthesize_layout`**
+
+In `musefs-format/src/ogg/mod.rs`, update `synthesize_layout`'s signature and its lacing loop:
+
+```rust
+pub fn synthesize_layout(
+    header: &OggHeader,
+    audio_offset: u64,
+    audio_length: u64,
+    tags: &[TagInput],
+    arts: &[OggArt],
+    src: &dyn ArtSource,
+) -> Result<RegionLayout> {
+    let arts: Vec<OggArt> = arts.to_vec();
+    let packet_chunks = build_packets_with_art(header, tags, &arts)?;
+    let mut segments: Vec<Segment> = Vec::new();
+    let mut seq = 0u32;
+    for (i, chunks) in packet_chunks.iter().enumerate() {
+        let (segs, used) =
+            crate::ogg::page::lace_chunks_to_segments(header.serial, seq, i == 0, chunks, src)?;
+        segments.extend(segs);
+        seq += used;
+    }
+    let seq_delta = i64::from(seq) - i64::from(header.header_pages);
+    segments.push(Segment::OggAudio {
+        offset: audio_offset,
+        len: audio_length,
+        seq_delta,
+    });
+    Ok(RegionLayout::validated(segments)?)
+}
+```
+
+`build_packets_with_art` keeps its signature (it consumes only `art.meta`); no change beyond Step 7's producer edits.
+
+- [ ] **Step 9: Add the core `DbArtSource` and delete `track_art_images`**
+
+In `musefs-core/src/mapping.rs`, delete `track_art_images` (the `pub(crate) fn track_art_images<M>(...)` at ~line 90) and its test `track_art_images_reads_stored_blob_bytes` (~line 412). Add the DB-backed source (it logs the typed `DbError` at the failure point, then returns the Eq-friendly `ArtRead { art_id }`):
+
+```rust
+/// `ArtSource` over the SQLite blob store, used by Ogg synthesis to stream art
+/// bytes for page CRCs. Read failures (e.g. a deleted/short blob) are logged with
+/// the underlying DB error and surfaced as `FormatError::ArtRead`.
+pub(crate) struct DbArtSource<'a, M>(pub &'a Db<M>);
+
+impl<M> musefs_format::ogg::ArtSource for DbArtSource<'_, M> {
+    fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> musefs_format::Result<()> {
+        self.0.read_art_chunk_into(art_id, offset, buf).map_err(|e| {
+            log::warn!("ogg synthesis: art {art_id} read failed at offset {offset}: {e}");
+            musefs_format::FormatError::ArtRead { art_id }
+        })
+    }
+}
+```
+
+- [ ] **Step 10: Update the `reader.rs` Ogg branch**
+
+In `musefs-core/src/reader.rs`, in `HeaderCache::build`, replace the `Format::Opus | Format::Vorbis | Format::OggFlac` arm body (currently reads `art_images` via `track_art_images` and zips into `OggArt { meta, image }`):
+
+```rust
+                    Format::Opus | Format::Vorbis | Format::OggFlac => {
+                        let front = read_front(
+                            Path::new(&track.backing_path),
+                            track.bounds.audio_offset(),
+                        )?;
+                        let header = musefs_format::ogg::read_metadata(&front)?;
+                        let arts: Vec<musefs_format::ogg::OggArt> = art_inputs
+                            .iter()
+                            .map(|meta| musefs_format::ogg::OggArt { meta })
+                            .collect();
+                        let src = crate::mapping::DbArtSource(db);
+                        musefs_format::ogg::synthesize_layout(
+                            &header,
+                            track.bounds.audio_offset(),
+                            track.bounds.audio_length(),
+                            &inputs,
+                            &arts,
+                            &src,
+                        )?
+                    }
+```
+
+- [ ] **Step 11: Update the in-format and zero-art callers**
+
+`musefs-core/src/ogg_index.rs:339` — update the zero-art call to pass an empty source:
+
+```rust
+            synthesize_layout(
+                &header,
+                scan.audio_offset,
+                scan.audio_length,
+                &[],
+                &[],
+                &musefs_format::ogg::MapArtSource::default(),
+            )
+            .unwrap();
+```
+
+(Confirm the import path of `synthesize_layout` in that file; if it is `use musefs_format::ogg::synthesize_layout`, the `MapArtSource` path above is correct.)
+
+`musefs-format/tests/proptest_ogg.rs:18` — pass an empty source:
+
+```rust
+            ogg::synthesize_layout(
+                &header,
+                scan.audio_offset,
+                scan.audio_length,
+                &taginputs,
+                &[],
+                &ogg::MapArtSource::default(),
+            )
+```
+
+- [ ] **Step 12: Migrate the format-crate tests in `mod.rs` and `page.rs`**
+
+Apply this mechanical rule everywhere a test constructs `OggArt`:
+
+- `OggArt { meta: &m, image: <anything> }` → `OggArt { meta: &m }` (drop the `image` field).
+
+For each test that calls `synthesize_layout(...)` with non-empty `arts`, add a trailing `src` argument built from the same images the test verifies against:
+
+```rust
+        let src = musefs_format::ogg::MapArtSource::new([(meta.art_id, image.clone())]);
+        // ...
+        let layout = synthesize_layout(
+            &header, scan.audio_offset, scan.audio_length, &tags, &[OggArt { meta: &meta }], &src,
+        ).unwrap();
+```
+
+(Inside the `ogg` module use `MapArtSource` directly, not the `musefs_format::ogg::` prefix.)
+
+Sites to update (verified by grep; `synthesize_layout` callers in `ogg/mod.rs` tests at approx. lines 618, 725, 857, 913, 1022, 1053, 1085 and the `OggArt` constructions at 918, 1027, 1058, 1091, 1095, 1123, 1151, 1186, 1320, 1327). Tests calling `build_packets_with_art` directly (the `oversized_full_art_value_rejected_by_build_packets`, `sum_overflow_art_value_rejected_by_build_packets`, `art_value_at_u32_max_boundary_is_accepted_by_build_packets` at ~1110-1200, and ~1320) only need the `image` field dropped — `build_packets_with_art` takes no source and reads no bytes.
+
+Then rewrite the lacer test in `page.rs` (`chunk_lacer_splits_art_across_pages_and_crcs_validate`, ~line 585) so the art is byte-consistent (image length == `art_total`) and base64 output spans pages. Replace its `chunks`/setup and the `lace_chunks_to_segments` call:
+
+```rust
+        let head = vec![0xA0u8; 50];
+        // 60_000 raw bytes -> b64 output ~80_000 > one page (65025), so it spans pages.
+        let image: Vec<u8> = (0..60_000u32).map(|i| (i % 251) as u8).collect();
+        let art_out = crate::ogg::b64::encode_b64_slice(
+            &image, 0, crate::convert::usize_from(crate::ogg::b64::b64_len(image.len() as u64)),
+        );
+        let tail = vec![0xB0u8; 10];
+        let chunks = vec![
+            PayloadChunk::Bytes(head.clone()),
+            PayloadChunk::Art { art_id: 42, base64: true, art_total: image.len() as u64 },
+            PayloadChunk::Bytes(tail.clone()),
+        ];
+        let src = crate::ogg::MapArtSource::new([(42i64, image.clone())]);
+        let (segments, pages) =
+            lace_chunks_to_segments(0x1234, 0, true, &chunks, &src).unwrap();
+        assert!(pages >= 2, "art run should span multiple pages");
+```
+
+The rest of that test (the `flatten(&segments, &art_out)` reconstruction and CRC validation) is unchanged — `flatten` already indexes `art_out` (now the base64 output) by the segment's output offset/len. Any later `assert_eq!(art_served, art_out.len() as u64)` stays valid because `art_out` is the run's full base64 output.
+
+- [ ] **Step 13: Add a bounded-window regression test**
+
+In `musefs-format/src/ogg/mod.rs` `mod tests`, add a counting source asserting no read exceeds one page (proves O(page) streaming, independent of art size):
+
+```rust
+    #[test]
+    fn synthesis_reads_art_in_page_bounded_windows() {
+        use std::cell::Cell;
+        struct Counting<'a> { inner: MapArtSource, max: &'a Cell<usize> }
+        impl ArtSource for Counting<'_> {
+            fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> crate::Result<()> {
+                self.max.set(self.max.get().max(buf.len()));
+                self.inner.read_window(art_id, offset, buf)
+            }
+        }
+
+        let (header, scan) = opus_header_and_scan(); // existing test helper that yields an Opus header
+        let image: Vec<u8> = (0..500_000u32).map(|i| (i % 251) as u8).collect();
+        let meta = crate::input::ArtInput {
+            art_id: 7,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: crate::input::BlobLen::new(image.len() as u64).unwrap(),
+        };
+        let max = Cell::new(0usize);
+        let src = Counting { inner: MapArtSource::new([(7i64, image.clone())]), max: &max };
+        synthesize_layout(&header, scan.audio_offset, scan.audio_length, &[], &[OggArt { meta: &meta }], &src).unwrap();
+        // One Ogg page's payload is at most 255*255 = 65025 bytes; raw windows are
+        // <= that. The 500 KB image is never read in a single call.
+        assert!(max.get() > 0 && max.get() <= 65_025, "max single read was {}", max.get());
+    }
+```
+
+If no `opus_header_and_scan()` helper exists, build the header inline the way the neighboring `synthesize_layout` Opus tests do (reuse their fixture-construction lines verbatim).
+
+- [ ] **Step 14: Migrate the fuzz target**
+
+Replace the art section of `fuzz/fuzz_targets/ogg.rs` (the comment about lengths being "free to disagree", the `images`/`arts` build, and the `synthesize_layout` call). Couple each image's length to its `data_len` so the streamed model is exercised faithfully; `Unstructured::fill_buffer` always yields exactly `data_len` bytes (zero-padding if input is short, never erroring):
+
+```rust
+    let arts_meta = arb_arts(&mut u).unwrap_or_default();
+    // Streaming couples image length to data_len (production enforces
+    // `byte_len = length(data)`), so generate exactly data_len bytes per image.
+    let images: Vec<Vec<u8>> = arts_meta
+        .iter()
+        .map(|m| {
+            let mut img = vec![0u8; m.data_len.get() as usize];
+            let _ = u.fill_buffer(&mut img);
+            img
+        })
+        .collect();
+    let src = ogg::MapArtSource::new(
+        arts_meta.iter().zip(images.iter()).map(|(m, img)| (m.art_id, img.clone())),
+    );
+    let arts: Vec<OggArt> = arts_meta.iter().map(|m| OggArt { meta: m }).collect();
+
+    if let Ok(layout) = ogg::synthesize_layout(
+        &header, scan.audio_offset, scan.audio_length, &tags, &arts, &src,
+    ) {
+        assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
+    }
+```
+
+Add `use musefs_format::ogg::MapArtSource;` (or reference `ogg::MapArtSource` as above) to the imports.
+
+- [ ] **Step 15: Compile, lint, test the workspace**
+
+Run: `cargo build --all-targets`
+Expected: PASS (no errors). Fix any remaining call sites the compiler flags using the same rules above.
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: PASS. Note `--all-targets` also compiles `benches/` and crate `tests/` (hidden API consumers); fix any there too.
+
+Run: `cargo test`
+Expected: PASS — crucially the existing Ogg byte-exactness tests (round-trip / `read_pictures` / CRC validation) stay green, proving served bytes are unchanged.
+
+- [ ] **Step 16: Build the fuzz target (out of workspace)**
+
+Run: `cargo +nightly fuzz build ogg`
+Expected: PASS (links). This catches format-layer signature drift the workspace build misses.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add musefs-format/src/error.rs musefs-format/src/ogg/art_source.rs \
+        musefs-format/src/ogg/mod.rs musefs-format/src/ogg/page.rs \
+        musefs-core/src/mapping.rs musefs-core/src/reader.rs musefs-core/src/ogg_index.rs \
+        musefs-format/tests/proptest_ogg.rs fuzz/fuzz_targets/ogg.rs
+git commit -m "$(cat <<'EOF'
+feat(ogg): stream artwork during layout synthesis instead of materializing it (#266)
+
+Introduce a format-layer ArtSource trait (DB-backed in core, in-memory for
+tests/fuzz) and an incremental page CRC fed in page-bounded windows. PayloadChunk
+and OggArt carry metadata only; comment/oggflac producers no longer buffer the
+image or its base64 copy. Served bytes are byte-identical; synthesis peak memory
+drops from ~2.3x the image to O(one Ogg page). Read failures surface as
+FormatError::ArtRead.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4: Documentation
+
+**Files:** `docs/OGG.md`, `ARCHITECTURE.md`
+
+- [ ] **Step 1: Update `docs/OGG.md`**
+
+Find the section describing art handling/synthesis. State that artwork is now streamed at synthesis (page CRCs are computed from page-bounded `ArtSource` windows; the full image and its base64 copy are never materialized), and that art exceeding `MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected at resolve. Keep the existing read-time base64-window description.
+
+- [ ] **Step 2: Update `ARCHITECTURE.md`**
+
+In the segment-model / freshness section, update the "art is streamed at read time, never materialized whole" invariant to note it now also holds for Ogg synthesis (previously the documented exception). In the external-writer-contract section, note the resolve-time `MAX_ART_BYTES` ceiling applies to all formats (oversize art is rejected with `ArtTooLarge`), and cross-reference #284 for the scanner's ingest-time drop.
+
+- [ ] **Step 3: Verify docs-only commit skips the cargo gate**
+
+Run: `git add docs/OGG.md ARCHITECTURE.md && git commit -m "docs: Ogg art is streamed at synthesis; document shared art cap (#266)"`
+Expected: the pre-commit hook prints "docs-only commit — skipping cargo" and passes.
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Byte-output invariance is the correctness bar.** The existing Ogg round-trip/`read_pictures`/CRC-validation tests must pass unchanged after Task 3. If a CRC test fails, the streamed base64 window does not equal the whole-image base64 substring — check `crc_feed_art`'s use of `b64_window`/`encode_b64_slice` against the read path in `reader.rs` (`OggArtSlice` arm), which is the proven reference.
+- **The cap (Task 1) and streaming (Tasks 2-3) are independent** and can be reviewed/landed separately; Task 1 ships value on its own.
+- **`CoreError` converts `FormatError` via `#[from]`** (`error.rs:14`), so the new `FormatError::ArtRead` reaches the FUSE layer with no conversion code to add.
+- **No schema change**, so no Python schema-mirror regeneration is needed.
+- **Mutation gate:** the cap test pins the exact boundary (`MAX_ART_BYTES` accepted, `+1` rejected) so a `>`→`>=` mutant is caught.

--- a/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
@@ -1,0 +1,220 @@
+# Ogg artwork: stream instead of materialize, and cap oversized art at resolve
+
+Issue: #266 (Reject or stream oversized Ogg artwork instead of materializing it
+during layout synthesis). Related: #284 (scanner silently drops oversized art).
+
+## Problem
+
+Ogg synthesis is the only format path that materializes a full artwork image —
+and, for Opus/Vorbis, its base64 copy too — while building regenerated header
+pages, before the final `RegionLayout` exists.
+
+- `musefs-core/src/mapping.rs::track_art_images` reads each linked art blob whole
+  via `db.read_art_chunk(..., 0, data_len)` into `Vec<Vec<u8>>`.
+- `musefs-format/src/ogg/mod.rs::comment_packet_chunks` stores
+  `b64_encode(art.image)` in `PayloadChunk::Art.out` (Opus/Vorbis, +1.33×).
+- `musefs-format/src/ogg/mod.rs::oggflac_packets_with_art` stores
+  `art.image.to_vec()` in `PayloadChunk::Art.out` (OggFLAC).
+
+Peak transient memory is ~2.3× the image size, paid once per resolve. Every other
+format (FLAC/MP3/MP4/WAV) streams art at read time via `Segment::ArtImage` and
+never buffers it, so this breaks the documented invariant — "large DB payloads
+are streamed at read time, not materialized whole" — for Ogg specifically.
+
+Two consequences:
+
+1. A hostile or careless SQLite writer can insert a large `art.data` row (the
+   store is a documented external-writer contract; the scanner's ingest cap does
+   not apply to direct inserts) and force a large resolve-time allocation.
+2. There is no serve-time ceiling on art size for Opus/Vorbis (only a ~3 GiB u32
+   VorbisComment guard) or, effectively, for MP3/MP4/WAV. Only FLAC/OggFLAC reject
+   oversize art at serve, as a structural consequence of FLAC's 24-bit
+   `MAX_BLOCK_BODY` (16 MiB − 1).
+
+### Why the materialization exists
+
+It is purely a page-CRC artifact. The layout output is already byte-free:
+
+- Lacing and page geometry derive from `lacing_values(total)` over chunk
+  `out_len()` — length-driven, no bytes needed.
+- `emit_segments` already stores art as `Segment::OggArtSlice { art_id, offset,
+  len, base64, art_total }` and reads no art bytes.
+
+The single consumer of art bytes at synthesis is the CRC pass: `copy_payload`
+assembles each full page into a `Vec` so `lace_chunks_to_segments` can
+`crc32(&page)`. Because a packet laces into pages strictly in order, the art's
+output range is walked forward once — a single sequential pass suffices, no random
+access or re-reads.
+
+## Goals
+
+- **Stream Ogg art end-to-end.** Synthesis peak memory becomes O(one Ogg page)
+  (≤ ~64 KiB), independent of art size. The "art is streamed at read time, never
+  materialized whole" invariant becomes true for Ogg.
+- **Enforce one art-size ceiling at resolve, for all formats.** Promote the
+  scanner's `MAX_ART_BYTES` (16 MiB − 64 KiB) to a serve-time invariant; reject
+  oversize art with a diagnosable log line rather than silently or opaquely.
+- **Byte-output-preserving.** Served Ogg files are byte-identical to today; only
+  synthesis-time memory changes.
+
+## Non-goals
+
+- Changing served bytes for any format.
+- Adding scanner-side logging for the silent oversize-art drop — tracked
+  separately as #284.
+- Per-art CRC memoization (`crc_shift_zeros` / `patch_page_header_algebraic`
+  combine machinery) — an optimization the layout cache already makes unnecessary.
+
+## Design
+
+Two independent components. Component A is separable and lands first; Component B
+is the streaming rework.
+
+### Component A — Shared resolve-time art cap (all formats)
+
+`MAX_ART_BYTES = 16 * 1024 * 1024 - 64 * 1024` currently lives as a private const
+in `musefs-core/src/scan.rs`, used only to filter scanned pictures at ingest.
+
+- Promote it to a constant shared by `scan.rs` and `mapping.rs` (a `pub(crate)`
+  const in a core module). `scan.rs` keeps using it for its ingest filter
+  unchanged.
+- In `musefs-core/src/mapping.rs::track_art_to_inputs` — the single art-input
+  builder consumed by every format branch in `reader.rs` — after deriving
+  `data_len`, reject any art whose `data_len.get()` exceeds `MAX_ART_BYTES` with a
+  new `CoreError::ArtTooLarge { track_id, art_id, byte_len }`, after emitting a
+  `log::warn!` naming the track, art id, byte length, and cap.
+
+Effects:
+
+- The check is in shared code, so the cap applies uniformly to
+  FLAC/MP3/MP4/WAV/Ogg.
+- Behavior on an oversize row: the track fails to resolve with `ArtTooLarge` —
+  consistent with FLAC's existing `MAX_BLOCK_BODY` reject — and the cause is
+  visible in the logs rather than surfacing only as an opaque read error.
+- Legitimate cover art is far below 16 MiB, so this bites only
+  pathological/hostile rows. The scanner's silent ingest drop is unchanged here
+  (see #284).
+
+### Component B — Stream Ogg art end-to-end
+
+Five edits. The format layer stays pure (no DB dependency) and fuzzable.
+
+1. **`PayloadChunk::Art` drops `out: Vec<u8>`.** It carries `{ art_id, base64,
+   art_total }`. `out_len()` computes `b64_len(art_total)` when `base64`, else
+   `art_total`. This removes the +1.33× base64 buffer (Opus/Vorbis) and the
+   `art.image.to_vec()` (OggFLAC) — the two materializations the issue names.
+
+2. **`OggArt` carries metadata only.** Drop `image: &[u8]`. Delete
+   `musefs-core/src/mapping.rs::track_art_images` and its test; `reader.rs` stops
+   pre-reading blobs into `art_images`.
+
+3. **`ArtSource` trait — defined in the format layer, implemented in core.** A
+   minimal reader over art bytes by id:
+
+   ```rust
+   pub trait ArtSource {
+       fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()>;
+   }
+   ```
+
+   where `Result` is `musefs-format`'s `Result<T, FormatError>`. `FormatError` is
+   currently a closed enum of structural errors with no I/O/DB variant, so a new
+   `FormatError::ArtRead(Box<dyn std::error::Error + Send + Sync>)` variant is
+   added: the core impl maps its typed `DbError` from `read_art_chunk_into` into it
+   (the inner error stays downcastable), keeping `synthesize_layout`'s return type
+   non-generic `Result<RegionLayout, FormatError>`. `musefs-core` implements the
+   trait over `read_art_chunk_into` (the existing streaming read); format-layer
+   tests and the `fuzz/` target implement it over an in-memory `art_id → &[u8]` map
+   (infallible). `synthesize_layout` takes art metadata plus `&dyn ArtSource`
+   instead of `&[OggArt]` carrying bytes.
+
+4. **Incremental CRC.** Add `crc32_update(state: u32, chunk: &[u8]) -> u32` to
+   `musefs-format/src/ogg/crc.rs`. The existing `crc32` starts at state 0 with no
+   final inversion, so `crc32(a ++ b) == crc32_update(crc32_update(0, &a), &b)` —
+   a direct extraction of the existing loop. `crc32(buf)` becomes
+   `crc32_update(0, buf)`.
+
+5. **Rewrite the CRC pass: `copy_payload` → a streaming feeder.**
+   `lace_chunks_to_segments` stops assembling a full `page` `Vec`. Per page:
+   - Build the 27-byte page header + lacing table with the CRC field zeroed; feed
+     it to a running CRC via `crc32_update`.
+   - Walk the page's payload span `[payload_pos, payload_pos + page_payload)`
+     across the chunk list, feeding the CRC:
+     - `Bytes` chunks: feed the overlapping slice directly (small header bytes,
+       already in memory).
+     - `Art` chunks: for the overlapping output span, use `b64_window` to compute
+       the 3-byte-aligned raw read plan, read that window from the `ArtSource`
+       into a reused buffer, base64-encode on the fly when `base64`, take exactly
+       the `[skip, skip + len)` output bytes, and feed them to the CRC. For raw
+       (OggFLAC) art, read and feed the raw window directly.
+   - Finalize the CRC, write it into `header[22..26]`, and call `emit_segments`
+     (unchanged — already byte-free) with the header.
+
+   The per-page art span is bounded by Ogg page geometry (≤ 255 × 255 ≈ 65025
+   output bytes), so the window buffer is inherently page-bounded. Total reads over
+   an art equal one full forward pass — the same I/O as today; only memory
+   improves. The 3-byte base64 alignment carry is exactly what `b64_window`
+   already solves on the read path, so it is reused, not reinvented.
+
+Peak synthesis memory after B: running CRC state + one page-sized raw window + its
+base64 buffer — independent of art size.
+
+### Data flow (Ogg resolve, after)
+
+```
+reader.rs (HeaderCache::build, Ogg branch)
+  → track_art_to_inputs(db, track_id)         # metadata only; enforces MAX_ART_BYTES (A)
+  → synthesize_layout(header, …, art_metas, &DbArtSource)   # no blob pre-read (B)
+      → build_packets_with_art → PayloadChunk::Art { art_id, base64, art_total }  # no bytes
+      → lace_chunks_to_segments
+          → per page: stream CRC via ArtSource windows (B); emit_segments → OggArtSlice
+  → RegionLayout (OggArtSlice runs, no art bytes)  # unchanged shape
+read_at (read time, unchanged)
+  → OggArtSlice → b64_window → read_art_chunk → encode_b64_slice
+```
+
+## Error handling
+
+- `CoreError::ArtTooLarge { track_id, art_id, byte_len }` is returned by
+  `track_art_to_inputs`, preceded by a `log::warn!`. It propagates like other
+  resolve errors (e.g. `OrphanedArt`) and makes the track unreadable until the row
+  is corrected — the same outcome FLAC already produces for oversize art.
+- `ArtSource::read_window` returns `Result<(), FormatError>`; the core impl wraps
+  its `DbError` in the new `FormatError::ArtRead(Box<…>)` variant, which
+  `synthesize_layout` surfaces without buffering. `reader.rs` already converts
+  `FormatError` into `CoreError`, so the read failure reaches the FUSE layer
+  unchanged in shape.
+- Existing structural guards stay as defense in depth: the u32 VorbisComment
+  value-length check in `build_packets_with_art`, and FLAC's `MAX_BLOCK_BODY` in
+  `oggflac_packets_with_art`.
+
+## Testing
+
+- **Cap (A):** `mapping.rs` unit test — art at exactly `MAX_ART_BYTES` resolves;
+  one byte over yields `ArtTooLarge` and logs a warning. Shared check, so it
+  covers all formats.
+- **Streaming (B):** existing Ogg synthesis byte-exactness tests must stay green
+  unchanged — byte-identical output is the correctness bar. Add a test asserting
+  the in-memory `ArtSource` is read in bounded windows (no single full-image
+  read). Keep the existing verify/round-trip helper (`ogg/mod.rs`, the
+  segment-reconstruction path) over the in-memory source.
+- **Fuzz:** update the out-of-workspace `fuzz/` Ogg target for the
+  `OggArt`/`PayloadChunk`/`ArtSource` signature change; confirm with
+  `cargo +nightly fuzz build`.
+- Pre-commit runs the full workspace suite, so every commit stays green.
+
+## Commit split
+
+1. Component A: promote `MAX_ART_BYTES`, add `CoreError::ArtTooLarge` + warn,
+   enforce in `track_art_to_inputs`, cross-format test, docs.
+2. Component B: `ArtSource` trait + DB impl, `crc32_update`, `PayloadChunk::Art`
+   and `OggArt` signature change, streaming CRC rewrite, delete
+   `track_art_images`, update format tests + fuzz target, docs.
+
+## Docs to update
+
+- `docs/OGG.md`: art is now streamed at synthesis (no whole-image
+  materialization); note the shared serve-time `MAX_ART_BYTES` cap.
+- `ARCHITECTURE.md`: the "art is streamed at read time, never materialized whole"
+  invariant now holds for Ogg; mention the resolve-time `MAX_ART_BYTES` cap in the
+  external-writer-contract section.

--- a/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
@@ -139,9 +139,10 @@ Five edits. The format layer stays pure (no DB dependency) and fuzzable.
    `musefs-core` implements the trait over `read_art_chunk_into` (the existing
    streaming read); format-layer tests and the `fuzz/` target implement it over an
    in-memory `art_id → &[u8]` map (infallible). `synthesize_layout` takes art
-   metadata plus `&dyn ArtSource` instead of `&[OggArt]` carrying bytes. Adding the
-   `ArtRead` variant requires extending the `From<FormatError> for CoreError`
-   conversion in `musefs-core`.
+   metadata plus `&dyn ArtSource` instead of `&[OggArt]` carrying bytes. The
+   `ArtRead` variant needs no conversion code: `CoreError` already takes
+   `FormatError` via `#[from]` (`musefs-core/src/error.rs`), so it reaches the FUSE
+   layer unchanged in shape.
 
 4. **Incremental CRC.** Add `crc32_update(state: u32, chunk: &[u8]) -> u32` to
    `musefs-format/src/ogg/crc.rs`. The existing `crc32` starts at state 0 with no

--- a/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
@@ -244,8 +244,9 @@ read_at (read time, unchanged)
   `track_art_to_inputs`, preceded by a `log::warn!`. It propagates like other
   resolve errors (e.g. `OrphanedArt`) and makes the track unreadable until the row
   is corrected — the same outcome FLAC already produces for oversize art.
-- `ArtSource::read_window` returns `Result<(), FormatError>`; the core impl wraps
-  its `DbError` in the new `FormatError::ArtRead(Box<…>)` variant, which
+- `ArtSource::read_window` returns `Result<(), FormatError>`; the core impl logs
+  its `DbError` and returns the new `FormatError::ArtRead { art_id }` variant (an
+  `i64` payload, so `FormatError`'s `PartialEq + Eq` derive stays valid), which
   `synthesize_layout` surfaces without buffering. `reader.rs` already converts
   `FormatError` into `CoreError`, so the read failure reaches the FUSE layer
   unchanged in shape.

--- a/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-11-ogg-art-streaming-design.md
@@ -117,16 +117,31 @@ Five edits. The format layer stays pure (no DB dependency) and fuzzable.
    }
    ```
 
-   where `Result` is `musefs-format`'s `Result<T, FormatError>`. `FormatError` is
-   currently a closed enum of structural errors with no I/O/DB variant, so a new
-   `FormatError::ArtRead(Box<dyn std::error::Error + Send + Sync>)` variant is
-   added: the core impl maps its typed `DbError` from `read_art_chunk_into` into it
-   (the inner error stays downcastable), keeping `synthesize_layout`'s return type
-   non-generic `Result<RegionLayout, FormatError>`. `musefs-core` implements the
-   trait over `read_art_chunk_into` (the existing streaming read); format-layer
-   tests and the `fuzz/` target implement it over an in-memory `art_id → &[u8]` map
-   (infallible). `synthesize_layout` takes art metadata plus `&dyn ArtSource`
-   instead of `&[OggArt]` carrying bytes.
+   where `Result` is `musefs-format`'s `Result<T, FormatError>`. `FormatError`
+   currently `#[derive(Debug, Error, PartialEq, Eq)]` (`error.rs:3`) and is compared
+   with `assert_eq!`/`matches!` across the format crate's tests, so the new variant
+   **must stay `PartialEq + Eq`** — a `Box<dyn std::error::Error>` payload would
+   break the derive and every comparison site. The variant is therefore
+   `FormatError::ArtRead { art_id: i64 }` (an `i64` is `Eq`). The core `ArtSource`
+   impl logs the underlying typed `DbError` from `read_art_chunk_into` (with art id
+   and offset) at the point of failure, then returns `ArtRead { art_id }`; the
+   typed error is preserved in the log, not in the enum. This keeps
+   `synthesize_layout`'s return type non-generic `Result<RegionLayout, FormatError>`
+   and leaves the `Eq` derive intact.
+
+   Rejected alternative: making `ArtSource` carry an associated `Error` and
+   `synthesize_layout` generic over it. It avoids a new `FormatError` variant but
+   ripples a generic error parameter through `synthesize_layout` →
+   `lace_chunks_to_segments` → the CRC feeder, and the read path already flattens
+   every art-read failure to `CoreError` at the `reader.rs` boundary, so the typed
+   error buys nothing the log doesn't already give.
+
+   `musefs-core` implements the trait over `read_art_chunk_into` (the existing
+   streaming read); format-layer tests and the `fuzz/` target implement it over an
+   in-memory `art_id → &[u8]` map (infallible). `synthesize_layout` takes art
+   metadata plus `&dyn ArtSource` instead of `&[OggArt]` carrying bytes. Adding the
+   `ArtRead` variant requires extending the `From<FormatError> for CoreError`
+   conversion in `musefs-core`.
 
 4. **Incremental CRC.** Add `crc32_update(state: u32, chunk: &[u8]) -> u32` to
    `musefs-format/src/ogg/crc.rs`. The existing `crc32` starts at state 0 with no
@@ -158,6 +173,55 @@ Five edits. The format layer stays pure (no DB dependency) and fuzzable.
 
 Peak synthesis memory after B: running CRC state + one page-sized raw window + its
 base64 buffer — independent of art size.
+
+#### Coupling: `art_total` now equals the art's byte length
+
+Today `PayloadChunk::Art` carries `out` (the actual output bytes; geometry follows
+`out.len()`) *and* a separate `art_total` (metadata for the read-time
+`OggArtSlice`). Because `out` is self-consistent, the two are free to disagree, and
+the `fuzz/fuzz_targets/ogg.rs` target and the `chunk_lacer_splits_art_across_pages_
+and_crcs_validate` test in `page.rs` deliberately exercise that disagreement
+(e.g. `art_total: 12345` with a 70 000-byte `out`).
+
+After B there is no `out`: geometry is derived from `art_total` (`out_len()` =
+`b64_len(art_total)` or `art_total`) and the bytes come from the `ArtSource`. So
+`art_total` must equal the number of bytes the source yields — the two can no
+longer diverge. This is sound in production: `musefs-db/src/schema.rs` enforces
+`CHECK (byte_len = length(data))` on the `art` table (test
+`v4_art_rejects_byte_len_mismatch`), and `data_len`/`art_total` derive from
+`byte_len`, so the stored blob is always exactly `art_total` bytes.
+
+Consequence for the harnesses (both must change in Component B):
+
+- `fuzz/fuzz_targets/ogg.rs`: drop the "lengths must be free to disagree"
+  decoupling; generate each image with length equal to its `data_len` (or derive
+  `data_len` from the generated image) and feed it through the in-memory
+  `ArtSource`. The current comment documenting the divergence is removed.
+- `page.rs` `chunk_lacer_splits_art_across_pages_and_crcs_validate`: construct
+  `PayloadChunk::Art { art_id, base64, art_total: N }` with a matching in-memory
+  source of exactly `N` bytes (choosing `N` large enough that `b64_len(N)` still
+  spans pages).
+
+### Callers / migration surface
+
+Signature changes ripple to a bounded, mostly-test set (verified by grep):
+
+- `synthesize_layout` (now metadata + `&dyn ArtSource`): real caller
+  `reader.rs:282`; zero-art callers passing `&[]` (`ogg_index.rs:339`,
+  `proptest_ogg.rs:18`, several `ogg/mod.rs` tests) adapt trivially; with-art test
+  callers in `ogg/mod.rs` (≈ lines 918, 1027, 1058, 1091, 1123, 1151, 1186, 1320)
+  and `fuzz/fuzz_targets/ogg.rs:53` migrate to the in-memory `ArtSource`.
+- `OggArt` (loses `image`): all ~13 construction sites are tests + `reader.rs:277`
+  + `fuzz`.
+- `PayloadChunk::Art` (loses `out`): producers `ogg/mod.rs:410`
+  (`comment_packet_chunks`), `ogg/mod.rs:471` (`oggflac_packets_with_art`),
+  `page.rs:591` (test); consumers `out_len` (`page.rs:283`), `copy_payload`
+  (`page.rs:365`, rewritten), `emit_segments` (`page.rs:392`, already byte-free).
+- `track_art_images`: delete the fn (`mapping.rs:95`), its test
+  (`mapping.rs:413`), and the `reader.rs:273` call site.
+- The `flatten`/reconstruct verify helpers (`page.rs:557`, `ogg/mod.rs` header
+  region) already take an `art_id → bytes` map and become the in-memory
+  `ArtSource`.
 
 ### Data flow (Ogg resolve, after)
 

--- a/fuzz/fuzz_targets/ogg.rs
+++ b/fuzz/fuzz_targets/ogg.rs
@@ -32,33 +32,25 @@ fuzz_target!(|data: &[u8]| {
     let mut u = Unstructured::new(data);
     let tags = arb_tags(&mut u).unwrap_or_default();
 
-    // Derive art metadata from the shared helper (so OGG exercises the same
-    // randomized width/height/data_len as every other format target), then
-    // generate each image's bytes independently. OGG is the one synthesis path
-    // carrying both a `data_len` field and a separate `image` slice, so their
-    // lengths must be free to disagree. Images stay non-empty: synthesize_layout
-    // documents that the bridge drops zero-length art at construction.
     let arts_meta = arb_arts(&mut u).unwrap_or_default();
+    // Streaming couples image length to data_len (production enforces
+    // `byte_len = length(data)`), so generate exactly data_len bytes per image.
     let images: Vec<Vec<u8>> = arts_meta
         .iter()
-        .map(|_| {
-            let len = u.int_in_range(1..=8192usize).unwrap_or(1);
-            u.bytes(len).map(<[u8]>::to_vec).unwrap_or_default()
+        .map(|m| {
+            let mut img = vec![0u8; m.data_len.get() as usize];
+            let _ = u.fill_buffer(&mut img);
+            img
         })
         .collect();
-    let arts: Vec<OggArt> = arts_meta
-        .iter()
-        .zip(images.iter())
-        .filter(|(_, image)| !image.is_empty())
-        .map(|(meta, image)| OggArt {
-            meta,
-            image: image.as_slice(),
-        })
-        .collect();
+    let src = ogg::MapArtSource::new(
+        arts_meta.iter().zip(images.iter()).map(|(m, img)| (m.art_id, img.clone())),
+    );
+    let arts: Vec<OggArt> = arts_meta.iter().map(|m| OggArt { meta: m }).collect();
 
-    if let Ok(layout) =
-        ogg::synthesize_layout(&header, scan.audio_offset, scan.audio_length, &tags, &arts)
-    {
+    if let Ok(layout) = ogg::synthesize_layout(
+        &header, scan.audio_offset, scan.audio_length, &tags, &arts, &src,
+    ) {
         assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
     }
 });

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -34,6 +34,13 @@ pub enum CoreError {
         art_id: i64,
         value: u32,
     },
+    #[error("track {track_id} art {art_id} is {byte_len} bytes, exceeds the {cap}-byte art cap")]
+    ArtTooLarge {
+        track_id: i64,
+        art_id: i64,
+        byte_len: u64,
+        cap: u64,
+    },
     #[error("track {0} not found")]
     TrackNotFound(i64),
     #[error("no such inode: {0}")]

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -86,6 +86,22 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
     Ok(inputs)
 }
 
+/// `ArtSource` over the SQLite blob store, used by Ogg synthesis to stream art
+/// bytes for page CRCs. Read failures (e.g. a deleted/short blob) are logged with
+/// the underlying DB error and surfaced as `FormatError::ArtRead`.
+pub(crate) struct DbArtSource<'a, M>(pub &'a Db<M>);
+
+impl<M> musefs_format::ogg::ArtSource for DbArtSource<'_, M> {
+    fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> musefs_format::Result<()> {
+        self.0
+            .read_art_chunk_into(art_id, offset, buf)
+            .map_err(|e| {
+                log::warn!("ogg synthesis: art {art_id} read failed at offset {offset}: {e}");
+                musefs_format::FormatError::ArtRead { art_id }
+            })
+    }
+}
+
 /// Map a track's binary tag rows to `BinaryTagInput`s for synthesis. Never reads
 /// the payload bytes — only `(rowid, key, byte_len)`; the bytes stream at read
 /// time. Ordered by (key, ordinal), matching `get_binary_tags`.
@@ -102,22 +118,6 @@ pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<
             })
         })
         .collect())
-}
-
-/// Read each embedded image's raw bytes for synthesis (Ogg needs the bytes to
-/// compute page CRCs at resolve). Parallel to `track_art_to_inputs`; returns the
-/// same order. Only the Ogg synthesis path calls this — FLAC/MP3/MP4 stream art
-/// via `ArtImage` and never materialize it.
-pub(crate) fn track_art_images<M>(db: &Db<M>, inputs: &[ArtInput]) -> Result<Vec<Vec<u8>>> {
-    let mut out = Vec::with_capacity(inputs.len());
-    for a in inputs {
-        out.push(db.read_art_chunk(
-            a.art_id,
-            0,
-            musefs_db::convert::usize_from(a.data_len.get()),
-        )?);
-    }
-    Ok(out)
 }
 
 #[cfg(test)]
@@ -422,66 +422,6 @@ mod tests {
                     if track_id == tid && art_id == orphan_id
             ),
             "orphaned track_art must yield OrphanedArt with the offending ids, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn track_art_images_reads_stored_blob_bytes() {
-        use musefs_db::{NewArt, TrackArt};
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("art.db");
-        let db = Db::open(&path).unwrap();
-        let tid = db
-            .upsert_track(&NewTrack {
-                backing_path: "/a.flac".into(),
-                format: Format::Flac,
-                audio_offset: 0,
-                audio_length: 0,
-                backing_size: 0,
-                backing_mtime: 0,
-            })
-            .unwrap();
-        let first = db
-            .upsert_art(&NewArt {
-                mime: "image/png".into(),
-                width: None,
-                height: None,
-                data: vec![1, 2, 3, 4],
-            })
-            .unwrap();
-        let second = db
-            .upsert_art(&NewArt {
-                mime: "image/jpeg".into(),
-                width: None,
-                height: None,
-                data: vec![7, 8, 9],
-            })
-            .unwrap();
-        db.set_track_art(
-            tid,
-            &[
-                TrackArt {
-                    art_id: first,
-                    picture_type: 3,
-                    description: String::new(),
-                    ordinal: 0,
-                },
-                TrackArt {
-                    art_id: second,
-                    picture_type: 4,
-                    description: String::new(),
-                    ordinal: 1,
-                },
-            ],
-        )
-        .unwrap();
-
-        let inputs = super::track_art_to_inputs(&db, tid).unwrap();
-        let images = super::track_art_images(&db, &inputs).unwrap();
-        assert_eq!(
-            images,
-            vec![vec![1, 2, 3, 4], vec![7, 8, 9]],
-            "must return each stored blob's exact bytes, in input order"
         );
     }
 

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -498,4 +498,43 @@ mod tests {
             "oversize art must yield ArtTooLarge with the offending ids, got {err:?}"
         );
     }
+
+    #[test]
+    fn db_art_source_reads_windows_and_maps_failures_to_artread() {
+        use musefs_db::NewArt;
+        use musefs_format::ogg::ArtSource;
+        let dir = tempfile::tempdir().unwrap();
+        let db = Db::open(dir.path().join("src.db")).unwrap();
+        let art_id = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![10, 20, 30, 40, 50],
+            })
+            .unwrap();
+        let src = super::DbArtSource(&db);
+
+        // In-bounds window returns the exact stored bytes.
+        let mut buf = [0u8; 3];
+        src.read_window(art_id, 1, &mut buf).unwrap();
+        assert_eq!(buf, [20, 30, 40]);
+
+        // Reading past the blob end is a short read from the DB, mapped to ArtRead.
+        let mut over = [0u8; 4];
+        let err = src.read_window(art_id, 2, &mut over).unwrap_err();
+        assert!(
+            matches!(err, musefs_format::FormatError::ArtRead { art_id: a } if a == art_id),
+            "out-of-range read must map to ArtRead, got {err:?}"
+        );
+
+        // A missing art row likewise surfaces ArtRead, naming the offending id.
+        let missing = art_id + 999;
+        let mut one = [0u8; 1];
+        let err = src.read_window(missing, 0, &mut one).unwrap_err();
+        assert!(
+            matches!(err, musefs_format::FormatError::ArtRead { art_id: a } if a == missing),
+            "missing art row must map to ArtRead, got {err:?}"
+        );
+    }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -50,6 +50,22 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
         let Some(data_len) = musefs_format::BlobLen::new(meta.byte_len) else {
             continue; // zero-length art: synthesis would skip it anyway (now type-level).
         };
+
+        if data_len.get() > crate::scan::MAX_ART_BYTES as u64 {
+            log::warn!(
+                "track {track_id} art {} is {} bytes, exceeds the {}-byte art cap; refusing to serve",
+                ta.art_id,
+                data_len.get(),
+                crate::scan::MAX_ART_BYTES,
+            );
+            return Err(crate::error::CoreError::ArtTooLarge {
+                track_id,
+                art_id: ta.art_id,
+                byte_len: data_len.get(),
+                cap: crate::scan::MAX_ART_BYTES as u64,
+            });
+        }
+
         let Some(picture_type) = musefs_format::PictureType::new(ta.picture_type) else {
             return Err(crate::error::CoreError::InvalidPictureType {
                 track_id,
@@ -466,6 +482,80 @@ mod tests {
             images,
             vec![vec![1, 2, 3, 4], vec![7, 8, 9]],
             "must return each stored blob's exact bytes, in input order"
+        );
+    }
+
+    #[test]
+    fn track_art_to_inputs_enforces_art_cap() {
+        use crate::CoreError;
+        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
+        // The boundary uses the real MAX_ART_BYTES (not a smaller test value) so the
+        // mutation gate catches a `>`→`>=` flip; this hashes ~32 MiB across the two
+        // blobs, which is fine here — do not "optimize" the boundary away.
+        let cap = crate::scan::MAX_ART_BYTES;
+        let dir = tempfile::tempdir().unwrap();
+        let db = Db::open(dir.path().join("cap.db")).unwrap();
+        let tid = db
+            .upsert_track(&NewTrack {
+                backing_path: "/a.opus".into(),
+                format: Format::Opus,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime: 0,
+            })
+            .unwrap();
+
+        // Exactly at the cap: accepted.
+        let at_cap = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![0u8; cap],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[TrackArt {
+                art_id: at_cap,
+                picture_type: 3,
+                description: String::new(),
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+        let ok = super::track_art_to_inputs(&db, tid).unwrap();
+        assert_eq!(ok.len(), 1, "art exactly at the cap must be accepted");
+
+        // One byte over the cap: rejected with ArtTooLarge naming the offending ids.
+        let over = db
+            .upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![0u8; cap + 1],
+            })
+            .unwrap();
+        db.set_track_art(
+            tid,
+            &[TrackArt {
+                art_id: over,
+                picture_type: 3,
+                description: String::new(),
+                ordinal: 0,
+            }],
+        )
+        .unwrap();
+        let err = super::track_art_to_inputs(&db, tid).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CoreError::ArtTooLarge { track_id, art_id, byte_len, cap: c }
+                    if track_id == tid && art_id == over
+                        && byte_len == (cap as u64) + 1 && c == cap as u64
+            ),
+            "oversize art must yield ArtTooLarge with the offending ids, got {err:?}"
         );
     }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -51,6 +51,9 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
             continue; // zero-length art: synthesis would skip it anyway (now type-level).
         };
 
+        // Backstop to the V4 `byte_len <= MAX_ART_BYTES` schema CHECK (#291): a
+        // writer that disables check enforcement can still plant an oversize row,
+        // and Component B would stream it with bounded memory, but we refuse it.
         if data_len.get() > crate::scan::MAX_ART_BYTES as u64 {
             log::warn!(
                 "track {track_id} art {} is {} bytes, exceeds the {}-byte art cap; refusing to serve",
@@ -428,13 +431,20 @@ mod tests {
     #[test]
     fn track_art_to_inputs_enforces_art_cap() {
         use crate::CoreError;
-        use musefs_db::{NewArt, TrackArt}; // NewTrack already in scope at module level
-        // The boundary uses the real MAX_ART_BYTES (not a smaller test value) so the
-        // mutation gate catches a `>`→`>=` flip; this hashes ~32 MiB across the two
-        // blobs, which is fine here — do not "optimize" the boundary away.
+        use musefs_db::TrackArt; // NewTrack already in scope at module level
+        // The V4 schema CHECK (byte_len <= MAX_ART_BYTES, #291) already rejects
+        // oversize art at write time. The only way an oversize row reaches the
+        // reader is a writer that disables CHECK enforcement (PRAGMA
+        // ignore_check_constraints / writable_schema) — which also evades the
+        // schema-identity gate, since the schema text is unchanged. This
+        // resolve-time cap is the backstop for exactly that, so the test plants
+        // the adversarial rows on a raw connection with checks off (empty blobs;
+        // track_art_to_inputs reads byte_len only) and pins the boundary so the
+        // mutation gate catches a `>`->`>=` flip.
         let cap = crate::scan::MAX_ART_BYTES;
         let dir = tempfile::tempdir().unwrap();
-        let db = Db::open(dir.path().join("cap.db")).unwrap();
+        let path = dir.path().join("cap.db");
+        let db = Db::open(&path).unwrap();
         let tid = db
             .upsert_track(&NewTrack {
                 backing_path: "/a.opus".into(),
@@ -446,15 +456,21 @@ mod tests {
             })
             .unwrap();
 
-        // Exactly at the cap: accepted.
-        let at_cap = db
-            .upsert_art(&NewArt {
-                mime: "image/png".into(),
-                width: None,
-                height: None,
-                data: vec![0u8; cap],
-            })
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.execute_batch("PRAGMA ignore_check_constraints = ON;")
             .unwrap();
+        let plant = |byte_len: i64, sha: &str| {
+            raw.execute(
+                "INSERT INTO art (sha256, mime, byte_len, data) VALUES (?1, 'image/png', ?2, X'')",
+                rusqlite::params![sha, byte_len],
+            )
+            .unwrap();
+            raw.last_insert_rowid()
+        };
+        let at_cap = plant(i64::try_from(cap).unwrap(), &"a".repeat(64));
+        let over = plant(i64::try_from(cap + 1).unwrap(), &"b".repeat(64));
+
+        // Exactly at the cap: accepted.
         db.set_track_art(
             tid,
             &[TrackArt {
@@ -469,14 +485,6 @@ mod tests {
         assert_eq!(ok.len(), 1, "art exactly at the cap must be accepted");
 
         // One byte over the cap: rejected with ArtTooLarge naming the offending ids.
-        let over = db
-            .upsert_art(&NewArt {
-                mime: "image/png".into(),
-                width: None,
-                height: None,
-                data: vec![0u8; cap + 1],
-            })
-            .unwrap();
         db.set_track_art(
             tid,
             &[TrackArt {

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -335,8 +335,15 @@ mod tests {
         use musefs_format::ogg::{locate_audio, read_header, synthesize_layout};
         let scan = locate_audio(file).unwrap();
         let header = read_header(file).unwrap();
-        let layout =
-            synthesize_layout(&header, scan.audio_offset, scan.audio_length, &[], &[]).unwrap();
+        let layout = synthesize_layout(
+            &header,
+            scan.audio_offset,
+            scan.audio_length,
+            &[],
+            &[],
+            &musefs_format::ogg::MapArtSource::default(),
+        )
+        .unwrap();
         let (hdr_bytes, ao, alen, delta) = materialize_header_and_audio_params(&layout);
 
         let dir = tempfile::tempdir().unwrap();

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -270,21 +270,18 @@ impl HeaderCache {
                             track.bounds.audio_offset(),
                         )?;
                         let header = musefs_format::ogg::read_metadata(&front)?;
-                        let art_images = crate::mapping::track_art_images(db, &art_inputs)?;
                         let arts: Vec<musefs_format::ogg::OggArt> = art_inputs
                             .iter()
-                            .zip(art_images.iter())
-                            .map(|(meta, image)| musefs_format::ogg::OggArt {
-                                meta,
-                                image: image.as_slice(),
-                            })
+                            .map(|meta| musefs_format::ogg::OggArt { meta })
                             .collect();
+                        let src = crate::mapping::DbArtSource(db);
                         musefs_format::ogg::synthesize_layout(
                             &header,
                             track.bounds.audio_offset(),
                             track.bounds.audio_length(),
                             &inputs,
                             &arts,
+                            &src,
                         )?
                     }
                 };

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -24,11 +24,11 @@ const MAX_WIDEN_RETRIES: usize = 8;
 /// giant `NeedMore` widen.
 const MAX_PROBE_BYTES: u64 = 64 << 20; // 64 MiB
 
-/// Skip embedded art whose image bytes exceed this. The binding limit is FLAC's
-/// 24-bit PICTURE block length (~16 MiB for the whole block); reserve 64 KiB of
-/// headroom so the block framing + mime + description can never push a near-cap
-/// image past the limit at synthesis time. Real cover art is far smaller.
-const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
+/// The artwork-size ceiling. Enforced here at ingest (oversize scanned art is
+/// dropped) and at resolve in `mapping::track_art_to_inputs` (oversize art from
+/// any writer is rejected). Sized to clear FLAC's 24-bit block length with
+/// headroom for the picture-block framing.
+pub(crate) const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
 
 /// Per-frame cap for opaque binary tags, mirroring `MAX_ART_BYTES`. Oversize
 /// payloads (e.g. a GEOB embedding a multi-MB file) are logged-and-skipped.

--- a/musefs-format/src/error.rs
+++ b/musefs-format/src/error.rs
@@ -18,6 +18,8 @@ pub enum FormatError {
     InvalidLayout(#[from] crate::layout::LayoutError),
     #[error("producer invariant violated: {0}")]
     ProducerBug(&'static str),
+    #[error("failed to read art {art_id} bytes for synthesis")]
+    ArtRead { art_id: i64 },
 }
 
 pub type Result<T> = std::result::Result<T, FormatError>;

--- a/musefs-format/src/ogg/art_source.rs
+++ b/musefs-format/src/ogg/art_source.rs
@@ -1,0 +1,41 @@
+use crate::error::{FormatError, Result};
+use std::collections::HashMap;
+
+/// A source of raw art bytes used during synthesis to compute page CRCs. The
+/// production implementation (in `musefs-core`) streams from the SQLite blob
+/// store; tests and fuzzing use [`MapArtSource`]. `offset` and `buf.len()` are in
+/// raw-image coordinates; a read past the stored image is an error (mirrors the
+/// short-read semantics of the DB blob path), surfaced as `FormatError::ArtRead`.
+pub trait ArtSource {
+    fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()>;
+}
+
+/// In-memory `ArtSource` over an `art_id -> image bytes` map. For tests/fuzz.
+#[derive(Default)]
+pub struct MapArtSource {
+    images: HashMap<i64, Vec<u8>>,
+}
+
+impl MapArtSource {
+    pub fn new(images: impl IntoIterator<Item = (i64, Vec<u8>)>) -> Self {
+        Self {
+            images: images.into_iter().collect(),
+        }
+    }
+}
+
+impl ArtSource for MapArtSource {
+    fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> Result<()> {
+        let img = self
+            .images
+            .get(&art_id)
+            .ok_or(FormatError::ArtRead { art_id })?;
+        let start = crate::convert::usize_from(offset);
+        let end = start
+            .checked_add(buf.len())
+            .filter(|&e| e <= img.len())
+            .ok_or(FormatError::ArtRead { art_id })?;
+        buf.copy_from_slice(&img[start..end]);
+        Ok(())
+    }
+}

--- a/musefs-format/src/ogg/art_source.rs
+++ b/musefs-format/src/ogg/art_source.rs
@@ -30,7 +30,13 @@ impl ArtSource for MapArtSource {
             .images
             .get(&art_id)
             .ok_or(FormatError::ArtRead { art_id })?;
-        let start = crate::convert::usize_from(offset);
+        // Guard the u64 -> usize narrowing: an offset past `usize::MAX` (only
+        // reachable on a 32-bit target) must fail closed, not truncate and read
+        // the wrong bytes.
+        let start = usize::try_from(offset)
+            .ok()
+            .filter(|&s| s <= img.len())
+            .ok_or(FormatError::ArtRead { art_id })?;
         let end = start
             .checked_add(buf.len())
             .filter(|&e| e <= img.len())

--- a/musefs-format/src/ogg/crc.rs
+++ b/musefs-format/src/ogg/crc.rs
@@ -26,12 +26,18 @@ const fn build_table() -> [u32; 256] {
 
 const TABLE: [u32; 256] = build_table();
 
-pub fn crc32(buf: &[u8]) -> u32 {
-    let mut crc: u32 = 0;
+/// Fold `buf` into a running CRC `state`. `crc32(x) == crc32_update(0, x)` and
+/// `crc32(a ++ b) == crc32_update(crc32_update(0, &a), &b)`, so a page CRC can be
+/// computed in bounded windows without assembling the whole page.
+pub(crate) fn crc32_update(mut state: u32, buf: &[u8]) -> u32 {
     for &b in buf {
-        crc = (crc << 8) ^ TABLE[(((crc >> 24) as u8) ^ b) as usize];
+        state = (state << 8) ^ TABLE[(((state >> 24) as u8) ^ b) as usize];
     }
-    crc
+    state
+}
+
+pub fn crc32(buf: &[u8]) -> u32 {
+    crc32_update(0, buf)
 }
 
 pub fn crc_shift_zeros(crc: u32, n: usize) -> u32 {
@@ -135,6 +141,16 @@ mod tests {
         assert_eq!(crc32(b"123456789"), reference(b"123456789"));
         let blob: Vec<u8> = (0..=255u8).cycle().take(5000).collect();
         assert_eq!(crc32(&blob), reference(&blob));
+    }
+
+    #[test]
+    fn crc32_update_matches_oneshot_across_a_split() {
+        let data: Vec<u8> = (0..1000u32).map(|i| (i % 251) as u8).collect();
+        for split in [0usize, 1, 3, 255, 256, 700, 1000] {
+            let (a, b) = data.split_at(split);
+            let streamed = super::crc32_update(super::crc32_update(0, a), b);
+            assert_eq!(streamed, super::crc32(&data), "split at {split}");
+        }
     }
 
     #[test]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -1082,6 +1082,52 @@ mod tests {
     }
 
     #[test]
+    fn synthesize_oggflac_embeds_large_art_spanning_pages_round_trips() {
+        // A >64 KiB raw PICTURE block forces the art run across multiple pages,
+        // exercising the non-base64 streaming-CRC path at page boundaries (the
+        // base64 path is covered by the lacer test; this pins the raw path).
+        let mut data = oggflac_headers();
+        let (audio, _) = crate::ogg::page::lace_packet(77, 3, false, 4096, &[0u8; 64]);
+        data.extend_from_slice(&audio);
+        let scan = locate_audio(&data).unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
+
+        let image: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let meta = art_input(31, "image/png", image.len());
+        let src = MapArtSource::new([(meta.art_id, image.clone())]);
+        let layout = synthesize_layout(
+            &header,
+            scan.audio_offset,
+            scan.audio_length,
+            &[TagInput::new("title", "Big")],
+            &[OggArt { meta: &meta }],
+            &src,
+        )
+        .unwrap();
+
+        // The art run must split across pages: more than one raw OggArtSlice.
+        let art_slices = layout
+            .segments()
+            .iter()
+            .filter(|s| matches!(s, Segment::OggArtSlice { base64: false, .. }))
+            .count();
+        assert!(
+            art_slices >= 2,
+            "expected the raw art to span multiple pages, got {art_slices} slice(s)"
+        );
+
+        let bytes = materialize_header(&layout, &[(31, &image)]);
+        let h = read_header(&bytes).unwrap();
+        assert_eq!(h.codec, Codec::OggFlac);
+        let pics = read_pictures(&bytes).unwrap();
+        assert_eq!(pics.len(), 1);
+        assert_eq!(
+            pics[0].data, image,
+            "large art must round-trip byte-for-byte"
+        );
+    }
+
+    #[test]
     fn synthesize_opus_embeds_multiple_images() {
         let mut data = opus_headers();
         let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 64]);

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -1,6 +1,9 @@
+mod art_source;
 mod b64;
 mod crc;
 mod page;
+
+pub use art_source::{ArtSource, MapArtSource};
 
 pub use b64::{B64Window, b64_len, b64_window, encode_b64_slice};
 pub use page::{
@@ -243,25 +246,21 @@ pub fn read_metadata_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<OggH
 use crate::input::TagInput;
 use crate::layout::{RegionLayout, Segment};
 
-/// Assemble a synthesized layout: regenerated header pages (with embedded art as
-/// `OggArtSlice` runs) + one compact `OggAudio` segment renumbering the preserved
-/// audio pages. `arts` carries each embedded image's metadata + raw bytes (used
-/// transiently to compute page CRCs; not retained in the layout).
 pub fn synthesize_layout(
     header: &OggHeader,
     audio_offset: u64,
     audio_length: u64,
     tags: &[TagInput],
     arts: &[OggArt],
+    src: &dyn ArtSource,
 ) -> Result<RegionLayout> {
-    // All art inputs are non-zero-length (the bridge drops zero-length at construction).
     let arts: Vec<OggArt> = arts.to_vec();
     let packet_chunks = build_packets_with_art(header, tags, &arts)?;
     let mut segments: Vec<Segment> = Vec::new();
     let mut seq = 0u32;
     for (i, chunks) in packet_chunks.iter().enumerate() {
         let (segs, used) =
-            crate::ogg::page::lace_chunks_to_segments(header.serial, seq, i == 0, chunks);
+            crate::ogg::page::lace_chunks_to_segments(header.serial, seq, i == 0, chunks, src)?;
         segments.extend(segs);
         seq += used;
     }
@@ -316,11 +315,11 @@ fn picture_prefix(art: &crate::input::ArtInput) -> Result<Vec<u8>> {
 use crate::ogg::page::PayloadChunk;
 use base64::Engine;
 
-/// One image to embed: its metadata and raw bytes (read transiently at resolve).
+/// One image to embed: its metadata. Bytes are read from an `ArtSource` only to
+/// compute page CRCs at synthesis time; they are never retained in the layout.
 #[derive(Clone, Copy)]
 pub struct OggArt<'a> {
     pub meta: &'a crate::input::ArtInput,
-    pub image: &'a [u8],
 }
 
 fn b64_encode(bytes: &[u8]) -> Vec<u8> {
@@ -409,7 +408,6 @@ fn comment_packet_chunks(
         chunks.push(PayloadChunk::Bytes(std::mem::take(&mut head)));
         chunks.push(PayloadChunk::Art {
             art_id: art.meta.art_id,
-            out: b64_encode(art.image),
             base64: true,
             art_total: art.meta.data_len.get(),
         });
@@ -470,7 +468,6 @@ fn oggflac_packets_with_art(
             PayloadChunk::Bytes(blk),
             PayloadChunk::Art {
                 art_id: art.meta.art_id,
-                out: art.image.to_vec(),
                 base64: false,
                 art_total: art.meta.data_len.get(),
             },
@@ -621,6 +618,7 @@ mod tests {
             scan.audio_length,
             &[TagInput::new("album", "Geogaddi")],
             &[],
+            &MapArtSource::default(),
         )
         .unwrap();
 
@@ -660,8 +658,15 @@ mod tests {
             read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
 
         // Synthesis re-lays the Opus header into a known page count; record it.
-        let baseline =
-            synthesize_layout(&header, scan.audio_offset, scan.audio_length, &[], &[]).unwrap();
+        let baseline = synthesize_layout(
+            &header,
+            scan.audio_offset,
+            scan.audio_length,
+            &[],
+            &[],
+            &MapArtSource::default(),
+        )
+        .unwrap();
         let synth_pages = baseline
             .segments()
             .iter()
@@ -673,8 +678,15 @@ mod tests {
         // pages must be renumbered downward by exactly three.
         let original_pages = u32::try_from(synth_pages).unwrap() + 3;
         header.header_pages = original_pages;
-        let layout =
-            synthesize_layout(&header, scan.audio_offset, scan.audio_length, &[], &[]).unwrap();
+        let layout = synthesize_layout(
+            &header,
+            scan.audio_offset,
+            scan.audio_length,
+            &[],
+            &[],
+            &MapArtSource::default(),
+        )
+        .unwrap();
         let delta = layout
             .segments()
             .iter()
@@ -728,6 +740,7 @@ mod tests {
             scan.audio_length,
             &[TagInput::new("artist", "Autechre")],
             &[],
+            &MapArtSource::default(),
         )
         .unwrap();
 
@@ -860,6 +873,7 @@ mod tests {
             scan.audio_length,
             &[TagInput::new("title", "Kaini Industries")],
             &[],
+            &MapArtSource::default(),
         )
         .unwrap();
 
@@ -910,15 +924,14 @@ mod tests {
             height: 64,
             data_len: crate::input::BlobLen::new(image.len() as u64).unwrap(),
         };
+        let src = MapArtSource::new([(meta.art_id, image.clone())]);
         let layout = synthesize_layout(
             &header,
             scan.audio_offset,
             scan.audio_length,
             &[TagInput::new("title", "Cover")],
-            &[OggArt {
-                meta: &meta,
-                image: &image,
-            }],
+            &[OggArt { meta: &meta }],
+            &src,
         )
         .unwrap();
 
@@ -1019,15 +1032,14 @@ mod tests {
 
         let image: Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
         let meta = art_input(11, "image/png", image.len());
+        let src = MapArtSource::new([(meta.art_id, image.clone())]);
         let layout = synthesize_layout(
             &header,
             scan.audio_offset,
             scan.audio_length,
             &[TagInput::new("artist", "X")],
-            &[OggArt {
-                meta: &meta,
-                image: &image,
-            }],
+            &[OggArt { meta: &meta }],
+            &src,
         )
         .unwrap();
 
@@ -1050,15 +1062,14 @@ mod tests {
 
         let image: Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
         let meta = art_input(22, "image/png", image.len());
+        let src = MapArtSource::new([(meta.art_id, image.clone())]);
         let layout = synthesize_layout(
             &header,
             scan.audio_offset,
             scan.audio_length,
             &[TagInput::new("title", "Y")],
-            &[OggArt {
-                meta: &meta,
-                image: &image,
-            }],
+            &[OggArt { meta: &meta }],
+            &src,
         )
         .unwrap();
 
@@ -1082,21 +1093,17 @@ mod tests {
         let img_b: Vec<u8> = (0..1500u32).map(|i| ((i * 3) % 251) as u8).collect();
         let meta_a = art_input(1, "image/png", img_a.len());
         let meta_b = art_input(2, "image/jpeg", img_b.len());
+        let src = MapArtSource::new([
+            (meta_a.art_id, img_a.clone()),
+            (meta_b.art_id, img_b.clone()),
+        ]);
         let layout = synthesize_layout(
             &header,
             scan.audio_offset,
             scan.audio_length,
             &[TagInput::new("title", "Multi")],
-            &[
-                OggArt {
-                    meta: &meta_a,
-                    image: &img_a,
-                },
-                OggArt {
-                    meta: &meta_b,
-                    image: &img_b,
-                },
-            ],
+            &[OggArt { meta: &meta_a }, OggArt { meta: &meta_b }],
+            &src,
         )
         .unwrap();
 
@@ -1120,10 +1127,7 @@ mod tests {
             width: 0,
             height: 0,
         };
-        let art = OggArt {
-            meta: &meta,
-            image: &[],
-        };
+        let art = OggArt { meta: &meta };
         let header = OggHeader {
             codec: Codec::Vorbis,
             serial: 0,
@@ -1148,10 +1152,7 @@ mod tests {
             width: 0,
             height: 0,
         };
-        let art = OggArt {
-            meta: &meta,
-            image: &[],
-        };
+        let art = OggArt { meta: &meta };
         let header = OggHeader {
             codec: Codec::Vorbis,
             serial: 0,
@@ -1183,10 +1184,7 @@ mod tests {
             width: 0,
             height: 0,
         };
-        let art = OggArt {
-            meta: &meta,
-            image: &[],
-        };
+        let art = OggArt { meta: &meta };
         let header = OggHeader {
             codec: Codec::Vorbis,
             serial: 0,
@@ -1317,17 +1315,11 @@ mod tests {
         };
         let framing_len = picture_prefix(&mk(1)).unwrap().len() as u64;
         let at_limit = mk(crate::flac::MAX_BLOCK_BODY - framing_len);
-        let arts = [OggArt {
-            meta: &at_limit,
-            image: &[],
-        }];
+        let arts = [OggArt { meta: &at_limit }];
         assert!(oggflac_packets_with_art(&header, &[], &arts).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
         let over = mk(crate::flac::MAX_BLOCK_BODY - framing_len + 1);
-        let arts = [OggArt {
-            meta: &over,
-            image: &[],
-        }];
+        let arts = [OggArt { meta: &over }];
         assert!(matches!(
             oggflac_packets_with_art(&header, &[], &arts),
             Err(FormatError::TooLarge)
@@ -1398,6 +1390,63 @@ mod tests {
         let pad = declared - u32::try_from(art.description.len()).unwrap();
         assert!(pad <= 2, "pad must be 0..=2, got {pad}");
         assert_eq!(pad, 0, "base % 3 == 0 implies pad 0");
+    }
+
+    #[test]
+    fn synthesis_reads_art_in_page_bounded_windows() {
+        use std::cell::Cell;
+        struct Counting<'a> {
+            inner: MapArtSource,
+            max: &'a Cell<usize>,
+        }
+        impl ArtSource for Counting<'_> {
+            fn read_window(&self, art_id: i64, offset: u64, buf: &mut [u8]) -> crate::Result<()> {
+                self.max.set(self.max.get().max(buf.len()));
+                self.inner.read_window(art_id, offset, buf)
+            }
+        }
+
+        // Inline Opus fixture, mirroring synthesize_opus_emits_valid_header_and_audio_segment.
+        let mut data = opus_headers();
+        let scan = locate_audio({
+            let (audio, _) = crate::ogg::page::lace_packet(0x1234, 2, false, 960, &[0u8; 80]);
+            data.extend_from_slice(&audio);
+            &data
+        })
+        .unwrap();
+        let header = read_metadata(&data[..crate::convert::usize_from(scan.audio_offset)]).unwrap();
+
+        let image: Vec<u8> = (0..500_000u32).map(|i| (i % 251) as u8).collect();
+        let meta = crate::input::ArtInput {
+            art_id: 7,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: crate::input::BlobLen::new(image.len() as u64).unwrap(),
+        };
+        let max = Cell::new(0usize);
+        let src = Counting {
+            inner: MapArtSource::new([(7i64, image.clone())]),
+            max: &max,
+        };
+        synthesize_layout(
+            &header,
+            scan.audio_offset,
+            scan.audio_length,
+            &[],
+            &[OggArt { meta: &meta }],
+            &src,
+        )
+        .unwrap();
+        // One Ogg page's payload is at most 255*255 = 65025 bytes; raw windows are
+        // <= that. The 500 KB image is never read in a single call.
+        assert!(
+            max.get() > 0 && max.get() <= 65_025,
+            "max single read was {}",
+            max.get()
+        );
     }
 }
 

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -1,4 +1,5 @@
-use super::crc::{crc_shift_zeros, crc32};
+use super::art_source::ArtSource;
+use super::crc::{crc_shift_zeros, crc32, crc32_update};
 use crate::error::{FormatError, Result};
 
 pub const CAPTURE: &[u8; 4] = b"OggS";
@@ -264,13 +265,12 @@ use crate::layout::Segment;
 pub(crate) enum PayloadChunk {
     /// Literal bytes copied verbatim into the layout as `Inline`.
     Bytes(Vec<u8>),
-    /// An art run. `out` holds the run's full OUTPUT bytes (base64(image) when
-    /// `base64`, else raw image) — used here only to compute page CRCs and lengths,
-    /// then dropped; the layout stores an `OggArtSlice` referencing `art_id` so the
-    /// bytes are re-derived at read time. `art_total` is the raw image length.
+    /// An art run. Carries no bytes: its OUTPUT length is derived from `art_total`
+    /// (base64-expanded when `base64`), and its bytes are streamed from an
+    /// `ArtSource` to compute page CRCs, then never stored — the layout keeps an
+    /// `OggArtSlice` referencing `art_id`. `art_total` is the raw image length.
     Art {
         art_id: i64,
-        out: Vec<u8>,
         base64: bool,
         art_total: u64,
     },
@@ -280,29 +280,38 @@ impl PayloadChunk {
     fn out_len(&self) -> usize {
         match self {
             PayloadChunk::Bytes(b) => b.len(),
-            PayloadChunk::Art { out, .. } => out.len(),
+            PayloadChunk::Art {
+                base64, art_total, ..
+            } => {
+                let n = if *base64 {
+                    crate::ogg::b64::b64_len(*art_total)
+                } else {
+                    *art_total
+                };
+                crate::convert::usize_from(n)
+            }
         }
     }
 }
 
-/// Lace one packet (described as a chunk list) into pages starting at sequence
-/// `seq_start`, emitting layout segments: page headers + literal payload as
-/// `Inline` (CRCs baked in), and art runs as `OggArtSlice` (no bytes stored). The
-/// art `out` bytes are materialized only to compute page CRCs, then dropped.
-/// Returns `(segments, pages_used)`.
+/// Lace one packet (a chunk list) into pages from sequence `seq_start`, emitting
+/// layout segments: page headers + literal payload as `Inline` (CRCs baked in),
+/// art runs as `OggArtSlice` (no bytes stored). Art bytes are streamed from `src`
+/// only to compute page CRCs. Returns `(segments, pages_used)`.
 pub(crate) fn lace_chunks_to_segments(
     serial: u32,
     seq_start: u32,
     bos: bool,
     chunks: &[PayloadChunk],
-) -> (Vec<Segment>, u32) {
+    src: &dyn ArtSource,
+) -> crate::error::Result<(Vec<Segment>, u32)> {
     let total: usize = chunks.iter().map(PayloadChunk::out_len).sum();
     let laces = lacing_values(total);
 
     let mut segments: Vec<Segment> = Vec::new();
     let mut seq = seq_start;
     let mut lace_pos = 0usize;
-    let mut payload_pos = 0usize; // absolute position within the packet payload
+    let mut payload_pos = 0usize;
     let mut first = true;
 
     while first || lace_pos < laces.len() {
@@ -318,41 +327,43 @@ pub(crate) fn lace_chunks_to_segments(
             header_type |= FLAG_CONTINUED;
         }
 
-        // Assemble full page bytes (with art materialized) to compute the CRC.
-        let mut page = Vec::with_capacity(27 + seg_count + page_payload);
-        page.extend_from_slice(CAPTURE);
-        page.push(0);
-        page.push(header_type);
-        page.extend_from_slice(&0u64.to_le_bytes()); // granule 0 (header page)
-        page.extend_from_slice(&serial.to_le_bytes());
-        page.extend_from_slice(&seq.to_le_bytes());
-        page.extend_from_slice(&0u32.to_le_bytes()); // CRC placeholder
-        page.push(u8::try_from(seg_count).expect("seg_count is .min(255) so fits in u8"));
-        page.extend_from_slice(table);
-        copy_payload(&mut page, chunks, payload_pos, page_payload);
-        let crc = crc32(&page);
-        page[22..26].copy_from_slice(&crc.to_le_bytes());
-
+        // Build the page header + lacing table only (CRC field zeroed), then stream
+        // the page CRC over header+payload without materializing the payload.
         let header_len = 27 + seg_count;
-        emit_segments(
-            &mut segments,
-            &page[..header_len],
-            chunks,
-            payload_pos,
-            page_payload,
-        );
+        let mut header = Vec::with_capacity(header_len);
+        header.extend_from_slice(CAPTURE);
+        header.push(0);
+        header.push(header_type);
+        header.extend_from_slice(&0u64.to_le_bytes()); // granule 0 (header page)
+        header.extend_from_slice(&serial.to_le_bytes());
+        header.extend_from_slice(&seq.to_le_bytes());
+        header.extend_from_slice(&0u32.to_le_bytes()); // CRC placeholder
+        header.push(u8::try_from(seg_count).expect("seg_count is .min(255) so fits in u8"));
+        header.extend_from_slice(table);
+
+        let mut crc = crc32_update(0, &header);
+        crc_feed_payload(&mut crc, chunks, src, payload_pos, page_payload)?;
+        header[22..26].copy_from_slice(&crc.to_le_bytes());
+
+        emit_segments(&mut segments, &header, chunks, payload_pos, page_payload);
 
         payload_pos += page_payload;
         lace_pos += seg_count;
         seq += 1;
         first = false;
     }
-    (segments, seq - seq_start)
+    Ok((segments, seq - seq_start))
 }
 
-/// Append payload bytes `[p0, p0+plen)` (in packet-payload coordinates) into `dst`
-/// by copying from the chunk list (materializing art `out`).
-fn copy_payload(dst: &mut Vec<u8>, chunks: &[PayloadChunk], p0: usize, plen: usize) {
+/// Fold payload bytes `[p0, p0+plen)` (packet-payload coordinates) into `crc`,
+/// reading art runs from `src` instead of materializing them.
+fn crc_feed_payload(
+    crc: &mut u32,
+    chunks: &[PayloadChunk],
+    src: &dyn ArtSource,
+    p0: usize,
+    plen: usize,
+) -> crate::error::Result<()> {
     let end = p0 + plen;
     let mut cs = 0usize;
     for c in chunks {
@@ -360,14 +371,55 @@ fn copy_payload(dst: &mut Vec<u8>, chunks: &[PayloadChunk], p0: usize, plen: usi
         let os = p0.max(cs);
         let oe = end.min(ce);
         if os < oe {
-            let bytes: &[u8] = match c {
-                PayloadChunk::Bytes(b) => b,
-                PayloadChunk::Art { out, .. } => out,
-            };
-            dst.extend_from_slice(&bytes[os - cs..oe - cs]);
+            match c {
+                PayloadChunk::Bytes(b) => {
+                    *crc = crc32_update(*crc, &b[os - cs..oe - cs]);
+                }
+                PayloadChunk::Art {
+                    art_id,
+                    base64,
+                    art_total,
+                } => {
+                    crc_feed_art(
+                        crc,
+                        src,
+                        *art_id,
+                        *base64,
+                        *art_total,
+                        (os - cs) as u64,
+                        oe - os,
+                    )?;
+                }
+            }
         }
         cs = ce;
     }
+    Ok(())
+}
+
+/// Fold one art window — output bytes `[out_off, out_off+out_len)` of the run —
+/// into `crc`, base64-encoding on the fly when `base64`. `out_len` is page-bounded.
+fn crc_feed_art(
+    crc: &mut u32,
+    src: &dyn ArtSource,
+    art_id: i64,
+    base64: bool,
+    art_total: u64,
+    out_off: u64,
+    out_len: usize,
+) -> crate::error::Result<()> {
+    if base64 {
+        let w = crate::ogg::b64::b64_window(out_off, out_len as u64, art_total);
+        let mut raw = vec![0u8; crate::convert::usize_from(w.in_len)];
+        src.read_window(art_id, w.in_start, &mut raw)?;
+        let enc = crate::ogg::b64::encode_b64_slice(&raw, w.skip, out_len);
+        *crc = crc32_update(*crc, &enc);
+    } else {
+        let mut raw = vec![0u8; out_len];
+        src.read_window(art_id, out_off, &mut raw)?;
+        *crc = crc32_update(*crc, &raw);
+    }
+    Ok(())
 }
 
 /// Emit the page header + payload `[p0, p0+plen)` as layout segments: `Inline` for
@@ -393,7 +445,6 @@ fn emit_segments(
                     art_id,
                     base64,
                     art_total,
-                    ..
                 } => {
                     if !buf.is_empty() {
                         segments.push(Segment::Inline(std::mem::take(&mut buf)));
@@ -581,25 +632,32 @@ mod tests {
 
     #[test]
     fn chunk_lacer_splits_art_across_pages_and_crcs_validate() {
-        // A packet: 50 literal bytes, then a 70_000-byte art run (spans pages), then
+        use super::super::art_source::MapArtSource;
+        // A packet: 50 literal bytes, then a 60_000-byte art run (spans pages), then
         // 10 trailing literal bytes.
         let head = vec![0xA0u8; 50];
-        let art_out: Vec<u8> = (0..70_000u32).map(|i| (i % 251) as u8).collect();
+        // 60_000 raw bytes -> b64 output ~80_000 > one page (65025), so it spans pages.
+        let image: Vec<u8> = (0..60_000u32).map(|i| (i % 251) as u8).collect();
+        let art_out = crate::ogg::b64::encode_b64_slice(
+            &image,
+            0,
+            crate::convert::usize_from(crate::ogg::b64::b64_len(image.len() as u64)),
+        );
         let tail = vec![0xB0u8; 10];
         let chunks = vec![
             PayloadChunk::Bytes(head.clone()),
             PayloadChunk::Art {
                 art_id: 42,
-                out: art_out.clone(),
                 base64: true,
-                art_total: 12345,
+                art_total: image.len() as u64,
             },
             PayloadChunk::Bytes(tail.clone()),
         ];
-        let (segments, pages) = lace_chunks_to_segments(0x1234, 0, true, &chunks);
+        let src = MapArtSource::new([(42i64, image.clone())]);
+        let (segments, pages) = lace_chunks_to_segments(0x1234, 0, true, &chunks, &src).unwrap();
         assert!(pages >= 2, "art run should span multiple pages");
 
-        // Reassemble the packet payload and confirm it equals head ++ art ++ tail.
+        // Reassemble the packet payload and confirm it equals head ++ art_out ++ tail.
         let flat = flatten(&segments, &art_out);
         // Walk pages: validate CRC + collect payloads.
         let mut pos = 0usize;

--- a/musefs-format/tests/proptest_ogg.rs
+++ b/musefs-format/tests/proptest_ogg.rs
@@ -15,7 +15,14 @@ proptest! {
         let header = ogg::read_metadata(&file).unwrap();
         let taginputs: Vec<TagInput> = tags.iter().map(|(k, v)| TagInput::new(k, v)).collect();
         if let Ok(layout) =
-            ogg::synthesize_layout(&header, scan.audio_offset, scan.audio_length, &taginputs, &[])
+            ogg::synthesize_layout(
+                &header,
+                scan.audio_offset,
+                scan.audio_length,
+                &taginputs,
+                &[],
+                &ogg::MapArtSource::default(),
+            )
         {
             assert_backing_covers_audio(scan.audio_offset, scan.audio_length, &layout);
         }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -103,6 +103,7 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         | CoreError::DbOpen { .. }
         | CoreError::Mp4MetadataTooLarge { .. }
         | CoreError::OrphanedArt { .. }
+        | CoreError::ArtTooLarge { .. }
         | CoreError::InvalidPictureType { .. }
         | CoreError::Format(_) => fuser::Errno::EIO,
     }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -593,6 +593,16 @@ mod tests {
             .code(),
             libc::EIO
         );
+        assert_eq!(
+            errno(&CoreError::ArtTooLarge {
+                track_id: 1,
+                art_id: 2,
+                byte_len: 16_711_681,
+                cap: 16_711_680,
+            })
+            .code(),
+            libc::EIO
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #266.

## Problem

Ogg synthesis was the only format path that materialized a full artwork image — and, for Opus/Vorbis, its base64 copy too (~2.3× peak) — while building regenerated header pages, before the final `RegionLayout` existed. A hostile or careless SQLite writer (the store is a documented external-writer contract) could insert a large `art.data` row and force a large resolve-time allocation, and the "art is streamed at read time, never materialized whole" invariant did not actually hold for Ogg.

## What changed

Two independent components.

### A — Shared resolve-time art cap (all formats)
- Promoted the scanner's `MAX_ART_BYTES` (16 MiB − 64 KiB) to a resolve-time invariant enforced once in `track_art_to_inputs`, covering FLAC/MP3/MP4/WAV/Ogg uniformly.
- Oversize art is rejected with a logged `CoreError::ArtTooLarge` (mapped to `EIO` at the FUSE layer), closing the external-writer bypass that previously only FLAC's structural 24-bit block limit caught. Real cover art is far below the cap.

### B — Stream Ogg art end-to-end
- New format-layer `ArtSource` trait: DB-backed `DbArtSource` in core (streams via `read_art_chunk_into`), in-memory `MapArtSource` for tests/fuzz.
- Added incremental `crc32_update`; the page CRC is now computed by feeding the page header then streaming art in page-bounded (~64 KiB) windows, base64-encoded on the fly for Opus/Vorbis using the existing read-path `b64_window` helpers.
- `PayloadChunk::Art` and `OggArt` carry metadata only; the comment/OggFLAC producers no longer buffer the image or its base64 copy.
- **Served bytes are byte-identical to before** — only synthesis-time peak memory changes, from ~2.3× the image to O(one Ogg page), independent of art size. Read failures surface as `FormatError::ArtRead`.

## Testing
- Full workspace suite green (`cargo test`), `clippy --all-targets -D warnings` clean, `fmt --check` clean, and the out-of-workspace fuzz target builds (`cargo +nightly fuzz build ogg`).
- New coverage: a cap boundary test (at-cap accepted / +1 rejected, pinning the mutation gate), a `crc32_update` split-identity test, a bounded-window assertion (a 500 KB image is never read in a single call), an OggFLAC >64 KiB raw-art page-spanning round-trip, and a `DbArtSource` test mapping short/missing reads to `ArtRead`.
- Existing Ogg byte-exactness / CRC-validation tests pass unchanged, which is the byte-identity guarantee.

## Notes
- The spec and implementation plan are included under `docs/superpowers/`.
- The scanner's *separate* silent-drop of oversize art at ingest is tracked independently in #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oversized artwork is rejected at resolve time with a clear ArtTooLarge error; missing referential art now fails with EIO.
  * Ogg artwork is streamed during synthesis so full images/base64 copies are not materialized; page CRCs are computed from page-bounded artwork windows.

* **Documentation**
  * Architecture and Ogg format docs updated to describe streaming artwork and the unified MAX_ART_BYTES cap.

* **Tests**
  * Tests and fuzzing updated to validate bounded-window reads and the size-cap boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->