### PR TITLE
Strengthen backing-file freshness checks: nanosecond mtime + ctime (#276)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -100,13 +100,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_file" rows=2
-    'musefs-core/src/scan\.rs:376:35:',
+    'musefs-core/src/scan\.rs:375:35:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:383:34:',
+    'musefs-core/src/scan\.rs:382:34:',
     # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -114,18 +114,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:394:25:',
+    'musefs-core/src/scan\.rs:393:25:',
     # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:399:21:',
+    'musefs-core/src/scan\.rs:398:21:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:756:46:',
+    'musefs-core/src/scan\.rs:755:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -134,15 +134,15 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:849:32:',
+    'musefs-core/src/scan\.rs:848:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:849:47:',
+    'musefs-core/src/scan\.rs:848:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:849:62:',
+    'musefs-core/src/scan\.rs:848:62:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:859:55:',
+    'musefs-core/src/scan\.rs:858:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:859:70:',
+    'musefs-core/src/scan\.rs:858:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -150,9 +150,9 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:965:25:',
+    'musefs-core/src/scan\.rs:968:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:969:25:',
+    'musefs-core/src/scan\.rs:972:25:',
     # guard: op="+" fn="revalidate_with" rows=1
     'musefs-core/src/scan\.rs:1008:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -95,37 +95,37 @@ exclude_re = [
     # candidates is pinned by the disambiguation and collision-gate tests; only
     # the un-rankable constant replacements are excluded.
     'replace suffix_candidate -> String with',
-    # probe_file widen loop: `.max(want + 1)` is dominated — the bounded probers
+    # probe_body widen loop: `.max(want + 1)` is dominated — the bounded probers
     # only return `NeedMore{up_to}` with `up_to > want` (we widen precisely to a
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
-    # guard: op="+" fn="probe_file" rows=2
-    'musefs-core/src/scan\.rs:375:35:',
-    # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
+    # guard: op="+" fn="probe_body" rows=2
+    'musefs-core/src/scan\.rs:396:31:',
+    # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
-    # guard: op="<" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:382:34:',
-    # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
+    # guard: op="<" fn="probe_body" rows=3
+    'musefs-core/src/scan\.rs:403:30:',
+    # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
     # or `locate_audio_at_ceiling` rejects it on the same off+len>file_len bound
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
-    # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:393:25:',
-    # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
+    # guard: op=">" fn="probe_body" rows=3
+    'musefs-core/src/scan\.rs:414:21:',
+    # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
-    # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:398:21:',
+    # guard: op=">" fn="probe_body" rows=3
+    'musefs-core/src/scan\.rs:419:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:755:46:',
+    'musefs-core/src/scan\.rs:764:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -133,16 +133,26 @@ exclude_re = [
     # cadence mutation persists the identical track set. The win is fewer commits
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
+    # NB: line:col here (and for revalidate below) — `+=` and `>=`/`||` repeat in
+    # run_pipeline (e.g. the killable `*scanned += 1` at 833), so these cannot be
+    # safely description-anchored. Re-verify these coordinates (via
+    # `cargo mutants --list`) after any change that reformats scan.rs.
+    # guard: op="+=" fn="run_pipeline" rows=2
+    'musefs-core/src/scan\.rs:855:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:848:32:',
+    'musefs-core/src/scan\.rs:857:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:848:47:',
+    'musefs-core/src/scan\.rs:857:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:848:62:',
+    'musefs-core/src/scan\.rs:857:62:',
+    # guard: op="+=" fn="run_pipeline" rows=2
+    'musefs-core/src/scan\.rs:865:37:',
+    # guard: op=">=" fn="run_pipeline" rows=1
+    'musefs-core/src/scan\.rs:867:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:858:55:',
+    'musefs-core/src/scan\.rs:867:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:858:70:',
+    'musefs-core/src/scan\.rs:867:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -150,11 +160,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:968:25:',
+    'musefs-core/src/scan\.rs:977:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:972:25:',
+    'musefs-core/src/scan\.rs:981:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1008:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1017:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -100,13 +100,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_file" rows=2
-    'musefs-core/src/scan\.rs:336:31:',
+    'musefs-core/src/scan\.rs:376:35:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:343:30:',
+    'musefs-core/src/scan\.rs:383:34:',
     # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -114,18 +114,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:354:21:',
+    'musefs-core/src/scan\.rs:394:25:',
     # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:359:17:',
+    'musefs-core/src/scan\.rs:399:21:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:703:46:',
+    'musefs-core/src/scan\.rs:756:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -134,15 +134,15 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:796:32:',
+    'musefs-core/src/scan\.rs:849:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:796:47:',
+    'musefs-core/src/scan\.rs:849:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:796:62:',
+    'musefs-core/src/scan\.rs:849:62:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:806:55:',
+    'musefs-core/src/scan\.rs:859:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:806:70:',
+    'musefs-core/src/scan\.rs:859:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -150,11 +150,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:910:25:',
+    'musefs-core/src/scan\.rs:965:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:914:25:',
+    'musefs-core/src/scan\.rs:969:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:953:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1008:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -100,13 +100,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_file" rows=2
-    'musefs-core/src/scan\.rs:341:31:',
+    'musefs-core/src/scan\.rs:336:31:',
     # probe_file post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:348:30:',
+    'musefs-core/src/scan\.rs:343:30:',
     # probe_file WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -114,18 +114,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:359:21:',
+    'musefs-core/src/scan\.rs:354:21:',
     # probe_file oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_file" rows=3
-    'musefs-core/src/scan\.rs:364:17:',
+    'musefs-core/src/scan\.rs:359:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:707:46:',
+    'musefs-core/src/scan\.rs:703:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -133,26 +133,16 @@ exclude_re = [
     # cadence mutation persists the identical track set. The win is fewer commits
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
-    # NB: line:col here (and for revalidate below) — `replace += with` and
-    # `>=`/`||` repeat in run_pipeline (e.g. the killable `*scanned += 1` at
-    # 778), so these cannot be safely description-anchored. Re-verify these
-    # coordinates after any change that reformats scan.rs.
-    # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:800:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:802:32:',
+    'musefs-core/src/scan\.rs:796:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:802:47:',
+    'musefs-core/src/scan\.rs:796:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:802:62:',
-    # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:810:37:',
-    # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:812:40:',
+    'musefs-core/src/scan\.rs:796:62:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:812:55:',
+    'musefs-core/src/scan\.rs:806:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:812:70:',
+    'musefs-core/src/scan\.rs:806:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -160,11 +150,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:916:25:',
+    'musefs-core/src/scan\.rs:910:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:920:25:',
+    'musefs-core/src/scan\.rs:914:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:956:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:953:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,7 +117,7 @@ The store is the **interface external tools write to** — the beets and Picard
 plugins under `contrib/` write tags and art here out-of-band.
 
 - **V1** — the core tables: `tracks` (one row per backing file: path, format,
-  audio byte range, size/mtime stamps, `content_version`), `tags` (multi-value
+  audio byte range, size/nanosecond-mtime/ctime stamps, `content_version`), `tags` (multi-value
   key/value rows ordered by `ordinal`), `art` (content-addressed by sha256,
   deduplicated image blobs), and `track_art` (per-track art links with
   picture type and ordering). Deleting a track cascades to its `tags` and
@@ -147,7 +147,9 @@ plugins under `contrib/` write tags and art here out-of-band.
   `art_ad` (bumps every track referencing a deleted `art` row, so an orphaned
   reference rebuilds to a clean serve-time error rather than streaming stale
   bytes), `tracks_geometry_au` (bumps when scanner-owned geometry — `format`,
-  audio bounds, backing size/mtime — changes), and `structural_blocks_ai`/`_ad`
+  audio bounds, backing size/nanosecond-mtime — changes; keys on
+  `backing_mtime_ns` only — `backing_ctime_ns` is pure freshness identity, not a
+  served-byte input), and `structural_blocks_ai`/`_ad`
   (bump when FLAC structural blocks change).
 
 ### The external-writer contract
@@ -155,9 +157,9 @@ plugins under `contrib/` write tags and art here out-of-band.
 **Ownership.** External tools get full read/write on `tags`, `art`, and
 `track_art`. The scanner owns the structural columns of `tracks` (`id`,
 `backing_path`, `format`, `audio_offset`, `audio_length`, `backing_size`,
-`backing_mtime`, `content_version`, `updated_at`) and all of
-`structural_blocks`: those are derived from probing the file, and external
-tools must run `musefs scan` rather than compute them.
+`backing_mtime_ns`, `backing_ctime_ns`, `content_version`, `updated_at`) and
+all of `structural_blocks`: those are derived from probing the file, and
+external tools must run `musefs scan` rather than compute them.
 
 **What the store enforces.** As of V4, SQLite `CHECK` constraints reject the
 malformed *shapes* at commit, so an external writer cannot persist them:
@@ -192,10 +194,11 @@ a clean `EIO` on the now-orphaned reference instead of stale bytes.
 
 **What musefs defends at serve time.** CHECKs cannot catch a scanner-owned
 field mutated to a *well-formed* value that no longer matches the real file
-on disk: `backing_size` or `backing_mtime` that drift from the actual file's
-stat, or audio bounds that fit the stored `backing_size` but overrun the file
-once it has shrunk. musefs re-stats the backing file on every resolve and
-treats such rows as untrusted input, degrading to a controlled
+on disk: `backing_size` or `backing_mtime_ns`/`backing_ctime_ns` that drift
+from the actual file's stat, or audio bounds that fit the stored
+`backing_size` but overrun the file once it has shrunk. musefs re-stats the
+backing file on every resolve and treats such rows as untrusted input,
+degrading to a controlled
 `BackingChanged`/layout error, never undefined behavior. The store's V4
 `CHECK` rejects art over `MAX_ART_BYTES` (16 MiB − 64 KiB) at write time;
 resolve also re-checks it (`ArtTooLarge`, all formats) to backstop a writer
