### PR TITLE
fix(ci): gate releases on tag-triggered checks via run-start cutoff (#314)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,24 @@ jobs:
           # commit. release_gate.py decides: exit 0 = all green, 2 = keep
           # waiting, 1 = a required check failed. The tag also triggers ci.yml
           # and coverage.yml, so these checks are (re)generated for this tree.
+          # ci-ok/coverage-ok are late aggregator jobs, so the tag-triggered
+          # runs only appear minutes in. Until then a still-green run from the
+          # earlier main-branch push is the only completed one on this commit —
+          # trusting it would let the release skip the tag-only legs (e.g. the
+          # unconditional FreeBSD e2e). Gate on this release run's own start
+          # time: discard check-runs that began before the tag triggered us.
+          SINCE=""
+          for _ in 1 2 3; do
+            SINCE="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              -q .run_started_at || true)"
+            [ -n "$SINCE" ] && break
+            sleep 5
+          done
+          if [ -z "$SINCE" ]; then
+            echo "::error::Could not determine this run's start time; refusing to gate on possibly-stale checks."
+            exit 1
+          fi
+          echo "Gating on check-runs started at/after ${SINCE} (the tag trigger)."
           deadline=$(( $(date +%s) + 45 * 60 ))   # 45 min covers the full matrix
           while :; do
             # --slurp collects all pages into one JSON array; the jq filter then
@@ -57,7 +75,7 @@ jobs:
             gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
               --paginate --slurp -q '{check_runs: [.[].check_runs[]]}' > checks.json || true
             set +e
-            python scripts/release_gate.py --names ci-ok coverage-ok < checks.json
+            python scripts/release_gate.py --names ci-ok coverage-ok --since "$SINCE" < checks.json
             rc=$?
             set -e
             if [ "$rc" -eq 0 ]; then break; fi

--- a/scripts/release_gate.py
+++ b/scripts/release_gate.py
@@ -20,27 +20,40 @@ class Decision(enum.Enum):
     FAIL = "fail"
 
 
-def latest_completed_by_name(runs, name):
+def latest_completed_by_name(runs, name, since=None):
     """Return the newest *completed* check-run with ``name``, or ``None``.
 
     The Checks API returns every run of a name (including re-runs); the gate
     only trusts the most recently completed one, sorted by ``completed_at``.
+
+    When ``since`` (an ISO-8601 timestamp) is given, runs that *started* before
+    it are discarded as stale: ``ci-ok``/``coverage-ok`` are late aggregator
+    jobs, so a release tag's fresh runs only appear minutes in. Filtering on
+    ``started_at`` keeps the gate from trusting a still-green main-branch run
+    from before the tag, which would let the release skip the tag-only legs.
     """
     completed = [
         r
         for r in runs
-        if r.get("name") == name and r.get("status") == "completed" and r.get("completed_at")
+        if r.get("name") == name
+        and r.get("status") == "completed"
+        and r.get("completed_at")
+        and (since is None or (r.get("started_at") or "") >= since)
     ]
     if not completed:
         return None
     return max(completed, key=lambda r: r["completed_at"])
 
 
-def decide(runs, names):
-    """Return a :class:`Decision` for the required check ``names``."""
+def decide(runs, names, since=None):
+    """Return a :class:`Decision` for the required check ``names``.
+
+    ``since`` is forwarded to :func:`latest_completed_by_name` to discard
+    pre-tag (stale) runs.
+    """
     saw_missing = False
     for name in names:
-        chosen = latest_completed_by_name(runs, name)
+        chosen = latest_completed_by_name(runs, name, since)
         if chosen is None:
             saw_missing = True
             continue
@@ -52,6 +65,12 @@ def decide(runs, names):
 def main(argv=None, stdin_text=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--names", nargs="+", required=True, help="required check-run names")
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="ISO-8601 cutoff; ignore check-runs that started before it (stale "
+        "pre-tag runs). Pass the release run's run_started_at.",
+    )
     args = parser.parse_args(argv)
 
     text = stdin_text if stdin_text is not None else sys.stdin.read()
@@ -67,7 +86,7 @@ def main(argv=None, stdin_text=None):
     # mis-slurped gh payload can produce — must degrade to "wait", not raise.
     runs = (payload.get("check_runs") if isinstance(payload, dict) else None) or []
 
-    result = decide(runs, args.names)
+    result = decide(runs, args.names, args.since)
     if result is Decision.FAIL:
         print(f"::error::A required check did not succeed for this commit ({args.names}).")
         return 1

--- a/scripts/test_release_gate.py
+++ b/scripts/test_release_gate.py
@@ -6,12 +6,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from release_gate import Decision, decide, latest_completed_by_name, main  # noqa: E402
 
 
-def _run(name, status, conclusion, completed_at):
+def _run(name, status, conclusion, completed_at, started_at=None):
     return {
         "name": name,
         "status": status,
         "conclusion": conclusion,
         "completed_at": completed_at,
+        "started_at": started_at,
     }
 
 
@@ -100,3 +101,52 @@ def test_cli_handles_empty_or_garbled_input():
     # A failed `gh api` can leave checks.json empty/garbled; must wait, not crash.
     for bad in ("", "   ", "not json", "null"):
         assert main(["--names", "ci-ok"], stdin_text=bad) == 2
+
+
+def test_decide_since_waits_when_only_stale_completed_runs():
+    # Stale main-branch successes (started before the tag) must not satisfy the
+    # gate: the tag-triggered aggregator check-runs have not appeared yet.
+    runs = [
+        _run("ci-ok", "completed", "success", "2026-06-10T11:00:00Z", "2026-06-10T10:30:00Z"),
+        _run("coverage-ok", "completed", "success", "2026-06-10T11:05:00Z", "2026-06-10T10:35:00Z"),
+    ]
+    assert decide(runs, ["ci-ok", "coverage-ok"], since="2026-06-11T00:00:00Z") is Decision.WAIT
+
+
+def test_decide_since_passes_on_fresh_success():
+    runs = [
+        _run("ci-ok", "completed", "success", "2026-06-11T00:30:00Z", "2026-06-11T00:05:00Z"),
+        _run("coverage-ok", "completed", "success", "2026-06-11T00:32:00Z", "2026-06-11T00:06:00Z"),
+    ]
+    assert decide(runs, ["ci-ok", "coverage-ok"], since="2026-06-11T00:00:00Z") is Decision.PASS
+
+
+def test_decide_since_ignores_stale_success_and_waits_for_fresh_inprogress():
+    # The reported reproducer: a stale completed success plus a fresh, still
+    # running tag-triggered run for the same name must WAIT, not pass.
+    runs = [
+        _run("ci-ok", "completed", "success", "2026-06-10T11:00:00Z", "2026-06-10T10:30:00Z"),
+        _run("ci-ok", "in_progress", None, None, "2026-06-11T00:05:00Z"),
+    ]
+    assert decide(runs, ["ci-ok"], since="2026-06-11T00:00:00Z") is Decision.WAIT
+
+
+def test_decide_since_fails_on_fresh_failure_despite_stale_success():
+    runs = [
+        _run("ci-ok", "completed", "success", "2026-06-10T11:00:00Z", "2026-06-10T10:30:00Z"),
+        _run("ci-ok", "completed", "failure", "2026-06-11T00:30:00Z", "2026-06-11T00:05:00Z"),
+    ]
+    assert decide(runs, ["ci-ok"], since="2026-06-11T00:00:00Z") is Decision.FAIL
+
+
+def test_cli_since_waits_on_stale_completed():
+    payload = {
+        "check_runs": [
+            _run("ci-ok", "completed", "success", "2026-06-10T11:00:00Z", "2026-06-10T10:30:00Z"),
+        ]
+    }
+    rc = main(
+        ["--names", "ci-ok", "--since", "2026-06-11T00:00:00Z"],
+        stdin_text=json.dumps(payload),
+    )
+    assert rc == 2


### PR DESCRIPTION
Closes #314.

## Problem

`ci-ok`/`coverage-ok` are late *aggregator* jobs (`needs:` the whole matrix), so a release tag's fresh check-runs only appear minutes into the run. Until then, the only completed run on the tagged commit is the still-green one from the earlier `main`-branch push. `scripts/release_gate.py` selected the newest *completed* run and passed on it — so a release could proceed before the tag-triggered CI/coverage (including the tag-unconditional FreeBSD e2e leg) finished, bypassing the release-specific intent.

"Wait while anything is in-progress" can't fix this: early on there is no in-progress `ci-ok` yet, only the stale completed one.

## Fix (freshness cutoff)

- `scripts/release_gate.py` — `latest_completed_by_name`/`decide`/`main` gain an optional `since`; completed check-runs whose `started_at` precedes it are discarded as stale. `--since` absent keeps the previous behavior.
- `.github/workflows/release.yml` — before the poll loop, fetch this release run's own `run_started_at` (the tag-trigger instant, via `gh api .../actions/runs/$GITHUB_RUN_ID`, with retry + hard-fail if unobtainable) and pass it as `--since`. Stale pre-tag runs no longer satisfy the gate.

Using the trigger time rather than a wall-clock `now` in the loop is deliberate: the tag matrix starts concurrently with the release job, so a `now`-cutoff would wrongly exclude it and deadlock to the 45-min timeout.

## Known residual edge

Tagging a commit within minutes of its own `main` merge, *before* main-CI finishes, leaves both aggregators "fresh" — timestamp alone can't separate them. Fully closing that needs ref/check-suite matching, a larger rewrite, and is left out of scope.

## Tests

5 new `since`-cutoff cases in `scripts/test_release_gate.py` (incl. the issue reproducer: stale success + fresh in-progress -> WAIT; fresh failure despite stale success -> FAIL). Full pre-commit gate (fmt, clippy, `cargo test --workspace`, yamllint, ruff) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)