### PR TITLE
Validate user-defined tag keys before Vorbis synthesis (#300)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -333,6 +333,21 @@ exclude_re = [
     # description-anchored against `cargo fmt` line drift.
     'replace < with <= in read_segments_into',
 
+    # warn_invalid_vorbis_keys is a pure observability shim — it does nothing but
+    # `log::warn!` the user-defined keys that the Vorbis path drops. The drop
+    # itself happens independently in `vorbiscomment::build` (pinned by the
+    # format-layer build_skips_* tests and the end-to-end
+    # synthesis_drops_invalid_vorbis_key_end_to_end test), so neither replacing
+    # the body with `()` nor deleting the `!` on its `is_valid_vorbis_key` guard
+    # changes any synthesized byte or persisted state — the only observable is the
+    # log line. Same class as the probe_body `log::warn!` and the metrics counters
+    # above; the repo excludes log shims rather than carrying a log-capture test.
+    # Description-anchored so reader.rs line drift can't retire them.
+    # guard: count=1
+    'replace warn_invalid_vorbis_keys with \(\)',
+    # guard: count=1
+    'delete ! in warn_invalid_vorbis_keys',
+
     # wav walk_chunks advance guard `next <= buf.len() as u64` -> `true`: forcing
     # the guard true sets `pos = next` even when `next > buf.len()`, but the loop's
     # `while pos + 8 <= buf.len()` test is then immediately false (next can't wrap —

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -333,21 +333,6 @@ exclude_re = [
     # description-anchored against `cargo fmt` line drift.
     'replace < with <= in read_segments_into',
 
-    # warn_invalid_vorbis_keys is a pure observability shim — it does nothing but
-    # `log::warn!` the user-defined keys that the Vorbis path drops. The drop
-    # itself happens independently in `vorbiscomment::build` (pinned by the
-    # format-layer build_skips_* tests and the end-to-end
-    # synthesis_drops_invalid_vorbis_key_end_to_end test), so neither replacing
-    # the body with `()` nor deleting the `!` on its `is_valid_vorbis_key` guard
-    # changes any synthesized byte or persisted state — the only observable is the
-    # log line. Same class as the probe_body `log::warn!` and the metrics counters
-    # above; the repo excludes log shims rather than carrying a log-capture test.
-    # Description-anchored so reader.rs line drift can't retire them.
-    # guard: count=1
-    'replace warn_invalid_vorbis_keys with \(\)',
-    # guard: count=1
-    'delete ! in warn_invalid_vorbis_keys',
-
     # wav walk_chunks advance guard `next <= buf.len() as u64` -> `true`: forcing
     # the guard true sets `pos = next` even when `next > buf.len()`, but the loop's
     # `while pos + 8 <= buf.len()` test is then immediately false (next can't wrap —

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -125,7 +125,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:764:46:',
+    'musefs-core/src/scan\.rs:781:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -134,25 +134,25 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `+=` and `>=`/`||` repeat in
-    # run_pipeline (e.g. the killable `*scanned += 1` at 833), so these cannot be
+    # run_pipeline (e.g. the killable `*scanned += 1` at 850), so these cannot be
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:855:29:',
+    'musefs-core/src/scan\.rs:872:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:857:32:',
+    'musefs-core/src/scan\.rs:874:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:857:47:',
+    'musefs-core/src/scan\.rs:874:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:857:62:',
+    'musefs-core/src/scan\.rs:874:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:865:37:',
+    'musefs-core/src/scan\.rs:882:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:867:40:',
+    'musefs-core/src/scan\.rs:884:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:867:55:',
+    'musefs-core/src/scan\.rs:884:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:867:70:',
+    'musefs-core/src/scan\.rs:884:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -160,11 +160,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:977:25:',
+    'musefs-core/src/scan\.rs:994:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:981:25:',
+    'musefs-core/src/scan\.rs:998:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1017:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1034:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -171,6 +171,11 @@ malformed *shapes* at commit, so an external writer cannot persist them:
   length;
 - a `picture_type` outside `0..=20`;
 - a `tags.key` over 256 chars or `tags.value` over 256 KiB;
+- `tags.key` must be non-empty and contain no ASCII control characters (a DB
+  `CHECK` enforces this; violating writes are rejected). Additionally, only keys
+  within the Vorbis field-name grammar (ASCII `0x20`–`0x7D`, excluding `=`)
+  survive FLAC/Ogg synthesis — others are dropped and logged. MP3/M4A custom
+  keys may use the wider set (e.g. `=`, `:`, spaces, non-ASCII).
 - a `value_blob` over `MAX_BINARY_TAG_BYTES`;
 - an `art.mime` over 255 chars or `byte_len` over `MAX_ART_BYTES`;
 - a `track_art.description` over 1 KiB;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,10 +172,13 @@ malformed *shapes* at commit, so an external writer cannot persist them:
 - a `picture_type` outside `0..=20`;
 - a `tags.key` over 256 chars or `tags.value` over 256 KiB;
 - `tags.key` must be non-empty and contain no ASCII control characters (a DB
-  `CHECK` enforces this; violating writes are rejected). Additionally, only keys
-  within the Vorbis field-name grammar (ASCII `0x20`–`0x7D`, excluding `=`)
-  survive FLAC/Ogg synthesis — others are dropped and logged. MP3/M4A custom
-  keys may use the wider set (e.g. `=`, `:`, spaces, non-ASCII).
+  `CHECK` enforces this, rejecting violating writes — with one blind spot: an
+  embedded NUL terminates SQLite's `length()`/`GLOB`, so a key like `a\0b` slips
+  the `CHECK`. The scanner's own floor drops it before insert, and the Vorbis
+  path rejects it on synthesis). Additionally, only keys within the Vorbis
+  field-name grammar (ASCII `0x20`–`0x7D`, excluding `=`) survive FLAC/Ogg
+  synthesis — others are dropped and logged. MP3/M4A custom keys may use the
+  wider set (e.g. `=`, `:`, spaces, non-ASCII).
 - a `value_blob` over `MAX_BINARY_TAG_BYTES`;
 - an `art.mime` over 255 chars or `byte_len` over `MAX_ART_BYTES`;
 - a `track_art.description` over 1 KiB;

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -165,6 +165,8 @@ CREATE TABLE tags (
     CHECK (ordinal >= 0),
     CHECK (value_blob IS NULL OR value = ''),
     CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
     CHECK (length(value) <= 262144),
     CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
 );

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -162,6 +162,8 @@ CREATE TABLE tags (
     CHECK (ordinal >= 0),
     CHECK (value_blob IS NULL OR value = ''),
     CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
     CHECK (length(value) <= 262144),
     CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
 );

--- a/docs/FLAC.md
+++ b/docs/FLAC.md
@@ -11,6 +11,9 @@ model these layouts plug into, see
   `date`, `tracknumber`, …) map to their conventional Vorbis field names via
   the shared vocabulary (`musefs-format/src/tagmap.rs`); any other field
   round-trips verbatim by its own name. Multi-value fields keep their order.
+  User-defined keys that are not legal Vorbis field names (empty, containing `=`,
+  control characters, or non-ASCII bytes — i.e. outside ASCII `0x20`–`0x7D` minus
+  `=`) are dropped on synthesis and logged; they cannot round-trip by name.
 - **Binary metadata blocks.** `APPLICATION` and `CUESHEET` blocks are
   captured at scan time as binary tags (an `APPLICATION` payload includes its
   4-byte application id) and re-emitted on synthesis, streamed from the DB

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -29,6 +29,9 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
   builder as FLAC: canonical keys map to their conventional field names via
   the shared vocabulary (`musefs-format/src/tagmap.rs`); any other field
   round-trips verbatim by its own name, in order, multi-values included.
