### PR TITLE
fix(scan): reconcile counter semantics (#301) + dedup symlinked backing paths (#302)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:408:31:',
+    'musefs-core/src/scan\.rs:448:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:415:30:',
+    'musefs-core/src/scan\.rs:455:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,18 +127,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:426:21:',
+    'musefs-core/src/scan\.rs:466:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:431:17:',
+    'musefs-core/src/scan\.rs:471:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:796:46:',
+    'musefs-core/src/scan\.rs:837:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -147,25 +147,25 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `+=` and `>=`/`||` repeat in
-    # run_pipeline (e.g. the killable `*scanned += 1` at 861), so these cannot be
+    # run_pipeline (e.g. the killable `*scanned += 1` at 902), so these cannot be
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:883:29:',
+    'musefs-core/src/scan\.rs:924:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:885:32:',
+    'musefs-core/src/scan\.rs:926:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:885:47:',
+    'musefs-core/src/scan\.rs:926:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:885:62:',
+    'musefs-core/src/scan\.rs:926:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:893:37:',
+    'musefs-core/src/scan\.rs:934:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:895:40:',
+    'musefs-core/src/scan\.rs:936:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:895:55:',
+    'musefs-core/src/scan\.rs:936:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:895:70:',
+    'musefs-core/src/scan\.rs:936:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -173,11 +173,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1008:25:',
+    'musefs-core/src/scan\.rs:1049:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1012:25:',
+    'musefs-core/src/scan\.rs:1053:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1048:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1089:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:396:31:',
+    'musefs-core/src/scan\.rs:408:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:403:30:',
+    'musefs-core/src/scan\.rs:415:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,18 +127,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:414:21:',
+    'musefs-core/src/scan\.rs:426:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:419:17:',
+    'musefs-core/src/scan\.rs:431:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:781:46:',
+    'musefs-core/src/scan\.rs:796:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -147,25 +147,25 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `+=` and `>=`/`||` repeat in
-    # run_pipeline (e.g. the killable `*scanned += 1` at 850), so these cannot be
+    # run_pipeline (e.g. the killable `*scanned += 1` at 861), so these cannot be
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:872:29:',
+    'musefs-core/src/scan\.rs:883:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:874:32:',
+    'musefs-core/src/scan\.rs:885:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:874:47:',
+    'musefs-core/src/scan\.rs:885:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:874:62:',
+    'musefs-core/src/scan\.rs:885:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:882:37:',
+    'musefs-core/src/scan\.rs:893:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:884:40:',
+    'musefs-core/src/scan\.rs:895:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:884:55:',
+    'musefs-core/src/scan\.rs:895:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:884:70:',
+    'musefs-core/src/scan\.rs:895:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -173,11 +173,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:994:25:',
+    'musefs-core/src/scan\.rs:1008:25:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:998:25:',
+    'musefs-core/src/scan\.rs:1012:25:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1034:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1048:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -347,8 +347,9 @@ directory-symlink cycles. Passing `--follow-symlinks` resolves them — symlinke
 audio files and directories are scanned — guarded by a visited `(dev, ino)` set
 so symlink cycles terminate, and by a second file-level `(dev, ino)` set so a
 file reached via both a real path and a symlink is ingested once rather than
-upserting its canonical track row twice. Broken symlinks are logged and skipped
-without
+upserting its canonical track row twice. Because that set keys on `(dev, ino)`,
+multiple hardlinks to the same inode are likewise collapsed to a single track
+under `--follow-symlinks`. Broken symlinks are logged and skipped without
 aborting the scan. The `root` argument is always followed regardless of the
 flag; only links encountered during recursion are gated.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -345,7 +345,10 @@ Symlinks are **not followed by default**: a symlinked file or directory is
 logged (`RUST_LOG=info`/`warn`) and skipped, which keeps the walk immune to
 directory-symlink cycles. Passing `--follow-symlinks` resolves them — symlinked
 audio files and directories are scanned — guarded by a visited `(dev, ino)` set
-so symlink cycles terminate. Broken symlinks are logged and skipped without
+so symlink cycles terminate, and by a second file-level `(dev, ino)` set so a
+file reached via both a real path and a symlink is ingested once rather than
+upserting its canonical track row twice. Broken symlinks are logged and skipped
+without
 aborting the scan. The `root` argument is always followed regardless of the
 flag; only links encountered during recursion are gated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `id3 ` chunk. Parsing is now gated on validated ID3v2 frame bounds and an
   ID3v2 tag at offset 0 (the `id3` reader scans forward). Found by the `mp3` and
   `wav` fuzz targets.
+- **Scan counters now match their documented contract:** `musefs scan` reports
+  unsupported-extension files (e.g. `.txt`, `.jpg`) as `skipped` and
+  supported-extension files that fail to parse (e.g. a corrupt `.flac`) as
+  `failed`. Previously malformed files were miscounted as `skipped` and
+  unsupported files were not counted at all (#301).
+- **Symlink scans no longer double-count:** with `--follow-symlinks`, a file
+  reached via both its real path and a symlink is ingested and counted once
+  instead of inflating `scanned` (#302).
 
 ## [0.2.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ID3v2 tag at offset 0 (the `id3` reader scans forward). Found by the `mp3` and
   `wav` fuzz targets.
 - **Scan counters now match their documented contract:** `musefs scan` reports
-  unsupported-extension files (e.g. `.txt`, `.jpg`) as `skipped` and
-  supported-extension files that fail to parse (e.g. a corrupt `.flac`) as
-  `failed`. Previously malformed files were miscounted as `skipped` and
-  unsupported files were not counted at all (#301).
+  every non-audio file (any unsupported or missing extension — `.jpg`, `.cue`,
+  `.log`, `.nfo`, cover art, etc.) as `skipped`, and supported-extension files
+  that fail to parse (e.g. a corrupt `.flac`) as `failed`. Previously malformed
+  files were miscounted as `skipped` and unsupported files were not counted at
+  all, so expect `skipped` to be larger than before on a real library (#301).
 - **Symlink scans no longer double-count:** with `--follow-symlinks`, a file
   reached via both its real path and a symlink is ingested and counted once
   instead of inflating `scanned`; multiple hardlinks to the same inode are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unsupported files were not counted at all (#301).
 - **Symlink scans no longer double-count:** with `--follow-symlinks`, a file
   reached via both its real path and a symlink is ingested and counted once
-  instead of inflating `scanned` (#302).
+  instead of inflating `scanned`; multiple hardlinks to the same inode are
+  likewise collapsed to a single track (#302).
 
 ## [0.2.0] - 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ files or directories, and `--jobs N` controls probe parallelism.
 symlinks are logged and skipped). `--quiet`
 (`-q`) suppresses the per-target summary for scripting; scan failures still
 surface on stderr (raise detail with `RUST_LOG=info`).
+
+The per-target summary reads `scanned N: … skipped X, failed Y`. `skipped`
+counts every file that isn't a supported audio format — cover art, `.cue` /
+`.log` / `.nfo` sidecars, and anything else non-audio — so a large `skipped`
+number (hundreds or thousands on a big library) is expected, not an error.
+`failed` is the one to watch: those are audio files musefs recognised by
+extension but could not parse.
+
 `--revalidate` is the maintenance pass: it skips unchanged files —
 **preserving any tag edits you made in the store** — prunes tracks whose
 backing file is gone, and garbage-collects orphaned art.

--- a/docs/superpowers/plans/2026-06-12-scan-counters-and-symlink-dedup.md
+++ b/docs/superpowers/plans/2026-06-12-scan-counters-and-symlink-dedup.md
@@ -4,128 +4,71 @@
 
 **Goal:** Make `ScanStats` honest — `skipped` = unsupported-extension files (counted at collection), `failed` = supported-extension files that won't probe, `scanned` = distinct tracks — and stop double-counting a file reached via both a real path and a symlink under `--follow-symlinks`.
 
-**Architecture:** All changes are in `musefs-core/src/scan.rs` plus its two integration test files. #301 moves the `skipped` tally from the probe pipeline (where it actually counted parse failures) to the directory walk (where unsupported extensions are dropped), and reclassifies unparseable supported-extension files as `failed`. #302 adds a file-level `(dev, ino)` visited set beside the existing directory-cycle set, active only under follow, so duplicate canonical targets are dropped before dispatch.
+**Architecture:** All code changes are in `musefs-core/src/scan.rs` plus its two integration test files. #301 moves the `skipped` tally from the probe pipeline (where it actually counted parse failures) to the directory walk (where unsupported extensions are dropped), and reclassifies unparseable supported-extension files as `failed`. #302 adds a file-level `(dev, ino)` visited set beside the existing directory-cycle set, active only under follow, so duplicate canonical targets are dropped before dispatch.
 
-**Tech Stack:** Rust (workspace crate `musefs-core`), `cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt`, `cargo mutants` (in-diff gate). Serena symbolic tools are the primary edit tools for `scan.rs` per the repo's `CLAUDE.md`.
+**Tech Stack:** Rust (`musefs-core`), `cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt`, `cargo mutants` (anchor-drift guard + in-diff gate). Serena symbolic tools are the primary edit tools for `scan.rs` per the repo's `CLAUDE.md`.
 
 ---
 
-## Background the worker needs
+## Read this before starting
 
-Read [the design spec](../specs/2026-06-12-scan-counters-and-symlink-dedup-design.md) first. Key facts about the current code (`musefs-core/src/scan.rs`):
+1. **Read the spec:** [docs/superpowers/specs/2026-06-12-scan-counters-and-symlink-dedup-design.md](../specs/2026-06-12-scan-counters-and-symlink-dedup-design.md).
 
-- The directory walk is `collect_audio` → `collect_audio_inner` → `descend` (mutually recursive). It filters to supported *extensions* via `is_supported_audio`; non-audio files are silently dropped. A `HashSet<(dev, ino)>` (`dir_key`) guards directory-symlink cycles.
-- `probe_file` returns an `enum ProbeOutcome { Probed(..), Unsupported, Raced }`. `Unsupported` is produced when `probe_body` returns `None` — i.e. a **supported extension that would not parse** (collection already filtered out unsupported extensions, so `Unsupported` never means "wrong extension").
-- `run_pipeline` runs parallel probe workers feeding one writer thread. Workers map `Unsupported → skipped`, `Err(_)`/canonicalize-failure → `failed`, `Raced → raced`. The writer counts `scanned` once per drained unit.
-- `scan_directory_with`, `scan_directory_full_oracle` (a whole-file-probe oracle compared for equivalence against the bounded path), and `revalidate_with` all call `collect_audio`.
+2. **Line numbers in this plan are navigation hints, not edit coordinates.** Every code edit targets a *named symbol* via Serena (`replace_symbol_body`, `insert_after_symbol`); locate symbols by name, not by the cited line. The numbers were accurate at authoring but the file shifts as you edit it.
 
-**Pre-commit gate:** the hook runs `cargo fmt`, `cargo clippy -D warnings`, and the **full workspace test suite**. Every commit must be green — a commit with red tests is rejected. So each task below ends green.
+3. **The pre-commit hook is strict.** `.githooks/pre-commit` runs `cargo fmt`, `cargo clippy -D warnings`, the **full workspace test suite**, AND — whenever a `musefs-core/src/*.rs` file is staged and `cargo-mutants` is installed — a **mutant-anchor drift guard** (`scripts/check_mutant_anchors.py`). Every commit must satisfy all of them. A red test, a warning, or a drifted anchor rejects the commit.
 
-**A subtlety for #302 testing:** a symlink to an already-visited *directory* is already caught by the existing `dir_key` cycle guard, so "symlinked directory reaching the same file" mostly does not double-count today. The genuinely-buggy case is a **file** reachable via a real path and a symlink (same dir or different dir), because file symlinks bypass the directory guard. Tests below cover both, and a comment notes which path each exercises.
+4. **The mutant-anchor guard is the subtle one.** `.cargo/mutants.toml` excludes specific equivalent/unkillable mutants by exact `file:line:col`, each tagged with a `# guard: op="…" fn="…" rows=N` comment. The guard re-derives the live mutant list and checks each anchor still lands on exactly that operator in that function. **Any edit that shifts a line in `scan.rs` moves these anchors and trips the guard** — so each `scan.rs`-touching commit below re-anchors `.cargo/mutants.toml` in the *same* commit. The affected `scan.rs` anchors are at (authoring-time) lines 396, 403, 414, 419, 781, 872, 874, 882, 884, 994, 998, 1034. If `cargo-mutants` is not installed the local guard is skipped, but **CI enforces it regardless**, so re-anchor either way.
+
+### Re-anchor procedure (referenced by Task 1 and Task 2)
+
+Run after the code edits in a `scan.rs`-touching task, before committing:
+
+```bash
+# 1. Regenerate the live mutant list and run the guard.
+cargo mutants --no-config --list --json > /tmp/musefs-mutants.json
+python3 scripts/check_mutant_anchors.py --mutants-json /tmp/musefs-mutants.json
+```
+
+For each reported failure (`[mutants.toml:N] /…scan\.rs:LINE:COL:/ — … line likely shifted …`):
+- Read that entry's `# guard: op="OP" fn="FN" rows=R` comment in `.cargo/mutants.toml`.
+- Find the mutant's new coordinate in the plain list:
+
+```bash
+cargo mutants --no-config --list | grep -F 'in FN' | grep -F 'OP'
+```
+
+- Update the `musefs-core/src/scan\.rs:LINE:COL:` coordinate in `.cargo/mutants.toml` to the new `LINE:COL` (keep the rest of the regex, including any `replace + with -` description suffix).
+- Re-run the guard. Repeat until it prints `OK: N exclude_re entries validated against M mutants.`
+
+If a guard entry now matches **zero** mutants because the mutated expression was *removed* (not just moved), that exclusion is obsolete — delete the entry and its `# guard:` comment. (None of the planned edits remove an anchored expression — the removed `skipped` atomic is not anchored — but verify.)
 
 ---
 
 ## File map
 
-- **Modify** `musefs-core/src/scan.rs` — the enum, the walk (`collect_audio`/`collect_audio_inner`/`descend`), `run_pipeline`, `scan_directory_with`, `scan_directory_full_oracle`, and three in-module tests.
-- **Modify** `musefs-core/tests/scan_counters.rs` — update `oracle_counts_scanned_and_skipped_exactly` to the new contract and its mutation kill-anchor; add the #302 dedup tests.
-- **Modify** `ARCHITECTURE.md` and `CHANGELOG.md` — document the dedup and the operator-visible counter shift.
+- **Modify** `musefs-core/src/scan.rs` — the `ProbeOutcome` enum, the walk (`collect_audio`/`collect_audio_inner`/`descend`), a new `push_file` helper, `run_pipeline`, `scan_directory_with`, `scan_directory_full_oracle`, and three in-module tests.
+- **Modify** `musefs-core/tests/scan_counters.rs` — update `oracle_counts_scanned_and_skipped_exactly` to the new contract; add four symlink/skip tests.
+- **Modify** `.cargo/mutants.toml` — re-anchor drifted coordinates (Tasks 1 and 2).
+- **Modify** `ARCHITECTURE.md`, `CHANGELOG.md` — document the dedup and the operator-visible counter shift.
 
-No new files. No public API signature changes except `collect_audio` (private) gaining a `u64` return.
+No new files. No public API signature change except `collect_audio` (private) gaining a `u64` return.
 
----
+### A subtlety for #302 testing
 
-## Task 1a: Rename `ProbeOutcome::Unsupported` → `Unparseable` (pure rename, no behavior change)
-
-Mechanical rename to isolate the behavior change in Task 1b. After this task the variant still maps to `skipped`; all tests still pass.
-
-**Files:**
-- Modify: `musefs-core/src/scan.rs` (enum `ProbeOutcome` ~37-45; `probe_file` ~308-334; `run_pipeline` worker arm ~811; in-module test `oversize_unparseable_file_is_skipped_not_read_whole` ~2289-2310)
-
-- [ ] **Step 1: Rename the enum variant and tighten its doc**
-
-In `scan.rs`, replace the `ProbeOutcome` enum body (use Serena `replace_symbol_body` on `ProbeOutcome`):
-
-```rust
-/// Outcome of probing one backing file. `Unparseable` is a supported-extension
-/// file whose bytes did not parse (counted as a scan `failed`). `Raced` means
-/// the file changed under us between the pre- and post-probe `fstat` — the probe
-/// may be torn, so nothing is committed for it (#276).
-#[derive(Debug)]
-enum ProbeOutcome {
-    Probed(Probed, BackingStamp),
-    Unparseable,
-    Raced,
-}
-```
-
-- [ ] **Step 2: Update `probe_file` doc + construction**
-
-In `probe_file`, change the doc sentence and the `None` arm. The doc line currently reads "Returns `ProbeOutcome::Unsupported` for an unsupported/unparseable file (to be skipped)…"; replace with:
-
-```rust
-/// Returns `ProbeOutcome::Unparseable` for a supported-extension file that does
-/// not parse (counted as `failed`) and `ProbeOutcome::Raced` if the file
-/// changed under us.
-```
-
-And the match tail:
-
-```rust
-    Ok(match probed {
-        Some(p) => ProbeOutcome::Probed(p, s1),
-        None => ProbeOutcome::Unparseable,
-    })
-```
-
-- [ ] **Step 3: Update the `run_pipeline` worker arm (still maps to `skipped` for now)**
-
-In `run_pipeline`, the worker `match probe_file(...)` arm:
-
-```rust
-                    Ok(ProbeOutcome::Unparseable) => {
-                        skipped.fetch_add(1, Ordering::Relaxed);
-                    }
-```
-
-- [ ] **Step 4: Update the in-module test's variant reference**
-
-In `oversize_unparseable_file_is_skipped_not_read_whole`, change the `matches!` arm to `ProbeOutcome::Unparseable`:
-
-```rust
-        assert!(matches!(
-            probe_file(&path, WINDOW).unwrap(),
-            ProbeOutcome::Unparseable
-        ));
-```
-
-- [ ] **Step 5: Build, lint, test**
-
-Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
-Expected: PASS, no warnings. (Pure rename — behavior unchanged.)
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add musefs-core/src/scan.rs
-git commit -m "refactor(scan): rename ProbeOutcome::Unsupported to Unparseable
-
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
-```
+A symlink to an already-visited *directory* is already caught by the existing `dir_key` cycle guard, so "symlinked directory reaching the same file" mostly does not double-count today. The genuinely-buggy case is a **file** reachable via a real path and a symlink (same dir or a sibling dir), because file symlinks bypass the directory guard. The tests cover both; a comment notes which path each exercises.
 
 ---
 
-## Task 1b: Reclassify counters to the documented contract (#301)
+## Task 1: Reclassify scan counters to the documented contract (#301)
 
-Move `skipped` to the collection phase (unsupported extensions) and map `Unparseable → failed` in the pipeline and the oracle. This task flips behavior, so it updates the value-asserting tests in the same commit to stay green.
+Rename the probe outcome, move `skipped` to the collection phase (unsupported extensions), and map unparseable supported files to `failed` — across `run_pipeline`, both scan entry points, and the oracle. This flips behavior, so it updates the value-asserting tests and re-anchors `.cargo/mutants.toml` in the same commit.
 
-**Files:**
-- Modify: `musefs-core/src/scan.rs` (`collect_audio`, `collect_audio_inner`, `descend`, `run_pipeline`, `scan_directory_with`, `scan_directory_full_oracle`, in-module test `scan_directory_counts_scanned_and_skipped`)
-- Modify: `musefs-core/tests/scan_counters.rs` (`oracle_counts_scanned_and_skipped_exactly` + its kill-anchor)
+**Files:** `musefs-core/src/scan.rs`, `musefs-core/tests/scan_counters.rs`, `.cargo/mutants.toml`
 
 - [ ] **Step 1: Update the in-module counter test to the new contract (failing test)**
 
-In `scan.rs`'s `hardening_tests` module, replace `scan_directory_counts_scanned_and_skipped` (use Serena `replace_symbol_body` on `hardening_tests/scan_directory_counts_scanned_and_skipped`; **re-include the `#[test]` attribute** — `replace_symbol_body` drops leading attributes otherwise):
+In `scan.rs`'s `hardening_tests` module, replace `scan_directory_counts_scanned_and_skipped` (Serena `replace_symbol_body` on `hardening_tests/scan_directory_counts_scanned_and_skipped`; **re-include the `#[test]` attribute** — `replace_symbol_body` drops leading attributes):
 
 ```rust
     #[test]
@@ -155,7 +98,7 @@ In `scan.rs`'s `hardening_tests` module, replace `scan_directory_counts_scanned_
 
 - [ ] **Step 2: Update the oracle counter test (failing test)**
 
-In `musefs-core/tests/scan_counters.rs`, replace `oracle_counts_scanned_and_skipped_exactly` and the comment block immediately above it (the `// === Full-probe oracle counters …` divider, the doc comment, and the `// kills scan …` anchor) with:
+In `musefs-core/tests/scan_counters.rs`, replace `oracle_counts_scanned_and_skipped_exactly` and the comment block immediately above it (the `// === Full-probe oracle counters …` divider, the doc comment, and the `// kills scan L…` line). The replacement comment intentionally references the *expressions* (not scan.rs line numbers, which drift):
 
 ```rust
 // === Full-probe oracle counters (scan_directory_full_oracle) ===
@@ -164,9 +107,9 @@ In `musefs-core/tests/scan_counters.rs`, replace `oracle_counts_scanned_and_skip
 /// reflect the corpus exactly: one valid FLAC (`scanned`), one extension-only
 /// `.flac` of garbage that `is_supported_audio` collects but `probe_full`
 /// rejects (`failed`), and one unsupported-extension file dropped at collection
-/// (`skipped`). The `+=`→`-=` mutants underflow-panic from 0 and `+=`→`*=` pin
-/// the counter at 0, so all three must be asserted nonzero and exact.
-// kills scan L<scanned> `stats.scanned += 1` and L<failed> `stats.failed += 1` `+=`→`-=`/`*=`
+/// (`skipped`). Asserting all three nonzero-and-exact kills the `+=`→`-=`
+/// (underflow-panic from 0) and `+=`→`*=` (pinned at 0) mutants on the oracle's
+/// `stats.scanned += 1` / `stats.failed += 1` and on collection's `*skipped += 1`.
 #[test]
 fn oracle_counts_scanned_failed_and_skipped_exactly() {
     let dir = tempfile::tempdir().unwrap();
@@ -186,14 +129,61 @@ fn oracle_counts_scanned_failed_and_skipped_exactly() {
 }
 ```
 
-The `L<scanned>`/`L<failed>` placeholders in the kill-anchor are filled in during Step 11 once the oracle's final line numbers are known.
-
 - [ ] **Step 3: Run the two tests to verify they fail**
 
 Run: `cargo test -p musefs-core scan_directory_counts_scanned_failed_and_skipped oracle_counts_scanned_failed_and_skipped_exactly`
-Expected: FAIL — old code counts `bad.flac` as `skipped` (so `failed == 0`, `skipped` includes it) and does not count `notes.txt`.
+Expected: FAIL — old code counts `bad.flac` as `skipped` (so `failed == 0`) and does not count `notes.txt`.
 
-- [ ] **Step 4: Thread a `skipped` counter through the walk — `collect_audio`**
+- [ ] **Step 4: Rename the `ProbeOutcome` variant and tighten its doc**
+
+Replace the `ProbeOutcome` enum body (Serena `replace_symbol_body` on `ProbeOutcome`). Note `Unsupported` and `Unparseable` are both 11 chars, so the rename alone does not shift columns:
+
+```rust
+/// Outcome of probing one backing file. `Unparseable` is a supported-extension
+/// file whose bytes did not parse (counted as a scan `failed`). `Raced` means
+/// the file changed under us between the pre- and post-probe `fstat` — the probe
+/// may be torn, so nothing is committed for it (#276).
+#[derive(Debug)]
+enum ProbeOutcome {
+    Probed(Probed, BackingStamp),
+    Unparseable,
+    Raced,
+}
+```
+
+- [ ] **Step 5: Update `probe_file` doc + the `None` arm**
+
+In `probe_file`, change the doc sentence that mentions `Unsupported` and the match tail (Serena `replace_symbol_body` on `probe_file`, preserving the rest of its body):
+
+Doc sentence becomes:
+
+```rust
+/// Returns `ProbeOutcome::Unparseable` for a supported-extension file that does
+/// not parse (counted as `failed`) and `ProbeOutcome::Raced` if the file
+/// changed under us.
+```
+
+Match tail becomes:
+
+```rust
+    Ok(match probed {
+        Some(p) => ProbeOutcome::Probed(p, s1),
+        None => ProbeOutcome::Unparseable,
+    })
+```
+
+- [ ] **Step 6: Update the in-module probe test's variant reference**
+
+In `oversize_unparseable_file_is_skipped_not_read_whole` (Serena `replace_symbol_body`, re-include `#[test]`), change the `matches!` arm:
+
+```rust
+        assert!(matches!(
+            probe_file(&path, WINDOW).unwrap(),
+            ProbeOutcome::Unparseable
+        ));
+```
+
+- [ ] **Step 7: Thread a `skipped` counter through the walk — `collect_audio`**
 
 Replace `collect_audio` (Serena `replace_symbol_body`):
 
@@ -217,7 +207,7 @@ fn collect_audio(
 }
 ```
 
-- [ ] **Step 5: Count unsupported extensions in `collect_audio_inner`**
+- [ ] **Step 8: Count unsupported extensions in `collect_audio_inner`**
 
 Replace `collect_audio_inner` (Serena `replace_symbol_body`):
 
@@ -271,7 +261,7 @@ fn collect_audio_inner(
 }
 ```
 
-- [ ] **Step 6: Thread `skipped` through `descend`**
+- [ ] **Step 9: Thread `skipped` through `descend`**
 
 Replace `descend` (Serena `replace_symbol_body`):
 
@@ -301,13 +291,13 @@ fn descend(
 }
 ```
 
-- [ ] **Step 7: Map `Unparseable → failed` and drop the `skipped` atomic in `run_pipeline`**
+- [ ] **Step 10: Map `Unparseable → failed` and drop the `skipped` atomic in `run_pipeline`**
 
-Edit `run_pipeline` (Serena `replace_symbol_body`, or targeted `replace_content` for each spot). Make exactly these four changes:
+Edit `run_pipeline`. Make exactly these four changes (targeted `replace_content` per spot, or a full `replace_symbol_body`):
 
-1. Delete the declaration `let skipped = Arc::new(AtomicU64::new(0));`.
-2. Delete the per-worker clone line `let skipped = Arc::clone(&skipped);` (in the `for _ in 0..jobs` setup).
-3. Change the worker arm to:
+1. Delete the declaration line `let skipped = Arc::new(AtomicU64::new(0));`.
+2. Delete the per-worker clone line `let skipped = Arc::clone(&skipped);` (in the `for _ in 0..jobs` worker setup).
+3. Change the worker match arm to:
 
 ```rust
                     Ok(ProbeOutcome::Unparseable) => {
@@ -315,7 +305,7 @@ Edit `run_pipeline` (Serena `replace_symbol_body`, or targeted `replace_content`
                     }
 ```
 
-4. Change the final return to source `skipped` from nowhere (the caller fills it):
+4. Change the final return so `skipped` is sourced by the caller, not the pipeline:
 
 ```rust
     Ok(ScanStats {
@@ -326,9 +316,9 @@ Edit `run_pipeline` (Serena `replace_symbol_body`, or targeted `replace_content`
     })
 ```
 
-- [ ] **Step 8: Fill `skipped` from collection in `scan_directory_with`**
+- [ ] **Step 11: Fill `skipped` from collection in `scan_directory_with`**
 
-Replace `scan_directory_with` (Serena `replace_symbol_body`; keep the existing doc comment — re-include it in the body):
+Replace `scan_directory_with` (Serena `replace_symbol_body`; keep its doc comment — re-include it):
 
 ```rust
 /// Public entry: parallel-probe / single-writer scan of `root`.
@@ -359,7 +349,7 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
 }
 ```
 
-- [ ] **Step 9: Reclassify the oracle (`scan_directory_full_oracle`) in lockstep**
+- [ ] **Step 12: Reclassify the oracle (`scan_directory_full_oracle`) in lockstep**
 
 Replace `scan_directory_full_oracle` (Serena `replace_symbol_body`; re-include the `#[doc(hidden)]` attribute and doc comment):
 
@@ -400,43 +390,69 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
 }
 ```
 
-Note: `revalidate_with` needs **no edit** — its `collect_audio(...)?;` statement already discards the now-`u64` return, and reclassifying `Unparseable → failed` flows through `run_pipeline` automatically.
+`revalidate_with` needs **no edit** — its `collect_audio(...)?;` statement already discards the now-`u64` return (no `#[must_use]`, so no clippy warning under `-D warnings`), and reclassifying `Unparseable → failed` flows through `run_pipeline` automatically.
 
-- [ ] **Step 10: Build, lint, run the full crate suite**
+- [ ] **Step 13: Add a test for the symlink-target `skipped` site (failing test)**
+
+There are now **two** `*skipped += 1` sites in `collect_audio_inner` (the regular-file arm and the symlink-to-file arm). The in-module test covers the regular arm; add a test in `musefs-core/tests/scan_counters.rs` covering the symlink arm so its mutant is killable:
+
+```rust
+/// Under follow, a symlink whose target has an unsupported extension counts as
+/// skipped, symmetric with a regular unsupported file. Covers the symlink-arm
+/// `*skipped += 1` site.
+#[test]
+fn follow_symlinks_counts_unsupported_symlink_target_as_skipped() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let txt = dir.path().join("notes.txt");
+    std::fs::write(&txt, b"hi").unwrap();
+    symlink(&txt, dir.path().join("link.txt")).unwrap();
+    std::fs::write(dir.path().join("song.flac"), flac_minimal(b"AUDIO")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1);
+    // notes.txt (regular) + link.txt (symlink target) → both skipped.
+    assert_eq!(stats.skipped, 2);
+}
+```
+
+- [ ] **Step 14: Build, lint, run the full crate suite**
 
 Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
-Expected: PASS, no warnings. The two tests from Steps 1-2 now pass; the tolerant `assert_eq!(stats.skipped + stats.failed, 1)` test (zero-byte `bad.flac`) still passes (now `failed == 1`).
+Expected: PASS, no warnings. The three new/updated tests pass; the tolerant `assert_eq!(stats.skipped + stats.failed, 1)` test (zero-byte `bad.flac`) still passes (now `failed == 1`); the single-file `skipped == 0` tests and the existing `collect_audio_*` walk tests (scan.rs, ~1455-1588) stay green — the `Result<u64>` change is transparent to their `.unwrap()`.
 
-- [ ] **Step 11: Refresh the oracle test's kill-anchor line numbers**
+- [ ] **Step 15: Re-anchor `.cargo/mutants.toml`**
 
-Find the oracle's counter lines and fill the `L<scanned>`/`L<failed>` placeholders left in Step 2:
+Follow the **Re-anchor procedure** above. Every `scan.rs` anchor shifted (collection grew above the probe-internal anchors at 396/403/414/419; `run_pipeline` lost 2 lines under its 781/872/874/882/884 anchors; the oracle/`scan_directory_with` growth pushed the `revalidate_with` anchors 994/998/1034 down). The removed `skipped` atomic is **not** anchored, so no exclusion becomes obsolete. Re-run the guard until `OK`.
 
-Run: `grep -n "stats.scanned += 1\|stats.failed += 1" musefs-core/src/scan.rs`
-Take the two line numbers inside `scan_directory_full_oracle` and edit the `// kills scan L<…>` comment in `scan_counters.rs` to the real numbers, e.g. `// kills scan L933 \`stats.scanned += 1\` and L928 \`stats.failed += 1\` …`.
-
-- [ ] **Step 12: Commit**
+- [ ] **Step 16: Commit**
 
 ```bash
-git add musefs-core/src/scan.rs musefs-core/tests/scan_counters.rs
+git add musefs-core/src/scan.rs musefs-core/tests/scan_counters.rs .cargo/mutants.toml
 git commit -m "fix(scan): count unsupported extensions as skipped, malformed as failed (#301)
 
 skipped now tallies unsupported-extension files at collection; a
 supported-extension file that will not parse counts as failed, matching the
-documented ScanStats contract. The full-probe oracle is reclassified in
-lockstep so the bounded-vs-full equivalence property holds.
+documented ScanStats contract. ProbeOutcome::Unsupported is renamed Unparseable
+and the full-probe oracle is reclassified in lockstep so the bounded-vs-full
+equivalence property holds. Mutant anchors re-coordinated for the line shifts.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
 
 ---
 
-## Task 2: Deduplicate canonical backing paths under `--follow-symlinks` (#302)
+## Task 2: Deduplicate canonical backing targets under `--follow-symlinks` (#302)
 
-Add a file-level `(dev, ino)` visited set so a file reached via both a real path and a symlink (or two symlink paths) is collected once. Active only when `follow_symlinks` is true; off-mode behavior (incl. hardlinks) is unchanged.
+Add a file-level `(dev, ino)` visited set so a file reached via both a real path and a symlink (or two symlink paths) is collected once. Active only when `follow_symlinks` is true; off-mode behavior (including hardlinks) is unchanged.
 
-**Files:**
-- Modify: `musefs-core/src/scan.rs` (`collect_audio`, `collect_audio_inner`, `descend`; new helper `push_file`)
-- Modify: `musefs-core/tests/scan_counters.rs` (new dedup tests)
+**Files:** `musefs-core/src/scan.rs`, `musefs-core/tests/scan_counters.rs`, `.cargo/mutants.toml`
 
 - [ ] **Step 1: Write the dedup tests (failing tests)**
 
@@ -495,8 +511,8 @@ fn follow_symlinks_dedups_file_across_directories() {
 }
 
 /// A symlinked directory pointing at an already-walked directory reaches the
-/// same file by two paths but ingests once. (This case is handled by the
-/// existing directory-cycle guard; the test locks in the combined behavior.)
+/// same file by two paths but ingests once. (Handled by the existing
+/// directory-cycle guard; this locks in the combined behavior.)
 #[test]
 fn follow_symlinks_dedups_via_symlinked_directory() {
     use std::os::unix::fs::symlink;
@@ -559,7 +575,7 @@ fn push_file(
 }
 ```
 
-- [ ] **Step 4: Thread `files_visited` and route file pushes through `push_file` in `collect_audio_inner`**
+- [ ] **Step 4: Route file pushes through `push_file` and thread `files_visited` in `collect_audio_inner`**
 
 Replace `collect_audio_inner` (Serena `replace_symbol_body`):
 
@@ -680,18 +696,22 @@ fn collect_audio(
 - [ ] **Step 7: Build, lint, run the full crate suite**
 
 Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
-Expected: PASS, no warnings. All three #302 tests now pass.
+Expected: PASS, no warnings. All four #302-area tests pass.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 8: Re-anchor `.cargo/mutants.toml`**
+
+Follow the **Re-anchor procedure**. `push_file` inserted after `dir_key` shifts every anchor below it; re-coordinate them. The new `push_file`/dedup code is covered by the dedup tests (a mutant that disables dedup makes `scanned == 2`, killed), so no new exclusions are expected — but if the final in-diff gate (Task 4) surfaces a survivor here, add a documented exclusion then.
+
+- [ ] **Step 9: Commit**
 
 ```bash
-git add musefs-core/src/scan.rs musefs-core/tests/scan_counters.rs
+git add musefs-core/src/scan.rs musefs-core/tests/scan_counters.rs .cargo/mutants.toml
 git commit -m "fix(scan): dedup canonical backing targets under --follow-symlinks (#302)
 
 A file-level (dev, ino) visited set, active only when following symlinks,
 collapses a real file and a symlink to it (or a file reached via two paths)
 into one collected candidate, so scanned counts distinct tracks. Off-mode
-behavior is unchanged.
+behavior is unchanged. Mutant anchors re-coordinated for the line shifts.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -700,9 +720,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ## Task 3: Documentation + release note
 
-**Files:**
-- Modify: `ARCHITECTURE.md` (`--follow-symlinks` paragraph in the scanning section, ~344-352)
-- Modify: `CHANGELOG.md` (`[Unreleased]` section)
+**Files:** `ARCHITECTURE.md`, `CHANGELOG.md` (no `scan.rs` → no anchor guard)
 
 - [ ] **Step 1: Document the dedup in ARCHITECTURE.md**
 
@@ -718,7 +736,7 @@ canonical track row twice.
 
 - [ ] **Step 2: Add a CHANGELOG entry**
 
-Under `## [Unreleased]`, add a `### Fixed` section (after the existing `### Added`):
+Under `## [Unreleased]`, add a `### Fixed` section after the existing `### Added`:
 
 ```markdown
 ### Fixed
@@ -744,46 +762,37 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ---
 
-## Task 4: Full verification + mutation gate
-
-Confirm the whole workspace is green and the mutation kill-anchors did not silently rot.
+## Task 4: Full verification + in-diff mutation gate
 
 - [ ] **Step 1: Workspace fmt + clippy + tests**
 
 Run: `cargo fmt --all --check && cargo clippy --all-targets --workspace -- -D warnings && cargo test --workspace`
-Expected: all PASS. This includes `musefs-core/tests/probe_equivalence.rs`, whose corpus (`common::corpus::generate`) is all valid audio of each format — no unsupported extensions or garbage — so it compares DB rows only and is unaffected by the counter reclassification; confirm it stays green. (Note per repo memory: the `rtk` hook may summarize `cargo test` output to `cargo test: N passed`; trust the exit code, not a grep for "test result".)
+Expected: all PASS. This includes `musefs-core/tests/probe_equivalence.rs`, whose corpus (`common::corpus::generate`) is all valid audio of each format — no unsupported extensions or garbage — so it compares DB rows only and is unaffected by the reclassification; confirm it stays green. (Per repo memory: the `rtk` hook may summarize `cargo test` to `cargo test: N passed`; trust the exit code, not a grep for "test result".)
 
 - [ ] **Step 2: metrics-feature tests (CI's `check` job runs these; local `--workspace` skips them)**
 
 Run: `cargo test -p musefs-core --features metrics`
-Expected: PASS. This scan change touches `collect_audio`/`run_pipeline` but not the getattr/read stat counters, so these should be unaffected — confirm rather than assume.
+Expected: PASS. This change touches `collect_audio`/`run_pipeline` but not the getattr/read stat counters; confirm rather than assume.
 
-- [ ] **Step 3: Audit every `// kills scan L…` anchor for line drift**
+- [ ] **Step 3: Confirm anchor guard is green on the final tree**
 
-Run: `grep -n "kills scan L" musefs-core/tests/scan_counters.rs`
-For each anchor, open the cited expression in `musefs-core/src/scan.rs` and confirm the line number still matches; fix any that drifted from the Task 1b/Task 2 edits. The anchors reference lines in `probe_file`, `run_pipeline`, and `scan_directory_full_oracle` — all of which moved.
+Run: `cargo mutants --no-config --list --json > /tmp/musefs-mutants.json && python3 scripts/check_mutant_anchors.py --mutants-json /tmp/musefs-mutants.json`
+Expected: `OK: N exclude_re entries validated against M mutants.` If any anchor still drifts, finish re-anchoring (the Tasks 1/2 re-anchor steps were incomplete).
 
-- [ ] **Step 4: Run the in-diff mutation gate**
+- [ ] **Step 4: Run the in-diff mutation gate over the branch diff**
 
-Per repo convention (memory: copy-mode OOMs on worktree targets; use in-place, serial):
+Per repo memory (copy-mode OOMs on worktree targets — use in-place, serial):
 
-Run: `cargo mutants --in-place -p musefs-core` (or the project's in-diff invocation `cargo mutants --in-diff <diff>` if scoped to the branch diff)
-Expected: no surviving or unviable mutants introduced by the diff. If a counter-arithmetic mutant survives, the corresponding assertion or kill-anchor needs tightening. Sanity-check that the diff fed to the gate is non-empty (an empty diff is a silent false pass).
-
-- [ ] **Step 5 (if any anchor changed): commit the anchor fixes**
-
-```bash
-git add musefs-core/tests/scan_counters.rs
-git commit -m "test(scan): refresh mutation kill-anchors after counter changes
-
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
-```
+Run: `cargo mutants --in-place --in-diff <(git diff main...HEAD -- musefs-core/src/scan.rs) -j2`
+Expected: no surviving/missed mutants in the diff. Sanity-check the diff is non-empty before trusting a pass (an empty diff is a silent false pass). New killable sites to expect covered: oracle `stats.scanned += 1` / `stats.failed += 1` (oracle test), collection `*skipped += 1` ×2 (the `scan_directory_counts_*` and `follow_symlinks_counts_unsupported_symlink_target_*` tests), and the `push_file` dedup branch (the `follow_symlinks_dedups_*` tests). If a survivor appears, add a test that kills it (preferred) or a documented `exclude_re` with a `# guard:` tag in `.cargo/mutants.toml` — then re-run the anchor guard and amend the relevant commit.
 
 ---
 
 ## Self-review notes (for the executor)
 
-- **`replace_symbol_body` drops leading attributes/doc comments** — every replaced symbol in this plan re-includes its `#[test]` / `#[doc(hidden)]` / doc comment in the body. Do not strip them.
-- **Signatures change across Task 1b and Task 2** (`collect_audio` return type; `collect_audio_inner`/`descend` gain params). The code will not compile until *all* mutually-recursive callers in a task are updated — that is why each task builds only at its final "build + test" step, not between individual symbol edits.
-- **`revalidate_with` is intentionally untouched** — verify by `cargo test -p musefs-core revalidate` after Task 1b that its tests stay green.
-- **Type/name consistency check:** the variant is `ProbeOutcome::Unparseable` everywhere; the helper is `push_file`; the two visited sets are `visited` (directories) and `files_visited` (files); `collect_audio` returns `std::io::Result<u64>`.
+- **`replace_symbol_body` drops leading attributes/doc comments** — every replaced symbol re-includes its `#[test]` / `#[doc(hidden)]` / doc comment in the body. Do not strip them.
+- **Signatures change twice** (`collect_audio` return type and `*_inner`/`descend` params in Task 1; a second param added in Task 2). Mutually-recursive callers must all update together — the crate compiles only at each task's "build + test" step, not between individual symbol edits.
+- **Each `scan.rs` commit re-anchors `.cargo/mutants.toml`.** The pre-commit anchor guard (when cargo-mutants is installed) will otherwise reject the commit; CI rejects it regardless.
+- **`revalidate_with` is intentionally untouched** — verify with `cargo test -p musefs-core revalidate` after Task 1 that its tests stay green.
+- **The `// kills scan L…` comments in `scan_counters.rs` are descriptive only** — they are not the mutation gate (`.cargo/mutants.toml` is) and were already drifted in the baseline. The Task 1 rewrite replaces the oracle one with an expression-referencing comment so it stops chasing line numbers; do not reintroduce hard-coded scan.rs line numbers in test comments.
+- **Type/name consistency:** the variant is `ProbeOutcome::Unparseable` everywhere; the helper is `push_file`; the two visited sets are `visited` (directories) and `files_visited` (files); `collect_audio` returns `std::io::Result<u64>`.

--- a/docs/superpowers/plans/2026-06-12-scan-counters-and-symlink-dedup.md
+++ b/docs/superpowers/plans/2026-06-12-scan-counters-and-symlink-dedup.md
@@ -1,0 +1,789 @@
+# Scan counter semantics (#301) + symlink dedup (#302) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ScanStats` honest — `skipped` = unsupported-extension files (counted at collection), `failed` = supported-extension files that won't probe, `scanned` = distinct tracks — and stop double-counting a file reached via both a real path and a symlink under `--follow-symlinks`.
+
+**Architecture:** All changes are in `musefs-core/src/scan.rs` plus its two integration test files. #301 moves the `skipped` tally from the probe pipeline (where it actually counted parse failures) to the directory walk (where unsupported extensions are dropped), and reclassifies unparseable supported-extension files as `failed`. #302 adds a file-level `(dev, ino)` visited set beside the existing directory-cycle set, active only under follow, so duplicate canonical targets are dropped before dispatch.
+
+**Tech Stack:** Rust (workspace crate `musefs-core`), `cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt`, `cargo mutants` (in-diff gate). Serena symbolic tools are the primary edit tools for `scan.rs` per the repo's `CLAUDE.md`.
+
+---
+
+## Background the worker needs
+
+Read [the design spec](../specs/2026-06-12-scan-counters-and-symlink-dedup-design.md) first. Key facts about the current code (`musefs-core/src/scan.rs`):
+
+- The directory walk is `collect_audio` → `collect_audio_inner` → `descend` (mutually recursive). It filters to supported *extensions* via `is_supported_audio`; non-audio files are silently dropped. A `HashSet<(dev, ino)>` (`dir_key`) guards directory-symlink cycles.
+- `probe_file` returns an `enum ProbeOutcome { Probed(..), Unsupported, Raced }`. `Unsupported` is produced when `probe_body` returns `None` — i.e. a **supported extension that would not parse** (collection already filtered out unsupported extensions, so `Unsupported` never means "wrong extension").
+- `run_pipeline` runs parallel probe workers feeding one writer thread. Workers map `Unsupported → skipped`, `Err(_)`/canonicalize-failure → `failed`, `Raced → raced`. The writer counts `scanned` once per drained unit.
+- `scan_directory_with`, `scan_directory_full_oracle` (a whole-file-probe oracle compared for equivalence against the bounded path), and `revalidate_with` all call `collect_audio`.
+
+**Pre-commit gate:** the hook runs `cargo fmt`, `cargo clippy -D warnings`, and the **full workspace test suite**. Every commit must be green — a commit with red tests is rejected. So each task below ends green.
+
+**A subtlety for #302 testing:** a symlink to an already-visited *directory* is already caught by the existing `dir_key` cycle guard, so "symlinked directory reaching the same file" mostly does not double-count today. The genuinely-buggy case is a **file** reachable via a real path and a symlink (same dir or different dir), because file symlinks bypass the directory guard. Tests below cover both, and a comment notes which path each exercises.
+
+---
+
+## File map
+
+- **Modify** `musefs-core/src/scan.rs` — the enum, the walk (`collect_audio`/`collect_audio_inner`/`descend`), `run_pipeline`, `scan_directory_with`, `scan_directory_full_oracle`, and three in-module tests.
+- **Modify** `musefs-core/tests/scan_counters.rs` — update `oracle_counts_scanned_and_skipped_exactly` to the new contract and its mutation kill-anchor; add the #302 dedup tests.
+- **Modify** `ARCHITECTURE.md` and `CHANGELOG.md` — document the dedup and the operator-visible counter shift.
+
+No new files. No public API signature changes except `collect_audio` (private) gaining a `u64` return.
+
+---
+
+## Task 1a: Rename `ProbeOutcome::Unsupported` → `Unparseable` (pure rename, no behavior change)
+
+Mechanical rename to isolate the behavior change in Task 1b. After this task the variant still maps to `skipped`; all tests still pass.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (enum `ProbeOutcome` ~37-45; `probe_file` ~308-334; `run_pipeline` worker arm ~811; in-module test `oversize_unparseable_file_is_skipped_not_read_whole` ~2289-2310)
+
+- [ ] **Step 1: Rename the enum variant and tighten its doc**
+
+In `scan.rs`, replace the `ProbeOutcome` enum body (use Serena `replace_symbol_body` on `ProbeOutcome`):
+
+```rust
+/// Outcome of probing one backing file. `Unparseable` is a supported-extension
+/// file whose bytes did not parse (counted as a scan `failed`). `Raced` means
+/// the file changed under us between the pre- and post-probe `fstat` — the probe
+/// may be torn, so nothing is committed for it (#276).
+#[derive(Debug)]
+enum ProbeOutcome {
+    Probed(Probed, BackingStamp),
+    Unparseable,
+    Raced,
+}
+```
+
+- [ ] **Step 2: Update `probe_file` doc + construction**
+
+In `probe_file`, change the doc sentence and the `None` arm. The doc line currently reads "Returns `ProbeOutcome::Unsupported` for an unsupported/unparseable file (to be skipped)…"; replace with:
+
+```rust
+/// Returns `ProbeOutcome::Unparseable` for a supported-extension file that does
+/// not parse (counted as `failed`) and `ProbeOutcome::Raced` if the file
+/// changed under us.
+```
+
+And the match tail:
+
+```rust
+    Ok(match probed {
+        Some(p) => ProbeOutcome::Probed(p, s1),
+        None => ProbeOutcome::Unparseable,
+    })
+```
+
+- [ ] **Step 3: Update the `run_pipeline` worker arm (still maps to `skipped` for now)**
+
+In `run_pipeline`, the worker `match probe_file(...)` arm:
+
+```rust
+                    Ok(ProbeOutcome::Unparseable) => {
+                        skipped.fetch_add(1, Ordering::Relaxed);
+                    }
+```
+
+- [ ] **Step 4: Update the in-module test's variant reference**
+
+In `oversize_unparseable_file_is_skipped_not_read_whole`, change the `matches!` arm to `ProbeOutcome::Unparseable`:
+
+```rust
+        assert!(matches!(
+            probe_file(&path, WINDOW).unwrap(),
+            ProbeOutcome::Unparseable
+        ));
+```
+
+- [ ] **Step 5: Build, lint, test**
+
+Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
+Expected: PASS, no warnings. (Pure rename — behavior unchanged.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/scan.rs
+git commit -m "refactor(scan): rename ProbeOutcome::Unsupported to Unparseable
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 1b: Reclassify counters to the documented contract (#301)
+
+Move `skipped` to the collection phase (unsupported extensions) and map `Unparseable → failed` in the pipeline and the oracle. This task flips behavior, so it updates the value-asserting tests in the same commit to stay green.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (`collect_audio`, `collect_audio_inner`, `descend`, `run_pipeline`, `scan_directory_with`, `scan_directory_full_oracle`, in-module test `scan_directory_counts_scanned_and_skipped`)
+- Modify: `musefs-core/tests/scan_counters.rs` (`oracle_counts_scanned_and_skipped_exactly` + its kill-anchor)
+
+- [ ] **Step 1: Update the in-module counter test to the new contract (failing test)**
+
+In `scan.rs`'s `hardening_tests` module, replace `scan_directory_counts_scanned_and_skipped` (use Serena `replace_symbol_body` on `hardening_tests/scan_directory_counts_scanned_and_skipped`; **re-include the `#[test]` attribute** — `replace_symbol_body` drops leading attributes otherwise):
+
+```rust
+    #[test]
+    fn scan_directory_counts_scanned_failed_and_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        write_flac(
+            &dir.path().join("ok1.flac"),
+            &["ARTIST=A", "TITLE=T1"],
+            None,
+        );
+        write_flac(
+            &dir.path().join("ok2.flac"),
+            &["ARTIST=A", "TITLE=T2"],
+            None,
+        );
+        // Supported extension, unparseable bytes → a scan failure.
+        std::fs::write(dir.path().join("bad.flac"), b"garbage").unwrap();
+        // Unsupported extension → skipped at collection, never probed.
+        std::fs::write(dir.path().join("notes.txt"), b"hello").unwrap();
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let stats = crate::scan_directory(&db, dir.path()).unwrap();
+        assert_eq!(stats.scanned, 2);
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.skipped, 1);
+    }
+```
+
+- [ ] **Step 2: Update the oracle counter test (failing test)**
+
+In `musefs-core/tests/scan_counters.rs`, replace `oracle_counts_scanned_and_skipped_exactly` and the comment block immediately above it (the `// === Full-probe oracle counters …` divider, the doc comment, and the `// kills scan …` anchor) with:
+
+```rust
+// === Full-probe oracle counters (scan_directory_full_oracle) ===
+
+/// The full-file-probe oracle's `scanned`/`failed`/`skipped` counters must
+/// reflect the corpus exactly: one valid FLAC (`scanned`), one extension-only
+/// `.flac` of garbage that `is_supported_audio` collects but `probe_full`
+/// rejects (`failed`), and one unsupported-extension file dropped at collection
+/// (`skipped`). The `+=`→`-=` mutants underflow-panic from 0 and `+=`→`*=` pin
+/// the counter at 0, so all three must be asserted nonzero and exact.
+// kills scan L<scanned> `stats.scanned += 1` and L<failed> `stats.failed += 1` `+=`→`-=`/`*=`
+#[test]
+fn oracle_counts_scanned_failed_and_skipped_exactly() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("good.flac"), flac_minimal(b"AUDIO-OK")).unwrap();
+    // Extension-only: collected by `is_supported_audio`, rejected by `probe_full`.
+    std::fs::write(dir.path().join("bad.flac"), b"not a flac at all").unwrap();
+    // Unsupported extension: dropped at collection → skipped.
+    std::fs::write(dir.path().join("notes.txt"), b"not audio").unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_full_oracle(&db, dir.path()).unwrap();
+
+    assert_eq!(stats.scanned, 1, "exactly the one valid FLAC is scanned");
+    assert_eq!(stats.failed, 1, "the garbage .flac is a failure");
+    assert_eq!(stats.skipped, 1, "the .txt is skipped at collection");
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+```
+
+The `L<scanned>`/`L<failed>` placeholders in the kill-anchor are filled in during Step 11 once the oracle's final line numbers are known.
+
+- [ ] **Step 3: Run the two tests to verify they fail**
+
+Run: `cargo test -p musefs-core scan_directory_counts_scanned_failed_and_skipped oracle_counts_scanned_failed_and_skipped_exactly`
+Expected: FAIL — old code counts `bad.flac` as `skipped` (so `failed == 0`, `skipped` includes it) and does not count `notes.txt`.
+
+- [ ] **Step 4: Thread a `skipped` counter through the walk — `collect_audio`**
+
+Replace `collect_audio` (Serena `replace_symbol_body`):
+
+```rust
+fn collect_audio(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+) -> std::io::Result<u64> {
+    let mut visited = HashSet::new();
+    let mut skipped = 0u64;
+    if follow_symlinks {
+        // Seed with the root's identity so a symlink pointing back to it is
+        // caught as a cycle on the first descent.
+        if let Ok(meta) = std::fs::metadata(root) {
+            visited.insert(dir_key(&meta));
+        }
+    }
+    collect_audio_inner(root, out, follow_symlinks, &mut visited, &mut skipped)?;
+    Ok(skipped)
+}
+```
+
+- [ ] **Step 5: Count unsupported extensions in `collect_audio_inner`**
+
+Replace `collect_audio_inner` (Serena `replace_symbol_body`):
+
+```rust
+fn collect_audio_inner(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+    skipped: &mut u64,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ftype = entry.file_type()?;
+        if ftype.is_dir() {
+            descend(&path, out, follow_symlinks, visited, skipped)?;
+        } else if ftype.is_file() {
+            if is_supported_audio(&path) {
+                out.push(path);
+            } else {
+                *skipped += 1;
+            }
+        } else if ftype.is_symlink() {
+            if !follow_symlinks {
+                log::warn!(
+                    "skipping symlink {} (pass --follow-symlinks to scan it)",
+                    path.display()
+                );
+                continue;
+            }
+            match std::fs::metadata(&path) {
+                Ok(meta) if meta.is_dir() => {
+                    descend(&path, out, follow_symlinks, visited, skipped)?
+                }
+                Ok(meta) if meta.is_file() => {
+                    if is_supported_audio(&path) {
+                        out.push(path);
+                    } else {
+                        *skipped += 1;
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("skipping broken symlink {}: {e}", path.display());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Thread `skipped` through `descend`**
+
+Replace `descend` (Serena `replace_symbol_body`):
+
+```rust
+fn descend(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+    skipped: &mut u64,
+) -> std::io::Result<()> {
+    if !follow_symlinks {
+        return collect_audio_inner(path, out, follow_symlinks, visited, skipped);
+    }
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("skipping directory {}: {e}", path.display());
+            return Ok(());
+        }
+    };
+    if !visited.insert(dir_key(&meta)) {
+        log::warn!("skipping symlink cycle at {}", path.display());
+        return Ok(());
+    }
+    collect_audio_inner(path, out, follow_symlinks, visited, skipped)
+}
+```
+
+- [ ] **Step 7: Map `Unparseable → failed` and drop the `skipped` atomic in `run_pipeline`**
+
+Edit `run_pipeline` (Serena `replace_symbol_body`, or targeted `replace_content` for each spot). Make exactly these four changes:
+
+1. Delete the declaration `let skipped = Arc::new(AtomicU64::new(0));`.
+2. Delete the per-worker clone line `let skipped = Arc::clone(&skipped);` (in the `for _ in 0..jobs` setup).
+3. Change the worker arm to:
+
+```rust
+                    Ok(ProbeOutcome::Unparseable) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
+```
+
+4. Change the final return to source `skipped` from nowhere (the caller fills it):
+
+```rust
+    Ok(ScanStats {
+        scanned,
+        skipped: 0,
+        failed: failed.load(Ordering::Relaxed),
+        raced: raced.load(Ordering::Relaxed),
+    })
+```
+
+- [ ] **Step 8: Fill `skipped` from collection in `scan_directory_with`**
+
+Replace `scan_directory_with` (Serena `replace_symbol_body`; keep the existing doc comment — re-include it in the body):
+
+```rust
+/// Public entry: parallel-probe / single-writer scan of `root`.
+///
+/// Insert/update a track row for each supported audio file (FLAC, MP3, M4A,
+/// Opus, Vorbis, FLAC-in-Ogg) under `root` (with audio bounds and validation
+/// stamps), seeding its tags from the file's existing metadata. `root` may be
+/// a single audio file (only that file is scanned) or a directory (walked
+/// recursively). Files whose extension is not a supported audio format
+/// increment `ScanStats::skipped`; supported-extension files with a per-file
+/// I/O or parse error increment `ScanStats::failed` and do not abort the scan.
+pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
+    let mut files = Vec::new();
+    let mut skipped = 0u64;
+    if root.is_file() {
+        if is_supported_audio(root) {
+            files.push(root.to_path_buf());
+        } else {
+            skipped += 1;
+        }
+    } else {
+        skipped += collect_audio(root, &mut files, opts.follow_symlinks)?;
+    }
+    db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
+    let mut stats = run_pipeline(db, files, opts)?;
+    stats.skipped = skipped;
+    Ok(stats)
+}
+```
+
+- [ ] **Step 9: Reclassify the oracle (`scan_directory_full_oracle`) in lockstep**
+
+Replace `scan_directory_full_oracle` (Serena `replace_symbol_body`; re-include the `#[doc(hidden)]` attribute and doc comment):
+
+```rust
+/// Test/oracle only: scan using the legacy whole-file probe (`probe_full`). The
+/// equivalence property compares this against the bounded `scan_directory`.
+#[doc(hidden)]
+pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
+    let mut files = Vec::new();
+    let mut skipped = 0u64;
+    if root.is_file() {
+        if is_supported_audio(root) {
+            files.push(root.to_path_buf());
+        } else {
+            skipped += 1;
+        }
+    } else {
+        skipped += collect_audio(root, &mut files, false)?;
+    }
+    let mut stats = ScanStats {
+        scanned: 0,
+        skipped,
+        failed: 0,
+        raced: 0,
+    };
+    for path in files {
+        let bytes = std::fs::read(&path)?;
+        let Some(probed) = probe_full(&path, &bytes) else {
+            stats.failed += 1;
+            continue;
+        };
+        let meta = std::fs::metadata(&path)?;
+        let abs = std::fs::canonicalize(&path)?;
+        ingest(db, &abs.to_string_lossy(), &meta, probed)?;
+        stats.scanned += 1;
+    }
+    Ok(stats)
+}
+```
+
+Note: `revalidate_with` needs **no edit** — its `collect_audio(...)?;` statement already discards the now-`u64` return, and reclassifying `Unparseable → failed` flows through `run_pipeline` automatically.
+
+- [ ] **Step 10: Build, lint, run the full crate suite**
+
+Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
+Expected: PASS, no warnings. The two tests from Steps 1-2 now pass; the tolerant `assert_eq!(stats.skipped + stats.failed, 1)` test (zero-byte `bad.flac`) still passes (now `failed == 1`).
+
+- [ ] **Step 11: Refresh the oracle test's kill-anchor line numbers**
+
+Find the oracle's counter lines and fill the `L<scanned>`/`L<failed>` placeholders left in Step 2:
+
+Run: `grep -n "stats.scanned += 1\|stats.failed += 1" musefs-core/src/scan.rs`
+Take the two line numbers inside `scan_directory_full_oracle` and edit the `// kills scan L<…>` comment in `scan_counters.rs` to the real numbers, e.g. `// kills scan L933 \`stats.scanned += 1\` and L928 \`stats.failed += 1\` …`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/tests/scan_counters.rs
+git commit -m "fix(scan): count unsupported extensions as skipped, malformed as failed (#301)
+
+skipped now tallies unsupported-extension files at collection; a
+supported-extension file that will not parse counts as failed, matching the
+documented ScanStats contract. The full-probe oracle is reclassified in
+lockstep so the bounded-vs-full equivalence property holds.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Deduplicate canonical backing paths under `--follow-symlinks` (#302)
+
+Add a file-level `(dev, ino)` visited set so a file reached via both a real path and a symlink (or two symlink paths) is collected once. Active only when `follow_symlinks` is true; off-mode behavior (incl. hardlinks) is unchanged.
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs` (`collect_audio`, `collect_audio_inner`, `descend`; new helper `push_file`)
+- Modify: `musefs-core/tests/scan_counters.rs` (new dedup tests)
+
+- [ ] **Step 1: Write the dedup tests (failing tests)**
+
+Append to `musefs-core/tests/scan_counters.rs`:
+
+```rust
+// === Symlink dedup under --follow-symlinks (#302) ===
+
+/// A real file and a symlink to it in the same directory ingest once: file-level
+/// (dev, ino) dedup (the directory-cycle guard does not apply to file symlinks).
+#[test]
+fn follow_symlinks_dedups_file_and_sibling_symlink() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let song = dir.path().join("song.flac");
+    std::fs::write(&song, flac_minimal(b"AUDIO-SONG")).unwrap();
+    symlink(&song, dir.path().join("link.flac")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1, "real file and its symlink ingest once");
+    assert_eq!(stats.skipped, 0);
+    assert_eq!(stats.failed, 0);
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+
+/// The same file reached through two directory paths — one real, one a file
+/// symlink in a sibling directory — ingests once. Exercises cross-directory
+/// file-level dedup.
+#[test]
+fn follow_symlinks_dedups_file_across_directories() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a");
+    let b = dir.path().join("b");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let song = a.join("song.flac");
+    std::fs::write(&song, flac_minimal(b"AUDIO-SONG")).unwrap();
+    symlink(&song, b.join("alias.flac")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1);
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+
+/// A symlinked directory pointing at an already-walked directory reaches the
+/// same file by two paths but ingests once. (This case is handled by the
+/// existing directory-cycle guard; the test locks in the combined behavior.)
+#[test]
+fn follow_symlinks_dedups_via_symlinked_directory() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    std::fs::write(real.join("song.flac"), flac_minimal(b"AUDIO-SONG")).unwrap();
+    symlink(&real, dir.path().join("mirror")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1);
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+```
+
+- [ ] **Step 2: Run the dedup tests to verify they fail**
+
+Run: `cargo test -p musefs-core follow_symlinks_dedups`
+Expected: `follow_symlinks_dedups_file_and_sibling_symlink` and `follow_symlinks_dedups_file_across_directories` FAIL with `scanned == 2` / `list_tracks().len() == 2`. (`follow_symlinks_dedups_via_symlinked_directory` already passes via the directory guard — that is fine.)
+
+- [ ] **Step 3: Add the `push_file` dedup helper**
+
+Insert a new private function after `dir_key` (Serena `insert_after_symbol` on `dir_key`):
+
+```rust
+/// Collect one supported-extension file into `out`, deduplicating by target
+/// identity when following symlinks so a real file and a symlink to it (or a
+/// file reached via two symlink paths) are ingested once. `known_meta` is the
+/// already-resolved target metadata when the caller has it (the symlink arm),
+/// avoiding a second `stat`. Dedup is best-effort: if the target cannot be
+/// `stat`ed we push it and let the probe pipeline count it rather than dropping
+/// it silently.
+fn push_file(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    files_visited: &mut HashSet<(u64, u64)>,
+    known_meta: Option<&std::fs::Metadata>,
+) {
+    if !follow_symlinks {
+        out.push(path.to_path_buf());
+        return;
+    }
+    let key = match known_meta {
+        Some(m) => Some(dir_key(m)),
+        None => std::fs::metadata(path).ok().map(|m| dir_key(&m)),
+    };
+    match key {
+        Some(k) if !files_visited.insert(k) => {
+            log::debug!("skipping duplicate backing target {}", path.display());
+        }
+        _ => out.push(path.to_path_buf()),
+    }
+}
+```
+
+- [ ] **Step 4: Thread `files_visited` and route file pushes through `push_file` in `collect_audio_inner`**
+
+Replace `collect_audio_inner` (Serena `replace_symbol_body`):
+
+```rust
+fn collect_audio_inner(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+    files_visited: &mut HashSet<(u64, u64)>,
+    skipped: &mut u64,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let ftype = entry.file_type()?;
+        if ftype.is_dir() {
+            descend(&path, out, follow_symlinks, visited, files_visited, skipped)?;
+        } else if ftype.is_file() {
+            if is_supported_audio(&path) {
+                push_file(&path, out, follow_symlinks, files_visited, None);
+            } else {
+                *skipped += 1;
+            }
+        } else if ftype.is_symlink() {
+            if !follow_symlinks {
+                log::warn!(
+                    "skipping symlink {} (pass --follow-symlinks to scan it)",
+                    path.display()
+                );
+                continue;
+            }
+            match std::fs::metadata(&path) {
+                Ok(meta) if meta.is_dir() => {
+                    descend(&path, out, follow_symlinks, visited, files_visited, skipped)?
+                }
+                Ok(meta) if meta.is_file() => {
+                    if is_supported_audio(&path) {
+                        push_file(&path, out, follow_symlinks, files_visited, Some(&meta));
+                    } else {
+                        *skipped += 1;
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("skipping broken symlink {}: {e}", path.display());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Thread `files_visited` through `descend`**
+
+Replace `descend` (Serena `replace_symbol_body`):
+
+```rust
+fn descend(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    visited: &mut HashSet<(u64, u64)>,
+    files_visited: &mut HashSet<(u64, u64)>,
+    skipped: &mut u64,
+) -> std::io::Result<()> {
+    if !follow_symlinks {
+        return collect_audio_inner(path, out, follow_symlinks, visited, files_visited, skipped);
+    }
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("skipping directory {}: {e}", path.display());
+            return Ok(());
+        }
+    };
+    if !visited.insert(dir_key(&meta)) {
+        log::warn!("skipping symlink cycle at {}", path.display());
+        return Ok(());
+    }
+    collect_audio_inner(path, out, follow_symlinks, visited, files_visited, skipped)
+}
+```
+
+- [ ] **Step 6: Create the `files_visited` set in `collect_audio`**
+
+Replace `collect_audio` (Serena `replace_symbol_body`):
+
+```rust
+fn collect_audio(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+) -> std::io::Result<u64> {
+    let mut visited = HashSet::new();
+    let mut files_visited = HashSet::new();
+    let mut skipped = 0u64;
+    if follow_symlinks {
+        // Seed with the root's identity so a symlink pointing back to it is
+        // caught as a cycle on the first descent.
+        if let Ok(meta) = std::fs::metadata(root) {
+            visited.insert(dir_key(&meta));
+        }
+    }
+    collect_audio_inner(
+        root,
+        out,
+        follow_symlinks,
+        &mut visited,
+        &mut files_visited,
+        &mut skipped,
+    )?;
+    Ok(skipped)
+}
+```
+
+- [ ] **Step 7: Build, lint, run the full crate suite**
+
+Run: `cargo test -p musefs-core && cargo clippy -p musefs-core --all-targets`
+Expected: PASS, no warnings. All three #302 tests now pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/tests/scan_counters.rs
+git commit -m "fix(scan): dedup canonical backing targets under --follow-symlinks (#302)
+
+A file-level (dev, ino) visited set, active only when following symlinks,
+collapses a real file and a symlink to it (or a file reached via two paths)
+into one collected candidate, so scanned counts distinct tracks. Off-mode
+behavior is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Documentation + release note
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (`--follow-symlinks` paragraph in the scanning section, ~344-352)
+- Modify: `CHANGELOG.md` (`[Unreleased]` section)
+
+- [ ] **Step 1: Document the dedup in ARCHITECTURE.md**
+
+In the scanning section, the `--follow-symlinks` sentence currently ends "…symlinked audio files and directories are scanned — guarded by a visited `(dev, ino)` set so symlink cycles terminate." Extend it (Edit tool — markdown):
+
+```markdown
+flag. Passing `--follow-symlinks` resolves them — symlinked audio files and
+directories are scanned — guarded by a visited `(dev, ino)` set so symlink
+cycles terminate, and by a second file-level `(dev, ino)` set so a file reached
+via both a real path and a symlink is ingested once rather than upserting its
+canonical track row twice.
+```
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+Under `## [Unreleased]`, add a `### Fixed` section (after the existing `### Added`):
+
+```markdown
+### Fixed
+
+- **Scan counters now match their documented contract:** `musefs scan` reports
+  unsupported-extension files (e.g. `.txt`, `.jpg`) as `skipped` and
+  supported-extension files that fail to parse (e.g. a corrupt `.flac`) as
+  `failed`. Previously malformed files were miscounted as `skipped` and
+  unsupported files were not counted at all (#301).
+- **Symlink scans no longer double-count:** with `--follow-symlinks`, a file
+  reached via both its real path and a symlink is ingested and counted once
+  instead of inflating `scanned` (#302).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md CHANGELOG.md
+git commit -m "docs: scan counter semantics and symlink dedup (#301, #302)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full verification + mutation gate
+
+Confirm the whole workspace is green and the mutation kill-anchors did not silently rot.
+
+- [ ] **Step 1: Workspace fmt + clippy + tests**
+
+Run: `cargo fmt --all --check && cargo clippy --all-targets --workspace -- -D warnings && cargo test --workspace`
+Expected: all PASS. This includes `musefs-core/tests/probe_equivalence.rs`, whose corpus (`common::corpus::generate`) is all valid audio of each format — no unsupported extensions or garbage — so it compares DB rows only and is unaffected by the counter reclassification; confirm it stays green. (Note per repo memory: the `rtk` hook may summarize `cargo test` output to `cargo test: N passed`; trust the exit code, not a grep for "test result".)
+
+- [ ] **Step 2: metrics-feature tests (CI's `check` job runs these; local `--workspace` skips them)**
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: PASS. This scan change touches `collect_audio`/`run_pipeline` but not the getattr/read stat counters, so these should be unaffected — confirm rather than assume.
+
+- [ ] **Step 3: Audit every `// kills scan L…` anchor for line drift**
+
+Run: `grep -n "kills scan L" musefs-core/tests/scan_counters.rs`
+For each anchor, open the cited expression in `musefs-core/src/scan.rs` and confirm the line number still matches; fix any that drifted from the Task 1b/Task 2 edits. The anchors reference lines in `probe_file`, `run_pipeline`, and `scan_directory_full_oracle` — all of which moved.
+
+- [ ] **Step 4: Run the in-diff mutation gate**
+
+Per repo convention (memory: copy-mode OOMs on worktree targets; use in-place, serial):
+
+Run: `cargo mutants --in-place -p musefs-core` (or the project's in-diff invocation `cargo mutants --in-diff <diff>` if scoped to the branch diff)
+Expected: no surviving or unviable mutants introduced by the diff. If a counter-arithmetic mutant survives, the corresponding assertion or kill-anchor needs tightening. Sanity-check that the diff fed to the gate is non-empty (an empty diff is a silent false pass).
+
+- [ ] **Step 5 (if any anchor changed): commit the anchor fixes**
+
+```bash
+git add musefs-core/tests/scan_counters.rs
+git commit -m "test(scan): refresh mutation kill-anchors after counter changes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review notes (for the executor)
+
+- **`replace_symbol_body` drops leading attributes/doc comments** — every replaced symbol in this plan re-includes its `#[test]` / `#[doc(hidden)]` / doc comment in the body. Do not strip them.
+- **Signatures change across Task 1b and Task 2** (`collect_audio` return type; `collect_audio_inner`/`descend` gain params). The code will not compile until *all* mutually-recursive callers in a task are updated — that is why each task builds only at its final "build + test" step, not between individual symbol edits.
+- **`revalidate_with` is intentionally untouched** — verify by `cargo test -p musefs-core revalidate` after Task 1b that its tests stay green.
+- **Type/name consistency check:** the variant is `ProbeOutcome::Unparseable` everywhere; the helper is `push_file`; the two visited sets are `visited` (directories) and `files_visited` (files); `collect_audio` returns `std::io::Result<u64>`.

--- a/docs/superpowers/specs/2026-06-12-scan-counters-and-symlink-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-12-scan-counters-and-symlink-dedup-design.md
@@ -1,0 +1,135 @@
+# Scan counter semantics (#301) + symlink dedup (#302)
+
+## Problem
+
+Two related defects make `musefs scan` accounting dishonest, both in
+`musefs-core/src/scan.rs`.
+
+**#301 — counters contradict their documented contract.** Collection filters
+candidates to *supported extensions* only, so non-audio files (`.txt`, `.jpg`,
+`.cue`) never reach probing and are counted nowhere. A malformed file *with* a
+supported extension (e.g. a garbage `bad.flac`) makes `probe_body` return
+`None` → `ProbeOutcome::Unsupported` → `skipped += 1`. But the doc comment on
+`scan_directory_with` states: "Unsupported-format files increment
+`ScanStats::skipped`; files with a per-file I/O or parse error increment
+`ScanStats::failed`." So today the only thing incrementing `skipped` is a parse
+failure, which the docs say should be `failed`, and genuinely unsupported files
+are silently dropped. Operators cannot tell from the summary whether files were
+unsupported, malformed, or filtered.
+
+**#302 — duplicate canonical backing paths under symlink following.** With
+`follow_symlinks` enabled, `collect_audio_inner` enqueues both a real supported
+file and a symlink to it. Workers `canonicalize` only *after* probing, so both
+candidates are probed, both `ingest_bulk` upsert the same `backing_path` row
+(`ON CONFLICT(backing_path) DO UPDATE`), and both increment `scanned`. A
+directory with `song.flac` and `link.flac -> song.flac` scanned with
+`follow_symlinks: true` reports `scanned = 2` while `list_tracks().len() == 1`,
+and re-runs tag/art replacement for the same track within one batch.
+
+## Target contract for `ScanStats`
+
+- `scanned` — distinct tracks ingested (one per canonical `backing_path`).
+- `skipped` — files ignored because their extension is not a supported audio
+  format.
+- `failed` — supported-extension files we tried but could not probe/ingest
+  (parse error, I/O error, or `canonicalize` failure).
+- `raced` — file changed under us between the pre- and post-probe `fstat`.
+
+This is exactly what the existing `scan_directory_with` doc comment already
+claims; the fix makes the code match it.
+
+## #301 — counter reclassification
+
+Three code moves in `musefs-core/src/scan.rs`:
+
+1. **Count unsupported-extension files at collection.** `collect_audio` /
+   `collect_audio_inner` silently drop non-audio files today. Thread a skipped
+   counter so every regular file (and symlink-to-file under follow) whose
+   extension is not supported increments `skipped`. `collect_audio` returns the
+   count; both `scan_directory_with` and `scan_directory_full_oracle` consume
+   it. A single-file root that is not supported audio → `skipped = 1`. Broken
+   symlinks and non-file entries stay logged-and-uncounted — they are not
+   "unsupported audio".
+
+2. **Reclassify unparseable supported files as `failed`.** Because collection
+   only ever passes supported-extension files to the probe,
+   `ProbeOutcome::Unsupported` actually means "supported extension that would
+   not parse" — a parse failure. Rename it `Unparseable` and map it to `failed`
+   in `run_pipeline`. Remove the `skipped` atomic from `run_pipeline` entirely:
+   the pipeline now yields only `scanned`/`failed`/`raced`, and `skipped` comes
+   solely from collection.
+
+3. **Keep the oracle equivalent.** `scan_directory_full_oracle` maps
+   `probe_full` → `None` to `skipped` today; change it to `failed` and source
+   `skipped` from collection, so the bounded-vs-full equivalence property still
+   holds.
+
+`revalidate_with` needs no counter wiring — its `RevalidateStats` has no
+`skipped` field — but reclassification means a tracked file that became
+malformed now correctly surfaces as `failed` rather than being miscounted,
+addressing the issue's "revalidate skip-pass failures" point.
+
+## #302 — symlink dedup
+
+Add a file-level `HashSet<(dev, ino)>` visited set beside the existing
+directory-cycle set (`dir_key`), **active only when `follow_symlinks` is
+true**:
+
+- Before pushing a supported regular file or symlink-to-file under follow,
+  fetch its `(dev, ino)`. The symlink branch already has the resolved target
+  `meta` from `std::fs::metadata(&path)`; the regular-file branch fetches
+  `metadata` only when following. If the inode is already present, skip it and
+  debug-log a duplicate-target message. A deduped duplicate is counted in **no**
+  bucket — it collapses into the single track, keeping `scanned` = distinct
+  tracks.
+- When `follow_symlinks` is false: unchanged — no extra `stat`, no dedup,
+  hardlink behavior preserved.
+
+This dedups both issue cases — a symlink to a file, and a symlinked directory
+reaching the same file via two paths — since both resolve to the same target
+inode. Reusing `(dev, ino)` is consistent with the existing cycle guard and
+avoids a per-file `canonicalize`. Because `collect_audio` is shared,
+`revalidate_with` inherits the dedup for free.
+
+## Testing
+
+Adjust the existing `scan_directory_counts_scanned_and_skipped` test (its
+garbage `bad.flac` now asserts `failed == 1`; add a `notes.txt` asserting
+`skipped == 1`).
+
+**#301 regressions:**
+
+- unsupported extension (`notes.txt`) → `skipped == 1`, never probed.
+- garbage `bad.flac` (supported ext, unparseable) → `failed == 1`.
+- unreadable file (permission denied) → `failed`.
+- file disappearing between collection and probe (open fails) → `failed`.
+- revalidate of a tracked file that became malformed → counted `failed` in
+  `RevalidateStats`.
+
+**#302 regressions:**
+
+- real file + symlink to it, `follow_symlinks: true` → `scanned == 1` and
+  `list_tracks().len() == 1`.
+- symlinked directory reaching the same file via two paths → `scanned == 1`.
+- assert full stats (`scanned`/`skipped`/`failed`) and the final track count.
+- existing bounded-vs-full oracle equivalence still green (oracle reclassified
+  in lockstep).
+
+Permission-denied and disappearing-file cases belong in the existing
+`hardening_tests` module; note that permission tests are inert when the suite
+runs as root.
+
+## Documentation
+
+- Tighten the `scan_directory_with` doc comment to state the contract precisely.
+- Update the `probe_file` doc comment (`Unsupported` → `Unparseable`).
+- Update the ARCHITECTURE.md scanning section if it describes counter
+  semantics.
+- The CLI summary string (`scanned N: M file(s), skipped X, failed Y`) needs no
+  format change — its semantics now match the words.
+
+## Out of scope
+
+- Hardlink dedup when `follow_symlinks` is false (no behavior change).
+- New `ScanStats` fields or CLI summary format changes — we chose
+  reclassification over adding distinct `unsupported`/`malformed` counters.

--- a/docs/superpowers/specs/2026-06-12-scan-counters-and-symlink-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-12-scan-counters-and-symlink-dedup-design.md
@@ -44,12 +44,22 @@ Three code moves in `musefs-core/src/scan.rs`:
 
 1. **Count unsupported-extension files at collection.** `collect_audio` /
    `collect_audio_inner` silently drop non-audio files today. Thread a skipped
-   counter so every regular file (and symlink-to-file under follow) whose
-   extension is not supported increments `skipped`. `collect_audio` returns the
-   count; both `scan_directory_with` and `scan_directory_full_oracle` consume
-   it. A single-file root that is not supported audio → `skipped = 1`. Broken
-   symlinks and non-file entries stay logged-and-uncounted — they are not
-   "unsupported audio".
+   counter so every regular file whose extension is not supported increments
+   `skipped`. `collect_audio` returns the count; both `scan_directory_with` and
+   `scan_directory_full_oracle` consume it. Specifics that must be implemented
+   precisely (the walk has several entry/branch points):
+   - **Single-file root.** The `root.is_file()` branch in *both*
+     `scan_directory_with` (scan.rs:746) and `scan_directory_full_oracle`
+     (scan.rs:917) short-circuits before `collect_audio` is ever called, so the
+     "unsupported single-file root → `skipped = 1`" increment must be added
+     directly in each entry point's `else` arm — it cannot come from threading a
+     counter through `collect_audio`.
+   - **Symlink-to-file under follow.** In the `is_symlink` / `meta.is_file()`
+     arm of `collect_audio_inner` (scan.rs:145-150), an unsupported-extension
+     target counts once as `skipped`, symmetric with the regular-file arm.
+   - **Broken symlinks, non-file entries, and symlinks skipped because
+     `follow_symlinks` is false** stay logged-and-uncounted — they are not
+     "unsupported audio" and we do not pretend to know their target format.
 
 2. **Reclassify unparseable supported files as `failed`.** Because collection
    only ever passes supported-extension files to the probe,
@@ -71,19 +81,27 @@ addressing the issue's "revalidate skip-pass failures" point.
 
 ## #302 — symlink dedup
 
-Add a file-level `HashSet<(dev, ino)>` visited set beside the existing
-directory-cycle set (`dir_key`), **active only when `follow_symlinks` is
-true**:
+Add a **separate** file-level `HashSet<(dev, ino)>` visited set (distinct from
+the existing directory-cycle set, for clarity — file and directory inodes never
+collide within a device, but a separate set keeps the two concerns independent),
+**active only when `follow_symlinks` is true**:
 
-- Before pushing a supported regular file or symlink-to-file under follow,
-  fetch its `(dev, ino)`. The symlink branch already has the resolved target
-  `meta` from `std::fs::metadata(&path)`; the regular-file branch fetches
-  `metadata` only when following. If the inode is already present, skip it and
-  debug-log a duplicate-target message. A deduped duplicate is counted in **no**
-  bucket — it collapses into the single track, keeping `scanned` = distinct
-  tracks.
-- When `follow_symlinks` is false: unchanged — no extra `stat`, no dedup,
-  hardlink behavior preserved.
+- The dedup check happens **only after** `is_supported_audio` passes, so we
+  never `stat` the many unsupported files in a music tree just to dedup them.
+- The symlink-to-file arm already has the resolved target `meta` from
+  `std::fs::metadata(&path)` (scan.rs:144); reuse it. The regular-file arm
+  (scan.rs:132-135) currently calls only `entry.file_type()`, so under follow it
+  must add one `std::fs::metadata(&path)` *after* the `is_supported_audio`
+  check.
+- **Dedup is best-effort.** If that `metadata` call fails, do **not** drop the
+  candidate — skip the dedup for it and push it normally. The pipeline then
+  probes it and counts it (`scanned`, or `failed` if the error is real),
+  matching the no-silent-drop spirit of #301 and avoiding a new error arm in the
+  walk.
+- If the inode is already present, skip the candidate and debug-log a
+  duplicate-target message. A deduped duplicate is counted in **no** bucket — it
+  collapses into the single track, keeping `scanned` = distinct tracks.
+- When `follow_symlinks` is false: unchanged — no extra `stat`, no dedup.
 
 This dedups both issue cases — a symlink to a file, and a symlinked directory
 reaching the same file via two paths — since both resolve to the same target
@@ -91,10 +109,50 @@ inode. Reusing `(dev, ino)` is consistent with the existing cycle guard and
 avoids a per-file `canonicalize`. Because `collect_audio` is shared,
 `revalidate_with` inherits the dedup for free.
 
+**Acknowledged behavior change:** because `(dev, ino)` cannot distinguish "a
+symlink to X" from "a second hardlink to X", two hardlinks to the same inode
+reached via two paths *under `follow_symlinks: true`* now collapse to one
+`scanned` track (today they `canonicalize` to two distinct paths → two tracks).
+This is the intended outcome — one set of audio bytes is one logical track — and
+is confined to the opt-in follow mode. It is called out so it is not mistaken
+for a regression.
+
 ## Testing
 
-Adjust the existing `scan_directory_counts_scanned_and_skipped` test (its
-garbage `bad.flac` now asserts `failed == 1`; add a `notes.txt` asserting
+**External test files that encode the OLD semantics must be updated in lockstep
+— missing them means a red pre-commit suite.** Beyond the in-module tests in
+`scan.rs`, two integration files in `musefs-core/tests/` assert the current
+behavior, and some assertions carry **line-anchored mutation-gate kill
+comments** (`// kills scan L<n> …`) that move when the counter arithmetic moves:
+
+- `musefs-core/tests/scan_counters.rs`:
+  - `oracle_counts_scanned_and_skipped_exactly` (line ~344) writes garbage
+    `bad.flac` and asserts `stats.skipped == 1` via `scan_directory_full_oracle`
+    — must flip to `stats.failed == 1`. Its `// kills scan L858 stats.skipped
+    += 1 …` anchor (line ~342) refers to the oracle line we are changing from
+    `skipped += 1` to `failed += 1`; update the comment's line number, the cited
+    expression, and re-confirm the mutant is still killed.
+  - `revalidate_failed_carries_scan_failure` (line ~294, `// kills scan L711`)
+    relies on `RevalidateStats.failed == scan.failed + skip_failed`. The field
+    set is unchanged, but reclassifying `Unparseable → failed` changes what
+    `scan.failed` *contains*; re-verify this test passes rather than assuming it
+    is inert, and refresh its line anchor if shifted.
+  - Audit every other `// kills scan L…` anchor in this file (lines ~81, ~124,
+    ~170, ~219, ~260) — any that reference lines after the edits shift and need
+    their numbers refreshed.
+- `musefs-core/tests/probe_equivalence.rs` compares the bounded path against
+  `scan_directory_full_oracle`. Equivalence holds only if *both* sides
+  reclassify `None → failed` and source `skipped` from collection identically;
+  verify its corpus does not contain unsupported-extension files that would now
+  diverge.
+
+After the edits, re-run the in-diff mutation gate locally (per project
+convention: `cargo mutants --in-place`, serial) to confirm no anchor turned a
+killed mutant into a survivor or a false pass, and `cargo fmt --all --check`
+(the line anchors are fmt-fragile).
+
+Adjust the existing in-module `scan_directory_counts_scanned_and_skipped` test
+(its garbage `bad.flac` now asserts `failed == 1`; add a `notes.txt` asserting
 `skipped == 1`).
 
 **#301 regressions:**
@@ -122,14 +180,24 @@ runs as root.
 ## Documentation
 
 - Tighten the `scan_directory_with` doc comment to state the contract precisely.
-- Update the `probe_file` doc comment (`Unsupported` → `Unparseable`).
+- Rename `ProbeOutcome::Unsupported → Unparseable` at every site: the enum
+  variant (scan.rs:37-45), its construction in `probe_file` (scan.rs:333), the
+  `run_pipeline` match arm (scan.rs:811), both mentions in the `probe_file` doc
+  comment (scan.rs:308-316), and the unit test
+  `oversize_unparseable_file_is_skipped_not_read_whole` (scan.rs:~2309) — whose
+  name/assert may also need to reflect that the file is now counted `failed`,
+  not skipped.
 - Update the ARCHITECTURE.md scanning section if it describes counter
   semantics.
 - The CLI summary string (`scanned N: M file(s), skipped X, failed Y`) needs no
-  format change — its semantics now match the words.
+  format change, but the *meaning* shifts for operators: malformed files move
+  from `skipped` to `failed`, and non-audio files now appear in `skipped`. Add a
+  one-line CHANGELOG / release note so the behavior change is discoverable.
 
 ## Out of scope
 
-- Hardlink dedup when `follow_symlinks` is false (no behavior change).
+- Hardlink dedup when `follow_symlinks` is false (no behavior change). Hardlink
+  dedup *under* follow happens as a side effect of `(dev, ino)` — see the
+  acknowledged behavior change in the #302 section.
 - New `ScanStats` fields or CLI summary format changes — we chose
   reclassification over adding distinct `unsupported`/`malformed` counters.

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -35,13 +35,14 @@ pub(crate) const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
 /// payloads (e.g. a GEOB embedding a multi-MB file) are logged-and-skipped.
 const MAX_BINARY_TAG_BYTES: usize = MAX_ART_BYTES;
 
-/// Outcome of probing one backing file. `Raced` means the file changed under us
-/// between the pre- and post-probe `fstat` — the probe may be torn, so nothing
-/// is committed for it (#276).
+/// Outcome of probing one backing file. `Unparseable` is a supported-extension
+/// file whose bytes did not parse (counted as a scan `failed`). `Raced` means
+/// the file changed under us between the pre- and post-probe `fstat` — the probe
+/// may be torn, so nothing is committed for it (#276).
 #[derive(Debug)]
 enum ProbeOutcome {
     Probed(Probed, BackingStamp),
-    Unsupported,
+    Unparseable,
     Raced,
 }
 
@@ -106,8 +107,9 @@ fn collect_audio(
     root: &Path,
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
-) -> std::io::Result<()> {
+) -> std::io::Result<u64> {
     let mut visited = HashSet::new();
+    let mut skipped = 0u64;
     if follow_symlinks {
         // Seed with the root's identity so a symlink pointing back to it is
         // caught as a cycle on the first descent.
@@ -115,7 +117,8 @@ fn collect_audio(
             visited.insert(dir_key(&meta));
         }
     }
-    collect_audio_inner(root, out, follow_symlinks, &mut visited)
+    collect_audio_inner(root, out, follow_symlinks, &mut visited, &mut skipped)?;
+    Ok(skipped)
 }
 
 fn collect_audio_inner(
@@ -123,16 +126,19 @@ fn collect_audio_inner(
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
+    skipped: &mut u64,
 ) -> std::io::Result<()> {
     for entry in std::fs::read_dir(root)? {
         let entry = entry?;
         let path = entry.path();
         let ftype = entry.file_type()?;
         if ftype.is_dir() {
-            descend(&path, out, follow_symlinks, visited)?;
+            descend(&path, out, follow_symlinks, visited, skipped)?;
         } else if ftype.is_file() {
             if is_supported_audio(&path) {
                 out.push(path);
+            } else {
+                *skipped += 1;
             }
         } else if ftype.is_symlink() {
             if !follow_symlinks {
@@ -143,10 +149,14 @@ fn collect_audio_inner(
                 continue;
             }
             match std::fs::metadata(&path) {
-                Ok(meta) if meta.is_dir() => descend(&path, out, follow_symlinks, visited)?,
+                Ok(meta) if meta.is_dir() => {
+                    descend(&path, out, follow_symlinks, visited, skipped)?;
+                }
                 Ok(meta) if meta.is_file() => {
                     if is_supported_audio(&path) {
                         out.push(path);
+                    } else {
+                        *skipped += 1;
                     }
                 }
                 Ok(_) => {}
@@ -164,9 +174,10 @@ fn descend(
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
+    skipped: &mut u64,
 ) -> std::io::Result<()> {
     if !follow_symlinks {
-        return collect_audio_inner(path, out, follow_symlinks, visited);
+        return collect_audio_inner(path, out, follow_symlinks, visited, skipped);
     }
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
@@ -179,7 +190,7 @@ fn descend(
         log::warn!("skipping symlink cycle at {}", path.display());
         return Ok(());
     }
-    collect_audio_inner(path, out, follow_symlinks, visited)
+    collect_audio_inner(path, out, follow_symlinks, visited, skipped)
 }
 
 fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
@@ -312,8 +323,9 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
 /// probe. Never reads the audio payload (M4A uses the seek reader;
 /// front-anchored formats read only the metadata extent).
 ///
-/// Returns `ProbeOutcome::Unsupported` for an unsupported/unparseable file (to
-/// be skipped) and `ProbeOutcome::Raced` if the file changed under us.
+/// Returns `ProbeOutcome::Unparseable` for a supported-extension file that does
+/// not parse (counted as `failed`) and `ProbeOutcome::Raced` if the file
+/// changed under us.
 fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();
@@ -330,7 +342,7 @@ fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     }
     Ok(match probed {
         Some(p) => ProbeOutcome::Probed(p, s1),
-        None => ProbeOutcome::Unsupported,
+        None => ProbeOutcome::Unparseable,
     })
 }
 
@@ -739,20 +751,24 @@ fn ingest_bulk(
 /// Opus, Vorbis, FLAC-in-Ogg) under `root` (with audio bounds and validation
 /// stamps), seeding its tags from the file's existing metadata. `root` may be
 /// a single audio file (only that file is scanned) or a directory (walked
-/// recursively). Unsupported-format files increment `ScanStats::skipped`; files
-/// with a per-file I/O or parse error increment `ScanStats::failed` and do not
-/// abort the scan.
+/// recursively). Files whose extension is not a supported audio format
+/// increment `ScanStats::skipped`; supported-extension files with a per-file
+/// I/O or parse error increment `ScanStats::failed` and do not abort the scan.
 pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
     let mut files = Vec::new();
+    let mut skipped = 0u64;
     if root.is_file() {
         if is_supported_audio(root) {
             files.push(root.to_path_buf());
+        } else {
+            skipped += 1;
         }
     } else {
-        collect_audio(root, &mut files, opts.follow_symlinks)?;
+        skipped += collect_audio(root, &mut files, opts.follow_symlinks)?;
     }
     db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
-    let stats = run_pipeline(db, files, opts)?;
+    let mut stats = run_pipeline(db, files, opts)?;
+    stats.skipped = skipped;
     Ok(stats)
 }
 
@@ -772,7 +788,6 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
     let window = opts.window;
     let cap = opts.batch_bytes;
     let budget = Arc::new(ByteBudget::new(cap));
-    let skipped = Arc::new(AtomicU64::new(0));
     let failed = Arc::new(AtomicU64::new(0));
     let raced = Arc::new(AtomicU64::new(0));
 
@@ -785,7 +800,6 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         let work = Arc::clone(&work);
         let tx = tx.clone();
         let budget = Arc::clone(&budget);
-        let skipped = Arc::clone(&skipped);
         let failed = Arc::clone(&failed);
         let raced = Arc::clone(&raced);
         workers.push(std::thread::spawn(move || {
@@ -811,14 +825,11 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                             break;
                         }
                     }
-                    Ok(ProbeOutcome::Unsupported) => {
-                        skipped.fetch_add(1, Ordering::Relaxed);
+                    Ok(ProbeOutcome::Unparseable) | Err(_) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
                     }
                     Ok(ProbeOutcome::Raced) => {
                         raced.fetch_add(1, Ordering::Relaxed);
-                    }
-                    Err(_) => {
-                        failed.fetch_add(1, Ordering::Relaxed);
                     }
                 }
             }
@@ -902,7 +913,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
 
     Ok(ScanStats {
         scanned,
-        skipped: skipped.load(Ordering::Relaxed),
+        skipped: 0,
         failed: failed.load(Ordering::Relaxed),
         raced: raced.load(Ordering::Relaxed),
     })
@@ -913,23 +924,26 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
 #[doc(hidden)]
 pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
     let mut files = Vec::new();
+    let mut skipped = 0u64;
     if root.is_file() {
         if is_supported_audio(root) {
             files.push(root.to_path_buf());
+        } else {
+            skipped += 1;
         }
     } else {
-        collect_audio(root, &mut files, false)?;
+        skipped += collect_audio(root, &mut files, false)?;
     }
     let mut stats = ScanStats {
         scanned: 0,
-        skipped: 0,
+        skipped,
         failed: 0,
         raced: 0,
     };
     for path in files {
         let bytes = std::fs::read(&path)?;
         let Some(probed) = probe_full(&path, &bytes) else {
-            stats.skipped += 1;
+            stats.failed += 1;
             continue;
         };
         let meta = std::fs::metadata(&path)?;
@@ -1710,7 +1724,7 @@ mod hardening_tests {
     }
 
     #[test]
-    fn scan_directory_counts_scanned_and_skipped() {
+    fn scan_directory_counts_scanned_failed_and_skipped() {
         let dir = tempfile::tempdir().unwrap();
         write_flac(
             &dir.path().join("ok1.flac"),
@@ -1722,10 +1736,14 @@ mod hardening_tests {
             &["ARTIST=A", "TITLE=T2"],
             None,
         );
+        // Supported extension, unparseable bytes → a scan failure.
         std::fs::write(dir.path().join("bad.flac"), b"garbage").unwrap();
+        // Unsupported extension → skipped at collection, never probed.
+        std::fs::write(dir.path().join("notes.txt"), b"hello").unwrap();
         let db = musefs_db::Db::open_in_memory().unwrap();
         let stats = crate::scan_directory(&db, dir.path()).unwrap();
         assert_eq!(stats.scanned, 2);
+        assert_eq!(stats.failed, 1);
         assert_eq!(stats.skipped, 1);
     }
 
@@ -2306,7 +2324,7 @@ mod bounded_probe_tests {
 
         assert!(matches!(
             probe_file(&path, WINDOW).unwrap(),
-            ProbeOutcome::Unsupported
+            ProbeOutcome::Unparseable
         ));
     }
 

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -109,6 +109,7 @@ fn collect_audio(
     follow_symlinks: bool,
 ) -> std::io::Result<u64> {
     let mut visited = HashSet::new();
+    let mut files_visited = HashSet::new();
     let mut skipped = 0u64;
     if follow_symlinks {
         // Seed with the root's identity so a symlink pointing back to it is
@@ -117,7 +118,14 @@ fn collect_audio(
             visited.insert(dir_key(&meta));
         }
     }
-    collect_audio_inner(root, out, follow_symlinks, &mut visited, &mut skipped)?;
+    collect_audio_inner(
+        root,
+        out,
+        follow_symlinks,
+        &mut visited,
+        &mut files_visited,
+        &mut skipped,
+    )?;
     Ok(skipped)
 }
 
@@ -126,6 +134,7 @@ fn collect_audio_inner(
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
+    files_visited: &mut HashSet<(u64, u64)>,
     skipped: &mut u64,
 ) -> std::io::Result<()> {
     for entry in std::fs::read_dir(root)? {
@@ -133,10 +142,10 @@ fn collect_audio_inner(
         let path = entry.path();
         let ftype = entry.file_type()?;
         if ftype.is_dir() {
-            descend(&path, out, follow_symlinks, visited, skipped)?;
+            descend(&path, out, follow_symlinks, visited, files_visited, skipped)?;
         } else if ftype.is_file() {
             if is_supported_audio(&path) {
-                out.push(path);
+                push_file(&path, out, follow_symlinks, files_visited, None);
             } else {
                 *skipped += 1;
             }
@@ -150,11 +159,11 @@ fn collect_audio_inner(
             }
             match std::fs::metadata(&path) {
                 Ok(meta) if meta.is_dir() => {
-                    descend(&path, out, follow_symlinks, visited, skipped)?;
+                    descend(&path, out, follow_symlinks, visited, files_visited, skipped)?;
                 }
                 Ok(meta) if meta.is_file() => {
                     if is_supported_audio(&path) {
-                        out.push(path);
+                        push_file(&path, out, follow_symlinks, files_visited, Some(&meta));
                     } else {
                         *skipped += 1;
                     }
@@ -174,10 +183,11 @@ fn descend(
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
+    files_visited: &mut HashSet<(u64, u64)>,
     skipped: &mut u64,
 ) -> std::io::Result<()> {
     if !follow_symlinks {
-        return collect_audio_inner(path, out, follow_symlinks, visited, skipped);
+        return collect_audio_inner(path, out, follow_symlinks, visited, files_visited, skipped);
     }
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
@@ -190,12 +200,42 @@ fn descend(
         log::warn!("skipping symlink cycle at {}", path.display());
         return Ok(());
     }
-    collect_audio_inner(path, out, follow_symlinks, visited, skipped)
+    collect_audio_inner(path, out, follow_symlinks, visited, files_visited, skipped)
 }
 
 fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
     use std::os::unix::fs::MetadataExt;
     (meta.dev(), meta.ino())
+}
+
+/// Collect one supported-extension file into `out`, deduplicating by target
+/// identity when following symlinks so a real file and a symlink to it (or a
+/// file reached via two symlink paths) are ingested once. `known_meta` is the
+/// already-resolved target metadata when the caller has it (the symlink arm),
+/// avoiding a second `stat`. Dedup is best-effort: if the target cannot be
+/// `stat`ed we push it and let the probe pipeline count it rather than dropping
+/// it silently.
+fn push_file(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    files_visited: &mut HashSet<(u64, u64)>,
+    known_meta: Option<&std::fs::Metadata>,
+) {
+    if !follow_symlinks {
+        out.push(path.to_path_buf());
+        return;
+    }
+    let key = match known_meta {
+        Some(m) => Some(dir_key(m)),
+        None => std::fs::metadata(path).ok().map(|m| dir_key(&m)),
+    };
+    match key {
+        Some(k) if !files_visited.insert(k) => {
+            log::debug!("skipping duplicate backing target {}", path.display());
+        }
+        _ => out.push(path.to_path_buf()),
+    }
 }
 
 /// A backing file parsed into the fields a track row needs, plus its raw
@@ -768,6 +808,7 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
     }
     db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
     let mut stats = run_pipeline(db, files, opts)?;
+    // skipped is tallied during the walk, not the pipeline
     stats.skipped = skipped;
     Ok(stats)
 }
@@ -913,7 +954,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
 
     Ok(ScanStats {
         scanned,
-        skipped: 0,
+        skipped: 0, // counted at walk time; filled in by scan_directory_with
         failed: failed.load(Ordering::Relaxed),
         raced: raced.load(Ordering::Relaxed),
     })

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -507,3 +507,27 @@ fn follow_symlinks_mirrored_dir_counts_unsupported_file_once() {
     assert_eq!(stats.scanned, 0);
     assert_eq!(stats.skipped, 1, "notes.txt is skipped once, not twice");
 }
+
+/// Two hardlinks to the same inode collapse to a single track under follow: the
+/// `(dev, ino)` dedup keys on inode identity, so hardlinks dedup like symlinks.
+/// Locks in the documented #302 side effect.
+#[test]
+fn follow_symlinks_dedups_hardlinks_to_same_inode() {
+    let dir = tempfile::tempdir().unwrap();
+    let song = dir.path().join("song.flac");
+    std::fs::write(&song, flac_minimal(b"AUDIO-SONG")).unwrap();
+    std::fs::hard_link(&song, dir.path().join("link.flac")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(
+        stats.scanned, 1,
+        "hardlinks to one inode ingest once under follow"
+    );
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -331,27 +331,53 @@ fn revalidate_failed_carries_scan_failure() {
     );
 }
 
-// === Full-probe oracle counters (scan_directory_full_oracle, lines 858/864) ===
+// === Full-probe oracle counters (scan_directory_full_oracle) ===
 
-/// The full-file-probe oracle's `scanned`/`skipped` counters must reflect the
-/// corpus exactly. A directory with one valid FLAC and one extension-only
-/// `.flac` of garbage (collected by `is_supported_audio`, then rejected by
-/// `probe_full`) yields scanned == 1, skipped == 1. The `+=`→`-=` mutants
-/// underflow-panic from 0 and `+=`→`*=` pin the counter at 0, so both counters
-/// must be asserted nonzero and exact.
-// kills scan L858 `stats.skipped += 1` and L864 `stats.scanned += 1` `+=`→`-=`/`*=`
+/// The full-file-probe oracle's `scanned`/`failed`/`skipped` counters must
+/// reflect the corpus exactly: one valid FLAC (`scanned`), one extension-only
+/// `.flac` of garbage that `is_supported_audio` collects but `probe_full`
+/// rejects (`failed`), and one unsupported-extension file dropped at collection
+/// (`skipped`). Asserting all three nonzero-and-exact kills the `+=`→`-=`
+/// (underflow-panic from 0) and `+=`→`*=` (pinned at 0) mutants on the oracle's
+/// `stats.scanned += 1` / `stats.failed += 1` and on collection's `*skipped += 1`.
 #[test]
-fn oracle_counts_scanned_and_skipped_exactly() {
+fn oracle_counts_scanned_failed_and_skipped_exactly() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("good.flac"), flac_minimal(b"AUDIO-OK")).unwrap();
-    // Extension-only: `is_supported_audio` collects it, but `probe_full` returns
-    // None (no fLaC marker) → counted as skipped, not scanned.
+    // Extension-only: collected by `is_supported_audio`, rejected by `probe_full`.
     std::fs::write(dir.path().join("bad.flac"), b"not a flac at all").unwrap();
+    // Unsupported extension: dropped at collection → skipped.
+    std::fs::write(dir.path().join("notes.txt"), b"not audio").unwrap();
 
     let db = Db::open_in_memory().unwrap();
     let stats = scan_directory_full_oracle(&db, dir.path()).unwrap();
 
     assert_eq!(stats.scanned, 1, "exactly the one valid FLAC is scanned");
-    assert_eq!(stats.skipped, 1, "the garbage .flac is skipped");
+    assert_eq!(stats.failed, 1, "the garbage .flac is a failure");
+    assert_eq!(stats.skipped, 1, "the .txt is skipped at collection");
     assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+
+/// Under follow, a symlink whose target has an unsupported extension counts as
+/// skipped, symmetric with a regular unsupported file. Covers the symlink-arm
+/// `*skipped += 1` site.
+#[test]
+fn follow_symlinks_counts_unsupported_symlink_target_as_skipped() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let txt = dir.path().join("notes.txt");
+    std::fs::write(&txt, b"hi").unwrap();
+    symlink(&txt, dir.path().join("link.txt")).unwrap();
+    std::fs::write(dir.path().join("song.flac"), flac_minimal(b"AUDIO")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1);
+    // notes.txt (regular) + link.txt (symlink target) → both skipped.
+    assert_eq!(stats.skipped, 2);
 }

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -355,6 +355,79 @@ fn oracle_counts_scanned_failed_and_skipped_exactly() {
     assert_eq!(stats.scanned, 1, "exactly the one valid FLAC is scanned");
     assert_eq!(stats.failed, 1, "the garbage .flac is a failure");
     assert_eq!(stats.skipped, 1, "the .txt is skipped at collection");
+}
+
+// === Symlink dedup under --follow-symlinks (#302) ===
+
+/// A real file and a symlink to it in the same directory ingest once: file-level
+/// (dev, ino) dedup (the directory-cycle guard does not apply to file symlinks).
+#[test]
+fn follow_symlinks_dedups_file_and_sibling_symlink() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let song = dir.path().join("song.flac");
+    std::fs::write(&song, flac_minimal(b"AUDIO-SONG")).unwrap();
+    symlink(&song, dir.path().join("link.flac")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1, "real file and its symlink ingest once");
+    assert_eq!(stats.skipped, 0);
+    assert_eq!(stats.failed, 0);
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+
+/// The same file reached through two directory paths — one real, one a file
+/// symlink in a sibling directory — ingests once. Exercises cross-directory
+/// file-level dedup.
+#[test]
+fn follow_symlinks_dedups_file_across_directories() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a");
+    let b = dir.path().join("b");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let song = a.join("song.flac");
+    std::fs::write(&song, flac_minimal(b"AUDIO-SONG")).unwrap();
+    symlink(&song, b.join("alias.flac")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1);
+    assert_eq!(db.list_tracks().unwrap().len(), 1);
+}
+
+/// A symlinked directory pointing at an already-walked directory reaches the
+/// same file by two paths but ingests once. (Handled by the existing
+/// directory-cycle guard; this locks in the combined behavior.)
+#[test]
+fn follow_symlinks_dedups_via_symlinked_directory() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    std::fs::write(real.join("song.flac"), flac_minimal(b"AUDIO-SONG")).unwrap();
+    symlink(&real, dir.path().join("mirror")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 1);
     assert_eq!(db.list_tracks().unwrap().len(), 1);
 }
 

--- a/musefs-core/tests/scan_counters.rs
+++ b/musefs-core/tests/scan_counters.rs
@@ -454,3 +454,56 @@ fn follow_symlinks_counts_unsupported_symlink_target_as_skipped() {
     // notes.txt (regular) + link.txt (symlink target) → both skipped.
     assert_eq!(stats.skipped, 2);
 }
+
+/// A single unsupported file passed directly as the scan root is counted as
+/// skipped (kills the `scan_directory_with` single-file-root `skipped += 1`
+/// mutants — `-=` underflow-panics from 0, `*=` pins at 0).
+#[test]
+fn scan_single_unsupported_file_root_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let txt = dir.path().join("notes.txt");
+    std::fs::write(&txt, b"hi").unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, &txt).unwrap();
+    assert_eq!(stats.scanned, 0);
+    assert_eq!(stats.skipped, 1);
+}
+
+/// Same single-unsupported-file root, via the full-probe oracle (kills the
+/// oracle's single-file-root `skipped += 1` mutants).
+#[test]
+fn oracle_single_unsupported_file_root_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let txt = dir.path().join("notes.txt");
+    std::fs::write(&txt, b"hi").unwrap();
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_full_oracle(&db, &txt).unwrap();
+    assert_eq!(stats.scanned, 0);
+    assert_eq!(stats.skipped, 1);
+}
+
+/// Under follow, an unsupported file inside a directory that is ALSO reached via
+/// a directory symlink is counted as skipped exactly once: the directory-cycle
+/// guard skips the symlinked re-entry. Unsupported files are not file-deduped,
+/// so a missing guard would double-count `skipped` (kills the `descend`
+/// `if !follow_symlinks` gate mutant). The symlink targets a sibling real dir,
+/// not a cycle, so the walk terminates.
+#[test]
+fn follow_symlinks_mirrored_dir_counts_unsupported_file_once() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    std::fs::write(real.join("notes.txt"), b"not audio").unwrap();
+    symlink(&real, dir.path().join("mirror")).unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        follow_symlinks: true,
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+
+    assert_eq!(stats.scanned, 0);
+    assert_eq!(stats.skipped, 1, "notes.txt is skipped once, not twice");
+}


### PR DESCRIPTION
## Summary

Two related scan-accounting fixes in `musefs-core/src/scan.rs`.

- **#301 — counters match their documented contract.** `skipped` now tallies
  unsupported-extension files at the directory walk (previously uncounted);
  a supported-extension file that won't parse counts as `failed` (previously
  miscounted as `skipped`). `ProbeOutcome::Unsupported` is renamed `Unparseable`
  and mapped to `failed` in `run_pipeline`; the full-probe test oracle is
  reclassified in lockstep so the bounded-vs-full equivalence property holds.
  `scanned + skipped + failed` now partitions candidates exactly.
- **#302 — no double-counting under `--follow-symlinks`.** A file-level
  `(dev, ino)` visited set (separate from the existing directory-cycle guard),
  active only when following symlinks, collapses a file reached via both its real
  path and a symlink into one ingested track instead of inflating `scanned`.
  Hardlinks to the same inode are likewise collapsed under follow.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- [x] `cargo test --workspace` — 982 passed
- [x] `cargo test -p musefs-core --features metrics` — 391 passed (CI `check` job)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Mutant-anchor drift guard (`scripts/check_mutant_anchors.py`) — OK; `.cargo/mutants.toml` re-anchored for the line shifts
- [x] In-diff mutation gate over the `scan.rs` diff — 0 missed (new tests cover single-unsupported-file roots and the symlinked-directory skip-count)
- New regression tests in `musefs-core/tests/scan_counters.rs`: unsupported extension, garbage `.flac`, single-unsupported-file root, symlink/file dedup (same dir + cross dir), symlinked-directory mirror, and unsupported-symlink-target counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)