### PR TITLE
test(mutants): kill scan ordinal/oracle survivors; exclude reader equivalent

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -323,6 +323,15 @@ exclude_re = [
     # const being out of reach.)
     # guard: op="/" fn="" rows=2
     'musefs-core/src/reader\.rs:71:60: replace / with [%*]',
+    # read_segments_into splice loop's overlap guard `if ov_start < ov_end`,
+    # `<`->`<=`: the same equivalence class as serve_ogg_window's overlap-emit
+    # guards above. When the bound is equal the overlap is empty (n = ov_end -
+    # ov_start = 0), so every match arm extends by an empty slice / reads 0 payload
+    # bytes and the spliced output is byte-identical (the byte-fidelity proptest and
+    # the read_at tests pass with the mutation applied). The `<`->`==`/`>` siblings
+    # flip real behavior and ARE caught; the sole `<` in this fn, so
+    # description-anchored against `cargo fmt` line drift.
+    'replace < with <= in read_segments_into',
 
     # wav walk_chunks advance guard `next <= buf.len() as u64` -> `true`: forcing
     # the guard true sets `pos = next` even when `next > buf.len()`, but the loop's

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1806,6 +1806,55 @@ mod hardening_tests {
         assert_eq!(got[1].body, vec![0xB2]);
     }
 
+    /// Probed with two tags of the SAME key, to make the per-key ordinal
+    /// increment (`*ord += 1` in the tag loop) observable. The production
+    /// `ingest_bulk` path is exercised with a multi-value tag elsewhere, but the
+    /// oracle-only `ingest` is not, so without this its tag-ordinal mutants
+    /// survive. Distinct values under one key: a collapsed ordinal (the `-=`/`*=`
+    /// mutants) either underflows or duplicates the `(track_id, key, ordinal)`
+    /// primary key — both observable.
+    fn probed_with_duplicate_tag_key() -> Probed {
+        Probed {
+            format: musefs_db::Format::Flac,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: vec![
+                ("ARTIST".to_string(), "A".to_string()),
+                ("ARTIST".to_string(), "B".to_string()),
+            ],
+            pictures: Vec::new(),
+            binary_tags: Vec::new(),
+            structural_blocks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ingest_assigns_sequential_tag_ordinals_per_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.flac");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let db = Db::open_in_memory().unwrap();
+
+        ingest(
+            &db,
+            &path.to_string_lossy(),
+            &meta,
+            probed_with_duplicate_tag_key(),
+        )
+        .unwrap();
+
+        let tid = db.list_tracks().unwrap()[0].id;
+        let got = db.get_tags(tid).unwrap();
+        // get_tags is ORDER BY key, ordinal: the two same-key tags must hold
+        // ordinals 0 then 1 (the `-=`/`*=` mutants collapse or invert this).
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].ordinal, 0);
+        assert_eq!(got[0].value, "A");
+        assert_eq!(got[1].ordinal, 1);
+        assert_eq!(got[1].value, "B");
+    }
+
     #[test]
     fn ingest_bulk_assigns_sequential_structural_ordinals_per_kind() {
         let db = Db::open_in_memory().unwrap();

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -330,3 +330,28 @@ fn revalidate_failed_carries_scan_failure() {
         "failed must carry the re-probe scan failure (skip_failed == 0)"
     );
 }
+
+// === Full-probe oracle counters (scan_directory_full_oracle, lines 858/864) ===
+
+/// The full-file-probe oracle's `scanned`/`skipped` counters must reflect the
+/// corpus exactly. A directory with one valid FLAC and one extension-only
+/// `.flac` of garbage (collected by `is_supported_audio`, then rejected by
+/// `probe_full`) yields scanned == 1, skipped == 1. The `+=`→`-=` mutants
+/// underflow-panic from 0 and `+=`→`*=` pin the counter at 0, so both counters
+/// must be asserted nonzero and exact.
+// kills scan L858 `stats.skipped += 1` and L864 `stats.scanned += 1` `+=`→`-=`/`*=`
+#[test]
+fn oracle_counts_scanned_and_skipped_exactly() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("good.flac"), flac_minimal(b"AUDIO-OK")).unwrap();
+    // Extension-only: `is_supported_audio` collects it, but `probe_full` returns
+    // None (no fLaC marker) → counted as skipped, not scanned.
+    std::fs::write(dir.path().join("bad.flac"), b"not a flac at all").unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_full_oracle(&db, dir.path()).unwrap();
+
+    assert_eq!(stats.scanned, 1, "exactly the one valid FLAC is scanned");
+    assert_eq!(stats.skipped, 1, "the garbage .flac is skipped");
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}


### PR DESCRIPTION
Closes three surviving mutants from a `musefs-core` mutation campaign. Each was
re-validated against current `main` (line numbers had drifted) before fixing.

## Killed by new tests

- **`scan.rs` `ingest` tag-ordinal** `*ord += 1` (`+=`→`-=`/`*=`): the
  oracle-only `ingest` path had no duplicate-key-tag coverage, so its tag-ordinal
  mutants survived. Adds `probed_with_duplicate_tag_key` + `ingest_assigns_sequential_tag_ordinals_per_key`
  asserting two same-key tags get ordinals 0,1. (The production `ingest_bulk`
  twin is already pinned by the multi-value-ARTIST scan test via the
  `(track_id, key, ordinal)` primary key.)
- **`scan_directory_full_oracle` `scanned`/`skipped` counters** (`+=`→`-=`/`*=`):
  no test asserted the oracle's `ScanStats`. Adds `oracle_counts_scanned_and_skipped_exactly`
  (one valid + one garbage `.flac` → `scanned == 1`, `skipped == 1`).

## Excluded as equivalent

- **`reader.rs` `read_segments_into` overlap guard** `if ov_start < ov_end`
  (`<`→`<=`): an empty overlap means `n == 0`, so every match arm extends by an
  empty slice / reads 0 payload bytes → byte-identical spliced output. This is
  the same equivalence class as `serve_ogg_window`'s already-documented
  overlap-emit guards. Added a description-anchored `exclude_re` (line-robust;
  the sole `<` in the fn). The `<`→`==`/`>` siblings stay in scope and are caught.

## Verification

- `cargo mutants --in-place` over the in-scope `scan.rs` sites: **14/14 caught**.
- `check_mutant_anchors.py`: green (46 `exclude_re` entries / 2987 mutants).
- New tests pass; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for tag ordinal assignment when duplicate tag keys are present.
  * Added an integration test to verify accurate counting of scanned vs. skipped files and that only valid files are persisted.

* **Chores**
  * Updated mutation-testing suppression rules to exclude a known benign mutation case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->