### PR TITLE
docs(latencyfs): make passthrough scope claims honest (#310)

### DIFF
--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -1,8 +1,17 @@
-//! Bench-only passthrough FUSE that mirrors a backing directory and sleeps a
-//! configurable amount per operation, so HDD/NFS latency profiles are
-//! reproducible on one machine. The corpus AND the SQLite DB live under the
-//! mount, so backing reads and SQLite fsyncs are both delayed (and fsyncs
-//! counted). Not for production; requires /dev/fuse.
+//! Bench-only passthrough FUSE that forwards reads, writes, and directory ops
+//! to a backing directory and sleeps a configurable amount per operation, so
+//! HDD/NFS latency profiles are reproducible on one machine. The corpus AND the
+//! SQLite DB live under the mount, so backing reads and SQLite fsyncs are both
+//! delayed (and fsyncs counted). Not for production; requires /dev/fuse.
+//!
+//! Passthrough scope is deliberately narrow — only what the corpus + SQLite
+//! benches exercise; this is NOT full POSIX passthrough:
+//! - `setattr` honors `size` only (the one attr SQLite's WAL needs) and
+//!   accepts-but-ignores mode/uid/gid/atime/mtime/ctime/flags.
+//! - `access` always replies ok; the later backing op still enforces the real
+//!   permissions, so a probe can disagree with it.
+//! - symlinks are reported by `readdir`/`getattr` but `readlink` is
+//!   unimplemented — the bench corpus never resolves one.
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -433,6 +442,8 @@ impl fuser::Filesystem for PassthroughFs {
     }
 
     fn access(&self, _req: &Request, _ino: INodeNo, _mask: AccessFlags, reply: ReplyEmpty) {
+        // Bench scope: always ok. A probe may disagree with the later backing
+        // op, which enforces the real permissions (see the crate doc).
         reply.ok();
     }
 
@@ -578,9 +589,11 @@ impl fuser::Filesystem for PassthroughFs {
         let Some(p) = self.ipath(ino.0) else {
             return reply.error(fuser::Errno::ENOENT);
         };
-        // The only attr SQLite needs: truncate/extend the WAL. Propagate any
-        // failure rather than replying ok with the stale (un-truncated) size,
-        // which would lie to the kernel and desync the WAL on disk.
+        // Bench scope: only `size` is applied — it truncates/extends the WAL,
+        // the one attr SQLite needs. mode/uid/gid/times/flags are accepted but
+        // intentionally ignored (see the crate doc). Propagate any size failure
+        // rather than replying ok with the stale (un-truncated) size, which
+        // would lie to the kernel and desync the WAL on disk.
         if let Some(sz) = size
             && let Err(e) = OpenOptions::new()
                 .write(true)

--- a/musefs-latencyfs/tests/passthrough.rs
+++ b/musefs-latencyfs/tests/passthrough.rs
@@ -73,7 +73,7 @@ fn write_fsync_rename_unlink_through_the_mount() {
     }
     assert_eq!(std::fs::read(&p).unwrap(), b"abcdef");
     assert!(mount.fsyncs() >= 1, "fsync should have been counted");
-    // The bytes landed in the backing dir, not a tmpfs overlay (true passthrough).
+    // The bytes landed in the backing dir, not a tmpfs overlay (writes forwarded).
     assert_eq!(
         std::fs::read(backing.path().join("data.bin")).unwrap(),
         b"abcdef"
@@ -86,7 +86,7 @@ fn write_fsync_rename_unlink_through_the_mount() {
     std::fs::remove_file(&q).unwrap();
     assert!(!q.exists());
 
-    // The backing dir reflects the changes (true passthrough).
+    // The backing dir reflects the changes (rename/unlink forwarded).
     assert!(!backing.path().join("data.bin").exists());
 }
 
@@ -97,7 +97,7 @@ fn mkdir_rmdir_and_statfs_through_the_mount() {
     let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
     let mp = mount.path();
 
-    // mkdir then rmdir, each reflected in the backing dir (true passthrough).
+    // mkdir then rmdir, each reflected in the backing dir (forwarded to backing).
     std::fs::create_dir(mp.join("d")).unwrap();
     assert!(backing.path().join("d").is_dir());
     std::fs::remove_dir(mp.join("d")).unwrap();


### PR DESCRIPTION
Closes #310.

`musefs-latencyfs` is bench-only and its passthrough is deliberately narrower than the "true passthrough" its docs/tests claimed. Per the #280 triage this finding is a docs-overclaiming `enhancement` (the size-only `setattr` is a deliberate, commented shortcut), not a behavior bug — so this reword the overclaims rather than implementing bench-irrelevant metadata paths.

## What changed (docs/comments only — no behavior change)
- **Crate doc** (`src/lib.rs`): dropped "mirrors a backing directory"; now enumerates the three narrow-scope limits — `setattr` honors `size` only, `access` is always-ok (the backing op still enforces), and symlinks are reported by `readdir`/`getattr` but `readlink` is unimplemented (the bench corpus never resolves one).
- **`setattr` / `access` comments**: state the ignored attr fields and the always-ok reply are intentional bench shortcuts.
- **Tests** (`tests/passthrough.rs`): the three `(true passthrough)` comments reworded to accurate `(... forwarded)`.

`readlink` was deliberately left unimplemented — the bench corpus (audio files + SQLite DB) never resolves a symlink, so full POSIX passthrough would be dead scope.

## Verification
- `cargo fmt -p musefs-latencyfs --check` — clean
- `cargo clippy -p musefs-latencyfs --all-targets -- -D warnings` — clean
- pre-commit hook (full workspace test suite) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Clarified library documentation to better explain FUSE behavior limitations and which filesystem attributes are honored versus ignored during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->