### PR TITLE
Parser strictness hardening (#295 #296 #298 #299)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -74,6 +74,19 @@ exclude_re = [
     # sibling helper stays IN scope: core uses it only for slice bounds, so its
     # constant-return mutants die by prompt panic (verified caught).
     'musefs-format/src/convert\.rs:\d+:\d+: replace usize_from -> usize',
+    # wav walk_chunks chunk-advance `8u64 + size + (size & 1)`, the `8u64 + size`
+    # operator (col 28): the SAME MACHINE-KILLER class as convert.rs above. `+`->`*`
+    # zeroes the advance when size==0 (`8 * 0 + 0`), and `+`->`-` zeroes it when
+    # size==8 (`8 - 8 + 0`) — both real inputs in the test corpus. A zero advance
+    # freezes `pos` (next == pos passes the `next <= ceiling` guard) while the loop
+    # `out.push`-es the same chunk every iteration: an unbounded allocation that OOMs
+    # the runner before cargo-mutants' timeout fires (observed killing the in-diff CI
+    # job). The advance's correctness is pinned functionally by
+    # walk_chunks_advances_past_each_payload — a wrong advance lands off the next
+    # header. The `size + (size & 1)` operator at :35 and the `& 1` at :43 cannot
+    # zero the advance (min 8) and stay IN scope (caught by that same test).
+    # guard: op="+" fn="walk_chunks" rows=2
+    'musefs-format/src/wav\.rs:58:28:',
     # dirty_min_flip_ancestors (add-side walk) `id < introducing_id(child)`: the
     # `<`->`<=` boundary is unreachable-different. Equality needs the walked id to
     # BE the subtree's introducing id, which only a moved-in id can satisfy (pure
@@ -333,15 +346,16 @@ exclude_re = [
     # description-anchored against `cargo fmt` line drift.
     'replace < with <= in read_segments_into',
 
-    # wav walk_chunks advance guard `next <= buf.len() as u64` -> `true`: forcing
-    # the guard true sets `pos = next` even when `next > buf.len()`, but the loop's
-    # `while pos + 8 <= buf.len()` test is then immediately false (next can't wrap —
+    # wav walk_chunks advance guard `next <= ceiling as u64` -> `true`: forcing
+    # the guard true sets `pos = next` even when `next > ceiling`, but the loop's
+    # `while pos + 8 <= ceiling` test is then immediately false (next can't wrap —
     # checked_add guards overflow and usize_from doesn't truncate on 64-bit), so the
     # walk ends on the next iteration with the IDENTICAL output Vec the original's
     # `break` produced (the chunk header was pushed before the advance). Equivalent;
     # the in-file note in wav.rs's test module documents the hand-apply confirmation.
+    # (`ceiling = min(form_end, buf.len())` clamps the walk to the declared RIFF form.)
     # The sole match guard in walk_chunks, so description-anchored.
-    'replace match guard next <= buf.len\(\) as u64 with true in walk_chunks',
+    'replace match guard next <= ceiling as u64 with true in walk_chunks',
 
     # fuzz_check fixtures::wav RIFF-size sum `4 + fmt_chunk.len() + data_chunk.len()`
     # `+`->`*`: the computed `riff_size` is written into the RIFF header's size field,

--- a/docs/FLAC.md
+++ b/docs/FLAC.md
@@ -85,3 +85,7 @@ the streamed path.
   header length.
 - Block-body sizes are bounded at parse time (`MAX_BLOCK_BODY`); a crafted
   file cannot force a huge allocation.
+- The parser now rejects (at scan and synthesis) any FLAC whose metadata does
+  not begin with exactly one 34-byte STREAMINFO block; a crafted store
+  providing malformed structural rows fails synthesis with a controlled error
+  rather than emitting decoder-rejected output.

--- a/docs/MP3.md
+++ b/docs/MP3.md
@@ -49,6 +49,11 @@ described here is shared with WAV's embedded `id3 ` chunk — see
 - **ID3v1 is not read.** A file whose only tag is ID3v1 scans with no tags
   (populate the DB via beets/Picard instead). A trailing ID3v1 tag is also
   excluded from the audio region, so the synthesized file does not carry it.
+- The audio locator validates the ID3v2 major version (2–4) and rejects
+  synchsafe size bytes with the high bit set, producing a controlled
+  `Malformed` error rather than mask-decoding an invalid offset. Tags using
+  unsynchronisation or an extended header still scan — their declared size
+  already covers the audio boundary.
 - Scan-time tag extraction is skipped entirely — by a deliberate
   denial-of-service guard, see below — for tags using unsynchronisation, an
   extended header, non-zero frame flags (compression/encryption), malformed

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -93,7 +93,9 @@ pages are walked forward with each header patched algebraically and payload
 bytes served by exact positioned reads. A one-page memo on the resolved file
 short-circuits the scan for sequential reads. A page walk that overruns the
 scanned audio bounds is a hard `Malformed` error — corrupt or misaligned
-data is refused, not served.
+data is refused, not served. Synthesized page sequence numbers wrap modulo
+2³² (matching Ogg's `u32` sequence field), so files whose audio pages have
+very high sequence numbers serve correctly rather than failing the read.
 
 ## CRC patching: the linear-CRC trick
 

--- a/docs/WAV.md
+++ b/docs/WAV.md
@@ -84,14 +84,17 @@ The form covers bytes 8 through `8 + riff_size` and must encompass all
 top-level chunks (`fmt `, `data`, `LIST`, `id3 `, …). musefs enforces
 this at parse time:
 
-- `riff_wave_start` parses the RIFF size and returns `form_end = 8 +
-  riff_size`.
+- `riff_wave_start` parses the RIFF size and returns `form_end = 8 + riff_size`.
 - `locate_audio` and `locate_audio_at_ceiling` reject any file where
   `form_end` exceeds the physical file **or** where the `data` chunk
   payload extends past `form_end`.
 - Streaming or concatenated WAVs that write `riff_size = 0` or
-  `0xFFFFFFFF` are rejected (skipped from the virtual tree, never
-  modified). Allowing those sentinels is a deferred follow-up.
+  `0xFFFFFFFF` are rejected, but only incidentally: there is no explicit
+  sentinel check. `riff_size = 0` yields `form_end = 8`, which is smaller
+  than any file carrying a `data` payload, and `0xFFFFFFFF` yields a
+  `form_end` larger than any real file — both fall foul of the bounds
+  checks above. Detecting and honouring those sentinels explicitly is a
+  deferred follow-up.
 
 ## Quirks & invariants
 

--- a/docs/WAV.md
+++ b/docs/WAV.md
@@ -77,6 +77,22 @@ RIFF front, then serves the untouched payload:
 3. `BackingAudio` — the original `data` chunk payload, served verbatim by
    positioned reads.
 
+## RIFF form-size enforcement
+
+Every RIFF/WAVE file declares a form size at bytes 4..8 (`riff_size`).
+The form covers bytes 8 through `8 + riff_size` and must encompass all
+top-level chunks (`fmt `, `data`, `LIST`, `id3 `, …). musefs enforces
+this at parse time:
+
+- `riff_wave_start` parses the RIFF size and returns `form_end = 8 +
+  riff_size`.
+- `locate_audio` and `locate_audio_at_ceiling` reject any file where
+  `form_end` exceeds the physical file **or** where the `data` chunk
+  payload extends past `form_end`.
+- Streaming or concatenated WAVs that write `riff_size = 0` or
+  `0xFFFFFFFF` are rejected (skipped from the virtual tree, never
+  modified). Allowing those sentinels is a deferred follow-up.
+
 ## Quirks & invariants
 
 - A file must have both a `fmt ` chunk and a `data` chunk to scan; the

--- a/docs/superpowers/plans/2026-06-12-parser-strictness.md
+++ b/docs/superpowers/plans/2026-06-12-parser-strictness.md
@@ -241,10 +241,27 @@ Example for the binary-tag test:
     );
 ```
 
+Also update the **integration** test `synthesize_errors_on_oversized_picture` in `musefs-format/tests/synthesize_art.rs` — it likewise passes `&[]` and expects `TooLarge`. The `valid_streaminfo()` unit-test helper is NOT visible from the `tests/` directory, so build the block inline with the idiom the other integration tests use (`MetadataBlock { block_type: 0, body: streaminfo_body() }`; `streaminfo_body()` is already imported from `common` and returns a valid 34-byte body). Add `MetadataBlock` to the file's import and pass the block:
+
+```rust
+// add to the existing import at the top of musefs-format/tests/synthesize_art.rs:
+use musefs_format::flac::{locate_audio, synthesize_layout, MetadataBlock};
+
+// in synthesize_errors_on_oversized_picture, replace the `&[]` first argument:
+    let streaminfo = [MetadataBlock { block_type: 0, body: streaminfo_body() }];
+    assert_eq!(
+        synthesize_layout(&streaminfo, 0, 0, &[], &[], &[art]),
+        Err(FormatError::TooLarge)
+    );
+```
+
 - [ ] **Step 9: Run the full format suite to verify green**
 
 Run: `cargo test -p musefs-format`
-Expected: PASS. (Integration tests in `roundtrip.rs`/`synthesize_art.rs`/`synthesize_tags.rs` build structural via `streaminfo_body()` — a valid 34-byte body — so they stay green. `proptest_flac.rs` feeds `synthesize_layout` only successful `locate_audio` output, also green.)
+Expected: PASS. Note the split among integration tests:
+- `roundtrip.rs` and `synthesize_tags.rs` build structural via `MetadataBlock { block_type: 0, body: streaminfo_body() }` (valid 34-byte STREAMINFO) and the `make_flac`/`locate_audio` round-trip, so they stay green untouched.
+- `synthesize_art.rs::synthesize_errors_on_oversized_picture` is the one that passed `&[]`; it was fixed in Step 8.
+- `proptest_flac.rs` feeds `synthesize_layout` only successful `locate_audio` output (a valid STREAMINFO-first fixture), so it stays green.
 
 - [ ] **Step 10: Update FLAC docs**
 
@@ -255,7 +272,7 @@ In `docs/FLAC.md`, add a sentence to the metadata/synthesis section: the parser 
 ```bash
 cd /home/cfutro/git/musefs/.worktrees/parser-strictness
 cargo fmt
-git add musefs-format/src/flac.rs docs/FLAC.md
+git add musefs-format/src/flac.rs musefs-format/tests/synthesize_art.rs docs/FLAC.md
 git commit -m "$(cat <<'EOF'
 fix(flac): validate STREAMINFO structure at scan and synthesis (#295)
 
@@ -668,9 +685,12 @@ fn serve_ogg_window_wraps_seq_past_u32_max() {
     let mut out = Vec::new();
     serve_ogg_window(&backing, ao, alen, 1, 0, alen, &mut out, None).unwrap();
 
-    // The served page header must carry the wrapped sequence (u32::MAX + 1 == 0).
-    let want = patch_page_header(&page[..parse_page(&page, 0).unwrap().total_len()], 0).unwrap();
-    assert_eq!(&out[..want.len()], &want[..]);
+    // The served region must be the page with its sequence wrapped (u32::MAX + 1 == 0):
+    // patched header followed by the original payload bytes.
+    let h = parse_page(&page, 0).unwrap();
+    let mut want = patch_page_header(&page[..h.total_len()], 0).unwrap();
+    want.extend_from_slice(&page[h.header_len..h.total_len()]);
+    assert_eq!(out, want);
 }
 ```
 
@@ -744,7 +764,7 @@ Expected: no warnings; fmt clean (check exit status directly).
 
 The fuzz crate is outside the workspace and uses format-layer APIs. No public signatures changed (`riff_wave_start` is private; `locate_audio`/`synthesize_layout` signatures are unchanged), but confirm:
 Run: `cargo +nightly fuzz build flac ; cargo +nightly fuzz build mp3 ; cargo +nightly fuzz build wav ; cargo +nightly fuzz build ogg`
-Expected: builds succeed. (If any target now exercises the stricter parser and a corpus seed is a malformed file the parser used to accept, that seed simply returns `Err` — not a build break.)
+Expected: builds succeed. (If any target now exercises the stricter parser and a corpus seed is a malformed file the parser used to accept, that seed simply returns `Err` — not a build break.) The FLAC fuzz target chains `locate_audio` → `synthesize_layout(&scan.preserved, …)`; because strict `locate_audio` now succeeds only for valid STREAMINFO-first input, `scan.preserved` always satisfies the new synthesis check, so the chain gains no new panic/assert path.
 
 - [ ] **Step 4: Confirm the four commits are present and the tree is clean**
 

--- a/docs/superpowers/plans/2026-06-12-parser-strictness.md
+++ b/docs/superpowers/plans/2026-06-12-parser-strictness.md
@@ -1,0 +1,761 @@
+# Parser Strictness Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the FLAC, MP3, WAV, and Ogg parsers reject malformed container geometry with a controlled `FormatError` (at scan *and* synthesis time, per the crafted-DB threat model), and make Ogg page renumbering wrap mod 2³² instead of failing reads.
+
+**Architecture:** Per-format inline hardening in `musefs-format` (one change in `musefs-core` for the Ogg read path). Each format gets a small validation helper shared between its scan and synthesis paths where they overlap. No cross-format abstraction. Four independent issues → four sequenced commits, each green under the pre-commit hook (which runs the full workspace test suite).
+
+**Tech Stack:** Rust (workspace crates `musefs-format`, `musefs-core`); tests are inline `#[cfg(test)] mod tests` plus integration tests under `musefs-format/tests/`.
+
+**Source spec:** `docs/superpowers/specs/2026-06-12-parser-strictness-design.md`
+
+---
+
+## Conventions for every task
+
+- The pre-commit hook runs `cargo fmt`, `cargo clippy -D warnings`, and the **full workspace test suite**. A commit with any red test is rejected, so each task's implementation step and its test-churn step land in the **same commit** — the working tree must be fully green before `git commit`.
+- Run `cargo fmt` before every commit (CI fmt gate; check exit status).
+- `FormatError` variants used here: `Malformed`, `NotWav`, `NotMp3`, `NotFlac`, `TooLarge` (defined in `musefs-format/src/error.rs`).
+- Errors are referenced by function + file; line numbers drift, so navigate by symbol name.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs-format/src/flac.rs` | FLAC parse/synthesis | Add STREAMINFO structural validation to `parse_blocks`, `read_metadata_bounded`, `synthesize_layout`; update 2 characterization tests + 4 synth-boundary tests; add new tests |
+| `musefs-format/src/mp3.rs` | MP3 parse | Add shared `id3v2_header_len` helper; call from `locate_audio`, `locate_audio_bounded`, `id3v2_alloc_safe`; add tests |
+| `musefs-format/src/wav.rs` | WAV parse | `riff_wave_start` returns `(start, form_end)`; enforce form bounds in `locate_audio`/`locate_audio_at_ceiling`; fix `wav_front` + `riff_wave_start` test; add tests |
+| `musefs-core/src/ogg_index.rs` | Ogg read path | `serve_ogg_window` uses `wrapping_add` for seq; add wrap-boundary test |
+| `docs/{FLAC,MP3,OGG,WAV}.md` | Format docs | Document the new strictness / wrap behavior |
+
+---
+
+## Task 1: FLAC STREAMINFO validation (#295)
+
+**Files:**
+- Modify: `musefs-format/src/flac.rs` (`parse_blocks`, `read_metadata_bounded`, `synthesize_layout`, tests module)
+
+**Background — current behavior:** `parse_blocks` and `read_metadata_bounded` walk metadata blocks recording `STREAMINFO/APPLICATION/SEEKTABLE/CUESHEET` bodies, never enforcing that STREAMINFO is first, unique, and 34 bytes. `synthesize_layout(structural, …)` sorts blocks by type (`BLOCK_STREAMINFO == 0` sorts first) and emits them, trusting the rows. The DB-fed call site is `HeaderCache::build` in `musefs-core/src/reader.rs`.
+
+- [ ] **Step 1: Add the validation helper and a length constant**
+
+Insert near the top of `musefs-format/src/flac.rs` (after the `MAX_BLOCK_BODY` constant). `BLOCK_STREAMINFO` is already defined as `0`.
+
+```rust
+/// FLAC mandates a single STREAMINFO metadata block, first in the sequence, with
+/// a fixed 34-byte body.
+const STREAMINFO_BODY_LEN: usize = 34;
+
+/// Enforce FLAC's STREAMINFO rule for the metadata block at position `index`:
+/// the first block must be STREAMINFO with a 34-byte body, and STREAMINFO must
+/// not appear anywhere else (so it appears exactly once). Any violation is
+/// `FormatError::Malformed`.
+fn check_streaminfo_position(index: usize, block_type: u8, body_len: usize) -> Result<()> {
+    let is_streaminfo = block_type == BLOCK_STREAMINFO;
+    if index == 0 {
+        if !is_streaminfo || body_len != STREAMINFO_BODY_LEN {
+            return Err(FormatError::Malformed);
+        }
+    } else if is_streaminfo {
+        return Err(FormatError::Malformed);
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Write failing scan-time tests**
+
+Add to the `tests` module in `musefs-format/src/flac.rs` (helpers `raw_block`, `flac_with`, `BLOCK_*`, `read_metadata_bounded`, `Extent` are already in scope). Also add the reusable `valid_streaminfo` helper used by later steps.
+
+```rust
+/// A structural STREAMINFO block with a valid 34-byte body, for synthesis tests.
+fn valid_streaminfo() -> MetadataBlock {
+    MetadataBlock { block_type: BLOCK_STREAMINFO, body: vec![0u8; 34] }
+}
+
+#[test]
+fn locate_audio_rejects_missing_streaminfo() {
+    // First (and only) block is VORBIS_COMMENT, no STREAMINFO at all.
+    let file = flac_with(&[raw_block(BLOCK_VORBIS_COMMENT, &[], true, None)]);
+    assert_eq!(locate_audio(&file), Err(FormatError::Malformed));
+}
+
+#[test]
+fn locate_audio_rejects_streaminfo_wrong_body_len() {
+    // STREAMINFO present and first, but body is 10 bytes, not 34.
+    let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[0u8; 10], true, None)]);
+    assert_eq!(locate_audio(&file), Err(FormatError::Malformed));
+}
+
+#[test]
+fn locate_audio_rejects_duplicate_streaminfo() {
+    let file = flac_with(&[
+        raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None),
+        raw_block(BLOCK_STREAMINFO, &[0u8; 34], true, None),
+    ]);
+    assert_eq!(locate_audio(&file), Err(FormatError::Malformed));
+}
+
+#[test]
+fn read_metadata_bounded_rejects_duplicate_streaminfo() {
+    let file = flac_with(&[
+        raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None),
+        raw_block(BLOCK_STREAMINFO, &[0u8; 34], true, None),
+    ]);
+    assert_eq!(read_metadata_bounded(&file), Err(FormatError::Malformed));
+}
+
+#[test]
+fn synthesize_layout_rejects_structural_without_streaminfo() {
+    // Hostile DB rows: a SEEKTABLE but no STREAMINFO.
+    let structural = [MetadataBlock { block_type: BLOCK_SEEKTABLE, body: vec![0u8; 4] }];
+    assert_eq!(
+        synthesize_layout(&structural, 0, 0, &[], &[], &[]),
+        Err(FormatError::Malformed)
+    );
+}
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `cargo test -p musefs-format flac::tests::locate_audio_rejects_missing_streaminfo flac::tests::synthesize_layout_rejects_structural_without_streaminfo`
+Expected: FAIL (current parser accepts these; current `synthesize_layout` returns `Ok`).
+
+- [ ] **Step 4: Enforce the rule in `parse_blocks`**
+
+In `parse_blocks`, add an index counter and call the helper before recording each block. The diff is: add `let mut index = 0usize;` before the `loop`, call the check after `body_end` is validated, and `index += 1;` at the end of each iteration. The block-recording `match` is unchanged.
+
+```rust
+    let mut pos = 4usize;
+    let mut index = 0usize;
+    let mut preserved = Vec::new();
+    loop {
+        if pos + 4 > data.len() {
+            return Err(FormatError::Malformed);
+        }
+        let header = data[pos];
+        let is_last = (header & 0x80) != 0;
+        let block_type = header & 0x7F;
+        let len = u24_be(data[pos + 1], data[pos + 2], data[pos + 3]);
+        let body_start = pos + 4;
+        let body_end = body_start + len;
+        if body_end > data.len() {
+            return Err(FormatError::Malformed);
+        }
+        check_streaminfo_position(index, block_type, len)?;
+        match block_type {
+            BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
+                preserved.push(MetadataBlock {
+                    block_type,
+                    body: data[body_start..body_end].to_vec(),
+                });
+            }
+            _ => {}
+        }
+        pos = body_end;
+        index += 1;
+        if is_last {
+            break;
+        }
+    }
+```
+
+- [ ] **Step 5: Enforce the rule in `read_metadata_bounded`**
+
+Same change in `read_metadata_bounded`: add `let mut index = 0usize;` before the loop, call `check_streaminfo_position(index, block_type, len)?;` immediately after the `body_end > prefix.len()` `NeedMore` guard, and `index += 1;` before the `if is_last` break. (The `NeedMore` returns stay ahead of the check, so validation only runs once the block's body is present.)
+
+- [ ] **Step 6: Enforce the rule in `synthesize_layout`**
+
+Add at the very top of `synthesize_layout`, before `let mut ordered`:
+
+```rust
+    let streaminfo: Vec<&MetadataBlock> = structural
+        .iter()
+        .filter(|b| b.block_type == BLOCK_STREAMINFO)
+        .collect();
+    if streaminfo.len() != 1 || streaminfo[0].body.len() != STREAMINFO_BODY_LEN {
+        return Err(FormatError::Malformed);
+    }
+```
+
+- [ ] **Step 7: Repurpose the two characterization tests (preserve their mutant coverage)**
+
+`parse_blocks_accepts_header_flush_with_end` currently uses an empty STREAMINFO. Give it a valid 34-byte body so it still exercises "final header flushes at end" but obeys the new rule:
+
+```rust
+#[test]
+fn parse_blocks_accepts_header_flush_with_end() {
+    // Single last STREAMINFO with a valid 34-byte body, no audio: the final header
+    // still flushes at the buffer end (pos+4 == data.len() at the loop guard), so
+    // this keeps the :43 `> -> >=` mutant coverage while obeying STREAMINFO rules.
+    let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[0u8; 34], true, None)]);
+    let meta = parse_blocks(&file).unwrap();
+    assert_eq!(meta.audio_offset, 42); // 4 marker + 4 header + 34 body
+}
+```
+
+`bounded_is_last_flag_continues_past_nonlast_block` currently uses two STREAMINFO blocks (now a duplicate). Make block 1 a valid STREAMINFO and block 2 a SEEKTABLE so the "walk past a non-last block" coverage is preserved:
+
+```rust
+#[test]
+fn bounded_is_last_flag_continues_past_nonlast_block() {
+    // First NON-last STREAMINFO (valid 34-byte body), then a LAST SEEKTABLE.
+    // audio_offset must span BOTH, proving we walked past the non-last block.
+    let b1 = raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None); // 4+34 = 38
+    let b2 = raw_block(BLOCK_SEEKTABLE, &[0xBB, 0xBB, 0xBB], true, None); // 4+3 = 7
+    let file = flac_with(&[b1, b2]);
+    let expected_offset = (4 + 38 + 7) as u64; // marker + block1 + block2
+    match read_metadata_bounded(&file).unwrap() {
+        Extent::Complete(meta) => {
+            // kills flac `header & 0x80` `&` -> `|`: that mutant stops after block 1
+            // (audio_offset == 4+38 == 42). Spanning both blocks (49) kills it.
+            assert_eq!(meta.audio_offset, expected_offset);
+            assert_eq!(meta.preserved.len(), 2);
+        }
+        other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 8: Update the four synth-boundary tests to pass a valid STREAMINFO**
+
+These pass `&[]` structural and expect `TooLarge`; the new check now returns `Malformed` first. Change the first argument from `&[]` to `&[valid_streaminfo()]` in each, leaving the rest identical:
+
+- `synthesize_layout_picture_block_size_boundary_is_inclusive`: both `synthesize_layout(&[], …)` calls → `synthesize_layout(&[valid_streaminfo()], …)`.
+- `synthesize_layout_vorbis_comment_block_size_boundary_is_inclusive`: both calls.
+- `synthesize_layout_binary_tag_block_size_boundary_is_inclusive`: both calls.
+- `synthesize_layout_checked_picture_len_rejects_overflow`: the single call.
+
+Example for the binary-tag test:
+
+```rust
+    // len == 0x00FF_FFFF exactly must succeed.
+    assert!(synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[mk(0x00FF_FFFF)], &[]).is_ok());
+    // one byte over must still error, pinning the high side of the boundary.
+    assert_eq!(
+        synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[mk(0x0100_0000)], &[]),
+        Err(FormatError::TooLarge)
+    );
+```
+
+- [ ] **Step 9: Run the full format suite to verify green**
+
+Run: `cargo test -p musefs-format`
+Expected: PASS. (Integration tests in `roundtrip.rs`/`synthesize_art.rs`/`synthesize_tags.rs` build structural via `streaminfo_body()` — a valid 34-byte body — so they stay green. `proptest_flac.rs` feeds `synthesize_layout` only successful `locate_audio` output, also green.)
+
+- [ ] **Step 10: Update FLAC docs**
+
+In `docs/FLAC.md`, add a sentence to the metadata/synthesis section: the parser now rejects (at scan and synthesis) any FLAC whose metadata does not begin with exactly one 34-byte STREAMINFO block; a crafted store providing malformed structural rows fails synthesis with a controlled error rather than emitting decoder-rejected output.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/parser-strictness
+cargo fmt
+git add musefs-format/src/flac.rs docs/FLAC.md
+git commit -m "$(cat <<'EOF'
+fix(flac): validate STREAMINFO structure at scan and synthesis (#295)
+
+Require exactly one 34-byte STREAMINFO as the first metadata block in
+parse_blocks and read_metadata_bounded; reject the same in
+synthesize_layout so a crafted DB's structural rows cannot be emitted as
+decoder-rejected FLAC. Repurpose the two laxness-characterizing tests to
+keep their mutant coverage with valid STREAMINFO fixtures.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: pre-commit runs the full suite and passes; commit succeeds.
+
+---
+
+## Task 2: MP3 ID3v2 header validation (#296)
+
+**Files:**
+- Modify: `musefs-format/src/mp3.rs` (`locate_audio`, `locate_audio_bounded`, `id3v2_alloc_safe`, tests module)
+
+**Background:** The locators mask the high bit of each synchsafe size byte and never check the ID3 major version, so a malformed header like `49 44 33 04 00 00 00 00 00 80` ("ID3", v4, flags 0, size bytes `00 00 00 80` with the high bit set) mask-decodes to `audio_offset = 10`. `id3v2_alloc_safe` already rejects that shape. The fix shares a header validator. **Decided:** the locator does NOT reject unsynchronization/extended-header flags (they don't shift the audio offset).
+
+- [ ] **Step 1: Add the shared header validator**
+
+Insert in `musefs-format/src/mp3.rs` after `synchsafe_decode`:
+
+```rust
+/// Validate a leading ID3v2 header and return the tag length (10-byte header +
+/// declared body, *excluding* any footer), or `None` when there is no ID3v2
+/// header at offset 0 or the buffer is shorter than a 10-byte header.
+///
+/// A present-but-malformed header — unsupported major version, or a synchsafe
+/// size byte with its high bit set — is `FormatError::Malformed`. This is the
+/// intersection of the checks `id3v2_alloc_safe` makes on the header, so the
+/// audio locator and the allocation guard agree on which headers are well-formed
+/// instead of the locator mask-decoding shapes the guard rejects. Footer and
+/// frame-flag handling stay with the callers.
+fn id3v2_header_len(data: &[u8]) -> Result<Option<usize>> {
+    if data.len() < 10 || &data[0..3] != b"ID3" {
+        return Ok(None);
+    }
+    if !matches!(data[3], 2..=4) {
+        return Err(FormatError::Malformed);
+    }
+    if data[6] | data[7] | data[8] | data[9] >= 0x80 {
+        return Err(FormatError::Malformed);
+    }
+    Ok(Some(10 + synchsafe_decode(&data[6..10]) as usize))
+}
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Add to the `tests` module in `musefs-format/src/mp3.rs`:
+
+```rust
+#[test]
+fn locate_audio_rejects_high_bit_size_byte() {
+    // Malformed synchsafe size (last byte 0x80) that masks to body=0, with a valid
+    // frame sync at offset 10. Must reject rather than serve audio from offset 10.
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.extend_from_slice(&[0x04, 0x00, 0x00]); // major, rev, flags
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x80]); // high bit set -> malformed
+    data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]); // valid sync at offset 10
+    assert_eq!(locate_audio(&data), Err(FormatError::Malformed));
+}
+
+#[test]
+fn locate_audio_rejects_unsupported_major_version() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.extend_from_slice(&[0x05, 0x00, 0x00]); // major 5 (unsupported)
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+    data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+    assert_eq!(locate_audio(&data), Err(FormatError::Malformed));
+}
+
+#[test]
+fn locate_audio_bounded_rejects_high_bit_size_byte() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.extend_from_slice(&[0x04, 0x00, 0x00]);
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x80]);
+    data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+    let file_len = data.len() as u64;
+    assert_eq!(
+        locate_audio_bounded(&data, file_len, None),
+        Err(FormatError::Malformed)
+    );
+}
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `cargo test -p musefs-format mp3::tests::locate_audio_rejects_high_bit_size_byte`
+Expected: FAIL (current locator masks the high bit and returns `Ok`).
+
+- [ ] **Step 4: Rewrite the ID3 skip in `locate_audio`**
+
+Replace the leading-ID3 block in `locate_audio`:
+
+```rust
+    let mut audio_offset = 0usize;
+    if let Some(base) = id3v2_header_len(data)? {
+        let flags = data[5];
+        let mut tag_len = base;
+        if flags & 0x10 != 0 {
+            tag_len += 10; // ID3v2.4 footer
+        }
+        if tag_len > len {
+            return Err(FormatError::Malformed);
+        }
+        audio_offset = tag_len;
+    }
+```
+
+(`id3v2_header_len` returns `None` for buffers shorter than 10 bytes or without the `ID3` magic, preserving the "no ID3 → audio at 0" path; `Some(base)` guarantees `data[5]` is in bounds.)
+
+- [ ] **Step 5: Rewrite the ID3 skip in `locate_audio_bounded`**
+
+Replace the leading-ID3 block. Keep the existing short-prefix `NeedMore` guard so a prefix too short to hold the 10-byte header is widened before validation:
+
+```rust
+    let mut audio_offset = 0usize;
+    if prefix.len() < 10 && file_len >= 10 {
+        // Not enough bytes even to read the ID3v2 header.
+        return Ok(Extent::NeedMore { up_to: 10 });
+    }
+    if let Some(base) = id3v2_header_len(prefix)? {
+        let flags = prefix[5];
+        let mut tag_len = base;
+        if flags & 0x10 != 0 {
+            tag_len += 10; // ID3v2.4 footer
+        }
+        if tag_len as u64 > file_len {
+            return Err(FormatError::Malformed);
+        }
+        audio_offset = tag_len;
+    }
+```
+
+(The rest of `locate_audio_bounded` — the `audio_offset + 2 > file_len` fast-fail, the frame-sync `NeedMore`, and the trailer handling — is unchanged.)
+
+- [ ] **Step 6: Route `id3v2_alloc_safe`'s header decode through the helper**
+
+In `id3v2_alloc_safe`, replace the opening magic/version/high-bit/body-decode block with a call to the shared helper, keeping the flag check and everything after it unchanged:
+
+```rust
+    let Ok(Some(tag_end)) = id3v2_header_len(data) else {
+        // Not an ID3v2 tag at offset 0, or a malformed header: skip parsing.
+        return false;
+    };
+    let flags = data[5];
+    // Extended header (0x40) and unsynchronisation (0x80) complicate frame
+    // bounds; skip rather than risk mis-validating.
+    if flags & 0xC0 != 0 {
+        return false;
+    }
+    if tag_end > data.len() {
+        return false;
+    }
+    let body = tag_end - 10;
+```
+
+(`tag_end == 10 + body`. The `tag_end > data.len()` guard is the one previously applied right after the body decode — keep it. The subsequent frame walk uses `body`, `tag_end`, `major = data[3]`, and `header_len` exactly as before; keep those lines.)
+
+- [ ] **Step 7: Run the full format suite**
+
+Run: `cargo test -p musefs-format`
+Expected: PASS. The existing locate tests (`locate_audio_skips_id3v2_then_finds_sync`, `locate_audio_honors_footer_flag`, `locate_audio_no_id3_starts_at_zero`, `locate_audio_requires_frame_sync`, the bounded tests) use well-formed headers and stay green.
+
+- [ ] **Step 8: Run the metrics-feature tests (CI gap guard)**
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: PASS. (These changes don't touch getattr/read stat counts, but this is the documented local CI gap, so confirm.)
+
+- [ ] **Step 9: Update MP3 docs**
+
+In `docs/MP3.md`, clarify the audio-boundary contract: the locator now validates the ID3v2 major version (2–4) and rejects high-bit synchsafe size bytes, so a malformed ID3-looking prefix is rejected with a controlled error; unsynchronization/extended-header tags still scan (their declared size already covers the audio offset).
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/parser-strictness
+cargo fmt
+git add musefs-format/src/mp3.rs docs/MP3.md
+git commit -m "$(cat <<'EOF'
+fix(mp3): validate ID3v2 header in the audio locator (#296)
+
+Share an id3v2_header_len validator across locate_audio,
+locate_audio_bounded, and id3v2_alloc_safe so the audio locator rejects
+unsupported major versions and high-bit synchsafe size bytes instead of
+mask-decoding a malformed ID3-looking prefix into an audio offset.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: WAV RIFF form-size enforcement (#299)
+
+**Files:**
+- Modify: `musefs-format/src/wav.rs` (`riff_wave_start`, `walk_chunks`, `locate_audio`, `locate_audio_at_ceiling`, tests module)
+
+**Background:** `riff_wave_start` returns a bare `12` and ignores the RIFF size field; `locate_audio`/`locate_audio_at_ceiling` accept any in-bounds `data` chunk regardless of the declared form. We parse the RIFF size, compute `form_end = 8 + riff_size`, and reject geometry that lies outside it. `wav_file` (the main test helper) already writes a correct size; only `wav_front` writes `0`, and the `riff_wave_start` unit test asserts the old return type.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `tests` module in `musefs-format/src/wav.rs` (the `wav` helper builds a correctly-sized RIFF; `wav_front` builds a front-only buffer — to be fixed in Step 5):
+
+```rust
+#[test]
+fn locate_audio_rejects_form_end_before_data() {
+    // Correctly framed chunks, but the RIFF size declares a form that ends before
+    // the data payload. Build with `wav` (valid size) then overwrite bytes 4..8.
+    let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
+    buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // form_end = 16, before data
+    assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
+}
+
+#[test]
+fn locate_audio_rejects_form_end_past_file() {
+    let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
+    let huge = u32::try_from(buf.len()).unwrap() + 100;
+    buf[4..8].copy_from_slice(&huge.to_le_bytes()); // form_end > physical file
+    assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
+}
+
+#[test]
+fn locate_audio_accepts_valid_form_with_odd_chunk_and_trailing_metadata() {
+    // Odd-size chunk before data (word-padded) + a LIST chunk trailing data, all
+    // inside a correctly-sized RIFF form. Must still parse.
+    let buf = wav(&[
+        (b"fmt ", fmt_pcm()),
+        (b"data", vec![0x22; 7]), // odd payload -> 1 pad byte
+        (b"LIST", vec![0x33; 4]),
+    ]);
+    let b = locate_audio(&buf).unwrap();
+    assert_eq!(b.audio_length, 7);
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `cargo test -p musefs-format wav::tests::locate_audio_rejects_form_end_before_data`
+Expected: FAIL (current `locate_audio` ignores the RIFF size).
+
+- [ ] **Step 3: Change `riff_wave_start` to return `(start, form_end)`**
+
+```rust
+/// Validate the RIFF/WAVE container header and return `(first_chunk_offset,
+/// form_end)`, where `form_end = 8 + riff_size` is the byte just past the
+/// declared RIFF form. Rejects RF64/BW64 and any non-`WAVE` RIFF file.
+fn riff_wave_start(buf: &[u8]) -> Result<(usize, u64)> {
+    if buf.len() < 12 || &buf[0..4] != b"RIFF" || &buf[8..12] != b"WAVE" {
+        return Err(FormatError::NotWav);
+    }
+    let riff_size = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    Ok((12, 8 + u64::from(riff_size)))
+}
+```
+
+- [ ] **Step 4: Update `walk_chunks` to destructure the new return**
+
+Only the binding changes (the walk is still bounded by `buf.len()`; per-chunk form-end checks live in the locators):
+
+```rust
+    let Ok((mut pos, _form_end)) = riff_wave_start(buf) else {
+        return out;
+    };
+```
+
+(`read_structure` calls `riff_wave_start(front)?;` as a bare statement that discards the value, so it compiles unchanged — verify in Step 7.)
+
+- [ ] **Step 5: Enforce form bounds in `locate_audio` and `locate_audio_at_ceiling`**
+
+`locate_audio` (full buffer present):
+
+```rust
+pub fn locate_audio(buf: &[u8]) -> Result<WavBounds> {
+    let (_, form_end) = riff_wave_start(buf)?;
+    if form_end > buf.len() as u64 {
+        return Err(FormatError::Malformed);
+    }
+    let chunks = walk_chunks(buf);
+    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
+    let data = chunks.iter().find(|(id, _, _)| id == b"data");
+    match (has_fmt, data) {
+        (true, Some(&(_, off, len))) => {
+            let data_end = (off as u64).saturating_add(len);
+            if data_end > buf.len() as u64 || data_end > form_end {
+                return Err(FormatError::Malformed);
+            }
+            Ok(WavBounds { audio_offset: off as u64, audio_length: len })
+        }
+        _ => Err(FormatError::NotWav),
+    }
+}
+```
+
+`locate_audio_at_ceiling` (front-only prefix; `file_len` is the true size):
+
+```rust
+pub fn locate_audio_at_ceiling(prefix: &[u8], file_len: u64) -> Result<WavBounds> {
+    let (_, form_end) = riff_wave_start(prefix)?;
+    if form_end > file_len {
+        return Err(FormatError::Malformed);
+    }
+    let chunks = walk_chunks(prefix);
+    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
+    let data = chunks.iter().find(|(id, _, _)| id == b"data");
+    match (has_fmt, data) {
+        (true, Some(&(_, off, len))) => {
+            let data_end = (off as u64).saturating_add(len);
+            if data_end > file_len || data_end > form_end {
+                return Err(FormatError::Malformed);
+            }
+            Ok(WavBounds { audio_offset: off as u64, audio_length: len })
+        }
+        _ => Err(FormatError::NotWav),
+    }
+}
+```
+
+(The `has_fmt`/`data` presence check stays first, so a missing `fmt ` still returns `NotWav` before any geometry check — preserving `locate_audio_at_ceiling_requires_fmt_chunk`.)
+
+- [ ] **Step 6: Fix the `wav_front` fixture and the `riff_wave_start` unit test**
+
+`wav_front` writes a zero RIFF size; give it a valid one. The front is 44 bytes (RIFF+size+WAVE + 24-byte `fmt ` chunk + 8-byte `data` header), so the form covers `WAVE`(4) + `fmt ` chunk(24) + `data` header(8) + payload(`data_len`) = `36 + data_len`:
+
+```rust
+    let mut v = b"RIFF".to_vec();
+    let riff_size = 36u32 + u32::try_from(data_len).unwrap(); // form: WAVE + fmt + data hdr + payload
+    v.extend_from_slice(&riff_size.to_le_bytes());
+    v.extend_from_slice(b"WAVE");
+    v.extend_from_slice(&body);
+    v
+```
+
+`riff_wave_start_accepts_exactly_twelve_bytes` asserts the old `Ok(12)`; update to the new tuple (riff_size = 0 → form_end = 8):
+
+```rust
+    assert_eq!(riff_wave_start(&buf), Ok((12, 8)));
+```
+
+- [ ] **Step 7: Run the full format suite**
+
+Run: `cargo test -p musefs-format`
+Expected: PASS. Verify in particular: `locate_audio_at_ceiling_trusts_data_header_without_payload` and `_accepts_data_shorter_than_file` (now valid form size), `_rejects_data_running_past_file` (still `Malformed`, now also caught by `form_end > file_len`), `_requires_fmt_chunk` (still `NotWav`), `walk_chunks_advances_past_each_payload`, and `read_structure` callers compile.
+
+- [ ] **Step 8: Update WAV docs**
+
+In `docs/WAV.md`, document RIFF form-size enforcement (chunks must lie within `8 + riff_size`, which must not exceed the file) and the known limitation: streaming/concatenated WAVs that write `riff_size = 0` or `0xFFFFFFFF` are rejected (skipped from the virtual tree, never modified); allowing those sentinels is a deferred follow-up.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/parser-strictness
+cargo fmt
+git add musefs-format/src/wav.rs docs/WAV.md
+git commit -m "$(cat <<'EOF'
+fix(wav): enforce the RIFF form size before accepting chunk bounds (#299)
+
+riff_wave_start now parses the RIFF size and returns form_end = 8 +
+riff_size; locate_audio and locate_audio_at_ceiling reject a form that
+exceeds the file or ends before the data chunk. Streaming-sentinel sizes
+(0 / 0xFFFFFFFF) are rejected as a documented known limitation.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Ogg sequence-number wrap (#298)
+
+**Files:**
+- Modify: `musefs-core/src/ogg_index.rs` (`serve_ogg_window`, tests module)
+
+**Background:** `serve_ogg_window` patches each backing page's sequence with `u32::try_from(i64::from(old_seq) + seq_delta)`, which errors when the result leaves the `u32` range — a read-path availability bug for files with high (or, with a negative delta, low) page sequence numbers. Ogg's `page_sequence_number` is a `u32` that wraps naturally; the reference helper `new_reference_region` already uses `wrapping_add`.
+
+- [ ] **Step 1: Write the failing wrap-boundary test**
+
+Add to the `tests` module in `musefs-core/src/ogg_index.rs`. `lace_packet_pub(serial, seq, bos, granule, payload)` builds a single Ogg page (used elsewhere in this module's tests); place the page at audio offset 16 as the other fixtures do.
+
+```rust
+#[test]
+fn serve_ogg_window_wraps_seq_past_u32_max() {
+    use musefs_format::ogg::{parse_page, patch_page_header};
+    // A single audio page whose sequence number is u32::MAX. With seq_delta = +1
+    // the patched sequence must wrap to 0, not fail the read.
+    let payload = vec![0x5Au8; 300];
+    let (page, _) = lace_packet_pub(0x1234, u32::MAX, false, 0, &payload);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wrap.ogg");
+    let mut file = vec![0u8; 16];
+    file.extend_from_slice(&page);
+    std::fs::File::create(&path).unwrap().write_all(&file).unwrap();
+
+    let ao = 16u64;
+    let alen = page.len() as u64;
+    let backing = std::fs::File::open(&path).unwrap();
+    let mut out = Vec::new();
+    serve_ogg_window(&backing, ao, alen, 1, 0, alen, &mut out, None).unwrap();
+
+    // The served page header must carry the wrapped sequence (u32::MAX + 1 == 0).
+    let want = patch_page_header(&page[..parse_page(&page, 0).unwrap().total_len()], 0).unwrap();
+    assert_eq!(&out[..want.len()], &want[..]);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p musefs-core serve_ogg_window_wraps_seq_past_u32_max`
+Expected: FAIL — the current `u32::try_from(...)` returns `Err(Malformed)` for `u32::MAX + 1`, so `serve_ogg_window` returns an error and `.unwrap()` panics.
+
+- [ ] **Step 3: Switch to wrapping arithmetic**
+
+In `serve_ogg_window`, replace the checked conversion:
+
+```rust
+            let old_seq = u32::from_le_bytes(hdr_buf[18..22].try_into().unwrap());
+            let new_seq = old_seq.wrapping_add(seq_delta as u32);
+            patch_page_header_algebraic(&hdr_buf[..header_len], new_seq)?
+```
+
+(`seq_delta as u32` is `seq_delta mod 2³²`, so `old_seq.wrapping_add(seq_delta as u32)` equals `(old_seq + seq_delta) mod 2³²` for both positive and negative deltas. CRC patching already runs over `new_seq`, so the emitted bytes stay consistent.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p musefs-core serve_ogg_window_wraps_seq_past_u32_max`
+Expected: PASS.
+
+- [ ] **Step 5: Run the Ogg core suite**
+
+Run: `cargo test -p musefs-core ogg`
+Expected: PASS, including `serve_ogg_window_whole_region_matches_reference` (ordinary `seq_delta = 2`, still matches `new_reference_region`'s `wrapping_add(2)`).
+
+- [ ] **Step 6: Update Ogg docs**
+
+In `docs/OGG.md`, add to the page-renumbering section: synthesized page sequence numbers wrap modulo 2³² (matching Ogg's `u32` sequence field), so files whose audio pages have very high sequence numbers serve correctly rather than failing the read.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/parser-strictness
+cargo fmt
+git add musefs-core/src/ogg_index.rs docs/OGG.md
+git commit -m "$(cat <<'EOF'
+fix(ogg): wrap page sequence renumbering mod 2^32 (#298)
+
+serve_ogg_window patched seq with a checked conversion that failed reads
+when old_seq + seq_delta left the u32 range. Use wrapping_add so high
+(or, with a negative delta, low) sequence numbers wrap like Ogg's native
+u32 field instead of making the file unreadable.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Final cross-cutting verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full workspace test run**
+
+Run: `cargo test`
+Expected: PASS across all crates.
+
+- [ ] **Step 2: Clippy and fmt gates**
+
+Run: `cargo clippy --all-targets && cargo fmt --all --check`
+Expected: no warnings; fmt clean (check exit status directly).
+
+- [ ] **Step 3: Fuzz crate build check**
+
+The fuzz crate is outside the workspace and uses format-layer APIs. No public signatures changed (`riff_wave_start` is private; `locate_audio`/`synthesize_layout` signatures are unchanged), but confirm:
+Run: `cargo +nightly fuzz build flac ; cargo +nightly fuzz build mp3 ; cargo +nightly fuzz build wav ; cargo +nightly fuzz build ogg`
+Expected: builds succeed. (If any target now exercises the stricter parser and a corpus seed is a malformed file the parser used to accept, that seed simply returns `Err` — not a build break.)
+
+- [ ] **Step 4: Confirm the four commits are present and the tree is clean**
+
+Run: `git log --oneline -5 && git status`
+Expected: the four `fix(...)` commits (#295, #296, #299, #298) on top of the design-doc commits; clean working tree.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** #295 → Task 1 (scan via `parse_blocks`/`read_metadata_bounded`, synth via `synthesize_layout`); #296 → Task 2 (shared `id3v2_header_len` across both locators + `id3v2_alloc_safe`); #298 → Task 4 (`wrapping_add`); #299 → Task 3 (`form_end` enforcement in both locators). Docs for all four formats covered in their tasks.
+- **MP3 decision honored:** the locator validates only version + synchsafe size bytes; unsync/extended-header flag rejection stays in `id3v2_alloc_safe`, not pushed into the locator.
+- **Ordering hazard handled:** the FLAC synth STREAMINFO check runs before the `TooLarge` guards (Task 1 Step 6), and Task 1 Step 8 updates exactly the four `&[]`-structural boundary tests it affects.
+- **Type consistency:** `riff_wave_start` returns `(usize, u64)` everywhere (Task 3 Steps 3–5); `id3v2_header_len` returns `Result<Option<usize>>` and all three callers handle `Ok(None)`/`Err` (Task 2 Steps 4–6).

--- a/docs/superpowers/specs/2026-06-12-parser-strictness-design.md
+++ b/docs/superpowers/specs/2026-06-12-parser-strictness-design.md
@@ -1,0 +1,253 @@
+# Parser strictness hardening (#295 #296 #298 #299)
+
+## Summary
+
+Four independent parser-strictness fixes in `musefs-format` (one touching
+`musefs-core` read-path math), all from the same adversarial audit. Each parser
+currently accepts malformed *container geometry* that should fail closed with a
+controlled `FormatError`, and three of them also accept hostile DB-sourced
+structural data at synthesis time. The cardinal invariant is unaffected
+throughout: no change copies or mutates backing audio bytes — these fixes only
+turn "silently accept malformed geometry" into "reject with a controlled error",
+plus one read-path availability fix.
+
+- **#295 FLAC** — validate STREAMINFO structure at scan and synthesis.
+- **#296 MP3** — validate the ID3v2 header in the audio locator.
+- **#298 Ogg** — wrap page sequence renumbering mod 2³² instead of failing reads.
+- **#299 WAV** — enforce the RIFF form size before accepting chunk bounds.
+
+### Threat model
+
+Per `SECURITY.md`, the threat surface is parsing untrusted media *and* a crafted
+database (`--db` is trusted "only as far as the documented contract"). So both
+surfaces are in scope:
+
+- **Scan-time**: a crafted `.flac`/`.mp3`/`.wav`/`.ogg` file must fail with a
+  controlled `FormatError`, not scan into the store with malformed geometry.
+- **Synthesis-time**: hostile structural rows from a crafted DB must be rejected
+  by `synthesize_layout` rather than emitted into output a downstream decoder
+  rejects. (Confirmed: emitting bad structural rows cannot mutate audio bytes —
+  the served audio is still a positioned read — so this is defense-in-depth that
+  returns a controlled error instead of decoder-rejected output.)
+
+### Approach
+
+Per-format inline hardening: add the validation directly inside each format
+module, with a small shared helper *within* a module where its scan and synthesis
+paths overlap. No cross-format abstraction — FLAC metadata blocks, ID3 frames,
+RIFF chunks, and Ogg pages share a theme but no structure, so a common
+"container validator" would be a forced fit. One commit per issue, each green
+(the pre-commit hook runs the full workspace test suite).
+
+---
+
+## #295 — FLAC STREAMINFO validation
+
+### Current state
+
+`parse_blocks` (`musefs-format/src/flac.rs:37`) and its bounded twin
+`read_metadata_bounded` (`:83`) walk metadata blocks until the first last-block
+flag, recording `STREAMINFO`/`APPLICATION`/`SEEKTABLE`/`CUESHEET` bodies. Neither
+enforces the FLAC structural rule that STREAMINFO is the first metadata block,
+appears exactly once, and has a 34-byte body. `synthesize_layout` (`:235`) sorts
+stored structural blocks by type and emits them before the regenerated
+VORBIS_COMMENT, assuming the rows describe a valid FLAC front — but neither
+scanner rows nor hostile DB rows are required to contain exactly one valid
+STREAMINFO. It is invoked with DB-loaded `&structural` at
+`musefs-core/src/reader.rs:208`.
+
+Two existing unit tests intentionally characterize the laxness:
+`parse_blocks_accepts_header_flush_with_end` (accepts a single empty STREAMINFO)
+and `bounded_is_last_flag_continues_past_nonlast_block` (accepts two STREAMINFO).
+
+### Change
+
+Add a shared structural-validation check used by both `parse_blocks` and
+`read_metadata_bounded`. The FLAC structural rule to enforce:
+
+1. The **first** metadata block must be `STREAMINFO`.
+2. STREAMINFO appears **exactly once**.
+3. Its body length is **exactly 34** bytes.
+
+Any violation → `FormatError::Malformed` (the `fLaC` marker is present; the
+structure is malformed). In `read_metadata_bounded`, the first block's
+header+body may not yet be in the prefix — return `NeedMore { up_to }` as today
+until enough bytes are present to validate, then apply the check.
+
+In `synthesize_layout`, reject any `structural` slice that does not contain
+exactly one STREAMINFO with a 34-byte body → `FormatError::Malformed`. After the
+existing `sort_by_key(block_type)`, STREAMINFO (type 0) sorts to index 0, so a
+valid slice always emits STREAMINFO first. (APPLICATION/CUESHEET continue to ride
+through `binary_tags`, not `structural`; SEEKTABLE remains allowed in
+`structural`.)
+
+### Test churn
+
+- Flip `parse_blocks_accepts_header_flush_with_end` and
+  `bounded_is_last_flag_continues_past_nonlast_block` to expect
+  `FormatError::Malformed`.
+- Update synthesis unit/integration tests that pass empty or STREAMINFO-less
+  `structural` (e.g. the `synthesize_layout(&[], …)` boundary tests in
+  `flac.rs` tests, and any in `roundtrip.rs`/`synthesize_art.rs`/
+  `synthesize_tags.rs` that rely on the lax path) to pass a valid 34-byte
+  STREAMINFO block.
+
+### New tests (from the audit)
+
+- `locate_audio` rejects `fLaC` + last PADDING/VORBIS_COMMENT with no STREAMINFO.
+- `locate_audio` rejects a STREAMINFO whose body length is not 34.
+- `locate_audio` and `read_metadata_bounded` reject duplicate STREAMINFO.
+- `synthesize_layout` rejects hostile structural input lacking a valid
+  STREAMINFO (crafted-DB path).
+
+---
+
+## #296 — MP3 ID3v2 header validation in the locator
+
+### Current state
+
+`locate_audio` (`musefs-format/src/mp3.rs:26`) and `locate_audio_bounded` (`:66`)
+use a lightweight ID3v2 skip: they `synchsafe_decode` the size bytes (masking the
+high bit of each), honor the footer flag, and never validate the ID3 major
+version or reject high-bit size bytes. The stricter `id3v2_alloc_safe` (`:416`)
+rejects exactly those shapes. The divergence lets a malformed ID3-looking header
+(`ID3 04 00 00 00 00 00 80`) mask-decode to `audio_offset = 10`; if bytes 10–11
+satisfy the MPEG sync check the file scans as MP3 with an audio window starting
+inside malformed metadata.
+
+### Change
+
+Extract a shared ID3v2 header validator used by `locate_audio`,
+`locate_audio_bounded`, and the header decode in `id3v2_alloc_safe`. Given the
+10-byte header it requires:
+
+1. `ID3` magic.
+2. Major version in `2..=4`.
+3. High-bit-clear synchsafe size bytes (`data[6..10]`, each `< 0x80`).
+
+On success it returns the decoded tag length (the locators add the 10-byte footer
+when the footer flag is set, as today); on violation the locators return
+`FormatError::Malformed`.
+
+**Decided:** the locator does **not** reject unsynchronization or extended-header
+flags. The declared tag size already accounts for an extended header, and
+unsynchronization only affects frame *content*, not the size field — so neither
+shifts the audio offset, and rejecting them would gratuitously fail *valid*
+MP3s. `id3v2_alloc_safe` keeps its stricter skip-for-OOM behavior (those files
+still scan as MP3 but lose scan-time tag extraction, which is the existing,
+intentional behavior; tags come from the DB).
+
+### New tests (from the audit)
+
+- `locate_audio` and `locate_audio_bounded` reject high-bit size bytes even when
+  the masked offset lands on `0xff, 0xfb`.
+- `locate_audio` rejects unsupported ID3 major versions at offset 0.
+
+---
+
+## #298 — Ogg page sequence-number wrap
+
+### Current state
+
+`ogg::synthesize_layout` (`musefs-format/src/ogg/mod.rs:249`) computes
+`seq_delta = synth_header_pages − orig_header_pages`. At read time
+`serve_ogg_window` (`musefs-core/src/ogg_index.rs:134`) applies it with checked
+signed arithmetic:
+
+```rust
+let new_seq = u32::try_from(i64::from(old_seq) + seq_delta)
+    .map_err(|_| musefs_format::FormatError::Malformed)?;
+```
+
+A valid-or-crafted file whose first audio pages have high sequence numbers reads
+fine until a positive `seq_delta` pushes a page over `u32::MAX`, at which point
+reads fail — a read-path availability bug. The local reference helper at
+`ogg_index.rs:430` already uses `wrapping_add`.
+
+### Change
+
+Wrap mod 2³² (Ogg's `page_sequence_number` is a `u32` that naturally wraps in
+long streams; decoders use it only for gap detection):
+
+```rust
+let new_seq = old_seq.wrapping_add(seq_delta as u32);
+```
+
+`(a + d) mod 2³² == (a + (d mod 2³²)) mod 2³²`, and `seq_delta as u32` is
+`d mod 2³²`, so this is the correct wrapped value for both positive and negative
+deltas. CRC patching already runs over `new_seq`, so it stays consistent with the
+emitted header bytes. Document the wrap in `docs/OGG.md`.
+
+### New tests (from the audit)
+
+- First audio page `seq = u32::MAX` with `seq_delta = +1` wraps to `0` and reads
+  succeed.
+- Corresponding low-sequence / negative-delta case wraps and reads succeed.
+- Boundary regression comparing `serve_ogg_window` output against a full-page
+  wrapping oracle.
+
+---
+
+## #299 — WAV RIFF form-size enforcement
+
+### Current state
+
+`riff_wave_start` (`musefs-format/src/wav.rs:21`) validates only the `RIFF`/`WAVE`
+magic and ignores the size field at bytes 4..8. `walk_chunks` (`:31`) walks to the
+physical buffer length, not the declared form end. `locate_audio` (`:67`) and
+`locate_audio_at_ceiling` (`:99`) accept the first in-bounds `data` chunk
+regardless of the declared form size. A crafted WAV can declare a form size that
+ends before `data`, or larger than the file, and still be ingested. The ceiling
+fixture documents this by writing a zero RIFF size (`// size field unused by the
+walk`).
+
+### Change
+
+- `riff_wave_start` parses the RIFF size (`u32` LE at bytes 4..8) and exposes the
+  declared `form_end = 8 + riff_size` to callers (e.g. return
+  `(start, form_end)`).
+- `walk_chunks` walks chunks only within `min(form_end, buf.len())`.
+- `locate_audio` (full file present): reject when `form_end > buf.len()` or when
+  the `data` chunk's end exceeds `form_end` → `FormatError::Malformed`.
+- `locate_audio_at_ceiling` (file past probe budget): validate the declared RIFF
+  size against `file_len` — reject when `form_end > file_len` or the `data` end
+  exceeds `form_end`. It stays best-effort only about losing trailing metadata,
+  not about container geometry.
+- Update the ceiling-probe fixture to write a valid RIFF size.
+
+**Known limitation (accepted, documented):** strict enforcement rejects streaming
+or concatenated WAVs that write `riff_size = 0` or `0xFFFFFFFF` as a placeholder.
+These are rare in a curated music library — finished WAVs from CD rippers
+(EAC, dBpoweramp, XLD) and DAW exports patch the real size; the sentinel pattern
+comes from live capture to a pipe or files truncated mid-write, which rarely
+land in a library and are usually malformed when they do. Rejection is graceful
+(the file is skipped from the virtual tree, never touched; re-encoding fixes it).
+If a real user hits this, allowing the two sentinels is a trivial follow-up.
+
+### New tests (from the audit)
+
+- A RIFF header whose declared size ends before `data` is rejected.
+- A RIFF header whose declared size exceeds the physical file length is rejected.
+- A correctly sized RIFF with odd-size chunks and trailing metadata still parses.
+- The ceiling-probe fixture uses a valid RIFF size (or explicitly tests the chosen
+  best-effort exception).
+
+---
+
+## Documentation
+
+- `docs/FLAC.md`: note that the synthesized front requires exactly one 34-byte
+  STREAMINFO first, and that malformed STREAMINFO is rejected at scan/synthesis.
+- `docs/MP3.md`: clarify the ID3v2 audio-boundary contract (locator validates
+  version + synchsafe size; unsync/extended-header tags still scan).
+- `docs/OGG.md`: document that page sequence numbers wrap mod 2³².
+- `docs/WAV.md`: document RIFF form-size enforcement and the streaming-sentinel
+  known limitation.
+
+## Out of scope
+
+- Re-validating files already scanned under the lax rules — the freshness path
+  re-probes on change; no forced re-scan.
+- The `0`/`0xFFFFFFFF` RIFF-size carve-out (deferred per above).
+- Findings already tracked elsewhere (#266 Ogg art materialization, #267
+  unbounded text tags, #274 aggregate length math).

--- a/docs/superpowers/specs/2026-06-12-parser-strictness-design.md
+++ b/docs/superpowers/specs/2026-06-12-parser-strictness-design.md
@@ -45,16 +45,24 @@ RIFF chunks, and Ogg pages share a theme but no structure, so a common
 
 ### Current state
 
-`parse_blocks` (`musefs-format/src/flac.rs:37`) and its bounded twin
-`read_metadata_bounded` (`:83`) walk metadata blocks until the first last-block
-flag, recording `STREAMINFO`/`APPLICATION`/`SEEKTABLE`/`CUESHEET` bodies. Neither
+(Code is referenced by function + file; the codebase moves and line numbers go
+stale, so they are omitted deliberately.)
+
+`parse_blocks` (`musefs-format/src/flac.rs`) and its bounded twin
+`read_metadata_bounded` walk metadata blocks until the first last-block flag,
+recording `STREAMINFO`/`APPLICATION`/`SEEKTABLE`/`CUESHEET` bodies. Neither
 enforces the FLAC structural rule that STREAMINFO is the first metadata block,
-appears exactly once, and has a 34-byte body. `synthesize_layout` (`:235`) sorts
-stored structural blocks by type and emits them before the regenerated
+appears exactly once, and has a 34-byte body. `synthesize_layout` sorts stored
+structural blocks by type (`sort_by_key(block_type)`; `BLOCK_STREAMINFO == 0`, so
+STREAMINFO sorts to index 0) and emits them before the regenerated
 VORBIS_COMMENT, assuming the rows describe a valid FLAC front — but neither
 scanner rows nor hostile DB rows are required to contain exactly one valid
-STREAMINFO. It is invoked with DB-loaded `&structural` at
-`musefs-core/src/reader.rs:208`.
+STREAMINFO.
+
+`synthesize_layout` is invoked from `musefs-core/src/reader.rs` (`HeaderCache::build`)
+with structural data from one of two sources: DB rows filtered through
+`flac::structural_block_type` (the crafted-DB surface), or — when no structural
+rows exist — a fallback re-read `flac::read_metadata(&front)?.preserved`.
 
 Two existing unit tests intentionally characterize the laxness:
 `parse_blocks_accepts_header_flush_with_end` (accepts a single empty STREAMINFO)
@@ -75,22 +83,39 @@ header+body may not yet be in the prefix — return `NeedMore { up_to }` as toda
 until enough bytes are present to validate, then apply the check.
 
 In `synthesize_layout`, reject any `structural` slice that does not contain
-exactly one STREAMINFO with a 34-byte body → `FormatError::Malformed`. After the
-existing `sort_by_key(block_type)`, STREAMINFO (type 0) sorts to index 0, so a
-valid slice always emits STREAMINFO first. (APPLICATION/CUESHEET continue to ride
-through `binary_tags`, not `structural`; SEEKTABLE remains allowed in
-`structural`.)
+exactly one STREAMINFO with a 34-byte body → `FormatError::Malformed`. This check
+runs **first**, before the existing `TooLarge` size guards (validate inputs
+before doing size arithmetic). APPLICATION/CUESHEET continue to ride through
+`binary_tags`, not `structural`; SEEKTABLE remains allowed in `structural`.
+
+Consequence of the fallback re-read: because `read_metadata` → `parse_blocks`
+now enforces the rule, a file scanned under the old lax rules with malformed
+STREAMINFO and *no* structural DB rows will fail at serve time via the
+`reader.rs` fallback (`Err(Malformed)` propagates out of `HeaderCache::build`).
+This is intended — serving decoder-rejected FLAC is worse than a controlled
+failure — and is distinct from the "no forced re-scan" out-of-scope item (that
+concerns the scanner, not this serve-time re-parse).
 
 ### Test churn
 
 - Flip `parse_blocks_accepts_header_flush_with_end` and
   `bounded_is_last_flag_continues_past_nonlast_block` to expect
   `FormatError::Malformed`.
-- Update synthesis unit/integration tests that pass empty or STREAMINFO-less
-  `structural` (e.g. the `synthesize_layout(&[], …)` boundary tests in
-  `flac.rs` tests, and any in `roundtrip.rs`/`synthesize_art.rs`/
-  `synthesize_tags.rs` that rely on the lax path) to pass a valid 34-byte
-  STREAMINFO block.
+- **Ordering hazard — these pass `&[]` (STREAMINFO-less) `structural` and expect
+  `TooLarge`; with the new check running first they now return `Malformed`, so
+  each must be updated to pass a valid 34-byte STREAMINFO block:**
+  - `flac.rs` unit tests `synthesize_layout_picture_block_size_boundary_is_inclusive`,
+    `synthesize_layout_vorbis_comment_block_size_boundary_is_inclusive`,
+    `synthesize_layout_binary_tag_block_size_boundary_is_inclusive`,
+    `synthesize_layout_checked_picture_len_rejects_overflow`.
+  - `synthesize_art.rs::synthesize_errors_on_oversized_picture`
+    (`synthesize_layout(&[], …, &[art])` expecting `TooLarge`).
+- `roundtrip.rs`/`synthesize_art.rs`/`synthesize_tags.rs` tests that build
+  structural via `streaminfo_body()` (a valid 34-byte body) already pass a valid
+  STREAMINFO and stay green — do not "fix" them.
+- `proptest_flac.rs` stays green: it feeds `synthesize_layout` only the output of
+  a successful `locate_audio` on `fixtures::flac()`, which emits a valid 34-byte
+  STREAMINFO first; the new `parse_blocks` rule accepts that fixture unchanged.
 
 ### New tests (from the audit)
 
@@ -106,20 +131,23 @@ through `binary_tags`, not `structural`; SEEKTABLE remains allowed in
 
 ### Current state
 
-`locate_audio` (`musefs-format/src/mp3.rs:26`) and `locate_audio_bounded` (`:66`)
-use a lightweight ID3v2 skip: they `synchsafe_decode` the size bytes (masking the
-high bit of each), honor the footer flag, and never validate the ID3 major
-version or reject high-bit size bytes. The stricter `id3v2_alloc_safe` (`:416`)
-rejects exactly those shapes. The divergence lets a malformed ID3-looking header
-(`ID3 04 00 00 00 00 00 80`) mask-decode to `audio_offset = 10`; if bytes 10–11
-satisfy the MPEG sync check the file scans as MP3 with an audio window starting
-inside malformed metadata.
+`locate_audio` and `locate_audio_bounded` (`musefs-format/src/mp3.rs`) use a
+lightweight ID3v2 skip: they `synchsafe_decode` the size bytes (masking the high
+bit of each), honor the footer flag, and never validate the ID3 major version or
+reject high-bit size bytes. The stricter `id3v2_alloc_safe` rejects exactly those
+shapes (its `data[6] | data[7] | data[8] | data[9] >= 0x80` guard). The
+divergence lets a malformed ID3-looking 10-byte header
+(`49 44 33 04 00 00 00 00 00 80` — `"ID3"`, version 4, flags 0, size bytes
+`00 00 00 80` with the high bit set in the last byte) mask-decode to
+`audio_offset = 10`; if bytes 10–11 satisfy the MPEG sync check (`0xff`,
+`0xfb`) the file scans as MP3 with an audio window starting inside malformed
+metadata.
 
 ### Change
 
-Extract a shared ID3v2 header validator used by `locate_audio`,
-`locate_audio_bounded`, and the header decode in `id3v2_alloc_safe`. Given the
-10-byte header it requires:
+Extract a shared ID3v2 header validator — the **intersection** of the three
+checks, *not* a wholesale extraction of `id3v2_alloc_safe`. Given the 10-byte
+header it requires:
 
 1. `ID3` magic.
 2. Major version in `2..=4`.
@@ -127,7 +155,10 @@ Extract a shared ID3v2 header validator used by `locate_audio`,
 
 On success it returns the decoded tag length (the locators add the 10-byte footer
 when the footer flag is set, as today); on violation the locators return
-`FormatError::Malformed`.
+`FormatError::Malformed`. `id3v2_alloc_safe` calls this helper for the header
+portion and keeps its additional, stricter checks layered on top
+(extended-header/unsync flag rejection, frame walking) — the plan must not push
+those flag checks down into the locator (see Decided, below).
 
 **Decided:** the locator does **not** reject unsynchronization or extended-header
 flags. The declared tag size already accounts for an extended header, and
@@ -149,10 +180,10 @@ intentional behavior; tags come from the DB).
 
 ### Current state
 
-`ogg::synthesize_layout` (`musefs-format/src/ogg/mod.rs:249`) computes
-`seq_delta = synth_header_pages − orig_header_pages`. At read time
-`serve_ogg_window` (`musefs-core/src/ogg_index.rs:134`) applies it with checked
-signed arithmetic:
+`ogg::synthesize_layout` (`musefs-format/src/ogg/mod.rs`) computes
+`seq_delta = i64::from(seq) - i64::from(header.header_pages)` (synthesized header
+page count minus original header page count). At read time `serve_ogg_window`
+(`musefs-core/src/ogg_index.rs`) applies it with checked signed arithmetic:
 
 ```rust
 let new_seq = u32::try_from(i64::from(old_seq) + seq_delta)
@@ -161,8 +192,8 @@ let new_seq = u32::try_from(i64::from(old_seq) + seq_delta)
 
 A valid-or-crafted file whose first audio pages have high sequence numbers reads
 fine until a positive `seq_delta` pushes a page over `u32::MAX`, at which point
-reads fail — a read-path availability bug. The local reference helper at
-`ogg_index.rs:430` already uses `wrapping_add`.
+reads fail — a read-path availability bug. The local reference helper
+(`new_reference_region`) already uses `wrapping_add`.
 
 ### Change
 
@@ -182,9 +213,13 @@ emitted header bytes. Document the wrap in `docs/OGG.md`.
 
 - First audio page `seq = u32::MAX` with `seq_delta = +1` wraps to `0` and reads
   succeed.
-- Corresponding low-sequence / negative-delta case wraps and reads succeed.
-- Boundary regression comparing `serve_ogg_window` output against a full-page
-  wrapping oracle.
+- Corresponding low-sequence / negative-delta case (e.g. `seq = 0`,
+  `seq_delta = -1` → wraps to `u32::MAX`) wraps and reads succeed.
+- A regression that specifically crosses the `u32::MAX` boundary and compares
+  `serve_ogg_window` output to a wrapping oracle. (The existing
+  `serve_ogg_window_whole_region_matches_reference` already compares against
+  `new_reference_region` for ordinary deltas; the new test must exercise the
+  *wrap*, not just any delta.)
 
 ---
 
@@ -192,20 +227,22 @@ emitted header bytes. Document the wrap in `docs/OGG.md`.
 
 ### Current state
 
-`riff_wave_start` (`musefs-format/src/wav.rs:21`) validates only the `RIFF`/`WAVE`
-magic and ignores the size field at bytes 4..8. `walk_chunks` (`:31`) walks to the
-physical buffer length, not the declared form end. `locate_audio` (`:67`) and
-`locate_audio_at_ceiling` (`:99`) accept the first in-bounds `data` chunk
-regardless of the declared form size. A crafted WAV can declare a form size that
-ends before `data`, or larger than the file, and still be ingested. The ceiling
-fixture documents this by writing a zero RIFF size (`// size field unused by the
-walk`).
+`riff_wave_start` (`musefs-format/src/wav.rs`) validates only the `RIFF`/`WAVE`
+magic and ignores the size field at bytes 4..8. `walk_chunks` walks to the
+physical buffer length, not the declared form end. `locate_audio` and
+`locate_audio_at_ceiling` accept the first in-bounds `data` chunk regardless of
+the declared form size. A crafted WAV can declare a form size that ends before
+`data`, or larger than the file, and still be ingested. The ceiling fixture
+documents this by writing a zero RIFF size (`// size field unused by the walk`).
 
 ### Change
 
 - `riff_wave_start` parses the RIFF size (`u32` LE at bytes 4..8) and exposes the
   declared `form_end = 8 + riff_size` to callers (e.g. return
-  `(start, form_end)`).
+  `(start, form_end)`). This signature change touches every caller —
+  `walk_chunks`, `locate_audio`, `locate_audio_at_ceiling`, and `read_structure`
+  (which currently calls `riff_wave_start(front)?` and discards the result; it
+  must be updated to compile even though it ignores `form_end`).
 - `walk_chunks` walks chunks only within `min(form_end, buf.len())`.
 - `locate_audio` (full file present): reject when `form_end > buf.len()` or when
   the `data` chunk's end exceeds `form_end` → `FormatError::Malformed`.
@@ -220,9 +257,11 @@ or concatenated WAVs that write `riff_size = 0` or `0xFFFFFFFF` as a placeholder
 These are rare in a curated music library — finished WAVs from CD rippers
 (EAC, dBpoweramp, XLD) and DAW exports patch the real size; the sentinel pattern
 comes from live capture to a pipe or files truncated mid-write, which rarely
-land in a library and are usually malformed when they do. Rejection is graceful
-(the file is skipped from the virtual tree, never touched; re-encoding fixes it).
-If a real user hits this, allowing the two sentinels is a trivial follow-up.
+land in a library and are usually malformed when they do. Rejection is graceful:
+the scanner calls `locate_audio(bytes).ok()?` (in `scan.rs`'s `detect` helpers),
+so an `Err(Malformed)` becomes "not recognized as WAV" → the file is skipped from
+the virtual tree, never touched; re-encoding fixes it. If a real user hits this,
+allowing the two sentinels is a trivial follow-up.
 
 ### New tests (from the audit)
 

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -197,8 +197,8 @@ pub fn serve_ogg_window(
             h
         } else {
             let old_seq = u32::from_le_bytes(hdr_buf[18..22].try_into().unwrap());
-            let new_seq = u32::try_from(i64::from(old_seq) + seq_delta)
-                .map_err(|_| musefs_format::FormatError::Malformed)?;
+            #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let new_seq = old_seq.wrapping_add(seq_delta as u32);
             patch_page_header_algebraic(&hdr_buf[..header_len], new_seq)?
         };
         if let Some(m) = memo {
@@ -838,5 +838,35 @@ mod tests {
             find_page_start(&backing, 0, data.len() as u64, None).unwrap(),
             0
         );
+    }
+
+    #[test]
+    fn serve_ogg_window_wraps_seq_past_u32_max() {
+        use musefs_format::ogg::{parse_page, patch_page_header};
+        // A single audio page whose sequence number is u32::MAX. With seq_delta = +1
+        // the patched sequence must wrap to 0, not fail the read.
+        let payload = vec![0x5Au8; 300];
+        let (page, _) = lace_packet_pub(0x1234, u32::MAX, false, 0, &payload);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wrap.ogg");
+        let mut file = vec![0u8; 16];
+        file.extend_from_slice(&page);
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&file)
+            .unwrap();
+
+        let ao = 16u64;
+        let alen = page.len() as u64;
+        let backing = std::fs::File::open(&path).unwrap();
+        let mut out = Vec::new();
+        serve_ogg_window(&backing, ao, alen, 1, 0, alen, &mut out, None).unwrap();
+
+        // The served region must be the page with its sequence wrapped (u32::MAX + 1 == 0):
+        // patched header followed by the original payload bytes.
+        let h = parse_page(&page, 0).unwrap();
+        let mut want = patch_page_header(&page[..h.total_len()], 0).unwrap();
+        want.extend_from_slice(&page[h.header_len..h.total_len()]);
+        assert_eq!(out, want);
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -2331,8 +2331,9 @@ mod bounded_probe_tests {
         fmt.extend_from_slice(&16u16.to_le_bytes());
 
         let mut front = b"RIFF".to_vec();
-        // The RIFF size field is not validated by the chunk walk; placeholder.
-        front.extend_from_slice(&0u32.to_le_bytes());
+        // form: WAVE(4) + fmt chunk(24) + data header(8) + data payload
+        let riff_size = 36u32 + u32::try_from(data_len).unwrap();
+        front.extend_from_slice(&riff_size.to_le_bytes());
         front.extend_from_slice(b"WAVE");
         front.extend_from_slice(b"fmt ");
         front.extend_from_slice(&u32::try_from(fmt.len()).unwrap().to_le_bytes());
@@ -2368,7 +2369,9 @@ mod bounded_probe_tests {
             fmt.extend_from_slice(&v.to_le_bytes());
         }
         let mut front = b"RIFF".to_vec();
-        front.extend_from_slice(&0u32.to_le_bytes());
+        // form: WAVE(4) + fmt chunk(8+len) + data header(8) + data payload(64)
+        let riff_size = 4 + 8 + u32::try_from(fmt.len()).unwrap() + 8 + 64;
+        front.extend_from_slice(&riff_size.to_le_bytes());
         front.extend_from_slice(b"WAVE");
         front.extend_from_slice(b"fmt ");
         front.extend_from_slice(&u32::try_from(fmt.len()).unwrap().to_le_bytes());

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -40,6 +40,7 @@ fn parse_blocks(data: &[u8]) -> Result<FlacMeta> {
         return Err(FormatError::NotFlac);
     }
     let mut pos = 4usize;
+    let mut index = 0usize;
     let mut preserved = Vec::new();
     loop {
         if pos + 4 > data.len() {
@@ -54,6 +55,7 @@ fn parse_blocks(data: &[u8]) -> Result<FlacMeta> {
         if body_end > data.len() {
             return Err(FormatError::Malformed);
         }
+        check_streaminfo_position(index, block_type, len)?;
         match block_type {
             BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
                 preserved.push(MetadataBlock {
@@ -64,6 +66,7 @@ fn parse_blocks(data: &[u8]) -> Result<FlacMeta> {
             _ => {}
         }
         pos = body_end;
+        index += 1;
         if is_last {
             break;
         }
@@ -90,6 +93,7 @@ pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
         return Err(FormatError::NotFlac);
     }
     let mut pos = 4usize;
+    let mut index = 0usize;
     let mut preserved = Vec::new();
     loop {
         if pos + 4 > prefix.len() {
@@ -109,6 +113,7 @@ pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
                 up_to: body_end as u64,
             });
         }
+        check_streaminfo_position(index, block_type, len)?;
         match block_type {
             BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
                 preserved.push(MetadataBlock {
@@ -119,6 +124,7 @@ pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
             _ => {}
         }
         pos = body_end;
+        index += 1;
         if is_last {
             break;
         }
@@ -147,6 +153,26 @@ use crate::layout::{RegionLayout, Segment};
 
 /// Inclusive maximum body length of a FLAC metadata block (24-bit length field).
 pub const MAX_BLOCK_BODY: u64 = 0x00FF_FFFF;
+
+/// FLAC mandates a single STREAMINFO metadata block, first in the sequence, with
+/// a fixed 34-byte body.
+const STREAMINFO_BODY_LEN: usize = 34;
+
+/// Enforce FLAC's STREAMINFO rule for the metadata block at position `index`:
+/// the first block must be STREAMINFO with a 34-byte body, and STREAMINFO must
+/// not appear anywhere else (so it appears exactly once). Any violation is
+/// `FormatError::Malformed`.
+fn check_streaminfo_position(index: usize, block_type: u8, body_len: usize) -> Result<()> {
+    let is_streaminfo = block_type == BLOCK_STREAMINFO;
+    if index == 0 {
+        if !is_streaminfo || body_len != STREAMINFO_BODY_LEN {
+            return Err(FormatError::Malformed);
+        }
+    } else if is_streaminfo {
+        return Err(FormatError::Malformed);
+    }
+    Ok(())
+}
 
 pub(crate) fn push_block_header(
     out: &mut Vec<u8>,
@@ -246,6 +272,14 @@ pub fn synthesize_layout(
     binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<RegionLayout> {
+    let streaminfo: Vec<&MetadataBlock> = structural
+        .iter()
+        .filter(|b| b.block_type == BLOCK_STREAMINFO)
+        .collect();
+    if streaminfo.len() != 1 || streaminfo[0].body.len() != STREAMINFO_BODY_LEN {
+        return Err(FormatError::Malformed);
+    }
+
     let mut ordered: Vec<&MetadataBlock> = structural.iter().collect();
     ordered.sort_by_key(|b| b.block_type);
 
@@ -540,6 +574,59 @@ mod tests {
         f
     }
 
+    /// A structural STREAMINFO block with a valid 34-byte body, for synthesis tests.
+    fn valid_streaminfo() -> MetadataBlock {
+        MetadataBlock {
+            block_type: BLOCK_STREAMINFO,
+            body: vec![0u8; 34],
+        }
+    }
+
+    #[test]
+    fn locate_audio_rejects_missing_streaminfo() {
+        // First (and only) block is VORBIS_COMMENT, no STREAMINFO at all.
+        let file = flac_with(&[raw_block(BLOCK_VORBIS_COMMENT, &[], true, None)]);
+        assert_eq!(locate_audio(&file), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_rejects_streaminfo_wrong_body_len() {
+        // STREAMINFO present and first, but body is 10 bytes, not 34.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[0u8; 10], true, None)]);
+        assert_eq!(locate_audio(&file), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_rejects_duplicate_streaminfo() {
+        let file = flac_with(&[
+            raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None),
+            raw_block(BLOCK_STREAMINFO, &[0u8; 34], true, None),
+        ]);
+        assert_eq!(locate_audio(&file), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn read_metadata_bounded_rejects_duplicate_streaminfo() {
+        let file = flac_with(&[
+            raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None),
+            raw_block(BLOCK_STREAMINFO, &[0u8; 34], true, None),
+        ]);
+        assert_eq!(read_metadata_bounded(&file), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn synthesize_layout_rejects_structural_without_streaminfo() {
+        // Hostile DB rows: a SEEKTABLE but no STREAMINFO.
+        let structural = [MetadataBlock {
+            block_type: BLOCK_SEEKTABLE,
+            body: vec![0u8; 4],
+        }];
+        assert_eq!(
+            synthesize_layout(&structural, 0, 0, &[], &[], &[]),
+            Err(FormatError::Malformed)
+        );
+    }
+
     #[test]
     fn parse_blocks_rejects_short_and_wrong_marker() {
         // :37 `< -> ==`: 3-byte input -> original short-circuits NotFlac; the mutant
@@ -561,12 +648,12 @@ mod tests {
 
     #[test]
     fn parse_blocks_accepts_header_flush_with_end() {
-        // Single last STREAMINFO, empty body, no audio: the final header occupies the
-        // last 4 bytes, so pos+4 == data.len() at the loop guard. Original (`>`)
-        // proceeds and returns audio_offset == len; the :43 `> -> >=` mutant rejects.
-        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, None)]);
+        // Single last STREAMINFO with a valid 34-byte body, no audio: the final header
+        // still flushes at the buffer end (pos+4 == data.len() at the loop guard), so
+        // this keeps the :43 `> -> >=` mutant coverage while obeying STREAMINFO rules.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[0u8; 34], true, None)]);
         let meta = parse_blocks(&file).unwrap();
-        assert_eq!(meta.audio_offset, 8);
+        assert_eq!(meta.audio_offset, 42); // 4 marker + 4 header + 34 body
     }
 
     #[test]
@@ -766,38 +853,36 @@ mod tests {
 
     #[test]
     fn bounded_needmore_up_to_is_pos_plus_4_for_truncated_header() {
-        // Marker + a non-last STREAMINFO (empty body) then truncated: after the
-        // first block, pos = 4 + 4 + 0 = 8. The prefix ends exactly there, so the
-        // loop guard `pos + 4 > prefix.len()` fires with pos == 8.
-        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], false, None)]);
-        // file is fLaC(4) + header(4) = 8 bytes; pos lands at 8 == prefix.len().
-        assert_eq!(file.len(), 8);
+        // Marker + a non-last STREAMINFO (valid 34-byte body) then truncated: after the
+        // first block, pos = 4 + 4 + 34 = 42. The prefix ends exactly there, so the
+        // loop guard `pos + 4 > prefix.len()` fires with pos == 42.
+        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None)]);
+        // file is fLaC(4) + header(4) + body(34) = 42 bytes; pos lands at 42 == prefix.len().
+        assert_eq!(file.len(), 42);
         match read_metadata_bounded(&file).unwrap() {
             // kills flac L96 `pos + 4 > prefix.len()` `+` -> `-`: with `pos - 4`
-            // (8-4=4) the comparison 4 > 8 is false, so it would NOT return NeedMore
-            // and instead panic reading prefix[8..]. NeedMore here kills it.
-            // kills flac L99 up_to `(pos + 4)` `+` -> `-`/`*`: pos==8 -> correct
-            // up_to == 12. `pos - 4` gives 4; `pos * 4` gives 32. Exact 12 kills both.
-            Extent::NeedMore { up_to } => assert_eq!(up_to, 12),
-            other @ Extent::Complete(_) => panic!("expected NeedMore{{up_to:12}}, got {other:?}"),
+            // (42-4=38) the comparison 38 > 42 is false, so it would NOT return NeedMore
+            // and instead panic reading prefix[42..]. NeedMore here kills it.
+            // kills flac L99 up_to `(pos + 4)` `+` -> `-`/`*`: pos==42 -> correct
+            // up_to == 46. `pos - 4` gives 38; `pos * 4` gives 168. Exact 46 kills both.
+            Extent::NeedMore { up_to } => assert_eq!(up_to, 46),
+            other @ Extent::Complete(_) => panic!("expected NeedMore{{up_to:46}}, got {other:?}"),
         }
     }
 
     #[test]
     fn bounded_is_last_flag_continues_past_nonlast_block() {
-        // Two blocks: first NON-last STREAMINFO (body 0xAA*2), then a LAST
-        // STREAMINFO (body 0xBB*3) + no audio. audio_offset must span BOTH.
-        let b1 = raw_block(BLOCK_STREAMINFO, &[0xAA, 0xAA], false, None); // 4+2=6
-        let b2 = raw_block(BLOCK_STREAMINFO, &[0xBB, 0xBB, 0xBB], true, None); // 4+3=7
+        // First NON-last STREAMINFO (valid 34-byte body), then a LAST SEEKTABLE.
+        // audio_offset must span BOTH, proving we walked past the non-last block.
+        let b1 = raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None); // 4+34 = 38
+        let b2 = raw_block(BLOCK_SEEKTABLE, &[0xBB, 0xBB, 0xBB], true, None); // 4+3 = 7
         let file = flac_with(&[b1, b2]);
-        let expected_offset = (4 + 6 + 7) as u64; // marker + block1 + block2
+        let expected_offset = (4 + 38 + 7) as u64; // marker + block1 + block2
         match read_metadata_bounded(&file).unwrap() {
             Extent::Complete(meta) => {
-                // kills flac L103 `header & 0x80` `&` -> `|`: `header | 0x80` is always
-                // nonzero -> is_last always true -> it would stop after block 1 with
-                // audio_offset == 4+6 == 10. Spanning both blocks (17) kills it.
+                // kills flac `header & 0x80` `&` -> `|`: that mutant stops after block 1
+                // (audio_offset == 4+38 == 42). Spanning both blocks (49) kills it.
                 assert_eq!(meta.audio_offset, expected_offset);
-                // both STREAMINFO blocks preserved -> proves we walked past block 1.
                 assert_eq!(meta.preserved.len(), 2);
             }
             other @ Extent::NeedMore { .. } => panic!("expected Complete, got {other:?}"),
@@ -806,8 +891,8 @@ mod tests {
 
     #[test]
     fn bounded_block_type_mask_preserves_streaminfo() {
-        // A single last STREAMINFO (type 0) with a known body.
-        let body = vec![0x5A; 8];
+        // A single last STREAMINFO (type 0) with a known 34-byte body.
+        let body = vec![0x5A; 34];
         let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &body, true, None)]);
         match read_metadata_bounded(&file).unwrap() {
             Extent::Complete(meta) => {
@@ -826,13 +911,16 @@ mod tests {
 
     #[test]
     fn bounded_decodes_24bit_length_exactly() {
-        // Single last block whose declared length = 0x010203 (bytes 0x01,0x02,0x03),
-        // exercising all three length positions. Body is that many bytes so the block
-        // fits and we get a Complete with an exact audio_offset.
+        // STREAMINFO (valid, non-last) then a LAST SEEKTABLE whose declared length =
+        // 0x010203 (bytes 0x01,0x02,0x03), exercising all three length positions.
+        // Body is that many bytes so the block fits and we get a Complete with an
+        // exact audio_offset.
+        let b1 = raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None); // 4+34 = 38
         let len = 0x01_0203usize;
         let body = vec![0u8; len];
-        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &body, true, None)]);
-        let expected_offset = (4 + 4 + len) as u64;
+        let b2 = raw_block(BLOCK_SEEKTABLE, &body, true, None); // 4+len
+        let file = flac_with(&[b1, b2]);
+        let expected_offset = (4 + 38 + 4 + len) as u64;
         match read_metadata_bounded(&file).unwrap() {
             Extent::Complete(meta) => {
                 // The exact audio_offset pins all three bytes of the 24-bit length
@@ -862,11 +950,12 @@ mod tests {
 
     #[test]
     fn bounded_body_end_equal_to_prefix_is_complete() {
-        // A single LAST STREAMINFO whose body ends EXACTLY at the prefix end (no
-        // audio). body_end == prefix.len().
-        let body = vec![0xCC; 6];
-        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &body, true, None)]);
-        let total = file.len() as u64; // 4 + 4 + 6 == 14
+        // A STREAMINFO (valid 34-byte body, non-last) then a LAST SEEKTABLE whose
+        // body ends EXACTLY at the prefix end (no audio). body_end == prefix.len().
+        let b1 = raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None); // 4+34 = 38
+        let b2 = raw_block(BLOCK_SEEKTABLE, &[0xCC; 6], true, None); // 4+6 = 10
+        let file = flac_with(&[b1, b2]);
+        let total = file.len() as u64; // 4 + 38 + 10 == 52
         match read_metadata_bounded(&file).unwrap() {
             // kills flac L110 `body_end > prefix.len()` `>` -> `>=`: with `>=`,
             // body_end == prefix.len() is true -> wrongly returns NeedMore. Original
@@ -883,7 +972,7 @@ mod tests {
         // kills flac L116 (delete the STREAMINFO|APPLICATION|SEEKTABLE|CUESHEET arm):
         // a prefix containing each preserved type must yield all four in `preserved`.
         // Deleting the arm makes `preserved` empty -> these assertions fail.
-        let b_si = raw_block(BLOCK_STREAMINFO, &[0x01], false, None);
+        let b_si = raw_block(BLOCK_STREAMINFO, &[0x01; 34], false, None);
         let b_app = raw_block(BLOCK_APPLICATION, &[0x02, 0x02], false, None);
         let b_seek = raw_block(BLOCK_SEEKTABLE, &[0x03, 0x03, 0x03], false, None);
         let b_cue = raw_block(BLOCK_CUESHEET, &[0x04], true, None);
@@ -900,7 +989,7 @@ mod tests {
                         BLOCK_CUESHEET,
                     ]
                 );
-                assert_eq!(meta.preserved[0].body, vec![0x01]);
+                assert_eq!(meta.preserved[0].body, vec![0x01; 34]);
                 assert_eq!(meta.preserved[1].body, vec![0x02, 0x02]);
                 assert_eq!(meta.preserved[2].body, vec![0x03, 0x03, 0x03]);
                 assert_eq!(meta.preserved[3].body, vec![0x04]);
@@ -972,10 +1061,10 @@ mod tests {
         let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
         // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
         // (data_len is only a count; no large allocation occurs.)
-        assert!(synthesize_layout(&[], 0, 0, &[], &[], &[mk(at_limit)]).is_ok());
+        assert!(synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[], &[mk(at_limit)]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
         assert_eq!(
-            synthesize_layout(&[], 0, 0, &[], &[], &[mk(at_limit + 1)]),
+            synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[], &[mk(at_limit + 1)]),
             Err(FormatError::TooLarge)
         );
     }
@@ -992,12 +1081,12 @@ mod tests {
             .len() as u64;
         let at_limit = "x".repeat(crate::convert::usize_from(MAX_BLOCK_BODY - overhead));
         let tags = [TagInput::new("title", at_limit.as_str())];
-        assert!(synthesize_layout(&[], 0, 0, &tags, &[], &[]).is_ok());
+        assert!(synthesize_layout(&[valid_streaminfo()], 0, 0, &tags, &[], &[]).is_ok());
         // one byte over must still error, pinning the high side of the boundary.
         let over = format!("{at_limit}x");
         let tags = [TagInput::new("title", over.as_str())];
         assert_eq!(
-            synthesize_layout(&[], 0, 0, &tags, &[], &[]),
+            synthesize_layout(&[valid_streaminfo()], 0, 0, &tags, &[], &[]),
             Err(FormatError::TooLarge)
         );
     }
@@ -1017,7 +1106,7 @@ mod tests {
             data_len: BlobLen::new(data_len).unwrap(),
         };
         assert_eq!(
-            synthesize_layout(&[], 0, 0, &[], &[], &[mk(u64::MAX)]),
+            synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[], &[mk(u64::MAX)]),
             Err(FormatError::TooLarge)
         );
     }
@@ -1034,10 +1123,12 @@ mod tests {
             len: BlobLen::new(len).unwrap(),
         };
         // len == 0x00FF_FFFF exactly must succeed.
-        assert!(synthesize_layout(&[], 0, 0, &[], &[mk(0x00FF_FFFF)], &[]).is_ok());
+        assert!(
+            synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[mk(0x00FF_FFFF)], &[]).is_ok()
+        );
         // one byte over must still error, pinning the high side of the boundary.
         assert_eq!(
-            synthesize_layout(&[], 0, 0, &[], &[mk(0x0100_0000)], &[]),
+            synthesize_layout(&[valid_streaminfo()], 0, 0, &[], &[mk(0x0100_0000)], &[]),
             Err(FormatError::TooLarge)
         );
     }

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -106,6 +106,10 @@ pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
         let is_last = (header & 0x80) != 0;
         let block_type = header & 0x7F;
         let len = u24_be(prefix[pos + 1], prefix[pos + 2], prefix[pos + 3]);
+        // Header-only validation: fail closed on a bad STREAMINFO header (wrong
+        // position/length, or a duplicate) before widening the probe to read a
+        // body that can never make the file valid.
+        check_streaminfo_position(index, block_type, len)?;
         let body_start = pos + 4;
         let body_end = body_start + len;
         if body_end > prefix.len() {
@@ -113,7 +117,6 @@ pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
                 up_to: body_end as u64,
             });
         }
-        check_streaminfo_position(index, block_type, len)?;
         match block_type {
             BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
                 preserved.push(MetadataBlock {
@@ -615,6 +618,18 @@ mod tests {
     }
 
     #[test]
+    fn bounded_fails_closed_on_bad_first_header_before_widening() {
+        // First block header declares STREAMINFO with a non-34 body length, and
+        // the body is absent from the prefix. The header alone is invalid, so we
+        // must reject with Malformed immediately rather than return NeedMore and
+        // drive the prober to widen toward a body that can't make the file valid.
+        let mut prefix = b"fLaC".to_vec();
+        prefix.push(BLOCK_STREAMINFO | 0x80); // last STREAMINFO
+        prefix.extend_from_slice(&[0xFF, 0xFF, 0xFF]); // len = 0xFFFFFF, body absent
+        assert_eq!(read_metadata_bounded(&prefix), Err(FormatError::Malformed));
+    }
+
+    #[test]
     fn synthesize_layout_rejects_structural_without_streaminfo() {
         // Hostile DB rows: a SEEKTABLE but no STREAMINFO.
         let structural = [MetadataBlock {
@@ -936,13 +951,16 @@ mod tests {
     fn bounded_length_decodes_high_and_mid_bytes() {
         // Declare length 0x010100 (high byte 0x01, mid byte 0x01, low 0x00); correct
         // len = 65792. A decode that collapses the high or mid byte asks for a very
-        // different body.
+        // different body. The length-bearing block must NOT be the first one (the
+        // first must be a valid 34-byte STREAMINFO), so exercise it on a SEEKTABLE.
         // Use NeedMore: body is absent, so the correct parse asks for the full body.
-        let file = flac_with(&[raw_block(BLOCK_STREAMINFO, &[], true, Some(0x01_0100))]);
+        let b1 = raw_block(BLOCK_STREAMINFO, &[0u8; 34], false, None); // 4 + 34 = 38
+        let b2 = raw_block(BLOCK_SEEKTABLE, &[], true, Some(0x01_0100)); // declares len, body absent
+        let file = flac_with(&[b1, b2]);
         match read_metadata_bounded(&file).unwrap() {
             Extent::NeedMore { up_to } => {
-                // body_start = 4 + 4 = 8; up_to = body_end = 8 + 0x010100.
-                assert_eq!(up_to, 8 + 0x01_0100);
+                // body_start = 4 + 38 + 4 = 46; up_to = body_end = 46 + 0x010100.
+                assert_eq!(up_to, 46 + 0x01_0100);
             }
             other @ Extent::Complete(_) => panic!("expected NeedMore, got {other:?}"),
         }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -24,6 +24,29 @@ fn synchsafe_decode(b: &[u8]) -> u32 {
         | u32::from(b[3] & 0x7F)
 }
 
+/// Validate a leading ID3v2 header and return the tag length (10-byte header +
+/// declared body, *excluding* any footer), or `None` when there is no ID3v2
+/// header at offset 0 or the buffer is shorter than a 10-byte header.
+///
+/// A present-but-malformed header — unsupported major version, or a synchsafe
+/// size byte with its high bit set — is `FormatError::Malformed`. This is the
+/// intersection of the checks `id3v2_alloc_safe` makes on the header, so the
+/// audio locator and the allocation guard agree on which headers are well-formed
+/// instead of the locator mask-decoding shapes the guard rejects. Footer and
+/// frame-flag handling stay with the callers.
+fn id3v2_header_len(data: &[u8]) -> Result<Option<usize>> {
+    if data.len() < 10 || &data[0..3] != b"ID3" {
+        return Ok(None);
+    }
+    if !matches!(data[3], 2..=4) {
+        return Err(FormatError::Malformed);
+    }
+    if data[6] | data[7] | data[8] | data[9] >= 0x80 {
+        return Err(FormatError::Malformed);
+    }
+    Ok(Some(10 + synchsafe_decode(&data[6..10]) as usize))
+}
+
 /// Locate the audio region: skip a leading ID3v2 tag (if present) and a trailing
 /// 128-byte ID3v1 tag (if present), then require an MPEG frame sync at the audio
 /// offset. The synthesized file re-prepends a fresh ID3v2 tag, so the original
@@ -32,10 +55,9 @@ pub fn locate_audio(data: &[u8]) -> Result<Mp3Bounds> {
     let len = data.len();
 
     let mut audio_offset = 0usize;
-    if len >= 10 && &data[0..3] == b"ID3" {
+    if let Some(base) = id3v2_header_len(data)? {
         let flags = data[5];
-        let body = synchsafe_decode(&data[6..10]) as usize;
-        let mut tag_len = 10 + body;
+        let mut tag_len = base;
         if flags & 0x10 != 0 {
             tag_len += 10; // ID3v2.4 footer
         }
@@ -76,10 +98,13 @@ pub fn locate_audio_bounded(
     tail: Option<&[u8; 128]>,
 ) -> Result<Extent<Mp3Bounds>> {
     let mut audio_offset = 0usize;
-    if prefix.len() >= 10 && &prefix[0..3] == b"ID3" {
+    if prefix.len() < 10 && file_len >= 10 {
+        // Not enough bytes even to read the ID3v2 header.
+        return Ok(Extent::NeedMore { up_to: 10 });
+    }
+    if let Some(base) = id3v2_header_len(prefix)? {
         let flags = prefix[5];
-        let body = synchsafe_decode(&prefix[6..10]) as usize;
-        let mut tag_len = 10 + body;
+        let mut tag_len = base;
         if flags & 0x10 != 0 {
             tag_len += 10; // ID3v2.4 footer
         }
@@ -87,9 +112,6 @@ pub fn locate_audio_bounded(
             return Err(FormatError::Malformed);
         }
         audio_offset = tag_len;
-    } else if prefix.len() < 10 && file_len >= 10 {
-        // Not enough bytes even to read the ID3v2 header.
-        return Ok(Extent::NeedMore { up_to: 10 });
     }
 
     // The audio start (plus its 2-byte frame sync) must fit in the file. Mirrors
@@ -431,34 +453,20 @@ fn id3v2_alloc_safe(data: &[u8]) -> bool {
     // extraction for ID3v1-only files (no leading ID3v2 header) is skipped;
     // ID3v1 is legacy/fixed-size and tags can be populated via the DB
     // (beets/picard) regardless.
-    if data.len() < 10 || &data[0..3] != b"ID3" {
+    let Ok(Some(tag_end)) = id3v2_header_len(data) else {
+        // Not an ID3v2 tag at offset 0, or a malformed header: skip parsing.
         return false;
-    }
-    let major = data[3];
-    if !matches!(major, 2..=4) {
-        return false;
-    }
+    };
     let flags = data[5];
     // Extended header (0x40) and unsynchronisation (0x80) complicate frame
     // bounds; skip rather than risk mis-validating.
     if flags & 0xC0 != 0 {
         return false;
     }
-    // A well-formed synchsafe integer has the high bit clear in every byte.  If
-    // any byte has the high bit set the field is malformed; the id3 crate may
-    // not mask those bits, producing a body size much larger than our
-    // spec-correct synchsafe decode and walking frames we have not validated.
-    // Reject such tags conservatively rather than risk mis-validating bounds.
-    if data[6] | data[7] | data[8] | data[9] >= 0x80 {
-        return false;
-    }
-    let body = synchsafe_decode(&data[6..10]) as usize;
-    let Some(tag_end) = 10usize.checked_add(body) else {
-        return false;
-    };
     if tag_end > data.len() {
         return false;
     }
+    let major = data[3];
     let header_len = if major == 2 { 6 } else { 10 };
     // Walk frames over the entire remaining buffer (not just [10, tag_end)):
     // the id3 crate does not consistently stop at the declared tag body and
@@ -2134,6 +2142,42 @@ mod tests {
                 panic!("mp3 bounded/full divergence: full={full:?} bounded={bounded:?}")
             }
         }
+    }
+
+    #[test]
+    fn locate_audio_rejects_high_bit_size_byte() {
+        // Malformed synchsafe size (last byte 0x80) that masks to body=0, with a valid
+        // frame sync at offset 10. Must reject rather than serve audio from offset 10.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ID3");
+        data.extend_from_slice(&[0x04, 0x00, 0x00]); // major, rev, flags
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x80]); // high bit set -> malformed
+        data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]); // valid sync at offset 10
+        assert_eq!(locate_audio(&data), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_rejects_unsupported_major_version() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ID3");
+        data.extend_from_slice(&[0x05, 0x00, 0x00]); // major 5 (unsupported)
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+        assert_eq!(locate_audio(&data), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_bounded_rejects_high_bit_size_byte() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ID3");
+        data.extend_from_slice(&[0x04, 0x00, 0x00]);
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x80]);
+        data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+        let file_len = data.len() as u64;
+        assert_eq!(
+            locate_audio_bounded(&data, file_len, None),
+            Err(FormatError::Malformed)
+        );
     }
 
     #[test]

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -24,16 +24,6 @@ fn synchsafe_decode(b: &[u8]) -> u32 {
         | u32::from(b[3] & 0x7F)
 }
 
-/// Validate a leading ID3v2 header and return the tag length (10-byte header +
-/// declared body, *excluding* any footer), or `None` when there is no ID3v2
-/// header at offset 0 or the buffer is shorter than a 10-byte header.
-///
-/// A present-but-malformed header — unsupported major version, or a synchsafe
-/// size byte with its high bit set — is `FormatError::Malformed`. This is the
-/// intersection of the checks `id3v2_alloc_safe` makes on the header, so the
-/// audio locator and the allocation guard agree on which headers are well-formed
-/// instead of the locator mask-decoding shapes the guard rejects. Footer and
-/// frame-flag handling stay with the callers.
 fn id3v2_header_len(data: &[u8]) -> Result<Option<usize>> {
     if data.len() < 10 || &data[0..3] != b"ID3" {
         return Ok(None);
@@ -41,7 +31,9 @@ fn id3v2_header_len(data: &[u8]) -> Result<Option<usize>> {
     if !matches!(data[3], 2..=4) {
         return Err(FormatError::Malformed);
     }
-    if data[6] | data[7] | data[8] | data[9] >= 0x80 {
+    // A well-formed synchsafe size has the high bit clear in every byte; reject
+    // if any size byte has it set (the id3 crate may not mask those bits).
+    if data[6..10].iter().any(|&b| b & 0x80 != 0) {
         return Err(FormatError::Malformed);
     }
     Ok(Some(10 + synchsafe_decode(&data[6..10]) as usize))

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -586,6 +586,19 @@ mod tests {
     }
 
     #[test]
+    fn multipage_payload_cursor_advances_across_pages() {
+        // A >65 025-byte packet with DISTINCT bytes at every position: the second
+        // page must carry the *tail* of the packet, not a re-read from offset 0.
+        // Pins `payload_pos += page_payload` against a cursor stuck at 0 (a uniform
+        // payload, as in the other multi-page tests, can't observe this).
+        let packet: Vec<u8> = (0..70_000u32).map(|i| (i % 251) as u8).collect();
+        let (bytes, pages) = lace_packet(2, 0, false, 0, &packet);
+        assert_eq!(pages, 2);
+        let pkts = read_packets(&bytes, 1).unwrap();
+        assert_eq!(pkts[0].data, packet);
+    }
+
+    #[test]
     fn patch_page_header_updates_seq_and_crc() {
         let packet = vec![0x42u8; 300];
         let (page, _) = lace_packet(0xCAFE, 10, false, 7, &packet);

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -123,10 +123,10 @@ pub fn lace_packet(
 
         lace_pos += chunk;
         payload_pos += page_payload;
-        seq += 1;
+        seq = seq.wrapping_add(1);
         first = false;
     }
-    (out, seq - seq_start)
+    (out, seq.wrapping_sub(seq_start))
 }
 
 /// Lace a sequence of header packets onto fresh pages starting at sequence 0, with

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -74,21 +74,23 @@ pub fn locate_audio(buf: &[u8]) -> Result<WavBounds> {
         return Err(FormatError::Malformed);
     }
     let chunks = walk_chunks(buf);
-    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
+    let fmt = chunks.iter().find(|(id, _, _)| id == b"fmt ");
     let data = chunks.iter().find(|(id, _, _)| id == b"data");
-    match (has_fmt, data) {
-        (true, Some(&(_, off, len))) => {
-            let data_end = (off as u64).saturating_add(len);
-            if data_end > buf.len() as u64 || data_end > form_end {
-                return Err(FormatError::Malformed);
-            }
-            Ok(WavBounds {
-                audio_offset: off as u64,
-                audio_length: len,
-            })
-        }
-        _ => Err(FormatError::NotWav),
+    let (Some(&(_, fmt_off, fmt_len)), Some(&(_, off, len))) = (fmt, data) else {
+        return Err(FormatError::NotWav);
+    };
+    // `fmt ` and `data` must both fall within the declared RIFF form; a chunk
+    // past `form_end` means the form does not describe the audio. (Trailing
+    // metadata chunks beyond `form_end` are still walked for best-effort tags.)
+    let fmt_end = (fmt_off as u64).saturating_add(fmt_len);
+    let data_end = (off as u64).saturating_add(len);
+    if data_end > buf.len() as u64 || data_end > form_end || fmt_end > form_end {
+        return Err(FormatError::Malformed);
     }
+    Ok(WavBounds {
+        audio_offset: off as u64,
+        audio_length: len,
+    })
 }
 
 /// Bounded twin of [`locate_audio`]. WAV metadata chunks can trail the `data`
@@ -115,21 +117,22 @@ pub fn locate_audio_at_ceiling(prefix: &[u8], file_len: u64) -> Result<WavBounds
         return Err(FormatError::Malformed);
     }
     let chunks = walk_chunks(prefix);
-    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
+    let fmt = chunks.iter().find(|(id, _, _)| id == b"fmt ");
     let data = chunks.iter().find(|(id, _, _)| id == b"data");
-    match (has_fmt, data) {
-        (true, Some(&(_, off, len))) => {
-            let data_end = (off as u64).saturating_add(len);
-            if data_end > file_len || data_end > form_end {
-                return Err(FormatError::Malformed);
-            }
-            Ok(WavBounds {
-                audio_offset: off as u64,
-                audio_length: len,
-            })
-        }
-        _ => Err(FormatError::NotWav),
+    let (Some(&(_, fmt_off, fmt_len)), Some(&(_, off, len))) = (fmt, data) else {
+        return Err(FormatError::NotWav);
+    };
+    // `fmt ` and `data` must both fall within the declared RIFF form (mirrors
+    // [`locate_audio`]); the payload itself need not be present in `prefix`.
+    let fmt_end = (fmt_off as u64).saturating_add(fmt_len);
+    let data_end = (off as u64).saturating_add(len);
+    if data_end > file_len || data_end > form_end || fmt_end > form_end {
+        return Err(FormatError::Malformed);
     }
+    Ok(WavBounds {
+        audio_offset: off as u64,
+        audio_length: len,
+    })
 }
 
 /// Read the preserved structural chunks (`fmt `, optional `fact`) from the front
@@ -839,6 +842,27 @@ mod tests {
         let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
         let file_len = buf.len() as u64;
         buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // form_end = 16, before data
+        assert_eq!(
+            locate_audio_at_ceiling(&buf, file_len),
+            Err(FormatError::Malformed)
+        );
+    }
+
+    #[test]
+    fn locate_audio_rejects_fmt_outside_declared_form() {
+        // `data` first (in-form), then a `fmt ` chunk located past `form_end`. The
+        // declared form does not contain `fmt `, so reject even though the `data`
+        // payload fits the form. (data ends at 28; fmt spans 28..52.)
+        let mut buf = wav(&[(b"data", vec![0x11; 8]), (b"fmt ", fmt_pcm())]);
+        buf[4..8].copy_from_slice(&20u32.to_le_bytes()); // form_end = 28: covers data, not fmt
+        assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_at_ceiling_rejects_fmt_outside_declared_form() {
+        let mut buf = wav(&[(b"data", vec![0x11; 8]), (b"fmt ", fmt_pcm())]);
+        let file_len = buf.len() as u64;
+        buf[4..8].copy_from_slice(&20u32.to_le_bytes()); // form_end = 28: covers data, not fmt
         assert_eq!(
             locate_audio_at_ceiling(&buf, file_len),
             Err(FormatError::Malformed)

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -832,6 +832,20 @@ mod tests {
     }
 
     #[test]
+    fn locate_audio_at_ceiling_rejects_form_end_before_data() {
+        // Ceiling path (over-budget file): the RIFF size declares a form ending
+        // before the data payload, while the data payload still fits inside the
+        // physical file. Must reject on the `data_end > form_end` clause.
+        let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
+        let file_len = buf.len() as u64;
+        buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // form_end = 16, before data
+        assert_eq!(
+            locate_audio_at_ceiling(&buf, file_len),
+            Err(FormatError::Malformed)
+        );
+    }
+
+    #[test]
     fn wav_read_binary_tags_extracts_id3_chunk_frames() {
         use id3::frame::{Content, Unknown};
         use id3::{Frame, Tag, TagLike, Version};

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -19,14 +19,15 @@ pub struct WavScan {
     pub fact: Option<Vec<u8>>,
 }
 
-/// Validate the RIFF/WAVE container header and return the offset of the first
-/// chunk (always 12). Rejects RF64/BW64 (their form id is not `RIFF`) and any
-/// non-`WAVE` RIFF file.
-fn riff_wave_start(buf: &[u8]) -> Result<usize> {
+/// Validate the RIFF/WAVE container header and return `(first_chunk_offset,
+/// form_end)`, where `form_end = 8 + riff_size` is the byte just past the
+/// declared RIFF form. Rejects RF64/BW64 and any non-`WAVE` RIFF file.
+fn riff_wave_start(buf: &[u8]) -> Result<(usize, u64)> {
     if buf.len() < 12 || &buf[0..4] != b"RIFF" || &buf[8..12] != b"WAVE" {
         return Err(FormatError::NotWav);
     }
-    Ok(12)
+    let riff_size = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    Ok((12, 8 + u64::from(riff_size)))
 }
 
 /// Walk the top-level WAVE chunks, returning `(fourcc, payload_offset, payload_len)`
@@ -36,7 +37,7 @@ fn riff_wave_start(buf: &[u8]) -> Result<usize> {
 /// front-only buffer.
 fn walk_chunks(buf: &[u8]) -> Vec<([u8; 4], usize, u64)> {
     let mut out = Vec::new();
-    let Ok(mut pos) = riff_wave_start(buf) else {
+    let Ok((mut pos, _form_end)) = riff_wave_start(buf) else {
         return out;
     };
     while pos + 8 <= buf.len() {
@@ -68,13 +69,17 @@ fn chunk_slice(buf: &[u8], offset: usize, len: u64) -> Option<&[u8]> {
 /// Parse the file and return the `data` chunk payload bounds, or an error to skip
 /// it. Requires both `fmt ` and `data`, and the `data` payload must fit in `buf`.
 pub fn locate_audio(buf: &[u8]) -> Result<WavBounds> {
-    riff_wave_start(buf)?;
+    let (_, form_end) = riff_wave_start(buf)?;
+    if form_end > buf.len() as u64 {
+        return Err(FormatError::Malformed);
+    }
     let chunks = walk_chunks(buf);
     let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
     let data = chunks.iter().find(|(id, _, _)| id == b"data");
     match (has_fmt, data) {
         (true, Some(&(_, off, len))) => {
-            if (off as u64).saturating_add(len) > buf.len() as u64 {
+            let data_end = (off as u64).saturating_add(len);
+            if data_end > buf.len() as u64 || data_end > form_end {
                 return Err(FormatError::Malformed);
             }
             Ok(WavBounds {
@@ -105,13 +110,17 @@ pub fn locate_audio_bounded(prefix: &[u8], file_len: u64) -> Result<Extent<WavBo
 /// rejected. Unlike [`locate_audio`] the payload need not be present in `prefix`;
 /// any tags trailing it are necessarily lost.
 pub fn locate_audio_at_ceiling(prefix: &[u8], file_len: u64) -> Result<WavBounds> {
-    riff_wave_start(prefix)?;
+    let (_, form_end) = riff_wave_start(prefix)?;
+    if form_end > file_len {
+        return Err(FormatError::Malformed);
+    }
     let chunks = walk_chunks(prefix);
     let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
     let data = chunks.iter().find(|(id, _, _)| id == b"data");
     match (has_fmt, data) {
         (true, Some(&(_, off, len))) => {
-            if (off as u64).saturating_add(len) > file_len {
+            let data_end = (off as u64).saturating_add(len);
+            if data_end > file_len || data_end > form_end {
                 return Err(FormatError::Malformed);
             }
             Ok(WavBounds {
@@ -426,7 +435,7 @@ mod tests {
         // The `<=` mutant computes `12 <= 12` (true) and wrongly rejects it.
         let buf = b"RIFF\0\0\0\0WAVE".to_vec();
         assert_eq!(buf.len(), 12);
-        assert_eq!(riff_wave_start(&buf), Ok(12));
+        assert_eq!(riff_wave_start(&buf), Ok((12, 8)));
     }
 
     #[test]
@@ -733,7 +742,8 @@ mod tests {
         body.extend_from_slice(b"data");
         body.extend_from_slice(&u32::try_from(data_len).unwrap().to_le_bytes());
         let mut v = b"RIFF".to_vec();
-        v.extend_from_slice(&0u32.to_le_bytes()); // size field unused by the walk
+        let riff_size = 36u32 + u32::try_from(data_len).unwrap(); // form: WAVE + fmt + data hdr + payload
+        v.extend_from_slice(&riff_size.to_le_bytes());
         v.extend_from_slice(b"WAVE");
         v.extend_from_slice(&body);
         v
@@ -789,6 +799,36 @@ mod tests {
             locate_audio_at_ceiling(&front, file_len),
             Err(FormatError::NotWav)
         );
+    }
+
+    #[test]
+    fn locate_audio_rejects_form_end_before_data() {
+        // Correctly framed chunks, but the RIFF size declares a form that ends before
+        // the data payload. Build with `wav` (valid size) then overwrite bytes 4..8.
+        let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
+        buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // form_end = 16, before data
+        assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_rejects_form_end_past_file() {
+        let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
+        let huge = u32::try_from(buf.len()).unwrap() + 100;
+        buf[4..8].copy_from_slice(&huge.to_le_bytes()); // form_end > physical file
+        assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
+    }
+
+    #[test]
+    fn locate_audio_accepts_valid_form_with_odd_chunk_and_trailing_metadata() {
+        // Odd-size chunk before data (word-padded) + a LIST chunk trailing data, all
+        // inside a correctly-sized RIFF form. Must still parse.
+        let buf = wav(&[
+            (b"fmt ", fmt_pcm()),
+            (b"data", vec![0x22; 7]), // odd payload -> 1 pad byte
+            (b"LIST", vec![0x33; 4]),
+        ]);
+        let b = locate_audio(&buf).unwrap();
+        assert_eq!(b.audio_length, 7);
     }
 
     #[test]

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -37,10 +37,14 @@ fn riff_wave_start(buf: &[u8]) -> Result<(usize, u64)> {
 /// front-only buffer.
 fn walk_chunks(buf: &[u8]) -> Vec<([u8; 4], usize, u64)> {
     let mut out = Vec::new();
-    let Ok((mut pos, _form_end)) = riff_wave_start(buf) else {
+    let Ok((mut pos, form_end)) = riff_wave_start(buf) else {
         return out;
     };
-    while pos + 8 <= buf.len() {
+    // Walk only within the declared RIFF form: chunks past `form_end` are not
+    // part of the file's contract, so they must not surface to the audio locator
+    // or to tag/picture extraction (which persists into the store at scan time).
+    let ceiling = crate::convert::usize_from(form_end.min(buf.len() as u64));
+    while pos + 8 <= ceiling {
         let mut id = [0u8; 4];
         id.copy_from_slice(&buf[pos..pos + 4]);
         let size = u64::from(u32::from_le_bytes([
@@ -53,7 +57,7 @@ fn walk_chunks(buf: &[u8]) -> Vec<([u8; 4], usize, u64)> {
         out.push((id, payload_offset, size));
         let advance = 8u64 + size + (size & 1); // word-align: pad odd payloads
         match (pos as u64).checked_add(advance) {
-            Some(next) if next <= buf.len() as u64 => pos = crate::convert::usize_from(next),
+            Some(next) if next <= ceiling as u64 => pos = crate::convert::usize_from(next),
             _ => break,
         }
     }
@@ -67,30 +71,33 @@ fn chunk_slice(buf: &[u8], offset: usize, len: u64) -> Option<&[u8]> {
 }
 
 /// Parse the file and return the `data` chunk payload bounds, or an error to skip
-/// it. Requires both `fmt ` and `data`, and the `data` payload must fit in `buf`.
+/// it. Requires both `fmt ` and `data` within the declared RIFF form, and the
+/// `data` payload must fit in that form.
 pub fn locate_audio(buf: &[u8]) -> Result<WavBounds> {
     let (_, form_end) = riff_wave_start(buf)?;
     if form_end > buf.len() as u64 {
         return Err(FormatError::Malformed);
     }
     let chunks = walk_chunks(buf);
-    let fmt = chunks.iter().find(|(id, _, _)| id == b"fmt ");
+    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
     let data = chunks.iter().find(|(id, _, _)| id == b"data");
-    let (Some(&(_, fmt_off, fmt_len)), Some(&(_, off, len))) = (fmt, data) else {
-        return Err(FormatError::NotWav);
-    };
-    // `fmt ` and `data` must both fall within the declared RIFF form; a chunk
-    // past `form_end` means the form does not describe the audio. (Trailing
-    // metadata chunks beyond `form_end` are still walked for best-effort tags.)
-    let fmt_end = (fmt_off as u64).saturating_add(fmt_len);
-    let data_end = (off as u64).saturating_add(len);
-    if data_end > buf.len() as u64 || data_end > form_end || fmt_end > form_end {
-        return Err(FormatError::Malformed);
+    match (has_fmt, data) {
+        (true, Some(&(_, off, len))) => {
+            // `walk_chunks` bounds chunk headers to `form_end`; this additionally
+            // rejects a `data` chunk whose payload spills past the form. (`form_end
+            // <= buf.len()` is enforced above, so a separate buffer-bound check on
+            // `data_end` would be redundant.)
+            let data_end = (off as u64).saturating_add(len);
+            if data_end > form_end {
+                return Err(FormatError::Malformed);
+            }
+            Ok(WavBounds {
+                audio_offset: off as u64,
+                audio_length: len,
+            })
+        }
+        _ => Err(FormatError::NotWav),
     }
-    Ok(WavBounds {
-        audio_offset: off as u64,
-        audio_length: len,
-    })
 }
 
 /// Bounded twin of [`locate_audio`]. WAV metadata chunks can trail the `data`
@@ -117,22 +124,25 @@ pub fn locate_audio_at_ceiling(prefix: &[u8], file_len: u64) -> Result<WavBounds
         return Err(FormatError::Malformed);
     }
     let chunks = walk_chunks(prefix);
-    let fmt = chunks.iter().find(|(id, _, _)| id == b"fmt ");
+    let has_fmt = chunks.iter().any(|(id, _, _)| id == b"fmt ");
     let data = chunks.iter().find(|(id, _, _)| id == b"data");
-    let (Some(&(_, fmt_off, fmt_len)), Some(&(_, off, len))) = (fmt, data) else {
-        return Err(FormatError::NotWav);
-    };
-    // `fmt ` and `data` must both fall within the declared RIFF form (mirrors
-    // [`locate_audio`]); the payload itself need not be present in `prefix`.
-    let fmt_end = (fmt_off as u64).saturating_add(fmt_len);
-    let data_end = (off as u64).saturating_add(len);
-    if data_end > file_len || data_end > form_end || fmt_end > form_end {
-        return Err(FormatError::Malformed);
+    match (has_fmt, data) {
+        (true, Some(&(_, off, len))) => {
+            // `walk_chunks` bounds chunk headers to `form_end`; this additionally
+            // rejects a `data` chunk whose payload spills past the form. (`form_end
+            // <= file_len` is enforced above, so a separate file-bound check on
+            // `data_end` would be redundant.)
+            let data_end = (off as u64).saturating_add(len);
+            if data_end > form_end {
+                return Err(FormatError::Malformed);
+            }
+            Ok(WavBounds {
+                audio_offset: off as u64,
+                audio_length: len,
+            })
+        }
+        _ => Err(FormatError::NotWav),
     }
-    Ok(WavBounds {
-        audio_offset: off as u64,
-        audio_length: len,
-    })
 }
 
 /// Read the preserved structural chunks (`fmt `, optional `fact`) from the front
@@ -806,10 +816,11 @@ mod tests {
 
     #[test]
     fn locate_audio_rejects_form_end_before_data() {
-        // Correctly framed chunks, but the RIFF size declares a form that ends before
-        // the data payload. Build with `wav` (valid size) then overwrite bytes 4..8.
+        // The `data` header is in-form (so it is walked), but its payload spills past
+        // the declared form: data spans 36..52 while form_end = 48. Reject on the
+        // `data_end > form_end` check.
         let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
-        buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // form_end = 16, before data
+        buf[4..8].copy_from_slice(&40u32.to_le_bytes()); // form_end = 48, inside the data payload
         assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
     }
 
@@ -836,12 +847,12 @@ mod tests {
 
     #[test]
     fn locate_audio_at_ceiling_rejects_form_end_before_data() {
-        // Ceiling path (over-budget file): the RIFF size declares a form ending
-        // before the data payload, while the data payload still fits inside the
-        // physical file. Must reject on the `data_end > form_end` clause.
+        // Ceiling path: the `data` header is in-form but its payload spills past the
+        // declared form (data 36..52, form_end = 48) while still fitting the physical
+        // file. Must reject on the `data_end > form_end` check.
         let mut buf = wav(&[(b"fmt ", fmt_pcm()), (b"data", vec![0x11; 8])]);
         let file_len = buf.len() as u64;
-        buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // form_end = 16, before data
+        buf[4..8].copy_from_slice(&40u32.to_le_bytes()); // form_end = 48, inside the data payload
         assert_eq!(
             locate_audio_at_ceiling(&buf, file_len),
             Err(FormatError::Malformed)
@@ -850,12 +861,13 @@ mod tests {
 
     #[test]
     fn locate_audio_rejects_fmt_outside_declared_form() {
-        // `data` first (in-form), then a `fmt ` chunk located past `form_end`. The
-        // declared form does not contain `fmt `, so reject even though the `data`
-        // payload fits the form. (data ends at 28; fmt spans 28..52.)
+        // `data` first (in-form), then a `fmt ` chunk located past `form_end`.
+        // `walk_chunks` clamps to the form, so the out-of-form `fmt ` is invisible:
+        // the file has no in-form `fmt ` and is skipped as NotWav. (data spans
+        // 12..28 == form_end; fmt spans 28..52, entirely outside the form.)
         let mut buf = wav(&[(b"data", vec![0x11; 8]), (b"fmt ", fmt_pcm())]);
         buf[4..8].copy_from_slice(&20u32.to_le_bytes()); // form_end = 28: covers data, not fmt
-        assert_eq!(locate_audio(&buf), Err(FormatError::Malformed));
+        assert_eq!(locate_audio(&buf), Err(FormatError::NotWav));
     }
 
     #[test]
@@ -865,7 +877,7 @@ mod tests {
         buf[4..8].copy_from_slice(&20u32.to_le_bytes()); // form_end = 28: covers data, not fmt
         assert_eq!(
             locate_audio_at_ceiling(&buf, file_len),
-            Err(FormatError::Malformed)
+            Err(FormatError::NotWav)
         );
     }
 

--- a/musefs-format/tests/synthesize_art.rs
+++ b/musefs-format/tests/synthesize_art.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 
 use common::{make_flac, resolve_layout, streaminfo_body, vorbis_comment_body};
-use musefs_format::flac::{locate_audio, synthesize_layout};
+use musefs_format::flac::{MetadataBlock, locate_audio, synthesize_layout};
 use musefs_format::{ArtInput, BlobLen, PictureType, Segment, TagInput};
 
 fn fixture() -> (Vec<u8>, Vec<u8>) {
@@ -112,8 +112,12 @@ fn synthesize_errors_on_oversized_picture() {
         height: 0,
         data_len: BlobLen::new(0x0100_0000).unwrap(), // just over the 24-bit FLAC PICTURE block limit
     };
+    let streaminfo = [MetadataBlock {
+        block_type: 0,
+        body: streaminfo_body(),
+    }];
     assert_eq!(
-        synthesize_layout(&[], 0, 0, &[], &[], &[art]),
+        synthesize_layout(&streaminfo, 0, 0, &[], &[], &[art]),
         Err(FormatError::TooLarge)
     );
 }


### PR DESCRIPTION
Hardens four media parsers against malformed input and crafted-store rows, per
the parser-strictness findings. Both the scan path (untrusted media) and the
synthesis path (the DB is trusted only as far as the documented contract — see
SECURITY.md) are in scope.

## Changes

- **#295 FLAC** — validate STREAMINFO structure at both scan and synthesis.
  The metadata must begin with exactly one 34-byte STREAMINFO block, and
  STREAMINFO must not recur. A crafted store providing malformed structural
  rows fails synthesis with a controlled `Malformed` error instead of emitting
  decoder-rejected output.
- **#296 MP3** — the audio locator now validates the ID3v2 header (major
  version 2–4, high-bit-clear synchsafe size) via a shared `id3v2_header_len`
  helper used by `locate_audio`, `locate_audio_bounded`, and `id3v2_alloc_safe`,
  so the locator no longer mask-decodes a malformed ID3-looking prefix into an
  audio offset. Tags using unsynchronisation or an extended header still scan.
- **#298 Ogg** — synthesized page sequence numbers wrap modulo 2³² (matching
  Ogg's `u32` sequence field) during renumbering, so files whose audio pages
  carry very high sequence numbers serve correctly rather than failing the read.
- **#299 WAV** — enforce the declared RIFF form size: `riff_wave_start` returns
  `form_end = 8 + riff_size`, and both `locate_audio` and
  `locate_audio_at_ceiling` reject a file whose `form_end` exceeds the physical
  file or whose `data` payload extends past `form_end`.

The cardinal invariant is preserved throughout: original audio bytes are never
copied or modified; rejection is graceful (the track is skipped from the virtual
tree, never altered).

## Verification

- `cargo test --workspace`, `cargo clippy --all-targets -D warnings`, `cargo fmt`
- `cargo test -p musefs-core --features metrics` (the metrics-gated stat tests)
- `cargo +nightly fuzz build` (out-of-workspace fuzz crate)
- Per-PR in-diff mutation gate: **84 caught, 0 missed, 13 unviable**. The final
  commit closes seven survivors the initial pass left in the new code (the mp3
  synchsafe high-bit fold, the wav ceiling-path form-end guard, and the ogg
  multi-page payload cursor); no `mutants.toml` exclusions were added.

Per-format docs (`docs/{FLAC,MP3,OGG,WAV}.md`) and the design spec / plan under
`docs/superpowers/` are updated.

Closes #295
Closes #296
Closes #298
Closes #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed plan and design for parser strictness; updated FLAC, MP3, OGG, and WAV docs with new validation rules.

* **Bug Fixes**
  * Parsers now reject malformed container metadata with controlled errors instead of producing invalid outputs.
  * Ogg sequence numbers now correctly wrap at the 32-bit boundary.
  * WAV RIFF form-size enforcement prevents out-of-bounds audio/data interpretation.

* **Tests**
  * Expanded tests covering stricter validation and wrap-boundary behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->