### PR TITLE
fix(fuse): bound directory-handle and foreground-read resources (#307, #308)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-bound-fuse-resources.md
+++ b/docs/superpowers/plans/2026-06-12-bound-fuse-resources.md
@@ -1,0 +1,458 @@
+# Bound FUSE-layer Resources Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound two unbounded FUSE-adapter tables against a hostile local client — the per-open directory-handle snapshots (#307) and the foreground-read pool queue (#308) — each with a hardcoded cap whose overflow maps to a clean errno.
+
+**Architecture:** Both changes live entirely in `musefs-fuse/src/lib.rs`. Each bound is a pure decision helper (so the cap logic is unit-testable without a live FUSE mount) wired into the existing trait method. Part A admits a directory handle under the existing `dir_handles` mutex (`ENFILE` over cap); Part B reserves an in-flight-read slot synchronously on the dispatch thread before `pool.execute` (`EAGAIN` over cap, never blocking). Both mirror the existing `HandleTableFull → ENFILE` house pattern and the `PollPendingGuard` drop-guard.
+
+**Tech Stack:** Rust workspace (`musefs-fuse` crate), `fuser`, `threadpool`, `std::sync::atomic`, `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-bound-fuse-resources-design.md`
+
+---
+
+## Background the implementer needs
+
+- The single fuser dispatch thread calls every `Filesystem` trait method; blocking work is offloaded to `self.pool` (`threadpool::ThreadPool`, **unbounded** mpsc queue) and answered via the `Send` reply objects.
+- `opendir` (`musefs-fuse/src/lib.rs:351-368`) runs its **entire body on the pool thread**: it builds the listing, `dir_fh.fetch_add(1, Relaxed)` to allocate an id, then inserts into `dir_handles` under the mutex and replies. The cap check must move *inside* the existing lock hold, and the `fetch_add` must move *after* the check so a rejected open burns no id.
+- `read` (`lib.rs:419-452`) does a synchronous marker check on the dispatch thread, then offloads `core.read_into` to the pool. The slot reservation is added **on the dispatch thread, before `pool.execute`** — that is what caps the queue.
+- `dir_fh` starts at 1; `fetch_add` returns the *previous* value as the handle id (first handle = 1, counter becomes 2). `0` is a stateless sentinel and must stay reserved.
+- Drop-guard precedent: `PollPendingGuard<'a>(&'a AtomicBool)` (`lib.rs:140-146`). Part B's guard differs — it must *own* an `Arc<AtomicUsize>` so it can move into the `'static` worker closure.
+- Imports already present: `AtomicBool, AtomicU64, Ordering` (`lib.rs:8`), `Arc, Mutex` (`lib.rs:9`), `FileType` (`lib.rs:16`). Part B adds `AtomicUsize`.
+- Test module `mod tests` (`lib.rs:562`) opens with `use super::*;`, so every crate-level item (the new consts, helpers, guard, alias, and the atomics) is in scope inside the tests.
+- **Clippy runs `--all-targets -D warnings` in the pre-commit hook.** A helper that exists in the lib but is only called from `#[cfg(test)]` code triggers `dead_code` in the no-`cfg(test)` lib target. Therefore each task wires its helper into the lib (`opendir`/`read`) in the **same commit** as it introduces it — never commit an unused helper.
+- The pre-commit hook runs the full workspace test suite, clippy, and fmt; a red commit is rejected. Each task ends green.
+
+## File Structure
+
+- **Modify only:** `musefs-fuse/src/lib.rs`
+  - New crate-level items: `type DirListing`, `const MAX_DIR_HANDLES`, `fn try_admit_dir_handle`, `const MAX_INFLIGHT_READS`, `struct ReadSlotGuard` + `Drop`, `fn reserve_read_slot`.
+  - New `MusefsFs` field: `inflight_reads: Arc<AtomicUsize>`.
+  - Edited methods: `opendir`, `read`, `MusefsFs::new`; edited doc comment on `FuseConfig::max_background`.
+  - New unit tests appended to the existing `mod tests`.
+
+No other crates, no config/CLI surface, no schema changes, no `fuzz/` impact.
+
+---
+
+## Task 1: Part A — bound directory-handle snapshots (#307)
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` (add alias/const/helper near `build_dir_listing` ~line 129–136; rewrite `opendir` at 351–368; edit `MusefsFs::new` pool comment at 185–189)
+- Test: `musefs-fuse/src/lib.rs` (`mod tests`, appended before its closing `}` at line 694)
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append these three tests inside `mod tests` (just before its closing brace at `lib.rs:694`):
+
+```rust
+    fn empty_dir_handles() -> std::collections::HashMap<u64, Arc<DirListing>> {
+        std::collections::HashMap::new()
+    }
+
+    #[test]
+    fn try_admit_dir_handle_admits_and_allocates_id_below_cap() {
+        let mut handles = empty_dir_handles();
+        let counter = AtomicU64::new(1); // matches the live `dir_fh` start
+        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        assert_eq!(fh, Some(1), "first admit uses the pre-increment counter value");
+        assert_eq!(handles.len(), 1);
+        assert!(handles.contains_key(&1));
+        assert_eq!(counter.load(Ordering::Relaxed), 2, "id allocated on admit");
+    }
+
+    #[test]
+    fn try_admit_dir_handle_rejects_at_cap_without_inserting_or_advancing_id() {
+        let mut handles = empty_dir_handles();
+        handles.insert(10, Arc::new(Vec::new()));
+        handles.insert(11, Arc::new(Vec::new()));
+        let counter = AtomicU64::new(12);
+        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        assert_eq!(fh, None, "at cap must reject");
+        assert_eq!(handles.len(), 2, "must not insert on reject");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            12,
+            "must not burn a dir_fh id on reject"
+        );
+    }
+
+    #[test]
+    fn try_admit_dir_handle_frees_slot_after_removal() {
+        let mut handles = empty_dir_handles();
+        handles.insert(10, Arc::new(Vec::new()));
+        handles.insert(11, Arc::new(Vec::new()));
+        let counter = AtomicU64::new(12);
+        handles.remove(&10); // releasedir frees a slot
+        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        assert_eq!(fh, Some(12), "a freed slot admits again");
+        assert_eq!(handles.len(), 2);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-fuse try_admit_dir_handle`
+Expected: FAIL — compile error `E0412 cannot find type DirListing` / `E0425 cannot find function try_admit_dir_handle`.
+
+- [ ] **Step 3: Add the alias, the cap constant, and the helper**
+
+Insert immediately **before** the `build_dir_listing` doc comment (`lib.rs:129`):
+
+```rust
+/// One directory's readdir snapshot: `(child inode, entry type, name)` rows.
+/// Aliased so the handle-map signatures stay readable (and dodge
+/// `clippy::type_complexity`).
+type DirListing = Vec<(u64, FileType, String)>;
+
+/// Cap on concurrently-open directory handles (#307). Each `opendir` snapshots a
+/// full `DirListing`, so an unreleased handle pins memory ~ (entries × name
+/// length); the cap bounds the *number* of snapshots, not their inherent size (a
+/// single `ls` of the widest directory already allocates one). 1024 sits well
+/// above a heavy parallel indexer's concurrent-dir-handle count (~hundreds), so
+/// legitimate clients never hit it, while an over-cap `opendir` returns `ENFILE`
+/// — the directory-side analogue of the file-handle `HandleTableFull → ENFILE`.
+const MAX_DIR_HANDLES: usize = 1024;
+```
+
+Insert immediately **after** the `build_dir_listing` function (after its closing brace at `lib.rs:136`):
+
+```rust
+/// Admit a directory handle under the caller's `dir_handles` lock, enforcing
+/// `MAX_DIR_HANDLES` (#307). Returns the freshly allocated handle id on admit, or
+/// `None` when the table is at `cap` (the caller replies `ENFILE`). The id is
+/// drawn from `counter` only on the admit path, and the whole check-then-insert
+/// runs under the single lock the caller holds, so concurrent `opendir` closures
+/// cannot race the count past the cap and a rejected open burns no id.
+fn try_admit_dir_handle(
+    handles: &mut std::collections::HashMap<u64, Arc<DirListing>>,
+    counter: &AtomicU64,
+    cap: usize,
+    listing: DirListing,
+) -> Option<u64> {
+    if handles.len() >= cap {
+        return None;
+    }
+    let fh = counter.fetch_add(1, Ordering::Relaxed);
+    handles.insert(fh, Arc::new(listing));
+    Some(fh)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p musefs-fuse try_admit_dir_handle`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire `opendir` to use the helper**
+
+Replace the body of `opendir` (`lib.rs:351-368`) with:
+
+```rust
+    fn opendir(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        self.fire_poll_refresh();
+        let core = Arc::clone(&self.core);
+        let handles = Arc::clone(&self.dir_handles);
+        let counter = Arc::clone(&self.dir_fh);
+        self.pool.execute(move || {
+            let listing = match build_dir_listing(&core, ino.0) {
+                Ok(l) => l,
+                Err(e) => return reply.error(reply_errno("opendir", ino.0, &e)),
+            };
+            // Check + id allocation + insert under one lock hold, so concurrent
+            // opendir closures can't race the count past MAX_DIR_HANDLES (#307).
+            let admitted = {
+                let mut guard = handles
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                try_admit_dir_handle(&mut guard, &counter, MAX_DIR_HANDLES, listing)
+            };
+            match admitted {
+                Some(fh) => reply.opened(FileHandle(fh), FopenFlags::empty()),
+                None => reply.error(fuser::Errno::ENFILE),
+            }
+        });
+    }
+```
+
+- [ ] **Step 6: Update the stale `MusefsFs::new` pool comment**
+
+Replace the comment above `pool: ThreadPool::new(workers),` (`lib.rs:185-188`):
+
+```rust
+            // `ThreadPool`'s queue is unbounded, so foreground reads are gated by
+            // `inflight_reads`/`MAX_INFLIGHT_READS` before submission (#308) and
+            // directory handles are capped at `MAX_DIR_HANDLES` (#307); both reject
+            // over-cap work rather than letting it grow process memory.
+            // `max_background` (set in `init`) separately caps the kernel's
+            // background/readahead requests.
+            pool: ThreadPool::new(workers),
+```
+
+(The `inflight_reads` field referenced here lands in Task 2; this comment is written now to avoid a second edit of the same lines. It compiles regardless — comments reference nothing.)
+
+- [ ] **Step 7: Format, lint, and test the crate**
+
+Run: `cargo fmt --all && cargo clippy -p musefs-fuse --all-targets -- -D warnings && cargo test -p musefs-fuse`
+Expected: fmt applies cleanly, clippy clean (the helper is now used in `opendir`), all tests PASS. (The pre-commit hook re-checks fmt/clippy/full suite; running fmt now keeps the commit from being rejected on formatting.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-fuse/src/lib.rs
+git commit -m "fix(fuse): cap concurrent directory handles, ENFILE over the limit (#307)
+
+opendir snapshots a full directory listing per open with no quota; an
+adversarial client holding many directory fds open grows process memory
+unbounded. Cap the dir_handles table at MAX_DIR_HANDLES (1024) under the
+existing lock hold (id allocated only on admit), returning ENFILE over cap —
+the directory analogue of the file-handle HandleTableFull -> ENFILE path.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Part B — bound foreground read work (#308)
+
+**Files:**
+- Modify: `musefs-fuse/src/lib.rs` (add `AtomicUsize` import at line 8; add const + guard + helper after the `PollPendingGuard` Drop impl ~line 146; add field to `MusefsFs` ~line 175; init in `new` ~line 198; rewrite `read` at 419–452; edit `FuseConfig::max_background` doc)
+- Test: `musefs-fuse/src/lib.rs` (`mod tests`)
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append inside `mod tests` (before its closing brace):
+
+```rust
+    #[test]
+    fn reserve_read_slot_admits_up_to_cap() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let g1 = reserve_read_slot(&inflight, 2);
+        let g2 = reserve_read_slot(&inflight, 2);
+        assert!(g1.is_some() && g2.is_some(), "two reservations fit cap 2");
+        assert_eq!(inflight.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn reserve_read_slot_rejects_over_cap_and_releases() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let _g1 = reserve_read_slot(&inflight, 2);
+        let _g2 = reserve_read_slot(&inflight, 2);
+        let g3 = reserve_read_slot(&inflight, 2);
+        assert!(g3.is_none(), "third reservation exceeds cap 2");
+        assert_eq!(
+            inflight.load(Ordering::Relaxed),
+            2,
+            "a rejected reservation must release its own increment"
+        );
+    }
+
+    #[test]
+    fn read_slot_guard_releases_on_drop_and_panic() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        {
+            let _g = reserve_read_slot(&inflight, 4).expect("under cap");
+            assert_eq!(inflight.load(Ordering::Relaxed), 1);
+        }
+        assert_eq!(inflight.load(Ordering::Relaxed), 0, "guard releases on drop");
+
+        let inflight2 = Arc::new(AtomicUsize::new(0));
+        let i2 = Arc::clone(&inflight2);
+        let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = reserve_read_slot(&i2, 4).expect("under cap");
+            panic!("boom");
+        }));
+        assert!(r.is_err());
+        assert_eq!(
+            inflight2.load(Ordering::Relaxed),
+            0,
+            "guard releases its slot on unwind"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-fuse reserve_read_slot read_slot_guard`
+Expected: FAIL — compile error `E0425 cannot find function reserve_read_slot` / `E0433 ... AtomicUsize`.
+
+- [ ] **Step 3: Add the `AtomicUsize` import**
+
+Change `lib.rs:8` from:
+
+```rust
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+```
+
+to:
+
+```rust
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+```
+
+- [ ] **Step 4: Add the cap constant, the guard, and the reserve helper**
+
+Insert immediately **after** the `PollPendingGuard` `Drop` impl (after its closing brace at `lib.rs:146`):
+
+```rust
+/// Cap on concurrently outstanding foreground reads (#308). Every FUSE `read`
+/// reserves a slot on the dispatch thread *before* enqueuing onto the unbounded
+/// pool queue; over the cap the read is rejected with `EAGAIN` rather than
+/// queued, so the queue cannot grow past the cap. 1024 is far above any
+/// legitimate read fan-in (a player reads sequentially; readahead is bounded by
+/// `max_background`), so it is an attack-only response, and queued job state is
+/// small, keeping the bound cheap.
+const MAX_INFLIGHT_READS: usize = 1024;
+
+/// Releases one `inflight_reads` slot when dropped — on worker completion, on the
+/// over-cap reject path, and on panic. Owns an `Arc<AtomicUsize>` (unlike the
+/// borrow-based `PollPendingGuard`) so it can move into the `'static` worker
+/// closure.
+struct ReadSlotGuard(Arc<AtomicUsize>);
+
+impl Drop for ReadSlotGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Reserve one in-flight-read slot (#308). Increments `inflight` and returns a
+/// guard if the post-increment count is within `cap`; otherwise the guard drops
+/// immediately (undoing the increment) and `None` is returned, so the caller
+/// replies `EAGAIN` without enqueuing. The counter is a pure count with no
+/// happens-before tie to other data, so `Relaxed` ordering suffices.
+fn reserve_read_slot(inflight: &Arc<AtomicUsize>, cap: usize) -> Option<ReadSlotGuard> {
+    let count = inflight.fetch_add(1, Ordering::Relaxed) + 1;
+    let guard = ReadSlotGuard(Arc::clone(inflight));
+    if count > cap {
+        None // guard drops here, undoing the increment
+    } else {
+        Some(guard)
+    }
+}
+```
+
+- [ ] **Step 5: Add the `inflight_reads` field to `MusefsFs`**
+
+Insert after the `dir_fh` field (`lib.rs:173-175`, inside the struct):
+
+```rust
+    /// In-flight foreground-read counter. `read` reserves a slot before enqueuing;
+    /// over `MAX_INFLIGHT_READS` the read is rejected with `EAGAIN`, capping the
+    /// otherwise-unbounded pool queue (#308).
+    inflight_reads: Arc<AtomicUsize>,
+```
+
+- [ ] **Step 6: Initialise the field in `MusefsFs::new`**
+
+Insert after `dir_fh: Arc::new(AtomicU64::new(1)),` (`lib.rs:198`):
+
+```rust
+            inflight_reads: Arc::new(AtomicUsize::new(0)),
+```
+
+- [ ] **Step 7: Run the helper tests to verify they pass**
+
+Run: `cargo test -p musefs-fuse reserve_read_slot read_slot_guard`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Wire `read` to reserve a slot before offloading**
+
+Replace the body of `read` (`lib.rs:419-452`) with:
+
+```rust
+    fn read(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
+        reply: ReplyData,
+    ) {
+        if platform::spotlight::is_marker(ino.0) {
+            return reply.data(&[]);
+        }
+        // Reserve a slot on the dispatch thread before enqueuing; over the cap,
+        // reject with EAGAIN so the unbounded pool queue can't grow (#308).
+        let Some(slot) = reserve_read_slot(&self.inflight_reads, MAX_INFLIGHT_READS) else {
+            return reply.error(fuser::Errno::EAGAIN);
+        };
+        let core = Arc::clone(&self.core);
+        self.pool.execute(move || {
+            // Held until the read completes (or the worker panics), then released.
+            let _slot = slot;
+            READ_BUF.with(|b| {
+                let mut buf = b.borrow_mut();
+                match core.read_into(
+                    ino.0,
+                    NonZeroU64::new(fh.0).map(Fh::from),
+                    offset,
+                    u64::from(size),
+                    &mut buf,
+                ) {
+                    Ok(()) => reply.data(&buf),
+                    Err(e) => reply.error(reply_errno("read", ino.0, &e)),
+                }
+                if buf.capacity() > MAX_RETAINED_READ_BUF {
+                    buf.shrink_to(MAX_RETAINED_READ_BUF);
+                }
+            });
+        });
+    }
+```
+
+- [ ] **Step 9: Update the `FuseConfig::max_background` doc comment**
+
+Replace the doc comment on `max_background` (`lib.rs` `FuseConfig`, the three `///` lines ending `not by this.`):
+
+```rust
+    /// Max outstanding background (readahead/async) requests the kernel queues.
+    /// Caps that class of work delivered to the pool; foreground reads are
+    /// bounded separately by `MAX_INFLIGHT_READS` (#308), not by this.
+    pub max_background: u16,
+```
+
+- [ ] **Step 10: Format, lint, and test the crate**
+
+Run: `cargo fmt --all && cargo clippy -p musefs-fuse --all-targets -- -D warnings && cargo test -p musefs-fuse`
+Expected: fmt applies cleanly, clippy clean (`reserve_read_slot`, `ReadSlotGuard`, and `inflight_reads` are all used in `read`), all tests PASS.
+
+- [ ] **Step 11: Guard against the metrics-feature CI gap**
+
+The read path feeds `musefs-core`'s metrics counters (CI's `check` job asserts exact read/getattr counts). This change doesn't alter how often `core.read_into` runs per admitted FUSE read, but verify:
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: PASS (no count regressions).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add musefs-fuse/src/lib.rs
+git commit -m "fix(fuse): cap outstanding foreground reads, EAGAIN over the limit (#308)
+
+The threadpool queue is unbounded and foreground reads were bounded only by
+client concurrency, so a wide read storm grew the process queue (each queued
+job owns its reply and keeps request state alive). Reserve an in-flight-read
+slot on the dispatch thread before pool.execute; over MAX_INFLIGHT_READS (1024)
+reject with EAGAIN instead of enqueuing. A drop-guard releases the slot on
+completion, reject, and panic. Nothing blocking is added to the read path.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full workspace gate** (what the pre-commit hook enforces):
+
+Run: `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test`
+Expected: all green.
+
+## Optional follow-up (not required for completion)
+
+An `--ignored` end-to-end test for Part A — open `MAX_DIR_HANDLES + 1` directories on a live mount and assert the final `opendir` returns `ENFILE` — would exercise the wiring the unit tests can't reach (the trait methods need a real kernel reply channel). It requires `/dev/fuse` + libfuse and must follow the existing `musefs-fuse` e2e harness conventions (`cargo test -p musefs-fuse -- --ignored`). The decision logic for both bounds is already covered by the helper unit tests; this is integration-coverage polish, deliberately left out of the required path.

--- a/docs/superpowers/plans/2026-06-12-bound-fuse-resources.md
+++ b/docs/superpowers/plans/2026-06-12-bound-fuse-resources.md
@@ -88,6 +88,8 @@ Append these three tests inside `mod tests` (just before its closing brace at `l
         let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
         assert_eq!(fh, Some(12), "a freed slot admits again");
         assert_eq!(handles.len(), 2);
+        assert!(!handles.contains_key(&10), "the freed handle stays gone");
+        assert!(handles.contains_key(&12), "the new handle fills the freed slot");
     }
 ```
 
@@ -215,6 +217,8 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ---
 
 ## Task 2: Part B — bound foreground read work (#308)
+
+> **Anchor on the quoted text, not the line numbers.** Task 1 inserts ~30 lines, so every line number below is pre-Task-1 and will have shifted. Each step gives an unambiguous textual anchor — use it.
 
 **Files:**
 - Modify: `musefs-fuse/src/lib.rs` (add `AtomicUsize` import at line 8; add const + guard + helper after the `PollPendingGuard` Drop impl ~line 146; add field to `MusefsFs` ~line 175; init in `new` ~line 198; rewrite `read` at 419–452; edit `FuseConfig::max_background` doc)
@@ -383,7 +387,10 @@ Replace the body of `read` (`lib.rs:419-452`) with:
         };
         let core = Arc::clone(&self.core);
         self.pool.execute(move || {
-            // Held until the read completes (or the worker panics), then released.
+            // `_slot` (named) holds the guard until the read completes or the
+            // worker panics, then releases it. Do NOT simplify to bare `_`: that
+            // drops the guard immediately, releasing the slot before the work
+            // runs and neutering the cap.
             let _slot = slot;
             READ_BUF.with(|b| {
                 let mut buf = b.borrow_mut();
@@ -407,7 +414,16 @@ Replace the body of `read` (`lib.rs:419-452`) with:
 
 - [ ] **Step 9: Update the `FuseConfig::max_background` doc comment**
 
-Replace the doc comment on `max_background` (`lib.rs` `FuseConfig`, the three `///` lines ending `not by this.`):
+Find this exact doc comment on the `max_background` field in `FuseConfig`:
+
+```rust
+    /// Max outstanding background (readahead/async) requests the kernel queues.
+    /// Caps that class of work delivered to the pool; foreground reads are
+    /// bounded only by client concurrency, not by this.
+    pub max_background: u16,
+```
+
+Replace it with (only the final clause changes):
 
 ```rust
     /// Max outstanding background (readahead/async) requests the kernel queues.

--- a/docs/superpowers/specs/2026-06-12-bound-fuse-resources-design.md
+++ b/docs/superpowers/specs/2026-06-12-bound-fuse-resources-design.md
@@ -43,11 +43,26 @@ today's unbounded growth).
 
 ### Part A — bound directory-handle snapshots (#307)
 
-`opendir` already inserts under the `dir_handles` mutex. Add a count check
-against the live map **before** insert: if `map.len() >= MAX_DIR_HANDLES`, reply
-`ENFILE` without inserting (and without consuming a `dir_fh` id). `releasedir`
-already removes entries, so the count is self-healing — `map.len()` is the
-gauge, no separate counter.
+The whole `opendir` body runs on the pool thread, and it already takes the
+`dir_handles` mutex to insert. Extend that single lock hold to cover the cap
+check and the id allocation, so concurrent `opendir` closures (up to `workers`
+in flight) cannot race the count past the cap: under the lock, if
+`map.len() >= MAX_DIR_HANDLES`, reply `ENFILE`; otherwise `dir_fh.fetch_add(1)`
+and insert. `releasedir` already removes entries under the same mutex, so the
+count is self-healing — `map.len()` is the gauge, no separate counter.
+
+Two structural points the implementer must preserve (the current code does the
+opposite of the first):
+
+- **The `dir_fh.fetch_add` moves *after* the cap check, inside the lock.** Today
+  it happens before the lock (`lib.rs:361`). Allocating the id only on the admit
+  path keeps a rejected open from consuming an id, and keeping it inside the lock
+  keeps check-and-insert atomic. (Monotonicity of `dir_fh` is preserved either
+  way; the only behavioural change is that a rejected open no longer burns an
+  id.)
+- **The check is a pool-thread check under the existing mutex**, not a
+  dispatch-thread check like Part B's read gate. An implementer who mirrors Part
+  B's synchronous-on-dispatch structure here would build the wrong thing.
 
 `ENFILE` is correct here: a failed `opendir` is the literal "too many open files
 in system" condition that every directory walker already handles, and — unlike a
@@ -72,25 +87,38 @@ mid-stream read error — it cannot corrupt a playback stream.
 - *Degenerate caveat.* A flat template (e.g. `$title`) places the entire library
   in one directory, so the widest listing ≈ total track count and the product
   grows with library size. That is a self-inflicted template choice; it is
-  documented as a known edge rather than designed around. (An aggregate
+  documented as a known edge rather than designed around. Even here the cap is a
+  *strict improvement*: it bounds the multiplier to a finite `1024`, where today
+  the multiplier is unbounded — just not down to a small constant. (An aggregate
   byte-budget would be the answer if this case ever became real; it was
   considered and discarded in favour of the simpler count cap.)
 
 ### Part B — bound foreground read work (#308)
 
-Add `inflight_reads: Arc<AtomicUsize>` to `MusefsFs`. In `read`:
+Add `inflight_reads: Arc<AtomicUsize>` to `MusefsFs`. The gate runs
+**synchronously on the dispatch thread, in `read`, before `pool.execute`** — this
+is the load-bearing fact, because rejecting before submission is what actually
+caps the queue. Only `core.read_into` and the guard's `fetch_sub` run on the
+worker. In `read`:
 
-1. `fetch_add(1, …)`; bind a drop-guard that `fetch_sub(1, …)` on drop, so the
-   count is released on worker completion **and** on panic.
+1. `fetch_add(1, …)` and bind a drop-guard that `fetch_sub(1, …)` on drop, so
+   the reservation is released on worker completion **and** on panic. The guard
+   *owns* an `Arc<AtomicUsize>` (it is moved into a `'static` pool closure on the
+   admit path), so it cannot reuse the borrow-based `PollPendingGuard`; it is a
+   sibling type of the same shape.
 2. If the post-increment count `> MAX_INFLIGHT_READS`, reply `EAGAIN` and return
-   immediately — no enqueue, no read-buffer allocation, the `ReplyData` is
-   consumed by the error reply, the guard drops.
+   immediately on the dispatch thread — no enqueue, no read-buffer allocation,
+   the `ReplyData` is consumed by the error reply, the guard drops here.
 3. Otherwise enqueue as today, **moving the guard into the closure** so it
    decrements when the worker finishes.
 
-The dispatch thread never blocks. The pool queue cannot grow past the cap
-because submission stops once the count is exceeded. Nothing blocking is added
-to the read path: an over-cap read is rejected, not queued and not run inline.
+Because the single fuser dispatch thread checks reads serially, there is no
+TOCTOU among reads. The invariant: at most `MAX_INFLIGHT_READS` guards are held
+simultaneously by admitted (queued-or-running) reads; a rejected read transiently
+observes `cap + 1` and immediately releases. The dispatch thread never blocks,
+the pool queue cannot grow past the cap because submission stops once the count
+is exceeded, and nothing blocking is added to the read path: an over-cap read is
+rejected, not queued and not run inline.
 
 **Errno: `EAGAIN`.** Because nothing blocks, an over-cap read must surface *some*
 errno. No errno makes a blocking `read()` retry transparently (only `EINTR`
@@ -110,7 +138,10 @@ Queued-but-not-running job state is small — a boxed closure plus the `ReplyDat
 well under 1 KB — so 1024 queued ≈ ~1 MB; the large per-read buffers (≤
 `MAX_RETAINED_READ_BUF` = 2 MiB) exist only for the ≤ `workers` jobs actually
 running. 1024 is far above any legitimate foreground-read burst and keeps the
-bound cheap.
+bound cheap. The cap is on *concurrently outstanding* reads, not on worker
+count: the kernel can hold many foreground FUSE read requests in flight at once
+(well above `workers`), and that fan-in — not the drain rate — is the queue's
+growth lever, which is exactly what the cap targets.
 
 ### Scope boundary for Part B
 
@@ -125,12 +156,17 @@ genuine queue-growth lever.
 Mirror the existing house pattern: one direct unit test of the decision logic
 per part, plus end-to-end coverage where feasible.
 
-- **Part A.** Extract the cap-and-insert decision into a pure helper (a function
-  over the handle map and the cap, returning whether a new handle may be
-  admitted). Unit-test that `len >= cap` rejects, that a sub-cap state admits,
-  and that removing a handle frees a slot. Optional `--ignored` FUSE e2e: open
-  `MAX_DIR_HANDLES + 1` directories and assert the final `opendir` returns
-  `ENFILE`.
+- **Part A.** Extract the *guarded admit* into a pure helper — a function over
+  `&mut HashMap<…>`, the `dir_fh` counter, the cap, and the freshly built
+  listing, that performs the whole atomic step the caller runs under the lock:
+  reject (return `None`) when `len >= cap`, otherwise allocate the id, insert,
+  and return `Some(fh)`. Testing the helper then exercises the real
+  check-and-insert, not just `len >= cap` arithmetic — so the unit test catches a
+  regression that admits past the cap, which a bare predicate would miss.
+  Unit-test that a sub-cap state admits and inserts, that `len == cap` rejects
+  without inserting or advancing the id, and that removing a handle frees a slot.
+  Optional `--ignored` FUSE e2e: open `MAX_DIR_HANDLES + 1` directories and
+  assert the final `opendir` returns `ENFILE`.
 - **Part B.** Extract the reserve decision (the atomic counter and cap, yielding
   enqueue-vs-reject) into a pure helper. Unit-test the boundary
   (`count == cap` admits, `count > cap` rejects) and that the drop-guard
@@ -141,8 +177,18 @@ per part, plus end-to-end coverage where feasible.
 
 Update the two existing in-code rationale comments to point at the new bounds:
 the `ThreadPool` "queue is unbounded" note in `MusefsFs::new` and the
-`max_background` field doc on `FuseConfig`. No user-facing documentation changes,
-since neither bound adds configuration surface.
+`max_background` field doc on `FuseConfig`. Add a rationale comment at each new
+cap site (the `opendir` check and the `read` gate), in the style of the existing
+`MAX_RETAINED_READ_BUF` comment. No user-facing documentation changes, since
+neither bound adds configuration surface.
+
+## Implementation sequencing
+
+The pre-commit hook runs the full workspace test suite, so each commit must be
+green. The extracted decision helpers and their unit tests can land green in one
+commit ahead of wiring the call sites, satisfying that constraint cleanly; a
+natural split is a Part-A commit and a Part-B commit, each self-contained and
+green.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-12-bound-fuse-resources-design.md
+++ b/docs/superpowers/specs/2026-06-12-bound-fuse-resources-design.md
@@ -1,0 +1,154 @@
+# Bound FUSE-layer resources against a hostile local client
+
+**Issues:** #307 (directory-handle snapshots), #308 (foreground read queue).
+**Tracking:** #280 (audit Task 20).
+**Status:** design approved; ready for implementation planning.
+
+## Problem
+
+Two tables in the FUSE adapter (`musefs-fuse/src/lib.rs`) grow without bound
+under an adversarial local client, across the **local FUSE client → process
+memory** trust boundary:
+
+- **#307 — directory handles.** `opendir` builds a full directory listing and
+  stores it in `dir_handles: HashMap<u64, Arc<Vec<(u64, FileType, String)>>>`,
+  keyed by a monotonic `dir_fh`. `releasedir` removes the entry; `readdir`
+  clones the stored `Arc`. There is no quota: a client can repeatedly open a
+  large directory and hold the file descriptors open, and each open duplicates
+  the full listing vector. Memory grows with `unreleased handles × entries ×
+  name length`. This is weaker than the regular file-handle path, whose
+  `sharded_slab::Slab` insertion failure already maps to
+  `CoreError::HandleTableFull → ENFILE`.
+
+- **#308 — foreground reads.** `MusefsFs::new` uses `ThreadPool::new`, whose
+  queue is an unbounded `std::sync::mpsc::channel`. `max_background` (set in
+  `init`) caps only the kernel's *background/readahead* requests; foreground
+  reads are bounded only by client concurrency. Every FUSE `read` enqueues a
+  closure owning its `ReplyData`, and queued replies keep request state alive
+  until processed. A client driving many simultaneous foreground reads grows the
+  process queue independently of the worker count.
+
+## Approach
+
+Two independent, non-configurable bounds added to `musefs-fuse/src/lib.rs`. No
+`musefs-core`/`-db`/`-format` changes; no new config or CLI surface. Both follow
+the existing house pattern — a capacity-bounded table whose overflow maps to a
+clean errno — already used by the file-handle slab (`HandleTableFull → ENFILE`).
+
+The cap values are hardcoded constants (like `MAX_RETAINED_READ_BUF`), each with
+a rationale comment. They are sized from two opposing constraints: comfortably
+**above any legitimate client's concurrency**, so real clients never hit them,
+and bounding **worst-case adversarial memory** to a finite figure (versus
+today's unbounded growth).
+
+### Part A — bound directory-handle snapshots (#307)
+
+`opendir` already inserts under the `dir_handles` mutex. Add a count check
+against the live map **before** insert: if `map.len() >= MAX_DIR_HANDLES`, reply
+`ENFILE` without inserting (and without consuming a `dir_fh` id). `releasedir`
+already removes entries, so the count is self-healing — `map.len()` is the
+gauge, no separate counter.
+
+`ENFILE` is correct here: a failed `opendir` is the literal "too many open files
+in system" condition that every directory walker already handles, and — unlike a
+mid-stream read error — it cannot corrupt a playback stream.
+
+**`MAX_DIR_HANDLES = 1024`.** Reasoned over an absurd-but-plausible library:
+
+- *Legitimate ceiling.* A single `ls` holds one handle; depth-first `find`/`du`
+  holds O(depth) ≈ tens. The real stress case is a parallel indexer
+  (Spotlight / Tracker / `fd -jN`) under the `PARALLEL_DIROPS` capability the
+  adapter enables, holding ≈ `threads × depth` handles. A heavy 32-thread
+  indexer at depth 10 ≈ 320 concurrent handles. 1024 gives ~3× headroom, so
+  legitimate clients essentially never see `ENFILE`.
+- *Worst-case memory* = `1024 × widest-directory listing`. The virtual tree is
+  template-driven (`musefs-core/src/tree.rs`), so a directory's width is the
+  count of distinct rendered child components at that level. For a normal-huge
+  templated library (≈1M tracks, widest dir ≈50k entries at ≈70 B/entry ≈
+  3.5 MB) the product is ≈3.5 GB — finite and adversarial-only, versus today's
+  unbounded. The 3.5 MB base is *inherent*: a single legitimate `ls` of that
+  directory already allocates it once. The cap bounds only the *multiplier*
+  (the number of unreleased full copies).
+- *Degenerate caveat.* A flat template (e.g. `$title`) places the entire library
+  in one directory, so the widest listing ≈ total track count and the product
+  grows with library size. That is a self-inflicted template choice; it is
+  documented as a known edge rather than designed around. (An aggregate
+  byte-budget would be the answer if this case ever became real; it was
+  considered and discarded in favour of the simpler count cap.)
+
+### Part B — bound foreground read work (#308)
+
+Add `inflight_reads: Arc<AtomicUsize>` to `MusefsFs`. In `read`:
+
+1. `fetch_add(1, …)`; bind a drop-guard that `fetch_sub(1, …)` on drop, so the
+   count is released on worker completion **and** on panic.
+2. If the post-increment count `> MAX_INFLIGHT_READS`, reply `EAGAIN` and return
+   immediately — no enqueue, no read-buffer allocation, the `ReplyData` is
+   consumed by the error reply, the guard drops.
+3. Otherwise enqueue as today, **moving the guard into the closure** so it
+   decrements when the worker finishes.
+
+The dispatch thread never blocks. The pool queue cannot grow past the cap
+because submission stops once the count is exceeded. Nothing blocking is added
+to the read path: an over-cap read is rejected, not queued and not run inline.
+
+**Errno: `EAGAIN`.** Because nothing blocks, an over-cap read must surface *some*
+errno. No errno makes a blocking `read()` retry transparently (only `EINTR`
+does, and fabricating `EINTR` from FUSE collides with the kernel's
+request-interruption semantics, so it is excluded). Among the honest choices,
+`EAGAIN` ("resource temporarily unavailable") is the canonical transient /
+try-again signal and the one robust I/O code is most likely to retry; `ENOMEM`
+reads as fatal system-wide OOM, and `EBUSY` is non-idiomatic on `read()`.
+Because the cap is sized so a legitimate client never reaches it, `EAGAIN` is an
+attack-only response in practice, and its one downside — a naive app treating
+`EAGAIN` on a blocking fd as fatal — only bites an adversary.
+
+**`MAX_INFLIGHT_READS = 1024`.** A sequential player has one outstanding
+foreground read (kernel readahead is separately bounded by `max_background`);
+even parallel scans (`rsync`, a media-server library walk) reach only hundreds.
+Queued-but-not-running job state is small — a boxed closure plus the `ReplyData`,
+well under 1 KB — so 1024 queued ≈ ~1 MB; the large per-read buffers (≤
+`MAX_RETAINED_READ_BUF` = 2 MiB) exist only for the ≤ `workers` jobs actually
+running. 1024 is far above any legitimate foreground-read burst and keeps the
+bound cheap.
+
+### Scope boundary for Part B
+
+Gating covers `read` only. It is the operation with the largest payloads and the
+one that keeps request state alive in the queue. The other pool users are
+already bounded: `opendir` by Part A, `poll_refresh` by its single-flight gate
+(#89), and `lookup` / `getattr` / `open` carry tiny replies. Reads are the
+genuine queue-growth lever.
+
+## Testing
+
+Mirror the existing house pattern: one direct unit test of the decision logic
+per part, plus end-to-end coverage where feasible.
+
+- **Part A.** Extract the cap-and-insert decision into a pure helper (a function
+  over the handle map and the cap, returning whether a new handle may be
+  admitted). Unit-test that `len >= cap` rejects, that a sub-cap state admits,
+  and that removing a handle frees a slot. Optional `--ignored` FUSE e2e: open
+  `MAX_DIR_HANDLES + 1` directories and assert the final `opendir` returns
+  `ENFILE`.
+- **Part B.** Extract the reserve decision (the atomic counter and cap, yielding
+  enqueue-vs-reject) into a pure helper. Unit-test the boundary
+  (`count == cap` admits, `count > cap` rejects) and that the drop-guard
+  decrements on drop. The reject-reply path itself is integration-level; the
+  accounting is covered unit-side.
+
+## Documentation
+
+Update the two existing in-code rationale comments to point at the new bounds:
+the `ThreadPool` "queue is unbounded" note in `MusefsFs::new` and the
+`max_background` field doc on `FuseConfig`. No user-facing documentation changes,
+since neither bound adds configuration surface.
+
+## Out of scope
+
+- Configurable cap values (no evidence any deployment needs different limits).
+- An aggregate byte-budget for directory listings (the flat-template degenerate
+  case above); revisit only if a real flat-template-on-huge-library deployment
+  appears.
+- Bounding non-read pool work (`lookup`/`getattr`/`open`), already cheap or
+  bounded elsewhere.

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::ffi::OsStr;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
 
@@ -49,7 +49,7 @@ pub struct FuseConfig {
     pub max_readahead: u32,
     /// Max outstanding background (readahead/async) requests the kernel queues.
     /// Caps that class of work delivered to the pool; foreground reads are
-    /// bounded only by client concurrency, not by this.
+    /// bounded separately by `MAX_INFLIGHT_READS` (#308), not by this.
     pub max_background: u16,
     /// Keep the kernel page cache across opens (`FOPEN_KEEP_CACHE`). An external
     /// re-tag auto-invalidates the affected inode on refresh (`poll_refresh_notify`
@@ -179,6 +179,42 @@ impl Drop for PollPendingGuard<'_> {
     }
 }
 
+/// Cap on concurrently outstanding foreground reads (#308). Every FUSE `read`
+/// reserves a slot on the dispatch thread *before* enqueuing onto the unbounded
+/// pool queue; over the cap the read is rejected with `EAGAIN` rather than
+/// queued, so the queue cannot grow past the cap. 1024 is far above any
+/// legitimate read fan-in (a player reads sequentially; readahead is bounded by
+/// `max_background`), so it is an attack-only response, and queued job state is
+/// small, keeping the bound cheap.
+const MAX_INFLIGHT_READS: usize = 1024;
+
+/// Releases one `inflight_reads` slot when dropped — on worker completion, on the
+/// over-cap reject path, and on panic. Owns an `Arc<AtomicUsize>` (unlike the
+/// borrow-based `PollPendingGuard`) so it can move into the `'static` worker
+/// closure.
+struct ReadSlotGuard(Arc<AtomicUsize>);
+
+impl Drop for ReadSlotGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Reserve one in-flight-read slot (#308). Increments `inflight` and returns a
+/// guard if the post-increment count is within `cap`; otherwise the guard drops
+/// immediately (undoing the increment) and `None` is returned, so the caller
+/// replies `EAGAIN` without enqueuing. The counter is a pure count with no
+/// happens-before tie to other data, so `Relaxed` ordering suffices.
+fn reserve_read_slot(inflight: &Arc<AtomicUsize>, cap: usize) -> Option<ReadSlotGuard> {
+    let count = inflight.fetch_add(1, Ordering::Relaxed) + 1;
+    let guard = ReadSlotGuard(Arc::clone(inflight));
+    if count > cap {
+        None // guard drops here, undoing the increment
+    } else {
+        Some(guard)
+    }
+}
+
 /// A `fuser::Filesystem` that serves a `musefs_core::Musefs`. fuser dispatches
 /// on one thread; blocking ops (read/getattr/lookup-attr) are offloaded to a
 /// bounded worker pool and answered via the `Send` reply objects, so a slow
@@ -207,6 +243,10 @@ pub struct MusefsFs {
     dir_handles: Arc<Mutex<std::collections::HashMap<u64, Arc<Vec<(u64, FileType, String)>>>>>,
     /// Monotonic dir-handle id (starts at 1; 0 stays the stateless sentinel).
     dir_fh: Arc<AtomicU64>,
+    /// In-flight foreground-read counter. `read` reserves a slot before enqueuing;
+    /// over `MAX_INFLIGHT_READS` the read is rejected with `EAGAIN`, capping the
+    /// otherwise-unbounded pool queue (#308).
+    inflight_reads: Arc<AtomicUsize>,
 }
 
 impl MusefsFs {
@@ -232,6 +272,7 @@ impl MusefsFs {
             passthrough: platform::passthrough::PassthroughState::new(structure_only),
             dir_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
             dir_fh: Arc::new(AtomicU64::new(1)),
+            inflight_reads: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -472,8 +513,18 @@ impl Filesystem for MusefsFs {
         if platform::spotlight::is_marker(ino.0) {
             return reply.data(&[]);
         }
+        // Reserve a slot on the dispatch thread before enqueuing; over the cap,
+        // reject with EAGAIN so the unbounded pool queue can't grow (#308).
+        let Some(slot) = reserve_read_slot(&self.inflight_reads, MAX_INFLIGHT_READS) else {
+            return reply.error(fuser::Errno::EAGAIN);
+        };
         let core = Arc::clone(&self.core);
         self.pool.execute(move || {
+            // `_slot` (named) holds the guard until the read completes or the
+            // worker panics, then releases it. Do NOT simplify to bare `_`: that
+            // drops the guard immediately, releasing the slot before the work
+            // runs and neutering the cap.
+            let _slot = slot;
             READ_BUF.with(|b| {
                 let mut buf = b.borrow_mut();
                 match core.read_into(
@@ -783,6 +834,56 @@ mod tests {
         assert!(
             handles.contains_key(&12),
             "the new handle fills the freed slot"
+        );
+    }
+
+    #[test]
+    fn reserve_read_slot_admits_up_to_cap() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let g1 = reserve_read_slot(&inflight, 2);
+        let g2 = reserve_read_slot(&inflight, 2);
+        assert!(g1.is_some() && g2.is_some(), "two reservations fit cap 2");
+        assert_eq!(inflight.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn reserve_read_slot_rejects_over_cap_and_releases() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let _g1 = reserve_read_slot(&inflight, 2);
+        let _g2 = reserve_read_slot(&inflight, 2);
+        let g3 = reserve_read_slot(&inflight, 2);
+        assert!(g3.is_none(), "third reservation exceeds cap 2");
+        assert_eq!(
+            inflight.load(Ordering::Relaxed),
+            2,
+            "a rejected reservation must release its own increment"
+        );
+    }
+
+    #[test]
+    fn read_slot_guard_releases_on_drop_and_panic() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        {
+            let _g = reserve_read_slot(&inflight, 4).expect("under cap");
+            assert_eq!(inflight.load(Ordering::Relaxed), 1);
+        }
+        assert_eq!(
+            inflight.load(Ordering::Relaxed),
+            0,
+            "guard releases on drop"
+        );
+
+        let inflight2 = Arc::new(AtomicUsize::new(0));
+        let i2 = Arc::clone(&inflight2);
+        let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = reserve_read_slot(&i2, 4).expect("under cap");
+            panic!("boom");
+        }));
+        assert!(r.is_err());
+        assert_eq!(
+            inflight2.load(Ordering::Relaxed),
+            0,
+            "guard releases its slot on unwind"
         );
     }
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -126,6 +126,20 @@ fn reply_errno(op: &str, ino: u64, err: &CoreError) -> fuser::Errno {
     errno(err)
 }
 
+/// One directory's readdir snapshot: `(child inode, entry type, name)` rows.
+/// Aliased so the handle-map signatures stay readable (and dodge
+/// `clippy::type_complexity`).
+type DirListing = Vec<(u64, FileType, String)>;
+
+/// Cap on concurrently-open directory handles (#307). Each `opendir` snapshots a
+/// full `DirListing`, so an unreleased handle pins memory ~ (entries × name
+/// length); the cap bounds the *number* of snapshots, not their inherent size (a
+/// single `ls` of the widest directory already allocates one). 1024 sits well
+/// above a heavy parallel indexer's concurrent-dir-handle count (~hundreds), so
+/// legitimate clients never hit it, while an over-cap `opendir` returns `ENFILE`
+/// — the directory-side analogue of the file-handle `HandleTableFull → ENFILE`.
+const MAX_DIR_HANDLES: usize = 1024;
+
 /// Build a directory's full readdir listing once. Shared by `opendir`
 /// (snapshotted per fh) and the `readdir` fallback for an unknown fh.
 fn build_dir_listing(core: &Musefs, ino: u64) -> Result<Vec<(u64, FileType, String)>, CoreError> {
@@ -133,6 +147,26 @@ fn build_dir_listing(core: &Musefs, ino: u64) -> Result<Vec<(u64, FileType, Stri
     let parent = core.parent(ino).unwrap_or(ino);
     let marker = platform::spotlight::marker_dir_entry(ino);
     Ok(assemble_dir_listing(ino, parent, entries, marker))
+}
+
+/// Admit a directory handle under the caller's `dir_handles` lock, enforcing
+/// `MAX_DIR_HANDLES` (#307). Returns the freshly allocated handle id on admit, or
+/// `None` when the table is at `cap` (the caller replies `ENFILE`). The id is
+/// drawn from `counter` only on the admit path, and the whole check-then-insert
+/// runs under the single lock the caller holds, so concurrent `opendir` closures
+/// cannot race the count past the cap and a rejected open burns no id.
+fn try_admit_dir_handle(
+    handles: &mut std::collections::HashMap<u64, Arc<DirListing>>,
+    counter: &AtomicU64,
+    cap: usize,
+    listing: DirListing,
+) -> Option<u64> {
+    if handles.len() >= cap {
+        return None;
+    }
+    let fh = counter.fetch_add(1, Ordering::Relaxed);
+    handles.insert(fh, Arc::new(listing));
+    Some(fh)
 }
 
 /// Clears the `fire_poll_refresh` single-flight gate when the poll task ends,
@@ -182,10 +216,12 @@ impl MusefsFs {
         let structure_only = core.mode() == musefs_core::Mode::StructureOnly;
         MusefsFs {
             core: Arc::new(core),
-            // `ThreadPool`'s queue is unbounded. `max_background` (set in `init`)
-            // caps the kernel's *background/readahead* requests, bounding that
-            // class of work; foreground reads are bounded only by client
-            // concurrency, so a wide parallel read storm can still queue jobs.
+            // `ThreadPool`'s queue is unbounded, so foreground reads are gated by
+            // `inflight_reads`/`MAX_INFLIGHT_READS` before submission (#308) and
+            // directory handles are capped at `MAX_DIR_HANDLES` (#307); both reject
+            // over-cap work rather than letting it grow process memory.
+            // `max_background` (set in `init`) separately caps the kernel's
+            // background/readahead requests.
             pool: ThreadPool::new(workers),
             uid: config.uid,
             gid: config.gid,
@@ -358,12 +394,18 @@ impl Filesystem for MusefsFs {
                 Ok(l) => l,
                 Err(e) => return reply.error(reply_errno("opendir", ino.0, &e)),
             };
-            let fh = counter.fetch_add(1, Ordering::Relaxed);
-            handles
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .insert(fh, Arc::new(listing));
-            reply.opened(FileHandle(fh), FopenFlags::empty());
+            // Check + id allocation + insert under one lock hold, so concurrent
+            // opendir closures can't race the count past MAX_DIR_HANDLES (#307).
+            let admitted = {
+                let mut guard = handles
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                try_admit_dir_handle(&mut guard, &counter, MAX_DIR_HANDLES, listing)
+            };
+            match admitted {
+                Some(fh) => reply.opened(FileHandle(fh), FopenFlags::empty()),
+                None => reply.error(fuser::Errno::ENFILE),
+            }
         });
     }
 
@@ -689,6 +731,58 @@ mod tests {
         assert!(
             !fs.poll_pending.load(Ordering::SeqCst),
             "guard must clear the gate after the task finishes"
+        );
+    }
+
+    fn empty_dir_handles() -> std::collections::HashMap<u64, Arc<DirListing>> {
+        std::collections::HashMap::new()
+    }
+
+    #[test]
+    fn try_admit_dir_handle_admits_and_allocates_id_below_cap() {
+        let mut handles = empty_dir_handles();
+        let counter = AtomicU64::new(1); // matches the live `dir_fh` start
+        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        assert_eq!(
+            fh,
+            Some(1),
+            "first admit uses the pre-increment counter value"
+        );
+        assert_eq!(handles.len(), 1);
+        assert!(handles.contains_key(&1));
+        assert_eq!(counter.load(Ordering::Relaxed), 2, "id allocated on admit");
+    }
+
+    #[test]
+    fn try_admit_dir_handle_rejects_at_cap_without_inserting_or_advancing_id() {
+        let mut handles = empty_dir_handles();
+        handles.insert(10, Arc::new(Vec::new()));
+        handles.insert(11, Arc::new(Vec::new()));
+        let counter = AtomicU64::new(12);
+        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        assert_eq!(fh, None, "at cap must reject");
+        assert_eq!(handles.len(), 2, "must not insert on reject");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            12,
+            "must not burn a dir_fh id on reject"
+        );
+    }
+
+    #[test]
+    fn try_admit_dir_handle_frees_slot_after_removal() {
+        let mut handles = empty_dir_handles();
+        handles.insert(10, Arc::new(Vec::new()));
+        handles.insert(11, Arc::new(Vec::new()));
+        let counter = AtomicU64::new(12);
+        handles.remove(&10); // releasedir frees a slot
+        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        assert_eq!(fh, Some(12), "a freed slot admits again");
+        assert_eq!(handles.len(), 2);
+        assert!(!handles.contains_key(&10), "the freed handle stays gone");
+        assert!(
+            handles.contains_key(&12),
+            "the new handle fills the freed slot"
         );
     }
 }


### PR DESCRIPTION
Bounds two unbounded FUSE-adapter tables against a hostile local client (trust boundary: local FUSE client → process memory; tracking #280, audit Task 20). Both follow the existing house pattern — a capacity-bounded table whose overflow maps to a clean errno, like the file-handle slab's `HandleTableFull → ENFILE`. All changes are confined to `musefs-fuse/src/lib.rs`; no core/db/format changes, no config or CLI surface.

## #307 — directory-handle snapshots

`opendir` snapshotted a full directory listing per open into `dir_handles` with no quota; a client holding many directory fds open grew memory without bound. Now capped at `MAX_DIR_HANDLES = 1024` via `try_admit_dir_handle`, which does the cap check + id allocation + insert under the single existing `dir_handles` lock hold. The `dir_fh` id is drawn only on the admit path, so a rejected open burns no id; over the cap, `opendir` replies `ENFILE`.

## #308 — foreground read queue

The `threadpool` queue is an unbounded mpsc channel; `max_background` caps only kernel background/readahead work, so a wide read storm grew the process queue (each queued job owns its reply and keeps request state alive). Every `read` now reserves an in-flight slot via `reserve_read_slot` **synchronously on the dispatch thread, before `pool.execute`** — over `MAX_INFLIGHT_READS = 1024` it replies `EAGAIN` without enqueuing, so the queue can't grow past the cap. A `ReadSlotGuard` (owning `Arc<AtomicUsize>`) releases the slot on worker completion, on the reject path, and on panic. Nothing blocking is added to the read path.

`EAGAIN`/`ENFILE` and the 1024 caps are sized so a legitimate client never reaches them (the responses are attack-only); see the design doc for the worst-case-memory and legitimate-concurrency reasoning.

## Testing

Pure decision helpers (`try_admit_dir_handle`, `reserve_read_slot`/`ReadSlotGuard`) are unit-tested without a live mount: admit/reject boundaries, no-id-burn-on-reject, slot reuse after release, and guard release on drop **and** panic. The `EAGAIN`/`ENFILE` wiring needs a real kernel reply channel, so a live-mount e2e is left as optional follow-up.

- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings` — clean
- `cargo test` (workspace) and `cargo test -p musefs-core --features metrics` — green (no read/getattr count regression)

Design + plan: `docs/superpowers/specs/2026-06-12-bound-fuse-resources-design.md`, `docs/superpowers/plans/2026-06-12-bound-fuse-resources.md`.

Closes #307
Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced resource limits to the FUSE adapter to prevent unbounded resource consumption: capped concurrent directory operations (returns ENFILE when exceeded) and capped in-flight read operations (returns EAGAIN when exceeded).

* **Tests**
  * Added unit tests validating directory operation and read operation limit enforcement and capacity release behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->