+  User-defined keys outside the Vorbis field-name grammar (empty, containing `=`,
+  control characters, or non-ASCII — outside ASCII `0x20`–`0x7D` minus `=`) are
+  dropped on synthesis and logged.
 - **Embedded pictures**, with MIME type, picture type, description, and
   dimensions — in both art encodings (see below).
 - **Codec headers.** The identification packet (`OpusHead`, Vorbis

--- a/docs/superpowers/plans/2026-06-12-validate-tag-keys.md
+++ b/docs/superpowers/plans/2026-06-12-validate-tag-keys.md
@@ -1,0 +1,751 @@
+# Validate Tag Keys Before Vorbis Synthesis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop FLAC/Ogg synthesis from emitting malformed or boundary-shifting Vorbis comments by validating user-defined tag keys, with a universal hygiene floor at the DB and strict Vorbis grammar on the synthesis path.
+
+**Architecture:** Three layers. `musefs-format` owns the strict Vorbis field-name grammar (`is_valid_key`) and `build()` defensively skips out-of-grammar keys (total for any caller, including fuzz). `musefs-core` mirrors a weaker universal floor (`key_passes_floor`) in the scanner and logs dropped keys at the FLAC/Ogg synthesis dispatch. `musefs-db` adds a `CHECK` to `tags.key` (non-empty, no control chars) in place in `MIGRATION_V4` — no new migration, since there are no deployed databases.
+
+**Tech Stack:** Rust (workspace crates `musefs-format`, `musefs-core`, `musefs-db`), SQLite (rusqlite), `log` crate, `cargo`/`cargo +nightly fuzz`.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-validate-tag-keys-design.md`
+
+---
+
+## File Structure
+
+- `musefs-format/src/vorbiscomment.rs` — add `is_valid_key`; change `build` to skip invalid keys; change `parse` to skip empty field names. New unit tests.
+- `musefs-format/src/lib.rs` — re-export `is_valid_key` as `is_valid_vorbis_key`.
+- `musefs-core/src/scan.rs` — add `key_passes_floor`; filter both tag-collection loops (`ingest` at :575, `ingest_bulk` at :658). New scanner tests.
+- `musefs-core/src/reader.rs` — add `warn_invalid_vorbis_keys`; call it in the FLAC branch (:209) and Ogg branch (:285). New end-to-end Ogg regression test.
+- `musefs-db/src/schema.rs` — add the `tags.key` `CHECK` to `MIGRATION_V4`'s `CREATE TABLE tags` (:177). New rejection test.
+- `musefs-db/src/tags.rs` — new `replace_tags` rollback test.
+- `contrib/python-musefs/src/musefs_common/schema.py` + `contrib/picard/musefs/_common/schema.py` — regenerated mirrors (generated, not hand-edited).
+- `docs/FLAC.md`, `docs/OGG.md`, `ARCHITECTURE.md` — document the dropped-key behavior and the writer floor.
+
+---
+
+## Task 1: `is_valid_key` predicate + export
+
+**Files:**
+- Modify: `musefs-format/src/vorbiscomment.rs`
+- Modify: `musefs-format/src/lib.rs:32`
+- Test: `musefs-format/src/vorbiscomment.rs` (tests module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module at the bottom of `musefs-format/src/vorbiscomment.rs` (after `parse_canonicalizes_known_fields_and_preserves_unknown`):
+
+```rust
+    #[test]
+    fn is_valid_key_enforces_vorbis_grammar() {
+        // Legal: one-or-more ASCII 0x20..=0x7D, excluding '=' (0x3D).
+        assert!(is_valid_key("title"));
+        assert!(is_valid_key("CUSTOM_THING"));
+        assert!(is_valid_key("}")); // 0x7D, upper bound
+        assert!(is_valid_key(" ")); // 0x20, lower bound
+        // Illegal.
+        assert!(!is_valid_key("")); // empty
+        assert!(!is_valid_key("a=b")); // contains '='
+        assert!(!is_valid_key("a\u{1f}b")); // control char 0x1F
+        assert!(!is_valid_key("a\u{7f}b")); // DEL 0x7F
+        assert!(!is_valid_key("a~b")); // 0x7E, just past upper bound
+        assert!(!is_valid_key("género")); // non-ASCII high bytes
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p musefs-format is_valid_key_enforces_vorbis_grammar`
+Expected: FAIL to compile — `cannot find function 'is_valid_key'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert this function in `musefs-format/src/vorbiscomment.rs` immediately above `pub(crate) fn build` (after the `VENDOR` const, around line 9):
+
+```rust
+/// True if `key` is a legal VorbisComment field name: one or more characters in
+/// ASCII 0x20..=0x7D, excluding 0x3D (`=`). This is the Vorbis spec grammar and
+/// matches what mutagen/TagLib enforce when writing. Non-ASCII, control chars,
+/// `=`, and the empty string are all rejected.
+pub fn is_valid_key(key: &str) -> bool {
+    !key.is_empty() && key.bytes().all(|b| (0x20..=0x7D).contains(&b) && b != b'=')
+}
+```
+
+- [ ] **Step 4: Export it from the crate (ungated)**
+
+`musefs-core` calls this in normal (non-fuzzing) builds, so the re-export must
+**not** be under the `#[cfg(feature = "fuzzing")]` attribute. The bottom block of
+`lib.rs` (lines 29–32: `build_id3v2_segments`, `parse_vorbis_comment`) is all
+fuzzing-gated — do not add it there. Add it to the ungated public-API block,
+directly below `pub use probe::Extent;` (line 24):
+
+```rust
+pub use vorbiscomment::is_valid_key as is_valid_vorbis_key;
+```
+
+Verify it is ungated: `cargo build -p musefs-format` (no `--features fuzzing`) must
+compile, and later `cargo build -p musefs-core` must see the symbol.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p musefs-format is_valid_key_enforces_vorbis_grammar`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-format/src/vorbiscomment.rs musefs-format/src/lib.rs
+git commit -m "feat(format): add is_valid_key Vorbis field-name predicate (#300)"
+```
+
+---
+
+## Task 2: `build()` defensively skips invalid keys
+
+**Files:**
+- Modify: `musefs-format/src/vorbiscomment.rs:13-38` (the `build` function)
+- Test: `musefs-format/src/vorbiscomment.rs` (tests module)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `musefs-format/src/vorbiscomment.rs`:
+
+```rust
+    #[test]
+    fn build_skips_keys_outside_vorbis_grammar() {
+        // The issue's case: an `a=b` key would otherwise synthesize `A=B=c` and
+        // shift the boundary on re-parse. Empty keys are also dropped. Valid keys
+        // keep their order, and the comment count reflects only survivors.
+        let tags = vec![
+            TagInput::new("artist", "Alice"),
+            TagInput::new("a=b", "c"),
+            TagInput::new("", "x"),
+            TagInput::new("title", "Song"),
+        ];
+        let body = build(&tags).unwrap();
+        let parsed = parse(&body).unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                ("artist".to_string(), "Alice".to_string()),
+                ("title".to_string(), "Song".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_is_total_over_arbitrary_keys() {
+        // build() must remain total: it has no assert guarding key validity, so the
+        // fuzz harness can feed it arbitrary keys. It must never panic and must emit
+        // only valid comments.
+        let tags = vec![
+            TagInput::new("a=b=c", "v"),
+            TagInput::new("\u{0}\u{1}", "v"),
+            TagInput::new("ok", "v"),
+        ];
+        let body = build(&tags).unwrap();
+        let parsed = parse(&body).unwrap();
+        assert_eq!(parsed, vec![("ok".to_string(), "v".to_string())]);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-format build_skips_keys_outside_vorbis_grammar build_is_total_over_arbitrary_keys`
+Expected: FAIL — `build` currently writes `A=B=c` and `=x`, so the parsed vec contains extra/garbled entries.
+
+- [ ] **Step 3: Rewrite `build` to filter**
+
+Replace the body of `build` (`musefs-format/src/vorbiscomment.rs:13-38`) with:
+
+```rust
+pub(crate) fn build(tags: &[TagInput]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    out.extend_from_slice(
+        &u32::try_from(VENDOR.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(VENDOR.as_bytes());
+    // Skip keys outside the Vorbis field-name grammar (e.g. an `=` key would shift
+    // the key/value boundary on re-parse). build() is the single enforcement point,
+    // so it stays total for any caller — including the fuzz harness.
+    let valid: Vec<&TagInput> = tags.iter().filter(|t| is_valid_key(&t.key)).collect();
+    out.extend_from_slice(
+        &u32::try_from(valid.len())
+            .map_err(|_| FormatError::TooLarge)?
+            .to_le_bytes(),
+    );
+    for t in valid {
+        let field = crate::tagmap::key_to_vorbis(&t.key)
+            .map_or_else(|| t.key.to_ascii_uppercase(), str::to_string);
+        let comment = format!("{field}={}", t.value);
+        out.extend_from_slice(
+            &u32::try_from(comment.len())
+                .map_err(|_| FormatError::TooLarge)?
+                .to_le_bytes(),
+        );
+        out.extend_from_slice(comment.as_bytes());
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-format vorbiscomment`
+Expected: PASS — including the pre-existing `build_then_parse_round_trips` and `parse_canonicalizes_known_fields_and_preserves_unknown` (their keys are all valid).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/vorbiscomment.rs
+git commit -m "fix(format): build skips out-of-grammar Vorbis keys (#300)"
+```
+
+---
+
+## Task 3: `parse()` skips empty field names
+
+**Files:**
+- Modify: `musefs-format/src/vorbiscomment.rs:70-74` (inside `parse`)
+- Test: `musefs-format/src/vorbiscomment.rs` (tests module)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `musefs-format/src/vorbiscomment.rs`:
+
+```rust
+    fn body_with_one_comment(comment: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::try_from(VENDOR.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(VENDOR.as_bytes());
+        body.extend_from_slice(&1u32.to_le_bytes()); // count = 1
+        body.extend_from_slice(&u32::try_from(comment.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(comment.as_bytes());
+        body
+    }
+
+    #[test]
+    fn parse_skips_empty_field_name() {
+        // A "=value" comment has no field name; it must not become an empty-key tag.
+        assert!(parse(&body_with_one_comment("=value")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_splits_on_first_equals() {
+        // The exact boundary the issue is about: A=B=c -> key "A", value "B=c".
+        let parsed = parse(&body_with_one_comment("A=B=c")).unwrap();
+        assert_eq!(parsed, vec![("A".to_string(), "B=c".to_string())]);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-format parse_skips_empty_field_name parse_splits_on_first_equals`
+Expected: `parse_skips_empty_field_name` FAILS (currently yields `("", "value")`); `parse_splits_on_first_equals` already PASSES (first-`=` split is existing behavior — keep it green as a regression guard).
+
+- [ ] **Step 3: Guard the empty field name**
+
+In `parse` (`musefs-format/src/vorbiscomment.rs`), replace the block:
+
+```rust
+        if let Some((field, value)) = comment.split_once('=') {
+            let key = crate::tagmap::vorbis_to_key(field)
+                .map_or_else(|| field.to_string(), str::to_string);
+            out.push((key, value.to_string()));
+        }
+```
+
+with:
+
+```rust
+        if let Some((field, value)) = comment.split_once('=') {
+            // A comment whose field name is empty (e.g. "=value") is malformed and
+            // must not become an empty-key tag. The first-`=` split is preserved.
+            if !field.is_empty() {
+                let key = crate::tagmap::vorbis_to_key(field)
+                    .map_or_else(|| field.to_string(), str::to_string);
+                out.push((key, value.to_string()));
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-format vorbiscomment`
+Expected: PASS (all vorbiscomment tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-format/src/vorbiscomment.rs
+git commit -m "fix(format): parse skips empty Vorbis field names (#300)"
+```
+
+---
+
+## Task 4: Scanner universal floor (both loops)
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs:575` (`ingest` loop) and `:658` (`ingest_bulk` loop)
+- Test: `musefs-core/src/scan.rs` (tests module)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `musefs-core/src/scan.rs` (near the existing `ingest_filters_empty_and_oversize_binary_tags` test, ~line 1845):
+
+```rust
+    fn probed_with_text_tags(tags: &[(&str, &str)]) -> Probed {
+        Probed {
+            format: musefs_db::Format::Mp3,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: tags
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            pictures: Vec::new(),
+            binary_tags: Vec::new(),
+            structural_blocks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ingest_skips_empty_and_control_char_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.mp3");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let db = Db::open_in_memory().unwrap();
+
+        ingest(
+            &db,
+            &path.to_string_lossy(),
+            &meta,
+            probed_with_text_tags(&[
+                ("artist", "Alice"),
+                ("", "dropped"),       // empty key
+                ("a\u{7}b", "dropped"), // control char
+                ("a=b", "kept"),       // '=' is NOT a floor violation
+            ]),
+        )
+        .unwrap();
+
+        let tid = db.list_tracks().unwrap()[0].id;
+        let keys: Vec<String> = db.get_tags(tid).unwrap().into_iter().map(|t| t.key).collect();
+        // get_tags is ORDER BY key, ordinal: '=' (0x3D) sorts before 'a' (0x61).
+        assert_eq!(keys, vec!["a=b".to_string(), "artist".to_string()]);
+    }
+
+    #[test]
+    fn ingest_bulk_skips_empty_and_control_char_keys() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            ingest_bulk(
+                &mut bw,
+                "/a.mp3",
+                BackingStamp {
+                    size: 1,
+                    mtime_ns: 0,
+                    ctime_ns: 0,
+                },
+                probed_with_text_tags(&[
+                    ("artist", "Alice"),
+                    ("", "dropped"),
+                    ("a\u{7}b", "dropped"),
+                    ("a=b", "kept"),
+                ]),
+            )
+            .unwrap();
+            bw.commit().unwrap();
+        }
+        let tid = db.list_tracks().unwrap()[0].id;
+        let keys: Vec<String> = db.get_tags(tid).unwrap().into_iter().map(|t| t.key).collect();
+        assert_eq!(keys, vec!["a=b".to_string(), "artist".to_string()]);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-core ingest_skips_empty_and_control_char_keys ingest_bulk_skips_empty_and_control_char_keys`
+Expected: FAIL — empty/control keys are currently ingested, so `keys` has 4 entries, not 2.
+
+- [ ] **Step 3: Add the `key_passes_floor` predicate**
+
+Add this free function in `musefs-core/src/scan.rs` immediately above `fn ingest(` (around line 560):
+
+```rust
+/// The universal `tags.key` floor, mirrored from the DB `CHECK` exactly: a key
+/// must be non-empty and contain no byte below 0x20 (the control chars the DB
+/// rejects via its GLOB range; NUL also fails here, the DB's documented blind
+/// spot). DEL (0x7F) and high/non-ASCII bytes are accepted, matching the DB.
+/// Distinct from the strict Vorbis `is_valid_key` (which also bars `=`, 0x7E,
+/// 0x7F, and non-ASCII) — applying that here would wrongly drop legal MP3/M4A
+/// custom keys containing `=`/`:`/space.
+fn key_passes_floor(key: &str) -> bool {
+    !key.is_empty() && key.bytes().all(|b| b >= 0x20)
+}
+```
+
+- [ ] **Step 4: Filter both loops**
+
+In `ingest` (`scan.rs:575`), change:
+
+```rust
+    for (key, value) in probed.tags {
+        let ord = ordinals.entry(key.clone()).or_insert(0);
+        tags.push(Tag::new(&key, &value, *ord));
+        *ord += 1;
+    }
+```
+
+to:
+
+```rust
+    for (key, value) in probed.tags {
+        if !key_passes_floor(&key) {
+            continue;
+        }
+        let ord = ordinals.entry(key.clone()).or_insert(0);
+        tags.push(Tag::new(&key, &value, *ord));
+        *ord += 1;
+    }
+```
+
+In `ingest_bulk` (`scan.rs:658`), change:
+
+```rust
+    for (key, value) in &probed.tags {
+        let ord = ordinals.entry(key.clone()).or_insert(0);
+        tags.push(Tag::new(key, value, *ord));
+        *ord += 1;
+    }
+```
+
+to:
+
+```rust
+    for (key, value) in &probed.tags {
+        if !key_passes_floor(key) {
+            continue;
+        }
+        let ord = ordinals.entry(key.clone()).or_insert(0);
+        tags.push(Tag::new(key, value, *ord));
+        *ord += 1;
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core ingest_skips_empty_and_control_char_keys ingest_bulk_skips_empty_and_control_char_keys`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/scan.rs
+git commit -m "fix(scan): drop empty/control-char tag keys before insert (#300)"
+```
+
+---
+
+## Task 5: DB `CHECK` on `tags.key` + Python mirror regen
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs:177-189` (MIGRATION_V4 `CREATE TABLE tags`)
+- Modify (generated): `contrib/python-musefs/src/musefs_common/schema.py`, `contrib/picard/musefs/_common/schema.py`
+- Test: `musefs-db/src/schema.rs` (tests module), `musefs-db/src/tags.rs` (tests module)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `musefs-db/src/schema.rs` (near `v4_tracks_rejects_unknown_format`, which uses the existing `fresh` and `rejected` helpers):
+
+```rust
+    #[test]
+    fn v4_tags_rejects_empty_and_control_char_keys() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        fresh(&mut conn);
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime_ns, updated_at) \
+             VALUES ('/x','flac',0,0,0,0,0)",
+            [],
+        )
+        .unwrap();
+        rejected(
+            &conn,
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'','v',0)",
+        );
+        rejected(
+            &conn,
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,char(7),'v',0)",
+        );
+        // '=' is NOT a DB-floor violation — only Vorbis synthesis bars it.
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'a=b','c',0)",
+            [],
+        )
+        .unwrap();
+    }
+```
+
+Add to the `tests` module in `musefs-db/src/tags.rs` (near the existing `replace_tags` tests, which use `open_mem`, `new_track`, `Tag`):
+
+```rust
+    #[test]
+    fn replace_tags_rejects_floor_violating_keys() {
+        let db = open_mem();
+        let t = db.upsert_track(&new_track("/a.flac")).unwrap();
+        // A row violating the floor aborts the whole row-by-row transactional insert.
+        assert!(db.replace_tags(t, &[Tag::new("", "v", 0)]).is_err());
+        assert!(db.replace_tags(t, &[Tag::new("\u{7}", "v", 0)]).is_err());
+        // '=' passes the DB floor (only the Vorbis path bars it).
+        db.replace_tags(t, &[Tag::new("a=b", "c", 0)]).unwrap();
+        let got = db.get_tags(t).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].key, "a=b");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-db v4_tags_rejects_empty_and_control_char_keys replace_tags_rejects_floor_violating_keys`
+Expected: FAIL — empty/control-char inserts currently succeed, so the `is_err()` assertions fail.
+
+- [ ] **Step 3: Add the `CHECK` to MIGRATION_V4**
+
+In `musefs-db/src/schema.rs`, inside `MIGRATION_V4`'s `CREATE TABLE tags` (the occurrence at line 177, **not** the V1 copy at line 17 or the test fixture at line 1569), change:
+
+```sql
+    CHECK (length(key) <= 256),
+```
+
+to:
+
+```sql
+    CHECK (length(key) <= 256),
+    -- A field name must be non-empty and free of ASCII control chars (0x01-0x1F).
+    -- length()/GLOB stop at an embedded NUL, so a NUL inside a key evades this; the
+    -- Rust is_valid_key filter on the Vorbis path is the backstop for that case.
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+```
+
+- [ ] **Step 4: Regenerate and re-vendor the Python schema mirror**
+
+Run both steps (the `schema_py_fixture_is_fresh` test fails the full-workspace pre-commit gate until the canonical mirror is fresh):
+
+```bash
+MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py
+python contrib/python-musefs/vendor_to_picard.py
+```
+
+Verify both mirror files changed and the new `CHECK` appears in the **V4 rendering** (the second `CREATE TABLE tags` in each file):
+
+```bash
+git status --short contrib/
+grep -n "key NOT GLOB" contrib/python-musefs/src/musefs_common/schema.py contrib/picard/musefs/_common/schema.py
+```
+
+Expected: both files modified; `grep` shows the new CHECK in each.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-db`
+Expected: PASS — including the new rejection tests, `schema_py_fixture_is_fresh`, and the V3→V4 migration data-preservation test (`v4_rebuild_preserves_fk_children`, whose seeded key `'artist'` passes the floor).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-db/src/schema.rs musefs-db/src/tags.rs \
+  contrib/python-musefs/src/musefs_common/schema.py \
+  contrib/picard/musefs/_common/schema.py
+git commit -m "feat(db): reject empty/control-char tag keys via CHECK (#300)"
+```
+
+---
+
+## Task 6: Core logging + end-to-end Ogg regression
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs` (add helper; call in FLAC branch :209 and Ogg branch :285)
+- Test: `musefs-core/src/reader.rs` (tests module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `musefs-core/src/reader.rs` (next to `resolves_and_reads_opus_with_identical_audio`, reusing its `build_opus_file` helper and imports):
+
+```rust
+    #[test]
+    fn synthesis_drops_invalid_vorbis_key_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("track.opus");
+        let (audio_offset, audio_length) = build_opus_file(&path);
+
+        let db = Db::open_in_memory().unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let track_id = db
+            .upsert_track(&NewTrack {
+                backing_path: path.to_string_lossy().into_owned(),
+                format: Format::Opus,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len(),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
+            })
+            .unwrap();
+        // `a=b` passes the DB floor but is not a valid Vorbis field name. Without the
+        // fix it would synthesize `A=B=c` and re-parse as key "A", value "B=c".
+        db.replace_tags(
+            track_id,
+            &[
+                Tag::new("artist", "Alice", 0),
+                Tag::new("a=b", "c", 0),
+                Tag::new("title", "Song", 0),
+            ],
+        )
+        .unwrap();
+
+        let cache = HeaderCache::new(Mode::Synthesis);
+        let resolved = cache.resolve(&db, track_id).unwrap();
+        let out = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+
+        let tags = musefs_format::ogg::read_tags(&out).unwrap();
+        assert!(tags.iter().any(|(k, v)| k == "artist" && v == "Alice"));
+        assert!(tags.iter().any(|(k, v)| k == "title" && v == "Song"));
+        assert!(
+            !tags.iter().any(|(k, _)| k == "A" || k.contains('=')),
+            "the a=b key must be dropped, not synthesized as A=B=c: {tags:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it passes (behavior already correct from Task 2)**
+
+Run: `cargo test -p musefs-core synthesis_drops_invalid_vorbis_key_end_to_end`
+Expected: PASS — Task 2 made `build` drop the key; this test is the end-to-end Ogg guard the issue asks for. (If it fails, Task 2 regressed.)
+
+- [ ] **Step 3: Add the logging helper**
+
+Add this free function in `musefs-core/src/reader.rs` near the other read helpers (e.g. just above `pub fn read_at`):
+
+```rust
+/// Warn about user-defined tag keys that the Vorbis synthesis path will drop,
+/// so a silently-dropped key is observable. Runs during layout resolution (a
+/// cache miss), not per `read_at`, so a malformed key warns once per resolution.
+fn warn_invalid_vorbis_keys(track_id: i64, inputs: &[musefs_format::TagInput]) {
+    for t in inputs {
+        if !musefs_format::is_valid_vorbis_key(&t.key) {
+            log::warn!(
+                "track {track_id}: dropping tag key {:?} from Vorbis synthesis \
+                 (not a valid field name)",
+                t.key
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Call it in the FLAC and Ogg branches**
+
+In `reader.rs`, in the `Format::Flac` arm, immediately before the `flac::synthesize_layout(` call (line ~209), add:
+
+```rust
+                        warn_invalid_vorbis_keys(track.id, &inputs);
+```
+
+In the `Format::Opus | Format::Vorbis | Format::OggFlac` arm, immediately before the `musefs_format::ogg::synthesize_layout(` call (line ~285), add:
+
+```rust
+                        warn_invalid_vorbis_keys(track.id, &inputs);
+```
+
+- [ ] **Step 5: Run tests and lints to verify**
+
+Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
+Expected: PASS, no clippy warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/reader.rs
+git commit -m "feat(core): log tag keys dropped from Vorbis synthesis (#300)"
+```
+
+---
+
+## Task 7: Documentation, fuzz check, and final verification
+
+**Files:**
+- Modify: `docs/FLAC.md`, `docs/OGG.md`, `ARCHITECTURE.md`
+
+- [ ] **Step 1: Document the dropped-key behavior (FLAC)**
+
+In `docs/FLAC.md`, in the "What round-trips" section (around the user-defined-fields bullet, line ~11-13), add a sentence:
+
+```markdown
+User-defined keys that are not legal Vorbis field names (empty, containing `=`,
+control characters, or non-ASCII bytes — i.e. outside ASCII `0x20`–`0x7D` minus
+`=`) are dropped on synthesis and logged; they cannot round-trip by name.
+```
+
+- [ ] **Step 2: Document the dropped-key behavior (Ogg)**
+
+In `docs/OGG.md`, in its "What round-trips" section (around line 29-31), add the same note:
+
+```markdown
+User-defined keys outside the Vorbis field-name grammar (empty, containing `=`,
+control characters, or non-ASCII — outside ASCII `0x20`–`0x7D` minus `=`) are
+dropped on synthesis and logged.
+```
+
+- [ ] **Step 3: Document the writer floor (ARCHITECTURE)**
+
+In `ARCHITECTURE.md`, in the external-writer contract section, add a bullet describing the `tags.key` floor:
+
+```markdown
+- `tags.key` must be non-empty and contain no ASCII control characters (a DB
+  `CHECK` enforces this; violating writes are rejected). Additionally, only keys
+  within the Vorbis field-name grammar (ASCII `0x20`–`0x7D`, excluding `=`)
+  survive FLAC/Ogg synthesis — others are dropped and logged. MP3/M4A custom
+  keys may use the wider set (e.g. `=`, `:`, spaces, non-ASCII).
+```
+
+- [ ] **Step 4: Commit the docs**
+
+```bash
+git add docs/FLAC.md docs/OGG.md ARCHITECTURE.md
+git commit -m "docs: document tag-key validation and writer floor (#300)"
+```
+
+- [ ] **Step 5: Final full-workspace verification**
+
+Run each and confirm success:
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets
+cargo test
+cargo +nightly fuzz build
+```
+
+Expected: `fmt` clean; `clippy` no warnings; full test suite green; fuzz targets (`vorbiscomment`, `flac`, `ogg`) build — they feed `arb_tags` (arbitrary keys) into the changed `build`/`parse`, which are now total, so no signature break and no panic path.
+
+- [ ] **Step 6: Metrics-feature check (CI parity)**
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: PASS — the local default `cargo test` skips this feature; the change does not touch getattr/read counts, but run it to match the CI `check` job before pushing.
+
+---
+
+## Notes for the implementer
+
+- **Commit order matters for the green pre-commit gate.** Each task's commit must leave the full workspace test suite green (the pre-commit hook runs it). The order here (format → scanner floor → DB CHECK → core logging) ensures the scanner never feeds the new `CHECK` a violating key, and the DB-CHECK commit includes the regenerated Python mirror so `schema_py_fixture_is_fresh` stays green.
+- **Do not add a new migration.** The `CHECK` goes into `MIGRATION_V4` in place. `user_version` stays at 5, so the Picard `test_conftest_sanity.py` version assertion is unaffected.
+- **Two predicates, deliberately different.** `is_valid_vorbis_key` (format, strict: `0x20`–`0x7D`, no `=`) governs synthesis; `key_passes_floor` (core scanner, weaker: non-empty, no control char) mirrors the DB `CHECK`. Do not unify them — the scanner must keep legal MP3/M4A keys containing `=`/`:`/space.
+- The `fuzz/` crate is outside the workspace; `cargo +nightly fuzz build` is the only thing that compiles it.

--- a/docs/superpowers/specs/2026-06-12-validate-tag-keys-design.md
+++ b/docs/superpowers/specs/2026-06-12-validate-tag-keys-design.md
@@ -67,8 +67,9 @@ format layer remains a pure leaf.
     empty/control-char keys before `replace_tags`: `scan.rs:575` (iterates
     `probed.tags` by value) and `scan.rs:658` (iterates `&probed.tags` by
     reference). Both call one shared predicate — `key_passes_floor(&str) ->
-    bool` (non-empty, no control char) — which mirrors the DB `CHECK`, so a scan
-    never trips it. This is the **universal** floor, distinct from the strict
+    bool` (non-empty, no byte below 0x20) — which mirrors the DB `CHECK` exactly
+    (DEL 0x7F and high/non-ASCII bytes pass both), so a scan never trips it. This
+    is the **universal** floor, distinct from the strict
     `vorbiscomment::is_valid_key`: applying the Vorbis predicate here would
     wrongly drop legal MP3/M4A keys containing `=`/`:`/space.
 
@@ -158,8 +159,8 @@ Ripples:
 - **`is_valid_key` unit table:** boundary bytes `0x1F`/`0x20`/`0x3D`/`0x7D`/
   `0x7E`, empty string, a non-ASCII key.
 - **`build` totality:** `build` over arbitrary keys (including `a=b`, empty,
-  control char) never panics and emits only valid comments — the property the
-  fuzz harness relies on now that the old `debug_assert` is gone.
+  control char) never panics and emits only valid comments — the totality the
+  fuzz harness relies on (`build` has no assert guarding key validity).
 - **DB:** an external `replace_tags` with a control-char key (and with an empty
   key) returns a constraint error and rolls back the whole transaction (inserts
   are row-by-row, `tags.rs:177`) — documenting *why* the scanner floor exists; a

--- a/docs/superpowers/specs/2026-06-12-validate-tag-keys-design.md
+++ b/docs/superpowers/specs/2026-06-12-validate-tag-keys-design.md
@@ -1,0 +1,187 @@
+# Validate user-defined tag keys before Vorbis synthesis
+
+Design for [issue #300](https://github.com/Sohex/musefs/issues/300).
+
+## Problem
+
+FLAC and Ogg synthesis write user-defined `tags.key` values directly into
+Vorbis comment field-name position with no validation. A key containing `=`
+shifts the key/value boundary on a synthesize → scan round-trip: a stored key
+`a=b` with value `c` synthesizes the comment `A=B=c`, which a later musefs scan
+parses (via `split_once('=')`) as key `A`, value `B=c`. Empty keys and
+control-character keys are likewise accepted into field-name position, producing
+non-portable Vorbis comments. This contradicts the documented FLAC/Ogg promise
+that user-defined fields round-trip by name.
+
+The `=`/grammar problem is **specific to Vorbis**: musefs serves each track in
+its backing format (no cross-format conversion), and MP3 (`TXXX`) / M4A
+(freeform) custom keys legitimately contain `=`, `:`, and spaces. The scanner
+already writes such keys for those formats. So the strict rule must apply only
+on the FLAC/Ogg synthesis path, while a weaker universal-hygiene floor (no
+empty, no control-char keys) is safe for every format.
+
+## Grammar
+
+`is_valid_key` enforces the **strict Vorbis spec** for comment field names: one
+or more characters in ASCII `0x20`–`0x7D`, excluding `0x3D` (`=`). This rejects
+empty keys, control characters (`< 0x20`, `0x7F`), `=`, and all non-ASCII /
+high bytes.
+
+Strict (rather than lenient UTF-8-tolerant) matches the libraries musefs
+interoperates with: **mutagen** (which Picard is built on — directly in the
+contrib path) validates keys to exactly this range and raises on violations,
+and **TagLib** applies a legal-character check on Xiph field names when writing.
+A key those libraries would reject does not portably round-trip "by name"; it
+only survives a musefs→musefs loop. Dropped keys are logged, so the loss is
+never silent.
+
+## Architecture: three coordinated layers
+
+| Layer | Responsibility | Mechanism |
+| --- | --- | --- |
+| `musefs-db` | Universal hygiene floor for **all** formats | `CHECK` on `tags.key`: non-empty and no embedded control char |
+| `musefs-format` | Owns the Vorbis grammar and self-guarantees well-formed output; stays pure (no logging) | `vorbiscomment::is_valid_key(&str) -> bool`; `build()` **defensively skips** keys failing `is_valid_key` (emitting only valid comments, count reflecting them) |
+| `musefs-core` | Integration: observability | At the FLAC/Ogg dispatch, `log::warn!` each `inputs` key that fails `is_valid_key`, with its `track_id` |
+
+The grammar *check* lives in `format` (the layer that knows Vorbis rules) and
+`build()` is the single enforcement point — it is **total** for any caller,
+including the fuzz harnesses (`fuzz_targets/{flac,ogg}.rs` feed it arbitrary
+keys via `arb_tags`), so it must skip rather than assert. The *logging* lives in
+`core` (which already depends on `log`); core observes the same predicate purely
+to report which keys were dropped. The two are deliberately separate so the
+format layer remains a pure leaf.
+
+## Data flow
+
+### Write path (into the DB)
+
+- **External writers** (Picard, beets, …) hit the DB `CHECK` directly. An empty
+  or control-char key is rejected with a constraint error at write time — the
+  contract enforcement #300 asks for.
+- **Scanner** stays robust against malformed backing files:
+  - `vorbiscomment::parse` skips comments with an **empty field name** (a
+    `=value` comment has no name and is already malformed), so the scanner never
+    ingests an empty key from a real FLAC/Ogg. The first-`=` split is otherwise
+    unchanged: `A=B=c` still parses as key `A`, value `B=c`.
+  - The scanner's **two** tag-collection loops drop any remaining
+    empty/control-char keys before `replace_tags`: `scan.rs:575` (iterates
+    `probed.tags` by value) and `scan.rs:658` (iterates `&probed.tags` by
+    reference). Both call one shared predicate — `key_passes_floor(&str) ->
+    bool` (non-empty, no control char) — which mirrors the DB `CHECK`, so a scan
+    never trips it. This is the **universal** floor, distinct from the strict
+    `vorbiscomment::is_valid_key`: applying the Vorbis predicate here would
+    wrongly drop legal MP3/M4A keys containing `=`/`:`/space.
+
+The scanner *gracefully skips* malformed keys; external writers get a *hard
+rejection*. Both honor the same floor, each in the appropriate register.
+
+### Read / synthesis path (DB → served bytes)
+
+- `inputs = tags_to_inputs(get_tags(...))` is built once during layout
+  resolution (`reader.rs:172`), inside `HeaderCache::resolve` (`reader.rs:113`),
+  which caches the resulting `Arc<ResolvedFile>` per track. It is rebuilt only on
+  a cache miss/invalidation.
+- In the FLAC branch (`reader.rs:209`) and the Ogg branch (`reader.rs:285`),
+  core `log::warn!`s each `inputs` key that fails `is_valid_key`, with its
+  `track_id`. Because this runs during resolution (not per `read_at`), the
+  HeaderCache de-dupes the warning: a malformed key warns once per resolution,
+  not on every served byte range.
+- `inputs` is passed to `flac::synthesize_layout` / `ogg::synthesize_layout`
+  unchanged; `vorbiscomment::build` performs the actual drop. Core does not
+  pre-filter — `build` is the single enforcement point, so there is no second
+  predicate to keep in sync with core's logging beyond `is_valid_key` itself.
+- MP3 / M4A / WAV branches are untouched.
+
+**Worked example** — stored key `a=b`, value `c`:
+
+- FLAC/Ogg track → key dropped at synthesis and logged → no `A=B=c` boundary
+  shift.
+- MP3 track → preserved verbatim in `TXXX` (where `=` is legal).
+- Empty / control-char keys → rejected at the DB for external writers, skipped
+  by the scanner, and dropped at synthesis as defense in depth.
+
+## The DB CHECK (no new migration)
+
+There are no deployed databases, so a versioned migration is unnecessary. The
+`tags` table's canonical definition lives in `MIGRATION_V4`
+(`musefs-db/src/schema.rs:177`); `MIGRATION_V5` does not touch `tags`. The
+`CHECK` is added **in place** to V4's `CREATE TABLE tags`:
+
+```sql
+CHECK (length(key) >= 1
+       AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*')
+```
+
+Ripples:
+
+- The open-time schema verifier (`verify_schema`, `schema.rs:~401`) derives its
+  expectation by replaying the migration chain on a reference DB, so editing V4
+  auto-updates it — no snapshot to hand-maintain.
+- `user_version` stays at 5 (no migration added), so the Picard
+  `test_conftest_sanity.py` hardcoded version assertion is unaffected.
+- **Python mirror — two files, two steps.** There are two mirrors: the canonical
+  `contrib/python-musefs/src/musefs_common/schema.py` and the vendored Picard
+  copy `contrib/picard/musefs/_common/schema.py`. The `schema_py_fixture_is_fresh`
+  test (`schema.rs:~779`) fails the full-workspace pre-commit gate until the
+  canonical mirror is regenerated. Both steps are required:
+  1. `MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py` (rewrites the
+     canonical mirror);
+  2. `python contrib/python-musefs/vendor_to_picard.py` (copies it into Picard).
+  Verify the Picard copy actually changed. Each mirror renders the **full
+  migration chain**, so the `tags` CREATE appears **twice** (V1's original, then
+  V4's recreated table); confirm the new `CHECK` lands in the **V4 rendering**
+  (the second occurrence).
+- **NUL-inside-key limitation (accepted).** `length()`/`GLOB` stop at an embedded
+  NUL (`char(0)`), so a NUL *inside* a key evades the DB `CHECK`. On the
+  FLAC/Ogg path `build`'s `is_valid_key` drops it (NUL `< 0x20`), but for
+  **MP3/M4A external writers** there is no Rust backstop — such a key reaches
+  `TXXX`/freeform synthesis. A Rust guard in `replace_tags` would **not** close
+  this, because external writers write raw SQL and bypass `replace_tags`
+  entirely; only the `CHECK` governs them. An embedded-NUL custom key from an
+  external writer is pathological, so this gap is documented and tolerated rather
+  than chased. A one-line note goes in the schema comment.
+- Any migration-chain test that asserts V4's `tags` shape is updated.
+- The DB floor also applies to **WAV-backed** keys (the `tags` table is
+  format-agnostic): a WAV custom key with a control char is rejected at the DB.
+  This is the intended floor behavior even though WAV *grammar* is out of scope.
+
+## Testing
+
+- **`vorbiscomment` regression** (FLAC *and* Ogg): keys `a=b`, `""`,
+  `"\n"`/control char, and a normal custom key (`custom_thing`). Assert valid
+  keys survive in field-name position, invalid keys are dropped, and a
+  synthesize → parse round-trip preserves the key/value boundary (no `A=B=c`).
+- **Order preservation:** inputs `[valid1, a=b, valid2]` synthesize to
+  `valid1, valid2` in order, with values intact and the count reflecting only the
+  surviving tags (FLAC and Ogg). `get_tags` returns `ORDER BY key, ordinal`, so
+  dropping a key must not reorder or renumber the survivors.
+- **`is_valid_key` unit table:** boundary bytes `0x1F`/`0x20`/`0x3D`/`0x7D`/
+  `0x7E`, empty string, a non-ASCII key.
+- **`build` totality:** `build` over arbitrary keys (including `a=b`, empty,
+  control char) never panics and emits only valid comments — the property the
+  fuzz harness relies on now that the old `debug_assert` is gone.
+- **DB:** an external `replace_tags` with a control-char key (and with an empty
+  key) returns a constraint error and rolls back the whole transaction (inserts
+  are row-by-row, `tags.rs:177`) — documenting *why* the scanner floor exists; a
+  valid custom key inserts successfully.
+- **`parse`:** a `=value` comment yields no tag; a `A=B=c` comment still yields
+  key `A`, value `B=c` (first-`=` split preserved).
+- **Scanner:** a probed key that violates the floor is skipped, not aborted, and
+  the track's remaining tags persist — for **both** collection loops
+  (`scan.rs:575` and `:658`).
+- **Fuzz:** `cargo +nightly fuzz build` (the `fuzz/` crate is outside the
+  workspace; the touched `vorbiscomment`/`flac`/`ogg` targets feed `arb_tags`
+  and would break silently otherwise).
+
+## Documentation
+
+- `docs/FLAC.md` and `docs/OGG.md`: note that out-of-grammar user-defined keys
+  are dropped (with the strict Vorbis range) on synthesis.
+- The external-writer contract section in `ARCHITECTURE.md`: document the
+  `tags.key` floor (non-empty, no control chars) that writers must satisfy.
+
+## Out of scope
+
+- WAV `INFO` 4-byte key grammar (separate format, not implicated by #300).
+- Validating ID3 / M4A key grammar (their custom-key rules differ and are not
+  the boundary-shift vector).

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -206,6 +206,7 @@ impl HeaderCache {
                                     .collect();
                                 (structural, &binary_tag_inputs)
                             };
+                        warn_invalid_vorbis_keys(track.id, &inputs);
                         flac::synthesize_layout(
                             &structural,
                             track.bounds.audio_offset(),
@@ -282,6 +283,7 @@ impl HeaderCache {
                             .map(|meta| musefs_format::ogg::OggArt { meta })
                             .collect();
                         let src = crate::mapping::DbArtSource(db);
+                        warn_invalid_vorbis_keys(track.id, &inputs);
                         musefs_format::ogg::synthesize_layout(
                             &header,
                             track.bounds.audio_offset(),
@@ -356,6 +358,21 @@ pub fn read_at_into<M>(
         read_segments_into(resolved, db, Some(&file), offset, size, out)
     } else {
         read_segments_into(resolved, db, None, offset, size, out)
+    }
+}
+
+/// Warn about user-defined tag keys that the Vorbis synthesis path will drop,
+/// so a silently-dropped key is observable. Runs during layout resolution (a
+/// cache miss), not per `read_at`, so a malformed key warns once per resolution.
+fn warn_invalid_vorbis_keys(track_id: i64, inputs: &[musefs_format::TagInput]) {
+    for t in inputs {
+        if !musefs_format::is_valid_vorbis_key(&t.key) {
+            log::warn!(
+                "track {track_id}: dropping tag key {:?} from Vorbis synthesis \
+                 (not a valid field name)",
+                t.key
+            );
+        }
     }
 }
 
@@ -640,6 +657,50 @@ mod resolve_ogg_tests {
         assert!(
             tags.iter()
                 .any(|(k, v)| k == "title" && v == "Telephasic Workshop")
+        );
+    }
+
+    #[test]
+    fn synthesis_drops_invalid_vorbis_key_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("track.opus");
+        let (audio_offset, audio_length) = build_opus_file(&path);
+
+        let db = Db::open_in_memory().unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let track_id = db
+            .upsert_track(&NewTrack {
+                backing_path: path.to_string_lossy().into_owned(),
+                format: Format::Opus,
+                audio_offset,
+                audio_length,
+                backing_size: meta.len(),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
+            })
+            .unwrap();
+        // `a=b` passes the DB floor but is not a valid Vorbis field name. Without the
+        // fix it would synthesize `A=B=c` and re-parse as key "A", value "B=c".
+        db.replace_tags(
+            track_id,
+            &[
+                Tag::new("artist", "Alice", 0),
+                Tag::new("a=b", "c", 0),
+                Tag::new("title", "Song", 0),
+            ],
+        )
+        .unwrap();
+
+        let cache = HeaderCache::new(Mode::Synthesis);
+        let resolved = cache.resolve(&db, track_id).unwrap();
+        let out = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
+
+        let tags = musefs_format::ogg::read_tags(&out).unwrap();
+        assert!(tags.iter().any(|(k, v)| k == "artist" && v == "Alice"));
+        assert!(tags.iter().any(|(k, v)| k == "title" && v == "Song"));
+        assert!(
+            !tags.iter().any(|(k, _)| k == "A" || k.contains('=')),
+            "the a=b key must be dropped, not synthesized as A=B=c: {tags:?}"
         );
     }
 

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -206,7 +206,13 @@ impl HeaderCache {
                                     .collect();
                                 (structural, &binary_tag_inputs)
                             };
-                        warn_invalid_vorbis_keys(track.id, &inputs);
+                        for key in invalid_vorbis_keys(&inputs) {
+                            log::warn!(
+                                "track {}: dropping tag key {key:?} from Vorbis \
+                                 synthesis (not a valid field name)",
+                                track.id
+                            );
+                        }
                         flac::synthesize_layout(
                             &structural,
                             track.bounds.audio_offset(),
@@ -283,7 +289,13 @@ impl HeaderCache {
                             .map(|meta| musefs_format::ogg::OggArt { meta })
                             .collect();
                         let src = crate::mapping::DbArtSource(db);
-                        warn_invalid_vorbis_keys(track.id, &inputs);
+                        for key in invalid_vorbis_keys(&inputs) {
+                            log::warn!(
+                                "track {}: dropping tag key {key:?} from Vorbis \
+                                 synthesis (not a valid field name)",
+                                track.id
+                            );
+                        }
                         musefs_format::ogg::synthesize_layout(
                             &header,
                             track.bounds.audio_offset(),
@@ -361,19 +373,18 @@ pub fn read_at_into<M>(
     }
 }
 
-/// Warn about user-defined tag keys that the Vorbis synthesis path will drop,
-/// so a silently-dropped key is observable. Runs during layout resolution (a
-/// cache miss), not per `read_at`, so a malformed key warns once per resolution.
-fn warn_invalid_vorbis_keys(track_id: i64, inputs: &[musefs_format::TagInput]) {
-    for t in inputs {
-        if !musefs_format::is_valid_vorbis_key(&t.key) {
-            log::warn!(
-                "track {track_id}: dropping tag key {:?} from Vorbis synthesis \
-                 (not a valid field name)",
-                t.key
-            );
-        }
-    }
+/// The distinct user-defined keys in `inputs` that the Vorbis synthesis path
+/// drops because they are not valid field names. Pure and unit-tested; the
+/// caller logs them so a silently-dropped key is observable. Deduped so a
+/// multi-valued bad key warns once, not once per value.
+fn invalid_vorbis_keys(inputs: &[musefs_format::TagInput]) -> Vec<&str> {
+    let mut seen = HashSet::new();
+    inputs
+        .iter()
+        .map(|t| t.key.as_str())
+        .filter(|k| !musefs_format::is_valid_vorbis_key(k))
+        .filter(|k| seen.insert(*k))
+        .collect()
 }
 
 /// Allocating form of `read_at_into` (tests and non-hot-path callers).
@@ -658,6 +669,19 @@ mod resolve_ogg_tests {
             tags.iter()
                 .any(|(k, v)| k == "title" && v == "Telephasic Workshop")
         );
+    }
+
+    #[test]
+    fn invalid_vorbis_keys_reports_distinct_out_of_grammar_keys() {
+        use musefs_format::TagInput;
+        let inputs = vec![
+            TagInput::new("artist", "A"),
+            TagInput::new("a=b", "c"),
+            TagInput::new("a=b", "d"), // same bad key twice -> reported once
+            TagInput::new("title", "S"),
+        ];
+        // Only the out-of-grammar key, deduped; valid keys are not flagged.
+        assert_eq!(invalid_vorbis_keys(&inputs), vec!["a=b"]);
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1953,6 +1953,7 @@ mod hardening_tests {
                 ("artist", "Alice"),
                 ("", "dropped"),        // empty key
                 ("a\u{7}b", "dropped"), // control char
+                ("a\u{0}b", "dropped"), // embedded NUL — DB CHECK can't see it, the floor can
                 ("a=b", "kept"),        // '=' is NOT a floor violation
             ]),
         )
@@ -1986,6 +1987,7 @@ mod hardening_tests {
                     ("artist", "Alice"),
                     ("", "dropped"),
                     ("a\u{7}b", "dropped"),
+                    ("a\u{0}b", "dropped"), // embedded NUL — floor drops it
                     ("a=b", "kept"),
                 ]),
             )

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -556,6 +556,17 @@ fn payload_weight(p: &Probed) -> u64 {
     pictures + binary + structural
 }
 
+/// The universal `tags.key` floor, mirrored from the DB `CHECK` exactly: a key
+/// must be non-empty and contain no byte below 0x20 (the control chars the DB
+/// rejects via its GLOB range; NUL also fails here, the DB's documented blind
+/// spot). DEL (0x7F) and high/non-ASCII bytes are accepted, matching the DB.
+/// Distinct from the strict Vorbis `is_valid_key` (which also bars `=`, 0x7E,
+/// 0x7F, and non-ASCII) — applying that here would wrongly drop legal MP3/M4A
+/// custom keys containing `=`/`:`/space.
+fn key_passes_floor(key: &str) -> bool {
+    !key.is_empty() && key.bytes().all(|b| b >= 0x20)
+}
+
 /// Upsert a track from a probed backing file: write the track row, replace its
 /// seeded tags, and ingest its embedded art (capped, deduped, clamped).
 fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
@@ -573,6 +584,9 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     let mut tags = Vec::new();
     let mut ordinals: HashMap<String, u64> = HashMap::new();
     for (key, value) in probed.tags {
+        if !key_passes_floor(&key) {
+            continue;
+        }
         let ord = ordinals.entry(key.clone()).or_insert(0);
         tags.push(Tag::new(&key, &value, *ord));
         *ord += 1;
@@ -656,6 +670,9 @@ fn ingest_bulk(
     let mut tags = Vec::new();
     let mut ordinals: HashMap<String, u64> = HashMap::new();
     for (key, value) in &probed.tags {
+        if !key_passes_floor(key) {
+            continue;
+        }
         let ord = ordinals.entry(key.clone()).or_insert(0);
         tags.push(Tag::new(key, value, *ord));
         *ord += 1;
@@ -1903,6 +1920,86 @@ mod hardening_tests {
         );
         assert_eq!(rows[0].key, "PRIV");
         assert_eq!(rows[0].byte_len, 3);
+    }
+
+    fn probed_with_text_tags(tags: &[(&str, &str)]) -> Probed {
+        Probed {
+            format: musefs_db::Format::Mp3,
+            audio_offset: 0,
+            audio_length: 0,
+            tags: tags
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            pictures: Vec::new(),
+            binary_tags: Vec::new(),
+            structural_blocks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ingest_skips_empty_and_control_char_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.mp3");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let db = Db::open_in_memory().unwrap();
+
+        ingest(
+            &db,
+            &path.to_string_lossy(),
+            &meta,
+            probed_with_text_tags(&[
+                ("artist", "Alice"),
+                ("", "dropped"),        // empty key
+                ("a\u{7}b", "dropped"), // control char
+                ("a=b", "kept"),        // '=' is NOT a floor violation
+            ]),
+        )
+        .unwrap();
+
+        let tid = db.list_tracks().unwrap()[0].id;
+        let keys: Vec<String> = db
+            .get_tags(tid)
+            .unwrap()
+            .into_iter()
+            .map(|t| t.key)
+            .collect();
+        // get_tags is ORDER BY key, ordinal: '=' (0x3D) sorts before 'a' (0x61).
+        assert_eq!(keys, vec!["a=b".to_string(), "artist".to_string()]);
+    }
+
+    #[test]
+    fn ingest_bulk_skips_empty_and_control_char_keys() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let mut bw = db.bulk_writer().unwrap();
+            ingest_bulk(
+                &mut bw,
+                "/a.mp3",
+                BackingStamp {
+                    size: 1,
+                    mtime_ns: 0,
+                    ctime_ns: 0,
+                },
+                probed_with_text_tags(&[
+                    ("artist", "Alice"),
+                    ("", "dropped"),
+                    ("a\u{7}b", "dropped"),
+                    ("a=b", "kept"),
+                ]),
+            )
+            .unwrap();
+            bw.commit().unwrap();
+        }
+        let tid = db.list_tracks().unwrap()[0].id;
+        let keys: Vec<String> = db
+            .get_tags(tid)
+            .unwrap()
+            .into_iter()
+            .map(|t| t.key)
+            .collect();
+        assert_eq!(keys, vec!["a=b".to_string(), "artist".to_string()]);
     }
 
     /// Probed with two structural blocks of the SAME kind, to make the per-kind

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -184,6 +184,8 @@ CREATE TABLE tags (
     CHECK (ordinal >= 0),
     CHECK (value_blob IS NULL OR value = ''),
     CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
     CHECK (length(value) <= 262144),
     CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
 );
@@ -1497,6 +1499,33 @@ mod migration_v4_tests {
                 "missing trigger after V4: {expected}"
             );
         }
+    }
+
+    #[test]
+    fn v4_tags_rejects_empty_and_control_char_keys() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        fresh(&mut conn);
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime_ns, updated_at) \
+             VALUES ('/x','flac',0,0,0,0,0)",
+            [],
+        )
+        .unwrap();
+        rejected(
+            &conn,
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'','v',0)",
+        );
+        rejected(
+            &conn,
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,char(7),'v',0)",
+        );
+        // '=' is NOT a DB-floor violation — only Vorbis synthesis bars it.
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'a=b','c',0)",
+            [],
+        )
+        .unwrap();
     }
 }
 

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -494,4 +494,18 @@ mod tags_for_tracks_tests {
         let got = db.tags_grouped_for_keys(&[]).unwrap();
         assert!(got.is_empty());
     }
+
+    #[test]
+    fn replace_tags_rejects_floor_violating_keys() {
+        let db = open_mem();
+        let t = db.upsert_track(&new_track("/a.flac")).unwrap();
+        // A row violating the floor aborts the whole row-by-row transactional insert.
+        assert!(db.replace_tags(t, &[Tag::new("", "v", 0)]).is_err());
+        assert!(db.replace_tags(t, &[Tag::new("\u{7}", "v", 0)]).is_err());
+        // '=' passes the DB floor (only the Vorbis path bars it).
+        db.replace_tags(t, &[Tag::new("a=b", "c", 0)]).unwrap();
+        let got = db.get_tags(t).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].key, "a=b");
+    }
 }

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -508,4 +508,24 @@ mod tags_for_tracks_tests {
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].key, "a=b");
     }
+
+    #[test]
+    fn replace_tags_rolls_back_a_mixed_valid_invalid_batch() {
+        let db = open_mem();
+        let t = db.upsert_track(&new_track("/a.flac")).unwrap();
+        db.replace_tags(t, &[Tag::new("artist", "Alice", 0)])
+            .unwrap();
+        // replace_tags DELETEs the existing text rows before re-inserting; a CHECK
+        // violation later in the batch must roll the whole transaction back —
+        // including the DELETE — so the original rows survive rather than the batch
+        // half-applying.
+        assert!(
+            db.replace_tags(t, &[Tag::new("title", "ok", 0), Tag::new("", "bad", 0)])
+                .is_err()
+        );
+        let got = db.get_tags(t).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].key, "artist");
+        assert_eq!(got[0].value, "Alice");
+    }
 }

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -22,6 +22,7 @@ pub use input::{
 pub use layout::{LayoutError, RegionLayout, Segment};
 pub use ogg::{Codec, OggHeader, OggScan};
 pub use probe::Extent;
+pub use vorbiscomment::is_valid_key as is_valid_vorbis_key;
 
 // tagmap is pure &str→key mapping with no byte parsing and is already exercised
 // indirectly by the per-format fuzz targets (which pass arbitrary tag keys through

--- a/musefs-format/src/vorbiscomment.rs
+++ b/musefs-format/src/vorbiscomment.rs
@@ -7,6 +7,14 @@ use crate::input::TagInput;
 
 pub(crate) const VENDOR: &str = "musefs";
 
+/// True if `key` is a legal VorbisComment field name: one or more characters in
+/// ASCII 0x20..=0x7D, excluding 0x3D (`=`). This is the Vorbis spec grammar and
+/// matches what mutagen/TagLib enforce when writing. Non-ASCII, control chars,
+/// `=`, and the empty string are all rejected.
+pub fn is_valid_key(key: &str) -> bool {
+    !key.is_empty() && key.bytes().all(|b| (0x20..=0x7D).contains(&b) && b != b'=')
+}
+
 /// Build a VorbisComment body: vendor string then count then `KEY=value` comments.
 /// Lengths are 32-bit little-endian. Known canonical keys are mapped to their
 /// Vorbis field name via the vocabulary; unknown keys are upper-cased.
@@ -106,6 +114,22 @@ mod tests {
         body.extend_from_slice(&0u32.to_le_bytes()); // vendor_len = 0
         body.extend_from_slice(&u32::MAX.to_le_bytes()); // count ~= 4 billion; cap prevents OOM
         assert!(parse(&body).is_err());
+    }
+
+    #[test]
+    fn is_valid_key_enforces_vorbis_grammar() {
+        // Legal: one-or-more ASCII 0x20..=0x7D, excluding '=' (0x3D).
+        assert!(is_valid_key("title"));
+        assert!(is_valid_key("CUSTOM_THING"));
+        assert!(is_valid_key("}")); // 0x7D, upper bound
+        assert!(is_valid_key(" ")); // 0x20, lower bound
+        // Illegal.
+        assert!(!is_valid_key("")); // empty
+        assert!(!is_valid_key("a=b")); // contains '='
+        assert!(!is_valid_key("a\u{1f}b")); // control char 0x1F
+        assert!(!is_valid_key("a\u{7f}b")); // DEL 0x7F
+        assert!(!is_valid_key("a~b")); // 0x7E, just past upper bound
+        assert!(!is_valid_key("género")); // non-ASCII high bytes
     }
 
     #[test]

--- a/musefs-format/src/vorbiscomment.rs
+++ b/musefs-format/src/vorbiscomment.rs
@@ -15,9 +15,6 @@ pub fn is_valid_key(key: &str) -> bool {
     !key.is_empty() && key.bytes().all(|b| (0x20..=0x7D).contains(&b) && b != b'=')
 }
 
-/// Build a VorbisComment body: vendor string then count then `KEY=value` comments.
-/// Lengths are 32-bit little-endian. Known canonical keys are mapped to their
-/// Vorbis field name via the vocabulary; unknown keys are upper-cased.
 pub(crate) fn build(tags: &[TagInput]) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(
@@ -26,12 +23,16 @@ pub(crate) fn build(tags: &[TagInput]) -> Result<Vec<u8>> {
             .to_le_bytes(),
     );
     out.extend_from_slice(VENDOR.as_bytes());
+    // Skip keys outside the Vorbis field-name grammar (e.g. an `=` key would shift
+    // the key/value boundary on re-parse). build() is the single enforcement point,
+    // so it stays total for any caller — including the fuzz harness.
+    let valid: Vec<&TagInput> = tags.iter().filter(|t| is_valid_key(&t.key)).collect();
     out.extend_from_slice(
-        &u32::try_from(tags.len())
+        &u32::try_from(valid.len())
             .map_err(|_| FormatError::TooLarge)?
             .to_le_bytes(),
     );
-    for t in tags {
+    for t in valid {
         let field = crate::tagmap::key_to_vorbis(&t.key)
             .map_or_else(|| t.key.to_ascii_uppercase(), str::to_string);
         let comment = format!("{field}={}", t.value);
@@ -89,6 +90,43 @@ pub fn parse(body: &[u8]) -> Result<Vec<(String, String)>> {
 mod tests {
     use super::*;
     use crate::input::TagInput;
+
+    #[test]
+    fn build_skips_keys_outside_vorbis_grammar() {
+        // The issue's case: an `a=b` key would otherwise synthesize `A=B=c` and
+        // shift the boundary on re-parse. Empty keys are also dropped. Valid keys
+        // keep their order, and the comment count reflects only survivors.
+        let tags = vec![
+            TagInput::new("artist", "Alice"),
+            TagInput::new("a=b", "c"),
+            TagInput::new("", "x"),
+            TagInput::new("title", "Song"),
+        ];
+        let body = build(&tags).unwrap();
+        let parsed = parse(&body).unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                ("artist".to_string(), "Alice".to_string()),
+                ("title".to_string(), "Song".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_is_total_over_arbitrary_keys() {
+        // build() must remain total: it has no assert guarding key validity, so the
+        // fuzz harness can feed it arbitrary keys. It must never panic and must emit
+        // only valid comments.
+        let tags = vec![
+            TagInput::new("a=b=c", "v"),
+            TagInput::new("\u{0}\u{1}", "v"),
+            TagInput::new("ok", "v"),
+        ];
+        let body = build(&tags).unwrap();
+        let parsed = parse(&body).unwrap();
+        assert_eq!(parsed, vec![("OK".to_string(), "v".to_string())]);
+    }
 
     #[test]
     fn build_then_parse_round_trips() {

--- a/musefs-format/src/vorbiscomment.rs
+++ b/musefs-format/src/vorbiscomment.rs
@@ -77,9 +77,13 @@ pub fn parse(body: &[u8]) -> Result<Vec<(String, String)>> {
         }
         let comment = std::str::from_utf8(&body[pos..end]).map_err(|_| FormatError::Malformed)?;
         if let Some((field, value)) = comment.split_once('=') {
-            let key = crate::tagmap::vorbis_to_key(field)
-                .map_or_else(|| field.to_string(), str::to_string);
-            out.push((key, value.to_string()));
+            // A comment whose field name is empty (e.g. "=value") is malformed and
+            // must not become an empty-key tag. The first-`=` split is preserved.
+            if !field.is_empty() {
+                let key = crate::tagmap::vorbis_to_key(field)
+                    .map_or_else(|| field.to_string(), str::to_string);
+                out.push((key, value.to_string()));
+            }
         }
         pos = end;
     }
@@ -182,5 +186,28 @@ mod tests {
         // keeps unknown verbatim.
         assert_eq!(parsed[0], ("albumartist".to_string(), "VA".to_string()));
         assert_eq!(parsed[1], ("CUSTOM_THING".to_string(), "x".to_string()));
+    }
+
+    fn body_with_one_comment(comment: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::try_from(VENDOR.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(VENDOR.as_bytes());
+        body.extend_from_slice(&1u32.to_le_bytes()); // count = 1
+        body.extend_from_slice(&u32::try_from(comment.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(comment.as_bytes());
+        body
+    }
+
+    #[test]
+    fn parse_skips_empty_field_name() {
+        // A "=value" comment has no field name; it must not become an empty-key tag.
+        assert!(parse(&body_with_one_comment("=value")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_splits_on_first_equals() {
+        // The exact boundary the issue is about: A=B=c -> key "A", value "B=c".
+        let parsed = parse(&body_with_one_comment("A=B=c")).unwrap();
+        assert_eq!(parsed, vec![("A".to_string(), "B=c".to_string())]);
     }
 }


### PR DESCRIPTION
Closes #300.

FLAC and Ogg synthesis wrote arbitrary user-defined `tags.key` values straight into Vorbis comment field-name position. A key containing `=` (e.g. stored key `a=b`, value `c`) synthesized `A=B=c`, which a later musefs scan re-parsed via `split_once('=')` as key `A`, value `B=c` — a boundary shift. Empty and control-character keys were also accepted into field-name position.

## Approach — layered enforcement

musefs serves each track in its *backing* format (no cross-format conversion), and MP3 (`TXXX`) / M4A (freeform) custom keys legitimately contain `=`, `:`, and spaces. So the strict Vorbis rule applies only on the FLAC/Ogg synthesis path, with a weaker universal hygiene floor at the DB.

- **`musefs-format`** — `vorbiscomment::is_valid_key` (strict Vorbis grammar: non-empty, ASCII `0x20`–`0x7D` excluding `=`). `build()` defensively *skips* out-of-grammar keys (total for any caller, including the fuzz harness; the comment count reflects survivors). `parse()` skips comments with an empty field name; the first-`=` split is preserved (`A=B=c` → `A`/`B=c`).
- **`musefs-core`** — the scanner filters both tag-collection loops (`ingest`, `ingest_bulk`) through `key_passes_floor` (non-empty, no byte `< 0x20`), mirroring the DB floor so a malformed probed key is skipped rather than aborting the scan. `reader.rs` logs each dropped key once per layout resolution, on the FLAC and Ogg branches.
- **`musefs-db`** — `tags.key` gains `CHECK (length(key) >= 1 AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*')`, added in place to `MIGRATION_V4` (no new migration — there are no deployed databases). External writers are hard-rejected; the scanner skips gracefully. Both Python schema mirrors regenerated.

The `=` case now: dropped + logged on FLAC/Ogg, preserved on MP3 (where `=` is legal in `TXXX`).

## Tests
- `vorbiscomment`: `build` skips `a=b`/empty/control keys and preserves order/count; `build` totality over arbitrary keys; `parse` empty-field skip and first-`=` split; `is_valid_key` boundary table.
- Scanner: both loops skip empty/control keys, keep `a=b`.
- DB: `CHECK` rejects empty/control keys (external write + `replace_tags` rollback); `a=b` passes the floor.
- Core: end-to-end Ogg synthesis drops `a=b` rather than emitting `A=B=c`.

## Verification
Full workspace suite green; `metrics`-feature tests (383) green; `cargo +nightly fuzz build` for `vorbiscomment`/`flac`/`ogg`; clippy `-D warnings` + fmt clean; mutant-anchor guard validates (the `scan.rs` insertion shifted the `run_pipeline`/`revalidate_with` `exclude_re` anchors, which were re-anchored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validator for Vorbis/FLAC/Ogg tag keys exposed; invalid keys are skipped during synthesis and ingestion and emit warnings (deduped).

* **Bug Fixes**
  * Prevents malformed tag keys from being written to the database or corrupting metadata round-trips; mixed replace operations now rollback on invalid keys.

* **Documentation**
  * Clarified FLAC/Ogg and architecture docs about tag-key rules and retention behavior.

* **Tests**
  * Added unit and end-to-end tests for validation, ingestion skipping, schema rejection, and synthesis behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->