### PR TITLE
feat: allow_other/default_permissions for cross-user mounts (#294) + AppArmor docs (#293)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ musefs mount /path/to/mountpoint --db library.db \
 `mount` blocks until the filesystem is unmounted (`fusermount -u`, or
 Ctrl-C).
 
+> **Mounting at an arbitrary path may be denied by AppArmor.** On distros that
+> ship an AppArmor profile for `fusermount3` (Ubuntu 24.04+ / libfuse ≥ 3.17),
+> unprivileged FUSE mounts are only allowed when the mountpoint is under a
+> whitelisted prefix — the shipped profile permits `$HOME/**`, `/mnt`, `/media`,
+> `/tmp`, `/cvmfs`, `$XDG_RUNTIME_DIR`, plus flatpak dirs. Mounting elsewhere
+> (e.g. a data volume at `/data/...`) fails with `fusermount3: mount failed:
+> Permission denied`, and the kernel audit log shows
+> `apparmor="DENIED" operation="mount" … profile="fusermount3"`. The mountpoint's
+> own ownership is irrelevant — AppArmor rejects the `mount()` syscall first. Fix
+> it by mounting under a permitted prefix, or by whitelisting your prefix in
+> `/etc/apparmor.d/local/fusermount3` (the shipped profile ends with
+> `include if exists <local/fusermount3>`).
+
 Two modes:
 
 - **`synthesis`** (default) — files carry metadata freshly generated from
@@ -259,16 +272,33 @@ for the methodology and numbers).
 ### Ownership and permissions
 
 By default the mount presents the launching process's uid/gid and read-only
-permission bits (`555` dirs, `444` files). Override them to present a specific
-owner — e.g. a media-server service account — without running musefs as that
-user.
+permission bits (`555` dirs, `444` files), and is reachable only by the user who
+performed the mount (and root).
+
+To present a different owner — e.g. a media-server service account — and let that
+account actually reach the mount, pass `--owner`/`--group` (or `--allow-other`).
+Either makes musefs mount with `allow_other` and `default_permissions`: other
+users can traverse the mount, and the kernel enforces the presented owner/mode
+bits instead of ignoring them.
 
 | Flag | Default | What it does |
 | ---- | ------- | ------------ |
-| `--owner <NAME\|UID>` | process uid | User presented as the owner of every entry. Accepts a username or a numeric uid. |
-| `--group <NAME\|GID>` | process gid | Group presented for every entry. Accepts a group name or a numeric gid. |
+| `--owner <NAME\|UID>` | process uid | User presented as the owner of every entry. Accepts a username or a numeric uid. Implies `--allow-other`. |
+| `--group <NAME\|GID>` | process gid | Group presented for every entry. Accepts a group name or a numeric gid. Implies `--allow-other`. |
+| `--allow-other` | off | Mount with `allow_other` + `default_permissions` so accounts other than the mounting user can reach the mount and the owner/mode bits are enforced. Implied by `--owner`/`--group`. |
 | `--file-mode <OCTAL>` | `444` | Permission bits for regular files, in octal. The mount is read-only, so write bits are advertised but writes still fail with `EROFS`. |
 | `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |
+
+The default `444`/`555` bits are world-readable, so any account can read once
+`allow_other` is on. To restrict the mount to the presented owner/group, drop the
+world bits (e.g. `--file-mode 440 --dir-mode 550`) — only then does
+`--owner`/`--group` gate access rather than merely label it.
+
+**Non-root mounts need `user_allow_other`.** When you are not root, libfuse
+refuses an `allow_other` mount unless `/etc/fuse.conf` contains a line
+`user_allow_other`. musefs checks this before mounting and fails with an
+explanatory error if it is missing; add the line to `/etc/fuse.conf`, or run
+musefs as root. (This is libfuse/system policy, not a musefs restriction.)
 
 ### Configuring with environment variables
 

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -57,6 +57,11 @@ MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
 #MUSEFS_FILE_MODE=444
 # Permission bits for directories, octal. Default: 555.
 #MUSEFS_DIR_MODE=555
+# Mount with allow_other + default_permissions so accounts other than the
+# mounting user can reach the mount and the owner/mode bits are enforced.
+# Implied by MUSEFS_OWNER/MUSEFS_GROUP. Non-root mounts also need
+# 'user_allow_other' in /etc/fuse.conf. Default: false.
+#MUSEFS_ALLOW_OTHER=true
 
 # --- Scan -------------------------------------------------------------------
 # (scan targets are set in musefs-scan.service, not here.)

--- a/docs/superpowers/plans/2026-06-12-fuse-mount-access.md
+++ b/docs/superpowers/plans/2026-06-12-fuse-mount-access.md
@@ -440,6 +440,17 @@ In `musefs-cli/src/lib.rs`, in `struct MountArgs`, add after the `dir_mode` fiel
     pub allow_other: bool,
 ```
 
+Adding this field breaks the four **exhaustive** `MountArgs { … }` literals in the integration test file `musefs-cli/tests/cli.rs` (at lines 121, 153, 181, 230 — these build the struct field-by-field, not via argv). Each ends with `dir_mode: None,`; add `allow_other: false,` immediately after that line in all four. For example, the literal at ~line 121:
+
+```rust
+        file_mode: None,
+        dir_mode: None,
+        allow_other: false,
+    };
+```
+
+Apply the identical one-line addition to the literals at ~153, ~181, and ~230. (Without this the crate fails to compile and the pre-commit full-suite gate rejects the commit.)
+
 - [ ] **Step 4: Add the `effective_allow_other` helper and use it**
 
 In `musefs-cli/src/lib.rs`, add the helper near `parse_mount_config`:
@@ -470,7 +481,7 @@ Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --all --check`
 Expected: clean.
 
 ```bash
-git add musefs-cli/src/lib.rs
+git add musefs-cli/src/lib.rs musefs-cli/tests/cli.rs
 git commit -m "feat(cli): explicit --allow-other flag with owner/group auto-enable (#294)"
 ```
 
@@ -547,15 +558,27 @@ explanatory error if it is missing; add the line to `/etc/fuse.conf`, or run
 musefs as root. (This is libfuse/system policy, not a musefs restriction.)
 ```
 
-- [ ] **Step 3: Verify the rendered changes read correctly**
+- [ ] **Step 3: Add `MUSEFS_ALLOW_OTHER` to the systemd conf example**
 
-Run: `git diff README.md`
-Expected: the AppArmor blockquote appears under **Mount**; the **Ownership and permissions** section shows the new intro, the 5-row table including `--allow-other`, the world-bits note, and the `user_allow_other` note. Confirm no stray duplicate of the old table remains.
+`contrib/systemd/musefs.conf.example` is the canonical env-var list the README points at. In its "Mount: ownership & permissions" block, after the `#MUSEFS_DIR_MODE=555` entry (currently ~line 59), add:
 
-- [ ] **Step 4: Commit**
+```ini
+# Mount with allow_other + default_permissions so accounts other than the
+# mounting user can reach the mount and the owner/mode bits are enforced.
+# Implied by MUSEFS_OWNER/MUSEFS_GROUP. Non-root mounts also need
+# 'user_allow_other' in /etc/fuse.conf. Default: false.
+#MUSEFS_ALLOW_OTHER=true
+```
+
+- [ ] **Step 4: Verify the rendered changes read correctly**
+
+Run: `git diff README.md contrib/systemd/musefs.conf.example`
+Expected: the AppArmor blockquote appears under **Mount**; the **Ownership and permissions** section shows the new intro, the 5-row table including `--allow-other`, the world-bits note, and the `user_allow_other` note (no stray duplicate of the old table); the systemd example gains the `#MUSEFS_ALLOW_OTHER=true` entry.
+
+- [ ] **Step 5: Commit**
 
 ```bash
-git add README.md
+git add README.md contrib/systemd/musefs.conf.example
 git commit -m "docs: document AppArmor mountpoint restriction (#293) and allow_other ownership behaviour (#294)"
 ```
 