@@ -254,18 +257,22 @@ Two distinct counters drive correctness; they answer different questions.
 bytes change?"*. The DB triggers increment it on any input the database can see that changes
 synthesized bytes: tag and `track_art` edits, `art`-row deletes that orphan a
 reference, scanner-owned geometry changes (`format`, audio bounds, backing
-size/mtime), and FLAC structural-block changes (V5). It is therefore a
-superset key — the one input it cannot cover is an on-disk backing change with
-no DB write, which `resolve` (and, since #279, a size-cache `getattr` hit)
-catches by re-statting the backing file and degrading to `BackingChanged`.
-The `HeaderCache` (`reader.rs`) — a byte-budgeted concurrent cache (64 MiB
+size/nanosecond-mtime), and FLAC structural-block changes (V5). It is
+therefore a superset key — the one input it cannot cover is an on-disk backing
+change with no DB write, which `resolve` (and, since #279, a size-cache
+`getattr` hit) catches by re-statting the backing file and degrading to
+`BackingChanged`. The scanner stamps the backing file's `(size, mtime_ns,
+ctime_ns)` tuple from the **probed file descriptor** using a pre/post `fstat`
+sandwich: if the file's metadata changes between the two stats, the entry is
+dropped. `ctime` defeats an mtime-forging writer (e.g. `touch -m`). The
+`HeaderCache` (`reader.rs`) — a byte-budgeted concurrent cache (64 MiB
 default) of resolved layouts — keys each entry on it: a hit with a stale
 `content_version` rebuilds the layout. Independently of the cache, **every**
 resolve re-stats the backing file and errors with `BackingChanged` if its
-size or mtime drifted from the scanned values, so a silently replaced backing
-file is never spliced at stale offsets. The per-handle read path re-stats the
-held descriptor on every read too, so this guarantee holds on the hot path and
-not only through `resolve()`.
+size, mtime, or ctime drifted from the scanned values, so a silently replaced
+backing file is never spliced at stale offsets. The per-handle read path
+re-stats the held descriptor on every read too, so this guarantee holds on the
+hot path and not only through `resolve()`.
 
 **`data_version`** (`PRAGMA data_version`, whole-DB) answers *"did anyone
 commit anything?"*. `Musefs::poll_refresh` compares it to the last seen

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -340,8 +340,10 @@ aborting the scan. The `root` argument is always followed regardless of the
 flag; only links encountered during recursion are gated.
 
 `revalidate` is the maintenance pass (`scan --revalidate`): re-probe only
-files whose size/mtime changed (skipping unchanged files **preserves
-external tag edits** in the DB), delete tracks under the scanned root whose
+files whose `(size, mtime_ns, ctime_ns)` freshness stamp changed — a
+ctime-only move (e.g. a forged-mtime in-place rewrite) is still re-probed
+(skipping unchanged files **preserves external tag edits** in the DB),
+delete tracks under the scanned root whose
 backing file is gone, and garbage-collect now-unreferenced art. Pruning is
 scoped to the scanned root, so revalidating one library root never removes
 tracks belonging to another. Because a track is keyed by its *canonical*

--- a/contrib/beets/tests/conftest.py
+++ b/contrib/beets/tests/conftest.py
@@ -18,14 +18,20 @@ def db_path(tmp_path):
 
 
 def insert_track(
-    conn, backing_path, fmt="flac", audio_offset=0, audio_length=0, backing_size=0, backing_mtime=0
+    conn,
+    backing_path,
+    fmt="flac",
+    audio_offset=0,
+    audio_length=0,
+    backing_size=0,
+    backing_mtime_ns=0,
 ):
     """Insert a minimal track row (as `musefs scan` would) and return its id."""
     now = int(time.time())
     cur = conn.execute(
         "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
-        "backing_size, backing_mtime, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (backing_path, fmt, audio_offset, audio_length, backing_size, backing_mtime, now),
+        "backing_size, backing_mtime_ns, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (backing_path, fmt, audio_offset, audio_length, backing_size, backing_mtime_ns, now),
     )
     return cur.lastrowid
 

--- a/contrib/lidarr/tests/conftest.py
+++ b/contrib/lidarr/tests/conftest.py
@@ -71,7 +71,7 @@ def insert_track(conn, backing_path, fmt="flac"):
     now = int(time.time())
     cur = conn.execute(
         "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
-        "backing_size, backing_mtime, updated_at) VALUES (?, ?, 0, 0, 0, 0, ?)",
+        "backing_size, backing_mtime_ns, updated_at) VALUES (?, ?, 0, 0, 0, 0, ?)",
         (backing_path, fmt, now),
     )
     return cur.lastrowid

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -264,6 +264,11 @@ END;
 PRAGMA user_version = 4;
 
 -- ── MIGRATION_V5 ──
+ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
+ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0
+    CHECK (backing_ctime_ns >= 0);
+
+
 -- art rows are content-addressed by sha256: once written, their content
 -- columns are immutable. A writer needing different bytes/metadata inserts a
 -- NEW row and relinks via track_art (which bumps content_version through the
@@ -311,7 +316,7 @@ WHEN NEW.format        <> OLD.format
   OR NEW.audio_offset  <> OLD.audio_offset
   OR NEW.audio_length  <> OLD.audio_length
   OR NEW.backing_size  <> OLD.backing_size
-  OR NEW.backing_mtime <> OLD.backing_mtime
+  OR NEW.backing_mtime_ns <> OLD.backing_mtime_ns
 BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
 END;

--- a/contrib/picard/tests/conftest.py
+++ b/contrib/picard/tests/conftest.py
@@ -26,7 +26,7 @@ def insert_track(conn, backing_path, fmt="flac"):
     now = int(time.time())
     cur = conn.execute(
         "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
-        "backing_size, backing_mtime, updated_at) VALUES (?, ?, 0, 0, 0, 0, ?)",
+        "backing_size, backing_mtime_ns, updated_at) VALUES (?, ?, 0, 0, 0, 0, ?)",
         (backing_path, fmt, now),
     )
     return cur.lastrowid

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -261,6 +261,11 @@ END;
 PRAGMA user_version = 4;
 
 -- ── MIGRATION_V5 ──
+ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
+ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0
+    CHECK (backing_ctime_ns >= 0);
+
+
 -- art rows are content-addressed by sha256: once written, their content
 -- columns are immutable. A writer needing different bytes/metadata inserts a
 -- NEW row and relinks via track_art (which bumps content_version through the
@@ -308,7 +313,7 @@ WHEN NEW.format        <> OLD.format
   OR NEW.audio_offset  <> OLD.audio_offset
   OR NEW.audio_length  <> OLD.audio_length
   OR NEW.backing_size  <> OLD.backing_size
-  OR NEW.backing_mtime <> OLD.backing_mtime
+  OR NEW.backing_mtime_ns <> OLD.backing_mtime_ns
 BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
 END;

--- a/contrib/python-musefs/tests/conftest.py
+++ b/contrib/python-musefs/tests/conftest.py
@@ -40,7 +40,7 @@ def insert_track(conn, backing_path, fmt="flac"):
     now = int(time.time())
     cur = conn.execute(
         "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
-        "backing_size, backing_mtime, updated_at) VALUES (?, ?, 0, 0, 0, 0, ?)",
+        "backing_size, backing_mtime_ns, updated_at) VALUES (?, ?, 0, 0, 0, 0, ?)",
         (backing_path, fmt, now),
     )
     return cur.lastrowid

--- a/docs/superpowers/plans/2026-06-12-backing-freshness.md
+++ b/docs/superpowers/plans/2026-06-12-backing-freshness.md
@@ -1,0 +1,992 @@
+# Backing-File Freshness Strengthening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `(size, whole-second mtime)` backing-file freshness stamp with a `(size, nanosecond mtime, ctime)` stamp collected from the same descriptor the scanner probes (with a stat sandwich), so a same-size in-place rewrite — busy or adversarial — can no longer silently pair stale metadata with fresh audio bytes.
+
+**Architecture:** A new `BackingStamp` value type in `musefs-core` captures the three integers from one `fstat` and is compared at all three serve-path sites (`resolve`, `validate_opened_backing`, the `getattr` size-cache) and in the scanner. The `tracks.backing_mtime` column is renamed to `backing_mtime_ns` (nanoseconds) and a `backing_ctime_ns` column is added, edited directly into `MIGRATION_V5` since there are no extant databases. The scanner's `probe_file` opens once, fstats before and after the probe, and drops any file that moved mid-probe.
+
+**Tech Stack:** Rust workspace (`musefs-db` → `musefs-format` → `musefs-core`), SQLite via `rusqlite`, `std::os::unix::fs::MetadataExt` for `mtime`/`ctime` nanoseconds, two generated Python schema mirrors under `contrib/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-backing-freshness-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| ---- | -------------- | ------ |
+| `musefs-core/src/freshness.rs` | The `BackingStamp` type: capture from `Metadata`, from a `Track`, compare, display-seconds | **Create** |
+| `musefs-core/src/lib.rs` | Module wiring (`mod freshness;`) | Modify |
+| `musefs-db/src/schema.rs` | `MIGRATION_V5`: rename `backing_mtime`→`backing_mtime_ns`, add `backing_ctime_ns`, retarget geometry trigger | Modify |
+| `musefs-db/src/models.rs` | `Track`/`NewTrack` stamp fields | Modify |
+| `musefs-db/src/tracks.rs` | `track_select!`, `row_to_track`, `upsert_track` | Modify |
+| `musefs-db/src/bulk.rs` | `BulkWriter::upsert_track` | Modify |
+| `musefs-core/src/reader.rs` | `ResolvedFile` stamp, `resolve` compare, displayed-mtime ns→s, drop dup `mtime_secs` | Modify |
+| `musefs-core/src/facade.rs` | `validate_opened_backing`, `SizeEntry`, `getattr` size-cache compare, drop dup `mtime_secs` | Modify |
+| `musefs-core/src/scan.rs` | `probe_file` fstat sandwich + `ProbeOutcome`, `Unit`/`ingest`/`ingest_bulk` stamp, `raced` counter, revalidate skip, drop dup `mtime_secs` | Modify |
+| `contrib/python-musefs/src/musefs_common/schema.py` | Generated mirror | Regenerate |
+| `contrib/picard/musefs/_common/schema.py` | Vendored mirror | Re-vendor |
+| `ARCHITECTURE.md` | Freshness + contract prose | Modify |
+
+**Why this order:** Task 1 (`BackingStamp`) is additive and compiles against the current schema. Task 2 is the **atomic rename slice** — the column rename breaks the whole workspace at once, and the pre-commit hook runs the full workspace suite, so db + core + all test fixtures must land in one green commit. Tasks 3–4 layer the scanner sandwich and revalidate strengthening on top. Task 5 is docs.
+
+---
+
+## Task 1: `BackingStamp` value type
+
+**Files:**
+- Create: `musefs-core/src/freshness.rs`
+- Modify: `musefs-core/src/lib.rs:4` (insert `mod freshness;` between `mod facade;` and `mod lock;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the new file `musefs-core/src/freshness.rs` (the `BackingStamp` body in Step 3 goes above this `mod tests`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::MetadataExt;
+
+    #[test]
+    fn from_metadata_captures_ns_and_display_secs() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f");
+        std::fs::write(&p, b"hello").unwrap();
+        let meta = std::fs::metadata(&p).unwrap();
+
+        let s = BackingStamp::from_metadata(&meta);
+        assert_eq!(s.size, 5);
+        assert_eq!(s.mtime_ns, meta.mtime() * 1_000_000_000 + meta.mtime_nsec());
+        assert_eq!(s.ctime_ns, meta.ctime() * 1_000_000_000 + meta.ctime_nsec());
+        // Display is whole-second mtime, never the raw nanosecond value.
+        assert_eq!(s.display_secs(), meta.mtime());
+    }
+
+    #[test]
+    fn equality_is_field_wise() {
+        let a = BackingStamp { size: 1, mtime_ns: 2, ctime_ns: 3 };
+        assert_eq!(a, BackingStamp { size: 1, mtime_ns: 2, ctime_ns: 3 });
+        assert_ne!(a, BackingStamp { size: 1, mtime_ns: 2, ctime_ns: 4 });
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-core --lib freshness 2>&1 | tail -20`
+Expected: FAIL — `cannot find type BackingStamp` / module `freshness` not declared.
+
+- [ ] **Step 3: Write minimal implementation**
+
+At the **top** of `musefs-core/src/freshness.rs`:
+
+```rust
+//! The backing-file freshness stamp: the identity a `tracks` row records for
+//! its backing file, compared on every serve to detect an on-disk change that
+//! no database write covers. Strengthened past size + whole-second mtime to
+//! nanosecond mtime + ctime (#276) so a same-size in-place rewrite — including
+//! an adversarial one that resets mtime — cannot evade the guard.
+use std::os::unix::fs::MetadataExt;
+
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// `(size, mtime_ns, ctime_ns)` captured from one `fstat`. `mtime_ns`/`ctime_ns`
+/// are nanoseconds since the Unix epoch (good until ~2262). `ctime` is the
+/// adversarial backstop: a writer can reset mtime with `utimensat`, but ctime
+/// is bumped by any write and cannot be set backward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BackingStamp {
+    pub size: u64,
+    pub mtime_ns: i64,
+    pub ctime_ns: i64,
+}
+
+impl BackingStamp {
+    pub fn from_metadata(meta: &std::fs::Metadata) -> BackingStamp {
+        BackingStamp {
+            size: meta.len(),
+            mtime_ns: meta.mtime().saturating_mul(NANOS_PER_SEC).saturating_add(meta.mtime_nsec()),
+            ctime_ns: meta.ctime().saturating_mul(NANOS_PER_SEC).saturating_add(meta.ctime_nsec()),
+        }
+    }
+
+    pub fn from_track(t: &musefs_db::Track) -> BackingStamp {
+        BackingStamp {
+            size: t.backing_size,
+            mtime_ns: t.backing_mtime_ns,
+            ctime_ns: t.backing_ctime_ns,
+        }
+    }
+
+    /// Whole-second mtime for the FUSE `getattr` display surface (never the raw
+    /// nanosecond value, which would advertise a ~10^18-second timestamp).
+    pub fn display_secs(&self) -> i64 {
+        self.mtime_ns / NANOS_PER_SEC
+    }
+}
+```
+
+> **NOTE:** `from_track` references `Track::backing_mtime_ns` / `backing_ctime_ns`, which do **not exist yet** (added in Task 2). To keep Task 1 independently compilable, **omit `from_track` in this task** and add it in Task 2, Step 9. Ship Task 1 with only `from_metadata`, `display_secs`, and the type.
+
+Then add the module declaration in `musefs-core/src/lib.rs` (alphabetical position, after `mod facade;`):
+
+```rust
+mod freshness;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core --lib freshness 2>&1 | tail -20`
+Expected: PASS (2 tests). A `dead_code` warning on `from_metadata`/`display_secs` is expected until Task 2 wires them in; the crate uses `-D warnings` only in CI clippy, not in `cargo test`, so this is fine for now. To avoid the warning entirely, you may add `#[allow(dead_code)]` on the `impl` block and remove it in Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/freshness.rs musefs-core/src/lib.rs
+git commit -m "feat(core): add BackingStamp freshness value type (#276)"
+```
+
+---
+
+## Task 2: Rename to nanosecond stamp + strong serve-path comparison (atomic slice)
+
+This is one commit: the column rename breaks the whole workspace and the pre-commit hook runs the full suite. Write the new behavioral tests first (they will fail to compile until the slice lands), then make every edit, then green.
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs` (`MIGRATION_V5`, line ~285; geometry trigger ~327; test SQL)
+- Modify: `musefs-db/src/models.rs:124` (`Track`), `:137` (`NewTrack`)
+- Modify: `musefs-db/src/tracks.rs:9` (`track_select!`), `:32` (`row_to_track`), `:187` (`upsert_track`)
+- Modify: `musefs-db/src/bulk.rs:38` (`upsert_track`)
+- Modify: `musefs-core/src/freshness.rs` (add `from_track`)
+- Modify: `musefs-core/src/reader.rs` (`ResolvedFile` 17-40, `resolve` 110-131, `build` tail 145-320, drop `mtime_secs` 73)
+- Modify: `musefs-core/src/facade.rs` (`SizeEntry` 85-95, `mtime_secs` 107, `validate_opened_backing` 114, `getattr` 945-981)
+- Modify: `musefs-core/src/scan.rs` (`Unit` 480, `ingest` 504, `ingest_bulk` 581, worker 720-738, oracle 861-863, drop `mtime_secs` 52)
+- Test: `musefs-core/tests/backing_changed_fault.rs`, `musefs-core/tests/facade.rs`
+- Regenerate: both `contrib/.../schema.py`
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+Append to `musefs-core/tests/backing_changed_fault.rs`:
+
+```rust
+use std::os::unix::fs::MetadataExt;
+
+// A same-size in-place rewrite within the same whole second (the common case in
+// a fast test) changed only the sub-second mtime + ctime. The old whole-second
+// guard would have passed it; the ns stamp must reject it.
+#[test]
+fn same_size_subsecond_rewrite_yields_backing_changed() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    let (audio_offset, audio_length) = common::write_flac(&src, &["TITLE=T"], &[0xAB; 4096]);
+    let db = Db::open_in_memory().unwrap();
+    let meta = std::fs::metadata(&src).unwrap();
+    let id = db
+        .upsert_track(&musefs_db::NewTrack {
+            backing_path: src.to_string_lossy().into_owned(),
+            format: musefs_db::Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len(),
+            backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+            backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
+        })
+        .unwrap();
+    db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)]).unwrap();
+    HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+
+    // Rewrite the same number of bytes in place: size identical, mtime/ctime move.
+    std::fs::write(&src, {
+        let mut v = std::fs::read(&src).unwrap();
+        v[audio_offset as usize] ^= 0xFF;
+        v
+    })
+    .unwrap();
+
+    let err = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+// Adversary rewrites in place, then forges mtime back to the stored value.
+// mtime_ns now matches; only ctime (un-forgeable) caught the change.
+#[test]
+fn forged_mtime_is_caught_by_ctime() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    let (audio_offset, audio_length) = common::write_flac(&src, &["TITLE=T"], &[0xAB; 4096]);
+    let db = Db::open_in_memory().unwrap();
+    let meta = std::fs::metadata(&src).unwrap();
+    let original_modified = meta.modified().unwrap();
+    let id = db
+        .upsert_track(&musefs_db::NewTrack {
+            backing_path: src.to_string_lossy().into_owned(),
+            format: musefs_db::Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len(),
+            backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+            backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
+        })
+        .unwrap();
+    db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)]).unwrap();
+    HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+
+    // In-place same-size rewrite, then reset mtime back to the scanned instant.
+    let mut v = std::fs::read(&src).unwrap();
+    v[audio_offset as usize] ^= 0xFF;
+    std::fs::write(&src, v).unwrap();
+    let f = std::fs::OpenOptions::new().write(true).open(&src).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(original_modified)).unwrap();
+    drop(f);
+
+    // mtime_ns now equals the stored stamp; ctime advanced and must trip the guard.
+    let err = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+// The synthesized file's displayed mtime stays a plausible whole-second value
+// (≈ the backing file's mtime), not the renamed column's raw nanoseconds.
+#[test]
+fn displayed_mtime_is_whole_seconds() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    let (audio_offset, audio_length) = common::write_flac(&src, &["TITLE=T"], &[0xAB; 4096]);
+    let db = Db::open_in_memory().unwrap();
+    let meta = std::fs::metadata(&src).unwrap();
+    let id = db
+        .upsert_track(&musefs_db::NewTrack {
+            backing_path: src.to_string_lossy().into_owned(),
+            format: musefs_db::Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len(),
+            backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+            backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
+        })
+        .unwrap();
+    db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)]).unwrap();
+    let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+    // Plausible epoch-seconds (this millennium), never ~10^18.
+    assert!(resolved.mtime_secs >= meta.mtime() && resolved.mtime_secs < 32_503_680_000);
+}
+```
+
+Append to `musefs-core/tests/facade.rs` (uses the existing `config()` helper and the already-imported `scan_directory`, `Musefs`, `VirtualTree`, `CoreError`):
+
+```rust
+// Template-agnostic: walk readdir from the root to the first non-dir entry.
+fn first_file_inode(fs: &Musefs) -> u64 {
+    fn walk(fs: &Musefs, inode: u64) -> Option<u64> {
+        for (name, child, is_dir) in fs.readdir(inode).unwrap() {
+            if name == "." || name == ".." { continue; }
+            if is_dir {
+                if let Some(f) = walk(fs, child) { return Some(f); }
+            } else {
+                return Some(child);
+            }
+        }
+        None
+    }
+    walk(fs, VirtualTree::ROOT).expect("a file inode under root")
+}
+
+// getattr's warm size-cache hit must re-stat with the full stamp (#276/#279):
+// a same-size sub-second rewrite after the first getattr must surface
+// BackingChanged, not stale attrs.
+#[test]
+fn getattr_size_cache_rejects_subsecond_rewrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    common::write_flac(&src, &["TITLE=T", "ARTIST=A"], &[0xAB; 4096]);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let inode = first_file_inode(&fs);
+    fs.getattr(inode).unwrap(); // warm the size cache
+
+    let mut v = std::fs::read(&src).unwrap();
+    *v.last_mut().unwrap() ^= 0xFF; // same size, new mtime/ctime
+    std::fs::write(&src, v).unwrap();
+
+    let err = fs.getattr(inode).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+```
+
+> The recursive `walk` skips `.`/`..` defensively; the facade `readdir` returns real entries (the existing test at `facade.rs:44-46` consumes them directly), so the guard is belt-and-suspenders.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-core --test backing_changed_fault --test facade 2>&1 | tail -20`
+Expected: FAIL to compile — `NewTrack` has no field `backing_mtime_ns` / `backing_ctime_ns`. (This is the expected TDD red.)
+
+- [ ] **Step 3: Edit the schema (`musefs-db/src/schema.rs`)**
+
+At the very top of the `MIGRATION_V5` raw string (immediately after `const MIGRATION_V5: &str = r"`), insert:
+
+```sql
+-- #276: strengthen the freshness stamp. No extant databases, so edit V5 in
+-- place rather than adding a migration (user_version stays 5). RENAME COLUMN
+-- auto-rewrites the CHECK (backing_mtime >= 0) and is picked up by the geometry
+-- trigger recreated below. The column now holds nanoseconds since the epoch.
+ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
+ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0 CHECK (backing_ctime_ns >= 0);
+```
+
+In the same migration, change the `tracks_geometry_au` trigger's `WHEN` clause line from:
+
+```sql
+  OR NEW.backing_mtime <> OLD.backing_mtime
+```
+to:
+```sql
+  OR NEW.backing_mtime_ns <> OLD.backing_mtime_ns
+```
+
+Do **not** add `backing_ctime_ns` to the trigger (spec: pure freshness identity, not a served-byte input).
+
+Then fix the in-file test SQL: every `INSERT INTO tracks (... backing_mtime ...)` and any `UPDATE tracks SET backing_mtime ...` in `schema.rs`'s `#[cfg(test)]` modules must use `backing_mtime_ns` (grep `backing_mtime` within `schema.rs`; the `backing_ctime_ns` default of 0 lets you omit it from INSERT column lists).
+
+- [ ] **Step 4: Rename the model fields (`musefs-db/src/models.rs`)**
+
+`Track` (line 124): replace `pub backing_mtime: i64,` with:
+```rust
+    pub backing_mtime_ns: i64,
+    pub backing_ctime_ns: i64,
+```
+`NewTrack` (line 137): replace `pub backing_mtime: i64,` with:
+```rust
+    pub backing_mtime_ns: i64,
+    pub backing_ctime_ns: i64,
+```
+
+- [ ] **Step 5: Update reads/writes (`musefs-db/src/tracks.rs`)**
+
+`track_select!` column list (line 12-13): change to
+```rust
+            "SELECT id, backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime_ns, backing_ctime_ns, content_version, updated_at \
+             FROM tracks ",
+```
+
+`row_to_track` (line 45-54): replace `backing_mtime: r.get("backing_mtime")?,` with
+```rust
+        backing_mtime_ns: r.get("backing_mtime_ns")?,
+        backing_ctime_ns: r.get("backing_ctime_ns")?,
+```
+
+`upsert_track` (line 187): add the two columns to the INSERT list, `VALUES`, `ON CONFLICT DO UPDATE SET`, and `params!`:
+```rust
+        self.conn.execute(
+            "INSERT INTO tracks
+                (backing_path, format, audio_offset, audio_length, backing_size,
+                 backing_mtime_ns, backing_ctime_ns, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
+             ON CONFLICT(backing_path) DO UPDATE SET
+                format          = excluded.format,
+                audio_offset    = excluded.audio_offset,
+                audio_length    = excluded.audio_length,
+                backing_size    = excluded.backing_size,
+                backing_mtime_ns = excluded.backing_mtime_ns,
+                backing_ctime_ns = excluded.backing_ctime_ns,
+                updated_at      = CAST(strftime('%s','now') AS INTEGER)",
+            params![
+                t.backing_path,
+                t.format.as_str(),
+                t.audio_offset,
+                t.audio_length,
+                t.backing_size,
+                t.backing_mtime_ns,
+                t.backing_ctime_ns,
+            ],
+        )?;
+```
+
+- [ ] **Step 6: Update the bulk writer (`musefs-db/src/bulk.rs:38`)**
+
+```rust
+    pub fn upsert_track(&mut self, t: &NewTrack) -> Result<i64> {
+        self.tx.execute(
+            "INSERT INTO tracks
+                (backing_path, format, audio_offset, audio_length, backing_size,
+                 backing_mtime_ns, backing_ctime_ns, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
+             ON CONFLICT(backing_path) DO UPDATE SET
+                format=excluded.format, audio_offset=excluded.audio_offset,
+                audio_length=excluded.audio_length, backing_size=excluded.backing_size,
+                backing_mtime_ns=excluded.backing_mtime_ns,
+                backing_ctime_ns=excluded.backing_ctime_ns,
+                updated_at=CAST(strftime('%s','now') AS INTEGER)",
+            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length,
+                    t.backing_size, t.backing_mtime_ns, t.backing_ctime_ns],
+        )?;
+        Ok(self.tx.query_row(
+            "SELECT id FROM tracks WHERE backing_path = ?1",
+            params![t.backing_path],
+            |r| r.get(0),
+        )?)
+    }
+```
+
+- [ ] **Step 7: Fix db-layer test fixtures**
+
+Across `musefs-db` (`tests/tracks.rs`, `tests/art.rs`, `tests/common/mod.rs`, and `#[cfg(test)]` blocks in `tracks.rs`), update every `NewTrack { ... }` / `Track { ... }` literal: replace `backing_mtime: X,` with `backing_mtime_ns: X, backing_ctime_ns: 0,` (or `0,0` where the value is a don't-care). The compiler enumerates each site. Also update any raw SQL test strings referencing the `backing_mtime` column to `backing_mtime_ns`.
+
+- [ ] **Step 8: Verify the db crate alone is green**
+
+Run: `cargo test -p musefs-db 2>&1 | tail -25`
+Expected: PASS. If `schema_py` fails, that is expected here — it is fixed in Step 13 (regen). You may defer it: `cargo test -p musefs-db -- --skip schema_py`.
+
+- [ ] **Step 9: Add `BackingStamp::from_track` (`musefs-core/src/freshness.rs`)**
+
+Add the `from_track` method shown in Task 1, Step 3 (it now compiles — `Track` has the fields). Remove any `#[allow(dead_code)]` you added.
+
+- [ ] **Step 10: Switch the serve path in `reader.rs`**
+
+Delete the `mtime_secs` helper (lines 73-78). Change `ResolvedFile` (17-40): replace the two fields
+```rust
+    pub backing_size: u64,
+    pub backing_mtime_secs: i64,
+```
+with
+```rust
+    pub stamp: crate::freshness::BackingStamp,
+```
+(keep `pub mtime_secs: i64,` — that is the *displayed* mtime).
+
+In `resolve` (lines 117-121), replace the stat compare:
+```rust
+        crate::metrics::on_stat();
+        let meta = std::fs::metadata(&track.backing_path)?;
+        if crate::freshness::BackingStamp::from_metadata(&meta)
+            != crate::freshness::BackingStamp::from_track(&track)
+        {
+            return Err(CoreError::BackingChanged(track.backing_path.clone()));
+        }
+```
+
+In `build`, fix the two displayed-mtime sites. Line 149 (StructureOnly arm):
+```rust
+                (layout, meta.len(), crate::freshness::BackingStamp::from_track(track).display_secs())
+```
+Line 289 (Synthesis arm):
+```rust
+                (layout, total, crate::freshness::BackingStamp::from_track(track).display_secs().max(track.updated_at))
+```
+
+In the `ResolvedFile` construction (lines 309-320), replace
+```rust
+            backing_size: track.backing_size,
+            backing_mtime_secs: track.backing_mtime,
+            mtime_secs: mtime_secs_val,
+```
+with
+```rust
+            stamp: crate::freshness::BackingStamp::from_track(track),
+            mtime_secs: mtime_secs_val,
+```
+
+Update every `ResolvedFile { ... }` literal in `reader.rs`'s `#[cfg(test)]` module (and the construction above): replace `backing_size: N, backing_mtime_secs: M,` with `stamp: crate::freshness::BackingStamp { size: N, mtime_ns: M, ctime_ns: 0 },`.
+
+Deleting the `mtime_secs` helper also orphans its in-file test callers (reader.rs ~603, 643, 700, 739, 898, 926, 962, 994, 1041, 1063 — each `backing_mtime: mtime_secs(&meta),` inside a `NewTrack`/`Track` literal). Add a small test helper at the top of the `#[cfg(test)]` module and use it at each site:
+```rust
+fn meta_stamp(p: &std::path::Path) -> crate::freshness::BackingStamp {
+    crate::freshness::BackingStamp::from_metadata(&std::fs::metadata(p).unwrap())
+}
+```
+Then each `backing_mtime: mtime_secs(&meta),` becomes `backing_mtime_ns: meta_stamp(&path).mtime_ns, backing_ctime_ns: meta_stamp(&path).ctime_ns,` (use the `path` each test already has; if a site only has `meta`, build the stamp via `BackingStamp::from_metadata(&meta)` inline).
+
+- [ ] **Step 11: Switch the serve path in `facade.rs`**
+
+Delete the `mtime_secs` helper (lines 107-112). `SizeEntry` (85-95): replace
+```rust
+    backing_size: u64,
+    backing_mtime_secs: i64,
+```
+with
+```rust
+    stamp: crate::freshness::BackingStamp,
+```
+(keep `mtime_secs: i64` — displayed value.)
+
+`validate_opened_backing` (114-122):
+```rust
+fn validate_opened_backing(file: &std::fs::File, resolved: &ResolvedFile) -> Result<()> {
+    let meta = file.metadata()?;
+    if crate::freshness::BackingStamp::from_metadata(&meta) != resolved.stamp {
+        return Err(CoreError::BackingChanged(
+            resolved.backing_path.to_string_lossy().into_owned(),
+        ));
+    }
+    Ok(())
+}
+```
+
+`getattr` size-cache hit compare (lines 961-965):
+```rust
+                crate::metrics::on_stat();
+                let meta = std::fs::metadata(&track.backing_path)?;
+                if crate::freshness::BackingStamp::from_metadata(&meta) != e.stamp {
+                    return Err(CoreError::BackingChanged(track.backing_path.clone()));
+                }
+                return Ok((e.total_len, e.mtime_secs));
+```
+
+`SizeEntry` insert (lines 970-979):
+```rust
+            self.size_cache.insert(
+                track_id,
+                SizeEntry {
+                    content_version: track.content_version,
+                    total_len: resolved.total_len,
+                    mtime_secs: resolved.mtime_secs,
+                    stamp: resolved.stamp,
+                },
+            );
+```
+
+Deleting `facade.rs`'s `mtime_secs` helper also orphans its in-file test caller at `facade.rs:1216-1217` (a `ResolvedFile`-shaped literal): replace
+```rust
+            backing_mtime_secs: mtime_secs(&expected_meta),
+            mtime_secs: mtime_secs(&expected_meta),
+```
+with
+```rust
+            stamp: crate::freshness::BackingStamp::from_metadata(&expected_meta),
+            mtime_secs: crate::freshness::BackingStamp::from_metadata(&expected_meta).display_secs(),
+```
+(adjust if that literal also names `backing_size:` — fold it into the `stamp`).
+
+- [ ] **Step 12: Switch the scanner write sites in `scan.rs` (stamp from the path-stat for now)**
+
+Delete the `mtime_secs` helper (lines 52-56). `Unit` (480-487):
+```rust
+struct Unit {
+    abs_path: String,
+    stamp: crate::freshness::BackingStamp,
+    probed: Probed,
+    weight: u64,
+}
+```
+
+Worker `Unit` construction (lines 732-738): replace `meta_len`/`meta_mtime` with
+```rust
+                        let unit = Unit {
+                            abs_path: abs.to_string_lossy().into_owned(),
+                            stamp: crate::freshness::BackingStamp::from_metadata(&meta),
+                            probed,
+                            weight,
+                        };
+```
+
+Writer destructure (lines 768-777): replace the `meta_len`/`meta_mtime` bindings with `stamp`, and pass it to `ingest_bulk`:
+```rust
+        for Unit {
+            abs_path,
+            stamp,
+            probed,
+            weight,
+        } in batch.drain(..)
+        {
+            weights.push(weight);
+            ingest_bulk(&mut bw, &abs_path, stamp, probed)?;
+            *scanned += 1;
+        }
+```
+
+`ingest_bulk` (581): change signature + the `NewTrack`:
+```rust
+fn ingest_bulk(
+    bw: &mut musefs_db::BulkWriter<'_>,
+    abs_path: &str,
+    stamp: crate::freshness::BackingStamp,
+    probed: Probed,
+) -> Result<()> {
+    let track_id = bw.upsert_track(&NewTrack {
+        backing_path: abs_path.to_string(),
+        format: probed.format,
+        audio_offset: probed.audio_offset,
+        audio_length: probed.audio_length,
+        backing_size: stamp.size,
+        backing_mtime_ns: stamp.mtime_ns,
+        backing_ctime_ns: stamp.ctime_ns,
+    })?;
+    // ... rest unchanged ...
+```
+
+`ingest` (504): replace the `meta: &std::fs::Metadata` param with `stamp: crate::freshness::BackingStamp`, and the `NewTrack` body as above (`backing_size: stamp.size`, `backing_mtime_ns: stamp.mtime_ns`, `backing_ctime_ns: stamp.ctime_ns`). Its only non-test caller is `scan_directory_full_oracle` (line 863) — change it to:
+```rust
+        let meta = std::fs::metadata(&path)?;
+        let abs = std::fs::canonicalize(&path)?;
+        ingest(db, &abs.to_string_lossy(), crate::freshness::BackingStamp::from_metadata(&meta), probed)?;
+```
+and update the in-file `ingest(` test callers (scan.rs ~1724, ~1790) similarly (`crate::freshness::BackingStamp::from_metadata(&meta)` in place of `&meta`).
+
+- [ ] **Step 13: Fix core test fixtures and regenerate the Python mirrors**
+
+Across `musefs-core` tests (the files from `grep -rln backing_mtime musefs-core/tests`), update each `NewTrack`/`Track` literal: `backing_mtime: X` → `backing_mtime_ns: X, backing_ctime_ns: 0`. For `tests/backing_changed_fault.rs`'s pre-existing `shrinking_the_backing_file...` test, replace `backing_mtime: common::real_mtime(&src),` with:
+```rust
+            backing_mtime_ns: { let m = std::fs::metadata(&src).unwrap(); use std::os::unix::fs::MetadataExt; m.mtime() * 1_000_000_000 + m.mtime_nsec() },
+            backing_ctime_ns: { let m = std::fs::metadata(&src).unwrap(); use std::os::unix::fs::MetadataExt; m.ctime() * 1_000_000_000 + m.ctime_nsec() },
+```
+(or add a `common::real_stamp(&src) -> (i64, i64)` helper to `tests/common/mod.rs` and use it across the core tests to keep this DRY.) Update `ResolvedFile { ... }` literals in `tests/read_at.rs` / `tests/reader.rs` the same way as Step 10.
+
+Regenerate both schema mirrors:
+```bash
+MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py
+python contrib/python-musefs/vendor_to_picard.py
+```
+
+- [ ] **Step 14: Run the full workspace suite + the new tests**
+
+```bash
+cargo test 2>&1 | tail -30
+cargo test -p musefs-core --features metrics 2>&1 | tail -30
+cargo test -p musefs-core --test backing_changed_fault --test facade 2>&1 | tail -20
+```
+Expected: all PASS, including the four new tests. The `metrics` run must still pass with **no** assertion edits (the serve-path stat counts are unchanged — one `metadata` per getattr hit).
+
+- [ ] **Step 15: Lint + format**
+
+```bash
+cargo clippy --all-targets 2>&1 | tail -20
+cargo fmt --all
+```
+Expected: no warnings (CI uses `-D warnings`).
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add -A
+git commit -m "feat: nanosecond mtime + ctime freshness stamp (#276)"
+```
+
+---
+
+## Task 3: Scanner fstat sandwich (`probe_file`)
+
+Make `probe_file` open once, fstat before and after the probe, and report `Raced` when the file moved mid-probe — so the stored stamp and the probed bytes provably share one inode held still across the probe.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (`ScanStats`/`RevalidateStats`, `probe_file` 279-370, worker 716-752, `run_pipeline` counters 702-703, test call sites 2010/2050)
+
+- [ ] **Step 1: Write the failing test**
+
+In `scan.rs`'s `#[cfg(test)] mod tests`, add (model the file setup on `oversize_wav_is_served_via_data_header` at line 2014):
+
+```rust
+    #[test]
+    fn probe_file_reports_raced_on_mid_probe_mutation() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.wav");
+
+        // Minimal valid WAV the probe accepts (fmt + tiny data).
+        let mut fmt = Vec::new();
+        for v in [1u16, 1, 0, 0, 0, 16] { fmt.extend_from_slice(&v.to_le_bytes()); }
+        // (sample_rate/byte_rate left 0; the chunk walk does not validate them.)
+        let mut front = b"RIFF".to_vec();
+        front.extend_from_slice(&0u32.to_le_bytes());
+        front.extend_from_slice(b"WAVE");
+        front.extend_from_slice(b"fmt ");
+        front.extend_from_slice(&(fmt.len() as u32).to_le_bytes());
+        front.extend_from_slice(&fmt);
+        front.extend_from_slice(b"data");
+        front.extend_from_slice(&64u32.to_le_bytes());
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&front).unwrap();
+        f.set_len(front.len() as u64 + 64).unwrap();
+        drop(f);
+
+        let pc = path.clone();
+        set_after_s1_hook(move || {
+            let mut g = std::fs::OpenOptions::new().append(true).open(&pc).unwrap();
+            g.write_all(&[0u8; 4096]).unwrap(); // size moves → S2 != S1
+        });
+        let out = probe_file(&path, WINDOW);
+        clear_after_s1_hook();
+        assert!(matches!(out, Ok(ProbeOutcome::Raced)), "got {out:?}");
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p musefs-core --lib probe_file_reports_raced 2>&1 | tail -20`
+Expected: FAIL — `ProbeOutcome` / `set_after_s1_hook` undefined, and `probe_file` still takes `file_len`.
+
+- [ ] **Step 3: Add the outcome enum, test hook, and `raced` counters**
+
+Near the top of `scan.rs` (module scope):
+
+```rust
+/// Outcome of probing one backing file. `Raced` means the file changed under us
+/// between the pre- and post-probe `fstat` — the probe may be torn, so nothing
+/// is committed for it (#276).
+#[derive(Debug)]
+enum ProbeOutcome {
+    Probed(Probed, crate::freshness::BackingStamp),
+    Unsupported,
+    Raced,
+}
+
+#[cfg(test)]
+thread_local! {
+    static AFTER_S1_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+#[cfg(test)]
+fn fire_after_s1() {
+    AFTER_S1_HOOK.with(|h| { if let Some(f) = h.borrow_mut().as_mut() { f() } });
+}
+#[cfg(test)]
+fn set_after_s1_hook(f: impl FnMut() + 'static) {
+    AFTER_S1_HOOK.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+}
+#[cfg(test)]
+fn clear_after_s1_hook() {
+    AFTER_S1_HOOK.with(|h| *h.borrow_mut() = None);
+}
+```
+
+Add `pub raced: u64,` to both `ScanStats` (line 38) and `RevalidateStats` (line 45), and update every literal:
+- `run_pipeline`'s returned `ScanStats { ... }` (line 831): `raced: raced.load(Ordering::Relaxed)` (the new Arc counter from Step 5).
+- `scan_directory_full_oracle`'s `ScanStats { ... }` (line 850): `raced: 0` (whole-file oracle path; no sandwich).
+- `revalidate_with`'s `RevalidateStats { ... }` (line 952): `raced: scan.raced` (carry it through from the pipeline result).
+- Any `ScanStats`/`RevalidateStats` literal or field-assert in tests the compiler flags.
+
+- [ ] **Step 4: Rewrite `probe_file`'s open/stat/probe shell**
+
+Change the signature and wrap the existing probe body. The internal probe logic (m4a arm, front-anchored widen loop, fallbacks) is unchanged except it no longer receives `file_len` as a parameter — derive it from S1 and feed S1's `size` everywhere the old `file_len` was used (including `mp4::read_structure_from(&mut f, file_len)`):
+
+```rust
+fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
+    let file = std::fs::File::open(path)?;
+    crate::metrics::on_scan_open();
+    let s1 = crate::freshness::BackingStamp::from_metadata(&file.metadata()?);
+    #[cfg(test)]
+    fire_after_s1();
+    let file_len = s1.size;
+
+    // ---- existing probe body, verbatim, but using `file_len = s1.size` ----
+    let probed: Option<Probed> = { /* the current body, returning the Probed or None */ };
+    // -----------------------------------------------------------------------
+
+    let s2 = crate::freshness::BackingStamp::from_metadata(&file.metadata()?);
+    if s1 != s2 {
+        log::warn!("skipping {}: changed during probe", path.display());
+        return Ok(ProbeOutcome::Raced);
+    }
+    Ok(match probed {
+        Some(p) => ProbeOutcome::Probed(p, s1),
+        None => ProbeOutcome::Unsupported,
+    })
+}
+```
+
+> Mechanical refactor of the body: the current function has many early `return Ok(Some(p))` / `return Ok(None)` points. Convert them so the body yields an `Option<Probed>` bound to `probed` instead of returning directly (e.g. extract the current body into an inner closure `let probe = |file_len: u64| -> std::io::Result<Option<Probed>> { ... };` and call `let probed = probe(file_len)?;`). The inner closure keeps using the same `file` handle (capture `&file`).
+
+- [ ] **Step 5: Update the worker loop (`scan.rs:719-751`)**
+
+Remove the pre-probe `std::fs::metadata(&path)` at line 720 (open failure inside `probe_file` now routes to `failed`), and switch the match:
+
+```rust
+                let Some(path) = next else { break };
+                match probe_file(&path, window) {
+                    Ok(ProbeOutcome::Probed(probed, stamp)) => {
+                        let Ok(abs) = std::fs::canonicalize(&path) else {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            continue;
+                        };
+                        let weight = payload_weight(&probed);
+                        budget.acquire(weight);
+                        let unit = Unit {
+                            abs_path: abs.to_string_lossy().into_owned(),
+                            stamp,
+                            probed,
+                            weight,
+                        };
+                        if tx.send(unit).is_err() {
+                            budget.release(weight);
+                            break;
+                        }
+                    }
+                    Ok(ProbeOutcome::Unsupported) => { skipped.fetch_add(1, Ordering::Relaxed); }
+                    Ok(ProbeOutcome::Raced) => { raced.fetch_add(1, Ordering::Relaxed); }
+                    Err(_) => { failed.fetch_add(1, Ordering::Relaxed); }
+                }
+```
+
+Add a `raced` `Arc<AtomicU64>` alongside `skipped`/`failed` (lines 702-703, cloned into each worker like the others), and fold its final value into the returned `ScanStats.raced`.
+
+- [ ] **Step 6: Update the existing `probe_file` unit-test call sites**
+
+Line 2010: `assert!(matches!(probe_file(&path, WINDOW), Ok(ProbeOutcome::Unsupported)));`
+Line 2050-2052:
+```rust
+        let probed = match probe_file(&path, WINDOW).unwrap() {
+            ProbeOutcome::Probed(p, _) => p,
+            other => panic!("oversize wav should probe, got {other:?}"),
+        };
+```
+
+- [ ] **Step 7: Run the test + suite**
+
+```bash
+cargo test -p musefs-core --lib probe_file 2>&1 | tail -20
+cargo test 2>&1 | tail -20
+cargo clippy --all-targets 2>&1 | tail -10
+```
+Expected: PASS, no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(scan): fstat-sandwich probe_file, stamp from the probed fd (#276)"
+```
+
+---
+
+## Task 4: Revalidate skip pass compares the full stamp
+
+`scan --revalidate`'s pre-dispatch skip must treat a ctime-only change as "changed" so an adversarial mtime-reset-after-rewrite is re-probed instead of skipped.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (`revalidate_with` `existing` map 896-905 and skip compare 924-929)
+- Test: `musefs-core/tests/` (new integration test; create `revalidate_freshness.rs` or extend an existing revalidate test file if one exists — check `grep -rl revalidate musefs-core/tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `musefs-core/tests/revalidate_freshness.rs`:
+
+```rust
+mod common;
+use musefs_db::Db;
+
+// A ctime-only change (mtime forged back after an in-place same-size rewrite)
+// must NOT be skipped as "unchanged": revalidate re-probes it.
+#[test]
+fn revalidate_reprobes_on_ctime_only_change() {
+    use std::os::unix::fs::MetadataExt;
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    common::write_flac(&src, &["TITLE=Old"], &[0xAB; 4096]);
+    let db_path = dir.path().join("m.db");
+    {
+        let db = Db::open(&db_path).unwrap();
+        musefs_core::scan_directory(&db, dir.path()).unwrap();
+    }
+    let original_modified = std::fs::metadata(&src).unwrap().modified().unwrap();
+
+    // Rewrite in place (same size, new tag), then forge mtime back. ctime moved.
+    common::write_flac(&src, &["TITLE=New"], &[0xCD; 4096]);
+    let f = std::fs::OpenOptions::new().write(true).open(&src).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(original_modified)).unwrap();
+    drop(f);
+
+    let db = Db::open(&db_path).unwrap();
+    let stats = musefs_core::revalidate(&db, dir.path()).unwrap();
+    assert_eq!(stats.updated, 1, "ctime-only change must be re-probed");
+}
+```
+
+> `musefs_core::revalidate(db, root) -> RevalidateStats { updated, unchanged, pruned, failed, raced }` is re-exported from the crate root (`lib.rs:22`). `write_flac` returns `(audio_offset, audio_length)`; ignore them here.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p musefs-core --test revalidate_freshness 2>&1 | tail -20`
+Expected: FAIL — `updated == 0` (the old skip pass compares only size + whole-second mtime, both unchanged after the forge).
+
+- [ ] **Step 3: Widen the `existing` map and skip compare (`scan.rs`)**
+
+Change the `existing` map (lines 896-905) to carry `backing_ctime_ns`:
+
+```rust
+    let existing: HashMap<String, (crate::freshness::BackingStamp, i64, Format)> = db
+        .list_tracks()?
+        .into_iter()
+        .map(|t| {
+            (
+                t.backing_path.clone(),
+                (crate::freshness::BackingStamp::from_track(&t), t.id, t.format),
+            )
+        })
+        .collect();
+```
+
+Change the skip check (lines 924-929):
+
+```rust
+        if let Some((stamp, id, format)) = existing.get(&key).copied() {
+            let needs_backfill = format == Format::Flac && !have_structural.contains(&id);
+            if crate::freshness::BackingStamp::from_metadata(&meta) == stamp && !needs_backfill {
+                unchanged += 1;
+                continue;
+            }
+        }
+```
+
+> `from_track` borrows `t`; clone `backing_path` before the map closure moves it (shown above). `BackingStamp` is `Copy`, so `.copied()` on the `get` works.
+
+- [ ] **Step 4: Run the test + suite**
+
+```bash
+cargo test -p musefs-core --test revalidate_freshness 2>&1 | tail -20
+cargo test 2>&1 | tail -20
+cargo clippy --all-targets 2>&1 | tail -10
+```
+Expected: PASS, no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(scan): revalidate compares the full freshness stamp (#276)"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Update the freshness/contract prose**
+
+Edit `ARCHITECTURE.md`:
+- The `tracks` column list (around line 157-158, "Ownership"): replace `backing_mtime` with `backing_mtime_ns` and add `backing_ctime_ns` to the scanner-owned set.
+- "What musefs defends at serve time" (around 193-203): the serve-time guard now compares size + nanosecond mtime + ctime, not whole-second mtime.
+- "Freshness: two version counters" (around 249-268): describe the stamp as `(size, mtime_ns, ctime_ns)`; note the scanner stamps from the **probed descriptor** with a pre/post `fstat` sandwich and drops files that change mid-probe; note `ctime` defeats an mtime-forging writer.
+- V5 description (around 143-151) and the V1 `tracks` column description (around 119-120): reflect the renamed/added columns and that the geometry trigger keys on `backing_mtime_ns`.
+
+Keep edits factual and concise; do not restructure sections.
+
+- [ ] **Step 2: Final full verification**
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets 2>&1 | tail -10
+cargo test 2>&1 | tail -20
+cargo test -p musefs-core --features metrics 2>&1 | tail -20
+cargo +nightly fuzz build 2>&1 | tail -5   # format-layer signatures untouched; smoke only
+```
+Expected: all green. (The fuzz build is a precaution; no format-layer signature changed, so it should pass unchanged.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md
+git commit -m "docs: nanosecond mtime + ctime freshness stamp (#276)"
+```
+
+---
+
+## Done-when
+
+- Three serve-path compare sites (`resolve`, `validate_opened_backing`, `getattr` size-cache) and the revalidate skip use `(size, mtime_ns, ctime_ns)`.
+- The scanner stamps from the same descriptor it probes and drops mid-probe-mutated files (`raced`).
+- A same-size sub-second rewrite, and an adversarial mtime-reset-after-rewrite, both yield `BackingChanged`; the synthesized displayed mtime stays whole seconds.
+- `user_version` is still 5; both `schema.py` mirrors regenerated; full workspace suite + `metrics` feature green.

--- a/docs/superpowers/plans/2026-06-12-backing-freshness.md
+++ b/docs/superpowers/plans/2026-06-12-backing-freshness.md
@@ -348,7 +348,7 @@ to:
 
 Do **not** add `backing_ctime_ns` to the trigger (spec: pure freshness identity, not a served-byte input).
 
-Then fix the in-file test SQL: every `INSERT INTO tracks (... backing_mtime ...)` and any `UPDATE tracks SET backing_mtime ...` in `schema.rs`'s `#[cfg(test)]` modules must use `backing_mtime_ns` (grep `backing_mtime` within `schema.rs`; the `backing_ctime_ns` default of 0 lets you omit it from INSERT column lists).
+Then fix the in-file test SQL: every `INSERT INTO tracks (... backing_mtime ...)` and any `UPDATE tracks SET backing_mtime ...` in `schema.rs`'s `#[cfg(test)]` modules must use `backing_mtime_ns` (grep `backing_mtime` within `schema.rs`; the `backing_ctime_ns` default of 0 lets you omit it from INSERT column lists). The densest cluster is the `migration_v4_tests` module (raw `INSERT INTO tracks` strings around `schema.rs:462, 507, 561, 801, 937-1046`), including `v4_tracks_rejects_negative_backing_mtime` — these are **runtime** failures (the compiler does not check SQL strings), so sweep the whole module rather than relying on build errors.
 
 - [ ] **Step 4: Rename the model fields (`musefs-db/src/models.rs`)**
 
@@ -491,13 +491,13 @@ with
 
 Update every `ResolvedFile { ... }` literal in `reader.rs`'s `#[cfg(test)]` module (and the construction above): replace `backing_size: N, backing_mtime_secs: M,` with `stamp: crate::freshness::BackingStamp { size: N, mtime_ns: M, ctime_ns: 0 },`.
 
-Deleting the `mtime_secs` helper also orphans its in-file test callers (reader.rs ~603, 643, 700, 739, 898, 926, 962, 994, 1041, 1063 — each `backing_mtime: mtime_secs(&meta),` inside a `NewTrack`/`Track` literal). Add a small test helper at the top of the `#[cfg(test)]` module and use it at each site:
+Deleting the `mtime_secs` helper also orphans its in-file test callers — every `backing_mtime:` field in a `NewTrack`/`Track`/`ResolvedFile` literal in `reader.rs`'s `#[cfg(test)]` module that the compiler now flags. These appear in several forms: `backing_mtime: mtime_secs(&meta),`, inline `backing_mtime: meta.modified()…as_secs().cast_signed(),`, and bare `backing_mtime: 0,`. Add a small test helper at the top of the `#[cfg(test)]` module and use it for the file-backed sites:
 ```rust
 fn meta_stamp(p: &std::path::Path) -> crate::freshness::BackingStamp {
     crate::freshness::BackingStamp::from_metadata(&std::fs::metadata(p).unwrap())
 }
 ```
-Then each `backing_mtime: mtime_secs(&meta),` becomes `backing_mtime_ns: meta_stamp(&path).mtime_ns, backing_ctime_ns: meta_stamp(&path).ctime_ns,` (use the `path` each test already has; if a site only has `meta`, build the stamp via `BackingStamp::from_metadata(&meta)` inline).
+Then a file-backed `backing_mtime: <secs>,` becomes `backing_mtime_ns: meta_stamp(&path).mtime_ns, backing_ctime_ns: meta_stamp(&path).ctime_ns,` (use the `path`/`meta` each test already has — `BackingStamp::from_metadata(&meta)` inline where only `meta` is in scope). A bare `backing_mtime: 0,` (don't-care, no real file) becomes `backing_mtime_ns: 0, backing_ctime_ns: 0,`. Do not assume a fixed line set — fix each site the compiler reports.
 
 - [ ] **Step 11: Switch the serve path in `facade.rs`**
 
@@ -625,9 +625,26 @@ fn ingest_bulk(
 ```
 and update the in-file `ingest(` test callers (scan.rs ~1724, ~1790) similarly (`crate::freshness::BackingStamp::from_metadata(&meta)` in place of `&meta`).
 
+The two in-file `ingest_bulk(` test callers pass `meta_len`/`meta_mtime` **positionally** and must also change:
+- `scan.rs:1748` — `ingest_bulk(&mut bw, "/a.mp3", 1, 0, probed_with_mixed_binary_tags())` → replace the `1, 0` with `crate::freshness::BackingStamp { size: 1, mtime_ns: 0, ctime_ns: 0 }`.
+- `scan.rs:1814` — the multi-line `ingest_bulk(` call; replace its `meta_len, meta_mtime` (`1, 0`) args with `crate::freshness::BackingStamp { size: 1, mtime_ns: 0, ctime_ns: 0 }`.
+(These back synthetic `/a.*` paths never stat-compared, so a zero stamp is fine.)
+
 - [ ] **Step 13: Fix core test fixtures and regenerate the Python mirrors**
 
-Across `musefs-core` tests (the files from `grep -rln backing_mtime musefs-core/tests`), update each `NewTrack`/`Track` literal: `backing_mtime: X` → `backing_mtime_ns: X, backing_ctime_ns: 0`. For `tests/backing_changed_fault.rs`'s pre-existing `shrinking_the_backing_file...` test, replace `backing_mtime: common::real_mtime(&src),` with:
+Across `musefs-core` tests, update each `NewTrack`/`Track` literal. The compiler enumerates them; the named sites below need specific handling (do not blanket-replace, because some pass a **seconds** value that must become **nanoseconds**):
+
+- **`tests/metrics.rs:230`** — a `/x/ghost.mp3` track never stat-compared: `backing_mtime: 0,` → `backing_mtime_ns: 0, backing_ctime_ns: 0,`. (Re-compiled by the Step 14 `--features metrics` run.)
+- **`tests/external_contract.rs:34`** and **`tests/interop_emit.rs:170, :233`** — these back **real on-disk files** and pass each file's whole-second `real_mtime(...)` (a local helper in each file returning seconds). A seconds value in a `_ns` field would mismatch the real file's nanosecond stat and spuriously trip `BackingChanged`. Replace `backing_mtime: real_mtime(x),` with a real nanosecond stamp:
+  ```rust
+  backing_mtime_ns: { use std::os::unix::fs::MetadataExt; let m = std::fs::metadata(x).unwrap(); m.mtime() * 1_000_000_000 + m.mtime_nsec() },
+  backing_ctime_ns: { use std::os::unix::fs::MetadataExt; let m = std::fs::metadata(x).unwrap(); m.ctime() * 1_000_000_000 + m.ctime_nsec() },
+  ```
+  (`x` is `&audio_path` / `src` respectively.) Their now-unused local `real_mtime` helpers can be deleted, or kept if still referenced elsewhere in the file.
+- **`fuzz/fuzz_targets/serve.rs:29`** — the `fuzz/` crate is **outside the workspace**, so `cargo test`/`cargo build`/`clippy --all-targets` never compile it; this rename will break it invisibly to the Task-14 gates. Fix it here in the slice: change `backing_mtime: i64::try_from(...)` to `backing_mtime_ns: i64::try_from(...)` (keep the same value expression) and add `backing_ctime_ns: 0,`. This track backs a fuzz-synthesized file; a zero ctime is acceptable for the harness.
+- All other flagged `NewTrack`/`Track` literals (e.g. `tests/read_at.rs`, `tests/reader.rs`, `tests/concurrent_reads.rs`, `tests/flac_binary_tags.rs`, `tests/incremental_refresh.rs`, `tests/proptest_read_fidelity.rs`, `tests/reader_faults.rs`, `tests/db_corruption_fault.rs`): if the value is a real file's mtime, use the nanosecond form above (or the `common::real_stamp` helper); if it is a don't-care `0`, use `backing_mtime_ns: 0, backing_ctime_ns: 0`.
+
+For `tests/backing_changed_fault.rs`'s pre-existing `shrinking_the_backing_file...` test, replace `backing_mtime: common::real_mtime(&src),` with:
 ```rust
             backing_mtime_ns: { let m = std::fs::metadata(&src).unwrap(); use std::os::unix::fs::MetadataExt; m.mtime() * 1_000_000_000 + m.mtime_nsec() },
             backing_ctime_ns: { let m = std::fs::metadata(&src).unwrap(); use std::os::unix::fs::MetadataExt; m.ctime() * 1_000_000_000 + m.ctime_nsec() },
@@ -646,8 +663,9 @@ python contrib/python-musefs/vendor_to_picard.py
 cargo test 2>&1 | tail -30
 cargo test -p musefs-core --features metrics 2>&1 | tail -30
 cargo test -p musefs-core --test backing_changed_fault --test facade 2>&1 | tail -20
+cargo +nightly fuzz build serve 2>&1 | tail -5   # out-of-workspace; not covered by `cargo test`
 ```
-Expected: all PASS, including the four new tests. The `metrics` run must still pass with **no** assertion edits (the serve-path stat counts are unchanged — one `metadata` per getattr hit).
+Expected: all PASS, including the four new tests. The `metrics` run must still pass with **no** assertion edits (the serve-path stat counts are unchanged — one `metadata` per getattr hit). The fuzz build must succeed — the `NewTrack` rename touched `fuzz/fuzz_targets/serve.rs` (Step 13) and the fuzz crate is invisible to the other gates.
 
 - [ ] **Step 15: Lint + format**
 
@@ -971,9 +989,9 @@ cargo fmt --all --check
 cargo clippy --all-targets 2>&1 | tail -10
 cargo test 2>&1 | tail -20
 cargo test -p musefs-core --features metrics 2>&1 | tail -20
-cargo +nightly fuzz build 2>&1 | tail -5   # format-layer signatures untouched; smoke only
+cargo +nightly fuzz build 2>&1 | tail -5   # re-confirm; serve.rs was fixed in Task 2 Step 13
 ```
-Expected: all green. (The fuzz build is a precaution; no format-layer signature changed, so it should pass unchanged.)
+Expected: all green. (The `fuzz/` crate is out-of-workspace and consumes `NewTrack` in `serve.rs`; it was updated and built in Task 2. This is a final re-confirmation that the whole fuzz crate still builds.)
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/specs/2026-06-12-backing-freshness-design.md
+++ b/docs/superpowers/specs/2026-06-12-backing-freshness-design.md
@@ -1,0 +1,233 @@
+# Strengthen backing-file freshness checks (issue #276)
+
+## Problem
+
+The freshness stamp that decides whether a `tracks` row still matches its
+backing file is keyed only on `backing_size` plus a **whole-second** `mtime`.
+The same weak stamp is collected and compared in several places:
+
+- `musefs-core/src/scan.rs` records `meta.len()` and `mtime_secs(&meta)` taken
+  from a `stat(path)` (`scan.rs:720`, `:734-735`) that is **separate** from the
+  `open(path)` `probe_file` performs internally (`scan.rs:279`). The stored
+  stamp and the probed bytes can therefore come from two different versions of
+  the file.
+- `HeaderCache::resolve` (`musefs-core/src/reader.rs:119`) and
+  `validate_opened_backing` (`musefs-core/src/facade.rs:117`) reject drift only
+  when size or whole-second mtime differs.
+- Tests work around the whole-second truncation by forcing a distinct second
+  before expecting `BackingChanged`.
+
+Two concrete silent-drift windows follow:
+
+1. **Same-second, same-size in-place rewrite.** A file rewritten in place with
+   identical length inside the same clock second evades the guard. musefs then
+   pairs a cached/synthesized metadata layout from one version with backing
+   audio bytes from another.
+2. **Scan-time TOCTOU.** A worker stats a path, then opens/probes it
+   separately, then stores the earlier stamp. If the path changes between those
+   operations the committed row combines a probe of one version with a
+   validation stamp from another.
+
+## Goals
+
+- Make the stored backing identity strong enough that a busy *or adversarial*
+  same-size rewrite is detected, without a content hash on the hot path.
+- Close the scan-time race so the committed stamp and the probed bytes provably
+  come from one descriptor / one inode, held still across the whole probe.
+- Keep the serve path's existing doctrine: the DB is untrusted input; a
+  mismatch degrades to a controlled `BackingChanged`, never undefined behavior.
+
+## Non-goals
+
+- No content hashing (rejected in the issue as too expensive for the hot path).
+- No device/inode in the stamp. Inode/dev in a freshness key risk spurious
+  `BackingChanged` across a remount or on inode-reassigning filesystems
+  (network/overlay), and the size+mtime+ctime stamp already covers the in-place
+  and rename-swap rewrite cases this issue is about. Deferred.
+- No backwards-compatibility / migration upgrade path: there are no extant
+  deployed databases, so the schema is edited in place (see Migration).
+
+## Design
+
+### The freshness stamp
+
+Replace the `(backing_size, whole-second mtime)` pair with a three-integer
+stamp, each timestamp stored as **nanoseconds since the Unix epoch** in a
+single `INTEGER` column:
+
+```rust
+struct BackingStamp {
+    size: u64,
+    mtime_ns: i64,
+    ctime_ns: i64,
+}
+```
+
+Captured on unix from one `fstat` via `std::os::unix::fs::MetadataExt`:
+
+```rust
+let mtime_ns = meta.mtime() * 1_000_000_000 + meta.mtime_nsec();
+let ctime_ns = meta.ctime() * 1_000_000_000 + meta.ctime_nsec();
+```
+
+An `i64` of nanoseconds-since-epoch is good until ~2262.
+
+**Why ctime as well as nanosecond mtime.** Nanosecond mtime closes the
+same-second window for a merely-busy writer: a normal `write()` stamps the
+current time at nanosecond resolution, so a collision is effectively
+impossible. It does **not** stop an adversary who resets mtime backward with
+`utimensat` to the stored value. `ctime` (inode change time) is bumped by any
+write and **cannot be set backward** short of clock manipulation, so it closes
+the adversarial-reset case. Both come free from the same `fstat`.
+
+`BackingStamp` lives in `musefs-core` (the integration layer) and consolidates
+the three duplicated `mtime_secs` helpers (`reader.rs:73`, `facade.rs:108`,
+`scan.rs:52`) into one `from_metadata(&Metadata)` constructor plus an equality
+comparison. `musefs_db::Track` and `musefs_db::NewTrack` carry the two
+timestamp integers; `ResolvedFile` carries the whole stamp for the per-handle
+read path.
+
+### Schema (edit in place — no new migration)
+
+There are no extant databases, so the schema is edited in place rather than by
+appending a `MIGRATION_V6`. `user_version` stays at 5, so the Picard conftest
+`user_version` sanity assertion needs no bump.
+
+In `MIGRATION_V5` (`musefs-db/src/schema.rs`), before the trigger definitions:
+
+```sql
+ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
+ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0;
+```
+
+- The column is **renamed** (not silently repurposed) so a column named
+  `backing_mtime` cannot end up holding nanoseconds — the unit is in the name.
+- SQLite (`legacy_alter_table` off, the default) rewrites the existing
+  `CHECK (backing_mtime >= 0)` to reference `backing_mtime_ns` automatically on
+  `RENAME COLUMN`. Mirror it for the new column: `backing_ctime_ns >= 0`
+  semantics are preserved (ctime is `>= 0`; no tighter bound).
+- The `tracks_geometry_au` trigger (`schema.rs:327`) is written against the new
+  name. `backing_ctime_ns` is **not** added to its `WHEN` clause — see
+  Deliberate non-changes.
+- Columns are `NOT NULL`; every row is written with a full stamp by the updated
+  scanner. A stale developer database is simply rescanned (a `DEFAULT 0` ctime
+  on any pre-existing row mismatches the real file and forces a re-probe, which
+  is correct).
+
+The schema string is the source of truth; regenerate the Python mirror
+(`MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py`) and re-vendor.
+
+### DB read/write plumbing
+
+- `track_select!` column list (`tracks.rs:13`) and `row_to_track`
+  (`tracks.rs:32`) gain `backing_mtime_ns` (renamed) and `backing_ctime_ns`.
+- `upsert_track` (`tracks.rs:187`) and the bulk-writer insert (`ingest_bulk`'s
+  SQL) add both columns to the INSERT column list, the `VALUES`, and the
+  `ON CONFLICT DO UPDATE SET`.
+- `Track` (`models.rs:124`) and `NewTrack` (`models.rs:137`) replace
+  `backing_mtime: i64` with `backing_mtime_ns: i64` and add
+  `backing_ctime_ns: i64`.
+
+### Scanner — fd-based stamp + fstat sandwich
+
+`probe_file` (`scan.rs:279`) becomes the single point that opens, stamps, and
+probes one descriptor:
+
+1. `open(path)` once.
+2. `fstat` → **S1**. Its `len` is the `file_len` the probe already needs, and
+   S1 is the candidate stored stamp.
+3. Probe from that descriptor (existing probe logic unchanged).
+4. `fstat` → **S2**.
+5. If `S1 != S2` (size, mtime_ns, or ctime_ns moved) the file changed under us
+   mid-probe → return a "raced" outcome; commit nothing for this file.
+
+`probe_file` returns `Option<(Probed, BackingStamp)>`. The worker
+(`run_pipeline`, ~`scan.rs:716`) stores **that** stamp instead of the
+path-stat values, so the committed stamp and the probed bytes share one inode
+held still across the probe. The redundant pre-probe `std::fs::metadata(&path)`
+at `scan.rs:720` is removed: an `open` failure inside `probe_file` already
+returns `Err`, which the worker routes to the `failed` arm.
+
+Add a `raced` counter to `ScanStats` / `RevalidateStats` so mid-probe races are
+observable and assertable. (Logged at `warn`.)
+
+`Unit` (`scan.rs`), `ingest` (`scan.rs:507`), and `ingest_bulk`
+(`scan.rs:587`) carry and persist the three-integer stamp instead of
+`meta_len` / `meta_mtime`.
+
+### Serve-path validation
+
+Both compare sites switch to `BackingStamp`, re-stat, full three-field compare,
+`BackingChanged` on any mismatch:
+
+- `HeaderCache::resolve` (`reader.rs:110`): re-stat on every resolve
+  (`reader.rs:118`), compare `BackingStamp::from_metadata(&meta)` against the
+  track's stored stamp (`reader.rs:119`).
+- `validate_opened_backing` (`facade.rs:115`): same, against the held
+  descriptor's `file.metadata()` on every read. `ResolvedFile`
+  (`reader.rs:~26`, fields `backing_size` / `backing_mtime_secs`) carries the
+  full stamp, captured at resolve time (`reader.rs:~314`).
+
+### Revalidate skip pass
+
+The pre-dispatch skip check (`scan.rs:924-929`) compares the **full** stored
+stamp `(size, mtime_ns, ctime_ns)` against the candidate file; any difference
+forces a re-probe. This means a ctime-only change — e.g. an adversarial
+mtime-reset after an in-place rewrite — is no longer skipped as "unchanged".
+The existing `needs_backfill` FLAC-structural hook is unaffected.
+
+### Deliberate non-changes
+
+- `backing_ctime_ns` (and the nanosecond precision of `backing_mtime_ns`) are
+  **not** added to the `tracks_geometry_au` trigger's `WHEN` clause. They are
+  pure freshness identity, not inputs to synthesized bytes; their enforcement
+  is the serve-path re-stat, not `content_version`. Keeping them out preserves
+  `content_version`'s documented "minimal superset of served-byte inputs"
+  property (ARCHITECTURE.md, V5) and avoids cache churn on byte-identical
+  re-probes. A cache entry is keyed on `content_version`, but `resolve`
+  re-reads the track row and re-stats *before* the cache lookup, so a changed
+  stamp is always enforced regardless of `content_version`.
+
+## Testing
+
+- **Same-second sub-second rewrite** → `BackingChanged`. Removes the test-only
+  "force a distinct second" workaround.
+- **Adversarial reset**: rewrite in place, then `utimensat` mtime back to the
+  stored value → still caught via `ctime_ns`.
+- **Scan-time mutation**: mutate the file between S1 and S2 (a probe hook) →
+  `raced`, no row committed.
+- **Revalidate ctime-only change**: file whose ctime moved but size+mtime did
+  not is re-probed, not skipped.
+- **Serve-path per-read guard**: `validate_opened_backing` rejects a held
+  handle after a same-size sub-second rewrite.
+- Schema mirror regenerated; full workspace suite green, including
+  `cargo test -p musefs-core --features metrics` (the stat/open-count
+  assertions: the extra scan-time `fstat` and the removed path-stat shift
+  scanner stat counts — update expectations) and the FUSE e2e tier where
+  relevant.
+- `cargo +nightly fuzz build` if any format-layer signature is touched (it is
+  not expected to be).
+
+## Documentation updates
+
+- `ARCHITECTURE.md`: the freshness sections (the `tracks` column list at
+  `:157-158`, "What musefs defends at serve time" at `:193-203`, and "Freshness:
+  two version counters" at `:249-268`) describe the stamp as size + mtime;
+  update to size + nanosecond mtime + ctime, and note the scanner now stamps
+  from the probed descriptor with a stat sandwich.
+- The external-writer contract's scanner-owned column list (`ARCHITECTURE.md`
+  "Ownership") replaces `backing_mtime` with `backing_mtime_ns` and adds
+  `backing_ctime_ns`.
+
+## Affected files
+
+| File | Change |
+| ---- | ------ |
+| `musefs-db/src/schema.rs` | V5 rename + add column; trigger + CHECK; Python mirror regen |
+| `musefs-db/src/models.rs` | `Track`, `NewTrack` stamp fields |
+| `musefs-db/src/tracks.rs` | `track_select!`, `row_to_track`, `upsert_track`, bulk insert |
+| `musefs-core/src/reader.rs` | `BackingStamp`, `ResolvedFile`, `resolve` compare |
+| `musefs-core/src/facade.rs` | `validate_opened_backing` compare; drop dup `mtime_secs` |
+| `musefs-core/src/scan.rs` | `probe_file` fd-stat sandwich, `raced` counter, `Unit`/`ingest`/revalidate skip; drop dup `mtime_secs` |
+| `ARCHITECTURE.md` | freshness + contract docs |
+| Python schema mirror + vendored copy | regenerate |

--- a/docs/superpowers/specs/2026-06-12-backing-freshness-design.md
+++ b/docs/superpowers/specs/2026-06-12-backing-freshness-design.md
@@ -114,8 +114,15 @@ ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0;
   on any pre-existing row mismatches the real file and forces a re-probe, which
   is correct).
 
-The schema string is the source of truth; regenerate the Python mirror
-(`MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py`) and re-vendor.
+The schema string is the source of truth; both Python mirrors embed the full
+migration SQL verbatim and must be regenerated and re-vendored:
+`MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py` rewrites
+`contrib/python-musefs/src/musefs_common/schema.py`, then
+`python contrib/python-musefs/vendor_to_picard.py` propagates it to
+`contrib/picard/musefs/_common/schema.py`. The `schema_py` gate test
+(`schema.rs:685`) is part of the green-commit set. `user_version` is unchanged
+(still 5), so the Picard `test_conftest_sanity.py` `== 5` assertion needs no
+bump.
 
 ### DB read/write plumbing
 
@@ -141,32 +148,68 @@ probes one descriptor:
 5. If `S1 != S2` (size, mtime_ns, or ctime_ns moved) the file changed under us
    mid-probe → return a "raced" outcome; commit nothing for this file.
 
-`probe_file` returns `Option<(Probed, BackingStamp)>`. The worker
-(`run_pipeline`, ~`scan.rs:716`) stores **that** stamp instead of the
-path-stat values, so the committed stamp and the probed bytes share one inode
-held still across the probe. The redundant pre-probe `std::fs::metadata(&path)`
-at `scan.rs:720` is removed: an `open` failure inside `probe_file` already
-returns `Err`, which the worker routes to the `failed` arm.
+**Signature and return.** `probe_file` currently is
+`fn probe_file(path, file_len, window) -> io::Result<Option<Probed>>`, where
+`file_len` is supplied by the caller from a separate path-stat. After the
+refactor it takes no `file_len` (it derives the probe ceiling from S1's `len`,
+including the `m4a` arm's `mp4::read_structure_from` at `scan.rs:296`) and must
+distinguish **three** outcomes that `Ok(None)` alone cannot: probed-ok,
+unsupported/skip, and raced. Use a small enum, e.g.
 
-Add a `raced` counter to `ScanStats` / `RevalidateStats` so mid-probe races are
-observable and assertable. (Logged at `warn`.)
+```rust
+enum ProbeOutcome { Probed(Probed, BackingStamp), Unsupported, Raced }
+fn probe_file(path: &Path, window: usize) -> io::Result<ProbeOutcome>
+```
 
-`Unit` (`scan.rs`), `ingest` (`scan.rs:507`), and `ingest_bulk`
-(`scan.rs:587`) carry and persist the three-integer stamp instead of
-`meta_len` / `meta_mtime`.
+so `Raced` is counted as `raced` (not folded into the existing `skipped`, which
+means "unsupported/unparseable", nor `failed`, which means an IO error). The
+worker (`run_pipeline`, ~`scan.rs:716`) stores the returned stamp, so the
+committed stamp and the probed bytes share one inode held still across the
+probe. The redundant pre-probe `std::fs::metadata(&path)` at `scan.rs:720` is
+removed: an `open` failure inside `probe_file` already returns `Err`, routed to
+the `failed` arm.
+
+Add a `raced` counter to `ScanStats` / `RevalidateStats`, logged at `warn`.
+
+The stamp must flow through the worker→writer channel and the two ingest paths
+without re-statting (a fresh `Metadata` would reopen the TOCTOU this closes):
+
+- `Unit` (`scan.rs:482`) replaces `meta_len`/`meta_mtime` with the three-integer
+  stamp; update its construction (`scan.rs:732`) and the writer destructure
+  (`scan.rs:768`).
+- `ingest_bulk` (`scan.rs:587`) replaces its `meta_len`/`meta_mtime` params.
+- `ingest` (`scan.rs:507`) **replaces** its `meta: &Metadata` param with the
+  `BackingStamp` (it must not re-`stat`).
 
 ### Serve-path validation
 
-Both compare sites switch to `BackingStamp`, re-stat, full three-field compare,
-`BackingChanged` on any mismatch:
+**Three** compare sites switch to `BackingStamp`, re-stat, full three-field
+compare, `BackingChanged` on any mismatch:
 
 - `HeaderCache::resolve` (`reader.rs:110`): re-stat on every resolve
   (`reader.rs:118`), compare `BackingStamp::from_metadata(&meta)` against the
   track's stored stamp (`reader.rs:119`).
 - `validate_opened_backing` (`facade.rs:115`): same, against the held
-  descriptor's `file.metadata()` on every read. `ResolvedFile`
-  (`reader.rs:~26`, fields `backing_size` / `backing_mtime_secs`) carries the
-  full stamp, captured at resolve time (`reader.rs:~314`).
+  descriptor's `file.metadata()` on every read. `ResolvedFile` (`reader.rs:~26`)
+  carries the full stamp, captured at resolve time (`reader.rs:~314`).
+- **`Musefs::getattr`'s size-cache hit** (`facade.rs:963`, added in #279): the
+  warm-attr path re-stats and compares a whole-second mtime against
+  `SizeEntry.backing_mtime_secs` (`facade.rs:90`). This is the one metadata
+  surface that can outrun a backing change, so it must use the full stamp too:
+  widen `SizeEntry` to carry `BackingStamp` and switch the compare at
+  `facade.rs:963`. (The single `metadata` call → one `on_stat` is unchanged, so
+  the `getattr_size_cache_hit_restats_backing` metrics assertion still holds.)
+
+**Displayed mtime is independent of the stamp and stays in whole seconds.**
+`ResolvedFile` holds a second, distinct field `mtime_secs` (`reader.rs:28`) —
+the synthesized file's *displayed* mtime surfaced to FUSE `getattr`, derived at
+`reader.rs:149` (`track.backing_mtime`) and `reader.rs:289`
+(`track.backing_mtime.max(track.updated_at)`). After the rename these sites read
+`backing_mtime_ns`, which is **nanoseconds**; they must convert to seconds
+(`backing_mtime_ns / 1_000_000_000`) before the `.max(updated_at)` (seconds) and
+before storing into `mtime_secs`. Leaving them unconverted would advertise a
+~10¹⁸-second mtime. `ResolvedFile::mtime_secs` and the `SizeEntry.mtime_secs`
+display field remain seconds; only the *freshness stamp* fields go to ns.
 
 ### Revalidate skip pass
 
@@ -174,7 +217,10 @@ The pre-dispatch skip check (`scan.rs:924-929`) compares the **full** stored
 stamp `(size, mtime_ns, ctime_ns)` against the candidate file; any difference
 forces a re-probe. This means a ctime-only change — e.g. an adversarial
 mtime-reset after an in-place rewrite — is no longer skipped as "unchanged".
-The existing `needs_backfill` FLAC-structural hook is unaffected.
+The `existing` map it reads from (`scan.rs:896`, currently
+`HashMap<String,(u64,i64,i64,Format)>` = `(size, mtime, id, format)`) must be
+widened to carry `backing_ctime_ns`, sourced from the `list_tracks()`
+projection. The existing `needs_backfill` FLAC-structural hook is unaffected.
 
 ### Deliberate non-changes
 
@@ -200,11 +246,22 @@ The existing `needs_backfill` FLAC-structural hook is unaffected.
   not is re-probed, not skipped.
 - **Serve-path per-read guard**: `validate_opened_backing` rejects a held
   handle after a same-size sub-second rewrite.
-- Schema mirror regenerated; full workspace suite green, including
-  `cargo test -p musefs-core --features metrics` (the stat/open-count
-  assertions: the extra scan-time `fstat` and the removed path-stat shift
-  scanner stat counts — update expectations) and the FUSE e2e tier where
+- **`getattr` size-cache guard** (C1): a warm-cache `getattr` after a same-size
+  sub-second/ctime-only rewrite yields `BackingChanged`, not stale attrs.
+- **Displayed mtime sanity** (C2): the FUSE-advertised mtime of a synthesized
+  file is a plausible whole-second value (≈ the backing file's mtime, not a
+  ~10¹⁸ nanosecond value), guarding the ns→s conversion at `reader.rs:149`/`:289`.
+- Schema mirrors regenerated; full workspace suite green, including
+  `cargo test -p musefs-core --features metrics` and the FUSE e2e tier where
   relevant.
+  - **Metrics note:** the scan path is instrumented only with
+    `on_scan_open`/`on_scan_read`; an `fstat` is neither, and the path-stat
+    being removed (`scan.rs:720`) was never counted — so **no scan metric
+    assertion changes**. Do *not* wire `on_stat` (a serve-path-only counter)
+    into the scanner. The real check is that serve-path stat counts stay exact
+    after the `getattr` size-cache change (C1): the hit path still issues one
+    `metadata` → one `on_stat`, so `s.stats` assertions (`tests/metrics.rs`,
+    e.g. `getattr_size_cache_hit_restats_backing`) are unchanged.
 - `cargo +nightly fuzz build` if any format-layer signature is touched (it is
   not expected to be).
 
@@ -223,11 +280,22 @@ The existing `needs_backfill` FLAC-structural hook is unaffected.
 
 | File | Change |
 | ---- | ------ |
-| `musefs-db/src/schema.rs` | V5 rename + add column; trigger + CHECK; Python mirror regen |
+| `musefs-db/src/schema.rs` | V5 rename + add column; trigger + CHECK |
 | `musefs-db/src/models.rs` | `Track`, `NewTrack` stamp fields |
-| `musefs-db/src/tracks.rs` | `track_select!`, `row_to_track`, `upsert_track`, bulk insert |
-| `musefs-core/src/reader.rs` | `BackingStamp`, `ResolvedFile`, `resolve` compare |
-| `musefs-core/src/facade.rs` | `validate_opened_backing` compare; drop dup `mtime_secs` |
-| `musefs-core/src/scan.rs` | `probe_file` fd-stat sandwich, `raced` counter, `Unit`/`ingest`/revalidate skip; drop dup `mtime_secs` |
+| `musefs-db/src/tracks.rs` | `track_select!`, `row_to_track`, `upsert_track`, bulk insert, `list_tracks` projection |
+| `musefs-core/src/reader.rs` | `BackingStamp`, `ResolvedFile` (stamp + seconds `mtime_secs`), `resolve` compare, displayed-mtime ns→s conversion (`:149`,`:289`) |
+| `musefs-core/src/facade.rs` | `validate_opened_backing` compare; `SizeEntry` stamp widening + `getattr` size-cache compare (`:963`); drop dup `mtime_secs` |
+| `musefs-core/src/scan.rs` | `probe_file` fd-stat sandwich + new signature/`ProbeOutcome`, `raced` counter, `Unit`/`ingest`/`ingest_bulk` stamp, revalidate `existing`-tuple + skip; drop dup `mtime_secs` |
+| `musefs-core/src/metrics.rs` + `tests/metrics.rs` | verify serve-path `s.stats` assertions unchanged; no scan-counter change |
 | `ARCHITECTURE.md` | freshness + contract docs |
-| Python schema mirror + vendored copy | regenerate |
+| `contrib/python-musefs/src/musefs_common/schema.py` | regenerate (`schema_py`) |
+| `contrib/picard/musefs/_common/schema.py` | re-vendor (`vendor_to_picard.py`) |
+
+**Commit sequencing** (the pre-commit hook runs the full workspace suite +
+`schema_py` gate, so each commit must be green). The column rename touches the
+db layer and all four core compare sites at once, so they land together:
+(1) schema V5 edit + both schema.py mirrors + `models.rs`/`tracks.rs` plumbing +
+the `reader.rs`/`facade.rs` field rename and ns→s display conversion (compiles
+and passes only as one unit); (2) scanner fd-stat sandwich + `raced`;
+(3) the new freshness tests; (4) ARCHITECTURE.md. Steps may merge if that keeps
+each commit green.

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -5,6 +5,7 @@ use musefs_core::{HeaderCache, Mode, read_at_with_file};
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_fuzz::{MAX_INPUT, arb_arts, arb_tags};
 use std::io::Write;
+use std::os::unix::fs::MetadataExt;
 
 /// Build a one-track in-memory DB over `backing` written to a temp file, and
 /// return (tempdir, db, track_id). Returns None on any setup error.
@@ -26,14 +27,8 @@ fn setup(
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .ok()?
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .ok()?
-                    .as_secs(),
-            )
-            .ok()?,
+            backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+            backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
         })
         .ok()?;
     db.replace_tags(id, &[Tag::new("title", "T", 0)]).ok()?;

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -9,6 +9,7 @@ use musefs_db::{Db, Format};
 
 use crate::db_pool::DbPool;
 use crate::error::{CoreError, Result};
+use crate::freshness::BackingStamp;
 use crate::mapping::tags_to_fields;
 use crate::reader::{HeaderCache, ResolvedFile, read_at_into, read_at_with_file_into};
 use crate::refresh_diff::{ChangeSet, TrackRenderState, partition_changelog};
@@ -91,8 +92,7 @@ struct SizeEntry {
     content_version: i64,
     total_len: u64,
     mtime_secs: i64,
-    backing_size: u64,
-    backing_mtime_secs: i64,
+    stamp: BackingStamp,
 }
 
 /// Resets a single-flight flag on drop, so a panic (or early return) during a
@@ -105,16 +105,9 @@ impl Drop for RefreshGuard<'_> {
     }
 }
 
-fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
-    meta.modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs().cast_signed())
-}
-
 fn validate_opened_backing(file: &std::fs::File, resolved: &ResolvedFile) -> Result<()> {
     let meta = file.metadata()?;
-    if meta.len() != resolved.backing_size || mtime_secs(&meta) != resolved.backing_mtime_secs {
+    if BackingStamp::from_metadata(&meta) != resolved.stamp {
         return Err(CoreError::BackingChanged(
             resolved.backing_path.to_string_lossy().into_owned(),
         ));
@@ -960,7 +953,7 @@ impl Musefs {
                 // could outrun a backing change (read/open already re-stat).
                 crate::metrics::on_stat();
                 let meta = std::fs::metadata(&track.backing_path)?;
-                if meta.len() != e.backing_size || mtime_secs(&meta) != e.backing_mtime_secs {
+                if BackingStamp::from_metadata(&meta) != e.stamp {
                     return Err(CoreError::BackingChanged(track.backing_path.clone()));
                 }
                 return Ok((e.total_len, e.mtime_secs));
@@ -973,8 +966,7 @@ impl Musefs {
                     content_version: track.content_version,
                     total_len: resolved.total_len,
                     mtime_secs: resolved.mtime_secs,
-                    backing_size: resolved.backing_size,
-                    backing_mtime_secs: resolved.backing_mtime_secs,
+                    stamp: resolved.stamp,
                 },
             );
             Ok((resolved.total_len, resolved.mtime_secs))
@@ -1212,9 +1204,9 @@ mod tests {
             total_len: 8,
             content_version: 1,
             backing_path: expected_path,
-            backing_size: expected_meta.len(),
-            backing_mtime_secs: mtime_secs(&expected_meta),
-            mtime_secs: mtime_secs(&expected_meta),
+            stamp: crate::freshness::BackingStamp::from_metadata(&expected_meta),
+            mtime_secs: crate::freshness::BackingStamp::from_metadata(&expected_meta)
+                .display_secs(),
             last_page: std::sync::Mutex::new(None),
             cache_bytes: 0,
             has_binary_tag: false,
@@ -1761,7 +1753,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         let id_b = db
@@ -1771,7 +1764,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         assert!(id_a < id_b, "insertion assigns ascending ids");

--- a/musefs-core/src/freshness.rs
+++ b/musefs-core/src/freshness.rs
@@ -1,0 +1,88 @@
+//! The backing-file freshness stamp: the identity a `tracks` row records for
+//! its backing file, compared on every serve to detect an on-disk change that
+//! no database write covers. Strengthened past size + whole-second mtime to
+//! nanosecond mtime + ctime (#276) so a same-size in-place rewrite — including
+//! an adversarial one that resets mtime — cannot evade the guard.
+use std::os::unix::fs::MetadataExt;
+
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// `(size, mtime_ns, ctime_ns)` captured from one `fstat`. `mtime_ns`/`ctime_ns`
+/// are nanoseconds since the Unix epoch (good until ~2262). `ctime` is the
+/// adversarial backstop: a writer can reset mtime with `utimensat`, but ctime
+/// is bumped by any write and cannot be set backward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BackingStamp {
+    pub size: u64,
+    pub mtime_ns: i64,
+    pub ctime_ns: i64,
+}
+
+#[allow(dead_code)]
+impl BackingStamp {
+    pub fn from_metadata(meta: &std::fs::Metadata) -> BackingStamp {
+        BackingStamp {
+            size: meta.len(),
+            mtime_ns: meta
+                .mtime()
+                .saturating_mul(NANOS_PER_SEC)
+                .saturating_add(meta.mtime_nsec()),
+            ctime_ns: meta
+                .ctime()
+                .saturating_mul(NANOS_PER_SEC)
+                .saturating_add(meta.ctime_nsec()),
+        }
+    }
+
+    /// Whole-second mtime for the FUSE `getattr` display surface (never the raw
+    /// nanosecond value, which would advertise a ~10^18-second timestamp).
+    pub fn display_secs(&self) -> i64 {
+        self.mtime_ns / NANOS_PER_SEC
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::MetadataExt;
+
+    #[test]
+    fn from_metadata_captures_ns_and_display_secs() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("f");
+        std::fs::write(&p, b"hello").unwrap();
+        let meta = std::fs::metadata(&p).unwrap();
+
+        let s = BackingStamp::from_metadata(&meta);
+        assert_eq!(s.size, 5);
+        assert_eq!(s.mtime_ns, meta.mtime() * 1_000_000_000 + meta.mtime_nsec());
+        assert_eq!(s.ctime_ns, meta.ctime() * 1_000_000_000 + meta.ctime_nsec());
+        // Display is whole-second mtime, never the raw nanosecond value.
+        assert_eq!(s.display_secs(), meta.mtime());
+    }
+
+    #[test]
+    fn equality_is_field_wise() {
+        let a = BackingStamp {
+            size: 1,
+            mtime_ns: 2,
+            ctime_ns: 3,
+        };
+        assert_eq!(
+            a,
+            BackingStamp {
+                size: 1,
+                mtime_ns: 2,
+                ctime_ns: 3
+            }
+        );
+        assert_ne!(
+            a,
+            BackingStamp {
+                size: 1,
+                mtime_ns: 2,
+                ctime_ns: 4
+            }
+        );
+    }
+}

--- a/musefs-core/src/freshness.rs
+++ b/musefs-core/src/freshness.rs
@@ -12,13 +12,12 @@ const NANOS_PER_SEC: i64 = 1_000_000_000;
 /// adversarial backstop: a writer can reset mtime with `utimensat`, but ctime
 /// is bumped by any write and cannot be set backward.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct BackingStamp {
+pub struct BackingStamp {
     pub size: u64,
     pub mtime_ns: i64,
     pub ctime_ns: i64,
 }
 
-#[allow(dead_code)]
 impl BackingStamp {
     pub fn from_metadata(meta: &std::fs::Metadata) -> BackingStamp {
         BackingStamp {
@@ -31,6 +30,14 @@ impl BackingStamp {
                 .ctime()
                 .saturating_mul(NANOS_PER_SEC)
                 .saturating_add(meta.ctime_nsec()),
+        }
+    }
+
+    pub fn from_track(t: &musefs_db::Track) -> BackingStamp {
+        BackingStamp {
+            size: t.backing_size,
+            mtime_ns: t.backing_mtime_ns,
+            ctime_ns: t.backing_ctime_ns,
         }
     }
 

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -2,7 +2,7 @@ mod byte_budget;
 mod db_pool;
 mod error;
 mod facade;
-mod freshness;
+pub mod freshness;
 mod lock;
 mod mapping;
 pub mod metrics;

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -2,6 +2,7 @@ mod byte_budget;
 mod db_pool;
 mod error;
 mod facade;
+mod freshness;
 mod lock;
 mod mapping;
 pub mod metrics;

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -186,7 +186,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         let nonempty = db
@@ -241,7 +242,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.set_binary_tags(
@@ -273,7 +275,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(tid, &[Tag::new("artist", "A", 0)]).unwrap();
@@ -309,7 +312,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         let good = db
@@ -390,7 +394,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         let orphan_id = db
@@ -463,7 +468,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
 

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -12,6 +12,7 @@ use quick_cache::sync::Cache;
 
 use crate::error::{CoreError, Result};
 use crate::facade::Mode;
+use crate::freshness::BackingStamp;
 use crate::mapping::{tags_to_inputs, track_art_to_inputs};
 use crate::ogg_index::serve_ogg_window;
 
@@ -23,8 +24,7 @@ pub struct ResolvedFile {
     pub total_len: u64,
     pub content_version: i64,
     pub backing_path: PathBuf,
-    pub backing_size: u64,
-    pub backing_mtime_secs: i64,
+    pub stamp: BackingStamp,
     pub mtime_secs: i64,
     /// One-entry memo of the last patched Ogg page, so consecutive reads skip
     /// re-patching the page straddling a chunk boundary. Empty for non-Ogg files
@@ -69,13 +69,6 @@ pub const DEFAULT_CACHE_BUDGET: u64 = 64 * 1024 * 1024;
 /// observable public-API behavior, so its arithmetic carries an equivalent-mutant
 /// exclusion in .cargo/mutants.toml (cargo-mutants does mutate const initializers).
 const CACHE_ESTIMATED_ITEMS: usize = (DEFAULT_CACHE_BUDGET / 4096) as usize;
-
-fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
-    meta.modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs().cast_signed())
-}
 
 fn read_front(path: &Path, n: u64) -> crate::Result<Vec<u8>> {
     use std::io::Read;
@@ -126,7 +119,7 @@ impl HeaderCache {
         // on a cache hit, because the audio region may have shifted.
         crate::metrics::on_stat();
         let meta = std::fs::metadata(&track.backing_path)?;
-        if meta.len() != track.backing_size || mtime_secs(&meta) != track.backing_mtime {
+        if BackingStamp::from_metadata(&meta) != BackingStamp::from_track(&track) {
             return Err(CoreError::BackingChanged(track.backing_path.clone()));
         }
 
@@ -156,7 +149,11 @@ impl HeaderCache {
                     len: meta.len(),
                 }])
                 .map_err(musefs_format::FormatError::InvalidLayout)?;
-                (layout, meta.len(), track.backing_mtime)
+                (
+                    layout,
+                    meta.len(),
+                    BackingStamp::from_track(track).display_secs(),
+                )
             }
             Mode::Synthesis => {
                 // Guard the stored audio bounds before any cast/allocation: a negative
@@ -296,7 +293,13 @@ impl HeaderCache {
                     }
                 };
                 let total = layout.total_len();
-                (layout, total, track.backing_mtime.max(track.updated_at))
+                (
+                    layout,
+                    total,
+                    BackingStamp::from_track(track)
+                        .display_secs()
+                        .max(track.updated_at),
+                )
             }
         };
 
@@ -321,8 +324,7 @@ impl HeaderCache {
             total_len,
             content_version: track.content_version,
             backing_path: PathBuf::from(&track.backing_path),
-            backing_size: track.backing_size,
-            backing_mtime_secs: track.backing_mtime,
+            stamp: BackingStamp::from_track(track),
             mtime_secs: mtime_secs_val,
             last_page: Mutex::new(None),
             cache_bytes,
@@ -534,8 +536,11 @@ mod ogg_serve_tests {
             total_len: total,
             content_version: 0,
             backing_path: path.clone(),
-            backing_size: 0,
-            backing_mtime_secs: 0,
+            stamp: BackingStamp {
+                size: 0,
+                mtime_ns: 0,
+                ctime_ns: 0,
+            },
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 8,
@@ -576,6 +581,7 @@ mod resolve_ogg_tests {
     use musefs_db::{Db, Format, NewTrack, Tag};
     use musefs_format::ogg::page_test_support::lace_packet_pub;
     use std::io::Write;
+    use std::os::unix::fs::MetadataExt;
 
     fn build_opus_file(path: &std::path::Path) -> (u64, u64) {
         let head = b"OpusHead\x01\x02\x38\x01\x80\xbb\x00\x00\x00\x00\x00".to_vec();
@@ -610,7 +616,8 @@ mod resolve_ogg_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         db.replace_tags(track_id, &[Tag::new("title", "Telephasic Workshop", 0)])
@@ -650,7 +657,8 @@ mod resolve_ogg_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         let cache = HeaderCache::new(Mode::Synthesis);
@@ -707,7 +715,8 @@ mod resolve_ogg_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         db.replace_tags(track_id, &[Tag::new("title", "Wave One", 0)])
@@ -746,7 +755,8 @@ mod resolve_ogg_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         let cache = HeaderCache::new(Mode::Synthesis);
@@ -811,8 +821,11 @@ mod ogg_art_serve_tests {
             total_len: total,
             content_version: 0,
             backing_path: std::path::PathBuf::from("/dev/null"),
-            backing_size: 0,
-            backing_mtime_secs: 0,
+            stamp: BackingStamp {
+                size: 0,
+                mtime_ns: 0,
+                ctime_ns: 0,
+            },
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
@@ -859,8 +872,11 @@ mod ogg_art_serve_tests {
             total_len: total,
             content_version: 0,
             backing_path: std::path::PathBuf::from("/dev/null"),
-            backing_size: 0,
-            backing_mtime_secs: 0,
+            stamp: BackingStamp {
+                size: 0,
+                mtime_ns: 0,
+                ctime_ns: 0,
+            },
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
@@ -875,6 +891,7 @@ mod ogg_art_serve_tests {
 mod cache_bound_tests {
     use super::*;
     use musefs_db::{Db, Format, NewTrack};
+    use std::os::unix::fs::MetadataExt;
 
     fn entry(content_version: i64, inline_len: usize) -> Arc<ResolvedFile> {
         Arc::new(ResolvedFile {
@@ -882,8 +899,11 @@ mod cache_bound_tests {
             total_len: inline_len as u64,
             content_version,
             backing_path: std::path::PathBuf::from("/nonexistent"),
-            backing_size: 0,
-            backing_mtime_secs: 0,
+            stamp: BackingStamp {
+                size: 0,
+                mtime_ns: 0,
+                ctime_ns: 0,
+            },
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: inline_len as u64,
@@ -905,7 +925,8 @@ mod cache_bound_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         let cache = HeaderCache::new(Mode::Synthesis); // NOTE: not `mut` — resolve is &self now
@@ -933,7 +954,8 @@ mod cache_bound_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap()
         };
@@ -969,7 +991,8 @@ mod cache_bound_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap()
         };
@@ -1001,7 +1024,8 @@ mod cache_bound_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap()
         };
@@ -1048,7 +1072,8 @@ mod cache_bound_tests {
                 audio_offset,
                 audio_length,
                 backing_size: meta.len(),
-                backing_mtime: mtime_secs(&meta),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         (db, id)
@@ -1070,7 +1095,8 @@ mod cache_bound_tests {
             audio_offset: meta.len(),
             audio_length: 5,
             backing_size: meta.len(),
-            backing_mtime: mtime_secs(&meta),
+            backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+            backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
         });
         assert!(
             rejected.is_err(),
@@ -1216,6 +1242,7 @@ mod cache_bound_tests {
 mod binary_tag_serve_tests {
     use super::*;
     use musefs_db::{BinaryTag, NewTrack};
+    use std::os::unix::fs::MetadataExt;
 
     #[test]
     fn resolve_mp3_emits_binary_tag_in_synthesized_region() {
@@ -1250,13 +1277,8 @@ mod binary_tag_serve_tests {
                 audio_offset: bounds.audio_offset,
                 audio_length: bounds.audio_length,
                 backing_size: meta.len(),
-                backing_mtime: meta
-                    .modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs()
-                    .cast_signed(),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
             })
             .unwrap();
         db.set_binary_tags(
@@ -1288,7 +1310,8 @@ mod binary_tag_serve_tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.set_binary_tags(
@@ -1311,8 +1334,11 @@ mod binary_tag_serve_tests {
             total_len: 4,
             content_version: 0,
             backing_path: PathBuf::from("/x.mp3"),
-            backing_size: 0,
-            backing_mtime_secs: 0,
+            stamp: BackingStamp {
+                size: 0,
+                mtime_ns: 0,
+                ctime_ns: 0,
+            },
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
@@ -1347,13 +1373,15 @@ mod serve_cap_tests {
     /// `impl Db<ReadWrite>`, not the generic `impl<M> Db<M>`.
     fn hostile_track(db: &Db, path: &std::path::Path, format: Format) -> i64 {
         let meta = std::fs::metadata(path).unwrap();
+        let stamp = BackingStamp::from_metadata(&meta);
         db.upsert_track(&NewTrack {
             backing_path: path.to_string_lossy().into_owned(),
             format,
             audio_offset: CAP + 1,
             audio_length: 1,
             backing_size: meta.len(),
-            backing_mtime: mtime_secs(&meta),
+            backing_mtime_ns: stamp.mtime_ns,
+            backing_ctime_ns: stamp.ctime_ns,
         })
         .unwrap()
     }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -7,6 +7,8 @@ use musefs_format::{EmbeddedBinaryTag, EmbeddedPicture, Extent, flac, mp3, mp4, 
 
 use crate::byte_budget::ByteBudget;
 use crate::error::Result;
+use crate::freshness::BackingStamp;
+use std::os::unix::fs::MetadataExt;
 use std::sync::mpsc::sync_channel;
 
 const BATCH_FILES: usize = 256;
@@ -47,13 +49,6 @@ pub struct RevalidateStats {
     pub unchanged: u64,
     pub pruned: u64,
     pub failed: u64,
-}
-
-fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
-    meta.modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs().cast_signed())
 }
 
 fn has_ext(path: &Path, ext: &str) -> bool {
@@ -481,8 +476,7 @@ fn effective_jobs(jobs: usize) -> usize {
 /// One probed file ready to write, plus its art-byte weight for backpressure.
 struct Unit {
     abs_path: String,
-    meta_len: u64,
-    meta_mtime: i64,
+    stamp: BackingStamp,
     probed: Probed,
     weight: u64,
 }
@@ -505,13 +499,15 @@ fn payload_weight(p: &Probed) -> u64 {
 /// Upsert a track from a probed backing file: write the track row, replace its
 /// seeded tags, and ingest its embedded art (capped, deduped, clamped).
 fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
+    let stamp = BackingStamp::from_metadata(meta);
     let track_id = db.upsert_track(&NewTrack {
         backing_path: abs_path.to_string(),
         format: probed.format,
         audio_offset: probed.audio_offset,
         audio_length: probed.audio_length,
         backing_size: meta.len(),
-        backing_mtime: mtime_secs(meta),
+        backing_mtime_ns: stamp.mtime_ns,
+        backing_ctime_ns: stamp.ctime_ns,
     })?;
 
     let mut tags = Vec::new();
@@ -584,8 +580,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
 fn ingest_bulk(
     bw: &mut musefs_db::BulkWriter<'_>,
     abs_path: &str,
-    meta_len: u64,
-    meta_mtime: i64,
+    stamp: BackingStamp,
     probed: Probed,
 ) -> Result<()> {
     let track_id = bw.upsert_track(&NewTrack {
@@ -593,8 +588,9 @@ fn ingest_bulk(
         format: probed.format,
         audio_offset: probed.audio_offset,
         audio_length: probed.audio_length,
-        backing_size: meta_len,
-        backing_mtime: meta_mtime,
+        backing_size: stamp.size,
+        backing_mtime_ns: stamp.mtime_ns,
+        backing_ctime_ns: stamp.ctime_ns,
     })?;
 
     let mut tags = Vec::new();
@@ -731,8 +727,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                         budget.acquire(weight); // backpressure on in-flight art bytes
                         let unit = Unit {
                             abs_path: abs.to_string_lossy().into_owned(),
-                            meta_len: meta.len(),
-                            meta_mtime: mtime_secs(&meta),
+                            stamp: BackingStamp::from_metadata(&meta),
                             probed,
                             weight,
                         };
@@ -767,14 +762,13 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         let mut weights = Vec::with_capacity(batch.len());
         for Unit {
             abs_path,
-            meta_len,
-            meta_mtime,
+            stamp,
             probed,
             weight,
         } in batch.drain(..)
         {
             weights.push(weight);
-            ingest_bulk(&mut bw, &abs_path, meta_len, meta_mtime, probed)?;
+            ingest_bulk(&mut bw, &abs_path, stamp, probed)?;
             *scanned += 1;
         }
         bw.commit()?;
@@ -899,7 +893,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         .map(|t| {
             (
                 t.backing_path,
-                (t.backing_size, t.backing_mtime, t.id, t.format),
+                (t.backing_size, t.backing_mtime_ns, t.id, t.format),
             )
         })
         .collect();
@@ -923,7 +917,10 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         let key = abs.to_string_lossy().into_owned();
         if let Some(&(size, mtime, id, format)) = existing.get(&key) {
             let needs_backfill = format == Format::Flac && !have_structural.contains(&id);
-            if size == meta.len() && mtime == mtime_secs(&meta) && !needs_backfill {
+            if size == meta.len()
+                && mtime == meta.mtime() * 1_000_000_000 + meta.mtime_nsec()
+                && !needs_backfill
+            {
                 unchanged += 1;
                 continue;
             }
@@ -1679,7 +1676,8 @@ mod hardening_tests {
             audio_offset: 0,
             audio_length: 0,
             backing_size: 0,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         })
         .unwrap();
 
@@ -1809,7 +1807,17 @@ mod hardening_tests {
         let db = Db::open_in_memory().unwrap();
         {
             let mut bw = db.bulk_writer().unwrap();
-            ingest_bulk(&mut bw, "/a.mp3", 1, 0, probed_with_mixed_binary_tags()).unwrap();
+            ingest_bulk(
+                &mut bw,
+                "/a.mp3",
+                BackingStamp {
+                    size: 1,
+                    mtime_ns: 0,
+                    ctime_ns: 0,
+                },
+                probed_with_mixed_binary_tags(),
+            )
+            .unwrap();
             bw.commit().unwrap();
         }
         let tid = db.list_tracks().unwrap()[0].id;
@@ -1927,8 +1935,11 @@ mod hardening_tests {
             ingest_bulk(
                 &mut bw,
                 "/a.flac",
-                1,
-                0,
+                BackingStamp {
+                    size: 1,
+                    mtime_ns: 0,
+                    ctime_ns: 0,
+                },
                 probed_with_duplicate_structural_kind(),
             )
             .unwrap();

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -36,11 +36,44 @@ pub(crate) const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
 /// payloads (e.g. a GEOB embedding a multi-MB file) are logged-and-skipped.
 const MAX_BINARY_TAG_BYTES: usize = MAX_ART_BYTES;
 
+/// Outcome of probing one backing file. `Raced` means the file changed under us
+/// between the pre- and post-probe `fstat` — the probe may be torn, so nothing
+/// is committed for it (#276).
+#[derive(Debug)]
+enum ProbeOutcome {
+    Probed(Probed, BackingStamp),
+    Unsupported,
+    Raced,
+}
+
+#[cfg(test)]
+thread_local! {
+    static AFTER_S1_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+#[cfg(test)]
+fn fire_after_s1() {
+    AFTER_S1_HOOK.with(|h| {
+        if let Some(f) = h.borrow_mut().as_mut() {
+            f();
+        }
+    });
+}
+#[cfg(test)]
+fn set_after_s1_hook(f: impl FnMut() + 'static) {
+    AFTER_S1_HOOK.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+}
+#[cfg(test)]
+fn clear_after_s1_hook() {
+    AFTER_S1_HOOK.with(|h| *h.borrow_mut() = None);
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanStats {
     pub scanned: u64,
     pub skipped: u64,
     pub failed: u64,
+    pub raced: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +82,7 @@ pub struct RevalidateStats {
     pub unchanged: u64,
     pub pruned: u64,
     pub failed: u64,
+    pub raced: u64,
 }
 
 fn has_ext(path: &Path, ext: &str) -> bool {
@@ -156,6 +190,7 @@ fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
 
 /// A backing file parsed into the fields a track row needs, plus its raw
 /// `(key, value)` tags to seed.
+#[derive(Debug)]
 pub(crate) struct Probed {
     format: Format,
     audio_offset: u64,
@@ -272,97 +307,114 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
     Ok(Some(buf))
 }
 
-/// Bounded probe of one backing file: open once, read a bounded window, dispatch
-/// per format, widening on `NeedMore`. Never reads the audio payload (M4A uses
-/// the seek reader; front-anchored formats read only the metadata extent).
-/// Returns `Ok(None)` for an unsupported/unparseable file (to be skipped).
+/// Bounded probe of one backing file: open once, fstat before and after the
+/// probe, and report `Raced` when the file moved mid-probe — so the stored
+/// stamp and the probed bytes provably share one inode held still across the
+/// probe. Never reads the audio payload (M4A uses the seek reader;
+/// front-anchored formats read only the metadata extent).
 ///
-/// Metrics note: `on_scan_read` counts the front-anchored prefix/widen/tail
-/// reads only. The M4A seek reader does its own positioned reads internally, so
-/// its bytes are not reflected in `SCAN_BYTES_READ` (only `on_scan_open` fires
-/// for M4A); its win shows up in wall time and peak RSS instead.
-fn probe_file(path: &Path, file_len: u64, window: usize) -> std::io::Result<Option<Probed>> {
+/// Returns `ProbeOutcome::Unsupported` for an unsupported/unparseable file (to
+/// be skipped) and `ProbeOutcome::Raced` if the file changed under us.
+fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();
+    let s1 = BackingStamp::from_metadata(&file.metadata()?);
+    #[cfg(test)]
+    fire_after_s1();
+    let file_len = s1.size;
 
-    // M4A: seek reader, never touches mdat.
-    if has_ext(path, "m4a") || has_ext(path, "m4b") {
-        let mut f = &file;
-        let scan = match mp4::read_structure_from(&mut f, file_len) {
-            Ok(s) => s,
-            Err(e) => {
-                if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
-                    log::warn!("skipping {}: {e}", path.display());
+    // ---- existing probe body, using file_len = s1.size ----
+    let probed: Option<Probed> = (|file_len: u64| -> std::io::Result<Option<Probed>> {
+        // M4A: seek reader, never touches mdat.
+        if has_ext(path, "m4a") || has_ext(path, "m4b") {
+            let mut f = &file;
+            let scan = match mp4::read_structure_from(&mut f, file_len) {
+                Ok(s) => s,
+                Err(e) => {
+                    if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
+                        log::warn!("skipping {}: {e}", path.display());
+                    }
+                    return Ok(None);
                 }
-                return Ok(None);
-            }
+            };
+            return Ok(Some(Probed {
+                format: Format::M4a,
+                audio_offset: scan.mdat_payload_offset,
+                audio_length: scan.mdat_payload_len,
+                tags: mp4::read_tags(&scan.moov),
+                pictures: mp4::read_pictures(&scan.moov, MAX_ART_BYTES),
+                binary_tags: mp4::read_binary_tags(&scan.moov, MAX_BINARY_TAG_BYTES),
+                structural_blocks: Vec::new(),
+            }));
+        }
+
+        // Front-anchored formats: read a window, widen on NeedMore. Only the MP3
+        // arm of probe_prefix consumes the ID3v1 tail, and dispatch is by
+        // extension — so only .mp3 pays the tail read (#67).
+        let tail = if has_ext(path, "mp3") {
+            read_tail_128(&file, file_len)?
+        } else {
+            None
         };
-        return Ok(Some(Probed {
-            format: Format::M4a,
-            audio_offset: scan.mdat_payload_offset,
-            audio_length: scan.mdat_payload_len,
-            tags: mp4::read_tags(&scan.moov),
-            pictures: mp4::read_pictures(&scan.moov, MAX_ART_BYTES),
-            binary_tags: mp4::read_binary_tags(&scan.moov, MAX_BINARY_TAG_BYTES),
-            structural_blocks: Vec::new(),
-        }));
-    }
-
-    // Front-anchored formats: read a window, widen on NeedMore. Only the MP3
-    // arm of probe_prefix consumes the ID3v1 tail, and dispatch is by
-    // extension — so only .mp3 pays the tail read (#67).
-    let tail = if has_ext(path, "mp3") {
-        read_tail_128(&file, file_len)?
-    } else {
-        None
-    };
-    // Never read past the probe ceiling, however large the file or whatever a
-    // (possibly corrupt) header asks for via `NeedMore`.
-    let probe_cap = file_len.min(MAX_PROBE_BYTES);
-    let mut want = usize_from((window as u64).min(probe_cap));
-    let mut prefix = read_window(&file, want)?;
-    for _ in 0..MAX_WIDEN_RETRIES {
-        match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
-            Probe::Done(p) => return Ok(Some(p)),
-            Probe::Skip => return Ok(None),
-            Probe::NeedMore(up_to) => {
-                // Read everything we're willing to probe? Widening can't help.
-                if want as u64 >= probe_cap {
-                    break;
+        // Never read past the probe ceiling, however large the file or whatever a
+        // (possibly corrupt) header asks for via `NeedMore`.
+        let probe_cap = file_len.min(MAX_PROBE_BYTES);
+        let mut want = usize_from((window as u64).min(probe_cap));
+        let mut prefix = read_window(&file, want)?;
+        for _ in 0..MAX_WIDEN_RETRIES {
+            match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
+                Probe::Done(p) => return Ok(Some(p)),
+                Probe::Skip => return Ok(None),
+                Probe::NeedMore(up_to) => {
+                    // Read everything we're willing to probe? Widening can't help.
+                    if want as u64 >= probe_cap {
+                        break;
+                    }
+                    // Grow to at least `up_to` (capped at `probe_cap`), always making
+                    // progress (`+1`), then retry.
+                    want = usize_from(up_to.min(probe_cap))
+                        .max(want + 1)
+                        .min(usize_from(probe_cap));
+                    prefix = read_window(&file, want)?;
                 }
-                // Grow to at least `up_to` (capped at `probe_cap`), always making
-                // progress (`+1`), then retry.
-                want = usize_from(up_to.min(probe_cap))
-                    .max(want + 1)
-                    .min(usize_from(probe_cap));
-                prefix = read_window(&file, want)?;
             }
         }
+        // Fallback: full-buffer probe over the bytes we were willing to read.
+        if (prefix.len() as u64) < probe_cap {
+            prefix = read_window(&file, usize_from(probe_cap))?;
+        }
+        if let Some(p) = probe_full(path, &prefix) {
+            return Ok(Some(p));
+        }
+        // A WAV whose `data` payload runs past the probe ceiling fails the strict
+        // full-buffer parse (the payload isn't present to bound), yet its `fmt `/`data`
+        // headers sit at the front: trust the declared bounds and serve the audio,
+        // accepting the loss of any tag chunks trailing the payload.
+        if has_ext(path, "wav")
+            && file_len > MAX_PROBE_BYTES
+            && let Ok(bounds) = wav::locate_audio_at_ceiling(&prefix, file_len)
+        {
+            return Ok(Some(wav_probed(&prefix, &bounds)));
+        }
+        if file_len > MAX_PROBE_BYTES {
+            log::warn!(
+                "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
+                path.display()
+            );
+        }
+        Ok(None)
+    })(file_len)?;
+    // ---- end of existing probe body ----
+
+    let s2 = BackingStamp::from_metadata(&file.metadata()?);
+    if s1 != s2 {
+        log::warn!("skipping {}: changed during probe", path.display());
+        return Ok(ProbeOutcome::Raced);
     }
-    // Fallback: full-buffer probe over the bytes we were willing to read.
-    if (prefix.len() as u64) < probe_cap {
-        prefix = read_window(&file, usize_from(probe_cap))?;
-    }
-    if let Some(p) = probe_full(path, &prefix) {
-        return Ok(Some(p));
-    }
-    // A WAV whose `data` payload runs past the probe ceiling fails the strict
-    // full-buffer parse (the payload isn't present to bound), yet its `fmt `/`data`
-    // headers sit at the front: trust the declared bounds and serve the audio,
-    // accepting the loss of any tag chunks trailing the payload.
-    if has_ext(path, "wav")
-        && file_len > MAX_PROBE_BYTES
-        && let Ok(bounds) = wav::locate_audio_at_ceiling(&prefix, file_len)
-    {
-        return Ok(Some(wav_probed(&prefix, &bounds)));
-    }
-    if file_len > MAX_PROBE_BYTES {
-        log::warn!(
-            "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
-            path.display()
-        );
-    }
-    Ok(None)
+    Ok(match probed {
+        Some(p) => ProbeOutcome::Probed(p, s1),
+        None => ProbeOutcome::Unsupported,
+    })
 }
 
 /// Outcome of a single bounded dispatch attempt against the current `prefix`.
@@ -697,6 +749,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
     let budget = Arc::new(ByteBudget::new(cap));
     let skipped = Arc::new(AtomicU64::new(0));
     let failed = Arc::new(AtomicU64::new(0));
+    let raced = Arc::new(AtomicU64::new(0));
 
     // Work queue: a shared iterator behind a mutex (cheap; probing dominates).
     let work = Arc::new(std::sync::Mutex::new(files.into_iter()));
@@ -709,16 +762,13 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         let budget = Arc::clone(&budget);
         let skipped = Arc::clone(&skipped);
         let failed = Arc::clone(&failed);
+        let raced = Arc::clone(&raced);
         workers.push(std::thread::spawn(move || {
             loop {
                 let next = { work.lock().unwrap().next() };
                 let Some(path) = next else { break };
-                let Ok(meta) = std::fs::metadata(&path) else {
-                    failed.fetch_add(1, Ordering::Relaxed);
-                    continue;
-                };
-                match probe_file(&path, meta.len(), window) {
-                    Ok(Some(probed)) => {
+                match probe_file(&path, window) {
+                    Ok(ProbeOutcome::Probed(probed, stamp)) => {
                         let Ok(abs) = std::fs::canonicalize(&path) else {
                             failed.fetch_add(1, Ordering::Relaxed);
                             continue;
@@ -727,7 +777,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                         budget.acquire(weight); // backpressure on in-flight art bytes
                         let unit = Unit {
                             abs_path: abs.to_string_lossy().into_owned(),
-                            stamp: BackingStamp::from_metadata(&meta),
+                            stamp,
                             probed,
                             weight,
                         };
@@ -736,8 +786,11 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                             break;
                         }
                     }
-                    Ok(None) => {
+                    Ok(ProbeOutcome::Unsupported) => {
                         skipped.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Ok(ProbeOutcome::Raced) => {
+                        raced.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(_) => {
                         failed.fetch_add(1, Ordering::Relaxed);
@@ -826,6 +879,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         scanned,
         skipped: skipped.load(Ordering::Relaxed),
         failed: failed.load(Ordering::Relaxed),
+        raced: raced.load(Ordering::Relaxed),
     })
 }
 
@@ -845,6 +899,7 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
         scanned: 0,
         skipped: 0,
         failed: 0,
+        raced: 0,
     };
     for path in files {
         let bytes = std::fs::read(&path)?;
@@ -951,6 +1006,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         unchanged,
         pruned,
         failed: scan.failed + skip_failed,
+        raced: scan.raced,
     })
 }
 
@@ -1168,9 +1224,10 @@ mod scan_unit_tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("oversized_art.m4a");
         std::fs::write(&path, &bytes).unwrap();
-        let probed = probe_file(&path, bytes.len() as u64, 0)
-            .unwrap()
-            .expect("m4a should probe");
+        let probed = match probe_file(&path, 0).unwrap() {
+            ProbeOutcome::Probed(p, _) => p,
+            other => panic!("expected Probed, got {other:?}"),
+        };
         assert_eq!(probed.format, Format::M4a);
         assert!(
             probed.pictures.is_empty(),
@@ -1187,9 +1244,10 @@ mod scan_unit_tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("oversized_bin.m4a");
         std::fs::write(&path, &bytes).unwrap();
-        let probed = probe_file(&path, bytes.len() as u64, 0)
-            .unwrap()
-            .expect("m4a should probe");
+        let probed = match probe_file(&path, 0).unwrap() {
+            ProbeOutcome::Probed(p, _) => p,
+            other => panic!("expected Probed, got {other:?}"),
+        };
         assert_eq!(probed.format, Format::M4a);
         assert!(
             probed.binary_tags.is_empty(),
@@ -2131,7 +2189,10 @@ mod bounded_probe_tests {
         f.set_len(len).unwrap();
         drop(f);
 
-        assert!(probe_file(&path, len, WINDOW).unwrap().is_none());
+        assert!(matches!(
+            probe_file(&path, WINDOW).unwrap(),
+            ProbeOutcome::Unsupported
+        ));
     }
 
     #[test]
@@ -2171,11 +2232,46 @@ mod bounded_probe_tests {
         f.set_len(file_len).unwrap();
         drop(f);
 
-        let probed = probe_file(&path, file_len, WINDOW)
-            .unwrap()
-            .expect("oversize wav should probe");
+        let probed = match probe_file(&path, WINDOW).unwrap() {
+            ProbeOutcome::Probed(p, _) => p,
+            other => panic!("expected Probed, got {other:?}"),
+        };
         assert_eq!(probed.format, Format::Wav);
         assert_eq!(probed.audio_offset, audio_offset);
         assert_eq!(probed.audio_length, data_len);
+    }
+
+    #[test]
+    fn probe_file_reports_raced_on_mid_probe_mutation() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.wav");
+
+        // Minimal valid WAV the probe accepts (fmt + tiny data).
+        let mut fmt = Vec::new();
+        for v in [1u16, 1, 0, 0, 0, 16] {
+            fmt.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut front = b"RIFF".to_vec();
+        front.extend_from_slice(&0u32.to_le_bytes());
+        front.extend_from_slice(b"WAVE");
+        front.extend_from_slice(b"fmt ");
+        front.extend_from_slice(&u32::try_from(fmt.len()).unwrap().to_le_bytes());
+        front.extend_from_slice(&fmt);
+        front.extend_from_slice(b"data");
+        front.extend_from_slice(&64u32.to_le_bytes());
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&front).unwrap();
+        f.set_len(front.len() as u64 + 64).unwrap();
+        drop(f);
+
+        let pc = path.clone();
+        set_after_s1_hook(move || {
+            let mut g = std::fs::OpenOptions::new().append(true).open(&pc).unwrap();
+            g.write_all(&[0u8; 4096]).unwrap(); // size moves -> S2 != S1
+        });
+        let out = probe_file(&path, WINDOW);
+        clear_after_s1_hook();
+        assert!(matches!(out, Ok(ProbeOutcome::Raced)), "got {out:?}");
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -320,90 +320,8 @@ fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     let s1 = BackingStamp::from_metadata(&file.metadata()?);
     #[cfg(test)]
     fire_after_s1();
-    let file_len = s1.size;
 
-    // ---- existing probe body, using file_len = s1.size ----
-    let probed: Option<Probed> = (|file_len: u64| -> std::io::Result<Option<Probed>> {
-        // M4A: seek reader, never touches mdat.
-        if has_ext(path, "m4a") || has_ext(path, "m4b") {
-            let mut f = &file;
-            let scan = match mp4::read_structure_from(&mut f, file_len) {
-                Ok(s) => s,
-                Err(e) => {
-                    if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
-                        log::warn!("skipping {}: {e}", path.display());
-                    }
-                    return Ok(None);
-                }
-            };
-            return Ok(Some(Probed {
-                format: Format::M4a,
-                audio_offset: scan.mdat_payload_offset,
-                audio_length: scan.mdat_payload_len,
-                tags: mp4::read_tags(&scan.moov),
-                pictures: mp4::read_pictures(&scan.moov, MAX_ART_BYTES),
-                binary_tags: mp4::read_binary_tags(&scan.moov, MAX_BINARY_TAG_BYTES),
-                structural_blocks: Vec::new(),
-            }));
-        }
-
-        // Front-anchored formats: read a window, widen on NeedMore. Only the MP3
-        // arm of probe_prefix consumes the ID3v1 tail, and dispatch is by
-        // extension — so only .mp3 pays the tail read (#67).
-        let tail = if has_ext(path, "mp3") {
-            read_tail_128(&file, file_len)?
-        } else {
-            None
-        };
-        // Never read past the probe ceiling, however large the file or whatever a
-        // (possibly corrupt) header asks for via `NeedMore`.
-        let probe_cap = file_len.min(MAX_PROBE_BYTES);
-        let mut want = usize_from((window as u64).min(probe_cap));
-        let mut prefix = read_window(&file, want)?;
-        for _ in 0..MAX_WIDEN_RETRIES {
-            match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
-                Probe::Done(p) => return Ok(Some(p)),
-                Probe::Skip => return Ok(None),
-                Probe::NeedMore(up_to) => {
-                    // Read everything we're willing to probe? Widening can't help.
-                    if want as u64 >= probe_cap {
-                        break;
-                    }
-                    // Grow to at least `up_to` (capped at `probe_cap`), always making
-                    // progress (`+1`), then retry.
-                    want = usize_from(up_to.min(probe_cap))
-                        .max(want + 1)
-                        .min(usize_from(probe_cap));
-                    prefix = read_window(&file, want)?;
-                }
-            }
-        }
-        // Fallback: full-buffer probe over the bytes we were willing to read.
-        if (prefix.len() as u64) < probe_cap {
-            prefix = read_window(&file, usize_from(probe_cap))?;
-        }
-        if let Some(p) = probe_full(path, &prefix) {
-            return Ok(Some(p));
-        }
-        // A WAV whose `data` payload runs past the probe ceiling fails the strict
-        // full-buffer parse (the payload isn't present to bound), yet its `fmt `/`data`
-        // headers sit at the front: trust the declared bounds and serve the audio,
-        // accepting the loss of any tag chunks trailing the payload.
-        if has_ext(path, "wav")
-            && file_len > MAX_PROBE_BYTES
-            && let Ok(bounds) = wav::locate_audio_at_ceiling(&prefix, file_len)
-        {
-            return Ok(Some(wav_probed(&prefix, &bounds)));
-        }
-        if file_len > MAX_PROBE_BYTES {
-            log::warn!(
-                "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
-                path.display()
-            );
-        }
-        Ok(None)
-    })(file_len)?;
-    // ---- end of existing probe body ----
+    let probed = probe_body(path, &file, s1.size, window)?;
 
     let s2 = BackingStamp::from_metadata(&file.metadata()?);
     if s1 != s2 {
@@ -414,6 +332,97 @@ fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
         Some(p) => ProbeOutcome::Probed(p, s1),
         None => ProbeOutcome::Unsupported,
     })
+}
+
+/// The per-format metadata dispatch for one already-opened backing file, over
+/// its first `file_len` bytes. Split out of `probe_file` so the fstat-sandwich
+/// wrapper stays legible. Never reads the audio payload (M4A uses the seek
+/// reader; front-anchored formats read only the metadata extent). Returns
+/// `Ok(None)` for an unsupported/unparseable file.
+fn probe_body(
+    path: &Path,
+    file: &std::fs::File,
+    file_len: u64,
+    window: usize,
+) -> std::io::Result<Option<Probed>> {
+    // M4A: seek reader, never touches mdat.
+    if has_ext(path, "m4a") || has_ext(path, "m4b") {
+        let mut f = file;
+        let scan = match mp4::read_structure_from(&mut f, file_len) {
+            Ok(s) => s,
+            Err(e) => {
+                if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
+                    log::warn!("skipping {}: {e}", path.display());
+                }
+                return Ok(None);
+            }
+        };
+        return Ok(Some(Probed {
+            format: Format::M4a,
+            audio_offset: scan.mdat_payload_offset,
+            audio_length: scan.mdat_payload_len,
+            tags: mp4::read_tags(&scan.moov),
+            pictures: mp4::read_pictures(&scan.moov, MAX_ART_BYTES),
+            binary_tags: mp4::read_binary_tags(&scan.moov, MAX_BINARY_TAG_BYTES),
+            structural_blocks: Vec::new(),
+        }));
+    }
+
+    // Front-anchored formats: read a window, widen on NeedMore. Only the MP3
+    // arm of probe_prefix consumes the ID3v1 tail, and dispatch is by
+    // extension — so only .mp3 pays the tail read (#67).
+    let tail = if has_ext(path, "mp3") {
+        read_tail_128(file, file_len)?
+    } else {
+        None
+    };
+    // Never read past the probe ceiling, however large the file or whatever a
+    // (possibly corrupt) header asks for via `NeedMore`.
+    let probe_cap = file_len.min(MAX_PROBE_BYTES);
+    let mut want = usize_from((window as u64).min(probe_cap));
+    let mut prefix = read_window(file, want)?;
+    for _ in 0..MAX_WIDEN_RETRIES {
+        match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
+            Probe::Done(p) => return Ok(Some(p)),
+            Probe::Skip => return Ok(None),
+            Probe::NeedMore(up_to) => {
+                // Read everything we're willing to probe? Widening can't help.
+                if want as u64 >= probe_cap {
+                    break;
+                }
+                // Grow to at least `up_to` (capped at `probe_cap`), always making
+                // progress (`+1`), then retry.
+                want = usize_from(up_to.min(probe_cap))
+                    .max(want + 1)
+                    .min(usize_from(probe_cap));
+                prefix = read_window(file, want)?;
+            }
+        }
+    }
+    // Fallback: full-buffer probe over the bytes we were willing to read.
+    if (prefix.len() as u64) < probe_cap {
+        prefix = read_window(file, usize_from(probe_cap))?;
+    }
+    if let Some(p) = probe_full(path, &prefix) {
+        return Ok(Some(p));
+    }
+    // A WAV whose `data` payload runs past the probe ceiling fails the strict
+    // full-buffer parse (the payload isn't present to bound), yet its `fmt `/`data`
+    // headers sit at the front: trust the declared bounds and serve the audio,
+    // accepting the loss of any tag chunks trailing the payload.
+    if has_ext(path, "wav")
+        && file_len > MAX_PROBE_BYTES
+        && let Ok(bounds) = wav::locate_audio_at_ceiling(&prefix, file_len)
+    {
+        return Ok(Some(wav_probed(&prefix, &bounds)));
+    }
+    if file_len > MAX_PROBE_BYTES {
+        log::warn!(
+            "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
+            path.display()
+        );
+    }
+    Ok(None)
 }
 
 /// Outcome of a single bounded dispatch attempt against the current `prefix`.

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -8,7 +8,6 @@ use musefs_format::{EmbeddedBinaryTag, EmbeddedPicture, Extent, flac, mp3, mp4, 
 use crate::byte_budget::ByteBudget;
 use crate::error::Result;
 use crate::freshness::BackingStamp;
-use std::os::unix::fs::MetadataExt;
 use std::sync::mpsc::sync_channel;
 
 const BATCH_FILES: usize = 256;
@@ -916,7 +915,7 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
 }
 
 /// Re-validate an already-scanned library root: re-probe only files whose
-/// size/mtime changed since the last scan (skipping unchanged ones so external
+/// size/mtime/ctime changed since the last scan (skipping unchanged ones so external
 /// tag edits in the DB are preserved), then delete tracks **under `root`** whose
 /// backing file is gone (cascading tags/art links) and garbage-collect
 /// now-unreferenced art. `root` may be a single audio file (only that file is
@@ -940,15 +939,19 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
     }
     db.apply_bulk_pragmas_self()?;
 
-    // Main-thread pre-dispatch skip pass: load existing (path -> size,mtime,id,format) once,
+    // Main-thread pre-dispatch skip pass: load existing (path -> stamp,id,format) once,
     // stat each candidate, keep only changed files. Workers stay DB-free.
-    let existing: HashMap<String, (u64, i64, i64, Format)> = db
+    let existing: HashMap<String, (crate::freshness::BackingStamp, i64, Format)> = db
         .list_tracks()?
         .into_iter()
         .map(|t| {
             (
-                t.backing_path,
-                (t.backing_size, t.backing_mtime_ns, t.id, t.format),
+                t.backing_path.clone(),
+                (
+                    crate::freshness::BackingStamp::from_track(&t),
+                    t.id,
+                    t.format,
+                ),
             )
         })
         .collect();
@@ -970,12 +973,9 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
             continue;
         };
         let key = abs.to_string_lossy().into_owned();
-        if let Some(&(size, mtime, id, format)) = existing.get(&key) {
+        if let Some((stamp, id, format)) = existing.get(&key).copied() {
             let needs_backfill = format == Format::Flac && !have_structural.contains(&id);
-            if size == meta.len()
-                && mtime == meta.mtime() * 1_000_000_000 + meta.mtime_nsec()
-                && !needs_backfill
-            {
+            if crate::freshness::BackingStamp::from_metadata(&meta) == stamp && !needs_backfill {
                 unchanged += 1;
                 continue;
             }

--- a/musefs-core/tests/backing_changed_fault.rs
+++ b/musefs-core/tests/backing_changed_fault.rs
@@ -5,6 +5,7 @@ mod common;
 
 use musefs_core::{CoreError, HeaderCache, Mode};
 use musefs_db::Db;
+use std::os::unix::fs::MetadataExt;
 
 #[test]
 fn shrinking_the_backing_file_after_scan_yields_backing_changed() {
@@ -19,7 +20,8 @@ fn shrinking_the_backing_file_after_scan_yields_backing_changed() {
             audio_offset,
             audio_length,
             backing_size: std::fs::metadata(&src).unwrap().len(),
-            backing_mtime: common::real_mtime(&src),
+            backing_mtime_ns: common::real_mtime_ns(&src),
+            backing_ctime_ns: common::real_ctime_ns(&src),
         })
         .unwrap();
     db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)])
@@ -42,4 +44,113 @@ fn shrinking_the_backing_file_after_scan_yields_backing_changed() {
         CoreError::BackingChanged(path) => assert!(path.ends_with("a.flac")),
         other => panic!("expected BackingChanged, got {other:?}"),
     }
+}
+
+// A same-size in-place rewrite within the same whole second (the common case in
+// a fast test) changed only the sub-second mtime + ctime. The old whole-second
+// guard would have passed it; the ns stamp must reject it.
+#[test]
+#[allow(clippy::cast_possible_truncation)]
+fn same_size_subsecond_rewrite_yields_backing_changed() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    let (audio_offset, audio_length) = common::write_flac(&src, &["TITLE=T"], &[0xAB; 4096]);
+    let db = Db::open_in_memory().unwrap();
+    let meta = std::fs::metadata(&src).unwrap();
+    let id = db
+        .upsert_track(&musefs_db::NewTrack {
+            backing_path: src.to_string_lossy().into_owned(),
+            format: musefs_db::Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len(),
+            backing_mtime_ns: common::real_mtime_ns(&src),
+            backing_ctime_ns: common::real_ctime_ns(&src),
+        })
+        .unwrap();
+    db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)])
+        .unwrap();
+    HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+
+    // Rewrite the same number of bytes in place: size identical, mtime/ctime move.
+    std::fs::write(&src, {
+        let mut v = std::fs::read(&src).unwrap();
+        v[audio_offset as usize] ^= 0xFF;
+        v
+    })
+    .unwrap();
+
+    let err = HeaderCache::new(Mode::Synthesis)
+        .resolve(&db, id)
+        .unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+// Adversary rewrites in place, then forges mtime back to the stored value.
+// mtime_ns now matches; only ctime (un-forgeable) caught the change.
+#[test]
+#[allow(clippy::cast_possible_truncation)]
+fn forged_mtime_is_caught_by_ctime() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    let (audio_offset, audio_length) = common::write_flac(&src, &["TITLE=T"], &[0xAB; 4096]);
+    let db = Db::open_in_memory().unwrap();
+    let meta = std::fs::metadata(&src).unwrap();
+    let original_modified = meta.modified().unwrap();
+    let id = db
+        .upsert_track(&musefs_db::NewTrack {
+            backing_path: src.to_string_lossy().into_owned(),
+            format: musefs_db::Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len(),
+            backing_mtime_ns: common::real_mtime_ns(&src),
+            backing_ctime_ns: common::real_ctime_ns(&src),
+        })
+        .unwrap();
+    db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)])
+        .unwrap();
+    HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+
+    // In-place same-size rewrite, then reset mtime back to the scanned instant.
+    let mut v = std::fs::read(&src).unwrap();
+    v[audio_offset as usize] ^= 0xFF;
+    std::fs::write(&src, v).unwrap();
+    let f = std::fs::OpenOptions::new().write(true).open(&src).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+        .unwrap();
+    drop(f);
+
+    // mtime_ns now equals the stored stamp; ctime advanced and must trip the guard.
+    let err = HeaderCache::new(Mode::Synthesis)
+        .resolve(&db, id)
+        .unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
+}
+
+// The synthesized file's displayed mtime stays a plausible whole-second value
+// (≈ the backing file's mtime), not the renamed column's raw nanoseconds.
+#[test]
+fn displayed_mtime_is_whole_seconds() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    let (audio_offset, audio_length) = common::write_flac(&src, &["TITLE=T"], &[0xAB; 4096]);
+    let db = Db::open_in_memory().unwrap();
+    let meta = std::fs::metadata(&src).unwrap();
+    let id = db
+        .upsert_track(&musefs_db::NewTrack {
+            backing_path: src.to_string_lossy().into_owned(),
+            format: musefs_db::Format::Flac,
+            audio_offset,
+            audio_length,
+            backing_size: meta.len(),
+            backing_mtime_ns: common::real_mtime_ns(&src),
+            backing_ctime_ns: common::real_ctime_ns(&src),
+        })
+        .unwrap();
+    db.replace_tags(id, &[musefs_db::Tag::new("title", "T", 0)])
+        .unwrap();
+    let resolved = HeaderCache::new(Mode::Synthesis).resolve(&db, id).unwrap();
+    // Plausible epoch-seconds (this millennium), never ~10^18.
+    assert!(resolved.mtime_secs >= meta.mtime() && resolved.mtime_secs < 32_503_680_000);
 }

--- a/musefs-core/tests/backing_changed_fault.rs
+++ b/musefs-core/tests/backing_changed_fault.rs
@@ -50,7 +50,6 @@ fn shrinking_the_backing_file_after_scan_yields_backing_changed() {
 // a fast test) changed only the sub-second mtime + ctime. The old whole-second
 // guard would have passed it; the ns stamp must reject it.
 #[test]
-#[allow(clippy::cast_possible_truncation)]
 fn same_size_subsecond_rewrite_yields_backing_changed() {
     let dir = tempfile::tempdir().unwrap();
     let src = dir.path().join("a.flac");
@@ -75,7 +74,7 @@ fn same_size_subsecond_rewrite_yields_backing_changed() {
     // Rewrite the same number of bytes in place: size identical, mtime/ctime move.
     std::fs::write(&src, {
         let mut v = std::fs::read(&src).unwrap();
-        v[audio_offset as usize] ^= 0xFF;
+        v[usize::try_from(audio_offset).unwrap()] ^= 0xFF;
         v
     })
     .unwrap();
@@ -89,7 +88,6 @@ fn same_size_subsecond_rewrite_yields_backing_changed() {
 // Adversary rewrites in place, then forges mtime back to the stored value.
 // mtime_ns now matches; only ctime (un-forgeable) caught the change.
 #[test]
-#[allow(clippy::cast_possible_truncation)]
 fn forged_mtime_is_caught_by_ctime() {
     let dir = tempfile::tempdir().unwrap();
     let src = dir.path().join("a.flac");
@@ -114,7 +112,7 @@ fn forged_mtime_is_caught_by_ctime() {
 
     // In-place same-size rewrite, then reset mtime back to the scanned instant.
     let mut v = std::fs::read(&src).unwrap();
-    v[audio_offset as usize] ^= 0xFF;
+    v[usize::try_from(audio_offset).unwrap()] ^= 0xFF;
     std::fs::write(&src, v).unwrap();
     let f = std::fs::OpenOptions::new().write(true).open(&src).unwrap();
     f.set_times(std::fs::FileTimes::new().set_modified(original_modified))

--- a/musefs-core/tests/common/mod.rs
+++ b/musefs-core/tests/common/mod.rs
@@ -22,6 +22,20 @@ pub fn real_mtime(p: &std::path::Path) -> i64 {
         .cast_signed()
 }
 
+/// Return the mtime of `p` as nanoseconds since the Unix epoch.
+pub fn real_mtime_ns(p: &std::path::Path) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(p).unwrap();
+    meta.mtime() * 1_000_000_000 + meta.mtime_nsec()
+}
+
+/// Return the ctime of `p` as nanoseconds since the Unix epoch.
+pub fn real_ctime_ns(p: &std::path::Path) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(p).unwrap();
+    meta.ctime() * 1_000_000_000 + meta.ctime_nsec()
+}
+
 /// Write a simple FLAC (STREAMINFO + comment + audio) to `path`,
 /// returning (audio_offset, audio_length).
 pub fn write_flac(path: &Path, comments: &[&str], audio: &[u8]) -> (u64, u64) {

--- a/musefs-core/tests/concurrent_reads.rs
+++ b/musefs-core/tests/concurrent_reads.rs
@@ -37,7 +37,8 @@ fn build_store(n: usize) -> (std::path::PathBuf, Vec<i64>, tempfile::TempDir) {
                 audio_offset,
                 audio_length,
                 backing_size: std::fs::metadata(&src).unwrap().len(),
-                backing_mtime: common::real_mtime(&src),
+                backing_mtime_ns: common::real_mtime_ns(&src),
+                backing_ctime_ns: common::real_ctime_ns(&src),
             })
             .unwrap();
         db.replace_tags(id, &[musefs_db::Tag::new("title", &format!("T{i}"), 0)])

--- a/musefs-core/tests/db_corruption_fault.rs
+++ b/musefs-core/tests/db_corruption_fault.rs
@@ -18,7 +18,8 @@ fn corrupt_db_header_errors_instead_of_panicking() {
             audio_offset: 0,
             audio_length: 1,
             backing_size: 1,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         })
         .unwrap();
     } // connection dropped, file flushed

--- a/musefs-core/tests/external_contract.rs
+++ b/musefs-core/tests/external_contract.rs
@@ -1,17 +1,16 @@
 use musefs_db::{Db, Format, NewTrack};
 use musefs_format::fuzz_check::fixtures;
 
-fn real_mtime(path: &std::path::Path) -> i64 {
-    i64::try_from(
-        std::fs::metadata(path)
-            .unwrap()
-            .modified()
-            .unwrap()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-    )
-    .unwrap()
+fn real_mtime_ns(path: &std::path::Path) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(path).unwrap();
+    meta.mtime() * 1_000_000_000 + meta.mtime_nsec()
+}
+
+fn real_ctime_ns(path: &std::path::Path) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(path).unwrap();
+    meta.ctime() * 1_000_000_000 + meta.ctime_nsec()
 }
 
 #[test]
@@ -31,7 +30,8 @@ fn scanner_owned_bounds_mutation_is_rejected_by_the_contract() {
             audio_offset: bounds.audio_offset,
             audio_length: bounds.audio_length,
             backing_size: bytes.len() as u64,
-            backing_mtime: real_mtime(&audio_path),
+            backing_mtime_ns: real_mtime_ns(&audio_path),
+            backing_ctime_ns: real_ctime_ns(&audio_path),
         })
         .unwrap();
 

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -291,7 +291,8 @@ fn poll_refresh_picks_up_external_db_edits() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -315,7 +316,8 @@ fn poll_refresh_picks_up_external_db_edits() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -416,7 +418,8 @@ fn poll_refresh_keeps_unchanged_entries_and_prunes_vanished() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -446,7 +449,8 @@ fn poll_refresh_debounces_within_interval() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -469,7 +473,8 @@ fn poll_refresh_debounces_within_interval() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -496,7 +501,8 @@ fn unchanged_refresh_poll_consumes_debounce_window() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -524,7 +530,8 @@ fn unchanged_refresh_poll_consumes_debounce_window() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -555,7 +562,8 @@ fn failed_refresh_retries_after_backoff_not_every_call() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -579,7 +587,8 @@ fn failed_refresh_retries_after_backoff_not_every_call() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -613,7 +622,8 @@ fn poll_refresh_single_flights_concurrent_callers() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -636,7 +646,8 @@ fn poll_refresh_single_flights_concurrent_callers() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -672,7 +683,8 @@ fn inode_is_stable_across_refresh() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -697,7 +709,8 @@ fn inode_is_stable_across_refresh() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -988,7 +1001,8 @@ fn refresh_picks_up_externally_added_track() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -1008,7 +1022,8 @@ fn refresh_picks_up_externally_added_track() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(
@@ -1225,7 +1240,8 @@ fn forced_refresh_and_poll_refresh_never_publish_stale_tree() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.replace_tags(
@@ -1280,4 +1296,47 @@ fn forced_refresh_and_poll_refresh_never_publish_stale_tree() {
             "track A{n} missing — a stale rebuild published an outdated tree"
         );
     }
+}
+
+// Template-agnostic: walk readdir from the root to the first non-dir entry.
+fn first_file_inode(fs: &Musefs) -> u64 {
+    fn walk(fs: &Musefs, inode: u64) -> Option<u64> {
+        for (name, child, is_dir) in fs.readdir(inode).unwrap() {
+            if name == "." || name == ".." {
+                continue;
+            }
+            if is_dir {
+                if let Some(f) = walk(fs, child) {
+                    return Some(f);
+                }
+            } else {
+                return Some(child);
+            }
+        }
+        None
+    }
+    walk(fs, VirtualTree::ROOT).expect("a file inode under root")
+}
+
+// getattr's warm size-cache hit must re-stat with the full stamp (#276/#279):
+// a same-size sub-second rewrite after the first getattr must surface
+// BackingChanged, not stale attrs.
+#[test]
+fn getattr_size_cache_rejects_subsecond_rewrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    common::write_flac(&src, &["TITLE=T", "ARTIST=A"], &[0xAB; 4096]);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let inode = first_file_inode(&fs);
+    fs.getattr(inode).unwrap(); // warm the size cache
+
+    let mut v = std::fs::read(&src).unwrap();
+    *v.last_mut().unwrap() ^= 0xFF; // same size, new mtime/ctime
+    std::fs::write(&src, v).unwrap();
+
+    let err = fs.getattr(inode).unwrap_err();
+    assert!(matches!(err, CoreError::BackingChanged(_)), "got {err:?}");
 }

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -130,14 +130,8 @@ fn legacy_flac_without_structural_rows_serves_via_front_read_fallback() {
             audio_offset: scan.audio_offset,
             audio_length: scan.audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(

--- a/musefs-core/tests/incremental_refresh.rs
+++ b/musefs-core/tests/incremental_refresh.rs
@@ -435,7 +435,7 @@ proptest! {
                     let new = musefs_db::NewTrack {
                         backing_path: format!("/virt/added-{add_seq}.flac"),
                         format: musefs_db::Format::Flac,
-                        audio_offset: 0, audio_length: 1, backing_size: 1, backing_mtime: 0,
+                        audio_offset: 0, audio_length: 1, backing_size: 1, backing_mtime_ns: 0, backing_ctime_ns: 0,
                     };
                     // Surface DB errors instead of vacuously skipping the op.
                     let id = writer.upsert_track(&new).unwrap();

--- a/musefs-core/tests/interop_emit.rs
+++ b/musefs-core/tests/interop_emit.rs
@@ -104,17 +104,16 @@ fn richer_m4a(mdat_payload: &[u8]) -> Vec<u8> {
 const COVR_JPEG: &[u8] = b"\xFF\xD8\xFF\xE0interop-jpeg-cover";
 const COVR_PNG: &[u8] = b"\x89PNG\r\n\x1a\ninterop-png-cover";
 
-fn real_mtime(p: &Path) -> i64 {
-    i64::try_from(
-        std::fs::metadata(p)
-            .unwrap()
-            .modified()
-            .unwrap()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-    )
-    .unwrap()
+fn real_mtime_ns(p: &Path) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(p).unwrap();
+    meta.mtime() * 1_000_000_000 + meta.mtime_nsec()
+}
+
+fn real_ctime_ns(p: &Path) -> i64 {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(p).unwrap();
+    meta.ctime() * 1_000_000_000 + meta.ctime_nsec()
 }
 
 #[derive(Debug)]
@@ -167,7 +166,8 @@ fn emit(
             audio_offset,
             audio_length,
             backing_size: std::fs::metadata(src).unwrap().len(),
-            backing_mtime: real_mtime(src),
+            backing_mtime_ns: real_mtime_ns(src),
+            backing_ctime_ns: real_ctime_ns(src),
         })
         .unwrap();
     db.replace_tags(
@@ -230,7 +230,8 @@ fn emit_binary(
             audio_offset,
             audio_length,
             backing_size: std::fs::metadata(src).unwrap().len(),
-            backing_mtime: real_mtime(src),
+            backing_mtime_ns: real_mtime_ns(src),
+            backing_ctime_ns: real_ctime_ns(src),
         })
         .unwrap();
     db.replace_tags(id, text).unwrap();

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -227,7 +227,8 @@ fn layout_cache_survives_unrelated_refresh() {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db2.replace_tags(

--- a/musefs-core/tests/proptest_read_fidelity.rs
+++ b/musefs-core/tests/proptest_read_fidelity.rs
@@ -21,14 +21,8 @@ fn build(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>) {
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -51,14 +45,8 @@ fn build_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempDir, 
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -97,14 +85,8 @@ fn build_wav(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -126,14 +108,8 @@ fn build_wav_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -366,14 +342,8 @@ fn build_mp3(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -393,14 +363,8 @@ fn build_mp3_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -573,14 +537,8 @@ fn build_m4a(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -600,14 +558,8 @@ fn build_m4a_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -645,14 +597,8 @@ fn build_ogg(audio: &[u8], title: &str) -> (tempfile::TempDir, Db, i64, Vec<u8>)
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();
@@ -672,14 +618,8 @@ fn build_ogg_with_art(audio: &[u8], title: &str, art: &[u8]) -> (tempfile::TempD
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&path),
+            backing_ctime_ns: common::real_ctime_ns(&path),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", title, 0)]).unwrap();

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -1,5 +1,6 @@
 mod common;
 use common::write_flac;
+use musefs_core::freshness::BackingStamp;
 use musefs_core::{HeaderCache, Mode, read_at, read_at_with_file};
 use musefs_db::{Db, Format, NewTrack, Tag};
 
@@ -17,14 +18,8 @@ fn setup() -> (tempfile::TempDir, Db, i64) {
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&flac),
+            backing_ctime_ns: common::real_ctime_ns(&flac),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", "Real", 0)])
@@ -125,8 +120,11 @@ fn read_at_streams_art_image_segments() {
         total_len,
         content_version: 0,
         backing_path: std::path::PathBuf::from("/unused"),
-        backing_size: 0,
-        backing_mtime_secs: 0,
+        stamp: BackingStamp {
+            size: 0,
+            mtime_ns: 0,
+            ctime_ns: 0,
+        },
         mtime_secs: 0,
         last_page: std::sync::Mutex::new(None),
         cache_bytes: 0,

--- a/musefs-core/tests/reader.rs
+++ b/musefs-core/tests/reader.rs
@@ -18,14 +18,8 @@ fn setup() -> (tempfile::TempDir, Db, i64) {
             audio_offset,
             audio_length,
             backing_size: meta.len(),
-            backing_mtime: i64::try_from(
-                meta.modified()
-                    .unwrap()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-            .unwrap(),
+            backing_mtime_ns: common::real_mtime_ns(&flac),
+            backing_ctime_ns: common::real_ctime_ns(&flac),
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("title", "Real Title", 0)])
@@ -70,14 +64,8 @@ fn bounds_check_rejects_audio_region_overrunning_the_file() {
     let audio = vec![0x5A; 120];
     let _ = write_flac(&flac, &["TITLE=Orig"], &audio);
     let meta = std::fs::metadata(&flac).unwrap();
-    let mtime = i64::try_from(
-        meta.modified()
-            .unwrap()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-    )
-    .unwrap();
+    let mtime_ns = common::real_mtime_ns(&flac);
+    let ctime_ns = common::real_ctime_ns(&flac);
 
     let db = Db::open_in_memory().unwrap();
     let overrun = db.upsert_track(&NewTrack {
@@ -86,7 +74,8 @@ fn bounds_check_rejects_audio_region_overrunning_the_file() {
         audio_offset: 0,
         audio_length: meta.len() + 1,
         backing_size: meta.len(),
-        backing_mtime: mtime,
+        backing_mtime_ns: mtime_ns,
+        backing_ctime_ns: ctime_ns,
     });
     assert!(
         overrun.is_err(),

--- a/musefs-core/tests/reader_faults.rs
+++ b/musefs-core/tests/reader_faults.rs
@@ -22,7 +22,8 @@ fn resolve_one_flac() -> (Db, std::sync::Arc<ResolvedFile>, tempfile::TempDir) {
             audio_offset,
             audio_length,
             backing_size: std::fs::metadata(&src).unwrap().len(),
-            backing_mtime: common::real_mtime(&src),
+            backing_mtime_ns: common::real_mtime_ns(&src),
+            backing_ctime_ns: common::real_ctime_ns(&src),
         })
         .unwrap();
     db.replace_tags(id, &[musefs_db::Tag::new("title", "Faulty", 0)])

--- a/musefs-core/tests/revalidate_freshness.rs
+++ b/musefs-core/tests/revalidate_freshness.rs
@@ -1,0 +1,28 @@
+mod common;
+use musefs_db::Db;
+
+// A ctime-only change (mtime forged back after an in-place same-size rewrite)
+// must NOT be skipped as "unchanged": revalidate re-probes it.
+#[test]
+fn revalidate_reprobes_on_ctime_only_change() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.flac");
+    common::write_flac(&src, &["TITLE=Old"], &[0xAB; 4096]);
+    let db_path = dir.path().join("m.db");
+    {
+        let db = Db::open(&db_path).unwrap();
+        musefs_core::scan_directory(&db, dir.path()).unwrap();
+    }
+    let original_modified = std::fs::metadata(&src).unwrap().modified().unwrap();
+
+    // Rewrite in place (same size, new tag), then forge mtime back. ctime moved.
+    common::write_flac(&src, &["TITLE=New"], &[0xCD; 4096]);
+    let f = std::fs::OpenOptions::new().write(true).open(&src).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+        .unwrap();
+    drop(f);
+
+    let db = Db::open(&db_path).unwrap();
+    let stats = musefs_core::revalidate(&db, dir.path()).unwrap();
+    assert_eq!(stats.updated, 1, "ctime-only change must be re-probed");
+}

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -169,7 +169,8 @@ mod guard_tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         let art = db

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -39,14 +39,15 @@ impl BulkWriter<'_> {
     pub fn upsert_track(&mut self, t: &NewTrack) -> Result<i64> {
         self.tx.execute(
             "INSERT INTO tracks
-                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CAST(strftime('%s','now') AS INTEGER))
+                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime_ns, backing_ctime_ns, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
              ON CONFLICT(backing_path) DO UPDATE SET
                 format=excluded.format, audio_offset=excluded.audio_offset,
                 audio_length=excluded.audio_length, backing_size=excluded.backing_size,
-                backing_mtime=excluded.backing_mtime,
+                backing_mtime_ns=excluded.backing_mtime_ns,
+                backing_ctime_ns=excluded.backing_ctime_ns,
                 updated_at=CAST(strftime('%s','now') AS INTEGER)",
-            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime],
+            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime_ns, t.backing_ctime_ns],
         )?;
         Ok(self.tx.query_row(
             "SELECT id FROM tracks WHERE backing_path = ?1",
@@ -162,7 +163,8 @@ mod tests {
                         audio_offset: 100,
                         audio_length: 200,
                         backing_size: 300,
-                        backing_mtime: 1,
+                        backing_mtime_ns: 1,
+                        backing_ctime_ns: 0,
                     })
                     .unwrap();
                 bw.replace_tags(id, &[Tag::new("title", &format!("t{i}"), 0)])
@@ -261,7 +263,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.set_binary_tags(
@@ -302,7 +305,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         {
@@ -343,7 +347,8 @@ mod tests {
                     audio_offset: 0,
                     audio_length: 1,
                     backing_size: 1,
-                    backing_mtime: 0,
+                    backing_mtime_ns: 0,
+                    backing_ctime_ns: 0,
                 })
                 .unwrap();
             bw.set_structural_blocks(
@@ -383,7 +388,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 0,
                 backing_size: 0,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
             // Dropped here without `commit()` → Transaction rolls back.

--- a/musefs-db/src/models.rs
+++ b/musefs-db/src/models.rs
@@ -130,7 +130,8 @@ pub struct Track {
     pub format: Format,
     pub bounds: TrackBounds,
     pub backing_size: u64,
-    pub backing_mtime: i64,
+    pub backing_mtime_ns: i64,
+    pub backing_ctime_ns: i64,
     pub content_version: i64,
     pub updated_at: i64,
 }
@@ -142,7 +143,8 @@ pub struct NewTrack {
     pub audio_offset: u64,
     pub audio_length: u64,
     pub backing_size: u64,
-    pub backing_mtime: i64,
+    pub backing_mtime_ns: i64,
+    pub backing_ctime_ns: i64,
 }
 
 #[derive(Debug, Clone)]

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -283,6 +283,11 @@ END;
 ";
 
 const MIGRATION_V5: &str = r"
+ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
+ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0
+    CHECK (backing_ctime_ns >= 0);
+
+
 -- art rows are content-addressed by sha256: once written, their content
 -- columns are immutable. A writer needing different bytes/metadata inserts a
 -- NEW row and relinks via track_art (which bumps content_version through the
@@ -330,7 +335,7 @@ WHEN NEW.format        <> OLD.format
   OR NEW.audio_offset  <> OLD.audio_offset
   OR NEW.audio_length  <> OLD.audio_length
   OR NEW.backing_size  <> OLD.backing_size
-  OR NEW.backing_mtime <> OLD.backing_mtime
+  OR NEW.backing_mtime_ns <> OLD.backing_mtime_ns
 BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
 END;
@@ -460,7 +465,7 @@ mod migration_v2_tests {
         // value_blob exists on tags and defaults to NULL.
         conn.execute(
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/a.flac','flac',0,1,1,0,0)",
             [],
         )
@@ -559,7 +564,7 @@ mod migration_v3_tests {
     fn insert_track(conn: &Connection, path: &str) {
         conn.execute(
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES (?1,'flac',0,1,1,0,0)",
             [path],
         )
@@ -579,7 +584,7 @@ mod migration_v3_tests {
         assert_eq!(count_changes(&conn), 1);
 
         conn.execute(
-            "UPDATE tracks SET backing_mtime = 1 WHERE id = 1", // tracks AU -> 2 rows (geometry trigger nested UPDATE)
+            "UPDATE tracks SET backing_mtime_ns = 1 WHERE id = 1", // tracks AU -> 2 rows (geometry trigger nested UPDATE)
             [],
         )
         .unwrap();
@@ -634,7 +639,7 @@ mod migration_v3_tests {
         insert_track(&conn, "/a.flac");
         // Drive CAP + 100 changelog inserts via track updates.
         for i in 0..(super::CHANGELOG_CAP + 100) {
-            conn.execute("UPDATE tracks SET backing_mtime = ?1 WHERE id = 1", [i])
+            conn.execute("UPDATE tracks SET backing_mtime_ns = ?1 WHERE id = 1", [i])
                 .unwrap();
         }
         let (min_seq, max_seq, rows): (i64, i64, i64) = conn
@@ -659,7 +664,14 @@ mod migration_v3_tests {
         conn.execute_batch(super::MIGRATIONS[0]).unwrap();
         conn.execute_batch(super::MIGRATIONS[1]).unwrap();
         conn.pragma_update(None, "user_version", 2i64).unwrap();
-        insert_track(&conn, "/legacy.flac");
+        // V2 schema has `backing_mtime` (pre-rename); use it directly.
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime, updated_at) \
+             VALUES ('/legacy.flac','flac',0,1,1,0,0)",
+            [],
+        )
+        .unwrap();
 
         super::migrate(&mut conn).unwrap();
         let uv: i64 = conn
@@ -669,7 +681,7 @@ mod migration_v3_tests {
         // Pre-migration rows produce no retroactive changelog entries...
         assert_eq!(count_changes(&conn), 0);
         // ...but post-migration edits do.
-        conn.execute("UPDATE tracks SET backing_mtime = 9 WHERE id = 1", [])
+        conn.execute("UPDATE tracks SET backing_mtime_ns = 9 WHERE id = 1", [])
             .unwrap();
         assert_eq!(count_changes(&conn), 2);
     }
@@ -796,10 +808,20 @@ mod migration_v4_tests {
         super::migrate(conn).unwrap();
     }
 
-    fn insert_track(conn: &Connection, path: &str) {
+    fn insert_track_v3(conn: &Connection, path: &str) {
         conn.execute(
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
              backing_size, backing_mtime, updated_at) \
+             VALUES (?1,'flac',0,1,1,0,0)",
+            [path],
+        )
+        .unwrap();
+    }
+
+    fn insert_track(conn: &Connection, path: &str) {
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES (?1,'flac',0,1,1,0,0)",
             [path],
         )
@@ -866,7 +888,7 @@ mod migration_v4_tests {
         conn.execute_batch(super::MIGRATIONS[2]).unwrap();
         conn.pragma_update(None, "user_version", 3i64).unwrap();
 
-        insert_track(&conn, "/legacy.flac");
+        insert_track_v3(&conn, "/legacy.flac");
         conn.execute(
             "INSERT INTO art (sha256, mime, byte_len, data) VALUES (?1,'image/png',1,X'00')",
             [&"b".repeat(64)],
@@ -935,7 +957,7 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','aiff',0,0,0,0,0)",
         );
     }
@@ -950,7 +972,7 @@ mod migration_v4_tests {
         {
             conn.execute(
                 "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-                 backing_size, backing_mtime, updated_at) \
+                 backing_size, backing_mtime_ns, updated_at) \
                  VALUES (?1, ?2, 0, 0, 0, 0, 0)",
                 rusqlite::params![format!("/t{i}"), fmt],
             )
@@ -965,7 +987,7 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','flac',-1,0,0,0,0)",
         );
     }
@@ -977,7 +999,7 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','flac',0,-1,0,0,0)",
         );
     }
@@ -989,19 +1011,19 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','flac',0,0,-1,0,0)",
         );
     }
 
     #[test]
-    fn v4_tracks_rejects_negative_backing_mtime() {
+    fn v4_tracks_rejects_negative_backing_mtime_ns() {
         let mut conn = Connection::open_in_memory().unwrap();
         fresh(&mut conn);
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','flac',0,0,0,-1,0)",
         );
     }
@@ -1013,7 +1035,7 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, content_version, updated_at) \
+             backing_size, backing_mtime_ns, content_version, updated_at) \
              VALUES ('/x','flac',0,0,0,0,-1,0)",
         );
     }
@@ -1025,7 +1047,7 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','flac',0,0,0,0,-1)",
         );
     }
@@ -1037,12 +1059,12 @@ mod migration_v4_tests {
         rejected(
             &conn,
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/x','flac',5,10,14,0,0)",
         );
         conn.execute(
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES ('/ok','flac',5,10,15,0,0)",
             [],
         )
@@ -1242,8 +1264,8 @@ mod migration_v4_tests {
         conn.execute_batch(super::MIGRATIONS[1]).unwrap();
         conn.execute_batch(super::MIGRATIONS[2]).unwrap();
         conn.pragma_update(None, "user_version", 3i64).unwrap();
-        insert_track(&conn, "/a.flac");
-        insert_track(&conn, "/b.flac");
+        insert_track_v3(&conn, "/a.flac");
+        insert_track_v3(&conn, "/b.flac");
         conn.execute("DELETE FROM track_changes", []).unwrap();
 
         super::migrate(&mut conn).unwrap();
@@ -1405,7 +1427,7 @@ mod migration_v4_tests {
         conn.execute_batch(super::MIGRATIONS[2]).unwrap();
         conn.pragma_update(None, "user_version", 3i64).unwrap();
 
-        insert_track(&conn, "/legacy.flac");
+        insert_track_v3(&conn, "/legacy.flac");
         conn.execute(
             "INSERT INTO structural_blocks (track_id, kind, ordinal, body) VALUES (1, 'STREAMINFO', 0, X'AABB')",
             [],
@@ -1501,7 +1523,7 @@ mod identity_tests {
         let conn = migrated();
         conn.execute(
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) VALUES ('/a.flac','flac',0,1,1,0,0)",
+             backing_size, backing_mtime_ns, updated_at) VALUES ('/a.flac','flac',0,1,1,0,0)",
             [],
         )
         .unwrap();
@@ -1632,7 +1654,7 @@ mod migration_v5_tests {
     fn insert_track(conn: &Connection, path: &str) -> i64 {
         conn.execute(
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
+             backing_size, backing_mtime_ns, updated_at) \
              VALUES (?1,'flac',0,1,1,0,0)",
             [path],
         )

--- a/musefs-db/src/structural.rs
+++ b/musefs-db/src/structural.rs
@@ -92,7 +92,8 @@ mod guard_tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         (db, id)
@@ -188,7 +189,8 @@ mod tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         db.set_structural_blocks(

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -229,7 +229,8 @@ mod tags_for_tracks_tests {
             audio_offset: 0,
             audio_length: 1,
             backing_size: 1,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         }
     }
 

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -10,7 +10,7 @@ macro_rules! track_select {
     ($tail:literal) => {
         concat!(
             "SELECT id, backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, content_version, updated_at \
+             backing_size, backing_mtime_ns, backing_ctime_ns, content_version, updated_at \
              FROM tracks ",
             $tail
         )
@@ -48,7 +48,8 @@ fn row_to_track(r: &Row) -> rusqlite::Result<Track> {
         format,
         bounds,
         backing_size,
-        backing_mtime: r.get("backing_mtime")?,
+        backing_mtime_ns: r.get("backing_mtime_ns")?,
+        backing_ctime_ns: r.get("backing_ctime_ns")?,
         content_version: r.get("content_version")?,
         updated_at: r.get("updated_at")?,
     })
@@ -188,14 +189,15 @@ impl Db<ReadWrite> {
     pub fn upsert_track(&self, t: &NewTrack) -> Result<i64> {
         self.conn.execute(
             "INSERT INTO tracks
-                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CAST(strftime('%s','now') AS INTEGER))
+                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime_ns, backing_ctime_ns, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
              ON CONFLICT(backing_path) DO UPDATE SET
                 format        = excluded.format,
                 audio_offset  = excluded.audio_offset,
                 audio_length  = excluded.audio_length,
                 backing_size  = excluded.backing_size,
-                backing_mtime = excluded.backing_mtime,
+                backing_mtime_ns = excluded.backing_mtime_ns,
+                backing_ctime_ns = excluded.backing_ctime_ns,
                 updated_at    = CAST(strftime('%s','now') AS INTEGER)",
             params![
                 t.backing_path,
@@ -203,7 +205,8 @@ impl Db<ReadWrite> {
                 t.audio_offset,
                 t.audio_length,
                 t.backing_size,
-                t.backing_mtime,
+                t.backing_mtime_ns,
+                t.backing_ctime_ns,
             ],
         )?;
         let id = self.conn.query_row(
@@ -261,7 +264,8 @@ mod negative_audio_bounds_tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         // Simulate a malformed external write to a contract column. The V4
@@ -293,7 +297,8 @@ mod negative_audio_bounds_tests {
                 audio_offset: 0,
                 audio_length: 1,
                 backing_size: 1,
-                backing_mtime: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
             })
             .unwrap();
         // Plant offset+length > backing_size past the V4 CHECK (layer 1) so we can
@@ -330,7 +335,8 @@ mod render_key_tests {
             audio_offset: 0,
             audio_length: 1,
             backing_size: 1,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         }
     }
 

--- a/musefs-db/tests/art.rs
+++ b/musefs-db/tests/art.rs
@@ -104,7 +104,8 @@ fn gc_orphan_art_removes_unreferenced_rows() {
             audio_offset: 0,
             audio_length: 0,
             backing_size: 0,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         })
         .unwrap();
     let referenced = db

--- a/musefs-db/tests/common/mod.rs
+++ b/musefs-db/tests/common/mod.rs
@@ -9,7 +9,8 @@ pub fn new_track(path: &str) -> NewTrack {
         audio_offset: 100,
         audio_length: 1000,
         backing_size: 1100,
-        backing_mtime: 1_700_000_000,
+        backing_mtime_ns: 1_700_000_000_000_000_000,
+        backing_ctime_ns: 1_700_000_000_000_000_000,
     }
 }
 

--- a/musefs-db/tests/tracks.rs
+++ b/musefs-db/tests/tracks.rs
@@ -85,7 +85,8 @@ fn delete_track_cascades_tags_and_track_art() {
             audio_offset: 0,
             audio_length: 0,
             backing_size: 0,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         })
         .unwrap();
     db.replace_tags(id, &[Tag::new("artist", "A", 0)]).unwrap();
@@ -129,7 +130,8 @@ fn upsert_conflict_updates_all_mutable_columns() {
         audio_offset: 222,
         audio_length: 333,
         backing_size: 555,
-        backing_mtime: 555,
+        backing_mtime_ns: 555,
+        backing_ctime_ns: 666,
     };
     let id2 = db.upsert_track(&changed).unwrap();
     assert_eq!(id, id2, "conflict update must keep the same id");
@@ -139,7 +141,8 @@ fn upsert_conflict_updates_all_mutable_columns() {
     assert_eq!(t.bounds.audio_offset(), 222);
     assert_eq!(t.bounds.audio_length(), 333);
     assert_eq!(t.backing_size, 555);
-    assert_eq!(t.backing_mtime, 555);
+    assert_eq!(t.backing_mtime_ns, 555);
+    assert_eq!(t.backing_ctime_ns, 666);
 }
 
 #[test]

--- a/musefs-format/tests/proptest_mp3.rs
+++ b/musefs-format/tests/proptest_mp3.rs
@@ -103,7 +103,8 @@ proptest! {
             audio_offset: 0,
             audio_length: 0,
             backing_size: 0,
-            backing_mtime: 0,
+            backing_mtime_ns: 0,
+            backing_ctime_ns: 0,
         }).unwrap();
         let db_tags: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
             musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: u64::try_from(i).unwrap() }

--- a/musefs-format/tests/proptest_wav.rs
+++ b/musefs-format/tests/proptest_wav.rs
@@ -155,7 +155,7 @@ proptest! {
         let tid = db.upsert_track(&musefs_db::NewTrack {
             backing_path: "/a.wav".into(),
             format: musefs_db::Format::Wav,
-            audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime: 0,
+            audio_offset: 0, audio_length: 0, backing_size: 0, backing_mtime_ns: 0, backing_ctime_ns: 0,
         }).unwrap();
         let rows: Vec<musefs_db::BinaryTag> = opaque.iter().enumerate().map(|(i, e)| {
             musefs_db::BinaryTag { key: e.key.clone(), payload: e.payload.clone(), ordinal: u64::try_from(i).unwrap() }


### PR DESCRIPTION
Closes #276.

## Problem

The backing-file freshness guard compared only **size + whole-second mtime**, leaving two silent-drift windows:

1. A backing file rewritten in place with the same length within the same clock second evaded the guard, pairing stale synthesized metadata with fresh audio bytes.
2. A scanner race: a worker `stat`ed a path, then opened/probed it separately, so the committed stamp and the probed bytes could come from different file versions.

## Approach

Per the design + plan in `docs/superpowers/` (spec- and plan-reviewed before implementation):

- **Identity = nanosecond mtime + ctime.** `ctime` is the un-forgeable backstop — a writer can reset mtime via `utimensat`, but cannot set ctime backward — so an in-place same-size rewrite (even one that forges mtime back) is caught. Deliberately **not** dev/inode (spurious `BackingChanged` across remounts) and **not** a content hash.
- **`BackingStamp { size, mtime_ns, ctime_ns }`** value type (`musefs-core/src/freshness.rs`) drives all three serve-path compares (`resolve`, `validate_opened_backing`, the getattr size-cache hit) and the revalidate skip decision.
- **fstat sandwich** in the scanner: `fstat` → probe → `fstat`, dropping the file as `Raced` if it moved mid-probe, so the stored stamp and probed bytes provably share one inode held still across the probe.
- **Schema:** in-place V5 edit — `RENAME COLUMN backing_mtime → backing_mtime_ns`, `ADD COLUMN backing_ctime_ns`. `user_version` stays 5 (no deployed databases). Contrib Python schema mirror regenerated.
- **Displayed mtime** stays whole-seconds (`display_secs()`), never the raw nanosecond column.

## Threat coverage (tests, not just assertions)

- `same_size_subsecond_rewrite_yields_backing_changed` — closes the whole-second window.
- `forged_mtime_is_caught_by_ctime` — resets mtime; the ctime backstop catches it.
- `probe_file_reports_raced_on_mid_probe_mutation` — exercises the fstat sandwich.
- `revalidate_reprobes_on_ctime_only_change` — a ctime-only delta is re-probed, not skipped.

## Verification

- `cargo test --workspace` · `cargo test -p musefs-core --features metrics` · `cargo clippy --all-targets` · `cargo fmt --all --check` — all green
- `cargo +nightly fuzz build serve` (out-of-workspace) — builds
- mutant-anchor drift guard — 46 entries validated; in-diff mutation gate ran 0-missed on the scan changes

## Notes for review

The final commit (`fix(scan): correct mutants.toml anchors, extract probe_body`) addresses a review pass on the test/CI scaffolding: it extracts `probe_body` out of a nested closure, replaces two over-broad `#[allow(cast_possible_truncation)]` with `usize::try_from`, and regenerates the `mutants.toml` exclusion anchors from `cargo mutants --list` (the prior anchors had drifted off their target mutants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file freshness to nanosecond precision, improving detection of rapid/sub-second modifications.
  * Detect and reject files that change during probing to avoid race conditions.
  * Harder validation against same-size rewrites and forged modification times by also considering change-time (ctime).

* **Documentation**
  * Updated architecture and implementation plan describing the stronger freshness model and serve-time guarantees; displayed mtime remains whole seconds.

* **Tests**
  * Expanded tests and fuzz targets to cover sub-second races, ctime-based revalidation, and migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->