### PR TITLE
fix(core): preserve survivor inodes when folded directory casing changes (#305)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -391,6 +391,32 @@ exclude_re = [
     'replace truncate_component -> Cow<._, str> with Cow::Borrowed\(""\)',
     'replace truncate_component -> Cow<._, str> with Cow::Owned\(""\.to_owned\(\)\)',
 
+    # #305 folded-inode allocator — hang-class (TIMEOUT-only) mutants, the SP3
+    # non-terminating-loop precedent. InodeAllocator::key() transforms a path into
+    # the inode map key (case-folded on folded mounts, identity otherwise).
+    # Replacing its body with ANY constant — empty or "xyzzy", borrowed or owned —
+    # makes every path intern to one key, so every node collapses onto a single
+    # inode and becomes its own parent; path_of's `while cur != ROOT` walk then
+    # spins forever (observed canceling the in-diff CI job). All four const-returns
+    # share site 52:9 (one distinct site). key()'s real behavior is pinned
+    # functionally: the fold-vs-identity branch is exercised by
+    # folded_dir_recase_keeps_survivor_inode (folded) and
+    # case_sensitive_keeps_both_dirs_separate (identity).
+    'musefs-core/src/tree\.rs:\d+:\d+: replace InodeAllocator::key -> Cow<.a, str> with',
+    # intern const-returns `-> 0` / `-> 1`: same hang-class. A constant inode for
+    # every path collides all nodes (inode 0, or ROOT for 1) into a self-parenting
+    # cycle, so path_of loops forever. intern's real contract — a fresh inode per
+    # new path, reuse on repeat — is pinned by
+    # build_with_keeps_inodes_stable_across_rebuilds and the prune_retired tests.
+    # Both const-returns share site 62:9 (one site). The `+= -> -=` sibling at
+    # 67:19 underflows `next` to a panic and IS caught, so it stays in scope.
+    'musefs-core/src/tree\.rs:\d+:\d+: replace InodeAllocator::intern -> u64 with [01]',
+    # intern next-bump `self.next += 1` -> `*= 1`: leaves `next` pinned at 2, so
+    # every new path interns to inode 2 — the same self-parenting hang. The
+    # `+= -> -=` variant at this site underflows to a panic and IS caught; only the
+    # no-op `*=` is excluded.
+    'musefs-core/src/tree\.rs:\d+:\d+: replace \+= with \*= in InodeAllocator::intern',
+
     # Db::with_raw_conn is #[cfg(feature = "fuzzing")] — a test/fuzz-only raw
     # rusqlite-connection escape hatch enabled solely by the out-of-workspace fuzz
     # crate. The per-PR --in-diff gate runs cargo-mutants without that feature, so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -324,8 +324,10 @@ Inodes are **stable across rebuilds**: a persistent path→inode allocator
 (`InodeAllocator`) reuses an unchanged rendered path's inode and never
 recycles a retired one, so a descriptor held open across a refresh keeps
 resolving to the same node and a stale FUSE handle can never alias a
-different file. A path that vanished degrades to `ENOENT`, bounded by the
-entry/attr TTL. (Retired paths are pruned once they outnumber live ones,
+different file. On case-insensitive mounts the key is case-folded, so a
+survivor keeps its inode even when an unrelated deletion flips a merged
+directory's display casing (#305). A path that vanished degrades to
+`ENOENT`, bounded by the entry/attr TTL. (Retired paths are pruned once they outnumber live ones,
 bounding the allocator at twice the live tree; a path that returns after a
 prune gets a fresh inode.)
 

--- a/docs/superpowers/plans/2026-06-12-folded-inode-stability.md
+++ b/docs/superpowers/plans/2026-06-12-folded-inode-stability.md
@@ -1,0 +1,316 @@
+# Folded-Mount Inode Stability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In case-insensitive mounts, a surviving track keeps its inode when an unrelated deletion flips a merged directory's display casing (#305).
+
+**Architecture:** `InodeAllocator` (`musefs-core/src/tree.rs`) keys inodes by a path string and persists across full rebuilds. We make that key *case-folded* in case-insensitive mode, so `fold("Foo/B") == fold("foo/B")` and the inode no longer depends on which casing a rebuild happens to pick. The fix is confined to `musefs-core`; `musefs-fuse`/CLI/binary are untouched.
+
+**Tech Stack:** Rust, `im` persistent collections (`ImHashMap`), `std::borrow::Cow` (already imported at `tree.rs:2`).
+
+**Spec:** `docs/superpowers/specs/2026-06-12-folded-inode-stability-design.md`
+
+---
+
+## File structure
+
+- **Modify `musefs-core/src/tree.rs`** — add a `fold_keys` field to `InodeAllocator`, change `new()` → `new(case_insensitive: bool)`, add a private `key()` transform, route `intern`/`prune_retired` through it, update the struct doc, fix every `InodeAllocator::new()` call site, and add two regression tests in the existing `tests` module.
+- **Modify `musefs-core/src/facade.rs`** — construct the live allocator from `config.case_insensitive` in `Musefs::open`; mechanical `new()` → `new(false)` for the one case-sensitive test site.
+- **Modify `ARCHITECTURE.md`** — one clause noting the key is case-folded on case-insensitive mounts (docs-only commit).
+
+Why the incremental path is not touched: `poll_refresh_notify` forces case-insensitive mounts through `rebuild_full` → `build_with_ci`, so the fold-keyed allocator is only ever driven by `build_with_ci` + `prune_retired`, never by `apply_changes`/`rebuild_incremental`.
+
+---
+
+## Task 1: Fold the inode key in case-insensitive mode
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs` (`InodeAllocator` struct ~`:27-31`, `new` ~`:34-37`, `intern` ~`:40`, `prune_retired` ~`:56`, struct doc ~`:21`, all `InodeAllocator::new()` call sites)
+- Modify: `musefs-core/src/facade.rs` (`Musefs::open` ~`:239`, test ~`:1787`)
+- Test: `musefs-core/src/tree.rs` (`tests` module, after `case_insensitive_removal_keeps_folded_lookup_consistent`)
+
+- [ ] **Step 1: Add the `fold_keys` field to the struct**
+
+In `musefs-core/src/tree.rs`, change the struct definition:
+
+```rust
+pub struct InodeAllocator {
+    paths: ImHashMap<String, u64>,
+    next: u64,
+    fold_keys: bool,
+}
+```
+
+- [ ] **Step 2: Extend the struct doc comment**
+
+Append a sentence to the existing `InodeAllocator` doc block (just above the `#[derive(...)]`), so the last line reads:
+
+```rust
+/// Retired paths are dropped by `prune_retired` once they outnumber live ones,
+/// bounding the map at 2x the live tree between prunes; a path that returns
+/// after a prune gets a fresh inode rather than its old one.
+/// In case-insensitive mounts the key is case-folded, so a track keeps its
+/// inode when an unrelated deletion flips a merged directory's display casing
+/// (#305).
+```
+
+- [ ] **Step 3: Change `new` to take the case-sensitivity flag**
+
+Replace the body of `InodeAllocator::new`:
+
+```rust
+pub fn new(case_insensitive: bool) -> InodeAllocator {
+    let mut paths = ImHashMap::new();
+    paths.insert(String::new(), VirtualTree::ROOT); // root path "" -> inode 1
+    InodeAllocator {
+        paths,
+        next: 2,
+        fold_keys: case_insensitive,
+    }
+}
+```
+
+(`fold("")` is `""`, so the root key is unaffected by folding.)
+
+- [ ] **Step 4: Add the `key()` transform and route `intern`/`prune_retired` through it**
+
+Add this private method inside `impl InodeAllocator` (e.g. directly after `new`):
+
+```rust
+/// Transform a path into its map key: case-folded when the mount is
+/// case-insensitive (so a survivor keeps its inode when an unrelated deletion
+/// flips a merged directory's display casing, #305), identity otherwise.
+fn key<'a>(&self, path: &'a str) -> Cow<'a, str> {
+    if self.fold_keys {
+        Cow::Owned(fold(path))
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+```
+
+Replace the body of `intern`:
+
+```rust
+fn intern(&mut self, path: &str) -> u64 {
+    let key = self.key(path);
+    if let Some(&ino) = self.paths.get(key.as_ref()) {
+        return ino;
+    }
+    let ino = self.next;
+    self.next += 1;
+    self.paths.insert(key.into_owned(), ino);
+    ino
+}
+```
+
+Replace the body of `prune_retired`:
+
+```rust
+pub(crate) fn prune_retired(&mut self, tree: &VirtualTree) {
+    if self.paths.len() <= 2 * tree.nodes.len() {
+        return;
+    }
+    let mut live = ImHashMap::new();
+    for &ino in tree.nodes.keys() {
+        live.insert(self.key(&tree.path_of(ino)).into_owned(), ino);
+    }
+    self.paths = live;
+}
+```
+
+- [ ] **Step 5: Update the bulk call sites (mechanical)**
+
+The signature change makes every `InodeAllocator::new()` a compile error. Fix the common (case-sensitive) case in bulk:
+
+```bash
+sed -i 's/InodeAllocator::new()/InodeAllocator::new(false)/g' \
+  musefs-core/src/tree.rs musefs-core/src/facade.rs
+```
+
+- [ ] **Step 6: Flip the case-insensitive call sites to `new(true)`**
+
+The three inline allocators paired with a case-insensitive tree (`build_with_ci(..., true)`) must fold. Run:
+
+```bash
+sed -i 's/InodeAllocator::new(false), true)/InodeAllocator::new(true), true)/g' \
+  musefs-core/src/tree.rs
+```
+
+This targets exactly the three `build_with_ci(&entries, &mut InodeAllocator::new(false), true)` sites (`tree.rs:1077`, `:1097`, `:1128`) and nothing else — the case-sensitive control at `:1111` ends `..., false)` and is left untouched. (The throwaway allocator passed to `remove_track` at `:1132` stays `false` — `remove_track` takes `_alloc` and never interns or prunes, so its flag is irrelevant.) Note `:1128` lives in `case_insensitive_removal_keeps_folded_lookup_consistent`, which is also the Step 9 insertion anchor; flipping its allocator to `new(true)` is correct (the tree is case-insensitive) and harmless.
+
+- [ ] **Step 7: Wire the live allocator to the mount config**
+
+In `musefs-core/src/facade.rs`, the `Musefs::open` allocator must follow the mount's case sensitivity. Change:
+
+```rust
+    pub fn open(db: Db, config: MountConfig) -> Result<Musefs> {
+        let mut alloc = InodeAllocator::new(false);
+```
+
+to:
+
+```rust
+    pub fn open(db: Db, config: MountConfig) -> Result<Musefs> {
+        let mut alloc = InodeAllocator::new(config.case_insensitive);
+```
+
+(The other `facade.rs` site, in a test with `case_insensitive: false`, is correctly left at `new(false)` by Step 5.)
+
+- [ ] **Step 8: Confirm there are no stragglers and the crate builds**
+
+Run:
+
+```bash
+grep -rn "InodeAllocator::new()" . ; cargo build -p musefs-core
+```
+
+Expected: the `grep` prints **zero results** (every site now passes a bool); `cargo build` succeeds. (A leftover bare `new()` is both a grep hit and a compile error pointing at the exact line.)
+
+- [ ] **Step 9: Write the two regression tests**
+
+Insert these into the `tests` module of `musefs-core/src/tree.rs`, immediately after the `case_insensitive_removal_keeps_folded_lookup_consistent` test:
+
+```rust
+#[test]
+fn folded_dir_recase_keeps_survivor_inode() {
+    // #305: track 1 seen first wins the merged directory's casing ("Foo");
+    // track 2 merges under it. Removing track 1 lets the next full rebuild
+    // re-derive the casing from track 2 alone, rendering "foo". Track 2's
+    // rendered path is unchanged, so its inode must be stable.
+    let mut alloc = InodeAllocator::new(true);
+    let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+    let tree = VirtualTree::build_with_ci(&entries, &mut alloc, true);
+    let before = tree.inode_of_track(2).expect("track 2 inode");
+
+    let rebuilt =
+        VirtualTree::build_with_ci(&[(2i64, "foo/B".to_string())], &mut alloc, true);
+    let after = rebuilt.inode_of_track(2).expect("track 2 inode after rebuild");
+
+    assert_eq!(before, after, "survivor inode must survive a folded dir re-case");
+    // Scope is inode stability only: the directory legitimately re-cases to "foo".
+    assert!(rebuilt.lookup(VirtualTree::ROOT, "foo").is_some());
+}
+
+#[test]
+fn folded_inode_key_keeps_disambiguated_siblings_distinct() {
+    // Guard that folding the key never collapses a legitimately-disambiguated
+    // pair: "Song" and "song" fold equal, so the second becomes "song (2)";
+    // their fold-keys ("dir/song" vs "dir/song (2)") differ, so do their inodes.
+    let mut alloc = InodeAllocator::new(true);
+    let entries = vec![(1i64, "Dir/Song".to_string()), (2i64, "Dir/song".to_string())];
+    let tree = VirtualTree::build_with_ci(&entries, &mut alloc, true);
+    let a = tree.inode_of_track(1).expect("track 1 inode");
+    let b = tree.inode_of_track(2).expect("track 2 inode");
+    assert_ne!(a, b, "disambiguated folded siblings must not collapse to one inode");
+
+    let dir = tree.lookup(VirtualTree::ROOT, "Dir").expect("Dir");
+    assert_eq!(tree.lookup(dir, "Song"), Some(a));
+    assert_eq!(tree.lookup(dir, "song (2)"), Some(b));
+}
+```
+
+- [ ] **Step 10: Run the new tests — expect PASS**
+
+Run:
+
+```bash
+cargo test -p musefs-core folded_dir_recase_keeps_survivor_inode folded_inode_key_keeps_disambiguated_siblings_distinct
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 11: Prove the tests guard the fix (temporary revert)**
+
+Confirm the tests actually fail without the fold. Temporarily change the `key()` true-branch from `Cow::Owned(fold(path))` to `Cow::Borrowed(path)`, then run:
+
+```bash
+cargo test -p musefs-core folded_dir_recase_keeps_survivor_inode
+```
+
+Expected: FAIL on `assert_eq!(before, after, ...)` (the survivor gets a fresh inode). **Restore** the `Cow::Owned(fold(path))` line and re-run — expected: PASS.
+
+- [ ] **Step 12: Full crate gate**
+
+Run:
+
+```bash
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo test -p musefs-core
+```
+
+Expected: clippy clean (no `dead_code`/`if_same_then_else`), all `musefs-core` tests green — including the existing `case_*` and `prune_retired_*` tests, which pin the unchanged case-sensitive contract.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add musefs-core/src/tree.rs musefs-core/src/facade.rs
+git commit -m "$(cat <<'EOF'
+fix(core): fold inode key in case-insensitive mode (#305)
+
+In case-insensitive mounts a merged directory keeps the first-seen child's
+display casing. A full folded rebuild after an unrelated deletion can flip
+that casing, changing a survivor's disambiguated display path and — because
+InodeAllocator keyed on that path — reassigning its inode despite a stable
+rendered path. Key the allocator on the case-folded path in folded mode so
+the inode is casing-independent; case-sensitive mounts are unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+The pre-commit hook runs the full workspace suite; this commit is green.
+
+---
+
+## Task 2: Document the case-folded key in ARCHITECTURE.md
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (inode-stability paragraph, ~`:323-330`)
+
+- [ ] **Step 1: Add the folding clause**
+
+In the "Inodes are **stable across rebuilds**" paragraph, change:
+
+```
+(`InodeAllocator`) reuses an unchanged rendered path's inode and never
+recycles a retired one, so a descriptor held open across a refresh keeps
+resolving to the same node and a stale FUSE handle can never alias a
+different file.
+```
+
+to:
+
+```
+(`InodeAllocator`) reuses an unchanged rendered path's inode and never
+recycles a retired one, so a descriptor held open across a refresh keeps
+resolving to the same node and a stale FUSE handle can never alias a
+different file. On case-insensitive mounts the key is case-folded, so a
+survivor keeps its inode even when an unrelated deletion flips a merged
+directory's display casing (#305).
+```
+
+- [ ] **Step 2: Commit (docs-only)**
+
+```bash
+git add ARCHITECTURE.md
+git commit -m "$(cat <<'EOF'
+docs(arch): note case-folded inode key on folded mounts (#305)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(Docs-only commit; the pre-commit hook skips the cargo gate.)
+
+---
+
+## Definition of done
+
+- [ ] `folded_dir_recase_keeps_survivor_inode` and `folded_inode_key_keeps_disambiguated_siblings_distinct` pass, and were shown to fail without the fold (Task 1 Step 11).
+- [ ] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` are all green (the full workspace suite runs in the pre-commit hook).
+- [ ] No production behavior change for case-sensitive mounts (existing `case_*`/`prune_retired_*` tests unchanged and green).
+- [ ] In-diff mutation gate: run the local in-diff `cargo mutants --in-place` gate over the diff before pushing. The `key()` mutants are already covered — the never-fold mutants are killed by `folded_dir_recase_keeps_survivor_inode`, and the always-fold mutant (condition → `true`) is killed by the existing `case_sensitive_keeps_both_dirs_separate` test, whose `assert_ne!(lookup "Foo", lookup "foo")` compares the interned dir inodes (which the mutant would collide onto one). No extra assertion or `exclude_re` is expected; if the run reports an unkilled `key()` survivor anyway, add an `assert_ne!`-on-inodes line to that case-sensitive test rather than excluding it.

--- a/docs/superpowers/specs/2026-06-12-folded-inode-stability-design.md
+++ b/docs/superpowers/specs/2026-06-12-folded-inode-stability-design.md
@@ -71,7 +71,8 @@ casing affect the inode at all. Hence: fold the key.
 
 - Add a `fold_keys: bool` field.
 - `new(case_insensitive: bool)` sets `fold_keys` from its argument (was `new()`).
-- Add a private helper that applies the key transform:
+- Add a private helper that applies the key transform (`Cow` is already
+  imported at `tree.rs:2` — no new `use`):
 
   ```rust
   fn key<'a>(&self, path: &'a str) -> Cow<'a, str> {
@@ -102,10 +103,14 @@ threads both from the same `MountConfig`, so they cannot drift.
 
 ### 3. Call-site churn
 
-`InodeAllocator::new()` becomes `InodeAllocator::new(bool)` (~30 mechanical
-edits, almost all in `tree.rs` tests). The `build_with` helper passes `false`;
-`build_with_ci` test sites pass their own `case_insensitive` argument so the
-allocator's fold mode matches the tree under test.
+`InodeAllocator::new()` becomes `InodeAllocator::new(bool)` (~28 mechanical
+edits, almost all in `tree.rs` tests, plus the two `facade.rs` sites). Call
+sites that build case-sensitive trees construct `InodeAllocator::new(false)`;
+`build_with_ci` test sites construct the allocator with the same
+`case_insensitive` value they pass as the tree's fold flag, so the allocator's
+fold mode matches the tree under test. (`build_with` itself does not construct
+an allocator — it receives one and forwards `false` as the *tree's* fold flag;
+the bool originates at each call site.)
 
 ## Correctness
 
@@ -118,6 +123,13 @@ allocator's fold mode matches the tree under test.
 - **`prune_retired` semantics preserved.** Still keyed off live nodes, just
   under the folded key; the "retired inode is never reissued" guarantee and the
   `next` watermark are untouched.
+- **The incremental path is CI-unreachable, so it needs no change.**
+  `poll_refresh_notify` (`facade.rs`) forces case-insensitive mounts through
+  `force_full_rebuild` → `rebuild_full` → `build_with_ci`, so the fold-keyed
+  allocator is only ever driven by `build_with_ci` + `prune_retired`, never by
+  `apply_changes`/`rebuild_incremental` (including its `debug_assertions`
+  reference-tree divergence check, which clones `alloc` but is never entered in
+  CI mode). No incremental call site needs touching.
 
 ## Testing (TDD)
 
@@ -129,10 +141,16 @@ so the failing-first regression and its fix land in the same commit.
    track 2's inode. Drop track 1, rebuild from `[(2, "foo/B")]` with the same
    allocator, and assert track 2's inode is unchanged — while allowing the
    directory to now render `foo`.
-2. **Uniqueness guard.** A case-insensitive tree whose folded sibling paths
-   differ only by a disambiguation suffix still yields distinct inodes.
+2. **Uniqueness guard.** Build a case-insensitive tree from
+   `[(1, "Dir/Song"), (2, "Dir/song")]`, which disambiguates to `Song` and
+   `song (2)`. Assert the two tracks get distinct inodes *and* that their
+   fold-keys differ (`dir/song` vs `dir/song (2)`) — guarding that folding never
+   collapses a legitimately-disambiguated pair, not merely restating test #1.
 3. **Regression safety.** Existing `prune_retired_*` and `case_*` tests stay
    green (they pin the case-sensitive contract and folded lookup behavior).
 
-No documentation outside this spec needs updating; the change restores the
-already-documented stable-inode contract rather than altering it.
+The change restores the already-documented stable-inode contract rather than
+altering it, so no behavioral doc change is expected. The implementation plan
+must still grep `ARCHITECTURE.md` for any prose claiming inodes key on the
+*display* path specifically; if such a claim exists it gets a one-line
+correction (a doc touch, not a design change).

--- a/docs/superpowers/specs/2026-06-12-folded-inode-stability-design.md
+++ b/docs/superpowers/specs/2026-06-12-folded-inode-stability-design.md
@@ -1,0 +1,138 @@
+# Preserve survivor inodes when folded directory casing changes (#305)
+
+## Problem
+
+In case-insensitive mode, `VirtualTree::ensure_dir` (`musefs-core/src/tree.rs`)
+merges directories whose names fold equal and keeps the **first-seen** child's
+display casing. Full builds iterate entries ordered by track id, so insertion
+order decides which casing wins.
+
+`InodeAllocator::intern` keys inodes by the **disambiguated display path** and
+persists across full rebuilds — that persistence is what normally keeps an
+inode stable while a track's rendered path is unchanged.
+
+These two facts combine into a stability bug:
+
+- Track 1 at `Foo/A.flac` and track 2 at `foo/B.flac` build one merged `Foo`
+  directory (track 1 seen first). Track 2's display path is `Foo/B.flac`;
+  `intern` stores that key.
+- Track 1 is removed. `poll_refresh_notify` routes folded mounts through the
+  full-rebuild path, which rebuilds from `[(2, "foo/B.flac")]` only. Now
+  `ensure_dir` creates a fresh `foo` directory; track 2's display path becomes
+  `foo/B.flac` — a new `intern` key — so the survivor gets a **different inode**
+  even though its rendered path (`foo/B.flac`) never changed.
+
+This is not a stale-content bug (`notify_changed` invalidates the old inode).
+It is a stability/contract bug: an unrelated deletion reassigns inodes for
+tracks whose rendered inputs did not change, weakening the documented
+stable-inode guarantee and churning kernel dentries/cache.
+
+Affected trust boundary: virtual-tree inode stability contract
+(case-insensitive mounts). Tracking: #280.
+
+## Scope
+
+**Inode-stability only.** The fix preserves the survivor's inode across the
+casing flip. It does **not** pin the visible directory casing: a full rebuild
+may still legitimately render the merged directory as `foo` once `Foo`-cased
+tracks are gone. Pinning the displayed casing was considered and rejected — it
+would require new persistent per-folded-directory casing state and introduces a
+"stale casing" wrinkle (continuing to show `Foo` after every `Foo`-cased track
+is gone) that is arguably worse than a cosmetic re-case. The issue title scopes
+the work to inodes, not casing.
+
+## Approach: fold the inode key in case-insensitive mode
+
+Make the inode a function of the **folded** disambiguated path instead of the
+literal display path. `fold` is `to_lowercase()`, and `/` is invariant under
+it, so folding a whole path equals folding each component — identical to how
+`folded_children` already indexes. Then:
+
+```
+fold("Foo/B.flac") == fold("foo/B.flac") == "foo/b.flac"
+```
+
+Whichever casing a rebuild picks for the merged directory, the survivor's key —
+and therefore its inode — is unchanged.
+
+### Why "fix the casing winner" does not work
+
+Any rule that derives casing from the *currently present* tracks (first-seen,
+lexicographically smallest, lowest track id) flips the moment the track
+contributing the winning casing is deleted — that is the bug itself. The only
+deletion-stable rule that still preserves a real casing is to stop letting
+casing affect the inode at all. Hence: fold the key.
+
+## Components touched (all in `musefs-core`)
+
+`musefs-fuse`, `musefs-cli`, and the `musefs` binary are untouched.
+
+### 1. `InodeAllocator` (`musefs-core/src/tree.rs`)
+
+- Add a `fold_keys: bool` field.
+- `new(case_insensitive: bool)` sets `fold_keys` from its argument (was `new()`).
+- Add a private helper that applies the key transform:
+
+  ```rust
+  fn key<'a>(&self, path: &'a str) -> Cow<'a, str> {
+      if self.fold_keys {
+          Cow::Owned(fold(path))
+      } else {
+          Cow::Borrowed(path)
+      }
+  }
+  ```
+
+- `intern` keys its `paths` lookup and insert via `self.key(path)`.
+- `prune_retired` builds its `live` map via `self.key(&tree.path_of(ino))`.
+
+Both the intern path and the prune-on-churn path apply the **same** transform,
+so the rebuilt `paths` map stays consistent with how inodes were interned.
+
+### 2. `Musefs::open` (`musefs-core/src/facade.rs`)
+
+Construct the live allocator from config:
+
+```rust
+let mut alloc = InodeAllocator::new(config.case_insensitive);
+```
+
+The allocator's fold mode must match the tree's `case_insensitive`; production
+threads both from the same `MountConfig`, so they cannot drift.
+
+### 3. Call-site churn
+
+`InodeAllocator::new()` becomes `InodeAllocator::new(bool)` (~30 mechanical
+edits, almost all in `tree.rs` tests). The `build_with` helper passes `false`;
+`build_with_ci` test sites pass their own `case_insensitive` argument so the
+allocator's fold mode matches the tree under test.
+
+## Correctness
+
+- **No inode collisions.** In case-insensitive mode `disambiguate`/`taken`
+  already fold, so sibling names are folded-unique; folded paths are therefore
+  unique per node tree-wide — the same invariant `folded_children` lookups
+  already rely on. Two distinct nodes can never share a folded key.
+- **Case-sensitive mode is byte-for-byte unchanged.** `fold_keys` is false and
+  `key()` borrows the path as-is.
+- **`prune_retired` semantics preserved.** Still keyed off live nodes, just
+  under the folded key; the "retired inode is never reissued" guarantee and the
+  `next` watermark are untouched.
+
+## Testing (TDD)
+
+Each commit must be green (the pre-commit hook runs the full workspace suite),
+so the failing-first regression and its fix land in the same commit.
+
+1. **#305 regression (failing first).** Build a case-insensitive tree from
+   `[(1, "Foo/A"), (2, "foo/B")]` with a persistent `InodeAllocator`; capture
+   track 2's inode. Drop track 1, rebuild from `[(2, "foo/B")]` with the same
+   allocator, and assert track 2's inode is unchanged — while allowing the
+   directory to now render `foo`.
+2. **Uniqueness guard.** A case-insensitive tree whose folded sibling paths
+   differ only by a disambiguation suffix still yields distinct inodes.
+3. **Regression safety.** Existing `prune_retired_*` and `case_*` tests stay
+   green (they pin the case-sensitive contract and folded lookup behavior).
+
+No documentation outside this spec needs updating; the change restores the
+already-documented stable-inode contract rather than altering it.

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -236,7 +236,7 @@ struct IncrementalOutcome {
 
 impl Musefs {
     pub fn open(db: Db, config: MountConfig) -> Result<Musefs> {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(config.case_insensitive);
         // Capture both freshness stamps BEFORE the build: a write landing during
         // build_full then leaves data_version > stamp (the first poll triggers)
         // and seq > watermark (the changelog replays it) — at worst one redundant
@@ -1784,7 +1784,7 @@ mod tests {
         };
         let template = Template::parse(&config.template).expect("valid template");
 
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let (tree, _snapshot) = Musefs::build_full(&db, &template, &config, &mut alloc).unwrap();
 
         let root = VirtualTree::ROOT;

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -24,27 +24,48 @@ pub enum RebuildError {
 /// Retired paths are dropped by `prune_retired` once they outnumber live ones,
 /// bounding the map at 2x the live tree between prunes; a path that returns
 /// after a prune gets a fresh inode rather than its old one.
+/// In case-insensitive mounts the key is case-folded, so a track keeps its
+/// inode when an unrelated deletion flips a merged directory's display casing
+/// (#305).
 #[derive(Debug, Clone)]
 pub struct InodeAllocator {
     paths: ImHashMap<String, u64>,
     next: u64,
+    fold_keys: bool,
 }
 
 impl InodeAllocator {
-    pub fn new() -> InodeAllocator {
+    pub fn new(case_insensitive: bool) -> InodeAllocator {
         let mut paths = ImHashMap::new();
         paths.insert(String::new(), VirtualTree::ROOT); // root path "" -> inode 1
-        InodeAllocator { paths, next: 2 }
+        InodeAllocator {
+            paths,
+            next: 2,
+            fold_keys: case_insensitive,
+        }
     }
+
+    /// Transform a path into its map key: case-folded when the mount is
+    /// case-insensitive (so a survivor keeps its inode when an unrelated deletion
+    /// flips a merged directory's display casing, #305), identity otherwise.
+    fn key<'a>(&self, path: &'a str) -> Cow<'a, str> {
+        if self.fold_keys {
+            Cow::Owned(fold(path))
+        } else {
+            Cow::Borrowed(path)
+        }
+    }
+
     /// The inode for `path` (the disambiguated path from root), reused if seen
     /// before, else freshly allocated.
     fn intern(&mut self, path: &str) -> u64 {
-        if let Some(&ino) = self.paths.get(path) {
+        let key = self.key(path);
+        if let Some(&ino) = self.paths.get(key.as_ref()) {
             return ino;
         }
         let ino = self.next;
         self.next += 1;
-        self.paths.insert(path.to_string(), ino);
+        self.paths.insert(key.into_owned(), ino);
         ino
     }
 
@@ -60,7 +81,7 @@ impl InodeAllocator {
         }
         let mut live = ImHashMap::new();
         for &ino in tree.nodes.keys() {
-            live.insert(tree.path_of(ino), ino);
+            live.insert(self.key(&tree.path_of(ino)).into_owned(), ino);
         }
         self.paths = live;
     }
@@ -105,7 +126,7 @@ impl VirtualTree {
     pub const ROOT: u64 = 1;
 
     pub fn build(entries: &[(i64, String)]) -> VirtualTree {
-        VirtualTree::build_with(entries, &mut InodeAllocator::new())
+        VirtualTree::build_with(entries, &mut InodeAllocator::new(false))
     }
 
     /// Case-sensitive build (the default everywhere except a folded mount).
@@ -903,7 +924,7 @@ mod tests {
 
     #[test]
     fn build_with_keeps_inodes_stable_across_rebuilds() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let t1 = VirtualTree::build_with(&[(10, "Alice/Song.flac".into())], &mut alloc);
         let alice1 = t1.lookup(VirtualTree::ROOT, "Alice").unwrap();
         let song1 = t1.lookup(alice1, "Song.flac").unwrap();
@@ -934,7 +955,7 @@ mod tests {
 
     #[test]
     fn build_with_does_not_recycle_a_vanished_inode() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let t1 = VirtualTree::build_with(&[(10, "Gone/X.flac".into())], &mut alloc);
         let gone = t1.lookup(VirtualTree::ROOT, "Gone").unwrap();
         let x = t1.lookup(gone, "X.flac").unwrap();
@@ -946,7 +967,7 @@ mod tests {
 
     #[test]
     fn prune_retired_bounds_map_under_churn() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         for generation in 0..100 {
             let entries = vec![(1, format!("Gen{generation}/a.flac"))];
             let tree = VirtualTree::build_with(&entries, &mut alloc);
@@ -962,7 +983,7 @@ mod tests {
 
     #[test]
     fn prune_retired_keeps_live_inodes_stable() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let tree = VirtualTree::build_with(&[(1, "Keep/song.flac".into())], &mut alloc);
         let keep_dir = tree.lookup(VirtualTree::ROOT, "Keep").unwrap();
         let keep_file = tree.lookup(keep_dir, "song.flac").unwrap();
@@ -982,7 +1003,7 @@ mod tests {
 
     #[test]
     fn pruned_path_reborn_gets_fresh_inode_never_recycled() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let t1 = VirtualTree::build_with(&[(1, "Gone/x.flac".into())], &mut alloc);
         let gone_dir = t1.lookup(VirtualTree::ROOT, "Gone").unwrap();
         let gone_file = t1.lookup(gone_dir, "x.flac").unwrap();
@@ -1011,7 +1032,7 @@ mod tests {
     fn prune_retired_waits_for_threshold() {
         // Drives the map to exactly 2x live nodes: prune must NOT fire at
         // equality (pins the `<=` boundary for the mutation gate).
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let t1 = VirtualTree::build_with(&[(1, "A/x.flac".into())], &mut alloc);
         let a_dir = t1.lookup(VirtualTree::ROOT, "A").unwrap();
         // paths: "", A, A/x.flac = 3
@@ -1074,7 +1095,7 @@ mod tests {
         // Two artist dirs differing only by case collapse into one; both titles
         // live under the first-seen casing.
         let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
-        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), true);
+        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(true), true);
         let foo = tree.lookup(VirtualTree::ROOT, "Foo").expect("Foo dir");
         // Case-insensitive lookup resolves any casing to the same inode.
         assert_eq!(tree.lookup(VirtualTree::ROOT, "foo"), Some(foo));
@@ -1094,7 +1115,7 @@ mod tests {
             (1i64, "Dir/Song".to_string()),
             (2i64, "Dir/song".to_string()),
         ];
-        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), true);
+        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(true), true);
         let dir = tree.lookup(VirtualTree::ROOT, "Dir").expect("Dir");
         let names: Vec<String> = tree.children(dir).unwrap().keys().cloned().collect();
         // First-seen "Song" keeps its name; "song" becomes "song (2)".
@@ -1108,7 +1129,7 @@ mod tests {
         // Control: with folding OFF, "Foo" and "foo" are distinct dirs and a
         // differently-cased query misses.
         let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
-        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), false);
+        let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(false), false);
         assert_eq!(tree.children(VirtualTree::ROOT).unwrap().len(), 2);
         assert_ne!(
             tree.lookup(VirtualTree::ROOT, "Foo"),
@@ -1125,16 +1146,63 @@ mod tests {
             (1i64, "Dir/Song".to_string()),
             (2i64, "Dir/Other".to_string()),
         ];
-        let mut tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(), true);
+        let mut tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(true), true);
         let dir = tree.lookup(VirtualTree::ROOT, "dir").expect("dir");
         assert!(tree.lookup(dir, "song").is_some());
 
-        tree.remove_track(1, &mut InodeAllocator::new());
+        tree.remove_track(1, &mut InodeAllocator::new(false));
 
         // The removed file no longer resolves (any casing); the sibling still does.
         assert_eq!(tree.lookup(dir, "song"), None);
         assert_eq!(tree.lookup(dir, "Song"), None);
         assert!(tree.lookup(dir, "other").is_some());
+    }
+
+    #[test]
+    fn folded_dir_recase_keeps_survivor_inode() {
+        // #305: track 1 seen first wins the merged directory's casing ("Foo");
+        // track 2 merges under it. Removing track 1 lets the next full rebuild
+        // re-derive the casing from track 2 alone, rendering "foo". Track 2's
+        // rendered path is unchanged, so its inode must be stable.
+        let mut alloc = InodeAllocator::new(true);
+        let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+        let tree = VirtualTree::build_with_ci(&entries, &mut alloc, true);
+        let before = tree.inode_of_track(2).expect("track 2 inode");
+
+        let rebuilt = VirtualTree::build_with_ci(&[(2i64, "foo/B".to_string())], &mut alloc, true);
+        let after = rebuilt
+            .inode_of_track(2)
+            .expect("track 2 inode after rebuild");
+
+        assert_eq!(
+            before, after,
+            "survivor inode must survive a folded dir re-case"
+        );
+        // Scope is inode stability only: the directory legitimately re-cases to "foo".
+        assert!(rebuilt.lookup(VirtualTree::ROOT, "foo").is_some());
+    }
+
+    #[test]
+    fn folded_inode_key_keeps_disambiguated_siblings_distinct() {
+        // Guard that folding the key never collapses a legitimately-disambiguated
+        // pair: "Song" and "song" fold equal, so the second becomes "song (2)";
+        // their fold-keys ("dir/song" vs "dir/song (2)") differ, so do their inodes.
+        let mut alloc = InodeAllocator::new(true);
+        let entries = vec![
+            (1i64, "Dir/Song".to_string()),
+            (2i64, "Dir/song".to_string()),
+        ];
+        let tree = VirtualTree::build_with_ci(&entries, &mut alloc, true);
+        let a = tree.inode_of_track(1).expect("track 1 inode");
+        let b = tree.inode_of_track(2).expect("track 2 inode");
+        assert_ne!(
+            a, b,
+            "disambiguated folded siblings must not collapse to one inode"
+        );
+
+        let dir = tree.lookup(VirtualTree::ROOT, "Dir").expect("Dir");
+        assert_eq!(tree.lookup(dir, "Song"), Some(a));
+        assert_eq!(tree.lookup(dir, "song (2)"), Some(b));
     }
 
     #[test]
@@ -1167,7 +1235,7 @@ mod tests {
 
     #[test]
     fn children_by_rendered_updates_when_collision_member_removed() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(
             &[(10, "D/song.flac".into()), (20, "D/song.flac".into())],
             &mut alloc,
@@ -1183,7 +1251,7 @@ mod tests {
 
     #[test]
     fn children_by_rendered_updates_when_empty_dir_pruned() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(
             &[(10, "A/B/x.flac".into()), (20, "A/C/y.flac".into())],
             &mut alloc,
@@ -1223,7 +1291,7 @@ mod tests {
 
     #[test]
     fn introducing_id_is_min_descendant_track_id() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let t = VirtualTree::build_with(
             &[(30, "A/B/x.flac".into()), (10, "A/C/y.flac".into())],
             &mut alloc,
@@ -1234,7 +1302,7 @@ mod tests {
 
     #[test]
     fn remove_track_prunes_empty_ancestors_b() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(
             &[(10, "A/B/x.flac".into()), (20, "C/y.flac".into())],
             &mut alloc,
@@ -1247,7 +1315,7 @@ mod tests {
 
     #[test]
     fn remove_track_keeps_parent_with_surviving_sibling() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(
             &[(10, "A/x.flac".into()), (20, "A/y.flac".into())],
             &mut alloc,
@@ -1286,7 +1354,7 @@ mod tests {
     #[test]
     fn rebuild_subtree_reports_missing_rendered_path() {
         use std::collections::HashMap;
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut tree = VirtualTree::build_with(&[(10, "Alice/Song.flac".into())], &mut alloc);
         let dir = tree.lookup(VirtualTree::ROOT, "Alice").unwrap();
         let new_paths: HashMap<i64, TrackRenderState> = HashMap::new(); // omits track 10
@@ -1298,7 +1366,7 @@ mod tests {
 
     #[test]
     fn rebuild_subtree_reclaims_freed_base_name() {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(
             &[(10, "D/song.flac".into()), (20, "D/song.flac".into())],
             &mut alloc,
@@ -1322,7 +1390,7 @@ mod tests {
             (2, "P/X.flac/t.flac".to_string()),
         ];
         let reference = VirtualTree::build(&entries);
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         let p = t.lookup(VirtualTree::ROOT, "P").unwrap();
         let np: std::collections::HashMap<i64, TrackRenderState> =
@@ -1343,7 +1411,7 @@ mod tests {
             (9, "X.flac/b.flac".to_string()),
             (5, "X.flac".to_string()), // a FILE rendered "X.flac" in root
         ];
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         // Delete track 1 (the dir's min). Dir's introducing id rises to 9; file 5 (id 5 < 9)
         // should now claim base "X.flac" and the dir become "X.flac (2)".
@@ -1374,7 +1442,7 @@ mod tests {
         // Initial: file "X.flac" (id 2) claims the base name; dir "X.flac"
         // (introduced by id 5) is disambiguated to "X.flac (2)".
         let entries = vec![(2, "X.flac".to_string()), (5, "X.flac/a.flac".to_string())];
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         // ADD track 1 under the dir: its id (1) is now the dir's min (< file's 2), so a
         // full rebuild gives the DIR the base name and the file becomes "X.flac (2)".
@@ -1408,7 +1476,7 @@ mod tests {
             (2, "Old/b.flac".to_string()),
             (3, "New/c.flac".to_string()),
         ];
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         // Track 2 moves Old -> New.
         let mut new_entries = vec![
@@ -1436,7 +1504,7 @@ mod tests {
         // A `changed` id whose rendered path is identical (e.g. a tag edit that does
         // not affect the template) must leave structure untouched.
         let entries = vec![(1, "A/x.flac".to_string()), (2, "A/y.flac".to_string())];
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         let reference = VirtualTree::build(&entries);
         let new_paths: std::collections::HashMap<i64, TrackRenderState> =
@@ -1470,7 +1538,7 @@ mod tests {
         removed: &[i64],
         expected_rebuilds: usize,
     ) {
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(before, &mut alloc);
         let mut after_sorted = after.to_vec();
         after_sorted.sort_by_key(|(id, _)| *id);
@@ -1635,7 +1703,7 @@ mod tests {
             (2, "P/Sub/u.flac".to_string()),
             (3, "P/keep.flac".to_string()),
         ];
-        let mut alloc = InodeAllocator::new();
+        let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         let p = t.lookup(VirtualTree::ROOT, "P").unwrap();
         // Drop both tracks under Sub; rebuild P from the survivors only.


### PR DESCRIPTION
## Summary

Fixes #305. On case-insensitive mounts, `ensure_dir` merges directories whose names fold equal and keeps the **first-seen** child's display casing. Full builds iterate by track id, so deleting the track that contributed the winning casing lets the next full rebuild re-derive it from a different track — flipping the merged directory's display path (`Foo/B.flac` → `foo/B.flac`). Because `InodeAllocator` keyed inodes on that disambiguated *display* path, the survivor got a **fresh inode despite an unchanged rendered path**, weakening the documented stable-inode contract and churning kernel dentries.

The fix makes `InodeAllocator` key on the **case-folded** path in case-insensitive mode, so the inode is a function of `fold(path)` and no longer depends on which casing a rebuild happens to pick. Case-sensitive mounts are byte-for-byte unchanged.

Scope is **inode stability only** — the directory may still legitimately re-case (e.g. render `foo` once all `Foo`-cased tracks are gone); pinning the displayed casing was considered and deliberately rejected (it needs new persistent state and introduces a worse "stale casing" wrinkle).

## Why folding is safe

In case-insensitive mode `disambiguate`/`taken` already fold, so sibling names are folded-unique and every node has a unique folded path tree-wide — the same invariant `folded_children` lookups already rely on. Two distinct nodes can never share a folded key. `intern` and `prune_retired` apply the identical transform, so the rebuild-on-churn path stays consistent. The incremental path is untouched: `poll_refresh_notify` forces case-insensitive mounts through the full-rebuild path, so the fold-keyed allocator is never driven by `apply_changes`.

## Tests

- `folded_dir_recase_keeps_survivor_inode` — the #305 regression: a survivor keeps its inode across a folded-directory re-case (verified to fail without the fold).
- `folded_inode_key_keeps_disambiguated_siblings_distinct` — guards that folding never collapses a legitimately-disambiguated pair (`Song` / `song (2)`).
- Existing `case_*` / `prune_retired_*` tests pin the unchanged case-sensitive contract.

Full workspace suite, `clippy -D warnings`, `fmt`, and the local in-diff mutation gate all green.

## Process artifacts

Design spec and implementation plan are included under `docs/superpowers/{specs,plans}/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)