### PR TITLE
Harden musefs-format bounds: OggArtSlice validation (#273) + checked aggregate arithmetic (#274)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-layout-bounds-hardening.md
+++ b/docs/superpowers/plans/2026-06-12-layout-bounds-hardening.md
@@ -1,0 +1,980 @@
+# Layout Bounds Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `musefs-format` fail closed on adversarial DB-derived lengths at the exact arithmetic/validation boundary — bounds-check `Segment::OggArtSlice` in `RegionLayout::validate` (#273) and replace unchecked aggregate length math in the synthesis builders with checked helpers (#274).
+
+**Architecture:** A new `pub(crate)` `size` module supplies `checked_add`/`checked_sum` returning `FormatError::TooLarge`; the builders (`mp3`/`mp4`/`wav`/`flac`/`ogg`) call them in place of `+`/`+=`/`sum::<u64>()` over attacker-controlled lengths. `RegionLayout::validate` gains an `OggArtSlice` case using a new checked `b64_len_checked`; `b64_len` delegates to it (no behaviour change for real images). `validate` stays the final belt-and-suspenders check.
+
+**Tech Stack:** Rust (workspace crate `musefs-format`), `thiserror`, `cargo test`/`clippy`/`fmt`, `cargo +nightly fuzz build` for the out-of-workspace `fuzz/` crate.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-layout-bounds-hardening-design.md`
+
+---
+
+## File Structure
+
+- **Create** `musefs-format/src/size.rs` — `pub(crate)` checked aggregate-size helpers (`checked_add`, `checked_sum`) returning `FormatError::TooLarge`. One responsibility: overflow-safe size arithmetic for builders.
+- **Modify** `musefs-format/src/lib.rs` — register `mod size;`.
+- **Modify** `musefs-format/src/ogg/b64.rs` — add `b64_len_checked`; make `b64_len` delegate; add a reader-safety boundary test.
+- **Modify** `musefs-format/src/ogg/mod.rs` — re-export `b64_len_checked`; switch the two VorbisComment picture `value_len` computations to checked helpers; add an overflow test.
+- **Modify** `musefs-format/src/layout.rs` — two new `LayoutError` variants; `OggArtSlice` case in `validate`; Part A tests.
+- **Modify** `musefs-format/src/mp3.rs` — checked aggregates in `build_id3v2_segments`; overflow test.
+- **Modify** `musefs-format/src/mp4.rs` — checked aggregates in `build_udta` and `synthesize`; overflow test.
+- **Modify** `musefs-format/src/wav.rs` — checked aggregate for the RIFF size; note on testability.
+- **Modify** `musefs-format/src/flac.rs` — checked aggregate for the picture block body; overflow test.
+
+Commit order (each commit is green — the pre-commit hook runs the full workspace suite):
+1. `size` helpers
+2. `b64_len_checked` + delegation (fuzz build check after)
+3. Part A `validate` + variants
+4. mp3 · 5. mp4 · 6. wav · 7. flac · 8. ogg (fuzz build check after)
+
+`b64_len_checked` (Task 2) must land before the ogg builder (Task 8) which depends on it.
+
+---
+
+## Task 1: `size` module — checked aggregate helpers
+
+**Files:**
+- Create: `musefs-format/src/size.rs`
+- Modify: `musefs-format/src/lib.rs:5` (add `mod size;`)
+
+- [ ] **Step 1: Create the module with helpers and failing tests**
+
+Create `musefs-format/src/size.rs`:
+
+```rust
+//! Checked aggregate size arithmetic for synthesis builders. Aggregates over
+//! attacker-controlled, DB-derived lengths must fail closed with
+//! `FormatError::TooLarge` at the format arithmetic boundary, not wrap (release)
+//! or panic (debug) and only fail later via `RegionLayout::validate`.
+
+use crate::error::{FormatError, Result};
+
+/// `a + b`, mapping `u64` overflow to `FormatError::TooLarge`.
+pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64> {
+    a.checked_add(b).ok_or(FormatError::TooLarge)
+}
+
+/// Sum an iterator of `u64`, mapping any `u64` overflow to `FormatError::TooLarge`.
+pub(crate) fn checked_sum(iter: impl IntoIterator<Item = u64>) -> Result<u64> {
+    iter.into_iter().try_fold(0u64, checked_add)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_add_reports_overflow_as_too_large() {
+        assert_eq!(checked_add(2, 3), Ok(5));
+        assert_eq!(checked_add(u64::MAX, 1), Err(FormatError::TooLarge));
+    }
+
+    #[test]
+    fn checked_sum_reports_overflow_as_too_large() {
+        assert_eq!(checked_sum([1u64, 2, 3]), Ok(6));
+        assert_eq!(checked_sum(std::iter::empty::<u64>()), Ok(0));
+        assert_eq!(checked_sum([u64::MAX, 1]), Err(FormatError::TooLarge));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `musefs-format/src/lib.rs`, add `mod size;` after the `pub mod probe;` line (line 9):
+
+```rust
+pub mod probe;
+mod size;
+mod tagmap;
+```
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-format size::`
+Expected: PASS (3 assertions across 2 tests).
+
+- [ ] **Step 4: Lint**
+
+Run: `cargo clippy -p musefs-format --all-targets`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/size.rs musefs-format/src/lib.rs
+git commit -m "feat(format): add checked aggregate-size helpers (#274)"
+```
+
+---
+
+## Task 2: `b64_len_checked` + delegation
+
+**Files:**
+- Modify: `musefs-format/src/ogg/b64.rs:44-46` (the `b64_len` fn), test module at `:48`
+- Modify: `musefs-format/src/ogg/mod.rs:8` (re-export)
+
+- [ ] **Step 1: Write the failing reader-safety boundary test**
+
+Add to the `#[cfg(test)] mod tests` block in `musefs-format/src/ogg/b64.rs`:
+
+```rust
+    #[test]
+    fn b64_window_is_overflow_free_at_the_max_validated_boundary() {
+        // For any layout that passes RegionLayout::validate, an OggArtSlice
+        // satisfies offset + len <= b64_len(art_total) AND b64_len_checked(art_total)
+        // is Some. Under those bounds b64_window's internal +/* cannot overflow.
+        // Pin the worst case: the largest art_total whose b64_len still fits u64,
+        // reading the final 4 output chars. In debug, any intermediate overflow
+        // would panic here.
+        let art_total = u64::MAX / 4 * 3; // b64_len_checked(art_total) is Some
+        assert!(b64_len_checked(art_total).is_some());
+        let total = b64_len(art_total);
+        let w = b64_window(total - 4, 4, art_total);
+        assert!(w.in_start <= art_total);
+        assert!(w.in_len <= art_total);
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p musefs-format b64_window_is_overflow_free`
+Expected: FAIL to compile — `b64_len_checked` does not exist yet.
+
+- [ ] **Step 3: Add `b64_len_checked` and make `b64_len` delegate**
+
+In `musefs-format/src/ogg/b64.rs`, replace the existing `b64_len`:
+
+```rust
+/// Total base64 output length for an image of `img_total` bytes.
+pub fn b64_len(img_total: u64) -> u64 {
+    img_total.div_ceil(3) * 4
+}
+```
+
+with:
+
+```rust
+/// Total base64 output length for an image of `img_total` bytes, or `None` if it
+/// overflows `u64`. Only an adversarial `img_total` can overflow; every real
+/// image is far below this.
+pub fn b64_len_checked(img_total: u64) -> Option<u64> {
+    img_total.div_ceil(3).checked_mul(4)
+}
+
+/// Total base64 output length for an image of `img_total` bytes.
+pub fn b64_len(img_total: u64) -> u64 {
+    b64_len_checked(img_total).expect("base64 output length fits u64")
+}
+```
+
+- [ ] **Step 4: Re-export `b64_len_checked`**
+
+In `musefs-format/src/ogg/mod.rs`, change line 8 from:
+
+```rust
+pub use b64::{B64Window, b64_len, b64_window, encode_b64_slice};
+```
+
+to:
+
+```rust
+pub use b64::{B64Window, b64_len, b64_len_checked, b64_window, encode_b64_slice};
+```
+
+- [ ] **Step 5: Run the b64 tests**
+
+Run: `cargo test -p musefs-format b64`
+Expected: PASS — the new boundary test plus all pre-existing b64 tests (delegation returns identical values for real images).
+
+- [ ] **Step 6: Confirm the out-of-workspace fuzz crate still builds**
+
+Run: `cargo +nightly fuzz build` (from the repo root)
+Expected: builds — adding a function and changing `b64_len`'s body is API-compatible.
+(If the nightly toolchain or `cargo-fuzz` is unavailable, note it and skip; CI's smoke job covers it.)
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/ogg/b64.rs musefs-format/src/ogg/mod.rs
+git commit -m "feat(format): add checked b64_len_checked; b64_len delegates (#273)"
+```
+
+---
+
+## Task 3: Part A — `OggArtSlice` bounds in `RegionLayout::validate`
+
+**Files:**
+- Modify: `musefs-format/src/layout.rs:2-15` (`LayoutError`), `:142-160` (`validate`), `:163-203` (tests)
+
+- [ ] **Step 1: Write the failing validation tests**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/layout.rs`:
+
+```rust
+    #[test]
+    fn validate_rejects_raw_ogg_art_slice_past_source() {
+        // raw slice: offset + len must be <= art_total. end = 15 > art_total = 12.
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 5,
+            len: BlobLen::new(10).unwrap(),
+            base64: false,
+            art_total: 12,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_base64_ogg_art_slice_past_source() {
+        // base64 slice: end must be <= b64_len(art_total). art_total=3 -> b64_len=4.
+        // end = 6 > 4.
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 2,
+            len: BlobLen::new(4).unwrap(),
+            base64: true,
+            art_total: 3,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_ogg_art_slice_offset_len_overflow() {
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: u64::MAX,
+            len: BlobLen::new(1).unwrap(), // offset + len overflows u64
+            base64: false,
+            art_total: u64::MAX,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceRangeOverflow)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_base64_ogg_art_slice_when_b64_len_overflows() {
+        // art_total near u64::MAX makes b64_len(art_total) overflow u64.
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 0,
+            len: BlobLen::new(1).unwrap(),
+            base64: true,
+            art_total: u64::MAX,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceRangeOverflow)
+        );
+    }
+
+    #[test]
+    fn validate_accepts_ogg_art_slice_at_source_boundary() {
+        // raw: end == art_total exactly. base64: end == b64_len(art_total) exactly.
+        let raw = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 2,
+            len: BlobLen::new(10).unwrap(),
+            base64: false,
+            art_total: 12,
+        };
+        RegionLayout::new(vec![raw, Segment::BackingAudio { offset: 0, len: 1 }])
+            .validate()
+            .unwrap();
+        let b64 = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 0,
+            len: BlobLen::new(4).unwrap(),
+            base64: true,
+            art_total: 3,
+        };
+        RegionLayout::new(vec![b64, Segment::BackingAudio { offset: 0, len: 1 }])
+            .validate()
+            .unwrap();
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p musefs-format validate_rejects_raw_ogg_art_slice_past_source validate_accepts_ogg_art_slice_at_source_boundary`
+Expected: FAIL to compile — `LayoutError::OggArtSliceOutOfBounds` / `OggArtSliceRangeOverflow` do not exist yet.
+
+- [ ] **Step 3: Add the two `LayoutError` variants**
+
+In `musefs-format/src/layout.rs`, inside `enum LayoutError`, after the `BackingRangeOverflow` variant (line 14), add:
+
+```rust
+    /// An Ogg art slice's offset + length overflowed u64, or its base64 output
+    /// length (`b64_len(art_total)`) overflowed u64.
+    #[error("ogg art slice range (offset + length, or base64 output length) overflowed u64")]
+    OggArtSliceRangeOverflow,
+    /// An Ogg art slice names an output window past the end of its source art.
+    #[error("ogg art slice output window exceeds the source art length")]
+    OggArtSliceOutOfBounds,
+```
+
+- [ ] **Step 4: Add the `OggArtSlice` case to `validate`**
+
+In `RegionLayout::validate`, the loop currently reads:
+
+```rust
+        for seg in &self.segments {
+            let len = seg.len();
+            if len == 0 && !matches!(seg, Segment::BackingAudio { .. } | Segment::OggAudio { .. }) {
+                return Err(LayoutError::EmptySegment);
+            }
+            if let Segment::BackingAudio { offset, len } | Segment::OggAudio { offset, len, .. } =
+                seg
+            {
+                offset
+                    .checked_add(*len)
+                    .ok_or(LayoutError::BackingRangeOverflow)?;
+            }
+            total = total.checked_add(len).ok_or(LayoutError::TotalOverflow)?;
+        }
+```
+
+Insert the `OggArtSlice` check after the `BackingAudio`/`OggAudio` block and before the `total = ...` line:
+
+```rust
+            if let Segment::OggArtSlice {
+                offset,
+                len: slice_len,
+                base64,
+                art_total,
+                ..
+            } = seg
+            {
+                let permitted = if *base64 {
+                    crate::ogg::b64_len_checked(*art_total)
+                        .ok_or(LayoutError::OggArtSliceRangeOverflow)?
+                } else {
+                    *art_total
+                };
+                let end = offset
+                    .checked_add(slice_len.get())
+                    .ok_or(LayoutError::OggArtSliceRangeOverflow)?;
+                if end > permitted {
+                    return Err(LayoutError::OggArtSliceOutOfBounds);
+                }
+            }
+            total = total.checked_add(len).ok_or(LayoutError::TotalOverflow)?;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-format -- validate_rejects validate_accepts_ogg_art_slice`
+Expected: PASS (all five new tests).
+
+- [ ] **Step 6: Run the whole format suite (validate is on the synthesis path)**
+
+Run: `cargo test -p musefs-format`
+Expected: PASS — no existing layout/synthesis test regresses.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/layout.rs
+git commit -m "feat(format): validate OggArtSlice source bounds in RegionLayout (#273)"
+```
+
+---
+
+## Task 4: mp3 — checked aggregates in `build_id3v2_segments`
+
+**Files:**
+- Modify: `musefs-format/src/mp3.rs` — imports, `build_id3v2_segments` (`:237-395`), tests
+
+- [ ] **Step 1: Write the failing overflow test**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/mp3.rs`:
+
+```rust
+    #[test]
+    fn build_id3v2_segments_checked_art_len_rejects_overflow() {
+        // A hostile art data_len near u64::MAX must fail closed with TooLarge at
+        // the checked add, not panic (debug) / wrap (release).
+        let mk = |data_len: u64| ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(data_len).unwrap(),
+        };
+        assert_eq!(
+            build_id3v2_segments(&[], &[], &[mk(u64::MAX)]).err(),
+            Some(FormatError::TooLarge)
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p musefs-format build_id3v2_segments_checked_art_len_rejects_overflow`
+Expected: FAIL — panics with "attempt to add with overflow" at `framing.len() as u64 + art.data_len.get()` (debug), so the `assert_eq!` is never reached.
+
+- [ ] **Step 3: Add the `size` import**
+
+At the top of `musefs-format/src/mp3.rs`, add to the imports:
+
+```rust
+use crate::size;
+```
+
+- [ ] **Step 4: Convert the accumulation sites**
+
+Replace **every** occurrence (6 of them) of:
+
+```rust
+                frames_len += 10 + data.len() as u64;
+```
+
+with:
+
+```rust
+                frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
+```
+
+(`data` is a freshly built `Vec`, so `10 + data.len()` cannot itself overflow; only the running `frames_len` accumulation is the DB-derived aggregate.)
+
+Replace the binary-tag site:
+
+```rust
+        frames_len += 10 + bt.len.get();
+```
+
+with (here `bt.len.get()` is a raw DB length, so the inner `10 + …` is checked too):
+
+```rust
+        frames_len = size::checked_add(frames_len, size::checked_add(10, bt.len.get())?)?;
+```
+
+Replace the art-loop body length:
+
+```rust
+        let data_len = framing.len() as u64 + art.data_len.get();
+```
+
+with:
+
+```rust
+        let data_len = size::checked_add(framing.len() as u64, art.data_len.get())?;
+```
+
+Replace the art-loop accumulation:
+
+```rust
+        frames_len += 10 + data_len;
+```
+
+with:
+
+```rust
+        frames_len = size::checked_add(frames_len, size::checked_add(10, data_len)?)?;
+```
+
+Replace the final return:
+
+```rust
+    Ok((segments, 10 + frames_len))
+```
+
+with:
+
+```rust
+    Ok((segments, size::checked_add(10, frames_len)?))
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-format build_id3v2_segments_checked_art_len_rejects_overflow`
+Expected: PASS.
+
+- [ ] **Step 6: Run mp3 tests (including the existing total-tag boundary test)**
+
+Run: `cargo test -p musefs-format mp3`
+Expected: PASS — `build_id3v2_segments_rejects_oversized_total_tag` and all other mp3 tests still pass.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/mp3.rs
+git commit -m "fix(format): checked frame-length aggregates in mp3 synthesis (#274)"
+```
+
+---
+
+## Task 5: mp4 — checked aggregates in `build_udta` and `synthesize`
+
+**Files:**
+- Modify: `musefs-format/src/mp4.rs` — imports, `build_udta` (`:625-777`), `synthesize` (`:838-843`), tests
+
+- [ ] **Step 1: Write the failing overflow test**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/mp4.rs`:
+
+```rust
+    #[test]
+    fn build_udta_checked_art_len_rejects_overflow() {
+        // A hostile art data_len near u64::MAX must fail closed with TooLarge at
+        // the covr_size fold, not panic (debug) / wrap (release).
+        let mk = |data_len: u64| crate::input::ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(data_len).unwrap(),
+        };
+        assert_eq!(
+            build_udta(&[], &[], &[mk(u64::MAX)]).err(),
+            Some(FormatError::TooLarge)
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p musefs-format build_udta_checked_art_len_rejects_overflow`
+Expected: FAIL — panics with "attempt to add with overflow" inside the `16 + a.data_len.get()` sum (debug).
+
+- [ ] **Step 3: Add the `size` import**
+
+At the top of `musefs-format/src/mp4.rs`, add:
+
+```rust
+use crate::size;
+```
+
+- [ ] **Step 4: Convert the `build_udta` aggregates**
+
+Replace the first streamed accumulation:
+
+```rust
+        streamed_total += bt.len.get();
+```
+
+with:
+
+```rust
+        streamed_total = size::checked_add(streamed_total, bt.len.get())?;
+```
+
+Replace the covr size:
+
+```rust
+        let covr_size: u64 = 8 + arts.iter().map(|a| 16 + a.data_len.get()).sum::<u64>();
+```
+
+with (each `16 + data_len` and the running sum are checked):
+
+```rust
+        let covr_size: u64 = arts.iter().try_fold(8u64, |acc, a| {
+            size::checked_add(acc, size::checked_add(16, a.data_len.get())?)
+        })?;
+```
+
+Replace the per-art data size:
+
+```rust
+            let data_size = 8 + 8 + a.data_len.get(); // data header + type + locale + image
+```
+
+with:
+
+```rust
+            let data_size = size::checked_add(16, a.data_len.get())?; // data header + type + locale + image
+```
+
+Replace the second streamed accumulation:
+
+```rust
+            streamed_total += a.data_len.get();
+```
+
+with:
+
+```rust
+            streamed_total = size::checked_add(streamed_total, a.data_len.get())?;
+```
+
+Replace the three enclosing box sizes:
+
+```rust
+    let ilst_size = 8 + ilst_inline_len + streamed_total;
+    let meta_inline_len = 4 + hdlr.len() as u64 + 8 + ilst_inline_len; // [vf][hdlr][ilst hdr][ilst inline]
+    let meta_size = 8 + meta_inline_len + streamed_total;
+    let udta_inline_len = 8 + meta_inline_len; // [meta hdr][meta inline]
+    let udta_size = 8 + udta_inline_len + streamed_total;
+```
+
+with (only the `*_size` values fold in `streamed_total`, the DB aggregate; `*_inline_len` sum only inline framing and stay as-is):
+
+```rust
+    let ilst_size = size::checked_sum([8, ilst_inline_len, streamed_total])?;
+    let meta_inline_len = 4 + hdlr.len() as u64 + 8 + ilst_inline_len; // [vf][hdlr][ilst hdr][ilst inline]
+    let meta_size = size::checked_sum([8, meta_inline_len, streamed_total])?;
+    let udta_inline_len = 8 + meta_inline_len; // [meta hdr][meta inline]
+    let udta_size = size::checked_sum([8, udta_inline_len, streamed_total])?;
+```
+
+- [ ] **Step 5: Convert the `synthesize` aggregates**
+
+Replace:
+
+```rust
+    let new_moov_size = 8 + kept.len() as u64 + udta_total;
+```
+
+with:
+
+```rust
+    let new_moov_size = size::checked_sum([8, kept.len() as u64, udta_total])?;
+```
+
+Replace:
+
+```rust
+    let new_mdat_payload_pos =
+        scan.ftyp.len() as u64 + new_moov_size + scan.mdat_header.len() as u64;
+```
+
+with:
+
+```rust
+    let new_mdat_payload_pos = size::checked_sum([
+        scan.ftyp.len() as u64,
+        new_moov_size,
+        scan.mdat_header.len() as u64,
+    ])?;
+```
+
+(`udta_total` — the `.sum()` over `udta_segments` lengths just above — is left unchecked: it is only reached once `build_udta` has already succeeded, which bounds every box size to `<= u32::MAX`, so the sum cannot overflow.)
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-format build_udta_checked_art_len_rejects_overflow`
+Expected: PASS.
+
+- [ ] **Step 7: Run mp4 tests (including the `new_moov_size` / `udta_size` boundary tests)**
+
+Run: `cargo test -p musefs-format mp4`
+Expected: PASS — `synthesize_new_moov_size_exactly_u32_max_is_ok` and the other mp4 tests still pass.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/mp4.rs
+git commit -m "fix(format): checked box-size aggregates in mp4 synthesis (#274)"
+```
+
+---
+
+## Task 6: wav — checked aggregate for the RIFF size
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` — imports, the `synthesize` RIFF-size block (`:275-276`)
+
+- [ ] **Step 1: Add the `size` import**
+
+At the top of `musefs-format/src/wav.rs`, add:
+
+```rust
+use crate::size;
+```
+
+- [ ] **Step 2: Convert the body length and RIFF size**
+
+Replace:
+
+```rust
+    let body_len: u64 = segments.iter().map(Segment::len).sum();
+    let riff_size = u32::try_from(body_len + 4).map_err(|_| FormatError::TooLarge)?;
+```
+
+with:
+
+```rust
+    let body_len: u64 = size::checked_sum(segments.iter().map(Segment::len))?;
+    let riff_size =
+        u32::try_from(size::checked_add(body_len, 4)?).map_err(|_| FormatError::TooLarge)?;
+```
+
+- [ ] **Step 3: Run wav tests**
+
+Run: `cargo test -p musefs-format wav`
+Expected: PASS — `synthesize_rejects_riff_size_overflow` (the observable `riff_size > u32::MAX` boundary) and all other wav tests still pass.
+
+> **No new u64-overflow unit test:** the wav body is the id3 tag (bounded to ≤ `0x0FFF_FFFF` by `build_id3v2_segments`) plus a `u32`-bounded `data` chunk, so `body_len` cannot approach `u64::MAX` through the public API — the conversion is defensive, and `synthesize_rejects_riff_size_overflow` already pins the reachable boundary. Do not invent an unreachable test.
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/wav.rs
+git commit -m "fix(format): checked RIFF-size aggregate in wav synthesis (#274)"
+```
+
+---
+
+## Task 7: flac — checked aggregate for the picture block body
+
+**Files:**
+- Modify: `musefs-format/src/flac.rs` — imports, the picture loop (`:304`), tests
+
+- [ ] **Step 1: Write the failing overflow test**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/flac.rs`:
+
+```rust
+    #[test]
+    fn synthesize_layout_checked_picture_len_rejects_overflow() {
+        // A hostile art data_len near u64::MAX must fail closed with TooLarge at
+        // the checked add, not panic (debug) / wrap (release) past the
+        // MAX_BLOCK_BODY guard.
+        let mk = |data_len: u64| ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(data_len).unwrap(),
+        };
+        assert_eq!(
+            synthesize_layout(&[], 0, 0, &[], &[], &[mk(u64::MAX)]),
+            Err(FormatError::TooLarge)
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p musefs-format synthesize_layout_checked_picture_len_rejects_overflow`
+Expected: FAIL — panics with "attempt to add with overflow" at `framing.len() as u64 + art.data_len.get()` (debug).
+
+- [ ] **Step 3: Add the `size` import**
+
+At the top of `musefs-format/src/flac.rs`, add:
+
+```rust
+use crate::size;
+```
+
+- [ ] **Step 4: Convert the picture body length**
+
+Replace:
+
+```rust
+        let body_len = framing.len() as u64 + art.data_len.get();
+```
+
+with:
+
+```rust
+        let body_len = size::checked_add(framing.len() as u64, art.data_len.get())?;
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-format synthesize_layout_checked_picture_len_rejects_overflow`
+Expected: PASS.
+
+- [ ] **Step 6: Run flac tests (including the picture-block boundary test)**
+
+Run: `cargo test -p musefs-format flac`
+Expected: PASS — `synthesize_layout_picture_block_size_boundary_is_inclusive` and all other flac tests still pass.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/flac.rs
+git commit -m "fix(format): checked picture-block aggregate in flac synthesis (#274)"
+```
+
+---
+
+## Task 8: ogg — checked VorbisComment picture `value_len`
+
+**Files:**
+- Modify: `musefs-format/src/ogg/mod.rs` — imports, `build_packets_with_art` pre-flight (`:345-353`), `comment_packet_chunks` emit (`:396-405`), tests
+
+- [ ] **Step 1: Write the failing overflow test**
+
+Add to `#[cfg(test)] mod tests` in `musefs-format/src/ogg/mod.rs` (mirrors the existing `oversized_full_art_value_rejected_by_build_packets`):
+
+```rust
+    #[test]
+    fn near_u64_max_art_value_rejected_by_build_packets() {
+        // data_len near u64::MAX makes b64_len(data_len) overflow u64; the builder
+        // must fail closed with TooLarge at the checked b64 length, not panic
+        // (debug) inside the pre-flight value_len computation.
+        let meta = crate::input::ArtInput {
+            art_id: 0,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            data_len: crate::input::BlobLen::new(u64::MAX).unwrap(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+        };
+        let art = OggArt { meta: &meta };
+        let header = OggHeader {
+            codec: Codec::Vorbis,
+            serial: 0,
+            packets: vec![vec![], vec![], vec![]],
+            header_pages: 1,
+            audio_offset: 0,
+        };
+        assert_eq!(
+            build_packets_with_art(&header, &[], &[art]),
+            Err(FormatError::TooLarge)
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p musefs-format near_u64_max_art_value_rejected_by_build_packets`
+Expected: FAIL — panics with "attempt to multiply with overflow" inside `b64_len(a.meta.data_len.get())` (debug).
+
+- [ ] **Step 3: Add the `size` import**
+
+At the top of `musefs-format/src/ogg/mod.rs`, add (if not already present):
+
+```rust
+use crate::size;
+```
+
+- [ ] **Step 4: Convert the pre-flight value length**
+
+In `build_packets_with_art`, replace:
+
+```rust
+            for a in arts {
+                let prefix = picture_prefix(a.meta)?;
+                let b64_prefix_len = b64_len(prefix.len() as u64);
+                let value_len = METADATA_BLOCK_PICTURE_KEY.len() as u64
+                    + b64_prefix_len
+                    + b64_len(a.meta.data_len.get());
+                if value_len > u64::from(u32::MAX) {
+                    return Err(FormatError::TooLarge);
+                }
+            }
+```
+
+with:
+
+```rust
+            for a in arts {
+                let prefix = picture_prefix(a.meta)?;
+                let b64_prefix_len =
+                    b64_len_checked(prefix.len() as u64).ok_or(FormatError::TooLarge)?;
+                let b64_image_len =
+                    b64_len_checked(a.meta.data_len.get()).ok_or(FormatError::TooLarge)?;
+                let value_len = size::checked_sum([
+                    METADATA_BLOCK_PICTURE_KEY.len() as u64,
+                    b64_prefix_len,
+                    b64_image_len,
+                ])?;
+                if value_len > u64::from(u32::MAX) {
+                    return Err(FormatError::TooLarge);
+                }
+            }
+```
+
+(`b64_len_checked` is in scope via the re-export added in Task 2.)
+
+- [ ] **Step 5: Convert the emitted value length**
+
+In `comment_packet_chunks`, replace:
+
+```rust
+        let value_len = METADATA_BLOCK_PICTURE_KEY.len()
+            + b64_prefix.len()
+            + crate::convert::usize_from(b64_len(art.meta.data_len.get()));
+        head.extend_from_slice(
+            &u32::try_from(value_len)
+                .map_err(|_| FormatError::TooLarge)?
+                .to_le_bytes(),
+        );
+```
+
+with (compute in `u64` with checked helpers, then narrow to `u32`):
+
+```rust
+        let b64_image_len =
+            b64_len_checked(art.meta.data_len.get()).ok_or(FormatError::TooLarge)?;
+        let value_len = size::checked_sum([
+            METADATA_BLOCK_PICTURE_KEY.len() as u64,
+            b64_prefix.len() as u64,
+            b64_image_len,
+        ])?;
+        head.extend_from_slice(
+            &u32::try_from(value_len)
+                .map_err(|_| FormatError::TooLarge)?
+                .to_le_bytes(),
+        );
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-format near_u64_max_art_value_rejected_by_build_packets`
+Expected: PASS.
+
+- [ ] **Step 7: Run ogg tests (including the existing u32 value-length boundary tests)**
+
+Run: `cargo test -p musefs-format ogg`
+Expected: PASS — `oversized_full_art_value_rejected_by_build_packets`, `sum_overflow_art_value_rejected_by_build_packets`, and the `value_len == u32::MAX` acceptance test still pass.
+
+- [ ] **Step 8: Confirm the fuzz crate still builds**
+
+Run: `cargo +nightly fuzz build`
+Expected: builds — the ogg changes are internal (no public signature change).
+(Skip with a note if the nightly toolchain / `cargo-fuzz` is unavailable.)
+
+- [ ] **Step 9: Full workspace check, lint, commit**
+
+```bash
+cargo test -p musefs-format
+cargo clippy -p musefs-format --all-targets
+git add musefs-format/src/ogg/mod.rs
+git commit -m "fix(format): checked VorbisComment picture value_len in ogg synthesis (#274)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full workspace suite and lint (mirrors the pre-commit gate)**
+
+Run:
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets
+cargo test
+```
+Expected: all green.
+
+- [ ] **Confirm the fuzz crate builds one last time**
+
+Run: `cargo +nightly fuzz build`
+Expected: builds.

--- a/docs/superpowers/plans/2026-06-12-layout-bounds-hardening.md
+++ b/docs/superpowers/plans/2026-06-12-layout-bounds-hardening.md
@@ -15,7 +15,7 @@
 ## File Structure
 
 - **Create** `musefs-format/src/size.rs` — `pub(crate)` checked aggregate-size helpers (`checked_add`, `checked_sum`) returning `FormatError::TooLarge`. One responsibility: overflow-safe size arithmetic for builders.
-- **Modify** `musefs-format/src/lib.rs` — register `mod size;`.
+- **Modify** `musefs-format/src/lib.rs` — register `mod size;` (between `pub mod probe;` at line 9 and `mod tagmap;` at line 10).
 - **Modify** `musefs-format/src/ogg/b64.rs` — add `b64_len_checked`; make `b64_len` delegate; add a reader-safety boundary test.
 - **Modify** `musefs-format/src/ogg/mod.rs` — re-export `b64_len_checked`; switch the two VorbisComment picture `value_len` computations to checked helpers; add an overflow test.
 - **Modify** `musefs-format/src/layout.rs` — two new `LayoutError` variants; `OggArtSlice` case in `validate`; Part A tests.
@@ -437,19 +437,21 @@ use crate::size;
 
 - [ ] **Step 4: Convert the accumulation sites**
 
-Replace **every** occurrence (6 of them) of:
+This accumulator line appears **8 times** at three different indentation levels (text/id3-text paths at 16 spaces; the TXXX/COMMENT/USLT/fallback-TXXX `for value in values` loops at 20 spaces; and the **POPM and UFID** accumulators at 8 spaces). Use a **`replace_all`** keyed on the substring **starting at `frames_len`** (no leading whitespace in the match), so each line's existing indentation is left untouched and all 8 sites — including POPM/UFID — are converted in one operation. Do not key on an indented copy (it would match only the sites at that one indent level), and do not edit site-by-site (you may miss POPM/UFID).
 
-```rust
-                frames_len += 10 + data.len() as u64;
+Replace this substring (exactly, no leading spaces):
+
+```
+frames_len += 10 + data.len() as u64;
 ```
 
 with:
 
-```rust
-                frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
+```
+frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
 ```
 
-(`data` is a freshly built `Vec`, so `10 + data.len()` cannot itself overflow; only the running `frames_len` accumulation is the DB-derived aggregate.)
+After the replace, confirm with `grep -c "frames_len += 10 + data.len() as u64;" musefs-format/src/mp3.rs` returning `0`. (`data` is a freshly built `Vec`, so `10 + data.len()` cannot itself overflow; only the running `frames_len` accumulation is the DB-derived aggregate.)
 
 Replace the binary-tag site:
 
@@ -690,7 +692,7 @@ git commit -m "fix(format): checked box-size aggregates in mp4 synthesis (#274)"
 ## Task 6: wav — checked aggregate for the RIFF size
 
 **Files:**
-- Modify: `musefs-format/src/wav.rs` — imports, the `synthesize` RIFF-size block (`:275-276`)
+- Modify: `musefs-format/src/wav.rs` — imports, the `synthesize_layout` RIFF-size block (`:275-276`)
 
 - [ ] **Step 1: Add the `size` import**
 

--- a/docs/superpowers/specs/2026-06-12-layout-bounds-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-layout-bounds-hardening-design.md
@@ -1,0 +1,189 @@
+# Layout bounds hardening (#273 + #274)
+
+## Summary
+
+Two coordinated hardening changes in `musefs-format`, both failing closed at the
+exact arithmetic/validation boundary instead of relying on a downstream check:
+
+- **#273** — `RegionLayout::validate` does not bounds-check `Segment::OggArtSlice`
+  against its source art. Add the missing invariants.
+- **#274** — Several format synthesis builders use unchecked `+` / `+=` /
+  `sum::<u64>()` over attacker-controlled, DB-derived lengths before the final
+  format-size or `RegionLayout` validation boundary. Replace that aggregate math
+  with checked helpers that return `FormatError::TooLarge`.
+
+Both findings come from the same adversarial audit. In ordinary scanner-produced
+data the values are small; under a hostile or externally written store
+(`art.byte_len`, binary tag lengths, structural block bodies, text values) they
+can be adversarial. `RegionLayout::validate` often catches total-length overflow
+eventually, but that is too late and too indirect: debug builds can panic on
+overflow instead of returning `TooLarge`, release builds may wrap intermediate
+box/frame sizes and only fail later by accident, and future changes could weaken
+the later validation and turn a wrapped size into emitted metadata.
+
+## Part A — `OggArtSlice` bounds in `RegionLayout::validate` (#273)
+
+### Current state
+
+`RegionLayout::validate` (`musefs-format/src/layout.rs`) validates empty
+non-backing segments, `BackingAudio`/`OggAudio` range overflow
+(`offset + len`), and total synthesized length overflow. It does **not** verify
+that an `OggArtSlice` names a valid output window for its source art.
+
+`Segment::OggArtSlice { art_id, offset, len, base64, art_total }`:
+
+- raw (`base64 == false`): the run is `len` raw image bytes starting at raw
+  offset `offset`; the source is `art_total` bytes.
+- base64 (`base64 == true`): the run is `len` chars of `base64(image)` starting
+  at output offset `offset`; the full encoded length is `b64_len(art_total)`.
+
+The reader path (`musefs-core/src/reader.rs`, and `musefs-format/src/ogg`)
+assumes these relationships when it computes
+`b64_window(*offset + within, n, *art_total)` or streams raw art at
+`*offset + within`. An invalid layout can currently pass validation and reach
+serving code, producing unexpected read errors, short reads, or panics
+depending on which path observes the out-of-range slice.
+
+### Change
+
+Add a case for `Segment::OggArtSlice` to the `validate` loop. `len` is a
+`BlobLen` (`NonZeroU64`), so the existing `EmptySegment` check already covers
+zero length; the new logic only concerns bounds:
+
+1. Compute the permitted output length:
+   - raw: `art_total`
+   - base64: `b64_len(art_total)`
+2. `end = offset.checked_add(len.get())`; overflow → `OggArtSliceRangeOverflow`.
+3. `end > permitted` → `OggArtSliceOutOfBounds`.
+
+`b64_len` (`img_total.div_ceil(3) * 4`) can itself overflow `u64` for an
+adversarial `art_total`. To keep validation total, introduce a checked variant
+and have the existing function delegate to it:
+
+```rust
+// musefs-format/src/ogg/b64.rs
+pub fn b64_len_checked(img_total: u64) -> Option<u64> {
+    img_total.div_ceil(3).checked_mul(4)
+}
+
+pub fn b64_len(img_total: u64) -> u64 {
+    b64_len_checked(img_total).expect("b64 output length fits u64")
+}
+```
+
+For every real image (`img_total` from a scanned file) `b64_len` returns the
+same value as today; only a deliberately hostile `art_total` near `u64::MAX`
+can trip the overflow. Inside `validate`, base64 slices use `b64_len_checked`
+and treat `None` as a bounds failure (fail closed): a `None` permitted length
+maps to `OggArtSliceRangeOverflow`.
+
+### Error variants
+
+`LayoutError` gains two variants, mirroring the existing split between an
+overflow error (`BackingRangeOverflow`) and a semantic violation
+(`TotalOverflow`):
+
+```rust
+/// An Ogg art slice's offset + length overflowed u64, or its base64 output
+/// length overflowed u64.
+#[error("ogg art slice range offset + length overflowed u64")]
+OggArtSliceRangeOverflow,
+/// An Ogg art slice names an output window past the end of its source art.
+#[error("ogg art slice output window exceeds the source art length")]
+OggArtSliceOutOfBounds,
+```
+
+### Tests (`layout.rs` `tests`)
+
+- raw slice with `offset + len > art_total` → `OggArtSliceOutOfBounds`
+- base64 slice with `offset + len > b64_len(art_total)` → `OggArtSliceOutOfBounds`
+- slice with `offset + len` overflowing `u64` → `OggArtSliceRangeOverflow`
+- base64 slice with `art_total` whose `b64_len` overflows `u64` →
+  `OggArtSliceRangeOverflow`
+- passing boundary: raw `end == art_total` and base64 `end == b64_len(art_total)`
+  both validate `Ok`
+
+## Part B — checked aggregate length math in builders (#274)
+
+### Helpers
+
+New `pub(crate)` module `musefs-format/src/size.rs` (kept separate from
+`convert.rs`, which is scoped to sanctioned casts):
+
+```rust
+//! Checked aggregate size arithmetic for synthesis builders. Aggregates over
+//! attacker-controlled, DB-derived lengths must fail closed with
+//! `FormatError::TooLarge` at the format arithmetic boundary, not wrap (release)
+//! or panic (debug) and only fail later via `RegionLayout::validate`.
+
+pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64> {
+    a.checked_add(b).ok_or(FormatError::TooLarge)
+}
+
+pub(crate) fn checked_sum(iter: impl IntoIterator<Item = u64>) -> Result<u64> {
+    iter.into_iter().try_fold(0u64, checked_add)
+}
+```
+
+`u32` box/frame-size conversions keep their existing
+`u32::try_from(...).map_err(|_| FormatError::TooLarge)` form (and mp3's
+`SYNCHSAFE_MAX` filter), but now take an **already checked** `u64`, so the `+`
+inside the `try_from` argument can no longer wrap.
+
+### Sites
+
+- **`mp3.rs`** (`build_id3v2_segments`): every `frames_len += 10 + …` accumulation
+  (the per-frame `10 + data.len()`, `10 + bt.len.get()`, `10 + data_len` cases)
+  and the final returned `10 + frames_len`.
+- **`mp4.rs`** (`build_udta` / `synthesize`): `streamed_total += …`;
+  `covr_size = 8 + Σ(16 + data_len)`; `ilst_size` / `meta_size` / `udta_size`
+  (`8 + inline_len + streamed_total`); `new_moov_size`
+  (`8 + kept.len() + udta_total`); `new_mdat_payload_pos`
+  (`ftyp.len() + new_moov_size + mdat_header.len()`).
+- **`wav.rs`**: `body_len + 4` inside the `riff_size` `u32::try_from`.
+- **`flac.rs`**: picture/body aggregate lengths
+  (`framing.len() as u64 + art_len`, comment/body length sums).
+- **`ogg/mod.rs`**: `b64_prefix_len + b64_len(...)`,
+  `prefix.len() as u64 + b64_len(data_len)`, and Vorbis/MBP value-length sums.
+
+Each `+` / `+=` / `sum::<u64>()` over a DB-derived length becomes a
+`size::checked_add` / `size::checked_sum` returning `FormatError::TooLarge`.
+Constant-only additions over already-bounded local buffer lengths
+(`Vec::len()` of freshly built inline bytes) are left as-is where they cannot be
+attacker-driven; the audit's named sites — all of which mix in a DB-derived
+length — are the ones converted.
+
+### Tests
+
+Per affected builder, construct synthetic `ArtInput` / `BinaryTagInput` with
+lengths near `u64::MAX` (or several `i64::MAX`-sized inputs that sum past
+`u64::MAX`) and assert `Err(FormatError::TooLarge)` rather than a panic. These
+sit alongside the existing per-format overflow tests
+(`synthesize_rejects_riff_size_overflow`, the mp3 `frames_len` boundary tests,
+the mp4 `new_moov_size` boundary tests).
+
+## Non-goals
+
+- `RegionLayout::validate` keeps its role as the final belt-and-suspenders check;
+  it is not removed or weakened. Part B makes builders fail closed *earlier* so
+  validation is no longer the first line that discovers format arithmetic
+  overflow.
+- No new public API beyond `b64_len_checked` and the two `LayoutError` variants.
+  The `size.rs` helpers are `pub(crate)`.
+- No changes to serving/read paths; the reader already assumes the invariants
+  Part A now enforces.
+
+## Sequencing
+
+The pre-commit hook runs the full workspace test suite, so each commit must be
+green:
+
+1. `size.rs` helpers + their unit tests.
+2. `b64_len_checked` delegation + Part A `validate` changes, the two
+   `LayoutError` variants, and the layout bounds tests.
+3. Per-format builder conversions to the helpers, each commit carrying its own
+   `TooLarge` tests (mp3, mp4, wav, flac, ogg).
+
+The `fuzz/` crate is outside the workspace and consumes format-layer APIs;
+run `cargo +nightly fuzz build` after the `b64`/signature touchpoints to confirm
+no silent breakage.

--- a/docs/superpowers/specs/2026-06-12-layout-bounds-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-layout-bounds-hardening-design.md
@@ -77,6 +77,27 @@ can trip the overflow. Inside `validate`, base64 slices use `b64_len_checked`
 and treat `None` as a bounds failure (fail closed): a `None` permitted length
 maps to `OggArtSliceRangeOverflow`.
 
+### Why this keeps the reader safe (no read-path change needed)
+
+`b64_window` (`musefs-format/src/ogg/b64.rs`) computes its read plan with
+unchecked `+`/`*` (`(out_offset + take - 1) / 4`, then `(g1 + 1) * 3`). It is a
+format-layer helper, and the reader calls it as
+`b64_window(*offset + within, n, *art_total)` where `within + n <= len`
+(reads are clipped to the segment). The new Part A invariant is exactly what
+bounds those inputs:
+
+- `b64_len_checked(art_total)` is `Some`, so `b64_len(art_total) <= u64::MAX`.
+- `offset + len <= b64_len(art_total)`, and `within + n <= len`, so
+  `out_offset + take = offset + within + n <= offset + len <= b64_len(art_total)
+  <= u64::MAX` — the `out_offset + take - 1` cannot overflow.
+- Hence `g1 = (out_offset + take - 1) / 4 <= u64::MAX / 4`, so
+  `(g1 + 1) * 3 <= ~0.75 * u64::MAX` and `g0 * 3 <= ~0.75 * u64::MAX` — no
+  multiplication overflow.
+
+So for any layout that passes the extended `validate`, `b64_window` is
+overflow-free. `b64_window` itself is left unchanged; the read path is not
+touched. A boundary test (below) pins this invariant.
+
 ### Error variants
 
 `LayoutError` gains two variants, mirroring the existing split between an
@@ -85,8 +106,8 @@ overflow error (`BackingRangeOverflow`) and a semantic violation
 
 ```rust
 /// An Ogg art slice's offset + length overflowed u64, or its base64 output
-/// length overflowed u64.
-#[error("ogg art slice range offset + length overflowed u64")]
+/// length (`b64_len(art_total)`) overflowed u64.
+#[error("ogg art slice range (offset + length, or base64 output length) overflowed u64")]
 OggArtSliceRangeOverflow,
 /// An Ogg art slice names an output window past the end of its source art.
 #[error("ogg art slice output window exceeds the source art length")]
@@ -102,6 +123,10 @@ OggArtSliceOutOfBounds,
   `OggArtSliceRangeOverflow`
 - passing boundary: raw `end == art_total` and base64 `end == b64_len(art_total)`
   both validate `Ok`
+- reader-safety boundary (in `ogg/b64.rs` tests): a base64 window at the very end
+  of a maximal validated slice (`out_offset = b64_len(art_total) - take`) produces
+  a sane `B64Window` with no arithmetic overflow — locks the invariant the
+  "reader safe" argument above relies on
 
 ## Part B — checked aggregate length math in builders (#274)
 
@@ -130,21 +155,45 @@ pub(crate) fn checked_sum(iter: impl IntoIterator<Item = u64>) -> Result<u64> {
 `SYNCHSAFE_MAX` filter), but now take an **already checked** `u64`, so the `+`
 inside the `try_from` argument can no longer wrap.
 
+**Conversion rule.** Any aggregate expression that contains a DB-derived term is
+converted *in full* — including the constant and local-`Vec::len()` operands —
+because the wrap happens at the `+` regardless of which operand is large (e.g.
+`8 + kept.len() as u64 + udta_total` becomes a `checked_add` chain even though
+only `udta_total` is DB-derived). Additions over *only* freshly built local
+buffer lengths, with no DB-derived term, are left as-is.
+
 ### Sites
 
 - **`mp3.rs`** (`build_id3v2_segments`): every `frames_len += 10 + …` accumulation
   (the per-frame `10 + data.len()`, `10 + bt.len.get()`, `10 + data_len` cases)
   and the final returned `10 + frames_len`.
-- **`mp4.rs`** (`build_udta` / `synthesize`): `streamed_total += …`;
-  `covr_size = 8 + Σ(16 + data_len)`; `ilst_size` / `meta_size` / `udta_size`
-  (`8 + inline_len + streamed_total`); `new_moov_size`
-  (`8 + kept.len() + udta_total`); `new_mdat_payload_pos`
-  (`ftyp.len() + new_moov_size + mdat_header.len()`).
+- **`mp4.rs`** (`build_udta` / `synthesize`): the `streamed_total += bt.len.get()`
+  / `+= a.data_len.get()` accumulators (per-iteration `checked_add`, matching the
+  mp3 `frames_len` pattern); `covr_size = 8 + Σ(16 + data_len)` (a `checked_sum`
+  fold); `ilst_size` / `meta_size` / `udta_size` (`8 + inline_len +
+  streamed_total`); `new_moov_size` (`8 + kept.len() + udta_total`);
+  `new_mdat_payload_pos` (`ftyp.len() + new_moov_size + mdat_header.len()`).
 - **`wav.rs`**: `body_len + 4` inside the `riff_size` `u32::try_from`.
-- **`flac.rs`**: picture/body aggregate lengths
-  (`framing.len() as u64 + art_len`, comment/body length sums).
-- **`ogg/mod.rs`**: `b64_prefix_len + b64_len(...)`,
-  `prefix.len() as u64 + b64_len(data_len)`, and Vorbis/MBP value-length sums.
+- **`flac.rs`**: the one DB-derived aggregate, `body_len = framing.len() as u64 +
+  art.data_len.get()` (`flac.rs:304`), guarded immediately after by
+  `> MAX_BLOCK_BODY` — the `+` must not be allowed to wrap past that guard. (The
+  comment block uses `vc.len()` of an already-materialized `Vec` and binary tags
+  use `bt.len.get()` directly; neither is an unchecked aggregate, so neither is
+  touched.)
+- **`ogg/mod.rs`**: two computations of the VorbisComment picture `value_len`
+  over the DB-derived image length — the pre-flight `> u32::MAX` guard
+  (`mod.rs:347-350`, `u64`) and the emitted value in `comment_packet_chunks`
+  (`mod.rs:396-405`, `usize`). Both currently call the **panicking** `b64_len`
+  over `art.meta.data_len` *before* the `u32` guard, so a hostile `data_len`
+  panics (debug) or wraps (release) ahead of the check. Both call sites switch to
+  `b64_len_checked(...).ok_or(FormatError::TooLarge)?` and use checked adds for
+  the `KEY.len() + b64_prefix.len() + b64_len(data_len)` sum (the emitted one in
+  `usize`, the pre-flight in `u64`).
+
+  (Issue #274 also mentions "Vorbis/MBP value-length sums", but
+  `vorbiscomment::build` length-prefixes each comment individually with a guarded
+  `u32::try_from(comment.len())` over a single materialized `String` — there is no
+  unchecked aggregate there, so it is not touched.)
 
 Each `+` / `+=` / `sum::<u64>()` over a DB-derived length becomes a
 `size::checked_add` / `size::checked_sum` returning `FormatError::TooLarge`.
@@ -160,7 +209,9 @@ lengths near `u64::MAX` (or several `i64::MAX`-sized inputs that sum past
 `u64::MAX`) and assert `Err(FormatError::TooLarge)` rather than a panic. These
 sit alongside the existing per-format overflow tests
 (`synthesize_rejects_riff_size_overflow`, the mp3 `frames_len` boundary tests,
-the mp4 `new_moov_size` boundary tests).
+the mp4 `new_moov_size` boundary tests). For ogg specifically, add a test with an
+art `data_len` near `u64::MAX` asserting `Err(FormatError::TooLarge)` rather than
+a `b64_len` panic, covering both the pre-flight guard and the emitted value.
 
 ## Non-goals
 
@@ -184,6 +235,12 @@ green:
 3. Per-format builder conversions to the helpers, each commit carrying its own
    `TooLarge` tests (mp3, mp4, wav, flac, ogg).
 
-The `fuzz/` crate is outside the workspace and consumes format-layer APIs;
-run `cargo +nightly fuzz build` after the `b64`/signature touchpoints to confirm
-no silent breakage.
+The `fuzz/` crate is outside the workspace and consumes format-layer APIs, so it
+breaks only in CI's smoke job. There are two fuzz-visible touchpoints; run
+`cargo +nightly fuzz build` after each:
+
+- after commit 2 — `b64_len_checked` is added and `b64_len`'s body changes;
+- after the ogg commit (commit 3) — the ogg builder call sites change.
+
+(`b64_len_checked` lands in commit 2, so the ogg builder commit that depends on
+it must come after.)

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -1,5 +1,6 @@
 use crate::error::{FormatError, Result};
 use crate::probe::Extent;
+use crate::size;
 
 pub(crate) const FLAC_MARKER: &[u8; 4] = b"fLaC";
 
@@ -301,7 +302,7 @@ pub fn synthesize_layout(
 
     for art in arts {
         let framing = picture_body_framing(art)?;
-        let body_len = framing.len() as u64 + art.data_len.get();
+        let body_len = size::checked_add(framing.len() as u64, art.data_len.get())?;
         if body_len > MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
         }
@@ -997,6 +998,26 @@ mod tests {
         let tags = [TagInput::new("title", over.as_str())];
         assert_eq!(
             synthesize_layout(&[], 0, 0, &tags, &[], &[]),
+            Err(FormatError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn synthesize_layout_checked_picture_len_rejects_overflow() {
+        // A hostile art data_len near u64::MAX must fail closed with TooLarge at
+        // the checked add, not panic (debug) / wrap (release) past the
+        // MAX_BLOCK_BODY guard.
+        let mk = |data_len: u64| ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(data_len).unwrap(),
+        };
+        assert_eq!(
+            synthesize_layout(&[], 0, 0, &[], &[], &[mk(u64::MAX)]),
             Err(FormatError::TooLarge)
         );
     }

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -12,6 +12,13 @@ pub enum LayoutError {
     /// A backing-audio run's offset + length overflowed u64.
     #[error("backing-audio range offset + length overflowed u64")]
     BackingRangeOverflow,
+    /// An Ogg art slice's offset + length overflowed u64, or its base64 output
+    /// length (`b64_len(art_total)`) overflowed u64.
+    #[error("ogg art slice range (offset + length, or base64 output length) overflowed u64")]
+    OggArtSliceRangeOverflow,
+    /// An Ogg art slice names an output window past the end of its source art.
+    #[error("ogg art slice output window exceeds the source art length")]
+    OggArtSliceOutOfBounds,
 }
 
 /// One contiguous run of bytes in a synthesized virtual file.
@@ -155,6 +162,27 @@ impl RegionLayout {
                     .checked_add(*len)
                     .ok_or(LayoutError::BackingRangeOverflow)?;
             }
+            if let Segment::OggArtSlice {
+                offset,
+                len: slice_len,
+                base64,
+                art_total,
+                ..
+            } = seg
+            {
+                let permitted = if *base64 {
+                    crate::ogg::b64_len_checked(*art_total)
+                        .ok_or(LayoutError::OggArtSliceRangeOverflow)?
+                } else {
+                    *art_total
+                };
+                let end = offset
+                    .checked_add(slice_len.get())
+                    .ok_or(LayoutError::OggArtSliceRangeOverflow)?;
+                if end > permitted {
+                    return Err(LayoutError::OggArtSliceOutOfBounds);
+                }
+            }
             total = total.checked_add(len).ok_or(LayoutError::TotalOverflow)?;
         }
         Ok(())
@@ -164,6 +192,90 @@ impl RegionLayout {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_rejects_raw_ogg_art_slice_past_source() {
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 5,
+            len: BlobLen::new(10).unwrap(),
+            base64: false,
+            art_total: 12,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_base64_ogg_art_slice_past_source() {
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 2,
+            len: BlobLen::new(4).unwrap(),
+            base64: true,
+            art_total: 3,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_ogg_art_slice_offset_len_overflow() {
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: u64::MAX,
+            len: BlobLen::new(1).unwrap(),
+            base64: false,
+            art_total: u64::MAX,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceRangeOverflow)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_base64_ogg_art_slice_when_b64_len_overflows() {
+        let seg = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 0,
+            len: BlobLen::new(1).unwrap(),
+            base64: true,
+            art_total: u64::MAX,
+        };
+        assert_eq!(
+            RegionLayout::new(vec![seg, Segment::BackingAudio { offset: 0, len: 1 }]).validate(),
+            Err(LayoutError::OggArtSliceRangeOverflow)
+        );
+    }
+
+    #[test]
+    fn validate_accepts_ogg_art_slice_at_source_boundary() {
+        let raw = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 2,
+            len: BlobLen::new(10).unwrap(),
+            base64: false,
+            art_total: 12,
+        };
+        RegionLayout::new(vec![raw, Segment::BackingAudio { offset: 0, len: 1 }])
+            .validate()
+            .unwrap();
+        let b64 = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 0,
+            len: BlobLen::new(4).unwrap(),
+            base64: true,
+            art_total: 3,
+        };
+        RegionLayout::new(vec![b64, Segment::BackingAudio { offset: 0, len: 1 }])
+            .validate()
+            .unwrap();
+    }
 
     #[test]
     fn binary_tag_segment_len_and_validate() {

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -7,6 +7,7 @@ pub mod mp3;
 pub mod mp4;
 pub mod ogg;
 pub mod probe;
+mod size;
 mod tagmap;
 mod vorbiscomment;
 pub mod wav;

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -5,6 +5,7 @@ use crate::input::{
 };
 use crate::layout::{RegionLayout, Segment};
 use crate::probe::Extent;
+use crate::size;
 
 /// Where the MP3 audio frames begin and end (excluding any ID3v2 prefix and
 /// ID3v1 trailer). Unlike FLAC there is no preserved structural metadata: the
@@ -285,14 +286,14 @@ pub fn build_id3v2_segments(
                 let data = text_frame_data(values);
                 push_frame_header(&mut buf, id, data.len())?;
                 buf.extend_from_slice(&data);
-                frames_len += 10 + data.len() as u64;
+                frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
             }
             Some(crate::tagmap::Id3Slot::Txxx(desc)) => {
                 for value in values {
                     let data = txxx_frame_data(desc, value);
                     push_frame_header(&mut buf, b"TXXX", data.len())?;
                     buf.extend_from_slice(&data);
-                    frames_len += 10 + data.len() as u64;
+                    frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
                 }
             }
             Some(crate::tagmap::Id3Slot::Comment) => {
@@ -300,7 +301,7 @@ pub fn build_id3v2_segments(
                     let data = comm_like_frame_data(value);
                     push_frame_header(&mut buf, b"COMM", data.len())?;
                     buf.extend_from_slice(&data);
-                    frames_len += 10 + data.len() as u64;
+                    frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
                 }
             }
             Some(crate::tagmap::Id3Slot::Lyrics) => {
@@ -308,7 +309,7 @@ pub fn build_id3v2_segments(
                     let data = comm_like_frame_data(value);
                     push_frame_header(&mut buf, b"USLT", data.len())?;
                     buf.extend_from_slice(&data);
-                    frames_len += 10 + data.len() as u64;
+                    frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
                 }
             }
             None if is_id3_text_frame_id(key) => {
@@ -317,14 +318,14 @@ pub fn build_id3v2_segments(
                 let data = text_frame_data(values);
                 push_frame_header(&mut buf, &id, data.len())?;
                 buf.extend_from_slice(&data);
-                frames_len += 10 + data.len() as u64;
+                frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
             }
             None => {
                 for value in values {
                     let data = txxx_frame_data(key, value);
                     push_frame_header(&mut buf, b"TXXX", data.len())?;
                     buf.extend_from_slice(&data);
-                    frames_len += 10 + data.len() as u64;
+                    frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
                 }
             }
         }
@@ -335,13 +336,13 @@ pub fn build_id3v2_segments(
         let data = popm_frame_data(rating, popm_playcount);
         push_frame_header(&mut buf, b"POPM", data.len())?;
         buf.extend_from_slice(&data);
-        frames_len += 10 + data.len() as u64;
+        frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
     }
     if let Some(id) = &mbid {
         let data = ufid_frame_data(MUSICBRAINZ_UFID_OWNER, id.as_bytes());
         push_frame_header(&mut buf, b"UFID", data.len())?;
         buf.extend_from_slice(&data);
-        frames_len += 10 + data.len() as u64;
+        frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
     }
 
     // Opaque binary frames: header (inline) + streamed body (BinaryTag segment).
@@ -356,12 +357,12 @@ pub fn build_id3v2_segments(
             payload_id: bt.payload_id,
             len: bt.len,
         });
-        frames_len += 10 + bt.len.get();
+        frames_len = size::checked_add(frames_len, size::checked_add(10, bt.len.get())?)?;
     }
 
     for art in arts {
         let framing = apic_framing(art);
-        let data_len = framing.len() as u64 + art.data_len.get();
+        let data_len = size::checked_add(framing.len() as u64, art.data_len.get())?;
         push_frame_header(&mut buf, b"APIC", usize_from(data_len))?;
         buf.extend_from_slice(&framing);
         segments.push(Segment::Inline(std::mem::take(&mut buf)));
@@ -369,7 +370,7 @@ pub fn build_id3v2_segments(
             art_id: art.art_id,
             len: art.data_len,
         });
-        frames_len += 10 + data_len;
+        frames_len = size::checked_add(frames_len, size::checked_add(10, data_len)?)?;
     }
 
     if !buf.is_empty() {
@@ -392,7 +393,7 @@ pub fn build_id3v2_segments(
     header.extend_from_slice(&syncsafe(frames_len_ss));
     segments.insert(0, Segment::Inline(header));
 
-    Ok((segments, 10 + frames_len))
+    Ok((segments, size::checked_add(10, frames_len)?))
 }
 
 /// Build the synthesized region for an MP3: a fresh ID3v2.4 tag (text frames +
@@ -2089,6 +2090,25 @@ mod tests {
         assert!(
             !promoted.iter().any(|(k, v)| k == "rating" && v == "20"),
             "later rating must be dropped: {promoted:?}"
+        );
+    }
+
+    #[test]
+    fn build_id3v2_segments_checked_art_len_rejects_overflow() {
+        // A hostile art data_len near u64::MAX must fail closed with TooLarge at
+        // the checked add, not panic (debug) / wrap (release).
+        let mk = |data_len: u64| ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(data_len).unwrap(),
+        };
+        assert_eq!(
+            build_id3v2_segments(&[], &[], &[mk(u64::MAX)]).err(),
+            Some(FormatError::TooLarge)
         );
     }
 

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -620,7 +620,8 @@ fn freeform_binary_prefix(mean: &str, name: &str, payload_len: u64) -> Result<Ve
     let data_size = size::checked_add(16, payload_len)?; // data header + type + locale + payload
     let inner_len = size::checked_sum([mean_box.len() as u64, name_box.len() as u64, data_size])?;
 
-    let mut out = u32::try_from(8 + inner_len)
+    let outer_len = size::checked_add(8, inner_len)?;
+    let mut out = u32::try_from(outer_len)
         .map_err(|_| FormatError::TooLarge)?
         .to_be_bytes()
         .to_vec();
@@ -2471,6 +2472,19 @@ mod tests {
         }];
         assert_eq!(
             build_udta(&[], &bins, &[]).err(),
+            Some(FormatError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn freeform_binary_prefix_checked_outer_box_size_rejects_overflow() {
+        // A payload_len that slips past the data_size and inner_len checks can
+        // still overflow the outer `8 + inner_len` box-size add. With 1-char
+        // mean/name each boxed mean/name is 13 bytes, so inner_len = 26 + data_size
+        // = 42 + payload_len; payload_len = u64::MAX - 42 drives inner_len to exactly
+        // u64::MAX, so the outer add must fail closed, not panic (debug) / wrap (release).
+        assert_eq!(
+            freeform_binary_prefix("m", "n", u64::MAX - 42).err(),
             Some(FormatError::TooLarge)
         );
     }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -617,8 +617,8 @@ fn freeform_binary_prefix(mean: &str, name: &str, payload_len: u64) -> Result<Ve
     name_body.extend_from_slice(name.as_bytes());
     let name_box = boxed(b"name", &name_body)?;
 
-    let data_size = 8 + 8 + payload_len; // data header + type + locale + payload
-    let inner_len = mean_box.len() as u64 + name_box.len() as u64 + data_size;
+    let data_size = size::checked_add(16, payload_len)?; // data header + type + locale + payload
+    let inner_len = size::checked_sum([mean_box.len() as u64, name_box.len() as u64, data_size])?;
 
     let mut out = u32::try_from(8 + inner_len)
         .map_err(|_| FormatError::TooLarge)?
@@ -2455,6 +2455,22 @@ mod tests {
         };
         assert_eq!(
             build_udta(&[], &[], &[mk(u64::MAX)]).err(),
+            Some(FormatError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn build_udta_checked_binary_tag_len_rejects_overflow() {
+        // A hostile freeform binary-tag len near u64::MAX must fail closed with
+        // TooLarge inside freeform_binary_prefix's data_size/inner_len arithmetic,
+        // not panic (debug) / wrap (release) before the u32 box-size narrowing.
+        let bins = vec![crate::input::BinaryTagInput {
+            key: "----:com.example:x".to_string(),
+            payload_id: 1,
+            len: BlobLen::new(u64::MAX).unwrap(),
+        }];
+        assert_eq!(
+            build_udta(&[], &bins, &[]).err(),
             Some(FormatError::TooLarge)
         );
     }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -9,6 +9,7 @@ use crate::input::{
     ArtInput, BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture, PictureType, TagInput,
 };
 use crate::layout::{RegionLayout, Segment};
+use crate::size;
 use std::io::{self, Read, Seek, SeekFrom};
 
 const MAX_MP4_METADATA_BYTES: u64 = 256 * 1024 * 1024;
@@ -693,13 +694,15 @@ fn build_udta(
             payload_id: bt.payload_id,
             len: bt.len,
         });
-        streamed_total += bt.len.get();
+        streamed_total = size::checked_add(streamed_total, bt.len.get())?;
     }
 
     if !arts.is_empty() {
         // One covr atom; each art is its own `data` child (the iTunes
         // convention for multiple artworks).
-        let covr_size: u64 = 8 + arts.iter().map(|a| 16 + a.data_len.get()).sum::<u64>();
+        let covr_size: u64 = arts.iter().try_fold(8u64, |acc, a| {
+            size::checked_add(acc, size::checked_add(16, a.data_len.get())?)
+        })?;
         ilst_inline.extend_from_slice(
             &u32::try_from(covr_size)
                 .map_err(|_| FormatError::TooLarge)?
@@ -708,7 +711,7 @@ fn build_udta(
         ilst_inline.extend_from_slice(b"covr");
         for a in arts {
             let type_code: u32 = if a.mime == "image/png" { 14 } else { 13 };
-            let data_size = 8 + 8 + a.data_len.get(); // data header + type + locale + image
+            let data_size = size::checked_add(16, a.data_len.get())?; // data header + type + locale + image
             ilst_inline.extend_from_slice(
                 &u32::try_from(data_size)
                     .map_err(|_| FormatError::TooLarge)?
@@ -722,7 +725,7 @@ fn build_udta(
                 art_id: a.art_id,
                 len: a.data_len,
             });
-            streamed_total += a.data_len.get();
+            streamed_total = size::checked_add(streamed_total, a.data_len.get())?;
         }
     } else if !ilst_inline.is_empty() {
         ilst_segments.push(Segment::Inline(std::mem::take(&mut ilst_inline)));
@@ -745,11 +748,11 @@ fn build_udta(
     // Box sizes. Each enclosing box adds its 8-byte header to the inline content of
     // its child and carries `streamed_total` through unchanged (the streamed bytes
     // live at the deepest level, inside ilst).
-    let ilst_size = 8 + ilst_inline_len + streamed_total;
+    let ilst_size = size::checked_sum([8, ilst_inline_len, streamed_total])?;
     let meta_inline_len = 4 + hdlr.len() as u64 + 8 + ilst_inline_len; // [vf][hdlr][ilst hdr][ilst inline]
-    let meta_size = 8 + meta_inline_len + streamed_total;
+    let meta_size = size::checked_sum([8, meta_inline_len, streamed_total])?;
     let udta_inline_len = 8 + meta_inline_len; // [meta hdr][meta inline]
-    let udta_size = 8 + udta_inline_len + streamed_total;
+    let udta_size = size::checked_sum([8, udta_inline_len, streamed_total])?;
 
     // MP4 box sizes are 32-bit. udta encloses all inner boxes, so converting it
     // first bounds them all; refuse oversized metadata at the format boundary
@@ -849,12 +852,15 @@ pub fn synthesize_layout(
     let (udta_segments, _streamed_total) = build_udta(tags, binary_tags, &arts)?;
     let udta_total: u64 = udta_segments.iter().map(Segment::len).sum();
 
-    let new_moov_size = 8 + kept.len() as u64 + udta_total;
+    let new_moov_size = size::checked_sum([8, kept.len() as u64, udta_total])?;
     // MP4 box sizes are 32-bit; mirror build_udta's bound. The try_from below
     // (writing the size field) is the enforcing check.
     let new_moov_size_u32 = u32::try_from(new_moov_size).map_err(|_| FormatError::TooLarge)?;
-    let new_mdat_payload_pos =
-        scan.ftyp.len() as u64 + new_moov_size + scan.mdat_header.len() as u64;
+    let new_mdat_payload_pos = size::checked_sum([
+        scan.ftyp.len() as u64,
+        new_moov_size,
+        scan.mdat_header.len() as u64,
+    ])?;
     let delta = new_mdat_payload_pos.cast_signed() - scan.mdat_payload_offset.cast_signed();
 
     patch_chunk_offsets(&mut kept, delta)?;
@@ -2431,6 +2437,25 @@ mod tests {
         assert!(
             matches!(err, Mp4ScanError::Io(_)),
             "exact-cap box must pass the strict `>` guard (got {err:?})"
+        );
+    }
+
+    #[test]
+    fn build_udta_checked_art_len_rejects_overflow() {
+        // A hostile art data_len near u64::MAX must fail closed with TooLarge at
+        // the covr_size fold, not panic (debug) / wrap (release).
+        let mk = |data_len: u64| crate::input::ArtInput {
+            art_id: 1,
+            mime: "image/png".to_string(),
+            description: String::new(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(data_len).unwrap(),
+        };
+        assert_eq!(
+            build_udta(&[], &[], &[mk(u64::MAX)]).err(),
+            Some(FormatError::TooLarge)
         );
     }
 }

--- a/musefs-format/src/ogg/b64.rs
+++ b/musefs-format/src/ogg/b64.rs
@@ -40,9 +40,16 @@ pub fn encode_b64_slice(raw: &[u8], skip: usize, take: usize) -> Vec<u8> {
     enc.as_bytes()[skip..skip + take].to_vec()
 }
 
+/// Total base64 output length for an image of `img_total` bytes, or `None` if it
+/// overflows `u64`. Only an adversarial `img_total` can overflow; every real
+/// image is far below this.
+pub fn b64_len_checked(img_total: u64) -> Option<u64> {
+    img_total.div_ceil(3).checked_mul(4)
+}
+
 /// Total base64 output length for an image of `img_total` bytes.
 pub fn b64_len(img_total: u64) -> u64 {
-    img_total.div_ceil(3) * 4
+    b64_len_checked(img_total).expect("base64 output length fits u64")
 }
 
 #[cfg(test)]
@@ -136,5 +143,21 @@ mod tests {
                 skip: 2
             }
         );
+    }
+
+    #[test]
+    fn b64_window_is_overflow_free_at_the_max_validated_boundary() {
+        // For any layout that passes RegionLayout::validate, an OggArtSlice
+        // satisfies offset + len <= b64_len(art_total) AND b64_len_checked(art_total)
+        // is Some. Under those bounds b64_window's internal +/* cannot overflow.
+        // Pin the worst case: the largest art_total whose b64_len still fits u64,
+        // reading the final 4 output chars. In debug, any intermediate overflow
+        // would panic here.
+        let art_total = u64::MAX / 4 * 3; // b64_len_checked(art_total) is Some
+        assert!(b64_len_checked(art_total).is_some());
+        let total = b64_len(art_total);
+        let w = b64_window(total - 4, 4, art_total);
+        assert!(w.in_start <= art_total);
+        assert!(w.in_len <= art_total);
     }
 }

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -5,7 +5,7 @@ mod page;
 
 pub use art_source::{ArtSource, MapArtSource};
 
-pub use b64::{B64Window, b64_len, b64_window, encode_b64_slice};
+pub use b64::{B64Window, b64_len, b64_len_checked, b64_window, encode_b64_slice};
 pub use page::{
     PageHeader, parse_page, patch_page_header, patch_page_header_algebraic, verify_page_crc,
 };

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -12,6 +12,7 @@ pub use page::{
 
 use crate::error::{FormatError, Result};
 use crate::probe::Extent;
+use crate::size;
 
 /// The codec carried inside an Ogg logical bitstream that we synthesize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -344,10 +345,15 @@ fn build_packets_with_art(
             // the image; any one of these alone may fit in u32 but the sum may not.
             for a in arts {
                 let prefix = picture_prefix(a.meta)?;
-                let b64_prefix_len = b64_len(prefix.len() as u64);
-                let value_len = METADATA_BLOCK_PICTURE_KEY.len() as u64
-                    + b64_prefix_len
-                    + b64_len(a.meta.data_len.get());
+                let b64_prefix_len =
+                    b64_len_checked(prefix.len() as u64).ok_or(FormatError::TooLarge)?;
+                let b64_image_len =
+                    b64_len_checked(a.meta.data_len.get()).ok_or(FormatError::TooLarge)?;
+                let value_len = size::checked_sum([
+                    METADATA_BLOCK_PICTURE_KEY.len() as u64,
+                    b64_prefix_len,
+                    b64_image_len,
+                ])?;
                 if value_len > u64::from(u32::MAX) {
                     return Err(FormatError::TooLarge);
                 }
@@ -395,9 +401,13 @@ fn comment_packet_chunks(
     for art in arts {
         let prefix = picture_prefix(art.meta)?;
         let b64_prefix = b64_encode(&prefix);
-        let value_len = METADATA_BLOCK_PICTURE_KEY.len()
-            + b64_prefix.len()
-            + crate::convert::usize_from(b64_len(art.meta.data_len.get()));
+        let b64_image_len =
+            b64_len_checked(art.meta.data_len.get()).ok_or(FormatError::TooLarge)?;
+        let value_len = size::checked_sum([
+            METADATA_BLOCK_PICTURE_KEY.len() as u64,
+            b64_prefix.len() as u64,
+            b64_image_len,
+        ])?;
         head.extend_from_slice(
             &u32::try_from(value_len)
                 .map_err(|_| FormatError::TooLarge)?
@@ -1243,6 +1253,33 @@ mod tests {
             accepted,
             "value_len exactly u32::MAX must be accepted by build_packets_with_art"
         );
+    }
+
+    #[test]
+    fn near_u64_max_art_value_rejected_by_build_packets() {
+        // data_len near u64::MAX makes b64_len(data_len) overflow u64; the builder
+        // must fail closed with TooLarge at the checked b64 length, not panic
+        // (debug) inside the pre-flight value_len computation.
+        let meta = crate::input::ArtInput {
+            art_id: 0,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            data_len: crate::input::BlobLen::new(u64::MAX).unwrap(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+        };
+        let art = OggArt { meta: &meta };
+        let header = OggHeader {
+            codec: Codec::Vorbis,
+            serial: 0,
+            packets: vec![vec![], vec![], vec![]],
+            header_pages: 1,
+            audio_offset: 0,
+        };
+        let result = build_packets_with_art(&header, &[], &[art]);
+        let is_too_large = matches!(&result, Err(FormatError::TooLarge));
+        assert!(is_too_large, "expected Err(TooLarge) for near-u64::MAX art");
     }
 
     #[test]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -467,7 +467,7 @@ fn oggflac_packets_with_art(
     block_packets.push(vec![PayloadChunk::Bytes(comment)]);
     for art in arts {
         let prefix = picture_prefix(art.meta)?;
-        let body_len = prefix.len() as u64 + art.meta.data_len.get();
+        let body_len = size::checked_add(prefix.len() as u64, art.meta.data_len.get())?;
         if body_len > crate::flac::MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
         }
@@ -1274,6 +1274,35 @@ mod tests {
             codec: Codec::Vorbis,
             serial: 0,
             packets: vec![vec![], vec![], vec![]],
+            header_pages: 1,
+            audio_offset: 0,
+        };
+        let result = build_packets_with_art(&header, &[], &[art]);
+        let is_too_large = matches!(&result, Err(FormatError::TooLarge));
+        assert!(is_too_large, "expected Err(TooLarge) for near-u64::MAX art");
+    }
+
+    #[test]
+    fn near_u64_max_art_value_rejected_by_oggflac_build_packets() {
+        // The Ogg-FLAC art path builds a METADATA_BLOCK_PICTURE body as
+        // prefix + raw image. A hostile data_len near u64::MAX must fail closed
+        // with TooLarge, not panic (debug) / wrap (release). picture_prefix's u32
+        // length field already rejects it; the checked add keeps the body-length
+        // site self-defending regardless of that ordering.
+        let meta = crate::input::ArtInput {
+            art_id: 0,
+            mime: "image/jpeg".to_string(),
+            description: String::new(),
+            data_len: crate::input::BlobLen::new(u64::MAX).unwrap(),
+            picture_type: crate::input::PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+        };
+        let art = OggArt { meta: &meta };
+        let header = OggHeader {
+            codec: Codec::OggFlac,
+            serial: 0,
+            packets: vec![vec![0x7F]],
             header_pages: 1,
             audio_offset: 0,
         };

--- a/musefs-format/src/size.rs
+++ b/musefs-format/src/size.rs
@@ -6,13 +6,11 @@
 use crate::error::{FormatError, Result};
 
 /// `a + b`, mapping `u64` overflow to `FormatError::TooLarge`.
-#[allow(dead_code)]
 pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64> {
     a.checked_add(b).ok_or(FormatError::TooLarge)
 }
 
 /// Sum an iterator of `u64`, mapping any `u64` overflow to `FormatError::TooLarge`.
-#[allow(dead_code)]
 pub(crate) fn checked_sum(iter: impl IntoIterator<Item = u64>) -> Result<u64> {
     iter.into_iter().try_fold(0u64, checked_add)
 }

--- a/musefs-format/src/size.rs
+++ b/musefs-format/src/size.rs
@@ -1,0 +1,36 @@
+//! Checked aggregate size arithmetic for synthesis builders. Aggregates over
+//! attacker-controlled, DB-derived lengths must fail closed with
+//! `FormatError::TooLarge` at the format arithmetic boundary, not wrap (release)
+//! or panic (debug) and only fail later via `RegionLayout::validate`.
+
+use crate::error::{FormatError, Result};
+
+/// `a + b`, mapping `u64` overflow to `FormatError::TooLarge`.
+#[allow(dead_code)]
+pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64> {
+    a.checked_add(b).ok_or(FormatError::TooLarge)
+}
+
+/// Sum an iterator of `u64`, mapping any `u64` overflow to `FormatError::TooLarge`.
+#[allow(dead_code)]
+pub(crate) fn checked_sum(iter: impl IntoIterator<Item = u64>) -> Result<u64> {
+    iter.into_iter().try_fold(0u64, checked_add)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_add_reports_overflow_as_too_large() {
+        assert_eq!(checked_add(2, 3), Ok(5));
+        assert_eq!(checked_add(u64::MAX, 1), Err(FormatError::TooLarge));
+    }
+
+    #[test]
+    fn checked_sum_reports_overflow_as_too_large() {
+        assert_eq!(checked_sum([1u64, 2, 3]), Ok(6));
+        assert_eq!(checked_sum(std::iter::empty::<u64>()), Ok(0));
+        assert_eq!(checked_sum([u64::MAX, 1]), Err(FormatError::TooLarge));
+    }
+}

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -1,6 +1,7 @@
 use crate::error::{FormatError, Result};
 use crate::input::{BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture};
 use crate::probe::Extent;
+use crate::size;
 use std::collections::HashSet;
 
 /// The served audio bounds of a WAV: the `data` chunk's payload.
@@ -272,8 +273,9 @@ pub fn synthesize_layout(
     }
 
     // RIFF size = (everything after the 8-byte "RIFF"+size prefix) = body + "WAVE".
-    let body_len: u64 = segments.iter().map(Segment::len).sum();
-    let riff_size = u32::try_from(body_len + 4).map_err(|_| FormatError::TooLarge)?;
+    let body_len: u64 = size::checked_sum(segments.iter().map(Segment::len))?;
+    let riff_size =
+        u32::try_from(size::checked_add(body_len, 4)?).map_err(|_| FormatError::TooLarge)?;
     let mut header = Vec::with_capacity(12);
     header.extend_from_slice(b"RIFF");
     header.extend_from_slice(&riff_size.to_le_bytes());


### PR DESCRIPTION
Closes #273. Closes #274.

Makes `musefs-format` fail closed on adversarial, DB-derived lengths at the exact arithmetic/validation boundary instead of relying on later checks (or wrapping in release / panicking in debug).

## #273 — OggArtSlice source bounds in `RegionLayout::validate`
`validate` previously checked `OggArtSlice` length/total only structurally, never that the named output window lies within its source art. Added two `LayoutError` variants and a validation arm:
- raw slices: `offset + len <= art_total`
- base64 slices: `offset + len <= b64_len(art_total)`
- checked arithmetic throughout: `offset + len` overflow and `b64_len(art_total)` overflow both reject (`OggArtSliceRangeOverflow`); an in-range-but-past-source window rejects (`OggArtSliceOutOfBounds`).

New `b64_len_checked(img_total) -> Option<u64>`; the panicking `b64_len` now delegates to it (no behaviour change for real images). A boundary test pins that `b64_window`'s internal arithmetic stays overflow-free for any layout that passes `validate`.

## #274 — checked aggregate length arithmetic in the synthesis builders
New `pub(crate)` `size` module (`checked_add`/`checked_sum`, both mapping `u64` overflow to `FormatError::TooLarge`). Replaced unchecked `+`/`+=`/`sum::<u64>()` over attacker-controlled lengths in:
- **mp3** `build_id3v2_segments` — all frame-length accumulators (text/TXXX/COMM/USLT/POPM/UFID/binary-tag/art) and the returned total
- **mp4** `build_udta` / `synthesize` — covr/data/ilst/meta/udta box sizes, `new_moov_size`, `new_mdat_payload_pos`, **and** `freeform_binary_prefix`'s binary-tag box size (the one path with no upstream u32 bound on the DB length)
- **wav** `synthesize_layout` — RIFF size aggregate
- **flac** `synthesize_layout` — picture-block body aggregate
- **ogg** `build_packets_with_art` / `comment_packet_chunks` — VorbisComment picture `value_len` (now via `b64_len_checked`)

The format builders now fail closed with `TooLarge`; `RegionLayout::validate` remains the final belt-and-suspenders check.

## Notes
- Spec + plan included under `docs/superpowers/`.
- The mp4 `freeform_binary_prefix` site was caught in post-implementation review (the only binary-tag length not capped by a u32 field upstream); the analogous ogg-flac art path was found already guarded by `picture_prefix`'s u32 data-length field, so it was left unchanged.
- Each commit is independently green (full workspace suite via the pre-commit hook). The out-of-workspace `fuzz/` crate builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened overflow-safe size accounting across MP3, MP4, WAV, FLAC, and OGG (new checked size helpers)
  * Added strict Ogg art-slice bounds validation and safer base64-length checks to prevent out-of-bounds/overflow
  * Oversized inputs now return clear errors instead of producing corrupted layouts

* **Documentation**
  * Added design and plan documents detailing the layout bounds hardening

* **Tests**
  * Added overflow-boundary and validation tests covering new checks and error paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->