### PR TITLE
test: close #280 e2e/fuzz coverage gaps (#320, #306, #313)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -390,4 +390,14 @@ exclude_re = [
     # stands in for the `'` in `Cow<'_, str>`, which a TOML literal string can't hold.)
     'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)',
     'replace truncate_component -> Cow<._, str> with Cow::Owned\(""\.to_owned\(\)\)',
+
+    # Db::with_raw_conn is #[cfg(feature = "fuzzing")] — a test/fuzz-only raw
+    # rusqlite-connection escape hatch enabled solely by the out-of-workspace fuzz
+    # crate. The per-PR --in-diff gate runs cargo-mutants without that feature, so
+    # the body is cfg'd out and any mutation there is unobservable — reported
+    # MISSED yet unkillable in that config, the same class as the metrics counters
+    # in exclude_globs above. It has no serving/correctness role and is covered
+    # functionally by the fuzzing-gated accessor test in the same file.
+    # guard: count=1
+    'musefs-db/src/lib\.rs:\d+:\d+: replace Db<M>::with_raw_conn -> R with Default::default\(\)',
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,10 @@ jobs:
         run: cargo test -p musefs-fuse -- --ignored
       - name: FUSE fault-injection + concurrency (metrics feature)
         run: cargo test -p musefs-fuse --features metrics -- --ignored
+      - name: Binary-level end-to-end tests (musefs)
+        run: cargo test -p musefs -- --ignored
+      - name: latencyfs end-to-end tests
+        run: cargo test -p musefs-latencyfs -- --ignored
 
   macos:
     needs: changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,11 @@ Coverage notes: the per-format targets also drive the bounded/ceiling probers
 differential oracle against the full-buffer parse. The `serve` target fuzzes the
 read-time serve path (`read_at_with_file` over adversarial layouts, including
 `serve_ogg_window`/`OggArtSlice`) and is scheduled-only (built per-PR, not
-smoke-run) because it builds a DB + temp backing file per input.
+smoke-run) because it builds a DB + temp backing file per input. The `serve`
+target also exercises hostile DB rows (negative/oversized geometry,
+invalid formats, orphaned/oversized art, stale binary-tag handles, content-version
+mismatch) via the `musefs-db` `fuzzing`-gated `with_raw_conn`, plus binary-tag
+streaming and distinct Opus/Vorbis/OggFLAC fixtures.
 
 ### Independent-reader interop (mutagen)
 
@@ -382,7 +386,10 @@ cargo llvm-cov --workspace --exclude musefs-fuse --exclude musefs-latencyfs --lc
 
 `musefs-fuse` and `musefs-latencyfs` are excluded because these FUSE crates'
 tests need a real mount; their behavior is covered by the separate `e2e` CI
-job rather than `llvm-cov`. CI (`coverage.yml`) runs this on every push/PR and
+job rather than `llvm-cov`. The CI `e2e` job also runs the binary-level
+`cargo test -p musefs -- --ignored` and
+`cargo test -p musefs-latencyfs -- --ignored` suites so they cannot silently
+rot (they require `/dev/fuse` + `fusermount3`). CI (`coverage.yml`) runs this on every push/PR and
 uploads to Codecov (`CODECOV_TOKEN` repo secret).
 
 ## Code conventions