--- a/docs/superpowers/plans/2026-06-12-fuse-mount-access.md
+++ b/docs/superpowers/plans/2026-06-12-fuse-mount-access.md
@@ -1,0 +1,586 @@
+# FUSE mount-access (#293 + #294) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the advertised `--owner`/`--group` cross-user use case work by adding `allow_other` + `default_permissions` (auto-enabled by `--owner`/`--group`, plus an explicit `--allow-other`), with a clear non-root pre-flight error, and document the AppArmor `fusermount3` mountpoint restriction.
+
+**Architecture:** `allow_other`/`default_permissions` are FUSE *mount options* (passed to fusermount3), distinct from the `init`-time `KernelConfig` knobs. They flow `FuseConfig.allow_other` → `mount_with`/`spawn_with` → `new_session` → `mount_config` → `platform::mount::options`. A Linux-only pre-flight reads `/etc/fuse.conf` before the mount handshake and fails fast with an actionable, self-contained error when a non-root mount lacks `user_allow_other`. The CLI auto-enables `allow_other` whenever `--owner`/`--group` is given.
+
+**Tech Stack:** Rust workspace (`musefs-fuse`, `musefs-cli`), `fuser` 0.17 (`MountOption::{AllowOther, DefaultPermissions}`), `rustix::process::geteuid`, `clap`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+| ---- | -------------- | ------ |
+| `musefs-fuse/src/lib.rs` | `FuseConfig` + mount entry points (`mount_with`/`spawn_with`/`new_session`/`mount_config`) | Add `allow_other` field; thread it to options; call pre-flight in `new_session` |
+| `musefs-fuse/src/platform/mount.rs` | Per-OS mount options + the Linux `/etc/fuse.conf` pre-flight | `options()` gains `allow_other`; add parser, decision, `check_allow_other` |
+| `musefs-cli/src/lib.rs` | `MountArgs` + `parse_mount_config` | Add `--allow-other`; set `allow_other` (auto-enable from owner/group) |
+| `README.md` | User docs | #293 AppArmor note (Mount section); #294 ownership rewrite |
+
+**Pre-flight context (read before Task 2):** `new_session` (`musefs-fuse/src/lib.rs:599`) holds `MOUNT_SETUP` (a `Mutex`) only around the racy fusermount3 handshake. The pre-flight read must run *before* taking that lock so the file I/O does not extend the critical section. The error must be self-contained because `run_mount` wraps mount errors as `mounting at <path>: …` (`musefs-cli/src/lib.rs:297`).
+
+---
+
+## Task 1: Thread `allow_other` into mount options + auto-enable from `--owner`/`--group`
+
+**Files:**
+- Modify: `musefs-fuse/src/platform/mount.rs` (`options` signature + body + tests)
+- Modify: `musefs-fuse/src/lib.rs` (`FuseConfig` struct + `Default`, `mount_config`, `new_session`, `mount_with`, `spawn_with`)
+- Modify: `musefs-cli/src/lib.rs` (`parse_mount_config` struct literal)
+
+- [ ] **Step 1: Write the failing options tests**
+
+In `musefs-fuse/src/platform/mount.rs`, update the existing `tests` module so the two existing calls use the new two-arg signature, and add two new tests:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_are_always_read_only_and_named() {
+        let opts = options("musefs", false);
+        assert!(opts.contains(&MountOption::RO));
+        assert!(opts.contains(&MountOption::FSName("musefs".to_string())));
+    }
+
+    #[test]
+    fn allow_other_adds_allow_other_and_default_permissions() {
+        let opts = options("musefs", true);
+        assert!(opts.contains(&MountOption::AllowOther));
+        assert!(opts.contains(&MountOption::DefaultPermissions));
+    }
+
+    #[test]
+    fn no_allow_other_omits_allow_other_and_default_permissions() {
+        let opts = options("musefs", false);
+        assert!(!opts.contains(&MountOption::AllowOther));
+        assert!(!opts.contains(&MountOption::DefaultPermissions));
+    }
+}
+```
+
+Also update the macOS test module's call (`musefs-fuse/src/platform/mount.rs`):
+
+```rust
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::*;
+
+    #[test]
+    fn macos_adds_volname_and_noappledouble() {
+        let opts = options("musefs", false);
+        assert!(opts.contains(&MountOption::CUSTOM("volname=musefs".to_string())));
+        assert!(opts.contains(&MountOption::CUSTOM("noappledouble".to_string())));
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail to compile**
+
+Run: `cargo test -p musefs-fuse options`
+Expected: FAIL — compile error, `options` takes 1 argument but 2 were supplied (signature not yet changed).
+
+- [ ] **Step 3: Change `options()` to take and apply `allow_other`**
+
+In `musefs-fuse/src/platform/mount.rs`, replace the `options` function:
+
+```rust
+/// Read-only mount options for `fs_name`, plus any per-OS additions. With
+/// `allow_other`, also mount `allow_other` + `default_permissions` so an account
+/// other than the mounting user can reach the mount and the presented owner/mode
+/// bits are kernel-enforced.
+pub fn options(fs_name: &str, allow_other: bool) -> Vec<MountOption> {
+    let mut opts = vec![MountOption::RO, MountOption::FSName(fs_name.to_string())];
+    if allow_other {
+        opts.push(MountOption::AllowOther);
+        opts.push(MountOption::DefaultPermissions);
+    }
+    extend_os_specific(&mut opts, fs_name);
+    opts
+}
+```
+
+- [ ] **Step 4: Add the `allow_other` field to `FuseConfig` and its `Default`**
+
+In `musefs-fuse/src/lib.rs`, in `struct FuseConfig` add a field after `dir_mode`:
+
+```rust
+    /// Permission bits for directories (bare mode word, no type bits).
+    pub dir_mode: u16,
+    /// Mount with `allow_other` + `default_permissions`: accounts other than the
+    /// mounting user can reach the mount and the kernel enforces the presented
+    /// owner/mode bits. Non-root mounts also require `user_allow_other` in
+    /// `/etc/fuse.conf` (validated at mount time).
+    pub allow_other: bool,
+```
+
+In `impl Default for FuseConfig`, add the field after `dir_mode: 0o555,`:
+
+```rust
+            dir_mode: 0o555,
+            allow_other: false,
+```
+
+- [ ] **Step 5: Thread `allow_other` through `mount_config`, `new_session`, `mount_with`, `spawn_with`**
+
+In `musefs-fuse/src/lib.rs`, replace `mount_config`:
+
+```rust
+fn mount_config(fs_name: &str, allow_other: bool) -> Config {
+    let mut cfg = Config::default();
+    cfg.mount_options = platform::mount::options(fs_name, allow_other);
+    cfg
+}
+```
+
+Replace `new_session` (add the `allow_other` parameter; the pre-flight call is added in Task 2):
+
+```rust
+fn new_session(
+    fs: MusefsFs,
+    mountpoint: &Path,
+    fs_name: &str,
+    allow_other: bool,
+) -> std::io::Result<Session<MusefsFs>> {
+    // Recover from a poisoned lock: it guards only ordering, so a prior panic
+    // during a mount leaves no inconsistent state to protect against.
+    let _guard = MOUNT_SETUP
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    Session::new(fs, mountpoint, &mount_config(fs_name, allow_other))
+}
+```
+
+In `mount_with`, capture `allow_other` before `config` is moved into `MusefsFs::new`:
+
+```rust
+    let allow_other = config.allow_other;
+    let fs = MusefsFs::new(core, config);
+    let cell = fs.notifier_cell();
+    let session = new_session(fs, mountpoint, fs_name, allow_other)?;
+```
+
+Apply the identical change in `spawn_with`:
+
+```rust
+    let allow_other = config.allow_other;
+    let fs = MusefsFs::new(core, config);
+    let cell = fs.notifier_cell();
+    let session = new_session(fs, mountpoint, fs_name, allow_other)?;
+```
+
+- [ ] **Step 6: Set `allow_other` (auto-enable) in the CLI config builder**
+
+In `musefs-cli/src/lib.rs`, in `parse_mount_config`, add the field to the `FuseConfig` struct literal after `dir_mode`:
+
+```rust
+        file_mode: args.file_mode.unwrap_or(defaults.file_mode),
+        dir_mode: args.dir_mode.unwrap_or(defaults.dir_mode),
+        allow_other: args.owner.is_some() || args.group.is_some(),
+    };
+```
+
+- [ ] **Step 7: Add CLI auto-enable tests**
+
+In `musefs-cli/src/lib.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn owner_or_group_auto_enables_allow_other() {
+        use clap::Parser;
+        for arg in [["--owner", "0"], ["--group", "0"]] {
+            let cli = Cli::try_parse_from(
+                ["musefs", "mount", "/mnt", "--db", "/tmp/x.db", arg[0], arg[1]],
+            )
+            .unwrap();
+            let Command::Mount(args) = cli.command else {
+                panic!("expected Mount");
+            };
+            let (_config, fuse_config) = parse_mount_config(&args);
+            assert!(fuse_config.allow_other, "{arg:?} should enable allow_other");
+        }
+    }
+
+    #[test]
+    fn allow_other_defaults_off_without_owner_group() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "mount", "/mnt", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        assert!(!fuse_config.allow_other);
+    }
+```
+
+- [ ] **Step 8: Run the workspace tests**
+
+Run: `cargo test -p musefs-fuse -p musefs-cli`
+Expected: PASS — all `options`/allow_other tests pass; existing tests still pass.
+
+- [ ] **Step 9: Lint and commit**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --all --check`
+Expected: clean.
+
+```bash
+git add musefs-fuse/src/lib.rs musefs-fuse/src/platform/mount.rs musefs-cli/src/lib.rs
+git commit -m "feat(fuse): allow_other/default_permissions, auto-enabled by --owner/--group (#294)"
+```
+
+---
+
+## Task 2: Pre-flight `/etc/fuse.conf` check for non-root `allow_other` mounts
+
+**Files:**
+- Modify: `musefs-fuse/src/platform/mount.rs` (parser, decision, `check_allow_other`, tests)
+- Modify: `musefs-fuse/src/lib.rs` (`new_session` calls the pre-flight before the lock)
+
+- [ ] **Step 1: Write the failing pre-flight tests**
+
+In `musefs-fuse/src/platform/mount.rs`, add a Linux-gated test module (place it after the existing `tests` module):
+
+```rust
+#[cfg(all(test, target_os = "linux"))]
+mod preflight_tests {
+    use super::*;
+
+    #[test]
+    fn parser_accepts_active_directive_forms() {
+        assert!(user_allow_other_active("user_allow_other"));
+        assert!(user_allow_other_active("   user_allow_other   "));
+        assert!(user_allow_other_active("user_allow_other # enable for media server"));
+        assert!(user_allow_other_active("mount_max=1000\nuser_allow_other\n"));
+    }
+
+    #[test]
+    fn parser_rejects_inactive_or_absent() {
+        assert!(!user_allow_other_active("# user_allow_other"));
+        assert!(!user_allow_other_active("#user_allow_other"));
+        assert!(!user_allow_other_active("mount_max=1000"));
+        assert!(!user_allow_other_active(""));
+    }
+
+    #[test]
+    fn preflight_passes_when_not_requested_or_root() {
+        assert!(preflight_decision(false, false, None).is_ok());
+        assert!(preflight_decision(true, true, None).is_ok());
+    }
+
+    #[test]
+    fn preflight_requires_directive_for_nonroot() {
+        assert!(preflight_decision(true, false, Some("user_allow_other")).is_ok());
+        assert!(preflight_decision(true, false, Some("# nope")).is_err());
+        assert!(preflight_decision(true, false, None).is_err());
+    }
+
+    #[test]
+    fn preflight_error_is_self_contained() {
+        let err = preflight_decision(true, false, None).unwrap_err();
+        assert!(err.contains("/etc/fuse.conf"));
+        assert!(err.contains("user_allow_other"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-fuse preflight`
+Expected: FAIL — compile error, `user_allow_other_active` / `preflight_decision` not found.
+
+- [ ] **Step 3: Implement the parser, decision, and public check**
+
+In `musefs-fuse/src/platform/mount.rs`, add at the end of the module (before the test modules):
+
+```rust
+/// Mount-time guard for `allow_other`: libfuse refuses an `allow_other` mount for
+/// a non-root user unless `/etc/fuse.conf` enables `user_allow_other`. Check it
+/// up front to replace fusermount3's cryptic "Permission denied" with actionable
+/// guidance. Non-Linux platforms don't gate on `/etc/fuse.conf`, so it's a no-op.
+pub fn check_allow_other(allow_other: bool) -> std::io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let is_root = rustix::process::geteuid().as_raw() == 0;
+        // `.ok()` collapses any read failure (missing, EACCES, dangling symlink)
+        // to `None`, which the decision treats as "not permitted" — fail-safe.
+        let conf = std::fs::read_to_string("/etc/fuse.conf").ok();
+        preflight_decision(allow_other, is_root, conf.as_deref())
+            .map_err(|msg| std::io::Error::new(std::io::ErrorKind::PermissionDenied, msg))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = allow_other;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+const ALLOW_OTHER_HELP: &str = "allow_other is enabled (via --allow-other, or implied by --owner/--group) \
+but '/etc/fuse.conf' does not enable 'user_allow_other'; libfuse refuses a non-root allow_other mount without it. \
+Add a line 'user_allow_other' to /etc/fuse.conf, or run musefs as root.";
+
+/// True if `contents` has an active `user_allow_other` directive: a line whose
+/// text before any `#` comment trims to exactly `user_allow_other`.
+#[cfg(target_os = "linux")]
+fn user_allow_other_active(contents: &str) -> bool {
+    contents
+        .lines()
+        .any(|line| line.split('#').next().unwrap_or("").trim() == "user_allow_other")
+}
+
+/// Pure pre-flight decision. `conf` is `None` when `/etc/fuse.conf` could not be
+/// read; treated as "not permitted" so the actionable error fires (a false
+/// positive is harmless — fusermount3 would have failed the mount anyway). Root
+/// and the no-`allow_other` case always pass.
+#[cfg(target_os = "linux")]
+fn preflight_decision(allow_other: bool, is_root: bool, conf: Option<&str>) -> Result<(), String> {
+    if !allow_other || is_root {
+        return Ok(());
+    }
+    if conf.is_some_and(user_allow_other_active) {
+        return Ok(());
+    }
+    Err(ALLOW_OTHER_HELP.to_string())
+}
+```
+
+- [ ] **Step 4: Call the pre-flight in `new_session` before the mount lock**
+
+In `musefs-fuse/src/lib.rs`, insert the check as the first statement of `new_session`, before `MOUNT_SETUP.lock()`:
+
+```rust
+fn new_session(
+    fs: MusefsFs,
+    mountpoint: &Path,
+    fs_name: &str,
+    allow_other: bool,
+) -> std::io::Result<Session<MusefsFs>> {
+    // Validate the allow_other environment before taking the mount lock: the
+    // /etc/fuse.conf read is unrelated to the fusermount3 handshake the lock
+    // serializes, so it must not extend that critical section.
+    platform::mount::check_allow_other(allow_other)?;
+    // Recover from a poisoned lock: it guards only ordering, so a prior panic
+    // during a mount leaves no inconsistent state to protect against.
+    let _guard = MOUNT_SETUP
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    Session::new(fs, mountpoint, &mount_config(fs_name, allow_other))
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p musefs-fuse preflight`
+Expected: PASS.
+
+- [ ] **Step 6: Lint and commit**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --all --check`
+Expected: clean. (Note: the `--target x86_64-unknown-freebsd` clippy gate — see CONTRIBUTING — will compile the non-Linux branch; the Linux-only helpers and their tests are `cfg(target_os = "linux")`-gated so they are absent there and produce no dead-code warnings.)
+
+```bash
+git add musefs-fuse/src/lib.rs musefs-fuse/src/platform/mount.rs
+git commit -m "feat(fuse): pre-flight /etc/fuse.conf user_allow_other check for non-root allow_other mounts (#294)"
+```
+
+---
+
+## Task 3: Explicit `--allow-other` flag + effective-value helper
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs` (`MountArgs`, `effective_allow_other`, `parse_mount_config`, tests)
+
+- [ ] **Step 1: Write the failing helper + flag tests**
+
+In `musefs-cli/src/lib.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn effective_allow_other_combines_flag_and_owner_group() {
+        assert!(!effective_allow_other(false, None, None));
+        assert!(effective_allow_other(true, None, None));
+        // Auto-enable wins even when the flag is explicitly false (env path).
+        assert!(effective_allow_other(false, Some(0), None));
+        assert!(effective_allow_other(false, None, Some(0)));
+    }
+
+    #[test]
+    fn explicit_allow_other_flag_enables_it() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(
+            ["musefs", "mount", "/mnt", "--db", "/tmp/x.db", "--allow-other"],
+        )
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        assert!(fuse_config.allow_other);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p musefs-cli allow_other`
+Expected: FAIL — `effective_allow_other` not found and `--allow-other` is an unknown argument.
+
+- [ ] **Step 3: Add the `--allow-other` flag to `MountArgs`**
+
+In `musefs-cli/src/lib.rs`, in `struct MountArgs`, add after the `dir_mode` field:
+
+```rust
+    /// Mount with `allow_other` + `default_permissions` so accounts other than
+    /// the mounting user can reach the mount and the presented owner/mode bits
+    /// are kernel-enforced. Implied by `--owner`/`--group`. Non-root mounts also
+    /// require `user_allow_other` in `/etc/fuse.conf`.
+    #[arg(long, env = "MUSEFS_ALLOW_OTHER")]
+    pub allow_other: bool,
+```
+
+- [ ] **Step 4: Add the `effective_allow_other` helper and use it**
+
+In `musefs-cli/src/lib.rs`, add the helper near `parse_mount_config`:
+
+```rust
+/// Effective `allow_other`: the explicit flag, or implied by a presented
+/// owner/group (the cross-user use case is unreachable without it). Auto-enable
+/// wins over an explicit `--allow-other false` (only reachable via the env var).
+fn effective_allow_other(flag: bool, owner: Option<u32>, group: Option<u32>) -> bool {
+    flag || owner.is_some() || group.is_some()
+}
+```
+
+In `parse_mount_config`, replace the `allow_other` line in the `FuseConfig` literal:
+
+```rust
+        allow_other: effective_allow_other(args.allow_other, args.owner, args.group),
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p musefs-cli allow_other`
+Expected: PASS. Also re-run the Task 1 auto-enable tests: `cargo test -p musefs-cli` → PASS.
+
+- [ ] **Step 6: Lint and commit**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --all --check`
+Expected: clean.
+
+```bash
+git add musefs-cli/src/lib.rs
+git commit -m "feat(cli): explicit --allow-other flag with owner/group auto-enable (#294)"
+```
+
+---
+
+## Task 4: Documentation (#293 AppArmor note + #294 ownership rewrite)
+
+**Files:**
+- Modify: `README.md`
+
+This is a docs-only commit; the pre-commit cargo gate skips it. No tests.
+
+- [ ] **Step 1: Add the AppArmor mountpoint note (#293) to the Mount section**
+
+In `README.md`, find the paragraph (currently ~line 200):
+
+```
+`mount` blocks until the filesystem is unmounted (`fusermount -u`, or
+Ctrl-C).
+```
+
+Insert immediately after it:
+
+```markdown
+
+> **Mounting at an arbitrary path may be denied by AppArmor.** On distros that
+> ship an AppArmor profile for `fusermount3` (Ubuntu 24.04+ / libfuse ≥ 3.17),
+> unprivileged FUSE mounts are only allowed when the mountpoint is under a
+> whitelisted prefix — the shipped profile permits `$HOME/**`, `/mnt`, `/media`,
+> `/tmp`, `/cvmfs`, `$XDG_RUNTIME_DIR`, plus flatpak dirs. Mounting elsewhere
+> (e.g. a data volume at `/data/...`) fails with `fusermount3: mount failed:
+> Permission denied`, and the kernel audit log shows
+> `apparmor="DENIED" operation="mount" … profile="fusermount3"`. The mountpoint's
+> own ownership is irrelevant — AppArmor rejects the `mount()` syscall first. Fix
+> it by mounting under a permitted prefix, or by whitelisting your prefix in
+> `/etc/apparmor.d/local/fusermount3` (the shipped profile ends with
+> `include if exists <local/fusermount3>`).
+```
+
+- [ ] **Step 2: Rewrite the "Ownership and permissions" section (#294)**
+
+In `README.md`, replace the entire current section (intro paragraph + table, currently lines ~259–271):
+
+```markdown
+### Ownership and permissions
+
+By default the mount presents the launching process's uid/gid and read-only
+permission bits (`555` dirs, `444` files), and is reachable only by the user who
+performed the mount (and root).
+
+To present a different owner — e.g. a media-server service account — and let that
+account actually reach the mount, pass `--owner`/`--group` (or `--allow-other`).
+Either makes musefs mount with `allow_other` and `default_permissions`: other
+users can traverse the mount, and the kernel enforces the presented owner/mode
+bits instead of ignoring them.
+
+| Flag | Default | What it does |
+| ---- | ------- | ------------ |
+| `--owner <NAME\|UID>` | process uid | User presented as the owner of every entry. Accepts a username or a numeric uid. Implies `--allow-other`. |
+| `--group <NAME\|GID>` | process gid | Group presented for every entry. Accepts a group name or a numeric gid. Implies `--allow-other`. |
+| `--allow-other` | off | Mount with `allow_other` + `default_permissions` so accounts other than the mounting user can reach the mount and the owner/mode bits are enforced. Implied by `--owner`/`--group`. |
+| `--file-mode <OCTAL>` | `444` | Permission bits for regular files, in octal. The mount is read-only, so write bits are advertised but writes still fail with `EROFS`. |
+| `--dir-mode <OCTAL>` | `555` | Permission bits for directories, in octal. |
+
+The default `444`/`555` bits are world-readable, so any account can read once
+`allow_other` is on. To restrict the mount to the presented owner/group, drop the
+world bits (e.g. `--file-mode 440 --dir-mode 550`) — only then does
+`--owner`/`--group` gate access rather than merely label it.
+
+**Non-root mounts need `user_allow_other`.** When you are not root, libfuse
+refuses an `allow_other` mount unless `/etc/fuse.conf` contains a line
+`user_allow_other`. musefs checks this before mounting and fails with an
+explanatory error if it is missing; add the line to `/etc/fuse.conf`, or run
+musefs as root. (This is libfuse/system policy, not a musefs restriction.)
+```
+
+- [ ] **Step 3: Verify the rendered changes read correctly**
+
+Run: `git diff README.md`
+Expected: the AppArmor blockquote appears under **Mount**; the **Ownership and permissions** section shows the new intro, the 5-row table including `--allow-other`, the world-bits note, and the `user_allow_other` note. Confirm no stray duplicate of the old table remains.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document AppArmor mountpoint restriction (#293) and allow_other ownership behaviour (#294)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full workspace suite and lints (the pre-commit gate):**
+
+Run: `cargo test && cargo clippy --all-targets -- -D warnings && cargo fmt --all --check`
+Expected: all green.
+
+- [ ] **Cross-platform compile check (non-Linux branch of the pre-flight):**
+
+Run: `cargo clippy -p musefs-fuse --target x86_64-unknown-freebsd -- -D warnings`
+Expected: clean — the non-Linux `check_allow_other` branch compiles and the Linux-only helpers/tests are absent (no dead-code warnings).
+
+---
+
+## Self-review notes (coverage map)
+
+- Spec "one `--allow-other` flag enabling both" → Task 1 (`options` pushes both `AllowOther` + `DefaultPermissions`) + Task 3 (flag).
+- Spec "auto-enable on `--owner`/`--group`, auto-enable wins" → Task 1 (auto-enable) + Task 3 (`effective_allow_other`, tested with `(false, Some, None) == true`).
+- Spec "pre-flight, Linux-only, before `MOUNT_SETUP`, self-contained error, read-error ⇒ not permitted, root exempt" → Task 2 (all covered; tests assert root-exempt, not-permitted, self-contained message).
+- Spec "parser semantics: strip trailing `#…`, trim, exact token" → Task 2 `user_allow_other_active` + `parser_*` tests.
+- Spec "struct-literal sites: `FuseConfig::default` + `parse_mount_config`" → Task 1 Steps 4 & 6.
+- Spec "permission matrix / world-bits load-bearing" + "AppArmor prefix list" → Task 4 docs.
+- Spec "AutoUnmount unchanged" → no task touches it (confirmed zero usage); intentionally untouched.

--- a/docs/superpowers/specs/2026-06-12-fuse-mount-access-design.md
+++ b/docs/superpowers/specs/2026-06-12-fuse-mount-access-design.md
@@ -1,0 +1,125 @@
+# FUSE mount-access behaviour (#293 + #294)
+
+Date: 2026-06-12
+
+## Problem
+
+Two GitHub issues concern FUSE mount-access behaviour the docs don't reflect:
+
+- **#293** — On distros shipping an AppArmor profile for `fusermount3` (Ubuntu
+  24.04+ / libfuse ≥ 3.17), unprivileged FUSE mounts are only permitted when the
+  mountpoint falls under a whitelisted prefix (`$HOME/**`, `/mnt`, `/media`,
+  `/tmp`, `/cvmfs`, `$XDG_RUNTIME_DIR`, plus flatpak dirs). Mounting elsewhere
+  (e.g. `/data/...`) fails with `fusermount3: mount failed: Permission denied`.
+  AppArmor rejects the `mount()` syscall before the mountpoint's own ownership is
+  ever checked, so it reads as a musefs bug rather than an environmental
+  restriction. The README's mount instructions don't mention it.
+
+- **#294** — The README advertises `--owner`/`--group` as a way to present a
+  service account as the owner "without running musefs as that user", but that
+  use case is unreachable. musefs mounts with a fixed option set (`RO` +
+  `FSName`); there is no `allow_other`, so a default FUSE mount is accessible
+  only by the mounting user (and root) — the service account cannot traverse the
+  mount at all. And without `default_permissions` the kernel does not enforce the
+  presented mode/owner bits, so `--owner`/`--group` are purely cosmetic in
+  `stat`/`ls -l`.
+
+## Goals
+
+- #293: document the AppArmor `fusermount3` mountpoint restriction and the two
+  workarounds.
+- #294: make the advertised cross-user use case actually work by adding
+  `allow_other` + `default_permissions` support, auto-enabled when the user asks
+  for a specific owner/group, with a clear pre-flight error when the environment
+  can't satisfy it.
+
+## Non-goals
+
+- No change to the cardinal read-only / byte-preserving invariants.
+- No change to the default mode bits (`444` files, `555` dirs) — they stay
+  world-readable so the cross-user case works out of the box.
+- No `allow_root` support (out of scope; `allow_other` covers the use case).
+
+## #294 — user-facing contract
+
+- New flag `--allow-other` (bool, env `MUSEFS_ALLOW_OTHER`, default `false`).
+  When effective, the mount adds **both** `allow_other` and
+  `default_permissions`.
+- **Auto-enable:** the effective value is
+  `--allow-other || --owner given || --group given`. Passing an owner or group
+  implies the intent to let a different account reach the mount, so it stops
+  being cosmetic. `--allow-other false` does **not** override the auto-enable
+  when `--owner`/`--group` is present (simplest rule: auto-enable wins).
+- `default_permissions` makes the kernel enforce the presented owner/mode bits.
+  Defaults stay `444`/`555` (world-readable), so the service account can read
+  immediately; tightening `--file-mode`/`--dir-mode` now becomes real access
+  control rather than cosmetic.
+- **Pre-flight check (Linux, non-root):** before mounting, if `allow_other` is
+  effective, we are not root, and `/etc/fuse.conf` lacks an active
+  `user_allow_other` directive, fail fast with an actionable error (what line to
+  add to `/etc/fuse.conf`, and that running as root is exempt) instead of letting
+  fusermount3 emit a cryptic `Permission denied`. On non-Linux the check is a
+  no-op.
+
+## #294 — implementation
+
+Layering: `allow_other`/`default_permissions` are **mount options** passed to
+fusermount3 (unlike `max_readahead`/`max_background`, which are negotiated at
+`init` time via `KernelConfig`). They must therefore flow through
+`mount_config`/`options`, which today receive only `fs_name`.
+
+- `FuseConfig` (`musefs-fuse/src/lib.rs`) gains `allow_other: bool`
+  (default `false`).
+- `mount_with`/`spawn_with` extract `config.allow_other` and pass it into
+  `new_session(fs, mountpoint, fs_name, allow_other)` →
+  `mount_config(fs_name, allow_other)` → `options(fs_name, allow_other)`.
+- `platform::mount::options` pushes `MountOption::AllowOther` and
+  `MountOption::DefaultPermissions` when `allow_other` is true (both exist in
+  fuser 0.17).
+- The pre-flight check lives in `musefs-fuse` `platform::mount` (Linux-gated),
+  invoked from `new_session` before `Session::new`. It returns an
+  `io::Error` that the CLI surfaces with context. A small `/etc/fuse.conf`
+  parser detects an active `user_allow_other` directive, ignoring comment
+  (`#`) and whitespace-only lines and treating a missing file as "not
+  permitted".
+- CLI (`musefs-cli/src/lib.rs`): add `--allow-other` to `MountArgs`; in the
+  `FuseConfig` builder set
+  `allow_other: args.allow_other || args.owner.is_some() || args.group.is_some()`.
+
+## #293 + #294 — documentation
+
+- **#293** (README **Mount** section): note that an arbitrary mountpoint (e.g.
+  `/data/...`) may be rejected by the `fusermount3` AppArmor profile on
+  Ubuntu 24.04+/libfuse ≥ 3.17, with the `apparmor="DENIED" operation="mount"`
+  audit-log signature, and the two fixes: mount under a permitted prefix
+  (`$HOME`, `/mnt`, `/media`, `/tmp`, `$XDG_RUNTIME_DIR`, …) or whitelist the
+  desired prefix via `/etc/apparmor.d/local/fusermount3` (the shipped profile
+  already ends with `include if exists <local/fusermount3>`).
+- **#294** (README **Ownership and permissions** section): rewrite to document
+  `--allow-other`, the auto-enable on `--owner`/`--group`, that
+  `default_permissions` makes mode/owner bits enforced (not cosmetic), and the
+  `user_allow_other`/`/etc/fuse.conf` requirement for non-root mounts (root
+  exempt). Add the `MUSEFS_ALLOW_OTHER` entry to the environment-variable
+  section coverage as applicable.
+
+## Testing
+
+- `options()` unit tests: `allow_other=true` adds both `AllowOther` and
+  `DefaultPermissions`; `allow_other=false` adds neither.
+- `/etc/fuse.conf` parser unit tests: detects `user_allow_other`, ignores
+  commented and whitespace-only lines, treats a missing file as not permitted.
+- Pre-flight unit tests: root-exemption path and the missing-config error path,
+  injecting the conf contents and root-ness rather than touching real `/etc`.
+- CLI tests: `--owner`/`--group` each auto-enable `allow_other` in the built
+  `FuseConfig`; explicit `--allow-other` works; default is off.
+- Existing FUSE e2e (ignored) remains; a privileged cross-user e2e is out of
+  scope (needs two real accounts).
+
+## Risks / trade-offs
+
+- Auto-enabling on `--owner`/`--group` changes behaviour for an existing setup
+  that passed `--owner` cosmetically on a box without `user_allow_other`: the
+  mount will now fail the pre-flight check instead of mounting. This is
+  intentional — the previous behaviour silently failed the advertised use case —
+  and the pre-flight error tells the user exactly how to proceed (add the
+  directive, or drop `--owner`/`--group`/`--allow-other`).

--- a/docs/superpowers/specs/2026-06-12-fuse-mount-access-design.md
+++ b/docs/superpowers/specs/2026-06-12-fuse-mount-access-design.md
@@ -39,6 +39,11 @@ Two GitHub issues concern FUSE mount-access behaviour the docs don't reflect:
 - No change to the default mode bits (`444` files, `555` dirs) — they stay
   world-readable so the cross-user case works out of the box.
 - No `allow_root` support (out of scope; `allow_other` covers the use case).
+- **No `AutoUnmount`.** `allow_other` mounts are a classic motivation for
+  `AutoUnmount` (a crashed daemon leaves a mount other users are stuck on), but
+  we do not add it here — cleanup stays the existing signal-handler path that
+  shells out to `fusermount3 -u` (`musefs-cli/src/signal.rs`). Adding
+  `AutoUnmount` is a separate decision.
 
 ## #294 — user-facing contract
 
@@ -51,15 +56,50 @@ Two GitHub issues concern FUSE mount-access behaviour the docs don't reflect:
   being cosmetic. `--allow-other false` does **not** override the auto-enable
   when `--owner`/`--group` is present (simplest rule: auto-enable wins).
 - `default_permissions` makes the kernel enforce the presented owner/mode bits.
-  Defaults stay `444`/`555` (world-readable), so the service account can read
+  Defaults stay `444`/`555` (world-readable), so any account can read
   immediately; tightening `--file-mode`/`--dir-mode` now becomes real access
   control rather than cosmetic.
+
+### Permission model under `default_permissions`
+
+With `default_permissions` on, the kernel checks the caller's identity against
+the **presented** owner/group/mode of each entry. The **world (other) bits are
+the load-bearing mechanism** for the default cross-user case — access is granted
+via the world-read bit, not via an owner/group match. The matrix for the default
+`444`/`555` (world-readable) entries:
+
+| Caller \ `--owner svc` | not set (owner = mounting user) | set to `svc` |
+| ---------------------- | ------------------------------- | ------------ |
+| mounting user          | read (owner bit, and world bit) | read (world bit) |
+| `svc` service account  | read (world bit)                | read (owner bit, and world bit) |
+| any other user         | read (world bit)                | read (world bit) |
+
+Implication to document: making the mount *private* to the presented owner/group
+requires dropping the world bits (e.g. `--file-mode 440 --dir-mode 550`); only
+then does `--owner`/`--group` restrict access rather than merely label it. Bare
+`--allow-other` (no `--owner`) keeps the mounting user as owner and simply lets
+other real users browse the world-readable tree — that is its standalone use
+case.
+
 - **Pre-flight check (Linux, non-root):** before mounting, if `allow_other` is
-  effective, we are not root, and `/etc/fuse.conf` lacks an active
-  `user_allow_other` directive, fail fast with an actionable error (what line to
-  add to `/etc/fuse.conf`, and that running as root is exempt) instead of letting
-  fusermount3 emit a cryptic `Permission denied`. On non-Linux the check is a
-  no-op.
+  effective, we are not root (`geteuid() != 0`), and `/etc/fuse.conf` lacks an
+  active `user_allow_other` directive, fail fast with an actionable, **self-
+  contained** error (it must read well even when the CLI wraps it as
+  `mounting at <path>: …`, so it states the exact line to add to
+  `/etc/fuse.conf` and that root is exempt) instead of letting fusermount3 emit a
+  cryptic `Permission denied`. Root is exempt because libfuse only enforces
+  `user_allow_other` for non-root callers. On non-Linux the check is a no-op.
+
+  **`user_allow_other` detection semantics.** For each line: strip a trailing
+  `#…` comment, then trim surrounding whitespace; the directive is *active* iff
+  the remaining token equals exactly `user_allow_other`. Therefore
+  `   user_allow_other   ` ⇒ active; `user_allow_other # note` ⇒ active;
+  `# user_allow_other` and `#user_allow_other` ⇒ inactive; `mount_max=10` and
+  other directives ⇒ ignored. **Any read failure is treated as "not permitted"**
+  — missing file, `EACCES`, dangling symlink, etc. — so the actionable error
+  fires. A false positive here is harmless because fusermount3 would have failed
+  the mount anyway; failing safe gives the user the helpful message instead of
+  the cryptic one.
 
 ## #294 — implementation
 
@@ -77,24 +117,36 @@ fusermount3 (unlike `max_readahead`/`max_background`, which are negotiated at
   `MountOption::DefaultPermissions` when `allow_other` is true (both exist in
   fuser 0.17).
 - The pre-flight check lives in `musefs-fuse` `platform::mount` (Linux-gated),
-  invoked from `new_session` before `Session::new`. It returns an
-  `io::Error` that the CLI surfaces with context. A small `/etc/fuse.conf`
-  parser detects an active `user_allow_other` directive, ignoring comment
-  (`#`) and whitespace-only lines and treating a missing file as "not
-  permitted".
-- CLI (`musefs-cli/src/lib.rs`): add `--allow-other` to `MountArgs`; in the
-  `FuseConfig` builder set
+  invoked from `new_session` **before acquiring the `MOUNT_SETUP` mutex** — the
+  conf-file read is unrelated to the racy fusermount3 handshake the lock guards,
+  so it must not extend that critical section. It returns a self-contained
+  `io::Error` (see the contract above; the CLI wraps mount errors as
+  `mounting at <path>: …`, so the message cannot rely on additional context).
+  The `/etc/fuse.conf` parser implements the detection semantics defined above.
+- CLI (`musefs-cli/src/lib.rs`): add `--allow-other` to `MountArgs`
+  (`env = "MUSEFS_ALLOW_OTHER"`). In `parse_mount_config` (the `(MountConfig,
+  FuseConfig)` builder, ~cli.rs:254–275), set the new field in the `FuseConfig`
+  struct literal:
   `allow_other: args.allow_other || args.owner.is_some() || args.group.is_some()`.
+- **Struct-literal sites to update** (adding a field to `FuseConfig` breaks
+  exhaustive literals): `FuseConfig::default` (lib.rs:~70) and the
+  `parse_mount_config` literal (cli.rs:~264). The `keep_cache` test site uses
+  `..Default::default()` and is unaffected. The plan should grep for
+  `FuseConfig {` and `MountArgs {` literals to confirm no other exhaustive sites
+  exist (existing CLI tests construct `MountArgs` via argv parsing, not bare
+  literals, so they are non-breaking — verify).
 
 ## #293 + #294 — documentation
 
 - **#293** (README **Mount** section): note that an arbitrary mountpoint (e.g.
   `/data/...`) may be rejected by the `fusermount3` AppArmor profile on
   Ubuntu 24.04+/libfuse ≥ 3.17, with the `apparmor="DENIED" operation="mount"`
-  audit-log signature, and the two fixes: mount under a permitted prefix
-  (`$HOME`, `/mnt`, `/media`, `/tmp`, `$XDG_RUNTIME_DIR`, …) or whitelist the
-  desired prefix via `/etc/apparmor.d/local/fusermount3` (the shipped profile
-  already ends with `include if exists <local/fusermount3>`).
+  audit-log signature, and the two fixes: mount under a permitted prefix (the
+  shipped profile allows `$HOME/**`, `/mnt`, `/media`, `/tmp`, `/cvmfs`,
+  `$XDG_RUNTIME_DIR`, plus flatpak dirs) or whitelist the desired prefix via
+  `/etc/apparmor.d/local/fusermount3` (the shipped profile already ends with
+  `include if exists <local/fusermount3>`). The README may show a representative
+  subset of this list; keep the two consistent.
 - **#294** (README **Ownership and permissions** section): rewrite to document
   `--allow-other`, the auto-enable on `--owner`/`--group`, that
   `default_permissions` makes mode/owner bits enforced (not cosmetic), and the
@@ -106,14 +158,22 @@ fusermount3 (unlike `max_readahead`/`max_background`, which are negotiated at
 
 - `options()` unit tests: `allow_other=true` adds both `AllowOther` and
   `DefaultPermissions`; `allow_other=false` adds neither.
-- `/etc/fuse.conf` parser unit tests: detects `user_allow_other`, ignores
-  commented and whitespace-only lines, treats a missing file as not permitted.
-- Pre-flight unit tests: root-exemption path and the missing-config error path,
-  injecting the conf contents and root-ness rather than touching real `/etc`.
-- CLI tests: `--owner`/`--group` each auto-enable `allow_other` in the built
-  `FuseConfig`; explicit `--allow-other` works; default is off.
+- `/etc/fuse.conf` parser unit tests covering the detection vectors above:
+  `user_allow_other`, leading/trailing whitespace, trailing inline comment (all
+  active); `# user_allow_other`, `#user_allow_other`, `mount_max=10`, empty file
+  (all inactive); and read failure / missing file ⇒ not permitted.
+- Pre-flight unit tests: root-exemption path and the not-permitted error path,
+  injecting the conf contents and root-ness rather than touching real `/etc`;
+  assert the error message is self-contained (mentions `/etc/fuse.conf` +
+  `user_allow_other`) so it survives the CLI's `mounting at …` wrapper.
+- CLI tests: `--owner` alone and `--group` alone each auto-enable `allow_other`
+  in the built `FuseConfig`; explicit `--allow-other` works; default is off; and
+  the env path — `MUSEFS_OWNER` set with `MUSEFS_ALLOW_OTHER=false` still yields
+  effective `true` (auto-enable wins).
 - Existing FUSE e2e (ignored) remains; a privileged cross-user e2e is out of
   scope (needs two real accounts).
+- The README changes (#293, #294) are docs-only and the pre-commit cargo gate
+  skips them, so they can land as a separate green commit from the code.
 
 ## Risks / trade-offs
 

--- a/docs/superpowers/specs/2026-06-12-fuse-mount-access-design.md
+++ b/docs/superpowers/specs/2026-06-12-fuse-mount-access-design.md
@@ -131,10 +131,12 @@ fusermount3 (unlike `max_readahead`/`max_background`, which are negotiated at
 - **Struct-literal sites to update** (adding a field to `FuseConfig` breaks
   exhaustive literals): `FuseConfig::default` (lib.rs:~70) and the
   `parse_mount_config` literal (cli.rs:~264). The `keep_cache` test site uses
-  `..Default::default()` and is unaffected. The plan should grep for
-  `FuseConfig {` and `MountArgs {` literals to confirm no other exhaustive sites
-  exist (existing CLI tests construct `MountArgs` via argv parsing, not bare
-  literals, so they are non-breaking — verify).
+  `..Default::default()` and is unaffected. **Adding a field to `MountArgs` also
+  breaks the four exhaustive `MountArgs { … }` literals in the integration test
+  `musefs-cli/tests/cli.rs` (lines 121, 153, 181, 230)** — each must gain
+  `allow_other: false,`. (The in-`src` CLI tests build `MountArgs` via argv
+  parsing and are non-breaking.) The plan should grep `FuseConfig {` and
+  `MountArgs {` to confirm no further exhaustive sites exist.
 
 ## #293 + #294 — documentation
 

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -109,6 +109,12 @@ pub struct MountArgs {
     /// Permission bits for directories, octal (e.g. 555). Defaults to 555.
     #[arg(long, env = "MUSEFS_DIR_MODE", value_name = "OCTAL", value_parser = parse_octal_mode)]
     pub dir_mode: Option<u16>,
+    /// Mount with `allow_other` + `default_permissions` so accounts other than
+    /// the mounting user can reach the mount and the presented owner/mode bits
+    /// are kernel-enforced. Implied by `--owner`/`--group`. Non-root mounts also
+    /// require `user_allow_other` in `/etc/fuse.conf`.
+    #[arg(long, env = "MUSEFS_ALLOW_OTHER")]
+    pub allow_other: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -249,6 +255,13 @@ fn write_bit_warning(flag: &str, mode: u16) -> Option<String> {
     })
 }
 
+/// Effective `allow_other`: the explicit flag, or implied by a presented
+/// owner/group (the cross-user use case is unreachable without it). Auto-enable
+/// wins over an explicit `--allow-other false` (only reachable via the env var).
+fn effective_allow_other(flag: bool, owner: Option<u32>, group: Option<u32>) -> bool {
+    flag || owner.is_some() || group.is_some()
+}
+
 /// Parse mount CLI flags into `MountConfig` and `FuseConfig`. Pure function —
 /// no DB access, no mounting. Exported for unit testing.
 pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseConfig) {
@@ -270,7 +283,7 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         gid: args.group.unwrap_or(defaults.gid),
         file_mode: args.file_mode.unwrap_or(defaults.file_mode),
         dir_mode: args.dir_mode.unwrap_or(defaults.dir_mode),
-        allow_other: args.owner.is_some() || args.group.is_some(),
+        allow_other: effective_allow_other(args.allow_other, args.owner, args.group),
     };
     (config, fuse_config)
 }
@@ -582,5 +595,33 @@ mod tests {
         };
         let (_config, fuse_config) = parse_mount_config(&args);
         assert!(!fuse_config.allow_other);
+    }
+
+    #[test]
+    fn effective_allow_other_combines_flag_and_owner_group() {
+        assert!(!effective_allow_other(false, None, None));
+        assert!(effective_allow_other(true, None, None));
+        // Auto-enable wins even when the flag is explicitly false (env path).
+        assert!(effective_allow_other(false, Some(0), None));
+        assert!(effective_allow_other(false, None, Some(0)));
+    }
+
+    #[test]
+    fn explicit_allow_other_flag_enables_it() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "mount",
+            "/mnt",
+            "--db",
+            "/tmp/x.db",
+            "--allow-other",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        assert!(fuse_config.allow_other);
     }
 }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -270,6 +270,7 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         gid: args.group.unwrap_or(defaults.gid),
         file_mode: args.file_mode.unwrap_or(defaults.file_mode),
         dir_mode: args.dir_mode.unwrap_or(defaults.dir_mode),
+        allow_other: args.owner.is_some() || args.group.is_some(),
     };
     (config, fuse_config)
 }
@@ -548,5 +549,38 @@ mod tests {
         assert_eq!(parse_group("1234").unwrap(), 1234);
         assert!(parse_group("").is_err());
         assert!(parse_group("definitely-no-such-group-xyzzy").is_err());
+    }
+
+    #[test]
+    fn owner_or_group_auto_enables_allow_other() {
+        use clap::Parser;
+        for arg in [["--owner", "0"], ["--group", "0"]] {
+            let cli = Cli::try_parse_from([
+                "musefs",
+                "mount",
+                "/mnt",
+                "--db",
+                "/tmp/x.db",
+                arg[0],
+                arg[1],
+            ])
+            .unwrap();
+            let Command::Mount(args) = cli.command else {
+                panic!("expected Mount");
+            };
+            let (_config, fuse_config) = parse_mount_config(&args);
+            assert!(fuse_config.allow_other, "{arg:?} should enable allow_other");
+        }
+    }
+
+    #[test]
+    fn allow_other_defaults_off_without_owner_group() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "mount", "/mnt", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (_config, fuse_config) = parse_mount_config(&args);
+        assert!(!fuse_config.allow_other);
     }
 }

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -135,6 +135,7 @@ fn parse_mount_config_defaults_are_sensible() {
         group: None,
         file_mode: None,
         dir_mode: None,
+        allow_other: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
@@ -167,6 +168,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         group: None,
         file_mode: None,
         dir_mode: None,
+        allow_other: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
@@ -195,6 +197,7 @@ fn parse_mount_config_saturating_readahead() {
         group: None,
         file_mode: None,
         dir_mode: None,
+        allow_other: false,
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
@@ -247,6 +250,7 @@ fn parse_mount_config_populates_per_field_fallbacks() {
         group: None,
         file_mode: None,
         dir_mode: None,
+        allow_other: false,
     };
     let (config, _) = parse_mount_config(&args);
     assert_eq!(

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -608,6 +608,10 @@ fn new_session(
     fs_name: &str,
     allow_other: bool,
 ) -> std::io::Result<Session<MusefsFs>> {
+    // Validate the allow_other environment before taking the mount lock: the
+    // /etc/fuse.conf read is unrelated to the fusermount3 handshake the lock
+    // serializes, so it must not extend that critical section.
+    platform::mount::check_allow_other(allow_other)?;
     // Recover from a poisoned lock: it guards only ordering, so a prior panic
     // during a mount leaves no inconsistent state to protect against.
     let _guard = MOUNT_SETUP

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -63,6 +63,11 @@ pub struct FuseConfig {
     pub file_mode: u16,
     /// Permission bits for directories (bare mode word, no type bits).
     pub dir_mode: u16,
+    /// Mount with `allow_other` + `default_permissions`: accounts other than the
+    /// mounting user can reach the mount and the kernel enforces the presented
+    /// owner/mode bits. Non-root mounts also require `user_allow_other` in
+    /// `/etc/fuse.conf` (validated at mount time).
+    pub allow_other: bool,
 }
 
 impl Default for FuseConfig {
@@ -76,6 +81,7 @@ impl Default for FuseConfig {
             gid: rustix::process::getgid().as_raw(),
             file_mode: 0o444,
             dir_mode: 0o555,
+            allow_other: false,
         }
     }
 }
@@ -579,9 +585,9 @@ impl Filesystem for MusefsFs {
 }
 
 /// Read-only mount options tagged with the filesystem name, plus per-OS extras.
-fn mount_config(fs_name: &str) -> Config {
+fn mount_config(fs_name: &str, allow_other: bool) -> Config {
     let mut cfg = Config::default();
-    cfg.mount_options = platform::mount::options(fs_name);
+    cfg.mount_options = platform::mount::options(fs_name, allow_other);
     cfg
 }
 
@@ -600,13 +606,14 @@ fn new_session(
     fs: MusefsFs,
     mountpoint: &Path,
     fs_name: &str,
+    allow_other: bool,
 ) -> std::io::Result<Session<MusefsFs>> {
     // Recover from a poisoned lock: it guards only ordering, so a prior panic
     // during a mount leaves no inconsistent state to protect against.
     let _guard = MOUNT_SETUP
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    Session::new(fs, mountpoint, &mount_config(fs_name))
+    Session::new(fs, mountpoint, &mount_config(fs_name, allow_other))
 }
 
 /// Mount `core` at `mountpoint` with default fuse tuning, blocking until unmounted.
@@ -621,9 +628,10 @@ pub fn mount_with(
     fs_name: &str,
     config: FuseConfig,
 ) -> std::io::Result<()> {
+    let allow_other = config.allow_other;
     let fs = MusefsFs::new(core, config);
     let cell = fs.notifier_cell();
-    let session = new_session(fs, mountpoint, fs_name)?;
+    let session = new_session(fs, mountpoint, fs_name, allow_other)?;
     let _ = cell.set(session.notifier());
     let bg = session.spawn()?;
     bg.join()
@@ -641,9 +649,10 @@ pub fn spawn_with(
     fs_name: &str,
     config: FuseConfig,
 ) -> std::io::Result<BackgroundSession> {
+    let allow_other = config.allow_other;
     let fs = MusefsFs::new(core, config);
     let cell = fs.notifier_cell();
-    let session = new_session(fs, mountpoint, fs_name)?;
+    let session = new_session(fs, mountpoint, fs_name, allow_other)?;
     // Set the notifier BEFORE `spawn()` starts the dispatch thread, so the first
     // request can't observe an empty cell. `session.notifier()` and the spawned
     // session's notifier clone the same channel sender, so they're equivalent.

--- a/musefs-fuse/src/platform/mount.rs
+++ b/musefs-fuse/src/platform/mount.rs
@@ -3,9 +3,16 @@
 
 use fuser::MountOption;
 
-/// Read-only mount options for `fs_name`, plus any per-OS additions.
-pub fn options(fs_name: &str) -> Vec<MountOption> {
+/// Read-only mount options for `fs_name`, plus any per-OS additions. With
+/// `allow_other`, also mount `allow_other` + `default_permissions` so an account
+/// other than the mounting user can reach the mount and the presented owner/mode
+/// bits are kernel-enforced.
+pub fn options(fs_name: &str, allow_other: bool) -> Vec<MountOption> {
     let mut opts = vec![MountOption::RO, MountOption::FSName(fs_name.to_string())];
+    if allow_other {
+        opts.push(MountOption::CUSTOM("allow_other".to_string()));
+        opts.push(MountOption::DefaultPermissions);
+    }
     extend_os_specific(&mut opts, fs_name);
     opts
 }
@@ -27,9 +34,23 @@ mod tests {
 
     #[test]
     fn options_are_always_read_only_and_named() {
-        let opts = options("musefs");
+        let opts = options("musefs", false);
         assert!(opts.contains(&MountOption::RO));
         assert!(opts.contains(&MountOption::FSName("musefs".to_string())));
+    }
+
+    #[test]
+    fn allow_other_adds_allow_other_and_default_permissions() {
+        let opts = options("musefs", true);
+        assert!(opts.contains(&MountOption::CUSTOM("allow_other".to_string())));
+        assert!(opts.contains(&MountOption::DefaultPermissions));
+    }
+
+    #[test]
+    fn no_allow_other_omits_allow_other_and_default_permissions() {
+        let opts = options("musefs", false);
+        assert!(!opts.contains(&MountOption::CUSTOM("allow_other".to_string())));
+        assert!(!opts.contains(&MountOption::DefaultPermissions));
     }
 }
 
@@ -39,7 +60,7 @@ mod macos_tests {
 
     #[test]
     fn macos_adds_volname_and_noappledouble() {
-        let opts = options("musefs");
+        let opts = options("musefs", false);
         assert!(opts.contains(&MountOption::CUSTOM("volname=musefs".to_string())));
         assert!(opts.contains(&MountOption::CUSTOM("noappledouble".to_string())));
     }

--- a/musefs-fuse/src/platform/mount.rs
+++ b/musefs-fuse/src/platform/mount.rs
@@ -17,6 +17,56 @@ pub fn options(fs_name: &str, allow_other: bool) -> Vec<MountOption> {
     opts
 }
 
+/// Mount-time guard for `allow_other`: libfuse refuses an `allow_other` mount for
+/// a non-root user unless `/etc/fuse.conf` enables `user_allow_other`. Check it
+/// up front to replace fusermount3's cryptic "Permission denied" with actionable
+/// guidance. Non-Linux platforms don't gate on `/etc/fuse.conf`, so it's a no-op.
+pub fn check_allow_other(allow_other: bool) -> std::io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let is_root = rustix::process::geteuid().as_raw() == 0;
+        // `.ok()` collapses any read failure (missing, EACCES, dangling symlink)
+        // to `None`, which the decision treats as "not permitted" — fail-safe.
+        let conf = std::fs::read_to_string("/etc/fuse.conf").ok();
+        preflight_decision(allow_other, is_root, conf.as_deref())
+            .map_err(|msg| std::io::Error::new(std::io::ErrorKind::PermissionDenied, msg))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = allow_other;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+const ALLOW_OTHER_HELP: &str = "allow_other is enabled (via --allow-other, or implied by --owner/--group) \
+but '/etc/fuse.conf' does not enable 'user_allow_other'; libfuse refuses a non-root allow_other mount without it. \
+Add a line 'user_allow_other' to /etc/fuse.conf, or run musefs as root.";
+
+/// True if `contents` has an active `user_allow_other` directive: a line whose
+/// text before any `#` comment trims to exactly `user_allow_other`.
+#[cfg(target_os = "linux")]
+fn user_allow_other_active(contents: &str) -> bool {
+    contents
+        .lines()
+        .any(|line| line.split('#').next().unwrap_or("").trim() == "user_allow_other")
+}
+
+/// Pure pre-flight decision. `conf` is `None` when `/etc/fuse.conf` could not be
+/// read; treated as "not permitted" so the actionable error fires (a false
+/// positive is harmless — fusermount3 would have failed the mount anyway). Root
+/// and the no-`allow_other` case always pass.
+#[cfg(target_os = "linux")]
+fn preflight_decision(allow_other: bool, is_root: bool, conf: Option<&str>) -> Result<(), String> {
+    if !allow_other || is_root {
+        return Ok(());
+    }
+    if conf.is_some_and(user_allow_other_active) {
+        return Ok(());
+    }
+    Err(ALLOW_OTHER_HELP.to_string())
+}
+
 #[cfg(target_os = "macos")]
 fn extend_os_specific(opts: &mut Vec<MountOption>, fs_name: &str) {
     // fuser 0.17 has no `VolName` variant; macOS-specific options go through
@@ -63,5 +113,50 @@ mod macos_tests {
         let opts = options("musefs", false);
         assert!(opts.contains(&MountOption::CUSTOM("volname=musefs".to_string())));
         assert!(opts.contains(&MountOption::CUSTOM("noappledouble".to_string())));
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod preflight_tests {
+    use super::*;
+
+    #[test]
+    fn parser_accepts_active_directive_forms() {
+        assert!(user_allow_other_active("user_allow_other"));
+        assert!(user_allow_other_active("   user_allow_other   "));
+        assert!(user_allow_other_active(
+            "user_allow_other # enable for media server"
+        ));
+        assert!(user_allow_other_active(
+            "mount_max=1000\nuser_allow_other\n"
+        ));
+    }
+
+    #[test]
+    fn parser_rejects_inactive_or_absent() {
+        assert!(!user_allow_other_active("# user_allow_other"));
+        assert!(!user_allow_other_active("#user_allow_other"));
+        assert!(!user_allow_other_active("mount_max=1000"));
+        assert!(!user_allow_other_active(""));
+    }
+
+    #[test]
+    fn preflight_passes_when_not_requested_or_root() {
+        assert!(preflight_decision(false, false, None).is_ok());
+        assert!(preflight_decision(true, true, None).is_ok());
+    }
+
+    #[test]
+    fn preflight_requires_directive_for_nonroot() {
+        assert!(preflight_decision(true, false, Some("user_allow_other")).is_ok());
+        assert!(preflight_decision(true, false, Some("# nope")).is_err());
+        assert!(preflight_decision(true, false, None).is_err());
+    }
+
+    #[test]
+    fn preflight_error_is_self_contained() {
+        let err = preflight_decision(true, false, None).unwrap_err();
+        assert!(err.contains("/etc/fuse.conf"));
+        assert!(err.contains("user_allow_other"));
     }
 }

--- a/musefs-fuse/src/platform/mount.rs
+++ b/musefs-fuse/src/platform/mount.rs
@@ -21,6 +21,10 @@ pub fn options(fs_name: &str, allow_other: bool) -> Vec<MountOption> {
 /// a non-root user unless `/etc/fuse.conf` enables `user_allow_other`. Check it
 /// up front to replace fusermount3's cryptic "Permission denied" with actionable
 /// guidance. Non-Linux platforms don't gate on `/etc/fuse.conf`, so it's a no-op.
+// On non-Linux the body unconditionally returns `Ok`, which trips
+// `clippy::unnecessary_wraps`; the Linux build genuinely returns `Err`, so keep
+// the `Result` and silence the lint only where it fires.
+#[cfg_attr(not(target_os = "linux"), allow(clippy::unnecessary_wraps))]
 pub fn check_allow_other(allow_other: bool) -> std::io::Result<()> {
     #[cfg(target_os = "linux")]
     {


### PR DESCRIPTION
Closes #293, closes #294.

## Summary

Makes the advertised `--owner`/`--group` cross-user use case actually work, and documents two FUSE mount-access behaviours the docs didn't reflect.

- **#294 — `allow_other` + `default_permissions`.** musefs mounted with a fixed option set (`RO` + `FSName`), so a default FUSE mount was reachable only by the mounting user — the media-server service account the README pointed `--owner`/`--group` at couldn't traverse it, and without `default_permissions` the presented owner/mode bits were purely cosmetic. A mount now adds `allow_other` + `default_permissions` when requested.
  - New `--allow-other` flag (`MUSEFS_ALLOW_OTHER`), enabling both options together.
  - **Auto-enabled** whenever `--owner`/`--group` is given — passing an owner/group implies you want another account to reach the mount, so it stops being cosmetic. Auto-enable wins over an explicit `--allow-other false`.
  - **Pre-flight check** (Linux, non-root): if `allow_other` is effective and `/etc/fuse.conf` lacks an active `user_allow_other`, the mount fails fast with an actionable, self-contained error instead of fusermount3's cryptic `Permission denied`. Root is exempt; any conf read failure is treated as "not permitted" (fail-safe). No-op on non-Linux.

- **#293 — AppArmor mountpoint note.** On distros shipping an AppArmor `fusermount3` profile (Ubuntu 24.04+/libfuse ≥ 3.17), unprivileged mounts are only allowed under whitelisted prefixes; mounting elsewhere (e.g. `/data/...`) fails with `Permission denied` before ownership is ever checked. The README now documents the constraint and the two workarounds.

## Behaviour / docs

- Defaults stay `444`/`555` (world-readable), so any account can read once `allow_other` is on; the README explains that restricting access to the presented owner/group means dropping the world bits (e.g. `--file-mode 440 --dir-mode 550`).
- README ownership section rewritten; `MUSEFS_ALLOW_OTHER` added to the systemd conf example.

## Notes

- `allow_other` is emitted as `MountOption::CUSTOM("allow_other")` because fuser 0.17 has no `AllowOther` variant; it renders to the same `-o allow_other` option. `default_permissions` uses the typed `MountOption::DefaultPermissions`.
- `AutoUnmount` is intentionally unchanged — cleanup remains the existing signal-handler `fusermount3 -u` path.
- Design spec and implementation plan are included under `docs/superpowers/`.

## Testing

- 11 new unit tests: mount-option assembly, the `/etc/fuse.conf` parser semantics, the pre-flight decision (root-exempt / not-permitted / self-contained error), and the CLI auto-enable/effective-value logic.
- Full workspace suite green (989 passed); `clippy --all-targets -D warnings` and `fmt --check` clean. FreeBSD cross-clippy left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
