### PR TITLE
Make content_version a freshness superset; stat backing on getattr hits (#271, #272, #279)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,6 +140,15 @@ plugins under `contrib/` write tags and art here out-of-band.
   four tables (stashing rows past the FK cascade) and recreates their
   triggers after the bulk refill so the rebuild does not pump the
   `track_changes` ring. A pre-existing violating row aborts the migration.
+- **V5** — freshness-superset triggers that make `content_version` cover every
+  DB-knowable input to synthesized bytes, not only tag/`track_art` edits:
+  `art_reject_content_update` (rejects in-place mutation of an `art` row's
+  content columns — art is content-addressed, so a changed image is a new row),
+  `art_ad` (bumps every track referencing a deleted `art` row, so an orphaned
+  reference rebuilds to a clean serve-time error rather than streaming stale
+  bytes), `tracks_geometry_au` (bumps when scanner-owned geometry — `format`,
+  audio bounds, backing size/mtime — changes), and `structural_blocks_ai`/`_ad`
+  (bump when FLAC structural blocks change).
 
 ### The external-writer contract
 
@@ -170,6 +179,16 @@ malformed *shapes* at commit, so an external writer cannot persist them:
 `sqlite_master` comparison against a freshly-migrated reference plus `PRAGMA
 foreign_key_check`, rejecting anything that is not the canonical latest schema
 with a message telling the user to run `musefs scan`.
+
+**Art is immutable once written.** `art` rows are content-addressed by
+`sha256`; as of V5 a trigger rejects any in-place `UPDATE` of an art row's
+content columns (`data`, `sha256`, `mime`, `byte_len`, `width`, `height`) with
+`RAISE(ABORT)` — a multi-row `UPDATE art` touching any content column aborts the
+whole statement. To change a track's art, insert a new content-addressed row
+and relink it via `track_art` (which bumps `content_version`); do not mutate an
+existing row. Deleting an `art` row still referenced by `track_art` (possible
+only with `foreign_keys` OFF) bumps every referencing track so the mount serves
+a clean `EIO` on the now-orphaned reference instead of stale bytes.
 
 **What musefs defends at serve time.** CHECKs cannot catch a scanner-owned
 field mutated to a *well-formed* value that no longer matches the real file
@@ -232,7 +251,14 @@ variant hands each reader thread its own connection — WAL reads never contend.
 Two distinct counters drive correctness; they answer different questions.
 
 **`content_version`** (per-track column) answers *"did this track's served
-bytes change?"*. The DB triggers increment it on any tag/art edit. The
+bytes change?"*. The DB triggers increment it on any input the database can see that changes
+synthesized bytes: tag and `track_art` edits, `art`-row deletes that orphan a
+reference, scanner-owned geometry changes (`format`, audio bounds, backing
+size/mtime), and FLAC structural-block changes (V5). It is therefore a
+superset key — the one input it cannot cover is an on-disk backing change with
+no DB write, which `resolve` (and, since #279, a size-cache `getattr` hit)
+catches by re-statting the backing file and degrading to `BackingChanged`.
+The
 `HeaderCache` (`reader.rs`) — a byte-budgeted concurrent cache (64 MiB
 default) of resolved layouts — keys each entry on it: a hit with a stale
 `content_version` rebuilds the layout. Independently of the cache, **every**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,8 +258,7 @@ size/mtime), and FLAC structural-block changes (V5). It is therefore a
 superset key — the one input it cannot cover is an on-disk backing change with
 no DB write, which `resolve` (and, since #279, a size-cache `getattr` hit)
 catches by re-statting the backing file and degrading to `BackingChanged`.
-The
-`HeaderCache` (`reader.rs`) — a byte-budgeted concurrent cache (64 MiB
+The `HeaderCache` (`reader.rs`) — a byte-budgeted concurrent cache (64 MiB
 default) of resolved layouts — keys each entry on it: a hit with a stale
 `content_version` rebuilds the layout. Independently of the cache, **every**
 resolve re-stats the backing file and errors with `BackingChanged` if its

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -264,6 +264,12 @@ END;
 PRAGMA user_version = 4;
 
 -- ── MIGRATION_V5 ──
+-- art rows are content-addressed by sha256: once written, their content
+-- columns are immutable. A writer needing different bytes/metadata inserts a
+-- NEW row and relinks via track_art (which bumps content_version through the
+-- V1 track_art triggers). This closes #271, where an in-place art edit changed
+-- served bytes without bumping any referencing track. width/height use IS NOT
+-- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
 CREATE TRIGGER art_reject_content_update
 BEFORE UPDATE ON art
 WHEN NEW.data   <> OLD.data
@@ -277,12 +283,22 @@ BEGIN
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
 
+-- Deleting an art row that still has track_art references (an orphan an
+-- external writer can produce with foreign_keys OFF) bumps every referencing
+-- track, so the mount rebuilds and serves a clean EIO on the orphan rather
+-- than streaming stale bytes from an old cached layout. Inert on the normal
+-- gc_orphan_art path, where the deleted row has no references.
 CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
     UPDATE tracks SET content_version = content_version + 1,
                       updated_at = CAST(strftime('%s','now') AS INTEGER)
     WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
 END;
 
+-- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
+-- not touch content_version. Bump it whenever a geometry column actually
+-- changes, making content_version a true superset of served-byte inputs
+-- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
+-- content_version changes), so the recursion terminates after exactly one bump.
 CREATE TRIGGER tracks_geometry_au
 AFTER UPDATE ON tracks
 WHEN NEW.format        <> OLD.format
@@ -294,6 +310,11 @@ BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
 END;
 
+-- FLAC structural blocks feed synthesized headers and flip the synthesis path
+-- (legacy front-read fallback vs streamed fast path), so a change must bump.
+-- set_structural_blocks is DELETE-then-INSERT (no UPDATE path exists), so these
+-- fire on every rewrite; the resulting over-bump on a byte-identical re-probe
+-- is harmless monotone churn (content_version is compared only for equality).
 CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
 END;

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -283,6 +283,12 @@ BEGIN
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
 
+-- Index the reverse art -> track_art edge. track_art is keyed (track_id,
+-- ordinal), so without this both the art_ad trigger below and SQLite's own
+-- REFERENCES art(id) check on art deletes scan the whole join table per
+-- deleted row, which makes bulk orphan-GC O(deletes * rows).
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
 -- Deleting an art row that still has track_art references (an orphan an
 -- external writer can produce with foreign_keys OFF) bumps every referencing
 -- track, so the mount rebuilds and serves a clean EIO on the orphan rather

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -262,6 +262,45 @@ CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
     INSERT INTO track_changes (track_id) VALUES (OLD.id);
 END;
 PRAGMA user_version = 4;
+
+-- ── MIGRATION_V5 ──
+CREATE TRIGGER art_reject_content_update
+BEFORE UPDATE ON art
+WHEN NEW.data   <> OLD.data
+  OR NEW.sha256 <> OLD.sha256
+  OR NEW.mime   <> OLD.mime
+  OR NEW.byte_len <> OLD.byte_len
+  OR NEW.width  IS NOT OLD.width
+  OR NEW.height IS NOT OLD.height
+BEGIN
+    SELECT RAISE(ABORT,
+        'art rows are immutable; insert a new content-addressed row and relink via track_art');
+END;
+
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+
+CREATE TRIGGER tracks_geometry_au
+AFTER UPDATE ON tracks
+WHEN NEW.format        <> OLD.format
+  OR NEW.audio_offset  <> OLD.audio_offset
+  OR NEW.audio_length  <> OLD.audio_length
+  OR NEW.backing_size  <> OLD.backing_size
+  OR NEW.backing_mtime <> OLD.backing_mtime
+BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
+END;
+PRAGMA user_version = 5;
 """
 
-USER_VERSION = 4
+USER_VERSION = 5

--- a/contrib/picard/tests/test_conftest_sanity.py
+++ b/contrib/picard/tests/test_conftest_sanity.py
@@ -5,7 +5,7 @@ def test_db_path_has_schema(db_path):
     conn = connect(db_path)
     try:
         # user_version applied from the fixture SQL.
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 5
     finally:
         conn.close()
 

--- a/contrib/python-musefs/README.md
+++ b/contrib/python-musefs/README.md
@@ -141,6 +141,10 @@ that bite plugin authors:
   `CHECK` on the row).
 - **Content-address art** through `upsert_art` (sha256 de-dup) rather than
   inserting `art` rows by hand; `sync_files` does this for you.
+- **Art rows are immutable.** As of V5 a trigger rejects in-place updates of an
+  `art` row's content columns (`data`, `sha256`, `mime`, `byte_len`, `width`,
+  `height`). To change a track's art, insert a new content-addressed row via
+  `upsert_art` and relink it via `replace_track_art`.
 - **Path layout is just a tag.** To drive a reorganized mount, write your
   computed relative path into a custom tag (e.g. `beets_path`) and mount with
   `--template '$!{beets_path}'`. musefs sanitizes each path segment, so a writer

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -259,6 +259,45 @@ CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
     INSERT INTO track_changes (track_id) VALUES (OLD.id);
 END;
 PRAGMA user_version = 4;
+
+-- ── MIGRATION_V5 ──
+CREATE TRIGGER art_reject_content_update
+BEFORE UPDATE ON art
+WHEN NEW.data   <> OLD.data
+  OR NEW.sha256 <> OLD.sha256
+  OR NEW.mime   <> OLD.mime
+  OR NEW.byte_len <> OLD.byte_len
+  OR NEW.width  IS NOT OLD.width
+  OR NEW.height IS NOT OLD.height
+BEGIN
+    SELECT RAISE(ABORT,
+        'art rows are immutable; insert a new content-addressed row and relink via track_art');
+END;
+
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+
+CREATE TRIGGER tracks_geometry_au
+AFTER UPDATE ON tracks
+WHEN NEW.format        <> OLD.format
+  OR NEW.audio_offset  <> OLD.audio_offset
+  OR NEW.audio_length  <> OLD.audio_length
+  OR NEW.backing_size  <> OLD.backing_size
+  OR NEW.backing_mtime <> OLD.backing_mtime
+BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
+END;
+PRAGMA user_version = 5;
 """
 
-USER_VERSION = 4
+USER_VERSION = 5

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -280,6 +280,12 @@ BEGIN
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
 
+-- Index the reverse art -> track_art edge. track_art is keyed (track_id,
+-- ordinal), so without this both the art_ad trigger below and SQLite's own
+-- REFERENCES art(id) check on art deletes scan the whole join table per
+-- deleted row, which makes bulk orphan-GC O(deletes * rows).
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
 -- Deleting an art row that still has track_art references (an orphan an
 -- external writer can produce with foreign_keys OFF) bumps every referencing
 -- track, so the mount rebuilds and serves a clean EIO on the orphan rather

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -261,6 +261,12 @@ END;
 PRAGMA user_version = 4;
 
 -- ── MIGRATION_V5 ──
+-- art rows are content-addressed by sha256: once written, their content
+-- columns are immutable. A writer needing different bytes/metadata inserts a
+-- NEW row and relinks via track_art (which bumps content_version through the
+-- V1 track_art triggers). This closes #271, where an in-place art edit changed
+-- served bytes without bumping any referencing track. width/height use IS NOT
+-- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
 CREATE TRIGGER art_reject_content_update
 BEFORE UPDATE ON art
 WHEN NEW.data   <> OLD.data
@@ -274,12 +280,22 @@ BEGIN
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
 
+-- Deleting an art row that still has track_art references (an orphan an
+-- external writer can produce with foreign_keys OFF) bumps every referencing
+-- track, so the mount rebuilds and serves a clean EIO on the orphan rather
+-- than streaming stale bytes from an old cached layout. Inert on the normal
+-- gc_orphan_art path, where the deleted row has no references.
 CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
     UPDATE tracks SET content_version = content_version + 1,
                       updated_at = CAST(strftime('%s','now') AS INTEGER)
     WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
 END;
 
+-- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
+-- not touch content_version. Bump it whenever a geometry column actually
+-- changes, making content_version a true superset of served-byte inputs
+-- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
+-- content_version changes), so the recursion terminates after exactly one bump.
 CREATE TRIGGER tracks_geometry_au
 AFTER UPDATE ON tracks
 WHEN NEW.format        <> OLD.format
@@ -291,6 +307,11 @@ BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
 END;
 
+-- FLAC structural blocks feed synthesized headers and flip the synthesis path
+-- (legacy front-read fallback vs streamed fast path), so a change must bump.
+-- set_structural_blocks is DELETE-then-INSERT (no UPDATE path exists), so these
+-- fire on every rewrite; the resulting over-bump on a byte-identical re-probe
+-- is harmless monotone churn (content_version is compared only for equality).
 CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
 END;

--- a/contrib/python-musefs/tests/test_constants.py
+++ b/contrib/python-musefs/tests/test_constants.py
@@ -2,7 +2,7 @@ from musefs_common import constants
 
 
 def test_expected_user_version_matches_rust_migrations():
-    assert constants.EXPECTED_USER_VERSION == 4
+    assert constants.EXPECTED_USER_VERSION == 5
 
 
 def test_max_art_bytes_is_16mib_minus_64kib():

--- a/docs/superpowers/plans/2026-06-11-content-version-freshness.md
+++ b/docs/superpowers/plans/2026-06-11-content-version-freshness.md
@@ -250,6 +250,9 @@ fn rescan_with_changed_geometry_bumps_content_version() {
     rescan.audio_length = 900;
     db.upsert_track(&rescan).unwrap();
 
+    // Exactly +1 (not just ">") is deliberate: it asserts the WHEN guard halts
+    // the geometry trigger's own nested UPDATE, mirroring
+    // geometry_change_bumps_content_version_by_exactly_one in triggers.rs.
     assert_eq!(
         db.track_content_version(id).unwrap(),
         cv_before + 1,
@@ -276,6 +279,9 @@ In `track_art_to_inputs_errors_on_negative_byte_len` (starts at `musefs-core/src
         let raw = rusqlite::Connection::open(&path).unwrap();
         raw.pragma_update(None, "ignore_check_constraints", true)
             .unwrap();
+        // 5 bytes of data with byte_len = -1 is the deliberate malformation
+        // under test (data length and byte_len disagree, and byte_len is
+        // negative) — do not "fix" the mismatch.
         raw.execute(
             "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
              VALUES (?1, 'image/png', NULL, NULL, -1, X'0909090909')",
@@ -329,6 +335,7 @@ Expected: FAIL. Specifically:
 - `triggers::structural_block_change_bumps_content_version` — fails (no structural trigger).
 - `tracks::rescan_with_changed_geometry_bumps_content_version` — fails (no bump yet).
 - The seven `assert_eq!(uv, 4)` assertions still pass at this point (we change them in Step 7).
+- `schema_sql_matches_migrate` and `schema_py_fixture_is_fresh` also still pass here — both derive from `MIGRATIONS`, which has not yet grown. They go red only *after* Step 6 adds `MIGRATION_V5`, and `schema_py_fixture_is_fresh` is fixed by Step 8's regen. So a `cargo test` run between Steps 6 and 8 will show `schema_py_fixture_is_fresh` failing; that interim red is expected, not a mistake.
 
 This confirms the new tests fail for the right reason before implementing the migration.
 
@@ -428,6 +435,27 @@ The latest `user_version` is now 5. Update each of these assertions in `musefs-d
 
 (Line numbers will drift after inserting `MIGRATION_V5`; if so, search for `assert_eq!(uv, 4)` and `assert_eq!(uv2, 4)` and update every occurrence — each is a "migrate reaches latest version" assertion. Do NOT touch the `pragma_update(None, "user_version", 1i64/2i64/3i64)` lines, which deliberately set a starting version for partial-upgrade tests.)
 
+- [ ] **Step 7b: Fix the now-false `set_format_for_test` doc-comment in `musefs-db/src/tracks.rs`**
+
+The `tracks_geometry_au` trigger's WHEN clause includes `NEW.format <> OLD.format`, so `set_format_for_test`'s `UPDATE tracks SET format = ...` now bumps `content_version` — which falsifies its doc-comment. No test asserts `content_version` here (the consumers `set_format_for_test_persists_the_new_format` and `incremental_refresh.rs`'s `format_only_change_notifies_old_inode` assert format persistence / inode notification only), so this is doc drift, not a green-commit hazard — but it lives in the same crate as this commit and the project polices drift (CLAUDE.md, PRs #259-263). Replace the doc-comment at `musefs-db/src/tracks.rs:225-228`:
+
+```rust
+    /// Test-only: force a track's format column directly (no rescan), bumping
+    /// data_version. The only way to exercise a format-only change — production
+    /// never mutates format without a rescan. content_version is NOT bumped (no
+    /// trigger fires on the tracks.format column), so this is a pure format-only edit.
+```
+
+with:
+
+```rust
+    /// Test-only: force a track's format column directly (no rescan), bumping
+    /// data_version. The only way to exercise a format-only change — production
+    /// never mutates format without a rescan. As of V5 this also bumps
+    /// content_version (the `tracks_geometry_au` format guard); it is no longer a
+    /// content_version-neutral edit.
+```
+
 - [ ] **Step 8: Regenerate the Python schema mirror and re-vendor**
 
 The `schema_py_fixture_is_fresh` test compares the vendored `schema.py` to one rendered from `MIGRATIONS`; it is stale until regenerated. Run:
@@ -452,7 +480,8 @@ Expected: no warnings, no formatting diff.
 - [ ] **Step 10: Commit**
 
 ```bash
-git add musefs-db/src/schema.rs musefs-db/tests/triggers.rs musefs-db/tests/tracks.rs \
+git add musefs-db/src/schema.rs musefs-db/src/tracks.rs \
+        musefs-db/tests/triggers.rs musefs-db/tests/tracks.rs \
         musefs-core/src/mapping.rs \
         contrib/python-musefs/src/musefs_common/schema.py
 # Add any files vendor_to_picard.py modified (check `git status` for the Picard copy):
@@ -776,6 +805,7 @@ EOF
 - Migration V5 append-only → Task 1 Steps 6-7. ✓
 - Python schema mirror regen + vendor → Task 1 Step 8. ✓
 - mapping.rs malformed-row test rework (the spec's flagged blocker) → Task 1 Step 4. ✓
+- `set_format_for_test` doc-comment drift (the geometry trigger's `format` guard falsifies its "content_version is NOT bumped" claim) → Task 1 Step 7b. ✓
 - Changelog double-pump → no over-tight changelog-row-count assertion is written (the new tests assert `content_version`, not `track_changes` counts), consistent with the spec's warning. ✓
 - Docs (ARCHITECTURE + contrib) → Task 3. ✓
 - Fuzz crate → unaffected (no format-layer signature change); no step needed, matching the spec. ✓

--- a/docs/superpowers/plans/2026-06-11-content-version-freshness.md
+++ b/docs/superpowers/plans/2026-06-11-content-version-freshness.md
@@ -1,0 +1,787 @@
+# content_version Freshness Superset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `content_version` a true superset of every DB-knowable input that affects synthesized bytes (closing #271 art mutations and #272 scanner-geometry/structural changes), and make `getattr` stat the backing file on size-cache hits so it cannot advertise stale attrs after an on-disk change (#279).
+
+**Architecture:** Three SQLite triggers added in a new V5 migration centralize freshness on `content_version` (art immutability + delete-bump; scanner-geometry bump; structural-block bump), so the caches' single-`i64` key stays valid and the read/synthesis hot path is untouched. The one thing the DB cannot observe — an on-disk backing change with no DB write — is caught by adding a stat to `getattr`'s size-cache hit, aligning it with the read/open paths that already stat.
+
+**Tech Stack:** Rust workspace (`musefs-db` → `musefs-format` → `musefs-core`), SQLite via `rusqlite`, triggers in `musefs-db/src/schema.rs`, Python schema mirror under `contrib/python-musefs/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-content-version-freshness-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs-db/src/schema.rs` | Append-only migration list; trigger DDL | Add `MIGRATION_V5` (5 triggers), append to `MIGRATIONS`, add `migration_v5_tests`, bump 7 `user_version`-is-4 assertions to 5 |
+| `musefs-db/tests/triggers.rs` | Integration tests for content_version triggers via the public `Db` API | Add #272 geometry + structural bump tests |
+| `musefs-db/tests/tracks.rs` | Track upsert/get integration tests | Invert `rescan_does_not_reset_content_version` (now bumps on geometry change) |
+| `musefs-core/src/mapping.rs` | `track_art_to_inputs` + its tests | Rework `track_art_to_inputs_errors_on_negative_byte_len` to plant the malformed row via INSERT (the V5 trigger blocks the old UPDATE) |
+| `musefs-core/src/facade.rs` | `getattr`, `SizeEntry` | Add backing stamp to `SizeEntry`; stat + compare on size-cache hit; 2 tests |
+| `contrib/python-musefs/src/musefs_common/schema.py` | Generated schema mirror | Regenerate (auto from `MIGRATIONS`) |
+| `contrib/python-musefs/` Picard vendored copy | Vendored mirror | Re-vendor via `vendor_to_picard.py` |
+| `ARCHITECTURE.md` | Store schema + freshness + external-writer contract docs | Document V5, art immutability, superset semantics |
+
+**Why Task 1 is one atomic commit:** the pre-commit hook runs the full workspace test suite and rejects any red commit (per `CLAUDE.md`). Shipping the V5 triggers *breaks three existing tests at once* — the geometry trigger breaks `rescan_does_not_reset_content_version`, the art-immutability trigger breaks `track_art_to_inputs_errors_on_negative_byte_len`, and the new latest-version is 5 not 4 — and the `schema.py` freshness gate fails until regeneration. All of these must land together to keep the suite green. Task 1's steps are therefore: write/adjust every affected test, confirm the expected red, add the migration, regenerate the mirror, confirm green, commit.
+
+---
+
+## Task 1: V5 migration — content_version freshness superset (#271, #272)
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs` (add `MIGRATION_V5`, append to `MIGRATIONS`, add `migration_v5_tests`, update 7 assertions)
+- Modify: `musefs-db/tests/triggers.rs` (add #272 tests)
+- Modify: `musefs-db/tests/tracks.rs` (invert rescan test)
+- Modify: `musefs-core/src/mapping.rs` (rework malformed-row test)
+- Regenerate: `contrib/python-musefs/src/musefs_common/schema.py` + Picard vendored copy
+
+- [ ] **Step 1: Add the `migration_v5_tests` module to `musefs-db/src/schema.rs`**
+
+Insert this module immediately after the existing `migration_v4_tests` module (it does not matter exactly where among the `#[cfg(test)]` modules, as long as it is inside the file's test region):
+
+```rust
+#[cfg(test)]
+mod migration_v5_tests {
+    use rusqlite::{params, Connection};
+
+    /// A fresh, fully-migrated DB. NOTE: `super::migrate` runs on a bare
+    /// connection, so `foreign_keys` defaults to OFF here — that is what lets
+    /// `deleting_referenced_art_bumps_tracks` produce the orphan case.
+    fn migrated() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        super::migrate(&mut conn).unwrap();
+        conn
+    }
+
+    fn insert_track(conn: &Connection, path: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime, updated_at) \
+             VALUES (?1,'flac',0,1,1,0,0)",
+            [path],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_art(conn: &Connection, sha: &str, data: &[u8]) -> i64 {
+        conn.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
+             VALUES (?1,'image/png',NULL,NULL,?2,?3)",
+            params![sha, data.len() as i64, data],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn migration_reaches_user_version_5() {
+        let conn = migrated();
+        let uv: i64 = conn
+            .pragma_query_value(None, "user_version", |r| r.get(0))
+            .unwrap();
+        assert_eq!(uv, 5);
+    }
+
+    #[test]
+    fn art_content_update_is_rejected() {
+        let conn = migrated();
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        // Mutating any content column aborts the statement.
+        assert!(conn
+            .execute("UPDATE art SET mime='image/jpeg' WHERE id=?1", [a])
+            .is_err());
+        assert!(conn
+            .execute("UPDATE art SET byte_len=99 WHERE id=?1", [a])
+            .is_err());
+        assert!(conn
+            .execute("UPDATE art SET data=X'04050607' WHERE id=?1", [a])
+            .is_err());
+        assert!(conn
+            .execute("UPDATE art SET width=10 WHERE id=?1", [a])
+            .is_err());
+        assert!(conn
+            .execute(
+                "UPDATE art SET sha256=?1 WHERE id=?2",
+                params![&"b".repeat(64), a],
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn art_noop_update_is_allowed() {
+        let conn = migrated();
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        // No content column changes value: the WHEN guard is false, so the
+        // trigger body never runs and the UPDATE proceeds.
+        conn.execute("UPDATE art SET mime=mime WHERE id=?1", [a])
+            .unwrap();
+    }
+
+    #[test]
+    fn deleting_referenced_art_bumps_tracks() {
+        let conn = migrated();
+        let t = insert_track(&conn, "/a.flac");
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        conn.execute(
+            "INSERT INTO track_art (track_id, art_id, picture_type, ordinal) \
+             VALUES (?1,?2,3,0)",
+            [t, a],
+        )
+        .unwrap();
+        // The track_art INSERT already bumped once; capture that baseline.
+        let cv0: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        conn.execute("DELETE FROM art WHERE id=?1", [a]).unwrap();
+        let cv1: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cv1, cv0 + 1, "art delete must bump the referencing track");
+    }
+
+    #[test]
+    fn deleting_unreferenced_art_bumps_nothing() {
+        let conn = migrated();
+        let t = insert_track(&conn, "/a.flac");
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        let cv0: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        // Orphan-GC style: the art row has no track_art references.
+        conn.execute("DELETE FROM art WHERE id=?1", [a]).unwrap();
+        let cv1: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cv1, cv0, "deleting an unreferenced art row must not bump");
+    }
+}
+```
+
+- [ ] **Step 2: Add the #272 trigger tests to `musefs-db/tests/triggers.rs`**
+
+Append these three tests to the existing file (which already has `mod common; use common::new_track; use musefs_db::{Db, Tag};` at the top). Add `StructuralBlock` to the `musefs_db` import line so it reads `use musefs_db::{Db, StructuralBlock, Tag};`:
+
+```rust
+#[test]
+fn geometry_change_bumps_content_version_by_exactly_one() {
+    let db = Db::open_in_memory().unwrap();
+    // Tagless track: no replace_tags to mask the geometry change. The first
+    // upsert is an INSERT (cv stays 0); the geometry trigger fires only on the
+    // ON CONFLICT UPDATE below.
+    let id = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    assert_eq!(db.track_content_version(id).unwrap(), 0);
+
+    let mut changed = new_track("/m/a.flac");
+    changed.audio_offset = 222;
+    db.upsert_track(&changed).unwrap();
+
+    // Exactly 1 proves the WHEN guard halts the trigger's own nested UPDATE
+    // (a recursing trigger would bump more than once or error).
+    assert_eq!(
+        db.track_content_version(id).unwrap(),
+        1,
+        "geometry change must bump content_version exactly once"
+    );
+}
+
+#[test]
+fn identical_rescan_does_not_bump_content_version() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    // Re-upsert identical geometry: updated_at is rewritten but no geometry
+    // column changes, so the WHEN guard is false and content_version holds.
+    db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    assert_eq!(db.track_content_version(id).unwrap(), 0);
+}
+
+#[test]
+fn structural_block_change_bumps_content_version() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    let before = db.track_content_version(id).unwrap();
+    db.set_structural_blocks(
+        id,
+        &[StructuralBlock {
+            kind: "STREAMINFO".to_string(),
+            ordinal: 0,
+            body: vec![1, 2, 3, 4],
+        }],
+    )
+    .unwrap();
+    // set_structural_blocks is DELETE-then-INSERT, so the bump may exceed 1;
+    // correctness only needs a strict increase (caches compare for equality).
+    assert!(
+        db.track_content_version(id).unwrap() > before,
+        "structural block write must bump content_version"
+    );
+}
+```
+
+- [ ] **Step 3: Invert the rescan test in `musefs-db/tests/tracks.rs`**
+
+Replace the existing `rescan_does_not_reset_content_version` (currently asserting the geometry rescan does NOT bump) with its inverse. Find the function at `musefs-db/tests/tracks.rs:56` and replace the whole function with:
+
+```rust
+#[test]
+fn rescan_with_changed_geometry_bumps_content_version() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/music/a.flac")).unwrap();
+    db.replace_tags(id, &[Tag::new("title", "T", 0)]).unwrap();
+    let cv_before = db.track_content_version(id).unwrap();
+    assert!(cv_before > 0);
+
+    // Re-scan the same path with changed offsets. content_version is now a
+    // superset of scanner-owned geometry, so this MUST bump (was pinned the
+    // other way before the V5 geometry trigger — see issue #272).
+    let mut rescan = new_track("/music/a.flac");
+    rescan.audio_offset = 100;
+    rescan.audio_length = 900;
+    db.upsert_track(&rescan).unwrap();
+
+    assert_eq!(
+        db.track_content_version(id).unwrap(),
+        cv_before + 1,
+        "a geometry-changing rescan must bump content_version exactly once"
+    );
+}
+```
+
+Note: `new_track` defaults `audio_offset = 100`, so to actually change geometry the rescan must differ from the default — here `audio_length` changes from `1000` to `900` (and `audio_offset` stays `100`), so the geometry trigger fires once.
+
+- [ ] **Step 4: Rework the malformed-row test in `musefs-core/src/mapping.rs`**
+
+In `track_art_to_inputs_errors_on_negative_byte_len` (starts at `musefs-core/src/mapping.rs:281`), the test currently plants the bad row by `upsert_art` + `UPDATE art SET byte_len = -1`. The V5 `art_reject_content_update` trigger blocks that UPDATE. Replace the `bad` art creation, the `set_track_art` call, and the raw `UPDATE` block (everything from the `let bad = db.upsert_art(...)` line through the `assert!(super::track_art_to_inputs(&db, tid).is_err(), ...)` closing) with:
+
+```rust
+        // Plant a malformed art row directly. art rows are immutable once
+        // written (the V5 `art_reject_content_update` trigger blocks UPDATEs of
+        // content columns), and the V4 `byte_len = length(data)` CHECK rejects
+        // byte_len = -1 on a normal connection — so INSERT the bad row on a raw
+        // connection with CHECK enforcement off. The trigger guards only
+        // UPDATE, so a fresh malformed INSERT (the realistic FK/CHECK-disabled
+        // external write) still reaches the row-reader defensive path this test
+        // pins.
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.pragma_update(None, "ignore_check_constraints", true)
+            .unwrap();
+        raw.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
+             VALUES (?1, 'image/png', NULL, NULL, -1, X'0909090909')",
+            [&"9".repeat(64)],
+        )
+        .unwrap();
+        raw.pragma_update(None, "ignore_check_constraints", false)
+            .unwrap();
+        let bad: i64 = raw
+            .query_row("SELECT id FROM art WHERE sha256 = ?1", [&"9".repeat(64)], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        drop(raw);
+
+        db.set_track_art(
+            tid,
+            &[
+                TrackArt {
+                    art_id: good,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 0,
+                },
+                TrackArt {
+                    art_id: bad,
+                    picture_type: 3,
+                    description: String::new(),
+                    ordinal: 1,
+                },
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            super::track_art_to_inputs(&db, tid).is_err(),
+            "negative byte_len must error at row-read, not be skipped"
+        );
+```
+
+Keep the test's existing header (the `let dir`, `let path`, `let db`, `let tid`, and the `good` art `upsert_art` with `data: vec![1, 2, 3, 4]`) unchanged. The `bad` row is now created by the raw INSERT above instead of `upsert_art`, and `set_track_art` now runs after the bad row exists.
+
+- [ ] **Step 5: Run the full workspace suite to confirm the expected RED**
+
+Run: `cargo test`
+Expected: FAIL. Specifically:
+- `migration_v5_tests::migration_reaches_user_version_5` — fails (`user_version` is 4).
+- `migration_v5_tests::art_content_update_is_rejected` — fails (UPDATE succeeds, no trigger).
+- `migration_v5_tests::deleting_referenced_art_bumps_tracks` — fails (no `art_ad`).
+- `triggers::geometry_change_bumps_content_version_by_exactly_one` — fails (no geometry trigger).
+- `triggers::structural_block_change_bumps_content_version` — fails (no structural trigger).
+- `tracks::rescan_with_changed_geometry_bumps_content_version` — fails (no bump yet).
+- The seven `assert_eq!(uv, 4)` assertions still pass at this point (we change them in Step 7).
+
+This confirms the new tests fail for the right reason before implementing the migration.
+
+- [ ] **Step 6: Add `MIGRATION_V5` and append it to `MIGRATIONS` in `musefs-db/src/schema.rs`**
+
+Add this const immediately after the `MIGRATION_V4` string literal (which ends with `";` at `musefs-db/src/schema.rs:261`) and before `const MIGRATIONS`:
+
+```rust
+const MIGRATION_V5: &str = r"
+-- art rows are content-addressed by sha256: once written, their content
+-- columns are immutable. A writer needing different bytes/metadata inserts a
+-- NEW row and relinks via track_art (which bumps content_version through the
+-- V1 track_art triggers). This closes #271, where an in-place art edit changed
+-- served bytes without bumping any referencing track. width/height use IS NOT
+-- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
+CREATE TRIGGER art_reject_content_update
+BEFORE UPDATE ON art
+WHEN NEW.data   <> OLD.data
+  OR NEW.sha256 <> OLD.sha256
+  OR NEW.mime   <> OLD.mime
+  OR NEW.byte_len <> OLD.byte_len
+  OR NEW.width  IS NOT OLD.width
+  OR NEW.height IS NOT OLD.height
+BEGIN
+    SELECT RAISE(ABORT, 'art rows are immutable; insert a new content-addressed row and relink via track_art');
+END;
+
+-- Deleting an art row that still has track_art references (an orphan an
+-- external writer can produce with foreign_keys OFF) bumps every referencing
+-- track, so the mount rebuilds and serves a clean EIO on the orphan rather
+-- than streaming stale bytes from an old cached layout. Inert on the normal
+-- gc_orphan_art path, where the deleted row has no references.
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+
+-- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
+-- not touch content_version. Bump it whenever a geometry column actually
+-- changes, making content_version a true superset of served-byte inputs
+-- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
+-- content_version changes), so the recursion terminates after exactly one bump.
+CREATE TRIGGER tracks_geometry_au
+AFTER UPDATE ON tracks
+WHEN NEW.format        <> OLD.format
+  OR NEW.audio_offset  <> OLD.audio_offset
+  OR NEW.audio_length  <> OLD.audio_length
+  OR NEW.backing_size  <> OLD.backing_size
+  OR NEW.backing_mtime <> OLD.backing_mtime
+BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
+END;
+
+-- FLAC structural blocks feed synthesized headers and flip the synthesis path
+-- (legacy front-read fallback vs streamed fast path), so a change must bump.
+-- set_structural_blocks is DELETE-then-INSERT (no UPDATE path exists), so these
+-- fire on every rewrite; the resulting over-bump on a byte-identical re-probe
+-- is harmless monotone churn (content_version is compared only for equality).
+CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
+END;
+";
+```
+
+Then change the `MIGRATIONS` line (`musefs-db/src/schema.rs:263`) from:
+
+```rust
+const MIGRATIONS: &[&str] = &[MIGRATION_V1, MIGRATION_V2, MIGRATION_V3, MIGRATION_V4];
+```
+
+to:
+
+```rust
+const MIGRATIONS: &[&str] = &[
+    MIGRATION_V1,
+    MIGRATION_V2,
+    MIGRATION_V3,
+    MIGRATION_V4,
+    MIGRATION_V5,
+];
+```
+
+- [ ] **Step 7: Bump the seven `user_version == 4` assertions to 5**
+
+The latest `user_version` is now 5. Update each of these assertions in `musefs-db/src/schema.rs` (all assert the post-migrate latest version) from `4` to `5`:
+- `musefs-db/src/schema.rs:299` — `assert_eq!(uv, 4);` → `assert_eq!(uv, 5);`
+- `musefs-db/src/schema.rs:336` — `assert_eq!(uv2, 4);` → `assert_eq!(uv2, 5);`
+- `musefs-db/src/schema.rs:365` — `assert_eq!(uv, 4);` → `assert_eq!(uv, 5);`
+- `musefs-db/src/schema.rs:417` — `assert_eq!(uv, 4);` → `assert_eq!(uv, 5);`
+- `musefs-db/src/schema.rs:509` — `assert_eq!(uv, 4);` → `assert_eq!(uv, 5);`
+- `musefs-db/src/schema.rs:658` — `assert_eq!(uv, 4);` → `assert_eq!(uv, 5);`
+- `musefs-db/src/schema.rs:733` — `assert_eq!(uv, 4);` → `assert_eq!(uv, 5);`
+
+(Line numbers will drift after inserting `MIGRATION_V5`; if so, search for `assert_eq!(uv, 4)` and `assert_eq!(uv2, 4)` and update every occurrence — each is a "migrate reaches latest version" assertion. Do NOT touch the `pragma_update(None, "user_version", 1i64/2i64/3i64)` lines, which deliberately set a starting version for partial-upgrade tests.)
+
+- [ ] **Step 8: Regenerate the Python schema mirror and re-vendor**
+
+The `schema_py_fixture_is_fresh` test compares the vendored `schema.py` to one rendered from `MIGRATIONS`; it is stale until regenerated. Run:
+
+```bash
+MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py
+python contrib/python-musefs/vendor_to_picard.py
+```
+
+Expected: the first command rewrites `contrib/python-musefs/src/musefs_common/schema.py` (now containing the V5 triggers and `USER_VERSION = 5`); the second propagates it to the Picard vendored copy.
+
+- [ ] **Step 9: Run the full workspace suite to confirm GREEN**
+
+Run: `cargo test`
+Expected: PASS, including all `migration_v5_tests`, the three new `triggers.rs` tests, the inverted `rescan_with_changed_geometry_bumps_content_version`, the reworked `track_art_to_inputs_errors_on_negative_byte_len`, and `schema_py_fixture_is_fresh`.
+
+Also run the lint and format gates the pre-commit hook enforces:
+
+Run: `cargo clippy --all-targets && cargo fmt --all --check`
+Expected: no warnings, no formatting diff.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add musefs-db/src/schema.rs musefs-db/tests/triggers.rs musefs-db/tests/tracks.rs \
+        musefs-core/src/mapping.rs \
+        contrib/python-musefs/src/musefs_common/schema.py
+# Add any files vendor_to_picard.py modified (check `git status` for the Picard copy):
+git add -p   # stage the vendored Picard schema mirror; do NOT blanket-add untracked files
+git commit -m "$(cat <<'EOF'
+feat(db): V5 triggers make content_version a freshness superset (#271, #272)
+
+art rows are immutable (art_reject_content_update) and deleting a referenced
+art row bumps referencing tracks (art_ad); scanner geometry changes bump via
+tracks_geometry_au; structural-block writes bump via structural_blocks_ai/_ad.
+This makes the content_version cache key a true superset of DB-knowable
+served-byte inputs, so the caches' single-i64 key stays valid.
+
+Reworks the mapping.rs malformed-row test to INSERT (the immutability trigger
+blocks the old UPDATE) and inverts the rescan test to expect a bump.
+Regenerates the Python schema mirror.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: getattr stats the backing file on size-cache hits (#279)
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs:85-91` (`SizeEntry` struct)
+- Modify: `musefs-core/src/facade.rs:923-976` (`getattr`)
+- Test: `musefs-core/src/facade.rs` (`tests` module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the `tests` module in `musefs-core/src/facade.rs` (the module already imports `CoreError`, `MountConfig`, `Mode`, `Musefs`, `VirtualTree`, `id3`, and uses `crate::scan::scan_directory`, as in `open_handle_reresolves_after_content_version_bump`):
+
+```rust
+#[test]
+fn getattr_size_cache_hit_detects_backing_change() {
+    use crate::scan::scan_directory;
+    use id3::TagLike;
+    use std::collections::BTreeMap;
+
+    let dir = tempfile::tempdir().unwrap();
+    let backing = dir.path().join("a.mp3");
+    {
+        let mut tag = id3::Tag::new();
+        tag.set_artist("Pix");
+        tag.set_title("Song");
+        let mut bytes = Vec::new();
+        tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+        bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+        std::fs::write(&backing, &bytes).unwrap();
+    }
+
+    let db_path = dir.path().join("m.db");
+    {
+        let db = musefs_db::Db::open(&db_path).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+    }
+    let cfg = MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
+    };
+    let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+    let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+
+    // First getattr populates size_cache (miss path: full resolve).
+    let attr1 = fs.getattr(file_inode).unwrap();
+    assert!(attr1.size > 0, "baseline attr must be non-empty");
+
+    // Second getattr with the file unchanged is a clean cache hit.
+    let attr2 = fs.getattr(file_inode).unwrap();
+    assert_eq!(attr1.size, attr2.size, "unchanged backing must stay a hit");
+
+    // Change the backing file out-of-band, without any DB write — so
+    // content_version is unchanged and the size_cache would otherwise hit.
+    {
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&backing)
+            .unwrap();
+        f.write_all(&[0u8; 64]).unwrap();
+    }
+
+    // getattr must now refuse to advertise stale attrs.
+    assert!(
+        matches!(fs.getattr(file_inode), Err(CoreError::BackingChanged(_))),
+        "getattr must degrade to BackingChanged after an on-disk backing change"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core getattr_size_cache_hit_detects_backing_change`
+Expected: FAIL — the final assertion fails because the current hit path returns stale attrs (`Ok`) instead of `Err(BackingChanged)`.
+
+- [ ] **Step 3: Add the backing stamp to `SizeEntry`**
+
+Replace the `SizeEntry` struct at `musefs-core/src/facade.rs:85-91`:
+
+```rust
+/// A cached file size/attr entry: validated at `content_version`.
+#[derive(Clone, Copy)]
+struct SizeEntry {
+    content_version: i64,
+    total_len: u64,
+    mtime_secs: i64,
+}
+```
+
+with:
+
+```rust
+/// A cached file size/attr entry: validated at `content_version`, plus the
+/// backing-file stamp it was built from so `getattr` can re-stat on a hit and
+/// catch an on-disk backing change that left `content_version` untouched (#279).
+#[derive(Clone, Copy)]
+struct SizeEntry {
+    content_version: i64,
+    total_len: u64,
+    mtime_secs: i64,
+    backing_size: u64,
+    backing_mtime_secs: i64,
+}
+```
+
+- [ ] **Step 4: Stat on the hit path and populate the stamp on the miss path in `getattr`**
+
+In `getattr` (`musefs-core/src/facade.rs`), replace the cache-hit block:
+
+```rust
+            if let Some(e) = self.size_cache.get(&track_id).map(|e| *e)
+                && e.content_version == track.content_version
+            {
+                // Hit: no backing stat, no synthesis. NOTE: a backing file
+                // changed in place without a rescan would leave mtime/size
+                // stale until the next scan bumps content_version — acceptable
+                // for a read-only mount (reads still validate at open()).
+                return Ok((e.total_len, e.mtime_secs));
+            }
+```
+
+with:
+
+```rust
+            if let Some(e) = self.size_cache.get(&track_id).map(|e| *e)
+                && e.content_version == track.content_version
+            {
+                // Hit: re-stat the backing file (no synthesis) and compare to
+                // the stamp the cached attrs were built from. An on-disk change
+                // that left content_version untouched would otherwise let
+                // getattr advertise stale attrs — the one metadata surface that
+                // could outrun a backing change (read/open already re-stat).
+                crate::metrics::on_stat();
+                let meta = std::fs::metadata(&track.backing_path)?;
+                if meta.len() != e.backing_size || mtime_secs(&meta) != e.backing_mtime_secs {
+                    return Err(CoreError::BackingChanged(track.backing_path.clone()));
+                }
+                return Ok((e.total_len, e.mtime_secs));
+            }
+```
+
+Then replace the miss-path insert:
+
+```rust
+            self.size_cache.insert(
+                track_id,
+                SizeEntry {
+                    content_version: track.content_version,
+                    total_len: resolved.total_len,
+                    mtime_secs: resolved.mtime_secs,
+                },
+            );
+```
+
+with:
+
+```rust
+            self.size_cache.insert(
+                track_id,
+                SizeEntry {
+                    content_version: track.content_version,
+                    total_len: resolved.total_len,
+                    mtime_secs: resolved.mtime_secs,
+                    backing_size: resolved.backing_size,
+                    backing_mtime_secs: resolved.backing_mtime_secs,
+                },
+            );
+```
+
+(`resolved` is an `Arc<ResolvedFile>`; `ResolvedFile` already exposes `backing_size: u64` and `backing_mtime_secs: i64` — see `musefs-core/src/reader.rs:17-40`. `mtime_secs` is the module-level helper at `musefs-core/src/facade.rs:104`.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core getattr_size_cache_hit_detects_backing_change`
+Expected: PASS.
+
+- [ ] **Step 6: Run the broader facade/getattr tests and lint gates**
+
+Run: `cargo test -p musefs-core facade`
+Expected: PASS (no regressions in existing getattr/size_cache tests).
+
+Run: `cargo clippy --all-targets && cargo fmt --all --check`
+Expected: no warnings, no formatting diff.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-core/src/facade.rs
+git commit -m "$(cat <<'EOF'
+feat(core): getattr re-stats backing on size-cache hits (#279)
+
+SizeEntry now carries the backing size/mtime stamp; a size-cache hit re-stats
+the backing file and degrades to BackingChanged on drift instead of advertising
+stale attrs, aligning getattr with the read/open paths. Catches an on-disk
+backing change that left content_version untouched.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Documentation — external-writer contract and freshness semantics
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (store-schema section ~135-140, external-writer contract ~142-170, freshness section ~212-225)
+- Modify: `contrib/python-musefs/` contract docs (the human-readable contract notes, not the generated `schema.py`)
+
+- [ ] **Step 1: Add the V5 entry to the store-schema list in `ARCHITECTURE.md`**
+
+After the `- **V4** — ...` bullet (`ARCHITECTURE.md:135-140`), add:
+
+```markdown
+- **V5** — freshness-superset triggers that make `content_version` cover every
+  DB-knowable input to synthesized bytes, not only tag/`track_art` edits:
+  `art_reject_content_update` (rejects in-place mutation of an `art` row's
+  content columns — art is content-addressed, so a changed image is a new row),
+  `art_ad` (bumps every track referencing a deleted `art` row, so an orphaned
+  reference rebuilds to a clean serve-time error rather than streaming stale
+  bytes), `tracks_geometry_au` (bumps when scanner-owned geometry — `format`,
+  audio bounds, backing size/mtime — changes), and `structural_blocks_ai`/`_ad`
+  (bump when FLAC structural blocks change).
+```
+
+- [ ] **Step 2: Update the external-writer contract in `ARCHITECTURE.md`**
+
+In the "Ownership" / "What the store enforces" region (`ARCHITECTURE.md:142-170`), add a paragraph documenting art immutability. Insert after the "What the store enforces" list (after the `- a picture_type outside 0..=20.` bullet at `ARCHITECTURE.md:159`):
+
+```markdown
+**Art is immutable once written.** `art` rows are content-addressed by
+`sha256`; as of V5 a trigger rejects any in-place `UPDATE` of an art row's
+content columns (`data`, `sha256`, `mime`, `byte_len`, `width`, `height`) with
+`RAISE(ABORT)` — a multi-row `UPDATE art` touching any content column aborts the
+whole statement. To change a track's art, insert a new content-addressed row
+and relink it via `track_art` (which bumps `content_version`); do not mutate an
+existing row. Deleting an `art` row still referenced by `track_art` (possible
+only with `foreign_keys` OFF) bumps every referencing track so the mount serves
+a clean `EIO` on the now-orphaned reference instead of stale bytes.
+```
+
+- [ ] **Step 3: Update the freshness section in `ARCHITECTURE.md`**
+
+In "Freshness: two version counters" (`ARCHITECTURE.md:212-225`), update the `content_version` description so it no longer says the triggers bump *only* on tag/art edits. Replace the sentence "The DB triggers increment it on any tag/art edit." (`ARCHITECTURE.md:217`) with:
+
+```markdown
+The DB triggers increment it on any input the database can see that changes
+synthesized bytes: tag and `track_art` edits, `art`-row deletes that orphan a
+reference, scanner-owned geometry changes (`format`, audio bounds, backing
+size/mtime), and FLAC structural-block changes (V5). It is therefore a
+superset key — the one input it cannot cover is an on-disk backing change with
+no DB write, which `resolve` (and, since #279, a size-cache `getattr` hit)
+catches by re-statting the backing file and degrading to `BackingChanged`.
+```
+
+- [ ] **Step 4: Mirror the art-immutability rule in the contrib contract docs**
+
+Locate the human-readable external-writer contract notes under `contrib/python-musefs/` (search: `grep -rl "track_art" contrib/python-musefs --include=*.md --include=*.py`; the contract is documented alongside the shared library, not in the generated `schema.py`). Add a note that art rows are immutable: writers must insert a new content-addressed row and relink via `track_art` rather than updating an existing `art` row. Match the surrounding doc style; keep it to two or three sentences.
+
+If no human-readable contract doc exists under `contrib/python-musefs/` (only the generated `schema.py` and code), skip this step — the `ARCHITECTURE.md` external-writer contract is the canonical statement — and note in the commit message that the contrib mirror had no prose contract to update.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ARCHITECTURE.md
+# Add the contrib contract doc only if Step 4 modified one:
+git add -p   # stage any contrib doc change from Step 4
+git commit -m "$(cat <<'EOF'
+docs: document V5 freshness-superset triggers and art immutability
+
+ARCHITECTURE.md: add the V5 schema entry, document that art rows are immutable
+(insert-and-relink, not in-place UPDATE), and update the freshness section to
+describe content_version as a superset key with the on-disk backing change as
+the one stat-caught exception (#271, #272, #279).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #271 art immutability → Task 1 `art_reject_content_update` + `art_content_update_is_rejected`/`art_noop_update_is_allowed` tests. ✓
+- #271 art delete-bump → Task 1 `art_ad` + `deleting_referenced_art_bumps_tracks`/`deleting_unreferenced_art_bumps_nothing` tests. ✓
+- #272 geometry bump → Task 1 `tracks_geometry_au` + `geometry_change_bumps_content_version_by_exactly_one`/`identical_rescan_does_not_bump_content_version` + inverted `tracks.rs` test. ✓
+- #272 structural blocks → Task 1 `structural_blocks_ai`/`_ad` + `structural_block_change_bumps_content_version`. ✓
+- #272 alternative (validate-at-hit) → explicitly rejected in spec; not implemented (correct). ✓
+- #279 getattr stat → Task 2 `SizeEntry` stamp + `getattr` stat + `getattr_size_cache_hit_detects_backing_change` (plus the preserved cache-hit assertion `attr1.size == attr2.size`). ✓
+- Migration V5 append-only → Task 1 Steps 6-7. ✓
+- Python schema mirror regen + vendor → Task 1 Step 8. ✓
+- mapping.rs malformed-row test rework (the spec's flagged blocker) → Task 1 Step 4. ✓
+- Changelog double-pump → no over-tight changelog-row-count assertion is written (the new tests assert `content_version`, not `track_changes` counts), consistent with the spec's warning. ✓
+- Docs (ARCHITECTURE + contrib) → Task 3. ✓
+- Fuzz crate → unaffected (no format-layer signature change); no step needed, matching the spec. ✓
+
+**Placeholder scan:** No TBD/TODO; every code and SQL step is complete. Step 4 of Task 3 has a conditional ("if no contract doc exists, skip") with an explicit fallback, not a placeholder.
+
+**Type/name consistency:** `SizeEntry` fields `backing_size`/`backing_mtime_secs` match `ResolvedFile`'s field names (`reader.rs:17-40`) and the `mtime_secs` helper (`facade.rs:104`). Trigger names (`art_reject_content_update`, `art_ad`, `tracks_geometry_au`, `structural_blocks_ai`, `structural_blocks_ad`) are used consistently across the migration SQL, tests, and docs. `StructuralBlock { kind, ordinal, body }` matches `models.rs:229`. The inverted test name `rescan_with_changed_geometry_bumps_content_version` matches the spec's suggested rename.
+
+**Scope:** One cohesive freshness-correctness change across three tasks; not decomposable further without splitting an atomic schema commit.

--- a/docs/superpowers/specs/2026-06-11-content-version-freshness-design.md
+++ b/docs/superpowers/specs/2026-06-11-content-version-freshness-design.md
@@ -25,12 +25,26 @@ inputs change served bytes or attrs without bumping it:
   `CHECK(byte_len = length(data))`, so an in-place data edit already violates
   the content-addressing contract.
 - **#272 — scanner geometry.** `format`, `audio_offset`, `audio_length`,
-  `backing_size`, `backing_mtime`, and FLAC `structural_blocks` change on
-  rescan without bumping `content_version` (pinned today by
-  `rescan_does_not_reset_content_version`). `resolve` re-stats and validates
-  the *current* track row against disk, but a cache hit only compares
+  `backing_size`, `backing_mtime`, and FLAC `structural_blocks` can change
+  without bumping `content_version`. `resolve` re-stats and validates the
+  *current* track row against disk, but a cache hit only compares
   `content_version`, so it can return an **old** `ResolvedFile` (old offsets)
   paired with the freshly-validated current row.
+
+  The genuine exposure is narrower than "every rescan." `upsert_track`
+  (`tracks.rs`/`bulk.rs`) writes geometry but not `content_version`, and the
+  integrated scan path's other writes mask this on the common path:
+  `replace_tags` is DELETE+INSERT (`tags.rs:177`) so re-tagging a re-probed
+  file already fires `tags_a{d,i}` and bumps; incremental rescan skips files
+  whose size/mtime are unchanged (`scan.rs`), so a re-probe implies the file
+  changed and the tag rewrite covers it. The real residual gaps are: **(1)** a
+  re-probed file with **zero text tags** (geometry changes, no tag rows to
+  rewrite, nothing bumps); **(2)** the one-time V2 structural-block backfill
+  pass (`scan.rs`), which populates `structural_blocks` on *unchanged* files —
+  flipping `reader.rs` synthesis from the legacy front-read fallback to the
+  streamed fast path, a layout change, with no geometry or tag edit; **(3)**
+  hostile raw-SQL geometry edits. `rescan_does_not_reset_content_version`
+  pins gap (1) as intended behavior today.
 - **#279 — getattr size-cache.** A `size_cache` hit in `getattr` returns
   size/mtime with **no backing stat** (by design — "no backing stat, no
   synthesis"). Read/open re-stat and degrade to `BackingChanged`; `getattr`
@@ -86,6 +100,19 @@ Two new triggers on `art`:
    in-place mutation *and* handle the delete path explicitly rather than
    leaving it solely to serve-time `EIO`.
 
+   **`art_ad` is inert on the normal delete path, by design.** The only art
+   deletion the codebase performs is `gc_orphan_art` (`art.rs`), which deletes
+   art with **no** `track_art` references — so the subquery returns zero rows
+   and nothing is bumped (correct: a GC'd orphan has no referencing tracks to
+   invalidate). On a track delete, the FK `ON DELETE CASCADE` removes the
+   `track_art` link *before* any later art GC, so again the subquery is empty.
+   `art_ad` does real work **only** in the FK-disabled-orphan case — exactly
+   the hostile/degraded write the contract already treats as untrusted.
+
+   `art_ad` bumps `updated_at` (unlike the Part B geometry trigger): an
+   external writer's art delete is not otherwise stamped, whereas the geometry
+   trigger's writer (`upsert_track`) already sets `updated_at` itself.
+
 ## Part B — #272: scanner geometry bumps `content_version` (schema, V5)
 
 1. **`tracks_geometry_au`** — `AFTER UPDATE ON tracks`, `WHEN` any of `format`,
@@ -98,20 +125,40 @@ Two new triggers on `art`:
 
    The `WHEN` guard is false on the nested self-fire (the bump changes only
    `content_version`, leaving the geometry columns equal), so the recursion
-   terminates after one bump. This catches **all** writers — including a
-   hostile raw-SQL edit — not just the scanner's `upsert_track`. `updated_at`
+   terminates after exactly one bump. This catches **all** writers — including
+   a hostile raw-SQL edit — not just the scanner's `upsert_track`. `updated_at`
    is already maintained by `upsert_track` itself, so the geometry trigger only
-   touches `content_version`.
+   touches `content_version`. The trigger is `AFTER UPDATE`, so it runs after
+   the V4 `CHECK (audio_offset + audio_length <= backing_size)` constraint and
+   neither relaxes nor interacts with it.
 
-2. **`structural_blocks_ai` / `_au` / `_ad`** — bump the owning track's
-   `content_version` on any insert/update/delete of `structural_blocks` (FLAC
-   `STREAMINFO`/`SEEKTABLE`/`APPLICATION`/`CUESHEET` feed synthesized headers).
-   The bump targets `track_id` from `NEW`/`OLD` as appropriate.
+2. **`structural_blocks_ai` / `_ad`** — bump the owning track's
+   `content_version` on insert/delete of `structural_blocks` (FLAC
+   `STREAMINFO`/`SEEKTABLE`/`APPLICATION`/`CUESHEET` feed synthesized headers),
+   targeting `track_id` from `NEW`/`OLD`. **No `_au` trigger:**
+   `set_structural_blocks` (`structural.rs`/`bulk.rs`) is DELETE-then-INSERT,
+   never UPDATE, so an update trigger would be dead code. Because every rewrite
+   is a DELETE followed by INSERTs, a rescan bumps `content_version` by more
+   than one (and bumps even when the re-written blocks are byte-identical).
+   This **over-bump is accepted as harmless**: `content_version` is a monotone
+   generation counter compared only for equality, so magnitude never affects
+   correctness — only how many times a cache entry rebuilds. The cases that
+   trigger it (a structural rewrite, or the one-time V2 backfill) are not hot
+   paths.
 
 This keeps the caches' single-`i64` key valid and untouched — no hot-path
 change for #272. The incremental-refresh path then invalidates these tracks
 through the same `content_version`-rose signal it already uses, with no new
 cache-maintenance code.
+
+**Changelog double-pump.** Each `content_version` bump trigger does an `UPDATE
+tracks`, which fires `tracks_changelog_au` and appends a `track_changes` row.
+So a single `upsert_track` that changes geometry now produces **two** changelog
+rows (the scanner's own UPDATE plus the trigger's), and a structural rewrite
+adds more. This is functionally harmless — `changelog_since` collapses to
+distinct track ids — but tests that assert an exact `track_changes` row count
+(e.g. the analog of `v4_metadata_edit_bumps_version_and_appends_one_changelog_row`)
+must expect the higher count rather than one.
 
 **Alternative considered (rejected):** validate geometry at cache-hit time in
 `reader.rs`/`facade.rs` — store the full geometry in `ResolvedFile`/`SizeEntry`
@@ -149,14 +196,31 @@ single surface that could outrun a backing change. Record the stat via
   grows by one entry and `user_version` advances. V5 only *adds* triggers (no
   table rebuild), so unlike V4 it does not need to stash/refill rows or
   recreate existing triggers.
+- **Existing-test fallout (must land in the V5 commit).**
+  `track_art_to_inputs`'s malformed-row test (`musefs-core/src/mapping.rs`)
+  plants a bad art row via `UPDATE art SET byte_len = -1` under
+  `PRAGMA ignore_check_constraints`. That pragma disables CHECKs but **not
+  triggers**, so `art_reject_content_update` would `RAISE(ABORT)` and fail the
+  test — and the pre-commit hook runs the full suite, so the commit would be
+  red. Rework the test to plant the malformed row via a **direct INSERT** (the
+  immutability trigger guards only UPDATE; a fresh malformed INSERT is the
+  realistic FK/CHECK-disabled external write and still reaches the row-reader
+  defensive path the test pins) rather than mutating an existing row. This is
+  the one place the "all commits stay green" claim needs active work, not just
+  additive triggers.
 - **Python schema mirror** (per CLAUDE.md): regenerate with
   `MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py`, then re-vendor
-  into `contrib/python-musefs/`.
+  into `contrib/python-musefs/`. Verified: the contrib writers
+  (`contrib/python-musefs/.../store.py` and the Picard copy) only ever
+  `INSERT ... ON CONFLICT DO NOTHING` on `art` and never UPDATE it, so the
+  immutability trigger breaks no contrib code.
 - **Docs**:
   - `ARCHITECTURE.md` external-writer contract — document that `art` rows are
     immutable (insert a new content-addressed row and relink via `track_art`;
-    do not mutate in place) and that `content_version` is now a superset of
-    scanner geometry and structural-block changes, not only tag/art edits.
+    do not mutate in place; a multi-row `UPDATE art` touching any content
+    column aborts the whole statement via `RAISE(ABORT)`) and that
+    `content_version` is now a superset of scanner geometry and structural-block
+    changes, not only tag/art edits.
   - `ARCHITECTURE.md` "Freshness: two version counters" — update the
     `content_version` description to reflect the superset semantics.
   - `ARCHITECTURE.md` store-schema section — add the V5 entry.
@@ -168,22 +232,34 @@ single surface that could outrun a backing change. Record the stat via
 
 Each issue's repro sketch becomes a test:
 
-- **#271:** an in-place `UPDATE` of `art` content columns is rejected
-  (`RAISE(ABORT)`); a no-op `UPDATE` succeeds; deleting a referenced `art` row
-  bumps `content_version` for every referencing track.
-- **#272:** a rescan that changes geometry bumps `content_version` and a
-  subsequent `resolve` rebuilds the layout (no stale offsets); an
-  identical-geometry rescan does not bump; a `structural_blocks` change bumps
-  the owning track. Invert/rename `rescan_does_not_reset_content_version`.
-- **#279:** populate `size_cache` via an initial `getattr`; mutate/delete the
-  backing file without changing DB `content_version`; assert the next
-  `getattr` returns `BackingChanged`/I-O error rather than stale attrs.
-  Preserve a cache-hit test asserting an unchanged backing file still serves
-  the cached attrs with no spurious error.
+- **#271:** an in-place `UPDATE` of each `art` content column
+  (`data`/`sha256`/`mime`/`byte_len`/`width`/`height`) is rejected
+  (`RAISE(ABORT)`); a no-op `UPDATE` (no content column changed) succeeds;
+  inserting a new art row and relinking via `track_art` succeeds and bumps;
+  deleting an FK-orphan `art` row (links left dangling) bumps `content_version`
+  for every referencing track, while a `gc_orphan_art`-style delete of an
+  unreferenced row bumps nothing.
+- **#272:** the test must reproduce a gap that fails *without* the fix — use a
+  **tagless** track (so no `replace_tags` masks the geometry change): upsert it,
+  resolve to cache a layout, change geometry via a second `upsert_track`, and
+  assert `content_version` rose by **exactly 1** (proving the `WHEN` guard
+  terminates the self-fire rather than looping) and that a subsequent `resolve`
+  rebuilds the layout with the new offsets. Assert an identical-geometry rescan
+  does **not** bump. Assert a `structural_blocks` rewrite bumps the owning
+  track (accepting the DELETE+INSERT over-bump — assert `> 0`, not `== 1`).
+  Invert/rename `rescan_does_not_reset_content_version`.
+- **#279:** populate `size_cache` via an initial `getattr`; change the backing
+  file's **size** (truncate or extend — a same-size, same-second in-place
+  rewrite is out of scope and would make the test flaky) without changing DB
+  `content_version`; assert the next `getattr` returns
+  `BackingChanged`/I-O error rather than stale attrs. Preserve a cache-hit test
+  asserting an unchanged backing file still serves the cached attrs with no
+  spurious error.
 
 All commits stay green: the pre-commit hook runs the full workspace test suite,
-so the schema-trigger changes and their tests land together, and the inverted
-rescan test lands in the same commit as the V5 migration.
+so the schema-trigger changes and their tests land together — including the
+reworked `mapping.rs` malformed-row test (see Cross-cutting) and the inverted
+rescan test, both of which land in the same commit as the V5 migration.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-11-content-version-freshness-design.md
+++ b/docs/superpowers/specs/2026-06-11-content-version-freshness-design.md
@@ -1,0 +1,195 @@
+# content_version freshness: make the freshness key a true superset
+
+**Issues:** #271, #272, #279
+**Branch:** `content-version-freshness`
+**Date:** 2026-06-11
+
+## Problem
+
+`content_version` (per-track column) is documented as *the* answer to "did
+this track's served bytes change?". The whole refresh + cache architecture
+keys freshness on it: a single `i64` compare gates every cache hit
+(`HeaderCache` layouts in `reader.rs`, `size_cache` attrs in `facade.rs`), and
+the incremental refresh path drops cache entries only for *removed* tracks
+(`facade.rs` `poll_refresh_notify`), relying on the `content_version` compare
+to lazily invalidate *changed* tracks.
+
+The defect class — restated across all three issues — is that `content_version`
+is **not a superset** of every input that affects synthesized bytes. Three
+inputs change served bytes or attrs without bumping it:
+
+- **#271 — `art` rows.** The `art` table has no triggers. Mutating
+  `art.data`/`mime`/`byte_len`/`width`/`height` in place changes synthesized
+  bytes but bumps nothing. (`track_art` *link* edits bump; the blob itself
+  changing does not.) `art` is content-addressed by `sha256` with
+  `CHECK(byte_len = length(data))`, so an in-place data edit already violates
+  the content-addressing contract.
+- **#272 — scanner geometry.** `format`, `audio_offset`, `audio_length`,
+  `backing_size`, `backing_mtime`, and FLAC `structural_blocks` change on
+  rescan without bumping `content_version` (pinned today by
+  `rescan_does_not_reset_content_version`). `resolve` re-stats and validates
+  the *current* track row against disk, but a cache hit only compares
+  `content_version`, so it can return an **old** `ResolvedFile` (old offsets)
+  paired with the freshly-validated current row.
+- **#279 — getattr size-cache.** A `size_cache` hit in `getattr` returns
+  size/mtime with **no backing stat** (by design — "no backing stat, no
+  synthesis"). Read/open re-stat and degrade to `BackingChanged`; `getattr`
+  does not, so it is the one metadata surface that advertises stale attrs
+  after an on-disk backing change with no DB write.
+
+## Design principle
+
+Make `content_version` a genuine superset of everything the **database can
+know** affects served bytes (#271, #272), and add a stat for the one thing the
+DB **cannot** know — an on-disk backing change with no DB write (#279). This
+stays on the existing grain: musefs already re-stats the backing file on every
+`resolve` and on every per-handle read, treating rows as untrusted input and
+degrading to a controlled `BackingChanged` rather than splicing at stale
+offsets. The bug is only that the *caches* short-circuit that discipline on a
+`content_version` match.
+
+Keeping the fix in the schema for #271/#272 means the caches' single-`i64` key
+stays valid and the hot path is untouched; only `getattr` (#279) gains a stat,
+aligning the one inconsistent surface with read/open.
+
+## Part A — #271: `art` immutability + delete-bump (schema, V5)
+
+Two new triggers on `art`:
+
+1. **`art_reject_content_update`** — `BEFORE UPDATE ON art`, `WHEN` any content
+   column (`data`, `sha256`, `mime`, `byte_len`, `width`, `height`) differs
+   from `OLD` → `RAISE(ABORT, 'art rows are immutable; insert a new
+   content-addressed row and relink via track_art')`. Art is content-addressed;
+   the new-row-and-relink path (which already bumps `content_version` through
+   the `track_art_*` triggers) becomes the only way to change a track's art. A
+   pure no-op `UPDATE` (no content column changed) still passes, so idempotent
+   writes are not penalized.
+
+   The full content-column lock (including `width`/`height`/`mime`, not just
+   `data`) is deliberate: `mime` and dimensions feed synthesized art headers,
+   and a content-addressed row whose `sha256` no longer matches its `data` is
+   incoherent regardless of which column drifted.
+
+2. **`art_ad`** — `AFTER DELETE ON art`, bump `content_version` (and
+   `updated_at`) for every track linked through `track_art` to `OLD.id`:
+
+   ```sql
+   UPDATE tracks SET content_version = content_version + 1,
+                     updated_at = CAST(strftime('%s','now') AS INTEGER)
+   WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+   ```
+
+   A deleted-but-still-referenced art row (an orphan an external writer can
+   produce with FK enforcement disabled) forces a rebuild of the referencing
+   tracks → an honest serve-time `EIO` on the orphan instead of streaming
+   stale bytes from an old cached layout. This is the "both" decision: reject
+   in-place mutation *and* handle the delete path explicitly rather than
+   leaving it solely to serve-time `EIO`.
+
+## Part B — #272: scanner geometry bumps `content_version` (schema, V5)
+
+1. **`tracks_geometry_au`** — `AFTER UPDATE ON tracks`, `WHEN` any of `format`,
+   `audio_offset`, `audio_length`, `backing_size`, `backing_mtime` differs from
+   `OLD`:
+
+   ```sql
+   UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
+   ```
+
+   The `WHEN` guard is false on the nested self-fire (the bump changes only
+   `content_version`, leaving the geometry columns equal), so the recursion
+   terminates after one bump. This catches **all** writers — including a
+   hostile raw-SQL edit — not just the scanner's `upsert_track`. `updated_at`
+   is already maintained by `upsert_track` itself, so the geometry trigger only
+   touches `content_version`.
+
+2. **`structural_blocks_ai` / `_au` / `_ad`** — bump the owning track's
+   `content_version` on any insert/update/delete of `structural_blocks` (FLAC
+   `STREAMINFO`/`SEEKTABLE`/`APPLICATION`/`CUESHEET` feed synthesized headers).
+   The bump targets `track_id` from `NEW`/`OLD` as appropriate.
+
+This keeps the caches' single-`i64` key valid and untouched — no hot-path
+change for #272. The incremental-refresh path then invalidates these tracks
+through the same `content_version`-rose signal it already uses, with no new
+cache-maintenance code.
+
+**Alternative considered (rejected):** validate geometry at cache-hit time in
+`reader.rs`/`facade.rs` — store the full geometry in `ResolvedFile`/`SizeEntry`
+and compare on hit instead of bumping in the schema. It needs no migration and
+also catches hostile edits, but it spreads freshness logic across two files,
+requires a structural-block fingerprint, and fights the architecture that
+already centralizes freshness on `content_version`. The schema bump is the
+smaller, more cohesive change.
+
+**Contract/test impact:** `rescan_does_not_reset_content_version`
+(`musefs-db/tests/tracks.rs`) currently changes `audio_offset`/`audio_length`
+on rescan and asserts `content_version` is unchanged — it pins the #272 bug as
+intended behavior. It is inverted: a geometry-changing rescan now bumps
+`content_version`; a separate case asserts an identical-geometry rescan still
+does not bump (the `WHEN` guard). Rename to reflect the new contract (e.g.
+`rescan_with_changed_geometry_bumps_content_version`).
+
+## Part C — #279: getattr stats the backing on size-cache hits (code)
+
+- Extend `SizeEntry` (`facade.rs`) with `backing_size: u64` and
+  `backing_mtime_secs: i64`, populated from the resolved file on the miss path.
+- On a `size_cache` hit in `getattr`, re-stat `track.backing_path` and compare
+  `meta.len()`/`mtime_secs(&meta)` to the stamp. On drift, degrade to
+  `CoreError::BackingChanged(track.backing_path)` — the same controlled error
+  read/open already return — instead of returning stale attrs.
+
+This adds one `stat` per `getattr` hit. `getattr` already performs a
+`get_track` per call, and read/open stat on every read, so this only aligns the
+single surface that could outrun a backing change. Record the stat via
+`crate::metrics::on_stat()` for consistency with `resolve`.
+
+## Cross-cutting work
+
+- **Migration V5** (`musefs-db/src/schema.rs`): append-only; `MIGRATIONS`
+  grows by one entry and `user_version` advances. V5 only *adds* triggers (no
+  table rebuild), so unlike V4 it does not need to stash/refill rows or
+  recreate existing triggers.
+- **Python schema mirror** (per CLAUDE.md): regenerate with
+  `MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py`, then re-vendor
+  into `contrib/python-musefs/`.
+- **Docs**:
+  - `ARCHITECTURE.md` external-writer contract — document that `art` rows are
+    immutable (insert a new content-addressed row and relink via `track_art`;
+    do not mutate in place) and that `content_version` is now a superset of
+    scanner geometry and structural-block changes, not only tag/art edits.
+  - `ARCHITECTURE.md` "Freshness: two version counters" — update the
+    `content_version` description to reflect the superset semantics.
+  - `ARCHITECTURE.md` store-schema section — add the V5 entry.
+  - `contrib/python-musefs/` contract docs — mirror the art-immutability rule.
+- **Fuzz crate**: no format-layer signature change, so `fuzz/` is unaffected
+  (no `cargo +nightly fuzz build` needed beyond the usual gate).
+
+## Testing
+
+Each issue's repro sketch becomes a test:
+
+- **#271:** an in-place `UPDATE` of `art` content columns is rejected
+  (`RAISE(ABORT)`); a no-op `UPDATE` succeeds; deleting a referenced `art` row
+  bumps `content_version` for every referencing track.
+- **#272:** a rescan that changes geometry bumps `content_version` and a
+  subsequent `resolve` rebuilds the layout (no stale offsets); an
+  identical-geometry rescan does not bump; a `structural_blocks` change bumps
+  the owning track. Invert/rename `rescan_does_not_reset_content_version`.
+- **#279:** populate `size_cache` via an initial `getattr`; mutate/delete the
+  backing file without changing DB `content_version`; assert the next
+  `getattr` returns `BackingChanged`/I-O error rather than stale attrs.
+  Preserve a cache-hit test asserting an unchanged backing file still serves
+  the cached attrs with no spurious error.
+
+All commits stay green: the pre-commit hook runs the full workspace test suite,
+so the schema-trigger changes and their tests land together, and the inverted
+rescan test lands in the same commit as the V5 migration.
+
+## Out of scope
+
+- Reworking the cache key away from `content_version` (the single-`i64` model
+  is preserved deliberately).
+- Same-size/same-second backing rewrites (#276) beyond what the #279 stat
+  already catches when size or mtime differs — a rewrite that preserves both
+  size and mtime-to-the-second remains outside this design, as it is for
+  read/open today.

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -83,12 +83,16 @@ impl std::os::fd::AsFd for PassthroughFd {
     }
 }
 
-/// A cached file size/attr entry: validated at `content_version`.
+/// A cached file size/attr entry: validated at `content_version`, plus the
+/// backing-file stamp it was built from so `getattr` can re-stat on a hit and
+/// catch an on-disk backing change that left `content_version` untouched (#279).
 #[derive(Clone, Copy)]
 struct SizeEntry {
     content_version: i64,
     total_len: u64,
     mtime_secs: i64,
+    backing_size: u64,
+    backing_mtime_secs: i64,
 }
 
 /// Resets a single-flight flag on drop, so a panic (or early return) during a
@@ -949,10 +953,16 @@ impl Musefs {
             if let Some(e) = self.size_cache.get(&track_id).map(|e| *e)
                 && e.content_version == track.content_version
             {
-                // Hit: no backing stat, no synthesis. NOTE: a backing file
-                // changed in place without a rescan would leave mtime/size
-                // stale until the next scan bumps content_version — acceptable
-                // for a read-only mount (reads still validate at open()).
+                // Hit: re-stat the backing file (no synthesis) and compare to
+                // the stamp the cached attrs were built from. An on-disk change
+                // that left content_version untouched would otherwise let
+                // getattr advertise stale attrs — the one metadata surface that
+                // could outrun a backing change (read/open already re-stat).
+                crate::metrics::on_stat();
+                let meta = std::fs::metadata(&track.backing_path)?;
+                if meta.len() != e.backing_size || mtime_secs(&meta) != e.backing_mtime_secs {
+                    return Err(CoreError::BackingChanged(track.backing_path.clone()));
+                }
                 return Ok((e.total_len, e.mtime_secs));
             }
             // Miss: full resolve (validates via stat, builds + caches the layout).
@@ -963,6 +973,8 @@ impl Musefs {
                     content_version: track.content_version,
                     total_len: resolved.total_len,
                     mtime_secs: resolved.mtime_secs,
+                    backing_size: resolved.backing_size,
+                    backing_mtime_secs: resolved.backing_mtime_secs,
                 },
             );
             Ok((resolved.total_len, resolved.mtime_secs))
@@ -1786,5 +1798,67 @@ mod tests {
         // matches the incremental path's min-id rule (tree.rs introducing_id).
         assert_eq!(tree.inode_of_track(id_a), Some(bare));
         assert_eq!(tree.inode_of_track(id_b), Some(suffixed));
+    }
+
+    #[test]
+    fn getattr_size_cache_hit_detects_backing_change() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        let backing = dir.path().join("a.mp3");
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(&backing, &bytes).unwrap();
+        }
+
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+        let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+        let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+
+        // First getattr populates size_cache (miss path: full resolve).
+        let attr1 = fs.getattr(file_inode).unwrap();
+        assert!(attr1.size > 0, "baseline attr must be non-empty");
+
+        // Second getattr with the file unchanged is a clean cache hit.
+        let attr2 = fs.getattr(file_inode).unwrap();
+        assert_eq!(attr1.size, attr2.size, "unchanged backing must stay a hit");
+
+        // Change the backing file out-of-band, without any DB write — so
+        // content_version is unchanged and the size_cache would otherwise hit.
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&backing)
+                .unwrap();
+            f.write_all(&[0u8; 64]).unwrap();
+        }
+
+        // getattr must now refuse to advertise stale attrs.
+        assert!(
+            matches!(fs.getattr(file_inode), Err(CoreError::BackingChanged(_))),
+            "getattr must degrade to BackingChanged after an on-disk backing change"
+        );
     }
 }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -320,14 +320,27 @@ mod tests {
                 data: vec![1, 2, 3, 4],
             })
             .unwrap();
-        let bad = db
-            .upsert_art(&NewArt {
-                mime: "image/png".into(),
-                width: None,
-                height: None,
-                data: vec![9, 9, 9, 9, 9],
-            })
+
+        let raw = rusqlite::Connection::open(&path).unwrap();
+        raw.pragma_update(None, "ignore_check_constraints", true)
             .unwrap();
+        raw.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
+             VALUES (?1, 'image/png', NULL, NULL, -1, X'0909090909')",
+            [&"9".repeat(64)],
+        )
+        .unwrap();
+        raw.pragma_update(None, "ignore_check_constraints", false)
+            .unwrap();
+        let bad: i64 = raw
+            .query_row(
+                "SELECT id FROM art WHERE sha256 = ?1",
+                [&"9".repeat(64)],
+                |r| r.get(0),
+            )
+            .unwrap();
+        drop(raw);
+
         db.set_track_art(
             tid,
             &[
@@ -347,18 +360,6 @@ mod tests {
         )
         .unwrap();
 
-        // A negative byte_len is a malformed external write to the contract
-        // column: the V4 `byte_len = length(data)` CHECK rejects it on a normal
-        // connection, so bypass CHECK enforcement to plant the bad row — the
-        // row-reader defensive path (not the CHECK) is what this test pins.
-        let raw = rusqlite::Connection::open(&path).unwrap();
-        raw.pragma_update(None, "ignore_check_constraints", true)
-            .unwrap();
-        raw.execute("UPDATE art SET byte_len = -1 WHERE id = ?1", [bad])
-            .unwrap();
-        raw.pragma_update(None, "ignore_check_constraints", false)
-            .unwrap();
-        drop(raw);
         assert!(
             super::track_art_to_inputs(&db, tid).is_err(),
             "negative byte_len must error at row-read, not be skipped"

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -321,9 +321,19 @@ mod tests {
             })
             .unwrap();
 
+        // Plant a malformed art row directly. art rows are immutable once
+        // written (the V5 `art_reject_content_update` trigger blocks UPDATEs of
+        // content columns), and the V4 `byte_len = length(data)` CHECK rejects
+        // byte_len = -1 — so INSERT the bad row on a raw connection with CHECK
+        // enforcement off. The trigger guards only UPDATE, so a fresh malformed
+        // INSERT (the realistic FK/CHECK-disabled external write) still reaches
+        // the row-reader defensive path this test pins.
         let raw = rusqlite::Connection::open(&path).unwrap();
         raw.pragma_update(None, "ignore_check_constraints", true)
             .unwrap();
+        // byte_len = -1 against 5 bytes of data is the deliberate malformation
+        // under test (length and byte_len disagree, and byte_len is negative) —
+        // do not "fix" the mismatch.
         raw.execute(
             "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
              VALUES (?1, 'image/png', NULL, NULL, -1, X'0909090909')",

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -158,7 +158,7 @@ fn handle_reuses_one_open_and_no_per_read_stat() {
 }
 
 #[test]
-fn getattr_size_cache_hit_skips_stat() {
+fn getattr_size_cache_hit_restats_backing() {
     let _guard = METRICS_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -179,11 +179,14 @@ fn getattr_size_cache_hit_skips_stat() {
 
     let first = fs.getattr(file_inode).unwrap(); // miss → resolve → stat
     metrics::reset();
-    let second = fs.getattr(file_inode).unwrap(); // hit → size cache, no stat
+    let second = fs.getattr(file_inode).unwrap(); // hit → size from cache, re-stat for freshness
     let s = metrics::snapshot();
 
     assert_eq!(first.size, second.size);
-    assert_eq!(s.stats, 0, "a warm getattr must not stat the backing file");
+    assert_eq!(
+        s.stats, 1,
+        "a warm getattr re-stats the backing file to detect out-of-band changes (#279)"
+    );
 }
 
 #[test]

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -184,18 +184,24 @@ mod guard_tests {
 
     #[test]
     fn get_art_meta_rejects_oversize_mime() {
-        let (db, _t, art) = db_track_art();
+        let (db, _t, _art) = db_track_art();
         db.conn
             .execute_batch("PRAGMA ignore_check_constraints=ON")
             .unwrap();
+        // art rows are immutable under the V5 `art_reject_content_update`
+        // trigger (which `ignore_check_constraints` does not disable), so plant
+        // the oversize-mime row with a fresh INSERT — the trigger guards only
+        // UPDATE — rather than mutating an existing row in place.
         let mime = "x".repeat(256);
         db.conn
             .execute(
-                "UPDATE art SET mime = ?1 WHERE id = ?2",
-                rusqlite::params![mime, art],
+                "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
+                 VALUES (?1, ?2, NULL, NULL, 1, X'00')",
+                rusqlite::params!["b".repeat(64), mime],
             )
             .unwrap();
-        let err = db.get_art_meta(art).unwrap_err();
+        let bad = db.conn.last_insert_rowid();
+        let err = db.get_art_meta(bad).unwrap_err();
         assert!(
             matches!(
                 err,

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -302,6 +302,12 @@ BEGIN
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
 
+-- Index the reverse art -> track_art edge. track_art is keyed (track_id,
+-- ordinal), so without this both the art_ad trigger below and SQLite's own
+-- REFERENCES art(id) check on art deletes scan the whole join table per
+-- deleted row, which makes bulk orphan-GC O(deletes * rows).
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
 -- Deleting an art row that still has track_art references (an orphan an
 -- external writer can produce with foreign_keys OFF) bumps every referencing
 -- track, so the mount rebuilds and serves a clean EIO on the orphan rather

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -283,6 +283,12 @@ END;
 ";
 
 const MIGRATION_V5: &str = r"
+-- art rows are content-addressed by sha256: once written, their content
+-- columns are immutable. A writer needing different bytes/metadata inserts a
+-- NEW row and relinks via track_art (which bumps content_version through the
+-- V1 track_art triggers). This closes #271, where an in-place art edit changed
+-- served bytes without bumping any referencing track. width/height use IS NOT
+-- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
 CREATE TRIGGER art_reject_content_update
 BEFORE UPDATE ON art
 WHEN NEW.data   <> OLD.data
@@ -296,12 +302,22 @@ BEGIN
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
 
+-- Deleting an art row that still has track_art references (an orphan an
+-- external writer can produce with foreign_keys OFF) bumps every referencing
+-- track, so the mount rebuilds and serves a clean EIO on the orphan rather
+-- than streaming stale bytes from an old cached layout. Inert on the normal
+-- gc_orphan_art path, where the deleted row has no references.
 CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
     UPDATE tracks SET content_version = content_version + 1,
                       updated_at = CAST(strftime('%s','now') AS INTEGER)
     WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
 END;
 
+-- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
+-- not touch content_version. Bump it whenever a geometry column actually
+-- changes, making content_version a true superset of served-byte inputs
+-- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
+-- content_version changes), so the recursion terminates after exactly one bump.
 CREATE TRIGGER tracks_geometry_au
 AFTER UPDATE ON tracks
 WHEN NEW.format        <> OLD.format
@@ -313,6 +329,11 @@ BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
 END;
 
+-- FLAC structural blocks feed synthesized headers and flip the synthesis path
+-- (legacy front-read fallback vs streamed fast path), so a change must bump.
+-- set_structural_blocks is DELETE-then-INSERT (no UPDATE path exists), so these
+-- fire on every rewrite; the resulting over-bump on a byte-identical re-probe
+-- is harmless monotone churn (content_version is compared only for equality).
 CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
 END;
@@ -552,7 +573,7 @@ mod migration_v3_tests {
         assert_eq!(count_changes(&conn), 1);
 
         conn.execute(
-            "UPDATE tracks SET backing_mtime = 1 WHERE id = 1", // tracks AU -> 1 row
+            "UPDATE tracks SET backing_mtime = 1 WHERE id = 1", // tracks AU -> 2 rows (geometry trigger nested UPDATE)
             [],
         )
         .unwrap();

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -282,7 +282,52 @@ CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
 END;
 ";
 
-const MIGRATIONS: &[&str] = &[MIGRATION_V1, MIGRATION_V2, MIGRATION_V3, MIGRATION_V4];
+const MIGRATION_V5: &str = r"
+CREATE TRIGGER art_reject_content_update
+BEFORE UPDATE ON art
+WHEN NEW.data   <> OLD.data
+  OR NEW.sha256 <> OLD.sha256
+  OR NEW.mime   <> OLD.mime
+  OR NEW.byte_len <> OLD.byte_len
+  OR NEW.width  IS NOT OLD.width
+  OR NEW.height IS NOT OLD.height
+BEGIN
+    SELECT RAISE(ABORT,
+        'art rows are immutable; insert a new content-addressed row and relink via track_art');
+END;
+
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+
+CREATE TRIGGER tracks_geometry_au
+AFTER UPDATE ON tracks
+WHEN NEW.format        <> OLD.format
+  OR NEW.audio_offset  <> OLD.audio_offset
+  OR NEW.audio_length  <> OLD.audio_length
+  OR NEW.backing_size  <> OLD.backing_size
+  OR NEW.backing_mtime <> OLD.backing_mtime
+BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
+END;
+";
+
+const MIGRATIONS: &[&str] = &[
+    MIGRATION_V1,
+    MIGRATION_V2,
+    MIGRATION_V3,
+    MIGRATION_V4,
+    MIGRATION_V5,
+];
 
 pub fn migrate(conn: &mut Connection) -> Result<()> {
     let latest = i64::try_from(MIGRATIONS.len()).expect("MIGRATIONS count must fit i64");
@@ -383,7 +428,7 @@ mod migration_v2_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 4);
+        assert_eq!(uv, 5);
 
         // value_blob exists on tags and defaults to NULL.
         conn.execute(
@@ -420,7 +465,7 @@ mod migration_v2_tests {
         let uv2: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv2, 4);
+        assert_eq!(uv2, 5);
     }
 
     #[test]
@@ -449,7 +494,7 @@ mod migration_v2_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 4);
+        assert_eq!(uv, 5);
 
         // The pre-existing row survived unchanged, with value_blob defaulted NULL.
         let (value, blob_is_null): (String, bool) = conn
@@ -501,7 +546,7 @@ mod migration_v3_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 4);
+        assert_eq!(uv, 5);
 
         insert_track(&conn, "/a.flac"); // tracks AI -> 1 row
         assert_eq!(count_changes(&conn), 1);
@@ -511,10 +556,10 @@ mod migration_v3_tests {
             [],
         )
         .unwrap();
-        assert_eq!(count_changes(&conn), 2);
+        assert_eq!(count_changes(&conn), 3);
 
         conn.execute("DELETE FROM tracks WHERE id = 1", []).unwrap(); // tracks AD -> 1 row
-        assert_eq!(count_changes(&conn), 3);
+        assert_eq!(count_changes(&conn), 4);
 
         let ids: Vec<i64> = conn
             .prepare("SELECT track_id FROM track_changes ORDER BY seq")
@@ -523,7 +568,7 @@ mod migration_v3_tests {
             .unwrap()
             .collect::<rusqlite::Result<_>>()
             .unwrap();
-        assert_eq!(ids, vec![1, 1, 1]);
+        assert_eq!(ids, vec![1, 1, 1, 1]);
     }
 
     /// Load-bearing nested-trigger dependency (see spec): a bare tag write fires
@@ -593,13 +638,13 @@ mod migration_v3_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 4);
+        assert_eq!(uv, 5);
         // Pre-migration rows produce no retroactive changelog entries...
         assert_eq!(count_changes(&conn), 0);
         // ...but post-migration edits do.
         conn.execute("UPDATE tracks SET backing_mtime = 9 WHERE id = 1", [])
             .unwrap();
-        assert_eq!(count_changes(&conn), 1);
+        assert_eq!(count_changes(&conn), 2);
     }
 
     /// The SQL literal and the exported constant must not drift.
@@ -742,7 +787,7 @@ mod migration_v4_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 4);
+        assert_eq!(uv, 5);
 
         insert_track(&conn, "/a.flac");
         conn.execute(
@@ -817,7 +862,7 @@ mod migration_v4_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 4);
+        assert_eq!(uv, 5);
 
         // Children survived the parent rebuild (no cascade-delete).
         let tags: i64 = conn
@@ -1541,5 +1586,130 @@ mod identity_tests {
             DbError::SchemaMismatch { object } => assert!(object.contains("tags_ai"), "{object}"),
             other => panic!("expected SchemaMismatch, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod migration_v5_tests {
+    use rusqlite::{Connection, params};
+
+    /// A fresh, fully-migrated DB with `foreign_keys` OFF — that is what lets
+    /// `deleting_referenced_art_bumps_tracks` produce the orphan case.
+    fn migrated() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        super::migrate(&mut conn).unwrap();
+        conn.pragma_update(None, "foreign_keys", false).unwrap();
+        conn
+    }
+
+    fn insert_track(conn: &Connection, path: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime, updated_at) \
+             VALUES (?1,'flac',0,1,1,0,0)",
+            [path],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_art(conn: &Connection, sha: &str, data: &[u8]) -> i64 {
+        conn.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
+             VALUES (?1,'image/png',NULL,NULL,?2,?3)",
+            params![sha, i64::try_from(data.len()).unwrap(), data],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn migration_reaches_user_version_5() {
+        let conn = migrated();
+        let uv: i64 = conn
+            .pragma_query_value(None, "user_version", |r| r.get(0))
+            .unwrap();
+        assert_eq!(uv, 5);
+    }
+
+    #[test]
+    fn art_content_update_is_rejected() {
+        let conn = migrated();
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        assert!(
+            conn.execute("UPDATE art SET mime='image/jpeg' WHERE id=?1", [a])
+                .is_err()
+        );
+        assert!(
+            conn.execute("UPDATE art SET byte_len=99 WHERE id=?1", [a])
+                .is_err()
+        );
+        assert!(
+            conn.execute("UPDATE art SET data=X'04050607' WHERE id=?1", [a])
+                .is_err()
+        );
+        assert!(
+            conn.execute("UPDATE art SET width=10 WHERE id=?1", [a])
+                .is_err()
+        );
+        assert!(
+            conn.execute(
+                "UPDATE art SET sha256=?1 WHERE id=?2",
+                params![&"b".repeat(64), a],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn art_noop_update_is_allowed() {
+        let conn = migrated();
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        conn.execute("UPDATE art SET mime=mime WHERE id=?1", [a])
+            .unwrap();
+    }
+
+    #[test]
+    fn deleting_referenced_art_bumps_tracks() {
+        let conn = migrated();
+        let t = insert_track(&conn, "/a.flac");
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        conn.execute(
+            "INSERT INTO track_art (track_id, art_id, picture_type, ordinal) \
+             VALUES (?1,?2,3,0)",
+            [t, a],
+        )
+        .unwrap();
+        let cv0: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        conn.execute("DELETE FROM art WHERE id=?1", [a]).unwrap();
+        let cv1: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cv1, cv0 + 1, "art delete must bump the referencing track");
+    }
+
+    #[test]
+    fn deleting_unreferenced_art_bumps_nothing() {
+        let conn = migrated();
+        let t = insert_track(&conn, "/a.flac");
+        let a = insert_art(&conn, &"a".repeat(64), &[1, 2, 3]);
+        let cv0: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        conn.execute("DELETE FROM art WHERE id=?1", [a]).unwrap();
+        let cv1: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=?1", [t], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cv1, cv0, "deleting an unreferenced art row must not bump");
     }
 }

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -224,8 +224,9 @@ impl Db<ReadWrite> {
 
     /// Test-only: force a track's format column directly (no rescan), bumping
     /// data_version. The only way to exercise a format-only change — production
-    /// never mutates format without a rescan. content_version is NOT bumped (no
-    /// trigger fires on the tracks.format column), so this is a pure format-only edit.
+    /// never mutates format without a rescan. As of V5 this also bumps
+    /// content_version (the `tracks_geometry_au` format guard); it is no longer a
+    /// content_version-neutral edit.
     #[doc(hidden)]
     pub fn set_format_for_test(&self, id: i64, fmt: Format) -> Result<()> {
         self.conn.execute(

--- a/musefs-db/tests/schema.rs
+++ b/musefs-db/tests/schema.rs
@@ -3,7 +3,7 @@ use musefs_db::Db;
 #[test]
 fn open_in_memory_runs_migration_to_latest() {
     let db = Db::open_in_memory().expect("open");
-    assert_eq!(db.user_version().expect("user_version"), 4);
+    assert_eq!(db.user_version().expect("user_version"), 5);
 }
 
 #[test]
@@ -12,12 +12,12 @@ fn migration_is_idempotent_across_reopen() {
     let path = dir.path().join("musefs.db");
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 4);
+    assert_eq!(db.user_version().unwrap(), 5);
     drop(db);
 
     // Reopening must not error and must not advance the version.
     let db2 = Db::open(&path).unwrap();
-    assert_eq!(db2.user_version().unwrap(), 4);
+    assert_eq!(db2.user_version().unwrap(), 5);
 }
 
 #[cfg(feature = "mutants")]

--- a/musefs-db/tests/tracks.rs
+++ b/musefs-db/tests/tracks.rs
@@ -53,15 +53,13 @@ fn get_missing_track_returns_none() {
 }
 
 #[test]
-fn rescan_does_not_reset_content_version() {
+fn rescan_with_changed_geometry_bumps_content_version() {
     let db = Db::open_in_memory().unwrap();
     let id = db.upsert_track(&new_track("/music/a.flac")).unwrap();
     db.replace_tags(id, &[Tag::new("title", "T", 0)]).unwrap();
     let cv_before = db.track_content_version(id).unwrap();
     assert!(cv_before > 0);
 
-    // Re-scan the same path with updated offsets; this must NOT reset the
-    // version counter, which tracks tag/art edits.
     let mut rescan = new_track("/music/a.flac");
     rescan.audio_offset = 100;
     rescan.audio_length = 900;
@@ -69,8 +67,8 @@ fn rescan_does_not_reset_content_version() {
 
     assert_eq!(
         db.track_content_version(id).unwrap(),
-        cv_before,
-        "re-scan must not reset content_version"
+        cv_before + 1,
+        "a geometry-changing rescan must bump content_version exactly once"
     );
 }
 

--- a/musefs-db/tests/tracks.rs
+++ b/musefs-db/tests/tracks.rs
@@ -65,6 +65,9 @@ fn rescan_with_changed_geometry_bumps_content_version() {
     rescan.audio_length = 900;
     db.upsert_track(&rescan).unwrap();
 
+    // Exactly +1 (not just ">") is deliberate: it asserts the `tracks_geometry_au`
+    // WHEN guard halts the trigger's own nested content_version UPDATE, so the
+    // recursion terminates after a single bump rather than running away.
     assert_eq!(
         db.track_content_version(id).unwrap(),
         cv_before + 1,

--- a/musefs-db/tests/triggers.rs
+++ b/musefs-db/tests/triggers.rs
@@ -1,6 +1,6 @@
 mod common;
 use common::new_track;
-use musefs_db::{Db, Tag};
+use musefs_db::{Db, StructuralBlock, Tag};
 
 #[test]
 fn tag_changes_bump_content_version() {
@@ -19,5 +19,51 @@ fn tag_changes_bump_content_version() {
     assert!(
         after_replace > after_insert,
         "replacing tags should bump content_version again"
+    );
+}
+
+#[test]
+fn geometry_change_bumps_content_version_by_exactly_one() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    assert_eq!(db.track_content_version(id).unwrap(), 0);
+
+    let mut changed = new_track("/m/a.flac");
+    changed.audio_offset = 222;
+    changed.backing_size = 1300;
+    db.upsert_track(&changed).unwrap();
+
+    assert_eq!(
+        db.track_content_version(id).unwrap(),
+        1,
+        "geometry change must bump content_version exactly once"
+    );
+}
+
+#[test]
+fn identical_rescan_does_not_bump_content_version() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    assert_eq!(db.track_content_version(id).unwrap(), 0);
+}
+
+#[test]
+fn structural_block_change_bumps_content_version() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    let before = db.track_content_version(id).unwrap();
+    db.set_structural_blocks(
+        id,
+        &[StructuralBlock {
+            kind: "STREAMINFO".to_string(),
+            ordinal: 0,
+            body: vec![1, 2, 3, 4],
+        }],
+    )
+    .unwrap();
+    assert!(
+        db.track_content_version(id).unwrap() > before,
+        "structural block write must bump content_version"
     );
 }


### PR DESCRIPTION
## What

`content_version` is the per-track freshness key for cached synthesized layouts and attrs, but it was not a superset of every input that affects served bytes. Three SQLite triggers (new V5 migration) centralize freshness on it, and `getattr` now re-stats the backing file on size-cache hits to catch the one input the DB cannot see.

Closes #271, #272, #279.

## Changes

**V5 migration triggers (`musefs-db/src/schema.rs`)** — `content_version` becomes a true superset of DB-knowable served-byte inputs:
- `art_reject_content_update` — art rows are content-addressed by `sha256`; a `BEFORE UPDATE` trigger `RAISE(ABORT)`s any in-place mutation of content columns (`data`/`sha256`/`mime`/`byte_len`/`width`/`height`). To change art, insert a new row and relink via `track_art`. (#271)
- `art_ad` — deleting an `art` row still referenced by `track_art` (an orphan, only producible with `foreign_keys` OFF) bumps every referencing track, so the mount rebuilds to a clean serve-time error instead of streaming stale bytes. Inert on the normal orphan-GC path. (#271)
- `tracks_geometry_au` — bumps when scanner-owned geometry (`format`, audio bounds, backing size/mtime) changes; the WHEN guard halts the trigger's own nested UPDATE after exactly one bump. (#272)
- `structural_blocks_ai`/`_ad` — bump on FLAC structural-block writes (DELETE-then-INSERT). (#272)

**getattr backing stat (`musefs-core/src/facade.rs`)** — `SizeEntry` now carries the backing size/mtime stamp; a size-cache hit re-stats the backing file and degrades to `BackingChanged` on drift instead of advertising stale attrs, aligning `getattr` with the read/open paths. Catches an on-disk backing change that left `content_version` untouched. (#279)

**Docs + mirror** — `ARCHITECTURE.md` (V5 schema entry, art-immutability contract, superset freshness semantics), `contrib/python-musefs` README art-immutability note, and the regenerated/re-vendored Python schema mirror (`USER_VERSION = 5`).

## Notes

- The geometry trigger's nested `content_version` UPDATE re-fires `tracks_changelog_au`, so a geometry rescan now writes two `track_changes` rows. Harmless — consumers dedup by `track_id` — and the existing changelog-count tests are updated accordingly.
- No format-layer signature change, so the out-of-workspace `fuzz/` crate is unaffected.

## Testing

- `cargo test --workspace` — 851 passed, 32 ignored
- `cargo clippy --all-targets` clean; `cargo fmt --all --check` clean
- Python schema-freshness gate (`schema_py`) green; Picard vendored mirror in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema V5: art content is immutable (create new art and relink); deleting referenced art bumps track freshness
  * content_version now advances for geometry and structural-block changes
  * Size-cache records backing size/mtime and detects out‑of‑band backing changes on cache hits

* **Bug Fixes**
  * File-attribute cache now signals backing-file changes instead of returning stale attributes

* **Documentation**
  * Architecture and contributor docs updated with V5 semantics and art immutability contract
<!-- end of auto-generated comment: release notes by coderabbit.ai -->