--- a/docs/superpowers/plans/2026-06-12-e2e-fuzz-coverage-gaps.md
+++ b/docs/superpowers/plans/2026-06-12-e2e-fuzz-coverage-gaps.md
@@ -1,0 +1,914 @@
+# E2E/Fuzz Coverage Gaps (#320, #306, #313) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close three independent test/fuzz coverage gaps from the #280 audit: fix and CI-wire the stale `musefs`/`musefs-latencyfs` e2e tests (#320), expand read-only refusal coverage (#306), and expand `serve` fuzzing with hostile DB rows, binary-tag streaming, and distinct Ogg fixtures (#313).
+
+**Architecture:** All changes are test/fuzz-only except one additive, feature-gated DB accessor (`Db::with_raw_conn`, behind a new off-by-default `fuzzing` feature consumed only by the out-of-workspace fuzz crate). No production behavior changes. The cardinal invariant (audio bytes never copied/modified) is untouched.
+
+**Tech Stack:** Rust, FUSE (fuser), SQLite (rusqlite), cargo-fuzz (libfuzzer), raw `libc` syscalls for the read-only probes.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-e2e-fuzz-coverage-gaps-design.md`
+
+**Environment note:** Tasks 1 and 2 produce `#[ignore]` e2e tests that require `/dev/fuse` + `fusermount3`. This host has them — run with `--ignored`. The pre-commit hook runs the full workspace test suite (excludes `--ignored`), so each commit is green regardless. The fuzz crate (`fuzz/`) is **outside** the workspace; verify it with `cargo +nightly fuzz build <target>`, never plain `cargo build`.
+
+---
+
+## File Structure
+
+- `musefs/tests/sigterm_unmount.rs` — (modify) add explicit `--template` to both mounts. *(Task 1)*
+- `.github/workflows/ci.yml` — (modify) wire `musefs` + `musefs-latencyfs` `--ignored` into the `e2e` job. *(Task 1)*
+- `musefs-fuse/tests/read_consistency.rs` — (modify) extend the read-only refusal test + add `assert_read_safe`. *(Task 2)*
+- `musefs-db/Cargo.toml` — (modify) add the `fuzzing` feature. *(Task 3)*
+- `musefs-db/src/lib.rs` — (modify) add `#[cfg(feature = "fuzzing")] Db::with_raw_conn`. *(Task 3)*
+- `musefs-format/src/fuzz_check.rs` — (modify) add `ogg_vorbis()` / `ogg_flac()` fixtures + recognition tests. *(Task 4)*
+- `fuzz/Cargo.toml` — (modify) enable `musefs-db/fuzzing`, add `rusqlite`. *(Task 5)*
+- `fuzz/fuzz_targets/serve.rs` — (modify) distinct Ogg selectors, binary-tag opt-in, hostile-row stage, assertion discipline. *(Task 5)*
+- `CONTRIBUTING.md` — (modify) document the new fuzz scope + CI e2e steps. *(Task 6)*
+
+---
+
+## Task 1: #320 — Fix stale sigterm tests + wire binary e2e into CI
+
+**Files:**
+- Modify: `musefs/tests/sigterm_unmount.rs:96` and `:142`
+- Modify: `.github/workflows/ci.yml` (the `e2e` job, after the existing `musefs-fuse` steps near `:304-306`)
+
+- [ ] **Step 1: Reproduce the failure (test is red on this `/dev/fuse` host)**
+
+Run: `cargo test -p musefs --test sigterm_unmount -- --ignored --test-threads=1`
+Expected: `FAILED. 0 passed; 2 failed`, both panicking `mount did not come up` (the fixture renders `Unknown/Unknown/Song.flac`, not the asserted `Alice/Song.flac`).
+
+- [ ] **Step 2: Add an explicit template to the first mount**
+
+In `sigterm_unmounts_cleanly`, change the mount invocation (currently at `:95-98`):
+
+```rust
+    let mut child = Command::new(bin)
+        .args(["mount", mp.path().to_str().unwrap(), "--db", db])
+        .spawn()
+        .unwrap();
+```
+
+to:
+
+```rust
+    let mut child = Command::new(bin)
+        .args([
+            "mount",
+            mp.path().to_str().unwrap(),
+            "--db",
+            db,
+            "--template",
+            "$artist/$title",
+        ])
+        .spawn()
+        .unwrap();
+```
+
+- [ ] **Step 3: Add the same explicit template to the second mount**
+
+In `sigterm_exits_bounded_when_mount_is_busy`, apply the identical change to the mount invocation (currently at `:141-143`):
+
+```rust
+    let mut child = Command::new(bin)
+        .args([
+            "mount",
+            mp.path().to_str().unwrap(),
+            "--db",
+            db,
+            "--template",
+            "$artist/$title",
+        ])
+        .spawn()
+        .unwrap();
+```
+
+(The fixtures already tag `ARTIST=Alice` / `TITLE=Song`, so `$artist/$title` renders the asserted `Alice/Song.flac`. No fixture or assertion-path change.)
+
+- [ ] **Step 4: Run the sigterm tests — expect green**
+
+Run: `cargo test -p musefs --test sigterm_unmount -- --ignored --test-threads=1`
+Expected: `2 passed; 0 failed`.
+
+- [ ] **Step 5: Verify the latencyfs ignored e2e is green BEFORE wiring it (contingency)**
+
+Run: `cargo test -p musefs-latencyfs -- --ignored --test-threads=1`
+Expected: all pass. **If any fail:** do NOT proceed to wire latencyfs. latencyfs is a read-write passthrough with no synthesis template, so a failure is passthrough/latency-behavior drift, **not** virtual-path drift — do not "fix" it with a template tweak. Stop, wire only `musefs` in Step 6, and report the latencyfs failure as a separate finding.
+
+- [ ] **Step 6: Wire both crates' ignored e2e into CI**
+
+In `.github/workflows/ci.yml`, the `e2e` job currently ends with (near `:304-306`):
+
+```yaml
+      - name: FUSE end-to-end tests
+        run: cargo test -p musefs-fuse -- --ignored
+      - name: FUSE fault-injection + concurrency (metrics feature)
+        run: cargo test -p musefs-fuse --features metrics -- --ignored
+```
+
+Add two steps immediately after the second one:
+
+```yaml
+      - name: Binary-level end-to-end tests (musefs)
+        run: cargo test -p musefs -- --ignored
+      - name: latencyfs end-to-end tests
+        run: cargo test -p musefs-latencyfs -- --ignored
+```
+
+(They inherit the job's `if: needs.changes.outputs.src == 'true'` gate — they run on `src`-touching PRs, matching the existing `musefs-fuse` steps.)
+
+- [ ] **Step 7: Lint the workflow file**
+
+Run: `yamllint .github/workflows/ci.yml`
+Expected: no errors (the pre-commit hook also runs this).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs/tests/sigterm_unmount.rs .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+test(musefs): pin sigterm e2e to explicit template; wire binary e2e into CI (#320)
+
+Both sigterm tests now mount with --template '$artist/$title' so the
+ARTIST/TITLE-only fixture renders the asserted Alice/Song.flac regardless
+of the default template. Wire musefs + musefs-latencyfs --ignored e2e into
+the CI e2e job so they cannot silently rot again.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: #306 — Expand read-only refusal coverage
+
+**Files:**
+- Modify: `musefs-fuse/tests/read_consistency.rs` (the `assert_refused` helper region `:273-285`, and the `write_ops_are_refused_on_read_only_mount` test `:287-356`)
+
+The existing test mounts a single FLAC at `mountpoint/Alice/Song.flac` (`with_single_flac_mount`, `:85-99`). `served` is that path; `mountpoint` is the mount root; `Alice` is a virtual directory. Existing helpers: `cstr(&Path) -> CString` (`:265`), `last_errno() -> i32` (`:269`), `assert_refused(ret: i32, accepted: &[i32], what: &str)` (`:275`).
+
+- [ ] **Step 1: Reproduce current pass (baseline)**
+
+Run: `cargo test -p musefs-fuse --test read_consistency write_ops_are_refused_on_read_only_mount -- --ignored`
+Expected: `1 passed` (we are adding coverage to a passing test).
+
+- [ ] **Step 2: Add the `assert_read_safe` helper**
+
+Immediately after `assert_refused` (after `:285`), add:
+
+```rust
+/// Assert a libc *read* call (getxattr/listxattr) did not error as if it were a
+/// write: it either succeeds (`ret >= 0`) or fails with a non-mutation errno in
+/// `accepted`. Refusing a read on a read-only mount would itself be the bug.
+fn assert_read_safe(ret: isize, accepted: &[i32], what: &str) {
+    if ret >= 0 {
+        return;
+    }
+    let e = last_errno();
+    assert!(
+        accepted.contains(&e),
+        "{what}: errno {e} not in accepted read-safe set {accepted:?}"
+    );
+}
+```
+
+- [ ] **Step 3: Extend the test body with the new mutating + read probes**
+
+In `write_ops_are_refused_on_read_only_mount`, the `new_dir` binding currently exists (`:298`) and `new_file` (`:297`). Add a `rename`/`link`/`symlink` destination and a directory target. Replace the tail of the `unsafe { … }` block — the part from the `utimes` call (`:349-353`) to the block's close `}` (`:354`) — so it reads:
+
+```rust
+            assert_refused(
+                libc::utimes(existing.as_ptr(), times.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "utimes",
+            );
+
+            // --- #306: additional mutating-syscall families ---
+            let renamed = cstr(&mountpoint.join("Alice").join("renamed.flac"));
+            let link_dst = cstr(&mountpoint.join("Alice").join("hardlink.flac"));
+            let sym_dst = cstr(&mountpoint.join("Alice").join("symlink.flac"));
+            let dir = cstr(&mountpoint.join("Alice"));
+
+            assert_refused(
+                libc::rename(existing.as_ptr(), renamed.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "rename",
+            );
+            assert_refused(
+                libc::rmdir(dir.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOTEMPTY],
+                "rmdir",
+            );
+            assert_refused(
+                libc::symlink(existing.as_ptr(), sym_dst.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "symlink",
+            );
+            assert_refused(
+                libc::chown(existing.as_ptr(), 0, 0),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "chown",
+            );
+            assert_refused(
+                libc::lchown(existing.as_ptr(), 0, 0),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "lchown",
+            );
+            // mknod a regular file (no privilege needed); ENOSYS tolerates a
+            // platform/FUSE build that does not implement the callback at all.
+            assert_refused(
+                libc::mknod(new_file.as_ptr(), libc::S_IFREG | 0o644, 0),
+                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOSYS],
+                "mknod",
+            );
+            assert_refused(
+                libc::link(existing.as_ptr(), link_dst.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOSYS],
+                "link",
+            );
+
+            // xattr syscalls differ in signature across platforms (Linux vs
+            // macOS); this test only ever *runs* on Linux (/dev/fuse), so gate
+            // the xattr probes so the macOS workspace build still compiles.
+            #[cfg(target_os = "linux")]
+            {
+                let xval = [0u8; 4];
+                assert_refused(
+                    libc::setxattr(
+                        existing.as_ptr(),
+                        c"user.test".as_ptr(),
+                        xval.as_ptr().cast(),
+                        xval.len(),
+                        0,
+                    ),
+                    &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOTSUP],
+                    "setxattr",
+                );
+                assert_refused(
+                    libc::removexattr(existing.as_ptr(), c"user.test".as_ptr()),
+                    &[
+                        libc::EROFS,
+                        libc::EPERM,
+                        libc::EACCES,
+                        libc::ENOTSUP,
+                        libc::ENODATA,
+                    ],
+                    "removexattr",
+                );
+
+                // Read probes: NOT mutations. Assert read-safety, never refusal.
+                let mut buf = [0u8; 256];
+                assert_read_safe(
+                    libc::getxattr(
+                        existing.as_ptr(),
+                        c"user.test".as_ptr(),
+                        buf.as_mut_ptr().cast(),
+                        buf.len(),
+                    ),
+                    &[libc::ENOTSUP, libc::ENODATA],
+                    "getxattr",
+                );
+                assert_read_safe(
+                    libc::listxattr(existing.as_ptr(), buf.as_mut_ptr().cast(), buf.len()),
+                    &[libc::ENOTSUP],
+                    "listxattr",
+                );
+            }
+        }
+```
+
+- [ ] **Step 4: Run the extended test — expect green on `/dev/fuse`**
+
+Run: `cargo test -p musefs-fuse --test read_consistency write_ops_are_refused_on_read_only_mount -- --ignored`
+Expected: `1 passed`. If a mutating syscall *succeeds*, that is a real read-only-contract regression — stop and investigate, do not loosen the assertion.
+
+- [ ] **Step 5: Confirm the workspace still compiles (non-Linux compile guard)**
+
+Run: `cargo test -p musefs-fuse --no-run`
+Expected: compiles clean (verifies the `#[cfg(target_os = "linux")]` gating and the new helper).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-fuse/tests/read_consistency.rs
+git commit -m "$(cat <<'EOF'
+test(fuse): cover rename/rmdir/symlink/chown/xattr/mknod/link refusal (#306)
+
+Extend write_ops_are_refused_on_read_only_mount with the remaining mutating
+syscall families (refused, broad errno sets) and exercise getxattr/listxattr
+as read-safe (success or ENOTSUP/ENODATA), not refused. xattr probes gated to
+Linux so the macOS workspace build still compiles.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: #313a — Feature-gated raw DB accessor
+
+**Files:**
+- Modify: `musefs-db/Cargo.toml` (`[features]`)
+- Modify: `musefs-db/src/lib.rs` (the `impl<M> Db<M>` block at `:128-145`; add a feature-gated test module at end of file)
+
+- [ ] **Step 1: Add the `fuzzing` feature**
+
+In `musefs-db/Cargo.toml`, the `[features]` section currently is:
+
+```toml
+[features]
+# Test-only: gates `Default` impls (Db + model structs) so cargo-mutants'
+# `Ok(Default::default())` mutants compile. Named after the activity that needs
+# it, mirroring musefs-format's `fuzzing` feature. Not for production use.
+mutants = []
+```
+
+Add below `mutants = []`:
+
+```toml
+# Test/fuzz-only: exposes `Db::with_raw_conn` so the out-of-workspace fuzz crate
+# can plant hostile rows the validating public API cannot produce. Never enabled
+# in normal builds. Mirrors the `mutants` feature pattern.
+fuzzing = []
+```
+
+- [ ] **Step 2: Add the `with_raw_conn` accessor**
+
+In `musefs-db/src/lib.rs`, inside the `impl<M> Db<M>` block, after the `path()` method (which ends at `:144`), add:
+
+```rust
+    /// TEST/FUZZ ONLY (the `fuzzing` feature). Hands the raw rusqlite connection
+    /// to `f` so fuzz harnesses can plant rows the validating public API cannot
+    /// produce — e.g. negative geometry under `PRAGMA ignore_check_constraints`,
+    /// or orphaned `track_art` under `PRAGMA foreign_keys = OFF`. Never compiled
+    /// in production: the `fuzzing` feature is enabled only by the out-of-workspace
+    /// fuzz crate.
+    #[cfg(feature = "fuzzing")]
+    pub fn with_raw_conn<R>(&self, f: impl FnOnce(&rusqlite::Connection) -> R) -> R {
+        f(&self.conn)
+    }
+```
+
+- [ ] **Step 3: Add a feature-gated round-trip test**
+
+At the end of `musefs-db/src/lib.rs`, add:
+
+```rust
+#[cfg(all(test, feature = "fuzzing"))]
+mod fuzzing_accessor_tests {
+    use super::*;
+    use crate::models::NewTrack;
+
+    #[test]
+    fn with_raw_conn_plants_a_constraint_violating_row() {
+        let db = Db::open_in_memory().unwrap();
+        let id = db
+            .upsert_track(&NewTrack {
+                backing_path: "/x".to_string(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
+            })
+            .unwrap();
+
+        db.with_raw_conn(|conn| {
+            conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+                .unwrap();
+            conn.execute(
+                "UPDATE tracks SET audio_offset = -1 WHERE id = ?1",
+                rusqlite::params![id],
+            )
+            .unwrap();
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
+        });
+
+        let off: i64 = db.with_raw_conn(|conn| {
+            conn.query_row(
+                "SELECT audio_offset FROM tracks WHERE id = ?1",
+                rusqlite::params![id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        });
+        assert_eq!(off, -1, "ignore_check_constraints let the negative offset land");
+    }
+}
+```
+
+- [ ] **Step 4: Verify the feature-on build + test**
+
+Run: `cargo test -p musefs-db --features fuzzing fuzzing_accessor_tests`
+Expected: `1 passed`.
+
+- [ ] **Step 5: Verify the feature-off workspace build is unaffected**
+
+Run: `cargo test -p musefs-db`
+Expected: passes; `fuzzing_accessor_tests` and `with_raw_conn` are not compiled (no errors, no warnings).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-db/Cargo.toml musefs-db/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(db): add fuzzing-gated Db::with_raw_conn for hostile-row injection (#313)
+
+Off-by-default `fuzzing` feature (mirrors the `mutants` pattern) exposes the
+raw rusqlite connection so the out-of-workspace fuzz crate can plant rows the
+validating public API cannot produce. Not compiled in normal builds.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: #313b — Distinct Ogg Vorbis / OggFLAC fixtures
+
+**Files:**
+- Modify: `musefs-format/src/fuzz_check.rs` (the `fixtures` module, after `ogg_opus()` at `:251`; the `fixtures_tests` module at `:408`)
+
+`fuzz_check` compiles under `#[cfg(any(test, feature = "fuzzing"))]`, so `cargo test -p musefs-format` runs the recognition tests — a real red/green loop. The Ogg page helpers are `crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty}`. `detect_codec` keys on the first packet's magic (`\x01vorbis`, `\x7FFLAC`); `read_header` reads 3 header packets for Vorbis and `1 + count` for OggFLAC (`count` = big-endian `u16` at mapping-header bytes 7..9).
+
+- [ ] **Step 1: Write the failing recognition tests**
+
+In `musefs-format/src/fuzz_check.rs`, inside `mod fixtures_tests` (after the existing FLAC/m4a tests), add:
+
+```rust
+    #[test]
+    fn ogg_vorbis_fixture_is_recognized() {
+        let f = fixtures::ogg_vorbis();
+        let h = crate::ogg::read_header(&f).unwrap();
+        assert_eq!(h.codec, crate::ogg::Codec::Vorbis);
+        let scan = crate::ogg::locate_audio(&f).unwrap();
+        assert!(scan.audio_length > 0, "audio must be non-empty");
+    }
+
+    #[test]
+    fn ogg_flac_fixture_is_recognized() {
+        let f = fixtures::ogg_flac();
+        let h = crate::ogg::read_header(&f).unwrap();
+        assert_eq!(h.codec, crate::ogg::Codec::OggFlac);
+        let scan = crate::ogg::locate_audio(&f).unwrap();
+        assert!(scan.audio_length > 0, "audio must be non-empty");
+    }
+```
+
+- [ ] **Step 2: Run them — expect failure (fixtures don't exist yet)**
+
+Run: `cargo test -p musefs-format fixtures_tests::ogg_`
+Expected: FAIL to compile (`no function ogg_vorbis in fixtures`).
+
+- [ ] **Step 3: Add the `ogg_vorbis()` fixture**
+
+In the `fixtures` module, immediately after `ogg_opus()` (after `:251`), add:
+
+```rust
+    /// Minimal Ogg **Vorbis**: 3 header packets (identification, comment, setup)
+    /// then one audio packet. `detect_codec` keys on the `\x01vorbis` magic of
+    /// packet 0; `read_header` reassembles exactly 3 Vorbis header packets. The
+    /// comment packet carries an empty (but valid, round-trippable) VorbisComment
+    /// body so synthesis can splice tags without erroring.
+    pub fn ogg_vorbis() -> Vec<u8> {
+        use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
+        let mut id = b"\x01vorbis".to_vec();
+        id.extend_from_slice(&[0u8; 23]); // pad toward the 30-byte id-header shape
+        let mut comment = b"\x03vorbis".to_vec();
+        comment.extend_from_slice(&vorbis_body_empty());
+        let setup = b"\x05vorbis".to_vec();
+        let (mut data, pages) = build_header_pub(0x4321, &[&id, &comment, &setup]);
+        let (audio, _) = lace_packet_pub(0x4321, pages, false, 960, &[0u8; 120]);
+        data.extend_from_slice(&audio);
+        data
+    }
+```
+
+- [ ] **Step 4: Add the `ogg_flac()` fixture**
+
+Immediately after `ogg_vorbis()`, add:
+
+```rust
+    /// Minimal **OggFLAC**: mapping header packet 0
+    /// (`0x7F "FLAC" major minor count(2 BE) "fLaC" STREAMINFO`) plus one
+    /// following VORBIS_COMMENT metadata-block packet (`count = 1`), then one
+    /// audio packet. `detect_codec` keys on `\x7FFLAC`; `read_header` reads
+    /// `1 + count` header packets. Lengths are computed from the bodies so the
+    /// 24-bit metadata-block length is always self-consistent.
+    pub fn ogg_flac() -> Vec<u8> {
+        use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
+
+        // STREAMINFO metadata block: header (type 0, not-last) + 24-bit len + body.
+        let mut streaminfo = vec![0x00u8, 0x00, 0x00, 0x22]; // len 34
+        streaminfo.extend_from_slice(&[0u8; 34]);
+
+        let mut p0 = Vec::new();
+        p0.push(0x7F);
+        p0.extend_from_slice(b"FLAC");
+        p0.push(1); // mapping major version
+        p0.push(0); // mapping minor version
+        p0.extend_from_slice(&1u16.to_be_bytes()); // count: 1 following packet
+        p0.extend_from_slice(b"fLaC");
+        p0.extend_from_slice(&streaminfo);
+
+        // Following packet: VORBIS_COMMENT block (type 4, last-metadata-block set).
+        let vc_body = vorbis_body_empty();
+        let mut p1 = Vec::new();
+        p1.push(0x84); // 0x80 last-flag | type 4
+        let len = u32::try_from(vc_body.len()).expect("empty vorbis body fits in u24");
+        p1.extend_from_slice(&len.to_be_bytes()[1..4]); // 24-bit big-endian length
+        p1.extend_from_slice(&vc_body);
+
+        let (mut data, pages) = build_header_pub(0x7777, &[&p0, &p1]);
+        let (audio, _) = lace_packet_pub(0x7777, pages, false, 960, &[0u8; 120]);
+        data.extend_from_slice(&audio);
+        data
+    }
+```
+
+- [ ] **Step 5: Run the recognition tests — expect green**
+
+Run: `cargo test -p musefs-format fixtures_tests::ogg_`
+Expected: `2 passed` (`ogg_vorbis_fixture_is_recognized`, `ogg_flac_fixture_is_recognized`).
+
+- [ ] **Step 6: Run the full format crate tests + fuzz build smoke**
+
+Run: `cargo test -p musefs-format`
+Expected: all pass.
+Run: `cargo +nightly fuzz build serve`
+Expected: builds (confirms the new fixtures compile under the `fuzzing` feature as the fuzz crate sees them).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add musefs-format/src/fuzz_check.rs
+git commit -m "$(cat <<'EOF'
+test(format): add ogg_vorbis/ogg_flac fuzz fixtures (#313)
+
+Distinct minimal Ogg Vorbis and OggFLAC fixtures (built from the existing
+page_test_support helpers) so the serve fuzz target's Ogg selectors can feed
+the shared Opus|Vorbis|OggFlac branch distinct inputs. Recognition tests pin
+codec detection + audio location.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: #313c — Hostile rows, binary tags, distinct selectors in `serve.rs`
+
+**Files:**
+- Modify: `fuzz/Cargo.toml` (`[dependencies]`)
+- Modify: `fuzz/fuzz_targets/serve.rs`
+
+The fuzz crate is out-of-workspace, so these edits never touch the workspace test suite — verify exclusively with `cargo +nightly fuzz build serve` and a short `cargo +nightly fuzz run serve`.
+
+- [ ] **Step 1: Enable the db `fuzzing` feature and add `rusqlite` to the fuzz crate**
+
+In `fuzz/Cargo.toml`, the `[dependencies]` currently include:
+
+```toml
+musefs-db = { path = "../musefs-db" }
+```
+
+Change that line to enable the feature, and add `rusqlite` (same version/features as `musefs-db`, so the build unifies):
+
+```toml
+musefs-db = { path = "../musefs-db", features = ["fuzzing"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
+```
+
+- [ ] **Step 2: Update imports in `serve.rs`**
+
+The current `use` block is:
+
+```rust
+use musefs_core::{HeaderCache, Mode, read_at_with_file};
+use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
+use musefs_fuzz::{MAX_INPUT, arb_arts, arb_tags};
+```
+
+Change the `musefs_db` line to add `BinaryTag`:
+
+```rust
+use musefs_db::{BinaryTag, Db, Format, NewArt, NewTrack, Tag, TrackArt};
+```
+
+- [ ] **Step 3: Split selectors 4/5/6 into Opus / Vorbis / OggFLAC**
+
+In `serve.rs`, the selector `match sel { … }` currently has a single `_ =>` arm building `ogg_opus()` for 4–6. Replace that final `_ =>` arm with three explicit arms:
+
+```rust
+        4 => {
+            let b = musefs_format::fuzz_check::fixtures::ogg_opus();
+            let s = match musefs_format::ogg::locate_audio(&b) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            (b, Format::Opus, s.audio_offset, s.audio_length)
+        }
+        5 => {
+            let b = musefs_format::fuzz_check::fixtures::ogg_vorbis();
+            let s = match musefs_format::ogg::locate_audio(&b) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            (b, Format::Vorbis, s.audio_offset, s.audio_length)
+        }
+        _ => {
+            let b = musefs_format::fuzz_check::fixtures::ogg_flac();
+            let s = match musefs_format::ogg::locate_audio(&b) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            (b, Format::OggFlac, s.audio_offset, s.audio_length)
+        }
+```
+
+- [ ] **Step 4: Add the binary-tag opt-in (after the existing art block)**
+
+After the `arb_arts` / `set_track_art` block (the `if let Some(a) = arts.first() { … }`), and before the `let resolved = …` line, add:
+
+```rust
+    // Optionally attach DB binary tags so synthesis materializes a
+    // Segment::BinaryTag and the read windows exercise read_binary_tag_chunk_into.
+    // Use format-appropriate opaque keys (MP3 GEOB frame, M4a freeform atom).
+    if u.arbitrary::<bool>().unwrap_or(false) {
+        let key = match format {
+            Format::Mp3 => "GEOB".to_string(),
+            Format::M4a => "----:com.apple.iTunes:FUZZ".to_string(),
+            _ => "PRIV".to_string(),
+        };
+        let _ = db.set_binary_tags(
+            id,
+            &[BinaryTag {
+                key,
+                payload: vec![0xCDu8; 64],
+                ordinal: 0,
+            }],
+        );
+    }
+```
+
+- [ ] **Step 5: Add the fuzzer-gated hostility selection + pre-resolve mutation**
+
+Immediately after the binary-tag block (still before `let resolved = …`), add:
+
+```rust
+    // Hostile-row stage. Variants 0/1/3 corrupt geometry/format/art-metadata that
+    // `resolve` validates (it returns Err -> the existing early-return below
+    // handles them). Variants 2/4/5 are read-time hostilities applied AFTER a
+    // successful resolve.
+    let hostile = if u.arbitrary::<bool>().unwrap_or(false) {
+        Some(u.int_in_range(0..=5u8).unwrap_or(0))
+    } else {
+        None
+    };
+    let hostile_val = u.arbitrary::<i64>().unwrap_or(i64::MAX);
+    if matches!(hostile, Some(0 | 1 | 3)) {
+        apply_hostile(&db, id, hostile.unwrap(), hostile_val);
+    }
+```
+
+- [ ] **Step 6: Apply post-resolve hostility and soften the reads (assertion discipline)**
+
+The current tail of the target is:
+
+```rust
+    let resolved = match HeaderCache::new(Mode::Synthesis).resolve(&db, id) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    let total = resolved.total_len;
+    let file = std::fs::File::open(&resolved.backing_path).expect("backing file opens");
+
+    // The single whole read every window is checked against (splice consistency).
+    let whole = read_at_with_file(&resolved, &db, &file, 0, total).unwrap();
+    assert_eq!(whole.len() as u64, total, "whole read length != total_len");
+```
+
+Replace it with (note: `resolve` already returns early on Err, which covers variants 0/1/3):
+
+```rust
+    let resolved = match HeaderCache::new(Mode::Synthesis).resolve(&db, id) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    // Read-time hostilities: apply only after a successful resolve.
+    let hostile_post = matches!(hostile, Some(2 | 4 | 5));
+    if hostile_post {
+        apply_hostile(&db, id, hostile.unwrap(), hostile_val);
+    }
+
+    let total = resolved.total_len;
+    let file = std::fs::File::open(&resolved.backing_path).expect("backing file opens");
+
+    // Splice-consistency invariants. A successfully-resolved layout is internally
+    // consistent regardless of how its rows were planted, so whenever the read
+    // returns Ok these MUST hold and are asserted. The only hostile-path
+    // relaxation: a read may return Err (missing art row, stale binary-tag
+    // handle, bumped content_version) -> return/break, do not assert.
+    let whole = match read_at_with_file(&resolved, &db, &file, 0, total) {
+        Ok(w) => w,
+        Err(_) if hostile_post => return,
+        Err(e) => panic!("clean-path whole read failed: {e:?}"),
+    };
+    assert_eq!(whole.len() as u64, total, "whole read length != total_len");
+```
+
+- [ ] **Step 7: Soften the per-window read inside the read loop**
+
+In the `for _ in 0..8 { … }` loop, the window read is currently:
+
+```rust
+        let got = read_at_with_file(&resolved, &db, &file, offset, size).unwrap();
+```
+
+Replace it with:
+
+```rust
+        let got = match read_at_with_file(&resolved, &db, &file, offset, size) {
+            Ok(g) => g,
+            Err(_) if hostile_post => break,
+            Err(e) => panic!("clean-path window read failed: {e:?}"),
+        };
+```
+
+(The existing clamp assertions on `got` that follow stay unchanged — they still run whenever the read returns `Ok`.)
+
+- [ ] **Step 8: Add the `apply_hostile` helper**
+
+After the `setup` function (before the `fuzz_target!` macro), add:
+
+```rust
+/// Plant one hostile mutation via the fuzzing-only raw accessor. Each variant is
+/// best-effort (`let _ =`): the production read path must reject the resulting
+/// state with `Err`, never UB. Pragmas are restored so a later well-formed write
+/// in the same iteration is not silently un-checked.
+fn apply_hostile(db: &Db, id: i64, variant: u8, val: i64) {
+    db.with_raw_conn(|conn| match variant {
+        // 0: negative/oversized integer geometry (resolve rejects at the bounds check).
+        0 => {
+            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = ON");
+            let _ = conn.execute(
+                "UPDATE tracks SET audio_offset = ?1 WHERE id = ?2",
+                rusqlite::params![val, id],
+            );
+            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = OFF");
+        }
+        // 1: invalid format discriminant (model deserialization must Err, not panic).
+        1 => {
+            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = ON");
+            let _ = conn.execute(
+                "UPDATE tracks SET format = 'bogus' WHERE id = ?1",
+                rusqlite::params![id],
+            );
+            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = OFF");
+        }
+        // 2: orphaned track_art (art_id -> no art row) under FK off.
+        2 => {
+            let _ = conn.execute_batch("PRAGMA foreign_keys = OFF");
+            let _ = conn.execute(
+                "UPDATE track_art SET art_id = 999999 WHERE track_id = ?1",
+                rusqlite::params![id],
+            );
+            let _ = conn.execute_batch("PRAGMA foreign_keys = ON");
+        }
+        // 3: oversized art mime (rejected before materialization).
+        3 => {
+            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = ON");
+            let _ = conn.execute(
+                "UPDATE art SET mime = ?1 \
+                 WHERE id IN (SELECT art_id FROM track_art WHERE track_id = ?2)",
+                rusqlite::params!["x".repeat(100_000), id],
+            );
+            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = OFF");
+        }
+        // 4: stale binary-tag handle (delete the blob rows the layout will read).
+        4 => {
+            let _ = conn.execute(
+                "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
+                rusqlite::params![id],
+            );
+        }
+        // 5: backing-geometry / content-version mismatch (per-read freshness guard).
+        _ => {
+            let _ = conn.execute(
+                "UPDATE tracks SET backing_size = backing_size + 1, \
+                 backing_mtime = backing_mtime + 1, \
+                 content_version = content_version + 1 WHERE id = ?1",
+                rusqlite::params![id],
+            );
+        }
+    });
+}
+```
+
+- [ ] **Step 9: Build the fuzz target**
+
+Run: `cargo +nightly fuzz build serve`
+Expected: builds clean (no unused-import/type errors).
+
+- [ ] **Step 10: Smoke-run the target**
+
+Run: `cargo +nightly fuzz run serve -- -runs=200000`
+Expected: completes with no crash. A crash here means either (a) a new Ogg fixture does not synthesize on the clean path — inspect the panic message `clean-path … read failed` and fix the fixture's comment/STREAMINFO bytes in Task 4; or (b) a genuine production defect on a hostile row — that is a real finding to file, not to silence.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add fuzz/Cargo.toml fuzz/fuzz_targets/serve.rs
+git commit -m "$(cat <<'EOF'
+test(fuzz): hostile rows, binary tags, distinct Ogg fixtures in serve (#313)
+
+Fuzzer-gated hostility stage plants negative/oversized geometry, invalid
+formats, orphaned/oversized art, stale binary-tag handles, and content-version
+mismatches via the fuzzing-only raw accessor; optional set_binary_tags exercises
+Segment::BinaryTag streaming; selectors 4/5/6 now feed distinct Opus/Vorbis/
+OggFLAC fixtures. Splice invariants stay asserted whenever reads succeed; the
+only relaxation is tolerating Err on the hostile path (reads no longer unwrap).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (the coverage-guided-fuzzing section and the e2e/test-tiers section)
+
+- [ ] **Step 1: Find the fuzzing + e2e doc anchors**
+
+Run: `grep -n 'fuzz\|--ignored\|e2e\|end-to-end' CONTRIBUTING.md`
+Expected: locates the coverage-guided-fuzzing subsection (lists the fuzz targets) and the test-tiers description of the `--ignored` e2e.
+
+- [ ] **Step 2: Note the new serve fuzz scope**
+
+In the coverage-guided-fuzzing section, where the `serve` target is described (or in the target list), add one sentence:
+
+```markdown
+The `serve` target also exercises hostile DB rows (negative/oversized geometry,
+invalid formats, orphaned/oversized art, stale binary-tag handles, content-version
+mismatch) via the `musefs-db` `fuzzing`-gated `with_raw_conn`, plus binary-tag
+streaming and distinct Opus/Vorbis/OggFLAC fixtures.
+```
+
+- [ ] **Step 3: Note the new CI e2e steps**
+
+Where the test tiers describe the `--ignored` FUSE e2e, add:
+
+```markdown
+The CI `e2e` job also runs the binary-level `cargo test -p musefs -- --ignored`
+and `cargo test -p musefs-latencyfs -- --ignored` suites so they cannot silently
+rot (they require `/dev/fuse` + `fusermount3`).
+```
+
+- [ ] **Step 4: Verify docs lint**
+
+Run: `git add CONTRIBUTING.md && git diff --cached --stat`
+Expected: only `CONTRIBUTING.md` staged. (Docs-only commit skips the cargo gate; ruff/yamllint do not apply to `.md`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: note expanded serve fuzz scope and new CI e2e steps (#320, #313)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Workspace suite green (what the pre-commit hook enforces):**
+  Run: `cargo test --workspace` — Expected: all pass.
+- [ ] **Metrics-feature core tests (CI `check` job; not covered by the bare workspace run):**
+  Run: `cargo test -p musefs-core --features metrics` — Expected: all pass. (These assert exact getattr/read counts; this branch does not touch those paths, but the gate is cheap insurance.)
+- [ ] **Clippy across all targets:**
+  Run: `cargo clippy --all-targets -- -D warnings` — Expected: clean.
+- [ ] **Format:**
+  Run: `cargo fmt --all --check` — Expected: clean.
+- [ ] **db fuzzing accessor:**
+  Run: `cargo test -p musefs-db --features fuzzing` — Expected: all pass.
+- [ ] **Fuzz build + smoke (out-of-workspace):**
+  Run: `cargo +nightly fuzz build serve && cargo +nightly fuzz run serve -- -runs=200000` — Expected: builds; no crash.
+- [ ] **Ignored e2e on this `/dev/fuse` host:**
+  Run: `cargo test -p musefs --test sigterm_unmount -- --ignored --test-threads=1`
+  Run: `cargo test -p musefs-fuse --test read_consistency write_ops_are_refused_on_read_only_mount -- --ignored`
+  Run: `cargo test -p musefs-latencyfs -- --ignored --test-threads=1`
+  Expected: all pass.

--- a/docs/superpowers/plans/2026-06-12-e2e-fuzz-coverage-gaps.md
+++ b/docs/superpowers/plans/2026-06-12-e2e-fuzz-coverage-gaps.md
@@ -437,6 +437,8 @@ EOF
 
 `fuzz_check` compiles under `#[cfg(any(test, feature = "fuzzing"))]`, so `cargo test -p musefs-format` runs the recognition tests — a real red/green loop. The Ogg page helpers are `crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty}`. `detect_codec` keys on the first packet's magic (`\x01vorbis`, `\x7FFLAC`); `read_header` reads 3 header packets for Vorbis and `1 + count` for OggFLAC (`count` = big-endian `u16` at mapping-header bytes 7..9).
 
+**Clean-path synthesis is safe by construction** (relevant once Task 5 feeds these through the full resolve+read path): Ogg synthesis clones the identification/setup/mapping packets verbatim and **rebuilds the comment packet from the DB `tags` table** — it never parses the fixture's VorbisComment body or STREAMINFO. So the deliberately-omitted framing bit and the all-zero STREAMINFO are never read on the synthesis path; a fixture that `read_header` recognizes will synthesize cleanly. The recognition tests below are therefore a sufficient gate.
+
 - [ ] **Step 1: Write the failing recognition tests**
 
 In `musefs-format/src/fuzz_check.rs`, inside `mod fixtures_tests` (after the existing FLAC/m4a tests), add:
@@ -640,12 +642,13 @@ After the `arb_arts` / `set_track_art` block (the `if let Some(a) = arts.first()
 ```rust
     // Optionally attach DB binary tags so synthesis materializes a
     // Segment::BinaryTag and the read windows exercise read_binary_tag_chunk_into.
-    // Use format-appropriate opaque keys (MP3 GEOB frame, M4a freeform atom).
-    if u.arbitrary::<bool>().unwrap_or(false) {
+    // Only MP3 (4-byte frame id) and M4a (`----:<mean>:<name>` freeform atom)
+    // synthesize opaque binary tags from the DB; for any other format the row is
+    // silently dropped at synthesis, so restrict the opt-in to those two.
+    if matches!(format, Format::Mp3 | Format::M4a) && u.arbitrary::<bool>().unwrap_or(false) {
         let key = match format {
             Format::Mp3 => "GEOB".to_string(),
-            Format::M4a => "----:com.apple.iTunes:FUZZ".to_string(),
-            _ => "PRIV".to_string(),
+            _ => "----:com.apple.iTunes:FUZZ".to_string(),
         };
         let _ = db.set_binary_tags(
             id,
@@ -750,50 +753,76 @@ Replace it with:
 After the `setup` function (before the `fuzz_target!` macro), add:
 
 ```rust
-/// Plant one hostile mutation via the fuzzing-only raw accessor. Each variant is
-/// best-effort (`let _ =`): the production read path must reject the resulting
-/// state with `Err`, never UB. Pragmas are restored so a later well-formed write
-/// in the same iteration is not silently un-checked.
+/// Plant one hostile mutation via the fuzzing-only raw accessor. The production
+/// read path must reject the resulting state with `Err`, never UB. Each fuzz
+/// iteration uses a fresh in-memory DB (`setup`), so dropping a trigger / leaving
+/// a pragma toggled is scoped to that iteration's connection.
+///
+/// Variants whose target row ALWAYS exists (0, 1, 5 — the single `tracks` row)
+/// assert `n == 1` so a future schema rename cannot silently turn the mutation
+/// into a swallowed no-op (this exact trap hid a `backing_mtime` -> `backing_mtime_ns`
+/// rename during planning). Variants 2/3/4 are genuinely conditional (they need an
+/// art row or binary-tag row that the earlier stages may not have created), so
+/// they stay best-effort (`let _ =`).
 fn apply_hostile(db: &Db, id: i64, variant: u8, val: i64) {
     db.with_raw_conn(|conn| match variant {
         // 0: negative/oversized integer geometry (resolve rejects at the bounds check).
         0 => {
-            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = ON");
-            let _ = conn.execute(
-                "UPDATE tracks SET audio_offset = ?1 WHERE id = ?2",
-                rusqlite::params![val, id],
-            );
-            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = OFF");
+            conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+                .unwrap();
+            let n = conn
+                .execute(
+                    "UPDATE tracks SET audio_offset = ?1, audio_length = ?1 WHERE id = ?2",
+                    rusqlite::params![val, id],
+                )
+                .unwrap();
+            assert_eq!(n, 1, "variant 0 must mutate the tracks row");
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
         }
         // 1: invalid format discriminant (model deserialization must Err, not panic).
         1 => {
-            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = ON");
-            let _ = conn.execute(
-                "UPDATE tracks SET format = 'bogus' WHERE id = ?1",
-                rusqlite::params![id],
-            );
-            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = OFF");
+            conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+                .unwrap();
+            let n = conn
+                .execute(
+                    "UPDATE tracks SET format = 'bogus' WHERE id = ?1",
+                    rusqlite::params![id],
+                )
+                .unwrap();
+            assert_eq!(n, 1, "variant 1 must mutate the tracks row");
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
         }
-        // 2: orphaned track_art (art_id -> no art row) under FK off.
+        // 2: orphaned track_art (art_id -> no art row) under FK off. No-op when no
+        // art row was attached this iteration.
         2 => {
-            let _ = conn.execute_batch("PRAGMA foreign_keys = OFF");
+            conn.execute_batch("PRAGMA foreign_keys = OFF").unwrap();
             let _ = conn.execute(
                 "UPDATE track_art SET art_id = 999999 WHERE track_id = ?1",
                 rusqlite::params![id],
             );
-            let _ = conn.execute_batch("PRAGMA foreign_keys = ON");
+            conn.execute_batch("PRAGMA foreign_keys = ON").unwrap();
         }
-        // 3: oversized art mime (rejected before materialization).
+        // 3: oversized art mime. `art` rows are immutable via the
+        // `art_reject_content_update` trigger, and `ignore_check_constraints` does
+        // NOT disable triggers, so the trigger must be dropped first (the length(mime)
+        // CHECK still needs the pragma). No-op when no art row was attached.
         3 => {
-            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = ON");
+            conn.execute_batch(
+                "PRAGMA ignore_check_constraints = ON; DROP TRIGGER art_reject_content_update;",
+            )
+            .unwrap();
             let _ = conn.execute(
                 "UPDATE art SET mime = ?1 \
                  WHERE id IN (SELECT art_id FROM track_art WHERE track_id = ?2)",
                 rusqlite::params!["x".repeat(100_000), id],
             );
-            let _ = conn.execute_batch("PRAGMA ignore_check_constraints = OFF");
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
         }
         // 4: stale binary-tag handle (delete the blob rows the layout will read).
+        // No-op unless the binary-tag opt-in fired for an MP3/M4a track.
         4 => {
             let _ = conn.execute(
                 "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
@@ -802,12 +831,15 @@ fn apply_hostile(db: &Db, id: i64, variant: u8, val: i64) {
         }
         // 5: backing-geometry / content-version mismatch (per-read freshness guard).
         _ => {
-            let _ = conn.execute(
-                "UPDATE tracks SET backing_size = backing_size + 1, \
-                 backing_mtime = backing_mtime + 1, \
-                 content_version = content_version + 1 WHERE id = ?1",
-                rusqlite::params![id],
-            );
+            let n = conn
+                .execute(
+                    "UPDATE tracks SET backing_size = backing_size + 1, \
+                     backing_mtime_ns = backing_mtime_ns + 1, \
+                     content_version = content_version + 1 WHERE id = ?1",
+                    rusqlite::params![id],
+                )
+                .unwrap();
+            assert_eq!(n, 1, "variant 5 must mutate the tracks row");
         }
     });
 }

--- a/docs/superpowers/specs/2026-06-12-e2e-fuzz-coverage-gaps-design.md
+++ b/docs/superpowers/specs/2026-06-12-e2e-fuzz-coverage-gaps-design.md
@@ -75,16 +75,27 @@ In `.github/workflows/ci.yml`, the `e2e` job currently runs only
 - `cargo test -p musefs-latencyfs -- --ignored`
 
 so binary-level and latencyfs e2e cannot silently rot again. (`musefs-cli` has
-no ignored tests, so it is not wired.)
+no ignored tests, so it is not wired.) Both steps inherit the job's
+`if: needs.changes.outputs.src == 'true'` gate (`ci.yml:293`), matching the
+existing `musefs-fuse` step: they run on `src`-touching PRs, not docs-/
+workflow-only ones — the same anti-rot coverage the `musefs-fuse` e2e already
+has, no weaker.
 
 ### Contingency
 
 `musefs-latencyfs` has its own ignored e2e (`latency_effect`, `passthrough`,
 `sqlite_wal`) that also have never run in CI and may themselves be stale. Before
-wiring them, run both suites locally on this `/dev/fuse` host. If a latencyfs
-test is stale in the same trivial way (drifted default/template/path), fix it
-in-scope. If a failure reveals something larger, do **not** wire a red test —
-surface it as a separate finding and wire only the green suites.
+wiring them, run both suites locally on this `/dev/fuse` host.
+
+Note the failure model differs from #320: **latencyfs is a read-write
+passthrough with no synthesis template**, so its tests (e.g.
+`write_fsync_rename_unlink_through_the_mount`, `fsync_count_rises_with_more_commits`)
+*write through* the mount and cannot rot the "default template changed" way the
+sigterm tests did. Any latencyfs staleness will be passthrough/latency-behavior
+drift, **not** virtual-path drift — do not "fix" a latencyfs failure with a
+template tweak. The rule stands regardless: do **not** wire a red test; if a
+failure reveals something larger, surface it as a separate finding and wire only
+the green suites.
 
 ---
 
@@ -128,9 +139,11 @@ did not mutate, which satisfies the contract.
 **Read probes** (`getxattr`, `listxattr`) — these are **not** mutations.
 Asserting they are "refused" would be a bug. Exercise them against an existing
 served file and assert **read-safety** instead: the call either succeeds
-(returns `>= 0`) or fails with `ENOTSUP` / `ENODATA` (no xattr support / no such
-attr). Add a small `assert_read_safe(ret, accepted_errnos, what)` helper rather
-than overloading `assert_refused`.
+(returns `>= 0` — `getxattr` with a zero-size buffer returns the needed size)
+or fails with `ENOTSUP` / `ENODATA` (no xattr support / no such attr). Use
+`libc::ENOTSUP` (on Linux `EOPNOTSUPP` is the same value but a distinct
+constant). Add a small `assert_read_safe(ret, accepted_errnos, what)` helper
+rather than overloading `assert_refused`.
 
 All raw libc calls stay inside the existing single `unsafe` block under the
 existing `#[expect(unsafe_code, …)]`; extend the `reason` text if needed.
@@ -176,6 +189,19 @@ fuzz crate is out-of-workspace, the feature never unifies into normal
 CI's `cargo +nightly fuzz build` smoke — the same exposure profile as the
 existing format `fuzzing` helpers.
 
+Pin the shape: the accessor lives on `impl<M> Db<M>` (so it is available
+regardless of the `ReadWrite`/`ReadOnly` marker; the fuzz target uses
+`open_in_memory()` → `Db<ReadWrite>`), takes `&self`, and hands out `&rusqlite::
+Connection` (already a non-optional dep). The fuzzer applies hostile writes via
+direct `conn.execute(...)` / `execute_batch(...)`.
+
+**`PRAGMA ignore_check_constraints` is connection-scoped and persistent.**
+Categories 1–2 need it to bypass the V4 bounds CHECK that otherwise rejects
+oversized/negative geometry at write time. It must be set on the *same*
+connection `with_raw_conn` exposes, and **toggled back off** after the hostile
+write so a later well-formed write in the same iteration (e.g. category 5's "set
+binary tags, then corrupt the handle") is not silently un-checked.
+
 In `fuzz/Cargo.toml`, change `musefs-db = { path = "../musefs-db" }` to enable
 `features = ["fuzzing"]`.
 
@@ -194,13 +220,16 @@ corrupt states. Categories (all via parameterized statements, using
 5. **Stale / reused `tags.rowid` binary handles** — set binary tags, resolve (capturing the layout/handles), then delete or replace the binary-tag row, then read. Stresses `read_binary_tag_chunk_into`'s missing/stale-handle path.
 6. **content-version / backing-geometry mismatch** — `backing_size` / `backing_mtime_ns` / `content_version` set to disagree with the real backing file. Stresses the freshness/staleness check.
 
+**Expected outcome of each category is `Err`, never panic** (the whole point — the production code must *reject* hostile state safely). The implementer should confirm during TDD, not assume: category 2's invalid `format` discriminant must make `get_track` deserialization return `Err` (an `unwrap`/`expect` on it would itself be the bug under test); category 5's deleted/replaced binary-tag row must surface as either the per-read `content_version` transactional guard tripping (`BackingChanged`) or `blob_open` returning `Err` — both are `Err`, both satisfied by the "any read `Err` is acceptable on the hostile path" rule. If any category instead *panics* in production code, that is a real finding to file, not something to paper over in the target.
+
 ### Design — binary-tag streaming
 
 When the chosen format supports binary tags and the fuzzer opts in, call
-`db.set_binary_tags(id, &[…])` with fuzzer-chosen key/mime/payload so a
-`Segment::BinaryTag` is materialized and the existing draw-up-to-8 read windows
-exercise `read_binary_tag_chunk_into`. (This composes with hostile category 5,
-which then corrupts the handle the windows read through.)
+`db.set_binary_tags(id, &[…])` so a `Segment::BinaryTag` is materialized and the
+existing draw-up-to-8 read windows exercise `read_binary_tag_chunk_into`.
+`BinaryTag` is `{ key: String, payload: Vec<u8>, ordinal: u64 }` (no `mime`
+field) — the fuzzer chooses `key`/`payload`/`ordinal`. (This composes with
+hostile category 5, which then corrupts the handle the windows read through.)
 
 ### Design — distinct Ogg fixtures
 
@@ -213,20 +242,51 @@ lace_packet_pub}` helpers, mirroring `ogg_opus()` (Vorbis identification header
 
 ### Assertion discipline (critical)
 
-The splice-consistency invariants — whole-read length `== total_len`, and each
-window equals the clamped slice of the whole read — hold **only on the clean,
-non-hostile path**. When the fuzzer has applied a hostile mutation:
+The key realization (verified against `musefs-core/src/reader.rs`): a
+**successfully-resolved layout is self-consistent regardless of how its rows
+were planted.** `HeaderCache::resolve` validates the backing stamp
+(size/mtime/ctime) first and, in `Synthesis` mode, rejects
+`audio_offset + audio_length > meta.len()` — both return `Err(BackingChanged)`.
+So the length-corrupting categories (1 negative/oversized integers, 6
+backing-geometry mismatch) almost always fail *at resolve*. If resolve succeeds,
+`resolved.total_len` and the layout are internally consistent; the whole read
+uses `total = resolved.total_len`, and `read_segments_into` clamps every window
+to `[offset, min(offset+size, total_len))` from that **same** `total_len`. The
+hostility that survives resolve is therefore in *segment byte contents* (art
+blob, binary-tag payload, mime), not in lengths.
 
-- `HeaderCache::resolve` returning `Err`, or a read returning `Err`, is
-  **acceptable and expected** — `return` early, do not assert.
-- The only contract on the hostile path is **no panic / no UB / no
-  out-of-bounds**. Reads that *do* succeed must still not read or copy audio
-  bytes outside `[offset, total)` (the existing clamp invariant), but length
-  equality against a "whole read" computed from a corrupt layout is not
-  asserted.
+Consequence — the splice invariants are **kept, not suppressed**, on the hostile
+path:
 
-Structurally: compute and assert the splice invariants before applying any
-hostile mutation (or guard them behind `if !hostile_applied`).
+- Whenever resolve **and** every read return `Ok`, assert the existing splice
+  invariants exactly as today (`whole.len() == total`; each window equals the
+  clamped slice of `whole`). A self-consistent layout cannot violate them no
+  matter how its bytes were planted, so asserting keeps the test's full power.
+- The **only** relaxation: on the hostile path, `HeaderCache::resolve` returning
+  `Err`, **or any read returning `Err`** (missing art row, stale binary-tag
+  handle, etc.), is acceptable and expected — `return` early, do not assert.
+  There is no "lengths may disagree" carve-out.
+
+**Required implementation change — the reads currently `.unwrap()`.** The whole
+read (`serve.rs:139`) and each window read (`serve.rs:157`) call
+`read_at_with_file(...).unwrap()`. Hostile categories 3 (orphaned art), 4
+(oversized/garbage), and 5 (stale binary-tag handle) are designed to make a read
+return `Err`; with the current `.unwrap()` that `Err` becomes a panic = a false
+fuzz crash. Both read sites must be changed so that **on the hostile path** an
+`Err` causes an early `return` (no assert), while **on the clean path the read
+stays strict** (`Err` is still a crash, preserving test power). Structurally:
+
+```rust
+let whole = match read_at_with_file(&resolved, &db, &file, 0, total) {
+    Ok(w) => w,
+    Err(_) if hostile_applied => return,
+    Err(e) => panic!("clean-path whole read failed: {e:?}"),
+};
+```
+
+and the analogous shape for each window read. "No out-of-bounds" on hostile
+reads is enforced structurally by `read_segments_into`'s clamp (under test) and
+observed via no-panic / ASan, not by a separate assertion.
 
 ### Skips (explicit, per "no silent caps")
 

--- a/docs/superpowers/specs/2026-06-12-e2e-fuzz-coverage-gaps-design.md
+++ b/docs/superpowers/specs/2026-06-12-e2e-fuzz-coverage-gaps-design.md
@@ -1,0 +1,280 @@
+# Design: close the #280 e2e/fuzz coverage gaps (#320, #306, #313)
+
+## Summary
+
+Three independent test/fuzz coverage gaps surfaced by the #280 audit, landed
+together on the `coverage` branch as one cohesive effort. None is a live
+production defect — each is missing or stale **test coverage** of an existing,
+correct invariant:
+
+- **#320** — `musefs/tests/sigterm_unmount.rs` asserts a path the current
+  default template no longer produces, so both e2e tests fail whenever actually
+  run; and the `musefs` / `musefs-latencyfs` binary-level `--ignored` e2e tests
+  never run in CI, so the staleness was undetectable.
+- **#306** — the read-only refusal e2e (`read_consistency.rs`) probes a subset
+  of mutating syscalls; whole families (`rename`, `rmdir`, `symlink`, `chown`,
+  xattr mutators, `mknod`/`link`) are uncovered.
+- **#313** — the `serve` fuzz target only builds well-formed DB rows via the
+  public API; it never fuzzes hostile/corrupt rows, never streams a
+  `Segment::BinaryTag`, and routes three selector values to a single Opus
+  fixture.
+
+The guiding invariant for the whole repo is unchanged: **original audio bytes
+are never copied or modified**, and the SQLite store is the external-writer
+contract. This work hardens the *tests* that guard that contract.
+
+## Non-goals
+
+- No production behavior change. The musefs binary, FUSE callbacks, read/
+  synthesis paths, and DB schema are not modified (except the additive,
+  feature-gated DB accessor in #313, which is compiled only for the
+  out-of-workspace fuzz crate).
+- No new `EROFS`-exact assertions: the read-only contract stays "mutation
+  refused", accepting any errno that proves no write occurred.
+- The malformed-FLAC-structural fuzz angle is **explicitly skipped** (see
+  Section C / Skips).
+
+---
+
+## Section A — #320: stale sigterm tests + CI wiring
+
+### Problem
+
+Both tests in `musefs/tests/sigterm_unmount.rs`
+(`sigterm_unmounts_cleanly`, `sigterm_exits_bounded_when_mount_is_busy`) build a
+FLAC fixture tagged only `ARTIST=Alice` / `TITLE=Song`, mount via the real
+binary with **no `--template`**, and assert the synthesized file at
+`Alice/Song.flac`. The default template is now `$albumartist/$album/$title`
+with `--default-fallback Unknown`, so the file actually renders at
+`Unknown/Unknown/Song.flac`. The asserted path never appears, and both tests
+panic `mount did not come up` at the 15 s poll. CI never runs
+`cargo test -p musefs -- --ignored`, so this was invisible there.
+
+### Fix — tests
+
+Pass an explicit `--template '$artist/$title'` to the `mount` command in **both**
+tests. The fixture stays `ARTIST=Alice` / `TITLE=Song`; the asserted path
+`Alice/Song.flac` is produced deterministically and is immune to future
+default-template changes (the exact failure mode that rotted these tests).
+
+Concretely, each test's mount invocation changes from:
+
+```rust
+.args(["mount", mp.path().to_str().unwrap(), "--db", db])
+```
+
+to add `"--template", "$artist/$title"`. No fixture, assertion-path, or SIGTERM
+logic changes.
+
+### Fix — CI
+
+In `.github/workflows/ci.yml`, the `e2e` job currently runs only
+`musefs-fuse` ignored tests. Add two steps:
+
+- `cargo test -p musefs -- --ignored`
+- `cargo test -p musefs-latencyfs -- --ignored`
+
+so binary-level and latencyfs e2e cannot silently rot again. (`musefs-cli` has
+no ignored tests, so it is not wired.)
+
+### Contingency
+
+`musefs-latencyfs` has its own ignored e2e (`latency_effect`, `passthrough`,
+`sqlite_wal`) that also have never run in CI and may themselves be stale. Before
+wiring them, run both suites locally on this `/dev/fuse` host. If a latencyfs
+test is stale in the same trivial way (drifted default/template/path), fix it
+in-scope. If a failure reveals something larger, do **not** wire a red test —
+surface it as a separate finding and wire only the green suites.
+
+---
+
+## Section B — #306: expand read-only refusal coverage
+
+### Problem
+
+The mount is `MountOption::RO` and `MusefsFs` implements no mutating callbacks,
+so no write-through defect exists. But the ignored e2e
+`write_ops_are_refused_on_read_only_mount` only probes `open(O_WRONLY)`,
+`open(O_RDWR)`, `open(O_CREAT)`, `unlink`, `truncate`, `ftruncate`, `mkdir`,
+`chmod`, `utimes`. Whole mutating-syscall families are unprobed, so a future
+platform change or a later callback could weaken the read-only contract without
+a test catching it.
+
+### Design
+
+Extend the existing `write_ops_are_refused_on_read_only_mount` test (do not add
+a parallel test). Reuse the existing `assert_refused(ret, accepted, what)`
+helper and its "mutation refused, not exactly `EROFS`" contract.
+
+**New mutating syscalls** — each asserted refused with a broad "no write
+happened" errno set:
+
+| Syscall | Target | Accepted errnos |
+|---------|--------|-----------------|
+| `rename` | existing served file → new name in `Alice/` | `EROFS`, `EPERM`, `EACCES` |
+| `rmdir` | a virtual dir (e.g. `Alice`) | `EROFS`, `EPERM`, `EACCES`, `ENOTEMPTY` |
+| `symlink` | new link in `Alice/` | `EROFS`, `EPERM`, `EACCES` |
+| `chown` | existing served file | `EROFS`, `EPERM`, `EACCES` |
+| `lchown` | existing served file | `EROFS`, `EPERM`, `EACCES` |
+| `setxattr` | existing served file | `EROFS`, `EPERM`, `EACCES`, `ENOTSUP` |
+| `removexattr` | existing served file | `EROFS`, `EPERM`, `EACCES`, `ENOTSUP`, `ENODATA` |
+| `mknod` | new regular file (`S_IFREG`, mode `0o644` — no privilege) | `EROFS`, `EPERM`, `EACCES`, `ENOSYS` |
+| `link` | existing served file → new name | `EROFS`, `EPERM`, `EACCES`, `ENOSYS` |
+
+`ENOSYS` tolerance covers the issue's "(where available)" caveat: if the
+platform/FUSE build does not implement the callback at all, the syscall still
+did not mutate, which satisfies the contract.
+
+**Read probes** (`getxattr`, `listxattr`) — these are **not** mutations.
+Asserting they are "refused" would be a bug. Exercise them against an existing
+served file and assert **read-safety** instead: the call either succeeds
+(returns `>= 0`) or fails with `ENOTSUP` / `ENODATA` (no xattr support / no such
+attr). Add a small `assert_read_safe(ret, accepted_errnos, what)` helper rather
+than overloading `assert_refused`.
+
+All raw libc calls stay inside the existing single `unsafe` block under the
+existing `#[expect(unsafe_code, …)]`; extend the `reason` text if needed.
+
+---
+
+## Section C — #313: expand serve fuzzing
+
+### Problem
+
+`fuzz/fuzz_targets/serve.rs` reaches the real core read path, but its DB state is
+built only through the public, validating API (`upsert_track`, `replace_tags`,
+`upsert_art`, `set_track_art`). It therefore never fuzzes rows that can exist
+only through a hostile SQLite writer or corruption, never calls
+`set_binary_tags` (so `Segment::BinaryTag` / `read_binary_tag_chunk_into` are
+unreached by fuzzed read windows), and routes selector values 4–6 all to the
+same `ogg_opus()` fixture.
+
+### Design — feature-gated raw DB accessor
+
+Add a `fuzzing` cargo feature to `musefs-db`, mirroring the existing
+`musefs-format` `fuzzing` feature and `musefs-db`'s own test-only `mutants`
+feature (both "named after the activity that needs it … not for production
+use"). Off by default; enabled only by the out-of-workspace fuzz crate.
+
+Under the feature, expose a raw-connection escape hatch on `Db`, e.g.:
+
+```rust
+#[cfg(feature = "fuzzing")]
+impl Db {
+    /// TEST/FUZZ ONLY. Hands the raw rusqlite connection to `f` so fuzz
+    /// harnesses can plant rows the validating public API cannot produce
+    /// (e.g. under `PRAGMA ignore_check_constraints`). Never compiled in
+    /// production: the `fuzzing` feature is enabled only by the fuzz crate,
+    /// which is outside the cargo workspace.
+    pub fn with_raw_conn<R>(&self, f: impl FnOnce(&rusqlite::Connection) -> R) -> R { … }
+}
+```
+
+The doc-comment must make the test/fuzz-only contract unmistakable. Because the
+fuzz crate is out-of-workspace, the feature never unifies into normal
+`cargo build` / `test` / `clippy`; the gated code is compiled and linted only by
+CI's `cargo +nightly fuzz build` smoke — the same exposure profile as the
+existing format `fuzzing` helpers.
+
+In `fuzz/Cargo.toml`, change `musefs-db = { path = "../musefs-db" }` to enable
+`features = ["fuzzing"]`.
+
+### Design — hostile-row stage in `serve.rs`
+
+After the existing well-formed setup, add a **fuzzer-gated** hostility stage:
+the fuzzer draws a selector deciding whether (and which) hostile mutation(s) to
+apply via `with_raw_conn`. One corpus thus reaches both the well-formed and the
+corrupt states. Categories (all via parameterized statements, using
+`PRAGMA ignore_check_constraints` where a CHECK would otherwise block the write):
+
+1. **Negative / oversized integers** — `UPDATE tracks SET audio_offset / audio_length / backing_size / backing_mtime_ns / backing_ctime_ns = <fuzzer i64, incl. negative & i64::MAX>`; likewise art `width`/`height`. Stresses `i64`→`u64`/`usize` model conversion before any read.
+2. **Constraint-bypassed `tracks` rows** — invalid `format` discriminant / impossible geometry planted with checks disabled. Stresses model deserialization and format dispatch.
+3. **Orphaned / missing art** — `track_art.art_id` pointed at a non-existent `art` row (or the `art` row deleted). Stresses `ArtImage` / `OggArtSlice` resolve + stream.
+4. **Oversized text / blob** — a multi-KB+ `mime` string or art blob whose safe rejection must happen before materialization.
+5. **Stale / reused `tags.rowid` binary handles** — set binary tags, resolve (capturing the layout/handles), then delete or replace the binary-tag row, then read. Stresses `read_binary_tag_chunk_into`'s missing/stale-handle path.
+6. **content-version / backing-geometry mismatch** — `backing_size` / `backing_mtime_ns` / `content_version` set to disagree with the real backing file. Stresses the freshness/staleness check.
+
+### Design — binary-tag streaming
+
+When the chosen format supports binary tags and the fuzzer opts in, call
+`db.set_binary_tags(id, &[…])` with fuzzer-chosen key/mime/payload so a
+`Segment::BinaryTag` is materialized and the existing draw-up-to-8 read windows
+exercise `read_binary_tag_chunk_into`. (This composes with hostile category 5,
+which then corrupts the handle the windows read through.)
+
+### Design — distinct Ogg fixtures
+
+Add `ogg_vorbis()` and `ogg_flac()` to `musefs-format::fuzz_check::fixtures`,
+built from the existing `ogg::page_test_support::{build_header_pub,
+lace_packet_pub}` helpers, mirroring `ogg_opus()` (Vorbis identification header
+`\x01vorbis…`; OggFLAC mapping header `\x7FFLAC…`). Split the `serve` selector so
+4 → Opus, 5 → Vorbis, 6 → OggFLAC, giving the shared
+`Format::Opus | Vorbis | OggFlac` Ogg branch distinct inputs.
+
+### Assertion discipline (critical)
+
+The splice-consistency invariants — whole-read length `== total_len`, and each
+window equals the clamped slice of the whole read — hold **only on the clean,
+non-hostile path**. When the fuzzer has applied a hostile mutation:
+
+- `HeaderCache::resolve` returning `Err`, or a read returning `Err`, is
+  **acceptable and expected** — `return` early, do not assert.
+- The only contract on the hostile path is **no panic / no UB / no
+  out-of-bounds**. Reads that *do* succeed must still not read or copy audio
+  bytes outside `[offset, total)` (the existing clamp invariant), but length
+  equality against a "whole read" computed from a corrupt layout is not
+  asserted.
+
+Structurally: compute and assert the splice invariants before applying any
+hostile mutation (or guard them behind `if !hostile_applied`).
+
+### Skips (explicit, per "no silent caps")
+
+The issue's 7th hostile category — **"malformed structural blocks for the FLAC
+fast-path synthesis"** — is **not** implemented here. It is *backing-byte*
+corruption, not a hostile DB row, and that surface is already the entire job of
+the dedicated `flac` fuzz target. Folding it into `serve` would add only the
+"corrupt structure reached at synthesis read-time" angle at meaningful overlap.
+The spec records the skip so it is visible; revisit only if read-time FLAC
+structural coverage is later judged worth the duplication.
+
+---
+
+## Testing & verification
+
+- **#320**: run `cargo test -p musefs --test sigterm_unmount -- --ignored
+  --test-threads=1` and `cargo test -p musefs-latencyfs -- --ignored` locally on
+  this `/dev/fuse` host; both must pass before the CI steps are wired (contingency
+  above).
+- **#306**: run `cargo test -p musefs-fuse --test read_consistency -- --ignored`
+  locally; the extended test must pass on `/dev/fuse`.
+- **#313**: `cargo +nightly fuzz build serve` (the fuzz crate is out-of-workspace,
+  so workspace build/test/clippy will not catch breakage in the target or the new
+  feature-gated accessor). A short local `cargo +nightly fuzz run serve` smoke to
+  confirm the hostile stage neither panics on clean inputs nor trivially crashes.
+- Full workspace suite via the pre-commit hook (fmt, clippy `-D warnings`, all
+  tests). The new `fuzzing`-gated `musefs-db` code is not compiled by the
+  workspace; ensure `musefs-db` still builds/lints with the feature off (default)
+  and that the fuzz build exercises it on.
+
+## Documentation
+
+- `CONTRIBUTING.md`: if the new `musefs-db/fuzzing` feature changes the documented
+  fuzz build invocation, update the coverage-guided-fuzzing section; note the new
+  `serve` hostile-row / binary-tag scope alongside the existing fuzz-target list.
+- Note the two new `e2e`-job steps where the CI e2e job / FUSE e2e tiers are
+  described (CONTRIBUTING.md test-tiers).
+
+## Commit shape (TDD-aware)
+
+The pre-commit hook rejects any commit with red workspace tests, so each commit
+must be green:
+
+1. #320 test fix + CI wiring (after local verification of latencyfs).
+2. #306 read-only test extension.
+3. #313 in two parts: (a) `musefs-db` `fuzzing` accessor + `fuzz/Cargo.toml`
+   feature + `ogg_vorbis`/`ogg_flac` fixtures (workspace stays green; fuzz build
+   verifies); (b) `serve.rs` hostile stage + binary-tag + selector split.
+
+Ordering within the branch is flexible since the three issues are independent;
+each lands as its own green commit.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "musefs-core",
  "musefs-db",
  "musefs-format",
+ "rusqlite",
  "tempfile",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,8 @@ libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
 musefs-format = { path = "../musefs-format", features = ["fuzzing"] }
 musefs-core = { path = "../musefs-core" }
-musefs-db = { path = "../musefs-db" }
+musefs-db = { path = "../musefs-db", features = ["fuzzing"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 tempfile = "3"
 
 [lib]

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -285,12 +285,17 @@ fuzz_target!(|data: &[u8]| {
 
     // Splice-consistency invariants. A successfully-resolved layout is internally
     // consistent regardless of how its rows were planted, so whenever the read
-    // returns Ok these MUST hold and are asserted. The only hostile-path
-    // relaxation: a read may return Err (missing art row, stale binary-tag
-    // handle, bumped content_version) -> return/break, do not assert.
+    // returns Ok these MUST hold and are asserted. The only relaxation: when ANY
+    // hostile mutation was applied, a read may return Err -> return/break, do not
+    // assert. This must key on `hostile.is_some()`, NOT `hostile_post`: resolve
+    // trusts the DB geometry for Ogg (it defers page parsing to read time), so a
+    // pre-resolve geometry corruption (variant 0) can survive resolve and surface
+    // as a clean Err(Format(Malformed)) at read time — that is the production code
+    // correctly rejecting hostile state, not a clean-path failure. Only a
+    // genuinely clean input (hostile == None) must read without error.
     let whole = match read_at_with_file(&resolved, &db, &file, 0, total) {
         Ok(w) => w,
-        Err(_) if hostile_post => return,
+        Err(_) if hostile.is_some() => return,
         Err(e) => panic!("clean-path whole read failed: {e:?}"),
     };
     assert_eq!(whole.len() as u64, total, "whole read length != total_len");
@@ -312,7 +317,7 @@ fuzz_target!(|data: &[u8]| {
         };
         let got = match read_at_with_file(&resolved, &db, &file, offset, size) {
             Ok(g) => g,
-            Err(_) if hostile_post => break,
+            Err(_) if hostile.is_some() => break,
             Err(e) => panic!("clean-path window read failed: {e:?}"),
         };
         // Mirror read_segments_into's clamp: served = [min(offset,total), min(offset+size,total)).

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -2,7 +2,7 @@
 use arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use musefs_core::{HeaderCache, Mode, read_at_with_file};
-use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
+use musefs_db::{BinaryTag, Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_fuzz::{MAX_INPUT, arb_arts, arb_tags};
 use std::io::Write;
 use std::os::unix::fs::MetadataExt;
@@ -33,6 +33,97 @@ fn setup(
         .ok()?;
     db.replace_tags(id, &[Tag::new("title", "T", 0)]).ok()?;
     Some((dir, db, id))
+}
+
+/// Plant one hostile mutation via the fuzzing-only raw accessor. The production
+/// read path must reject the resulting state with `Err`, never UB. Each fuzz
+/// iteration uses a fresh in-memory DB (`setup`), so dropping a trigger / leaving
+/// a pragma toggled is scoped to that iteration's connection.
+///
+/// Variants whose target row ALWAYS exists (0, 1, 5 — the single `tracks` row)
+/// assert `n == 1` so a future schema rename cannot silently turn the mutation
+/// into a swallowed no-op (this exact trap hid a `backing_mtime` -> `backing_mtime_ns`
+/// rename during planning). Variants 2/3/4 are genuinely conditional (they need an
+/// art row or binary-tag row that the earlier stages may not have created), so
+/// they stay best-effort (`let _ =`).
+fn apply_hostile(db: &Db, id: i64, variant: u8, val: i64) {
+    db.with_raw_conn(|conn| match variant {
+        // 0: negative/oversized integer geometry (resolve rejects at the bounds check).
+        0 => {
+            conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+                .unwrap();
+            let n = conn
+                .execute(
+                    "UPDATE tracks SET audio_offset = ?1, audio_length = ?1 WHERE id = ?2",
+                    rusqlite::params![val, id],
+                )
+                .unwrap();
+            assert_eq!(n, 1, "variant 0 must mutate the tracks row");
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
+        }
+        // 1: invalid format discriminant (model deserialization must Err, not panic).
+        1 => {
+            conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+                .unwrap();
+            let n = conn
+                .execute(
+                    "UPDATE tracks SET format = 'bogus' WHERE id = ?1",
+                    rusqlite::params![id],
+                )
+                .unwrap();
+            assert_eq!(n, 1, "variant 1 must mutate the tracks row");
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
+        }
+        // 2: orphaned track_art (art_id -> no art row) under FK off. No-op when no
+        // art row was attached this iteration.
+        2 => {
+            conn.execute_batch("PRAGMA foreign_keys = OFF").unwrap();
+            let _ = conn.execute(
+                "UPDATE track_art SET art_id = 999999 WHERE track_id = ?1",
+                rusqlite::params![id],
+            );
+            conn.execute_batch("PRAGMA foreign_keys = ON").unwrap();
+        }
+        // 3: oversized art mime. `art` rows are immutable via the
+        // `art_reject_content_update` trigger, and `ignore_check_constraints` does
+        // NOT disable triggers, so the trigger must be dropped first (the length(mime)
+        // CHECK still needs the pragma). No-op when no art row was attached.
+        3 => {
+            conn.execute_batch(
+                "PRAGMA ignore_check_constraints = ON; DROP TRIGGER art_reject_content_update;",
+            )
+            .unwrap();
+            let _ = conn.execute(
+                "UPDATE art SET mime = ?1 \
+                 WHERE id IN (SELECT art_id FROM track_art WHERE track_id = ?2)",
+                rusqlite::params!["x".repeat(100_000), id],
+            );
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
+        }
+        // 4: stale binary-tag handle (delete the blob rows the layout will read).
+        // No-op unless the binary-tag opt-in fired for an MP3/M4a track.
+        4 => {
+            let _ = conn.execute(
+                "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
+                rusqlite::params![id],
+            );
+        }
+        // 5: backing-geometry / content-version mismatch (per-read freshness guard).
+        _ => {
+            let n = conn
+                .execute(
+                    "UPDATE tracks SET backing_size = backing_size + 1, \
+                     backing_mtime_ns = backing_mtime_ns + 1, \
+                     content_version = content_version + 1 WHERE id = ?1",
+                    rusqlite::params![id],
+                )
+                .unwrap();
+            assert_eq!(n, 1, "variant 5 must mutate the tracks row");
+        }
+    });
 }
 
 fuzz_target!(|data: &[u8]| {
@@ -80,13 +171,29 @@ fuzz_target!(|data: &[u8]| {
             };
             (b, Format::M4a, s.mdat_payload_offset, s.mdat_payload_len)
         }
-        _ => {
+        4 => {
             let b = musefs_format::fuzz_check::fixtures::ogg_opus();
             let s = match musefs_format::ogg::locate_audio(&b) {
                 Ok(s) => s,
                 Err(_) => return,
             };
             (b, Format::Opus, s.audio_offset, s.audio_length)
+        }
+        5 => {
+            let b = musefs_format::fuzz_check::fixtures::ogg_vorbis();
+            let s = match musefs_format::ogg::locate_audio(&b) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            (b, Format::Vorbis, s.audio_offset, s.audio_length)
+        }
+        _ => {
+            let b = musefs_format::fuzz_check::fixtures::ogg_flac();
+            let s = match musefs_format::ogg::locate_audio(&b) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            (b, Format::OggFlac, s.audio_offset, s.audio_length)
         }
     };
 
@@ -128,15 +235,64 @@ fuzz_target!(|data: &[u8]| {
         }
     }
 
+    // Optionally attach DB binary tags so synthesis materializes a
+    // Segment::BinaryTag and the read windows exercise read_binary_tag_chunk_into.
+    // Only MP3 (4-byte frame id) and M4a (`----:<mean>:<name>` freeform atom)
+    // synthesize opaque binary tags from the DB; for any other format the row is
+    // silently dropped at synthesis, so restrict the opt-in to those two.
+    if matches!(format, Format::Mp3 | Format::M4a) && u.arbitrary::<bool>().unwrap_or(false) {
+        let key = match format {
+            Format::Mp3 => "GEOB".to_string(),
+            _ => "----:com.apple.iTunes:FUZZ".to_string(),
+        };
+        let _ = db.set_binary_tags(
+            id,
+            &[BinaryTag {
+                key,
+                payload: vec![0xCDu8; 64],
+                ordinal: 0,
+            }],
+        );
+    }
+
+    // Hostile-row stage. Variants 0/1/3 corrupt geometry/format/art-metadata that
+    // `resolve` validates (it returns Err -> the existing early-return below
+    // handles them). Variants 2/4/5 are read-time hostilities applied AFTER a
+    // successful resolve.
+    let hostile = if u.arbitrary::<bool>().unwrap_or(false) {
+        Some(u.int_in_range(0..=5u8).unwrap_or(0))
+    } else {
+        None
+    };
+    let hostile_val = u.arbitrary::<i64>().unwrap_or(i64::MAX);
+    if matches!(hostile, Some(0 | 1 | 3)) {
+        apply_hostile(&db, id, hostile.unwrap(), hostile_val);
+    }
+
     let resolved = match HeaderCache::new(Mode::Synthesis).resolve(&db, id) {
         Ok(r) => r,
         Err(_) => return,
     };
+
+    // Read-time hostilities: apply only after a successful resolve.
+    let hostile_post = matches!(hostile, Some(2 | 4 | 5));
+    if hostile_post {
+        apply_hostile(&db, id, hostile.unwrap(), hostile_val);
+    }
+
     let total = resolved.total_len;
     let file = std::fs::File::open(&resolved.backing_path).expect("backing file opens");
 
-    // The single whole read every window is checked against (splice consistency).
-    let whole = read_at_with_file(&resolved, &db, &file, 0, total).unwrap();
+    // Splice-consistency invariants. A successfully-resolved layout is internally
+    // consistent regardless of how its rows were planted, so whenever the read
+    // returns Ok these MUST hold and are asserted. The only hostile-path
+    // relaxation: a read may return Err (missing art row, stale binary-tag
+    // handle, bumped content_version) -> return/break, do not assert.
+    let whole = match read_at_with_file(&resolved, &db, &file, 0, total) {
+        Ok(w) => w,
+        Err(_) if hostile_post => return,
+        Err(e) => panic!("clean-path whole read failed: {e:?}"),
+    };
     assert_eq!(whole.len() as u64, total, "whole read length != total_len");
 
     // Draw up to 8 windows, including ranges that start at/after EOF or run past
@@ -154,7 +310,11 @@ fuzz_target!(|data: &[u8]| {
             Ok(v) => v,
             Err(_) => break,
         };
-        let got = read_at_with_file(&resolved, &db, &file, offset, size).unwrap();
+        let got = match read_at_with_file(&resolved, &db, &file, offset, size) {
+            Ok(g) => g,
+            Err(_) if hostile_post => break,
+            Err(e) => panic!("clean-path window read failed: {e:?}"),
+        };
         // Mirror read_segments_into's clamp: served = [min(offset,total), min(offset+size,total)).
         let end = offset.saturating_add(size).min(total);
         let expected = end.saturating_sub(offset.min(total));

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -19,6 +19,10 @@ thiserror = "2"
 # `Ok(Default::default())` mutants compile. Named after the activity that needs
 # it, mirroring musefs-format's `fuzzing` feature. Not for production use.
 mutants = []
+# Test/fuzz-only: exposes `Db::with_raw_conn` so the out-of-workspace fuzz crate
+# can plant hostile rows the validating public API cannot produce. Never enabled
+# in normal builds. Mirrors the `mutants` feature pattern.
+fuzzing = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -142,6 +142,17 @@ impl<M> Db<M> {
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }
+
+    /// TEST/FUZZ ONLY (the `fuzzing` feature). Hands the raw rusqlite connection
+    /// to `f` so fuzz harnesses can plant rows the validating public API cannot
+    /// produce — e.g. negative geometry under `PRAGMA ignore_check_constraints`,
+    /// or orphaned `track_art` under `PRAGMA foreign_keys = OFF`. Never compiled
+    /// in production: the `fuzzing` feature is enabled only by the out-of-workspace
+    /// fuzz crate.
+    #[cfg(feature = "fuzzing")]
+    pub fn with_raw_conn<R>(&self, f: impl FnOnce(&rusqlite::Connection) -> R) -> R {
+        f(&self.conn)
+    }
 }
 
 #[cfg(feature = "mutants")]
@@ -266,5 +277,52 @@ mod tests {
             crate::DbError::SchemaMismatch { object } => assert!(object.contains("foreign key")),
             other => panic!("expected SchemaMismatch (fk) on RO open, got {other:?}"),
         }
+    }
+}
+
+#[cfg(all(test, feature = "fuzzing"))]
+mod fuzzing_accessor_tests {
+    use super::*;
+    use crate::models::NewTrack;
+
+    #[test]
+    fn with_raw_conn_plants_a_constraint_violating_row() {
+        let db = Db::open_in_memory().unwrap();
+        let id = db
+            .upsert_track(&NewTrack {
+                backing_path: "/x".to_string(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
+            })
+            .unwrap();
+
+        db.with_raw_conn(|conn| {
+            conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+                .unwrap();
+            conn.execute(
+                "UPDATE tracks SET audio_offset = -1 WHERE id = ?1",
+                rusqlite::params![id],
+            )
+            .unwrap();
+            conn.execute_batch("PRAGMA ignore_check_constraints = OFF")
+                .unwrap();
+        });
+
+        let off: i64 = db.with_raw_conn(|conn| {
+            conn.query_row(
+                "SELECT audio_offset FROM tracks WHERE id = ?1",
+                rusqlite::params![id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        });
+        assert_eq!(
+            off, -1,
+            "ignore_check_constraints let the negative offset land"
+        );
     }
 }

--- a/musefs-format/src/fuzz_check.rs
+++ b/musefs-format/src/fuzz_check.rs
@@ -250,6 +250,60 @@ pub mod fixtures {
         data
     }
 
+    /// Minimal Ogg **Vorbis**: 3 header packets (identification, comment, setup)
+    /// then one audio packet. `detect_codec` keys on the `\x01vorbis` magic of
+    /// packet 0; `read_header` reassembles exactly 3 Vorbis header packets. The
+    /// comment packet carries an empty (but valid, round-trippable) VorbisComment
+    /// body so synthesis can splice tags without erroring.
+    pub fn ogg_vorbis() -> Vec<u8> {
+        use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
+        let mut id = b"\x01vorbis".to_vec();
+        id.extend_from_slice(&[0u8; 23]); // pad toward the 30-byte id-header shape
+        let mut comment = b"\x03vorbis".to_vec();
+        comment.extend_from_slice(&vorbis_body_empty());
+        let setup = b"\x05vorbis".to_vec();
+        let (mut data, pages) = build_header_pub(0x4321, &[&id, &comment, &setup]);
+        let (audio, _) = lace_packet_pub(0x4321, pages, false, 960, &[0u8; 120]);
+        data.extend_from_slice(&audio);
+        data
+    }
+
+    /// Minimal **OggFLAC**: mapping header packet 0
+    /// (`0x7F "FLAC" major minor count(2 BE) "fLaC" STREAMINFO`) plus one
+    /// following VORBIS_COMMENT metadata-block packet (`count = 1`), then one
+    /// audio packet. `detect_codec` keys on `\x7FFLAC`; `read_header` reads
+    /// `1 + count` header packets. Lengths are computed from the bodies so the
+    /// 24-bit metadata-block length is always self-consistent.
+    pub fn ogg_flac() -> Vec<u8> {
+        use crate::ogg::page_test_support::{build_header_pub, lace_packet_pub, vorbis_body_empty};
+
+        // STREAMINFO metadata block: header (type 0, not-last) + 24-bit len + body.
+        let mut streaminfo = vec![0x00u8, 0x00, 0x00, 0x22]; // len 34
+        streaminfo.extend_from_slice(&[0u8; 34]);
+
+        let mut p0 = Vec::new();
+        p0.push(0x7F);
+        p0.extend_from_slice(b"FLAC");
+        p0.push(1); // mapping major version
+        p0.push(0); // mapping minor version
+        p0.extend_from_slice(&1u16.to_be_bytes()); // count: 1 following packet
+        p0.extend_from_slice(b"fLaC");
+        p0.extend_from_slice(&streaminfo);
+
+        // Following packet: VORBIS_COMMENT block (type 4, last-metadata-block set).
+        let vc_body = vorbis_body_empty();
+        let mut p1 = Vec::new();
+        p1.push(0x84); // 0x80 last-flag | type 4
+        let len = u32::try_from(vc_body.len()).expect("empty vorbis body fits in u24");
+        p1.extend_from_slice(&len.to_be_bytes()[1..4]); // 24-bit big-endian length
+        p1.extend_from_slice(&vc_body);
+
+        let (mut data, pages) = build_header_pub(0x7777, &[&p0, &p1]);
+        let (audio, _) = lace_packet_pub(0x7777, pages, false, 960, &[0u8; 120]);
+        data.extend_from_slice(&audio);
+        data
+    }
+
     /// Minimal MP3 — a hand-crafted ID3v2.4 header (empty tag) followed by a
     /// minimal MPEG frame sync. `locate_audio` requires only `ID3` marker +
     /// syncsafe size + a valid `0xFF 0xE*` sync at the audio start; the "audio"
@@ -503,5 +557,23 @@ mod fixtures_tests {
     fn ogg_fixture_parses() {
         let f = fixtures::ogg_opus();
         crate::ogg::locate_audio(&f).unwrap();
+    }
+
+    #[test]
+    fn ogg_vorbis_fixture_is_recognized() {
+        let f = fixtures::ogg_vorbis();
+        let h = crate::ogg::read_header(&f).unwrap();
+        assert_eq!(h.codec, crate::ogg::Codec::Vorbis);
+        let scan = crate::ogg::locate_audio(&f).unwrap();
+        assert!(scan.audio_length > 0, "audio must be non-empty");
+    }
+
+    #[test]
+    fn ogg_flac_fixture_is_recognized() {
+        let f = fixtures::ogg_flac();
+        let h = crate::ogg::read_header(&f).unwrap();
+        assert_eq!(h.codec, crate::ogg::Codec::OggFlac);
+        let scan = crate::ogg::locate_audio(&f).unwrap();
+        assert!(scan.audio_length > 0, "audio must be non-empty");
     }
 }

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -404,9 +404,18 @@ fn write_ops_are_refused_on_read_only_mount() {
             );
             // mknod a regular file (no privilege needed); ENOSYS tolerates a
             // platform/FUSE build that does not implement the callback at all.
+            // EINVAL: FreeBSD's mknod(2) only creates special files and rejects
+            // S_IFREG at the syscall layer before the FUSE RO check — still a
+            // refusal (no node is created), which is all this test asserts.
             assert_refused(
                 libc::mknod(new_file.as_ptr(), libc::S_IFREG | 0o644, 0),
-                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOSYS],
+                &[
+                    libc::EROFS,
+                    libc::EPERM,
+                    libc::EACCES,
+                    libc::ENOSYS,
+                    libc::EINVAL,
+                ],
                 "mknod",
             );
             assert_refused(
@@ -415,9 +424,11 @@ fn write_ops_are_refused_on_read_only_mount() {
                 "link",
             );
 
-            // xattr syscalls differ in signature across platforms (Linux vs
-            // macOS); this test only ever *runs* on Linux (/dev/fuse), so gate
-            // the xattr probes so the macOS workspace build still compiles.
+            // xattr syscall signatures and names differ across platforms (Linux
+            // setxattr vs the BSD/macOS extattr_* family), so gate the probes to
+            // Linux: on macOS/FreeBSD the workspace build still compiles, and on
+            // FreeBSD (where this test *does* run, via fusefs) they are skipped
+            // rather than calling a syscall this code isn't written against.
             #[cfg(target_os = "linux")]
             {
                 let xval = [0u8; 4];

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -284,6 +284,20 @@ fn assert_refused(ret: i32, accepted: &[i32], what: &str) {
     );
 }
 
+/// Assert a libc *read* call (getxattr/listxattr) did not error as if it were a
+/// write: it either succeeds (`ret >= 0`) or fails with a non-mutation errno in
+/// `accepted`. Refusing a read on a read-only mount would itself be the bug.
+fn assert_read_safe(ret: isize, accepted: &[i32], what: &str) {
+    if ret >= 0 {
+        return;
+    }
+    let e = last_errno();
+    assert!(
+        accepted.contains(&e),
+        "{what}: errno {e} not in accepted read-safe set {accepted:?}"
+    );
+}
+
 #[test]
 #[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse --test read_consistency -- --ignored"]
 #[expect(
@@ -351,6 +365,98 @@ fn write_ops_are_refused_on_read_only_mount() {
                 &[libc::EROFS, libc::EPERM, libc::EACCES],
                 "utimes",
             );
+
+            // --- #306: additional mutating-syscall families ---
+            let renamed = cstr(&mountpoint.join("Alice").join("renamed.flac"));
+            let link_dst = cstr(&mountpoint.join("Alice").join("hardlink.flac"));
+            let sym_dst = cstr(&mountpoint.join("Alice").join("symlink.flac"));
+            let dir = cstr(&mountpoint.join("Alice"));
+
+            assert_refused(
+                libc::rename(existing.as_ptr(), renamed.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "rename",
+            );
+            assert_refused(
+                libc::rmdir(dir.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOTEMPTY],
+                "rmdir",
+            );
+            assert_refused(
+                libc::symlink(existing.as_ptr(), sym_dst.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "symlink",
+            );
+            assert_refused(
+                libc::chown(existing.as_ptr(), 0, 0),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "chown",
+            );
+            assert_refused(
+                libc::lchown(existing.as_ptr(), 0, 0),
+                &[libc::EROFS, libc::EPERM, libc::EACCES],
+                "lchown",
+            );
+            // mknod a regular file (no privilege needed); ENOSYS tolerates a
+            // platform/FUSE build that does not implement the callback at all.
+            assert_refused(
+                libc::mknod(new_file.as_ptr(), libc::S_IFREG | 0o644, 0),
+                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOSYS],
+                "mknod",
+            );
+            assert_refused(
+                libc::link(existing.as_ptr(), link_dst.as_ptr()),
+                &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOSYS],
+                "link",
+            );
+
+            // xattr syscalls differ in signature across platforms (Linux vs
+            // macOS); this test only ever *runs* on Linux (/dev/fuse), so gate
+            // the xattr probes so the macOS workspace build still compiles.
+            #[cfg(target_os = "linux")]
+            {
+                let xval = [0u8; 4];
+                assert_refused(
+                    libc::setxattr(
+                        existing.as_ptr(),
+                        c"user.test".as_ptr(),
+                        xval.as_ptr().cast(),
+                        xval.len(),
+                        0,
+                    ),
+                    &[libc::EROFS, libc::EPERM, libc::EACCES, libc::ENOTSUP],
+                    "setxattr",
+                );
+                assert_refused(
+                    libc::removexattr(existing.as_ptr(), c"user.test".as_ptr()),
+                    &[
+                        libc::EROFS,
+                        libc::EPERM,
+                        libc::EACCES,
+                        libc::ENOTSUP,
+                        libc::ENODATA,
+                    ],
+                    "removexattr",
+                );
+
+                // Read probes: NOT mutations. Assert read-safety, never refusal.
+                let mut buf = [0u8; 256];
+                assert_read_safe(
+                    libc::getxattr(
+                        existing.as_ptr(),
+                        c"user.test".as_ptr(),
+                        buf.as_mut_ptr().cast(),
+                        buf.len(),
+                    ),
+                    &[libc::ENOTSUP, libc::ENODATA],
+                    "getxattr",
+                );
+                assert_read_safe(
+                    libc::listxattr(existing.as_ptr(), buf.as_mut_ptr().cast(), buf.len()),
+                    &[libc::ENOTSUP],
+                    "listxattr",
+                );
+            }
         }
     });
 }

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -287,6 +287,11 @@ fn assert_refused(ret: i32, accepted: &[i32], what: &str) {
 /// Assert a libc *read* call (getxattr/listxattr) did not error as if it were a
 /// write: it either succeeds (`ret >= 0`) or fails with a non-mutation errno in
 /// `accepted`. Refusing a read on a read-only mount would itself be the bug.
+///
+/// Linux-gated to match its only call sites (the xattr probes), so the macOS /
+/// FreeBSD workspace build that compiles this `#[ignore]` test does not see it
+/// as dead code under `-D warnings`.
+#[cfg(target_os = "linux")]
 fn assert_read_safe(ret: isize, accepted: &[i32], what: &str) {
     if ret >= 0 {
         return;

--- a/musefs/tests/sigterm_unmount.rs
+++ b/musefs/tests/sigterm_unmount.rs
@@ -93,7 +93,14 @@ fn sigterm_unmounts_cleanly() {
     // Mount as a child process.
     let mp = tempfile::tempdir().unwrap();
     let mut child = Command::new(bin)
-        .args(["mount", mp.path().to_str().unwrap(), "--db", db])
+        .args([
+            "mount",
+            mp.path().to_str().unwrap(),
+            "--db",
+            db,
+            "--template",
+            "$artist/$title",
+        ])
         .spawn()
         .unwrap();
 
@@ -139,7 +146,14 @@ fn sigterm_exits_bounded_when_mount_is_busy() {
     // Mount as a child process.
     let mp = tempfile::tempdir().unwrap();
     let mut child = Command::new(bin)
-        .args(["mount", mp.path().to_str().unwrap(), "--db", db])
+        .args([
+            "mount",
+            mp.path().to_str().unwrap(),
+            "--db",
+            db,
+            "--template",
+            "$artist/$title",
+        ])
         .spawn()
         .unwrap();
 


### PR DESCRIPTION
Closes three independent test/fuzz coverage gaps from the #280 audit. All are coverage work — no production behavior changes except an additive, off-by-default `fuzzing`-gated DB accessor consumed only by the out-of-workspace fuzz crate.

## #320 — stale sigterm e2e + CI rot gap
- Both `musefs/tests/sigterm_unmount.rs` tests asserted `Alice/Song.flac`, a path the current default template (`$albumartist/$album/$title`) no longer produces, so they failed whenever actually run. Pinned both mounts to an explicit `--template '$artist/$title'` (immune to future default-template drift).
- Wired the binary-level `cargo test -p musefs -- --ignored` and `cargo test -p musefs-latencyfs -- --ignored` suites into the CI `e2e` job — they had never run in CI, which is why the staleness was undetectable. Both verified green locally on `/dev/fuse` first.

## #306 — read-only refusal coverage
Extended `write_ops_are_refused_on_read_only_mount` with the remaining mutating syscall families (`rename`, `rmdir`, `symlink`, `chown`, `lchown`, `setxattr`, `removexattr`, `mknod`, `link`) under the existing "mutation refused, broad errno set" contract, and exercised `getxattr`/`listxattr` as **read-safe** (success or `ENOTSUP`/`ENODATA`) rather than refused. xattr probes are Linux-gated so the macOS workspace build still compiles.

## #313 — serve-fuzz hostile rows, binary tags, distinct Ogg fixtures
- New off-by-default `musefs-db/fuzzing` feature exposing `Db::with_raw_conn` so the fuzz crate can plant rows the validating public API can't produce (mirrors the existing `musefs-format/fuzzing` + `musefs-db/mutants` patterns).
- `serve` target gained a fuzzer-gated hostility stage (negative/oversized geometry, invalid formats, orphaned/oversized art, stale binary-tag handles, content-version mismatch), optional `set_binary_tags` to exercise `Segment::BinaryTag` streaming, and distinct `ogg_vorbis()`/`ogg_flac()` fixtures so selectors 4/5/6 feed the shared Ogg branch distinct inputs. The malformed-FLAC-structural angle is deliberately skipped (overlaps the dedicated `flac` target).

### Fuzz already earned its keep
The `serve` target immediately found a crash — diagnosed as a **harness false-positive**, not a production defect: `resolve` trusts the DB geometry for Ogg and defers page parsing to read time, so a pre-resolve geometry corruption survives `resolve` and surfaces as a clean `Err(Format(Malformed))` at read time (the production code correctly rejecting hostile state). Fixed by keying the read-error tolerance on `hostile.is_some()` rather than the pre/post-resolve split; the captured crash now replays clean.

## Process
Brainstormed spec → plan, each reviewed by the spec-plan-reviewer (two rounds of fixes folded in, including two real `apply_hostile` defects caught pre-implementation). Spec and plan are included under `docs/superpowers/`.

## Verification (rebased on latest main)
fmt, clippy `--all-targets -D warnings`, `cargo test --workspace` (958 passed), `cargo test -p musefs-core --features metrics` (384), `cargo test -p musefs-db --features fuzzing`, `cargo +nightly fuzz build serve` + crash replay, and all three `/dev/fuse` e2e suites (sigterm, read-only refusal, latencyfs) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)