### PR TITLE
fix(lidarr): apply the shared scan timeout to autoscan (#312)

### DIFF
--- a/contrib/lidarr/src/musefs_lidarr/sync.py
+++ b/contrib/lidarr/src/musefs_lidarr/sync.py
@@ -5,6 +5,7 @@ import sys
 from dataclasses import dataclass
 
 from musefs_common import (
+    SCAN_TIMEOUT_SECONDS,
     SyncStats,
     check_schema_version,
     connect,
@@ -69,7 +70,7 @@ def scan_if_enabled(*, config: SyncConfig, paths: list[str], runner=run_scan) ->
     """Run ``musefs scan`` over ``paths`` when autoscan is on and paths exist."""
     if not config.autoscan or not paths:
         return
-    runner(config.musefs_bin, config.db_path, paths)
+    runner(config.musefs_bin, config.db_path, paths, timeout=SCAN_TIMEOUT_SECONDS)
 
 
 def _log_skipped(skipped, *, warning_printer) -> None:

--- a/contrib/lidarr/tests/test_sync.py
+++ b/contrib/lidarr/tests/test_sync.py
@@ -1,4 +1,4 @@
-from musefs_common import connect, realpath_key
+from musefs_common import SCAN_TIMEOUT_SECONDS, connect, realpath_key
 
 from musefs_lidarr.events import EventType, LidarrEvent
 from musefs_lidarr.import_link import LinkMode
@@ -92,10 +92,28 @@ def test_scan_if_enabled_calls_runner(tmp_path):
     scan_if_enabled(
         config=config,
         paths=["/music/a.flac"],
-        runner=lambda binary, db_path, targets: calls.append((binary, db_path, targets)),
+        runner=lambda binary, db_path, targets, *, timeout=None: calls.append(
+            (binary, db_path, targets)
+        ),
     )
 
     assert calls == [("musefs-dev", str(tmp_path / "m.db"), ["/music/a.flac"])]
+
+
+def test_scan_if_enabled_passes_shared_timeout(tmp_path):
+    captured = {}
+    config = SyncConfig(
+        db_path=str(tmp_path / "m.db"),
+        link_mode=LinkMode.SYMLINK,
+        autoscan=True,
+    )
+
+    def fake_runner(binary, db_path, targets, *, timeout=None):
+        captured["timeout"] = timeout
+
+    scan_if_enabled(config=config, paths=["/music/a.flac"], runner=fake_runner)
+
+    assert captured["timeout"] == SCAN_TIMEOUT_SECONDS == 120
 
 
 def test_sync_records_writes_tags(
@@ -229,7 +247,7 @@ def test_sync_event_with_payloads_scans_then_syncs(
     )
     calls = []
 
-    def fake_scan(binary, db_path_arg, targets):
+    def fake_scan(binary, db_path_arg, targets, *, timeout=None):
         calls.append(("scan", binary, db_path_arg, targets))
 
     def fake_prune(*, config, previous_paths):


### PR DESCRIPTION
## Summary

`scan_if_enabled` in the Lidarr integration invoked the scanner via `runner(config.musefs_bin, config.db_path, paths)` without `SCAN_TIMEOUT_SECONDS`. Unlike the beets and Picard integrations, a wedged `musefs scan` triggered by a Lidarr import/release event could therefore block the custom-script process indefinitely instead of failing with a controlled `ScanError(kind="timeout")`.

This passes the shared 120s timeout, bringing Lidarr in line with the other two integrations.

## Changes

- `contrib/lidarr/src/musefs_lidarr/sync.py`: `scan_if_enabled` now passes `timeout=SCAN_TIMEOUT_SECONDS` to the runner.
- `contrib/lidarr/tests/test_sync.py`: new `test_scan_if_enabled_passes_shared_timeout` (mirrors beets' `test_run_scan_passes_shared_timeout`), plus the two existing scanner doubles updated to accept the `timeout` keyword.

## Testing

- `pytest contrib/lidarr/tests` — 65 passed, 1 opt-in skip
- `ruff check` — clean

Closes #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)