### PR TITLE
fix(contrib): self-contained contract roundtrip + lidarr dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"
+    directory: "/contrib/lidarr"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
     directory: "/contrib/python-musefs"
     schedule:
       interval: "weekly"

--- a/scripts/contract-roundtrip.sh
+++ b/scripts/contract-roundtrip.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
+# Make the in-repo python-musefs importable without a prior `pip install`, and
+# prepend it so the current checkout always wins over an installed/stale copy.
+export PYTHONPATH="$repo_root/contrib/python-musefs/src${PYTHONPATH:+:$PYTHONPATH}"
+
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 backing="$work/backing"; mkdir -p "$backing"


### PR DESCRIPTION
Closes #311. Closes #315.

## #311 — `contract-roundtrip.sh` was not self-contained

The script calls itself the single source of truth for the Python → Rust contract round trip, but it invoked `python scripts/contract_writer.py` (which imports `musefs_common.store`) without making the in-repo package importable. A clean checkout failed before writing any metadata:

```text
ModuleNotFoundError: No module named 'musefs_common'
```

CI passed only because the `contract` job pip-installs `python-musefs` beforehand — which also means CI could validate an installed/stale package instead of the current checkout.

Fix: prepend `contrib/python-musefs/src` to `PYTHONPATH` at the top of the script. This makes it work from a clean checkout and, because front `PYTHONPATH` entries precede site-packages, guarantees the checkout always wins over any installed copy.

## #315 — Dependabot missing `contrib/lidarr`

`.github/dependabot.yml` tracked pip manifests for `contrib/beets`, `contrib/python-musefs`, `contrib/picard`, and `tests/interop`, but not `contrib/lidarr` — despite Lidarr being a first-class contrib package elsewhere. Added the matching weekly pip entry.

## Verification

- shellcheck + yamllint pass on the changed files.
- Import resolves to the in-repo `src` checkout under the new `PYTHONPATH` (verified with a clean and a populated env).
- Full pre-commit gate (fmt, clippy, workspace tests, shellcheck, yamllint, ruff) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)