### PR TITLE
fix(cli): reject a missing database on mount instead of creating it (#309)

### DIFF
--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -45,7 +45,8 @@ pub struct MountArgs {
     /// Empty directory to mount at.
     #[arg(env = "MUSEFS_MOUNTPOINT")]
     pub mountpoint: PathBuf,
-    /// Path to the SQLite database.
+    /// Path to the SQLite database (must already exist; unlike `scan`, mount
+    /// never creates it).
     #[arg(long, env = "MUSEFS_DB")]
     pub db: PathBuf,
     /// Path template, e.g. "$albumartist/$album/$title". Supports ${a|b}
@@ -274,8 +275,13 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
 }
 
 /// Build a `Musefs` from the DB at `args.db` and mount it (blocking) at
-/// `args.mountpoint`.
+/// `args.mountpoint`. Unlike `scan`, mount never creates the store: a missing
+/// database path is a configuration error (a typo would otherwise silently
+/// mount an empty view), so it is rejected before any FUSE setup.
 pub fn run_mount(args: &MountArgs) -> Result<()> {
+    if !args.db.exists() {
+        anyhow::bail!("database does not exist: {}", args.db.display());
+    }
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
     let (config, fuse_config) = parse_mount_config(args);

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -309,3 +309,32 @@ fn fallback_without_equals_is_rejected() {
     .unwrap_err();
     assert!(err.to_string().contains("FIELD=VALUE"), "{err}");
 }
+
+#[test]
+fn mount_fails_on_missing_db_without_creating_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("missing.db");
+    let mount_dir = tempfile::tempdir().unwrap();
+
+    let cli = Cli::parse_from([
+        "musefs",
+        "mount",
+        mount_dir.path().to_str().unwrap(),
+        "--db",
+        db_path.to_str().unwrap(),
+    ]);
+    let args = match cli.command {
+        Command::Mount(args) => args,
+        Command::Scan { .. } => panic!("expected mount"),
+    };
+
+    let err = musefs_cli::run_mount(&args).unwrap_err();
+    assert!(
+        err.to_string().contains("does not exist"),
+        "expected a missing-db error, got: {err}"
+    );
+    assert!(
+        !db_path.exists(),
+        "mount must not create the database when it is absent"
+    );
+}

--- a/musefs/tests/env_config.rs
+++ b/musefs/tests/env_config.rs
@@ -1,13 +1,13 @@
 //! The `musefs` binary reads MUSEFS_* environment variables for scalar mount
 //! and scan flags (clap's `env` feature). Each test spawns the real binary with
 //! an isolated environment, so they are parallel-safe and need no /dev/fuse:
-//! the children fail fast at arg-parse (exit 2) or DB-open (exit 1), never
-//! reaching a mount.
+//! the children fail fast at arg-parse (exit 2) or at the mount runtime's
+//! missing-db guard (exit 1), never reaching a mount.
 //!
 //! `env_clear()` is deliberate: it guarantees no ambient MUSEFS_* leaks in from
 //! the developer's shell. It is safe here — the binary is launched by absolute
 //! path (`CARGO_BIN_EXE_musefs`), and the assertions key on the
-//! `opening database at <path>` stderr, which `main` emits via anyhow/eprintln,
+//! `database does not exist` stderr, which `main` emits via anyhow/eprintln,
 //! not through env_logger — so a cleared `RUST_LOG` does not suppress it.
 
 use std::path::{Path, PathBuf};
@@ -19,8 +19,9 @@ fn musefs() -> Command {
     cmd
 }
 
-/// A DB path whose parent directory does not exist, so opening it fails
-/// deterministically — proving we got *past* arg parsing to the DB-open step.
+/// A DB path that does not exist (its parent directory is absent too), so the
+/// mount runtime's missing-db guard rejects it deterministically — proving we
+/// got *past* arg parsing into mount execution.
 fn unopenable_db(dir: &Path, name: &str) -> PathBuf {
     dir.join("missing").join(name)
 }
@@ -38,8 +39,12 @@ fn env_satisfies_required_mount_args() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     // Not a usage error: env satisfied the required mountpoint and --db.
     assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
-    // We reached DB-open, which fails on the missing parent directory.
-    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+    // We reached the mount runtime's missing-db guard, which rejects the
+    // non-existent path before any FUSE setup.
+    assert!(
+        stderr.contains("database does not exist"),
+        "stderr: {stderr}"
+    );
     assert!(
         stderr.contains(&db.display().to_string()),
         "stderr: {stderr}"
@@ -116,10 +121,13 @@ fn invalid_mode_env_is_rejected_but_flag_overrides_it() {
         .output()
         .unwrap();
     // --mode on the CLI wins; the bogus env is never parsed. We fall through to
-    // DB-open (exit 1), not a usage error.
+    // the mount runtime's missing-db guard (exit 1), not a usage error.
     let stderr = String::from_utf8_lossy(&flag_wins.stderr);
     assert_ne!(flag_wins.status.code(), Some(2), "stderr: {stderr}");
-    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("database does not exist"),
+        "stderr: {stderr}"
+    );
 }
 
 // Locks the per-flag env wiring: clap's `env` feature renders `[env: NAME=]` in
@@ -178,12 +186,15 @@ fn valid_boolean_env_is_accepted() {
         .env("MUSEFS_KEEP_CACHE", "true")
         .output()
         .unwrap();
-    // Got past parse for the right reason (reached DB-open), not merely "not
-    // exit 2". Proves a valid boolish env value is accepted, not silently
-    // dropped.
+    // Got past parse for the right reason (reached the mount runtime's
+    // missing-db guard), not merely "not exit 2". Proves a valid boolish env
+    // value is accepted, not silently dropped.
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert_ne!(out.status.code(), Some(2), "stderr: {stderr}");
-    assert!(stderr.contains("opening database"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("database does not exist"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`scan --db` is documented "created if absent", but `mount --db` was documented only as "Path to the SQLite database". Despite that, `run_mount` called `Db::open`, which (via `rusqlite::Connection::open`) **creates and migrates an empty store** when the path is absent. A typo in the mount DB path therefore silently mounted an empty view instead of failing before FUSE setup — masking the configuration mistake and letting automation run against an empty store.

Fixes #309.

## Change

- `run_mount` now rejects a non-existent `--db` path up front (`database does not exist: <path>`), before any DB open or FUSE setup. `scan` is unchanged — it still creates the store as documented.
- `mount --db` help text now states the DB must already exist, restoring the scan/mount asymmetry the issue noted.

## Tests

- New `musefs-cli` test `mount_fails_on_missing_db_without_creating_it`: asserts `run_mount` errors on a missing path and does not create the file.
- The `musefs` `env_config` integration tests previously keyed on the old `opening database` error as proof they reached mount execution past arg-parse; they now key on the missing-db guard (same intent, earlier stage).

Full workspace test suite + clippy pass via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)