### PR TITLE
test(scan): use a FIFO, not a Unix socket, for the non-file target (#277)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "dashmap",
  "id3",
  "im",
+ "libc",
  "log",
  "metaflac",
  "musefs-db",

--- a/docs/superpowers/plans/2026-06-12-scanner-fifo-test-fixture.md
+++ b/docs/superpowers/plans/2026-06-12-scanner-fifo-test-fixture.md
@@ -1,0 +1,117 @@
+# Scanner FIFO Test Fixture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Unix-socket fixture in the scanner symlink-to-non-file hardening test with a `libc::mkfifo` FIFO so the test stops failing in sandboxes that deny Unix-socket `bind` (issue #277).
+
+**Architecture:** Test-fixture-only change. The product code (`collect_audio`) is untouched. A FIFO is, like a Unix socket, neither a regular file nor a directory, so it exercises the identical `is_file()` branch the test asserts on — but `mkfifo` works in restricted environments that block socket `bind`. The single FFI call is wrapped in the workspace's documented `#[expect(unsafe_code, …)]` pattern (the workspace lints `unsafe_code = "deny"`).
+
+**Tech Stack:** Rust, `libc` 0.2 (already a workspace dep, added here as a `musefs-core` dev-dependency), `tempfile`.
+
+---
+
+### Task 1: Swap the Unix-socket fixture for a FIFO
+
+**Files:**
+- Modify: `musefs-core/Cargo.toml` (`[dev-dependencies]`)
+- Modify: `musefs-core/src/scan.rs` — fn `collect_audio_ignores_symlink_to_non_file_target_when_following` (currently lines 1549-1565)
+
+This is an existing test whose *assertion* already pins the behavior under test (a symlink to a non-file, non-dir target must not be collected). We are changing only the mechanism that creates the non-file target, so there is no new product behavior to drive with a fresh failing test. The verification is: the rewritten test compiles, still passes (behavior preserved), and no longer calls `UnixListener::bind`.
+
+- [ ] **Step 1: Add `libc` as a dev-dependency**
+
+In `musefs-core/Cargo.toml`, under the existing `[dev-dependencies]` block, add the line (alongside `tempfile`, `metaflac`, etc.):
+
+```toml
+libc = "0.2"
+```
+
+- [ ] **Step 2: Rewrite the test fixture to use a FIFO**
+
+In `musefs-core/src/scan.rs`, replace the entire body of
+`collect_audio_ignores_symlink_to_non_file_target_when_following` with:
+
+```rust
+#[test]
+fn collect_audio_ignores_symlink_to_non_file_target_when_following() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    // A FIFO is neither a regular file nor a directory, and mkfifo works in
+    // restricted sandboxes that deny Unix-socket bind (issue #277).
+    let fifo = dir.path().join("fifo");
+    let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    #[expect(unsafe_code, reason = "libc::mkfifo FFI; no std equivalent")]
+    let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+    assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+
+    // Name the link with a supported audio extension so the only thing
+    // keeping it out of `out` is the resolved target's is_file() check.
+    std::os::unix::fs::symlink(&fifo, dir.path().join("link.flac")).unwrap();
+
+    let mut out = Vec::new();
+    collect_audio(dir.path(), &mut out, true).unwrap();
+    assert!(
+        out.is_empty(),
+        "a symlink to a non-file, non-dir target must not be collected"
+    );
+}
+```
+
+- [ ] **Step 3: Run the test, verify it passes**
+
+Run: `cargo test -p musefs-core scan::hardening_tests::collect_audio_ignores_symlink_to_non_file_target_when_following -- --exact`
+Expected: PASS (`test result: ok. 1 passed`).
+
+- [ ] **Step 4: Run the full scanner test subset**
+
+Run: `cargo test -p musefs-core scan::`
+Expected: PASS — this is the exact subset the issue reported as failing.
+
+- [ ] **Step 5: Confirm the socket bind is gone**
+
+Run: `grep -n "UnixListener" musefs-core/src/scan.rs`
+Expected: no output (no remaining `UnixListener` references in the file).
+
+- [ ] **Step 6: Lint — the `#[expect(unsafe_code)]` must be fulfilled, not dangling**
+
+Run: `cargo clippy -p musefs-core --all-targets -- -D warnings`
+Expected: clean (no `unfulfilled_lint_expectations`, no warnings). Clippy compiles `--all-targets`, so the test module is linted here.
+
+- [ ] **Step 7: Format**
+
+Run: `cargo fmt`
+Then `cargo fmt --all --check` — expected: clean exit (0).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-core/Cargo.toml musefs-core/src/scan.rs
+git commit -m "$(cat <<'EOF'
+test(scan): use a FIFO, not a Unix socket, for the non-file target (#277)
+
+UnixListener::bind needs a privilege some sandboxes deny, panicking the
+test in setup. A FIFO is likewise neither a regular file nor a directory,
+exercises the same is_file() branch, and mkfifo works where socket bind
+does not. libc::mkfifo is wrapped in the workspace's sanctioned
+#[expect(unsafe_code)] pattern; libc is added as a musefs-core dev-dep.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Notes for the implementer
+
+- **Why `as_os_str().as_bytes()`:** `CString::new` needs bytes. On Unix, `OsStr::as_bytes` (from `std::os::unix::ffi::OsStrExt`, imported locally in the test) gives the path bytes directly without a lossy UTF-8 round-trip. The `tempfile` path has no interior NULs, so `CString::new` will not error.
+- **Why mode `0o644`:** arbitrary; the FIFO is never opened/read. Any valid mode works. `mkfifo` returns `0` on success, `-1` on error (inspect `std::io::Error::last_os_error()` — handled by the assert message).
+- **Do not** add a socket-then-FIFO fallback or any skip-on-error logic — out of scope per the spec; the FIFO alone is sufficient.
+- **Do not** touch `collect_audio` or any other test; this is a single-fixture change.
+
+## Self-review (done by plan author)
+
+- **Spec coverage:** spec's three change points — `libc` dev-dep (Step 1), `mkfifo` fixture rewrite (Step 2), unchanged symlink + assertion (preserved verbatim in Step 2) — all present. Spec's verification items (`scan::` passes, clippy clean, behavior preserved) map to Steps 3-7.
+- **Placeholders:** none; all code and commands are concrete.
+- **Type consistency:** `libc::mkfifo(*const c_char, mode_t) -> c_int`; `c_path.as_ptr()` yields `*const c_char`; `0o644` coerces to `mode_t`; `rc` compared against `0`. `OsStrExt::as_bytes` returns `&[u8]` accepted by `CString::new`. Consistent throughout.

--- a/docs/superpowers/specs/2026-06-12-scanner-fifo-test-fixture-design.md
+++ b/docs/superpowers/specs/2026-06-12-scanner-fifo-test-fixture-design.md
@@ -1,0 +1,100 @@
+# Scanner hardening test: FIFO fixture instead of Unix socket
+
+**Issue:** [#277](https://github.com/Sohex/musefs/issues/277)
+**Date:** 2026-06-12
+
+## Problem
+
+The scanner unit test
+`scan::hardening_tests::collect_audio_ignores_symlink_to_non_file_target_when_following`
+builds its fixture with `std::os::unix::net::UnixListener::bind`. Some restricted
+test environments (audit sandboxes, certain CI) deny Unix socket creation, so the
+bind fails with `PermissionDenied` and the test panics in setup:
+
+```text
+called `Result::unwrap()` on an `Err` value: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
+```
+
+This is an environmental failure unrelated to scanner behavior.
+
+## What the test actually asserts
+
+`collect_audio` follows symlinks (when `follow_symlinks` is true) and keeps a
+candidate only if the **resolved target is a regular file**. The fixture needs a
+target that is *neither a regular file nor a directory* so that the target's
+`is_file()` check is the sole reason `link.flac` is excluded. The Unix socket is
+incidental — any non-file, non-directory inode satisfies the assertion.
+
+A **FIFO** (named pipe) is also neither a regular file nor a directory, exercises
+the identical product-code branch, and is created with `mkfifo`, a basic
+filesystem syscall that restricted environments rarely block (the sandboxes that
+deny socket `bind` are restricting network primitives, not `mkfifo`).
+
+## Decision
+
+Replace the Unix socket with a FIFO outright (not a fallback). The socket and FIFO
+are interchangeable for what this test verifies, and the FIFO works in strictly
+more environments, so a socket-primary/FIFO-fallback path would add two code paths
+for no coverage benefit.
+
+`mkfifo` is not in `std`. Of the options (`libc::mkfifo`, shell out to `mkfifo(1)`,
+`nix::unistd::mkfifo`), use **`libc::mkfifo`**:
+
+- `libc` is already a workspace dependency (direct in `musefs-fuse` and
+  `musefs-latencyfs`, locked at `0.2`); adding it as a `dev-dependency` of
+  `musefs-core` is consistent and cheap.
+- It is the most direct route and the most robust against restricted environments
+  (no subprocess, no external coreutils binary).
+- The single FFI call is wrapped in the repo's documented, greppable
+  `#[expect(unsafe_code, reason = "…")]` pattern, satisfying the workspace-wide
+  `unsafe_code = "deny"` lint.
+
+## Changes
+
+### `musefs-core/Cargo.toml`
+
+Add under `[dev-dependencies]`:
+
+```toml
+libc = "0.2"
+```
+
+### `musefs-core/src/scan.rs`
+
+In `collect_audio_ignores_symlink_to_non_file_target_when_following`, replace the
+two `UnixListener` lines:
+
+```rust
+let sock = dir.path().join("sock");
+let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+```
+
+with a FIFO created via `libc::mkfifo`:
+
+```rust
+// A FIFO is neither a regular file nor a directory, and mkfifo works in
+// restricted sandboxes that deny Unix-socket bind (issue #277).
+let fifo = dir.path().join("fifo");
+let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+#[expect(unsafe_code, reason = "libc::mkfifo FFI; no std equivalent")]
+let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+```
+
+The symlink (`link.flac` → the FIFO), the `collect_audio(..., true)` call, and the
+`out.is_empty()` assertion are unchanged. `as_os_str().as_bytes()` requires
+`std::os::unix::ffi::OsStrExt`, brought in with a local `use`.
+
+## Out of scope
+
+- No fallback machinery (socket-then-FIFO). The FIFO alone is sufficient.
+- No changes to `collect_audio` or any product code; this is a test-fixture fix.
+- No skip-on-error logic; the test still asserts on every supported host.
+
+## Verification
+
+- `cargo test -p musefs-core scan::` passes.
+- `cargo clippy --all-targets` is clean (the `#[expect(unsafe_code, …)]` is
+  satisfied, not unfulfilled).
+- The assertion still fails if `collect_audio` were to wrongly include a
+  non-file symlink target (the behavior under test is preserved).

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "2"
 
 [dev-dependencies]
 musefs-latencyfs = { path = "../musefs-latencyfs" }
+libc = "0.2"
 tempfile = "3"
 metaflac = "0.2"
 id3 = "1"

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1547,13 +1547,20 @@ mod hardening_tests {
 
     #[test]
     fn collect_audio_ignores_symlink_to_non_file_target_when_following() {
+        use std::os::unix::ffi::OsStrExt;
+
         let dir = tempfile::tempdir().unwrap();
-        // A unix socket is neither a regular file nor a directory.
-        let sock = dir.path().join("sock");
-        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        // A FIFO is neither a regular file nor a directory, and mkfifo works in
+        // restricted sandboxes that deny Unix-socket bind (issue #277).
+        let fifo = dir.path().join("fifo");
+        let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        #[expect(unsafe_code, reason = "libc::mkfifo FFI; no std equivalent")]
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+        assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+
         // Name the link with a supported audio extension so the only thing
         // keeping it out of `out` is the resolved target's is_file() check.
-        std::os::unix::fs::symlink(&sock, dir.path().join("link.flac")).unwrap();
+        std::os::unix::fs::symlink(&fifo, dir.path().join("link.flac")).unwrap();
 
         let mut out = Vec::new();
         collect_audio(dir.path(), &mut out, true).unwrap();


### PR DESCRIPTION
Fixes #277.

## Problem

The scanner hardening test
`scan::hardening_tests::collect_audio_ignores_symlink_to_non_file_target_when_following`
builds its fixture with `UnixListener::bind`. Some restricted environments
(audit sandboxes, certain CI) deny Unix-socket creation, so the bind fails with
`PermissionDenied` and the test panics in setup — an environmental failure
unrelated to scanner behavior.

## Fix

The test only needs a target that is **neither a regular file nor a directory**,
so that `collect_audio`'s `is_file()` check on the resolved symlink target is the
sole reason `link.flac` is excluded. A **FIFO** satisfies that identically, and
`mkfifo` works in sandboxes that block socket `bind`. Swapped the socket for a
FIFO created via `libc::mkfifo`, wrapped in the workspace's sanctioned
`#[expect(unsafe_code, …)]` pattern; `libc` (already a workspace dep) is added as
a `musefs-core` dev-dependency. The symlink and assertion are unchanged, so the
behavior under test is preserved.

Chose outright replacement over a socket-then-FIFO fallback: the two are
interchangeable for what this test asserts, and the FIFO works in strictly more
environments, so fallback machinery would add a code path for no coverage benefit.

## Verification

- `cargo test -p musefs-core scan::` — passes (the subset the issue reported failing)
- `cargo clippy -p musefs-core --all-targets -- -D warnings` — clean
- full workspace pre-commit suite — green

Design + plan: `docs/superpowers/specs/2026-06-12-scanner-fifo-test-fixture-design.md`, `docs/superpowers/plans/2026-06-12-scanner-fifo-test-fixture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed specification and implementation planning documentation for test infrastructure improvements, including enhanced fixture setup procedures for improved compatibility and reliability.
* **Tests**
  * Updated symlink handling verification tests with revised fixture setup approach to ensure consistent and reliable behavior across different environment configurations.
* **Dependencies**
  * Added new development-time dependency to support test infrastructure enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->