### PR TITLE
Template & path hardening: reject malformed templates, cap path-field depth (#275 #303 #304)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-template-path-hardening.md
+++ b/docs/superpowers/plans/2026-06-12-template-path-hardening.md
@@ -49,7 +49,7 @@ fn path_field_segment_count_is_capped() {
     // MAX_PATH_FIELD_SEGMENTS is a private const = 64 in template.rs. A hostile
     // 256 KiB `a/a/a/...` tag would expand to tens of thousands of segments; the
     // cap clamps the rendered path to at most 64 directory components.
-    let value: String = std::iter::repeat("a").take(200).collect::<Vec<_>>().join("/");
+    let value = vec!["a"; 200].join("/");
     let f = fields(&[("p", value.as_str())]);
     let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     let body = rendered.strip_suffix(".flac").expect("ext appended");
@@ -387,9 +387,11 @@ proptest! {
 
 (The `value in ".{0,64}"` half is unchanged: path-field *values* are still sanitized — control bytes → `_` — never rejected.)
 
+This proptest is a **no-panic guard**, not the rejection test: the `.` strategy can generate `[`/control bytes, but the `if let Ok(t)` arm silently skips every rejected template, so it proves "parse-or-render never panics", not "bad templates are rejected". The actual rejection behaviour is pinned deterministically by the Step 11 tests (NUL, `0x01`, and the 64/65 nesting boundary).
+
 - [ ] **Step 11: Add the #275 / #304 acceptance tests**
 
-Add the #275 parse-rejection tests to `musefs-core/tests/template.rs` (needs `TemplateError` in scope — add `use musefs_core::TemplateError;` to the imports):
+Add the #275 parse-rejection tests to `musefs-core/tests/template.rs` (needs `TemplateError` in scope — merge it into the existing import so line 1 reads `use musefs_core::{Template, TemplateError};`):
 
 ```rust
 #[test]
@@ -475,6 +477,8 @@ cargo test
 ```
 
 Expected: clean build; no clippy warnings; all tests pass, including the new #275/#303/#304 tests, the rewritten proptest, and every renamed site.
+
+`cargo fmt --all` formats the whole workspace. If it reports changes in any file **outside** the five this task touches, stop and investigate — the by-name `git add` in Step 14 would otherwise leave that stray diff unstaged, and the pre-commit hook's `fmt --check` over tracked files would then reject the commit.
 
 - [ ] **Step 14: Commit**
 

--- a/docs/superpowers/plans/2026-06-12-template-path-hardening.md
+++ b/docs/superpowers/plans/2026-06-12-template-path-hardening.md
@@ -1,0 +1,507 @@
+# Template & Path Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject malformed mount-time templates (control/NUL bytes in literals #275, excessive section nesting #304) at `Musefs::open()`, and clamp hostile path-field segment counts (#303) at render time.
+
+**Architecture:** Two independent changes. (1) `sanitize_path` gains a post-filter segment cap — fully infallible, isolated, lands first. (2) `Template::parse` becomes fallible (`Result<Template, TemplateError>`); a new `CoreError::InvalidTemplate` surfaces the error from `open()`. Because parse rejects deep nesting at the single construction point, `render_parts`/`collect_field_names` need no per-consumer guards. The fallible-parse change is **one atomic commit** (see Task 2 preamble).
+
+**Tech Stack:** Rust workspace (musefs-core), `thiserror` for error enums, `proptest`, `cargo test`/`clippy`/`fmt`. Spec: `docs/superpowers/specs/2026-06-12-template-path-hardening-design.md`.
+
+---
+
+## Project constraints (read before starting)
+
+- **Pre-commit hook runs the FULL workspace test suite + `clippy -D warnings` + `fmt`.** Every commit must compile and be green. A signature change cannot be split across commits — all call sites land together.
+- Use **Serena** symbolic tools (`get_symbols_overview`, `find_symbol`, `replace_symbol_body`) for code reads/edits per the project's tooling rules; the code blocks below are the exact target bodies.
+- This change is in `musefs-core`, not the format layer, so the out-of-workspace `fuzz/` crate is unaffected (no `cargo +nightly fuzz build` needed). It does not touch getattr/read paths, so the `metrics` feature is unaffected.
+- Run targeted tests with: `cargo test -p musefs-core` (integration tests live in `musefs-core/tests/template.rs`; unit tests in `musefs-core/src/template.rs`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs-core/src/template.rs` | Template parse/render; sanitizers | Add `TemplateError`, `MAX_SECTION_DEPTH`, `MAX_PATH_FIELD_SEGMENTS`; make `parse`/`parse_parts` fallible; cap `sanitize_path`; in-module tests |
+| `musefs-core/src/error.rs` | `CoreError` enum | Add `InvalidTemplate(#[from] TemplateError)` |
+| `musefs-core/src/lib.rs` | Crate exports | Export `TemplateError` |
+| `musefs-core/src/facade.rs` | `Musefs::open` + facade tests | `?` at prod site; `.expect` at 2 test sites; new `open()`-rejection test |
+| `musefs-core/tests/template.rs` | Integration tests | `parse` helper + rename 30 sites; rewrite proptest; #275/#303 tests |
+
+---
+
+## Task 1: #303 — Path-field segment cap (independent, infallible)
+
+This task does not touch `parse`. It is a self-contained TDD cycle and commits on its own.
+
+**Files:**
+- Modify: `musefs-core/src/template.rs` (`sanitize_path`, new const)
+- Test: `musefs-core/tests/template.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `musefs-core/tests/template.rs` (file scope, near the other `$!{p}` tests, e.g. after `path_field_neutralizes_traversal_values`):
+
+```rust
+#[test]
+fn path_field_segment_count_is_capped() {
+    // MAX_PATH_FIELD_SEGMENTS is a private const = 64 in template.rs. A hostile
+    // 256 KiB `a/a/a/...` tag would expand to tens of thousands of segments; the
+    // cap clamps the rendered path to at most 64 directory components.
+    let value: String = std::iter::repeat("a").take(200).collect::<Vec<_>>().join("/");
+    let f = fields(&[("p", value.as_str())]);
+    let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let body = rendered.strip_suffix(".flac").expect("ext appended");
+    assert_eq!(body.split('/').count(), 64, "clamped to MAX_PATH_FIELD_SEGMENTS");
+}
+
+#[test]
+fn path_field_under_cap_is_unchanged() {
+    let f = fields(&[("p", "a/b/c")]);
+    let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(rendered, "a/b/c.flac");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-core --test template path_field_segment_count_is_capped`
+Expected: FAIL — `path_field_segment_count_is_capped` asserts 64 but renders 200 components. (`path_field_under_cap_is_unchanged` already passes — it documents the no-regression case.)
+
+- [ ] **Step 3: Add the constant and cap logic**
+
+In `musefs-core/src/template.rs`, add the constant near the top of the file (after the imports, before `pub struct Template`):
+
+```rust
+/// Max surviving segments a single `$!{}` path field may expand into. A hostile
+/// 256 KiB tag shaped `a/a/a/...` would otherwise build tens of thousands of
+/// directory levels (depth amplification across the DB trust boundary, #303).
+const MAX_PATH_FIELD_SEGMENTS: usize = 64;
+```
+
+Replace the body of `sanitize_path` with the post-filter-capped version:
+
+```rust
+fn sanitize_path(value: &str) -> String {
+    let mut out = String::new();
+    let mut count = 0usize;
+    for segment in value.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            continue;
+        }
+        if count == MAX_PATH_FIELD_SEGMENTS {
+            break;
+        }
+        if !out.is_empty() {
+            out.push('/');
+        }
+        sanitize_into(&mut out, segment);
+        count += 1;
+    }
+    out
+}
+```
+
+Note: `count` increments only *after* the empty/`.`/`..` guard, so dropped segments do not consume cap budget — `././a/./b` keeps both real segments.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-core --test template`
+Expected: PASS — both new tests pass, and the existing `path_field_neutralizes_traversal_values` + `render_never_panics_and_path_fields_stay_safe` stay green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/template.rs musefs-core/tests/template.rs
+git commit -m "$(cat <<'EOF'
+fix(template): cap path-field segment count at render (#303)
+
+A 256 KiB $!{field} value shaped a/a/a/... expanded into tens of thousands
+of virtual-tree path segments. sanitize_path now stops after
+MAX_PATH_FIELD_SEGMENTS (64) surviving segments, counted post-filter.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Fallible `Template::parse` — reject malformed config (#275, #304)
+
+**This is one atomic commit.** A Rust signature change does not compile until the error type, both `parse`/`parse_parts` signatures, all 34 call sites, and the proptest are consistent — and the pre-commit hook rejects any uncompilable/red commit. So all edits below land together; `cargo build`/`test` is run once at the end. The negative tests (Steps 9–11) are this task's acceptance criteria; they exercise the new API in the same commit that introduces it.
+
+**Files:**
+- Modify: `musefs-core/src/template.rs` (TemplateError, MAX_SECTION_DEPTH, `parse`, `parse_parts`, doc, in-module tests)
+- Modify: `musefs-core/src/error.rs` (`CoreError::InvalidTemplate`)
+- Modify: `musefs-core/src/lib.rs` (export `TemplateError`)
+- Modify: `musefs-core/src/facade.rs` (prod `?`, 2 test `.expect`, new open() test)
+- Modify: `musefs-core/tests/template.rs` (`parse` helper, 30-site rename, proptest rewrite, #275 tests)
+
+- [ ] **Step 1: Add `TemplateError` and `MAX_SECTION_DEPTH` to `template.rs`**
+
+At the top of `musefs-core/src/template.rs`, add the import alongside the existing `use` lines:
+
+```rust
+use thiserror::Error;
+```
+
+Add the error type and constant near the top (next to `MAX_PATH_FIELD_SEGMENTS` from Task 1, before `pub struct Template`):
+
+```rust
+/// Max `[...]` section nesting depth accepted by [`Template::parse`]. Beyond this
+/// the parser rejects the template rather than recursing further (#304). Real
+/// templates nest 2–3 deep; 64 is generous headroom that still bounds the
+/// adversarial `[[[…` case.
+const MAX_SECTION_DEPTH: usize = 64;
+
+/// Why a template was rejected at parse time. Surfaced to the operator via
+/// [`crate::CoreError::InvalidTemplate`] when `Musefs::open` parses a bad
+/// `--template`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TemplateError {
+    /// `[...]` sections nested deeper than `limit`.
+    #[error("template nesting exceeds the maximum depth of {limit}")]
+    NestingTooDeep { limit: usize },
+    /// A literal run contains a control byte (`< 0x20`, includes NUL), which is
+    /// not a valid POSIX path-component byte.
+    #[error("template literal contains control byte {byte:#04x}")]
+    ControlByte { byte: u8 },
+}
+```
+
+- [ ] **Step 2: Make `parse_parts` fallible**
+
+Replace the body of `parse_parts` in `musefs-core/src/template.rs`. Changes: return type `Result<Vec<Part>, TemplateError>`; parameter `in_section: bool` → `depth: usize`; `']' if in_section` → `']' if depth > 0`; nesting check + `?` on recursion in the `'['` arm; control-byte check in the catch-all arm; `Ok(parts)` at the end.
+
+```rust
+/// Parse parts until a closing `]` (when `depth > 0`) or end of input. `depth`
+/// is the current `[...]` nesting level (0 = top level).
+fn parse_parts(chars: &mut Peekable<Chars>, depth: usize) -> Result<Vec<Part>, TemplateError> {
+    let mut parts = Vec::new();
+    let mut literal = String::new();
+    while let Some(&c) = chars.peek() {
+        match c {
+            ']' if depth > 0 => {
+                chars.next(); // consume the closing ']'
+                break;
+            }
+            '[' => {
+                chars.next();
+                push_literal(&mut parts, &mut literal);
+                if depth + 1 > MAX_SECTION_DEPTH {
+                    return Err(TemplateError::NestingTooDeep {
+                        limit: MAX_SECTION_DEPTH,
+                    });
+                }
+                let inner = parse_parts(chars, depth + 1)?;
+                parts.push(Part::Section(inner));
+            }
+            '$' => {
+                chars.next(); // consume '$'
+                match chars.peek() {
+                    Some('[') => {
+                        chars.next();
+                        literal.push('[');
+                    }
+                    Some(']') => {
+                        chars.next();
+                        literal.push(']');
+                    }
+                    Some('{') => {
+                        chars.next();
+                        let names = parse_braced_names(chars);
+                        push_literal(&mut parts, &mut literal);
+                        parts.push(Part::Field { names, raw: false });
+                    }
+                    Some('!') => {
+                        chars.next(); // consume '!'
+                        if chars.peek() == Some(&'{') {
+                            chars.next(); // consume '{'
+                            let names = parse_braced_names(chars);
+                            push_literal(&mut parts, &mut literal);
+                            parts.push(Part::Field { names, raw: true });
+                        } else {
+                            literal.push('$');
+                            literal.push('!');
+                        }
+                    }
+                    Some(&nc) if is_field_char(nc) => {
+                        let name = parse_unbraced_name(chars);
+                        push_literal(&mut parts, &mut literal);
+                        parts.push(Part::Field {
+                            names: vec![name],
+                            raw: false,
+                        });
+                    }
+                    _ => literal.push('$'),
+                }
+            }
+            _ => {
+                if (c as u32) < 0x20 {
+                    // The only place a raw input control byte can reach a literal
+                    // run; the $[ / $] / $! escape arms push only brackets and
+                    // '$'/'!'. Cast is lossless under the < 0x20 guard.
+                    return Err(TemplateError::ControlByte { byte: c as u8 });
+                }
+                literal.push(c);
+                chars.next();
+            }
+        }
+    }
+    push_literal(&mut parts, &mut literal);
+    Ok(parts)
+}
+```
+
+- [ ] **Step 3: Make `Template::parse` fallible and update its doc**
+
+In `impl Template`, replace `parse`. Change the signature to return `Result`, call `parse_parts(&mut chars, 0)?`, wrap in `Ok`, and change the doc line `/// Parse a beets-style template. Infallible.` to note it now returns `Result`:
+
+```rust
+    /// Parse a beets-style template. Returns `Err` for a template that cannot
+    /// produce valid path components: control/NUL bytes in literal text
+    /// (#275) or `[...]` nesting deeper than [`MAX_SECTION_DEPTH`] (#304).
+    ///
+    /// - `$field` / `${field}` substitute a tag field; `${a|b|c}` is a fallback
+    ///   chain (first present wins). Names are matched case-insensitively.
+    /// - `$!{field}` is a path field: the value's '/' are kept as directory
+    ///   separators (each segment sanitized; empty / `.` / `..` dropped).
+    /// - `[...]` is a conditional section, suppressed when every field it
+    ///   references is empty. `$[` and `$]` emit literal brackets.
+    /// - A `$` not followed by a recognized form stays literal; an unterminated
+    ///   `${`/`$!{` consumes the rest as the name; an unterminated `[` runs to
+    ///   end of input.
+    pub fn parse(template: &str) -> Result<Template, TemplateError> {
+        let mut chars = template.chars().peekable();
+        let parts = parse_parts(&mut chars, 0)?;
+        Ok(Template { parts })
+    }
+```
+
+- [ ] **Step 4: Add the `CoreError::InvalidTemplate` variant**
+
+In `musefs-core/src/error.rs`, add a variant to `CoreError` (place it near the other `#[error(transparent)]` `#[from]` variants, e.g. after `Format`):
+
+```rust
+    #[error(transparent)]
+    InvalidTemplate(#[from] crate::template::TemplateError),
+```
+
+- [ ] **Step 5: Export `TemplateError` from the crate root**
+
+In `musefs-core/src/lib.rs`, change line 25 from:
+
+```rust
+pub use template::Template;
+```
+
+to:
+
+```rust
+pub use template::{Template, TemplateError};
+```
+
+- [ ] **Step 6: Update the production call site in `facade.rs`**
+
+In `Musefs::open` (`musefs-core/src/facade.rs:255`), add `?`:
+
+```rust
+        let template = Template::parse(&config.template)?;
+```
+
+(`open` returns `Result<Musefs>`; `#[from]` converts `TemplateError` → `CoreError::InvalidTemplate`.)
+
+- [ ] **Step 7: Update the two facade test call sites**
+
+`musefs-core/src/facade.rs:1530` — inside `render_entries` call:
+
+```rust
+        let (entries, snapshot) =
+            Musefs::render_entries(&db, &Template::parse(&cfg.template).expect("valid template"), &cfg)
+                .unwrap();
+```
+
+`musefs-core/src/facade.rs:1787` — in `full_rebuild_gives_bare_colliding_name_to_lower_id`:
+
+```rust
+        let template = Template::parse(&config.template).expect("valid template");
+```
+
+- [ ] **Step 8: Update the in-module `template.rs` test call site**
+
+`musefs-core/src/template.rs:315` (single site in `mod tests`):
+
+```rust
+        let t = Template::parse("$artist/$!{beets_path}/[$disc - ]${title|name}")
+            .expect("valid template");
+```
+
+- [ ] **Step 9: Rename existing integration call sites, then add the `parse` helper**
+
+Do the mechanical rename **first** (no helper exists yet, so nothing self-corrupts). This rewrites every existing `Template::parse(` site in the file — the ~28 original `.render`/`.referenced_fields` chains plus the 2 from Task 1 — to the bare `parse(` helper call. The proptest's `parse(&tmpl)` line is fixed up in Step 10; the new `Err`-asserting tests are added afterward in Step 11, so the sed never touches them:
+
+```bash
+sed -i 's/Template::parse(/parse(/g' musefs-core/tests/template.rs
+```
+
+Then add the file-scope helper next to `fields`/`owned` (this file is NOT wrapped in a `mod`), using the fully-qualified `Template::parse` so it is not self-recursive:
+
+```rust
+fn parse(t: &str) -> Template {
+    Template::parse(t).expect("valid template")
+}
+```
+
+Verify no stray self-reference remains: `grep -n 'Template::parse' musefs-core/tests/template.rs` should now show only the helper body (one line).
+
+- [ ] **Step 10: Rewrite the proptest for the fallible signature**
+
+Replace the whole `render_never_panics_and_path_fields_stay_safe` proptest body in `musefs-core/tests/template.rs`. The `tmpl` strategy now generates control bytes and deep `[` runs that `parse` legitimately rejects, so call `Template::parse` directly and only render on `Ok`; the fixed `$!{p}` half uses the `parse` helper:
+
+```rust
+proptest! {
+    // An arbitrary template either fails to parse or renders without panicking;
+    // a path field over an adversarial value yields only safe components.
+    #[test]
+    fn render_never_panics_and_path_fields_stay_safe(tmpl in ".{0,64}", value in ".{0,64}") {
+        let f = fields(&[("p", value.as_str())]);
+
+        // arbitrary templates must parse-or-reject, never panic on render
+        if let Ok(t) = Template::parse(&tmpl) {
+            let _ = t.render(&f, &BTreeMap::new(), "Unknown", "flac");
+        }
+
+        // a path field over an adversarial value yields only safe components
+        let rendered = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let body = rendered.strip_suffix(".flac").expect("ext appended");
+        for component in body.split('/') {
+            prop_assert!(!component.is_empty());
+            prop_assert_ne!(component, ".");
+            prop_assert_ne!(component, "..");
+        }
+    }
+}
+```
+
+(The `value in ".{0,64}"` half is unchanged: path-field *values* are still sanitized — control bytes → `_` — never rejected.)
+
+- [ ] **Step 11: Add the #275 / #304 acceptance tests**
+
+Add the #275 parse-rejection tests to `musefs-core/tests/template.rs` (needs `TemplateError` in scope — add `use musefs_core::TemplateError;` to the imports):
+
+```rust
+#[test]
+fn template_literal_nul_is_rejected() {
+    assert!(matches!(
+        Template::parse("a\0b/$title"),
+        Err(TemplateError::ControlByte { byte: 0 })
+    ));
+}
+
+#[test]
+fn template_literal_control_byte_is_rejected() {
+    assert!(matches!(
+        Template::parse("a\u{01}b"),
+        Err(TemplateError::ControlByte { byte: 1 })
+    ));
+}
+
+#[test]
+fn bracket_escapes_and_slashes_still_parse() {
+    // $[ / $] escapes and ordinary '/' separators are valid literal bytes.
+    let path = parse("$[$title$]/a/b").render(
+        &fields(&[("title", "X")]),
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "[X]/a/b.flac");
+}
+```
+
+Add the #304 nesting-boundary test to the in-module `mod tests` in `musefs-core/src/template.rs` (it can see the private `MAX_SECTION_DEPTH`):
+
+```rust
+    #[test]
+    fn nesting_at_limit_parses_one_past_limit_rejected() {
+        let at_limit = "[".repeat(MAX_SECTION_DEPTH);
+        assert!(Template::parse(&at_limit).is_ok(), "{MAX_SECTION_DEPTH} deep parses");
+
+        let past_limit = "[".repeat(MAX_SECTION_DEPTH + 1);
+        assert!(matches!(
+            Template::parse(&past_limit),
+            Err(TemplateError::NestingTooDeep { limit }) if limit == MAX_SECTION_DEPTH
+        ));
+    }
+```
+
+- [ ] **Step 12: Add the `open()`-surfacing test in `facade.rs`**
+
+Add to the `mod tests` in `musefs-core/src/facade.rs` (reuses the `Db::open_in_memory()` fixture pattern; no tracks needed — parse precedes build):
+
+```rust
+    #[test]
+    fn open_rejects_template_with_control_byte() {
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let config = MountConfig {
+            template: "a\0b/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+        };
+        assert!(matches!(
+            Musefs::open(db, config),
+            Err(crate::CoreError::InvalidTemplate(_))
+        ));
+    }
+```
+
+(If `BTreeMap`/`std::time::Duration` are not already imported in the facade `mod tests`, use fully-qualified paths or add the `use` — match the surrounding tests, several of which build `MountConfig` the same way.)
+
+- [ ] **Step 13: Build, lint, format, test the whole workspace**
+
+Run each and confirm success:
+
+```bash
+cargo build
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test -p musefs-core
+cargo test
+```
+
+Expected: clean build; no clippy warnings; all tests pass, including the new #275/#303/#304 tests, the rewritten proptest, and every renamed site.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add musefs-core/src/template.rs musefs-core/src/error.rs musefs-core/src/lib.rs \
+        musefs-core/src/facade.rs musefs-core/tests/template.rs
+git commit -m "$(cat <<'EOF'
+feat(template): reject malformed templates at mount (#275 #304)
+
+Template::parse is now fallible: literal control/NUL bytes (#275) and
+[...] nesting past MAX_SECTION_DEPTH (#304) return TemplateError, surfaced
+via CoreError::InvalidTemplate so a bad --template fails Musefs::open with
+a clear message. Bounding nesting at the single parse construction point
+keeps render/referenced_fields recursion safe without per-consumer guards.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review notes (verification of plan against spec)
+
+- **#275** → Task 2 Steps 2 (control-byte reject in catch-all arm), 11 (NUL + 0x01 reject, escapes still parse), 12 (open() surfaces InvalidTemplate). ✔
+- **#304** → Task 2 Steps 2 (depth check `depth + 1 > MAX_SECTION_DEPTH`), 11 (64 ok / 65 Err boundary). ✔
+- **#303** → Task 1 (post-filter segment cap; clamp test + under-cap no-regression test). ✔
+- **30-site rename + proptest** → Task 2 Steps 9–10, explicit per spec §1. ✔
+- **Doc/infallibility update** → Task 2 Step 3. ✔
+- **Out of scope** honored: `sanitize_into` unchanged; no `insert_file` backstop; no DB-limit changes. ✔

--- a/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
@@ -47,15 +47,31 @@ render time and must not be able to fail the mount, so it is clamped.
   template) fails `Musefs::open()` with a clear, actionable message.
 - `Template::parse` changes signature to
   `pub fn parse(template: &str) -> Result<Template, TemplateError>`.
-  - `parse_parts` gains a `depth: usize` parameter. Each `[` that opens a section
-    recurses with `depth + 1`; if `depth` would exceed `MAX_SECTION_DEPTH`, parse
-    returns `Err(TemplateError::NestingTooDeep { limit: MAX_SECTION_DEPTH })`.
-  - While accumulating literal text, any `char` with scalar value `< 0x20`
-    (covers NUL and all C0 control bytes) returns
-    `Err(TemplateError::ControlByte { byte })`. `/` remains legal in literals — it
-    is the structural path separator. (`< 0x20` matches the existing
-    `sanitize_into` rule exactly, so field-value and literal policy stay aligned.)
-  - The `Infallible` line in `Template::parse`'s doc comment is updated.
+  - **`parse_parts` itself becomes fallible** — its return type changes from
+    `Vec<Part>` to `Result<Vec<Part>, TemplateError>`. Both the recursive call in
+    the `'['` arm and `Template::parse`'s top-level call propagate with `?`. The
+    helpers it calls (`parse_braced_names`, `parse_unbraced_name`, `push_literal`)
+    stay infallible.
+  - **`depth` replaces the existing `in_section: bool` parameter** rather than
+    being added alongside it: `parse_parts(chars, depth: usize)`, with
+    `depth > 0` meaning "inside a section" (so every current use of `in_section`
+    becomes `depth > 0`). `Template::parse` calls `parse_parts(&mut chars, 0)`.
+  - Each `[` that opens a section recurses with `depth + 1`; reject with
+    `Err(TemplateError::NestingTooDeep { limit: MAX_SECTION_DEPTH })` when
+    `depth + 1 > MAX_SECTION_DEPTH`. Thus a template nested `MAX_SECTION_DEPTH`
+    sections deep parses and one `MAX_SECTION_DEPTH + 1` deep is rejected (the
+    comparison is `>`, not `>=`).
+  - **Control-byte check goes in the catch-all `_ =>` ordinary-character arm of
+    `parse_parts`**, before `literal.push(c)` — that is the only place a raw input
+    control byte can land (the `$[`/`$]`/`$!`/`$` escape arms only push bracket and
+    `$`/`!` literals). Reject the **first** offending char:
+    `if (c as u32) < 0x20 { return Err(TemplateError::ControlByte { byte: c as u8 }); }`.
+    The `c as u8` cast is lossless precisely because the `< 0x20` guard restricts
+    `c` to scalars that fit in `u8`. `/` remains legal in literals — it is the
+    structural path separator. (`< 0x20` matches the existing `sanitize_into` rule
+    exactly, so field-value and literal policy stay aligned.)
+  - The `Infallible` line in `impl Template`'s `parse` doc comment
+    (`template.rs:28`) is updated; no other doc references infallibility.
 
 **Why this bounds everything once:** because `parse` rejects deep nesting, a
 constructed `Template` *structurally cannot* exceed `MAX_SECTION_DEPTH`. Therefore
@@ -65,24 +81,35 @@ construction point.
 
 **Call sites (blast radius — larger than first estimated).** `Template::parse`
 is `pub` and has 34 call sites workspace-wide:
-- `facade.rs:255` — the single **production** site; propagate with `?` (already a
-  `Result` fn).
-- `facade.rs:1530`, `facade.rs:1787` and one in-module `template.rs` test —
-  `.expect(...)`.
+- `facade.rs:255` — the single **production** site. The concrete edit is
+  `let template = Template::parse(&config.template);` →
+  `let template = Template::parse(&config.template)?;` (the enclosing `open()`
+  already returns `Result`, and `#[from] TemplateError` makes `?` convert into
+  `CoreError::InvalidTemplate`).
+- `facade.rs:1530`, `facade.rs:1787` and the one in-module `template.rs` test
+  (line 315) — `.expect(...)`.
 - **30 calls in `musefs-core/tests/template.rs`** — every one breaks when the
   signature becomes fallible. The pre-commit gate runs the full workspace test
   suite, so all of these must compile (and stay green) in the same commit. To keep
-  the churn mechanical and readable, add a private test helper
+  the churn mechanical and readable, add a **file-scope** helper
   `fn parse(t: &str) -> Template { Template::parse(t).expect("valid template") }`
-  in that test module and the in-module `tests`, and rewrite the existing
-  call sites to use it; only the new negative-path tests call `Template::parse`
-  directly to assert `Err`. The implementation plan must list this rename as an
-  explicit step, not leave it implicit.
+  in `tests/template.rs` alongside the existing free `fields`/`owned` helpers
+  (this test file is **not** wrapped in a `mod`), and rewrite the 30 existing call
+  sites to use it. The in-module `template.rs` test has a single call site — leave
+  that one inline as `Template::parse(...).expect(...)` rather than adding a second
+  helper. Only the new negative-path tests call `Template::parse` directly to
+  assert `Err`. The implementation plan must list this rename as an explicit step,
+  not leave it implicit.
 
 ### 2. #303 — path-field segment cap (contain)
 
 - `sanitize_path` caps the number of **surviving** segments at
-  `MAX_PATH_FIELD_SEGMENTS`. Once the cap is reached, remaining `/`-separated
+  `MAX_PATH_FIELD_SEGMENTS`, counted **post-filter**: only segments that pass the
+  existing empty/`.`/`..` guard consume cap budget (increment the counter after the
+  `continue` guards, stop once it reaches `MAX_PATH_FIELD_SEGMENTS`). So a value
+  like `././a/./b` is not prematurely truncated by its dropped `.` segments, and
+  the existing `path_field_neutralizes_traversal_values` test
+  (`tests/template.rs:279`) stays green. Once the cap is reached, remaining
   segments are dropped. A 256 KiB `a/a/a/…` value therefore yields at most
   `MAX_PATH_FIELD_SEGMENTS` directory levels instead of tens of thousands, bounding
   the CPU/allocation/inode-map/refresh cost.
@@ -125,13 +152,18 @@ existing FUSE regression coverage):
   - `$[` / `$]` escapes and ordinary `/` separators still parse successfully.
   - Field-derived hostile values remain sanitized as today (unchanged behaviour).
 - **#304**
-  - A template with nesting deeper than `MAX_SECTION_DEPTH` → `NestingTooDeep`.
-  - A template nested exactly at the limit parses successfully.
+  - Boundary pair: a template nested exactly `MAX_SECTION_DEPTH` (64) sections
+    deep parses successfully; one nested `MAX_SECTION_DEPTH + 1` (65) deep returns
+    `NestingTooDeep` (pins the `>` comparison, not `>=`).
 - **#303**
   - A `$!{field}` value with many `/`-segments renders to at most
     `MAX_PATH_FIELD_SEGMENTS` components.
   - Values at/under the cap are unaffected; `.`/`..`/empty segments still dropped;
     per-segment control sanitization unchanged.
+  - Path-field **values** remain *sanitized* (control bytes → `_`, never
+    rejected) — only template *literals* are rejected. So the proptest's
+    `value in ".{0,64}"` strategy needs no change; the rewrite below touches only
+    the `tmpl` half.
 - **Existing proptest adaptation** (`render_never_panics_and_path_fields_stay_safe`,
   `tests/template.rs:261`). Its `tmpl in ".{0,64}"` strategy generates control
   bytes and `[` runs, which `Template::parse` now legitimately *rejects*. The

--- a/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
@@ -1,0 +1,125 @@
+# Template & path hardening (#275, #303, #304)
+
+## Summary
+
+Three adversarial-audit findings (Task 17, tracking #280) harden the template
+rendering and virtual-tree insertion paths against malformed or hostile input.
+They split cleanly by trust boundary:
+
+| Issue | Concern | Trust boundary | Policy |
+| ----- | ------- | -------------- | ------ |
+| #275 | Control/NUL bytes in template **literal** text reach path components unsanitized | mount-time template config | **reject** at mount |
+| #304 | Unbounded nested-section depth (`[[[…`) drives parse/render/reference recursion | mount-time template config | **reject** at mount |
+| #303 | A 256 KiB `$!{field}` value shaped `a/a/a/…` expands into tens of thousands of path segments | hostile/external-writer SQLite rows | **contain** at render |
+
+Config inputs are the operator's own; a malformed template should fail fast with
+a clear error rather than be silently mangled. Hostile DB data arrives per-row at
+render time and must not be able to fail the mount, so it is clamped.
+
+## Background (current behaviour)
+
+- `musefs-core/src/template.rs`
+  - `Template::parse` is **infallible**: it parses any string, treating malformed
+    input as graceful degradation (unterminated `${`/`[` etc. run to end of input).
+  - `parse_parts` recurses once per `[`; `render_parts` and `collect_field_names`
+    recurse over the same `Part::Section` structure. No depth bound.
+  - Substituted **field values** are sanitized: `sanitize_into` replaces `/` and
+    `char < 0x20` with `_`; `sanitize_path` (for `$!{}` path fields) splits on `/`,
+    drops empty/`.`/`..` segments, sanitizes each surviving segment, and rejoins.
+    No segment-count bound.
+  - `Part::Literal(lit)` is emitted by `render_parts` via `out.push_str(lit)`
+    **directly** — literal template text bypasses all sanitization.
+- `musefs-core/src/tree.rs` `VirtualTree::insert_file` splits the rendered path on
+  `/`, drops empty/`.`/`..`, truncates each component to `NAME_MAX` (255 bytes),
+  but does not sanitize control bytes or bound component count.
+- `Musefs::open()` (`facade.rs:255`) already returns `Result`; it is the single
+  production call site that parses `config.template`.
+
+## Design
+
+### 1. Validation & error surface
+
+- New `TemplateError` enum in `template.rs`:
+  - `NestingTooDeep { limit: usize }`
+  - `ControlByte { byte: u8 }`
+- New `CoreError::InvalidTemplate(#[from] TemplateError)` in
+  `musefs-core/src/error.rs`, so a malformed `--template` (or env/config-supplied
+  template) fails `Musefs::open()` with a clear, actionable message.
+- `Template::parse` changes signature to
+  `pub fn parse(template: &str) -> Result<Template, TemplateError>`.
+  - `parse_parts` gains a `depth: usize` parameter. Each `[` that opens a section
+    recurses with `depth + 1`; if `depth` would exceed `MAX_SECTION_DEPTH`, parse
+    returns `Err(TemplateError::NestingTooDeep { limit: MAX_SECTION_DEPTH })`.
+  - While accumulating literal text, any `char` with scalar value `< 0x20`
+    (covers NUL and all C0 control bytes) returns
+    `Err(TemplateError::ControlByte { byte })`. `/` remains legal in literals — it
+    is the structural path separator. (`< 0x20` matches the existing
+    `sanitize_into` rule exactly, so field-value and literal policy stay aligned.)
+  - The `Infallible` line in `Template::parse`'s doc comment is updated.
+
+**Why this bounds everything once:** because `parse` rejects deep nesting, a
+constructed `Template` *structurally cannot* exceed `MAX_SECTION_DEPTH`. Therefore
+`render_parts` and `collect_field_names`, which recurse over the same structure,
+need no per-consumer depth guards — the invariant is established at the single
+construction point.
+
+**Call sites:**
+- `facade.rs:255` — propagate with `?` (already in a `Result` fn).
+- `facade.rs:1530`, `facade.rs:1787` (tests) — `.unwrap()` / `.expect()`.
+
+### 2. #303 — path-field segment cap (contain)
+
+- `sanitize_path` caps the number of **surviving** segments at
+  `MAX_PATH_FIELD_SEGMENTS`. Once the cap is reached, remaining `/`-separated
+  segments are dropped. A 256 KiB `a/a/a/…` value therefore yields at most
+  `MAX_PATH_FIELD_SEGMENTS` directory levels instead of tens of thousands, bounding
+  the CPU/allocation/inode-map/refresh cost.
+- The track stays addressable at the shallower (truncated) path — clamping, not
+  dropping the row.
+- **No tree-level total-depth backstop.** Literal `/` separators are now-validated
+  operator config (trusted, and bounded by template length); the only depth
+  amplifier across a trust boundary is the per-field DB value, which this cap
+  contains directly. Adding a second cap at `insert_file` would be unused defense
+  against a non-threat (YAGNI).
+
+### 3. Constants
+
+Defined in `template.rs` (these are template/path-rendering concerns, distinct
+from the DB-boundary caps in `musefs-db/src/limits.rs`):
+
+- `MAX_SECTION_DEPTH = 64`
+- `MAX_PATH_FIELD_SEGMENTS = 64`
+
+Real templates nest 2–3 sections deep and path fields are 2–4 segments, so 64
+gives generous headroom for legitimate use while still bounding the adversarial
+case hard.
+
+## Testing (TDD)
+
+Each issue's checklist drives the tests, all in `template.rs` `tests` (plus the
+existing FUSE regression coverage):
+
+- **#275**
+  - Template literal with an embedded NUL → `Template::parse` returns
+    `Err(ControlByte { byte: 0 })`; via `open()`, surfaces as
+    `CoreError::InvalidTemplate`.
+  - Template literal with another control byte (e.g. `0x01`) → rejected.
+  - `$[` / `$]` escapes and ordinary `/` separators still parse successfully.
+  - Field-derived hostile values remain sanitized as today (unchanged behaviour).
+- **#304**
+  - A template with nesting deeper than `MAX_SECTION_DEPTH` → `NestingTooDeep`.
+  - A template nested exactly at the limit parses successfully.
+- **#303**
+  - A `$!{field}` value with many `/`-segments renders to at most
+    `MAX_PATH_FIELD_SEGMENTS` components.
+  - Values at/under the cap are unaffected; `.`/`..`/empty segments still dropped;
+    per-segment control sanitization unchanged.
+- **Regression**
+  - FUSE/`readdir` path names never contain NUL (covered by the now-enforced
+    literal rejection plus existing field-value sanitization).
+
+## Out of scope
+
+- No change to field-value sanitization rules (`sanitize_into`) — already correct.
+- No `insert_file` total-depth cap (see §2 rationale).
+- No new DB-boundary limits; `MAX_TAG_VALUE_LEN` is unchanged.

--- a/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
@@ -63,9 +63,21 @@ constructed `Template` *structurally cannot* exceed `MAX_SECTION_DEPTH`. Therefo
 need no per-consumer depth guards — the invariant is established at the single
 construction point.
 
-**Call sites:**
-- `facade.rs:255` — propagate with `?` (already in a `Result` fn).
-- `facade.rs:1530`, `facade.rs:1787` (tests) — `.unwrap()` / `.expect()`.
+**Call sites (blast radius — larger than first estimated).** `Template::parse`
+is `pub` and has 34 call sites workspace-wide:
+- `facade.rs:255` — the single **production** site; propagate with `?` (already a
+  `Result` fn).
+- `facade.rs:1530`, `facade.rs:1787` and one in-module `template.rs` test —
+  `.expect(...)`.
+- **30 calls in `musefs-core/tests/template.rs`** — every one breaks when the
+  signature becomes fallible. The pre-commit gate runs the full workspace test
+  suite, so all of these must compile (and stay green) in the same commit. To keep
+  the churn mechanical and readable, add a private test helper
+  `fn parse(t: &str) -> Template { Template::parse(t).expect("valid template") }`
+  in that test module and the in-module `tests`, and rewrite the existing
+  call sites to use it; only the new negative-path tests call `Template::parse`
+  directly to assert `Err`. The implementation plan must list this rename as an
+  explicit step, not leave it implicit.
 
 ### 2. #303 — path-field segment cap (contain)
 
@@ -81,6 +93,12 @@ construction point.
   amplifier across a trust boundary is the per-field DB value, which this cap
   contains directly. Adding a second cap at `insert_file` would be unused defense
   against a non-threat (YAGNI).
+- **The multiplier is bounded.** A template can interleave several `$!{}` path
+  fields and literal `/`s, so worst-case rendered depth is
+  `(path-field count × MAX_PATH_FIELD_SEGMENTS) + (literal-slash count)`. Both
+  multiplicands are properties of the now-validated template (operator config,
+  bounded by template length), not of hostile DB data — so the product stays
+  bounded by trusted input. That is precisely why the per-field cap suffices.
 
 ### 3. Constants
 
@@ -114,6 +132,15 @@ existing FUSE regression coverage):
     `MAX_PATH_FIELD_SEGMENTS` components.
   - Values at/under the cap are unaffected; `.`/`..`/empty segments still dropped;
     per-segment control sanitization unchanged.
+- **Existing proptest adaptation** (`render_never_panics_and_path_fields_stay_safe`,
+  `tests/template.rs:261`). Its `tmpl in ".{0,64}"` strategy generates control
+  bytes and `[` runs, which `Template::parse` now legitimately *rejects*. The
+  chained `Template::parse(&tmpl).render(...)` therefore breaks both at compile
+  time (`Result` has no `.render`) and semantically. Rewrite the property as: a
+  template either fails to parse **or** renders without panicking —
+  `if let Ok(t) = Template::parse(&tmpl) { let _ = t.render(...); }`. The fixed
+  `Template::parse("$!{p}")` half uses the test `parse` helper (`.expect`). The
+  path-field safety assertions are unchanged.
 - **Regression**
   - FUSE/`readdir` path names never contain NUL (covered by the now-enforced
     literal rejection plus existing field-value sanitization).

--- a/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-template-path-hardening-design.md
@@ -71,7 +71,7 @@ render time and must not be able to fail the mount, so it is clamped.
     structural path separator. (`< 0x20` matches the existing `sanitize_into` rule
     exactly, so field-value and literal policy stay aligned.)
   - The `Infallible` line in `impl Template`'s `parse` doc comment
-    (`template.rs:28`) is updated; no other doc references infallibility.
+    (`template.rs:30`) is updated; no other doc references infallibility.
 
 **Why this bounds everything once:** because `parse` rejects deep nesting, a
 constructed `Template` *structurally cannot* exceed `MAX_SECTION_DEPTH`. Therefore

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -12,6 +12,8 @@ pub enum CoreError {
     },
     #[error(transparent)]
     Format(#[from] musefs_format::FormatError),
+    #[error(transparent)]
+    InvalidTemplate(#[from] crate::template::TemplateError),
     #[error("MP4 {box_kind} box is {size} bytes, exceeds the {cap}-byte metadata cap")]
     Mp4MetadataTooLarge {
         box_kind: &'static str,

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -252,7 +252,7 @@ impl Musefs {
         // update, since the next poll would see both stamps as current.
         let last_data_version = db.data_version()?;
         let last_seq = db.changelog_since(i64::MAX)?.max_seq;
-        let template = Template::parse(&config.template);
+        let template = Template::parse(&config.template)?;
         let (tree, snapshot) = Self::build_full(&db, &template, &config, &mut alloc)?;
         let poll_interval = config.poll_interval;
         Ok(Musefs {
@@ -1526,8 +1526,12 @@ mod tests {
             case_insensitive: false,
         };
 
-        let (entries, snapshot) =
-            Musefs::render_entries(&db, &Template::parse(&cfg.template), &cfg).unwrap();
+        let (entries, snapshot) = Musefs::render_entries(
+            &db,
+            &Template::parse(&cfg.template).expect("valid template"),
+            &cfg,
+        )
+        .unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].1, "Pix/Song.mp3");
         let id = entries[0].0;
@@ -1784,7 +1788,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
         };
-        let template = Template::parse(&config.template);
+        let template = Template::parse(&config.template).expect("valid template");
 
         let mut alloc = InodeAllocator::new();
         let (tree, _snapshot) = Musefs::build_full(&db, &template, &config, &mut alloc).unwrap();
@@ -1860,5 +1864,22 @@ mod tests {
             matches!(fs.getattr(file_inode), Err(CoreError::BackingChanged(_))),
             "getattr must degrade to BackingChanged after an on-disk backing change"
         );
+    }
+
+    #[test]
+    fn open_rejects_template_with_control_byte() {
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let config = MountConfig {
+            template: "a\0b/$title".to_string(),
+            fallbacks: std::collections::BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+        };
+        assert!(matches!(
+            Musefs::open(db, config),
+            Err(crate::CoreError::InvalidTemplate(_))
+        ));
     }
 }

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -22,7 +22,7 @@ pub use scan::{
     RevalidateStats, ScanOptions, ScanStats, revalidate, revalidate_with, scan_directory,
     scan_directory_with,
 };
-pub use template::Template;
+pub use template::{Template, TemplateError};
 pub use tree::{Node, NodeKind, VirtualTree};
 
 #[cfg(test)]

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -2,11 +2,32 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::iter::Peekable;
 use std::str::Chars;
+use thiserror::Error;
 
 /// Max surviving segments a single `$!{}` path field may expand into. A hostile
 /// 256 KiB tag shaped `a/a/a/...` would otherwise build tens of thousands of
 /// directory levels (depth amplification across the DB trust boundary, #303).
 const MAX_PATH_FIELD_SEGMENTS: usize = 64;
+
+/// Max `[...]` section nesting depth accepted by [`Template::parse`]. Beyond this
+/// the parser rejects the template rather than recursing further (#304). Real
+/// templates nest 2–3 deep; 64 is generous headroom that still bounds the
+/// adversarial `[[[…` case.
+const MAX_SECTION_DEPTH: usize = 64;
+
+/// Why a template was rejected at parse time. Surfaced to the operator via
+/// [`crate::CoreError::InvalidTemplate`] when `Musefs::open` parses a bad
+/// `--template`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TemplateError {
+    /// `[...]` sections nested deeper than `limit`.
+    #[error("template nesting exceeds the maximum depth of {limit}")]
+    NestingTooDeep { limit: usize },
+    /// A literal run contains a control byte (`< 0x20`, includes NUL), which is
+    /// not a valid POSIX path-component byte.
+    #[error("template literal contains control byte {byte:#04x}")]
+    ControlByte { byte: u8 },
+}
 
 /// A parsed path template: literal runs, `$field` / `${field}` substitutions
 /// (with optional `${a|b}` fallback chains and `$!{field}` slash-preserving path
@@ -32,7 +53,9 @@ enum Part {
 }
 
 impl Template {
-    /// Parse a beets-style template. Infallible.
+    /// Parse a beets-style template. Returns `Err` for a template that cannot
+    /// produce valid path components: control/NUL bytes in literal text
+    /// (#275) or `[...]` nesting deeper than [`MAX_SECTION_DEPTH`] (#304).
     ///
     /// - `$field` / `${field}` substitute a tag field; `${a|b|c}` is a fallback
     ///   chain (first present wins). Names are matched case-insensitively.
@@ -43,17 +66,17 @@ impl Template {
     /// - A `$` not followed by a recognized form stays literal; an unterminated
     ///   `${`/`$!{` consumes the rest as the name; an unterminated `[` runs to
     ///   end of input.
-    pub fn parse(template: &str) -> Template {
+    pub fn parse(template: &str) -> Result<Template, TemplateError> {
         let mut chars = template.chars().peekable();
-        let parts = parse_parts(&mut chars, false);
-        Template { parts }
+        let parts = parse_parts(&mut chars, 0)?;
+        Ok(Template { parts })
     }
 
-    /// The set of field names this template references, across plain fields, `$!{}`
-    /// path fields, `|` fallback chains, and `[...]` sections. Names are already
-    /// ASCII-lowercased at parse time, matching `tags_to_fields`'s key folding, so a
-    /// key-filtered tag load (`Db::tags_grouped_for_keys`) fetches exactly what
-    /// rendering consumes.
+    /// The set of field names this template references, across plain fields,
+    /// `$!{}` path fields, `|` fallback chains, and `[...]` sections. Names
+    /// are already ASCII-lowercased at parse time, matching `tags_to_fields`'s
+    /// key folding, so a key-filtered tag load (`Db::tags_grouped_for_keys`)
+    /// fetches exactly what rendering consumes.
     pub fn referenced_fields(&self) -> BTreeSet<String> {
         let mut out = BTreeSet::new();
         collect_field_names(&self.parts, &mut out);
@@ -77,20 +100,26 @@ impl Template {
     }
 }
 
-/// Parse parts until a closing `]` (when `in_section`) or end of input.
-fn parse_parts(chars: &mut Peekable<Chars>, in_section: bool) -> Vec<Part> {
+/// Parse parts until a closing `]` (when `depth > 0`) or end of input. `depth`
+/// is the current `[...]` nesting level (0 = top level).
+fn parse_parts(chars: &mut Peekable<Chars>, depth: usize) -> Result<Vec<Part>, TemplateError> {
     let mut parts = Vec::new();
     let mut literal = String::new();
     while let Some(&c) = chars.peek() {
         match c {
-            ']' if in_section => {
+            ']' if depth > 0 => {
                 chars.next(); // consume the closing ']'
                 break;
             }
             '[' => {
                 chars.next();
                 push_literal(&mut parts, &mut literal);
-                let inner = parse_parts(chars, true);
+                if depth + 1 > MAX_SECTION_DEPTH {
+                    return Err(TemplateError::NestingTooDeep {
+                        limit: MAX_SECTION_DEPTH,
+                    });
+                }
+                let inner = parse_parts(chars, depth + 1)?;
                 parts.push(Part::Section(inner));
             }
             '$' => {
@@ -134,13 +163,16 @@ fn parse_parts(chars: &mut Peekable<Chars>, in_section: bool) -> Vec<Part> {
                 }
             }
             _ => {
+                if (c as u32) < 0x20 {
+                    return Err(TemplateError::ControlByte { byte: c as u8 });
+                }
                 literal.push(c);
                 chars.next();
             }
         }
     }
     push_literal(&mut parts, &mut literal);
-    parts
+    Ok(parts)
 }
 
 fn push_literal(parts: &mut Vec<Part>, literal: &mut String) {
@@ -319,7 +351,8 @@ mod tests {
 
     #[test]
     fn referenced_fields_collects_plain_path_section_and_fallback_names() {
-        let t = Template::parse("$artist/$!{beets_path}/[$disc - ]${title|name}");
+        let t = Template::parse("$artist/$!{beets_path}/[$disc - ]${title|name}")
+            .expect("valid template");
         let f = t.referenced_fields();
         assert!(f.contains("artist"));
         assert!(f.contains("beets_path"));
@@ -328,5 +361,20 @@ mod tests {
         assert!(f.contains("name"));
         // No spurious entries from literals.
         assert_eq!(f.len(), 5);
+    }
+
+    #[test]
+    fn nesting_at_limit_parses_one_past_limit_rejected() {
+        let at_limit = "[".repeat(MAX_SECTION_DEPTH);
+        assert!(
+            Template::parse(&at_limit).is_ok(),
+            "{MAX_SECTION_DEPTH} deep parses"
+        );
+
+        let past_limit = "[".repeat(MAX_SECTION_DEPTH + 1);
+        assert!(matches!(
+            Template::parse(&past_limit),
+            Err(TemplateError::NestingTooDeep { limit }) if limit == MAX_SECTION_DEPTH
+        ));
     }
 }

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -322,6 +322,11 @@ fn sanitize_into(out: &mut String, value: &str) {
     }
 }
 
+/// Split `value` on '/', drop empty / `.` / `..` segments, sanitize each
+/// surviving segment, and rejoin with '/'. Guarantees no empty, `.`, `..`, or
+/// leading/trailing-slash components reach the virtual tree. Stops after
+/// `MAX_PATH_FIELD_SEGMENTS` surviving segments, bounding the depth a single
+/// hostile path-field value can amplify into (#303).
 fn sanitize_path(value: &str) -> String {
     let mut out = String::new();
     let mut count = 0usize;

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -331,11 +331,11 @@ fn sanitize_path(value: &str) -> String {
     let mut out = String::new();
     let mut count = 0usize;
     for segment in value.split('/') {
-        if segment.is_empty() || segment == "." || segment == ".." {
-            continue;
-        }
         if count == MAX_PATH_FIELD_SEGMENTS {
             break;
+        }
+        if segment.is_empty() || segment == "." || segment == ".." {
+            continue;
         }
         if !out.is_empty() {
             out.push('/');

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -3,6 +3,11 @@ use std::collections::BTreeSet;
 use std::iter::Peekable;
 use std::str::Chars;
 
+/// Max surviving segments a single `$!{}` path field may expand into. A hostile
+/// 256 KiB tag shaped `a/a/a/...` would otherwise build tens of thousands of
+/// directory levels (depth amplification across the DB trust boundary, #303).
+const MAX_PATH_FIELD_SEGMENTS: usize = 64;
+
 /// A parsed path template: literal runs, `$field` / `${field}` substitutions
 /// (with optional `${a|b}` fallback chains and `$!{field}` slash-preserving path
 /// fields), and `[...]` conditional sections. Parse once per mount; `render`
@@ -285,19 +290,21 @@ fn sanitize_into(out: &mut String, value: &str) {
     }
 }
 
-/// Split `value` on '/', drop empty / `.` / `..` segments, sanitize each
-/// surviving segment, and rejoin with '/'. Guarantees no empty, `.`, `..`, or
-/// leading/trailing-slash components reach the virtual tree.
 fn sanitize_path(value: &str) -> String {
     let mut out = String::new();
+    let mut count = 0usize;
     for segment in value.split('/') {
         if segment.is_empty() || segment == "." || segment == ".." {
             continue;
+        }
+        if count == MAX_PATH_FIELD_SEGMENTS {
+            break;
         }
         if !out.is_empty() {
             out.push('/');
         }
         sanitize_into(&mut out, segment);
+        count += 1;
     }
     out
 }

--- a/musefs-core/tests/template.rs
+++ b/musefs-core/tests/template.rs
@@ -296,3 +296,26 @@ fn path_field_neutralizes_traversal_values() {
         }
     }
 }
+
+#[test]
+fn path_field_segment_count_is_capped() {
+    // MAX_PATH_FIELD_SEGMENTS is a private const = 64 in template.rs. A hostile
+    // 256 KiB `a/a/a/...` tag would expand to tens of thousands of segments; the
+    // cap clamps the rendered path to at most 64 directory components.
+    let value = vec!["a"; 200].join("/");
+    let f = fields(&[("p", value.as_str())]);
+    let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let body = rendered.strip_suffix(".flac").expect("ext appended");
+    assert_eq!(
+        body.split('/').count(),
+        64,
+        "clamped to MAX_PATH_FIELD_SEGMENTS"
+    );
+}
+
+#[test]
+fn path_field_under_cap_is_unchanged() {
+    let f = fields(&[("p", "a/b/c")]);
+    let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    assert_eq!(rendered, "a/b/c.flac");
+}

--- a/musefs-core/tests/template.rs
+++ b/musefs-core/tests/template.rs
@@ -1,4 +1,4 @@
-use musefs_core::Template;
+use musefs_core::{Template, TemplateError};
 use proptest::prelude::*;
 use std::collections::BTreeMap;
 
@@ -13,6 +13,10 @@ fn owned(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
         .collect()
 }
 
+fn parse(t: &str) -> Template {
+    Template::parse(t).expect("valid template")
+}
+
 #[test]
 fn substitutes_dollar_and_braced_fields_and_appends_ext() {
     let f = fields(&[
@@ -20,12 +24,8 @@ fn substitutes_dollar_and_braced_fields_and_appends_ext() {
         ("album", "Animals"),
         ("title", "Pigs"),
     ]);
-    let path = Template::parse("$albumartist/${album}/$title").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path =
+        parse("$albumartist/${album}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Pink Floyd/Animals/Pigs.flac");
 }
 
@@ -33,15 +33,14 @@ fn substitutes_dollar_and_braced_fields_and_appends_ext() {
 fn missing_field_uses_per_field_fallback_then_default() {
     let f = fields(&[("title", "Untitled Track")]);
     let fallbacks = owned(&[("albumartist", "Unknown Artist")]);
-    let path =
-        Template::parse("$albumartist/$album/$title").render(&f, &fallbacks, "Unknown", "flac");
+    let path = parse("$albumartist/$album/$title").render(&f, &fallbacks, "Unknown", "flac");
     assert_eq!(path, "Unknown Artist/Unknown/Untitled Track.flac");
 }
 
 #[test]
 fn sanitizes_path_illegal_characters_in_values() {
     let f = fields(&[("artist", "AC/DC"), ("title", "Back\u{0000}In")]);
-    let path = Template::parse("$artist/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$artist/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "AC_DC/Back_In.flac");
 }
 
@@ -50,85 +49,67 @@ fn lone_dollar_stays_literal() {
     let f = fields(&[("title", "Song")]);
     // '$' before a non-field char, and a trailing '$', both stay literal;
     // the non-field char after the lone '$' is kept.
-    let path = Template::parse("100$ bill/$title$").render(&f, &BTreeMap::new(), "Unknown", "mp3");
+    let path = parse("100$ bill/$title$").render(&f, &BTreeMap::new(), "Unknown", "mp3");
     assert_eq!(path, "100$ bill/Song$.mp3");
 }
 
 #[test]
 fn unterminated_brace_consumes_rest_as_field_name() {
     let f = fields(&[("album", "X")]);
-    let path = Template::parse("${album").render(&f, &BTreeMap::new(), "Unknown", "ogg");
+    let path = parse("${album").render(&f, &BTreeMap::new(), "Unknown", "ogg");
     assert_eq!(path, "X.ogg");
 }
 
 #[test]
 fn fallback_chain_uses_first_present_candidate() {
     let f = fields(&[("artist", "Beck"), ("title", "Loser")]);
-    let path = Template::parse("${albumartist|artist}/$title").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path =
+        parse("${albumartist|artist}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Beck/Loser.flac");
 }
 
 #[test]
 fn fallback_chain_skips_empty_value() {
     let f = fields(&[("albumartist", ""), ("artist", "Beck"), ("title", "Loser")]);
-    let path = Template::parse("${albumartist|artist}/$title").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path =
+        parse("${albumartist|artist}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Beck/Loser.flac");
 }
 
 #[test]
 fn fallback_chain_all_empty_falls_to_default_at_top_level() {
     let f = fields(&[("title", "Loser")]);
-    let path = Template::parse("${albumartist|artist}/$title").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path =
+        parse("${albumartist|artist}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Unknown/Loser.flac");
 }
 
 #[test]
 fn field_names_are_case_insensitive() {
     let f = fields(&[("albumartist", "VA")]);
-    let path = Template::parse("$AlbumArtist").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$AlbumArtist").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "VA.flac");
 }
 
 #[test]
 fn section_suppressed_when_field_absent() {
     let f = fields(&[("album", "LP")]);
-    let path =
-        Template::parse("$album[ - CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$album[ - CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP.flac");
 }
 
 #[test]
 fn section_emitted_when_field_present() {
     let f = fields(&[("album", "LP"), ("disc", "2")]);
-    let path =
-        Template::parse("$album[ - CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$album[ - CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP - CD 2.flac");
 }
 
 #[test]
 fn nested_section_outer_kept_inner_dropped() {
     let f = fields(&[("artist", "AC"), ("album", "LP"), ("title", "Song")]);
-    let path = Template::parse("$artist[/[$date - ]$album]/$title").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path =
+        parse("$artist[/[$date - ]$album]/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "AC/LP/Song.flac");
 }
 
@@ -140,132 +121,123 @@ fn nested_section_inner_present_renders_prefix() {
         ("album", "LP"),
         ("title", "Song"),
     ]);
-    let path = Template::parse("$artist[/[$date - ]$album]/$title").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path =
+        parse("$artist[/[$date - ]$album]/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "AC/1999 - LP/Song.flac");
 }
 
 #[test]
 fn section_all_referenced_fields_empty_is_suppressed() {
     let f = fields(&[("album", "LP")]);
-    let path =
-        Template::parse("$album[ $[$date$]]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$album[ $[$date$]]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP.flac");
 }
 
 #[test]
 fn escaped_brackets_render_literally_inside_kept_section() {
     let f = fields(&[("album", "LP"), ("date", "1999")]);
-    let path =
-        Template::parse("$album[ $[$date$]]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$album[ $[$date$]]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP [1999].flac");
 }
 
 #[test]
 fn empty_field_inside_kept_section_renders_blank_not_default() {
     let f = fields(&[("album", "LP")]);
-    let path = Template::parse("[$album$disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("[$album$disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP.flac");
 }
 
 #[test]
 fn empty_section_emits_nothing() {
     let f = fields(&[("title", "Song")]);
-    let path = Template::parse("$title[]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$title[]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Song.flac");
 }
 
 #[test]
 fn path_field_keeps_slashes_as_separators() {
     let f = fields(&[("p", "Pink Floyd/Animals/01 Pigs")]);
-    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Pink Floyd/Animals/01 Pigs.flac");
 }
 
 #[test]
 fn path_field_drops_empty_and_dot_segments() {
     let f = fields(&[("p", "a//../b/./c")]);
-    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "a/b/c.flac");
 }
 
 #[test]
 fn path_field_all_segments_dropped_falls_to_default() {
     let f = fields(&[("p", "..")]);
-    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Unknown.flac");
 }
 
 #[test]
 fn path_field_fallback_chain() {
     let f = fields(&[("lidarr_path", "Artist/Album/Song")]);
-    let path = Template::parse("$!{beets_path|lidarr_path}").render(
-        &f,
-        &BTreeMap::new(),
-        "Unknown",
-        "flac",
-    );
+    let path = parse("$!{beets_path|lidarr_path}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Artist/Album/Song.flac");
 }
 
 #[test]
 fn path_field_sanitizes_control_chars_within_segments() {
     let f = fields(&[("p", "a\u{0001}b/c")]);
-    let path = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "a_b/c.flac");
 }
 
 #[test]
 fn escaped_brackets_at_top_level_render_literally() {
     let f = fields(&[("title", "Song")]);
-    let path = Template::parse("$[$title$]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$[$title$]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "[Song].flac");
 }
 
 #[test]
 fn stray_closing_bracket_is_literal() {
     let f = fields(&[("title", "Song")]);
-    let path = Template::parse("$title]").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$title]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Song].flac");
 }
 
 #[test]
 fn unterminated_section_runs_to_end_of_input() {
     let f = fields(&[("album", "LP"), ("disc", "2")]);
-    let path = Template::parse("$album[ CD $disc").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$album[ CD $disc").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP CD 2.flac");
 }
 
 #[test]
 fn dollar_bang_without_brace_stays_literal() {
     let f = fields(&[("title", "Song")]);
-    let path = Template::parse("$!x/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$!x/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "$!x/Song.flac");
 }
 
 #[test]
 fn empty_braced_field_is_absent() {
     let f = fields(&[("title", "Song")]);
-    let path = Template::parse("${}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("${}/$title").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "Unknown/Song.flac");
 }
 
 proptest! {
-    // render must never panic, and a path field must never emit an empty,
-    // '.', or '..' component (no traversal / no absolute path into the tree).
+    // An arbitrary template either fails to parse or renders without panicking;
+    // a path field over an adversarial value yields only safe components.
     #[test]
     fn render_never_panics_and_path_fields_stay_safe(tmpl in ".{0,64}", value in ".{0,64}") {
         let f = fields(&[("p", value.as_str())]);
 
-        // arbitrary templates must not panic
-        let _ = Template::parse(&tmpl).render(&f, &BTreeMap::new(), "Unknown", "flac");
+        // arbitrary templates must parse-or-reject, never panic on render
+        if let Ok(t) = Template::parse(&tmpl) {
+            let _ = t.render(&f, &BTreeMap::new(), "Unknown", "flac");
+        }
 
         // a path field over an adversarial value yields only safe components
-        let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let rendered = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
         let body = rendered.strip_suffix(".flac").expect("ext appended");
         for component in body.split('/') {
             prop_assert!(!component.is_empty());
@@ -287,7 +259,7 @@ fn path_field_neutralizes_traversal_values() {
         ".",
     ] {
         let f = fields(&[("p", value)]);
-        let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+        let rendered = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
         let body = rendered.strip_suffix(".flac").unwrap();
         for component in body.split('/') {
             assert!(!component.is_empty(), "empty component from {value:?}");
@@ -304,7 +276,7 @@ fn path_field_segment_count_is_capped() {
     // cap clamps the rendered path to at most 64 directory components.
     let value = vec!["a"; 200].join("/");
     let f = fields(&[("p", value.as_str())]);
-    let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let rendered = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     let body = rendered.strip_suffix(".flac").expect("ext appended");
     assert_eq!(
         body.split('/').count(),
@@ -316,6 +288,33 @@ fn path_field_segment_count_is_capped() {
 #[test]
 fn path_field_under_cap_is_unchanged() {
     let f = fields(&[("p", "a/b/c")]);
-    let rendered = Template::parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let rendered = parse("$!{p}").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(rendered, "a/b/c.flac");
+}
+
+#[test]
+fn template_literal_nul_is_rejected() {
+    assert!(matches!(
+        Template::parse("a\0b/$title"),
+        Err(TemplateError::ControlByte { byte: 0 })
+    ));
+}
+
+#[test]
+fn template_literal_control_byte_is_rejected() {
+    assert!(matches!(
+        Template::parse("a\u{01}b"),
+        Err(TemplateError::ControlByte { byte: 1 })
+    ));
+}
+
+#[test]
+fn bracket_escapes_and_slashes_still_parse() {
+    let path = parse("$[$title$]/a/b").render(
+        &fields(&[("title", "X")]),
+        &BTreeMap::new(),
+        "Unknown",
+        "flac",
+    );
+    assert_eq!(path, "[X]/a/b.flac");
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -106,7 +106,8 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         | CoreError::ArtTooLarge { .. }
         | CoreError::InvalidPictureType { .. }
         | CoreError::HeaderTooLarge { .. }
-        | CoreError::Format(_) => fuser::Errno::EIO,
+        | CoreError::Format(_)
+        | CoreError::InvalidTemplate(_) => fuser::Errno::EIO,
     }
 }
 


### PR DESCRIPTION
Closes #275
Closes #303
Closes #304
(adversarial-audit cluster, tracking #280).

Three findings about template rendering and virtual-tree path insertion, split by trust boundary: reject malformed mount-time **config**, contain hostile **DB data**.

| Issue | Concern | Policy |
| ----- | ------- | ------ |
| #275 | Control/NUL bytes in template **literal** text reached path components unsanitized | **reject** at mount |
| #304 | Unbounded `[...]` section nesting drove parse/render recursion | **reject** at mount |
| #303 | A 256 KiB `$!{field}` value shaped `a/a/a/…` expanded into tens of thousands of path segments | **contain** at render |

## What changed

- **`Template::parse` is now fallible** (`Result<Template, TemplateError>`). It rejects literal control bytes (`< 0x20`, incl. NUL) and `[...]` nesting past `MAX_SECTION_DEPTH` (64). A new `CoreError::InvalidTemplate` surfaces this from `Musefs::open()`, so a bad `--template` fails the mount with a clear message instead of building unaddressable tree entries.
  - Bounding nesting at the single parse construction point keeps `render_parts`/`referenced_fields` recursion safe with no per-consumer guards.
- **`sanitize_path` caps surviving segments** at `MAX_PATH_FIELD_SEGMENTS` (64), counted post-filter (dropped `.`/`..`/empty don't consume budget). The track stays addressable at the shallower path — clamp, not drop.
- `errno()` in `musefs-fuse` gains the `InvalidTemplate` arm (exhaustive match; maps to `EIO`, though it only fires at mount before any FUSE op).

Field-value sanitization (`sanitize_into`) is unchanged; no new DB-boundary limits; no `insert_file` depth backstop (literal `/`s are now-validated operator config).

## Tests

- #275: NUL and `0x01` literals → `Err(ControlByte)`; `open()` surfaces `InvalidTemplate`; `$[`/`$]` escapes and `/` separators still parse.
- #304: boundary pair — 64-deep parses, 65-deep → `NestingTooDeep` (pins `>` not `>=`).
- #303: 200-segment value clamps to 64 components; under-cap unchanged; `.`/`..` still dropped.
- Existing `render_never_panics…` proptest adapted for the fallible signature (no-panic guard; rejection pinned by the deterministic tests above).

`cargo fmt`/`clippy --all-targets -D warnings`/full `cargo test` green (350 passed); `metrics` feature compiles.

Spec and plan included under `docs/superpowers/` (reviewed across two spec rounds + one plan round before implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mount-time template validation now rejects templates with excessive nesting or control bytes, causing invalid templates to be refused when opening a mount.
  * Rendering now caps the number of path segments derived from field values to prevent traversal surprises.

* **Documentation**
  * Added comprehensive design and implementation plans with acceptance tests and TDD steps for template/path hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->