### PR TITLE
Harden deployment assets: scanner sandbox, mount-unit fix, non-root containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ than FUSE mounting (mounting arbitrary filesystems, and more). It is unavoidable
 for an in-container FUSE mount, but it is another reason to prefer running musefs
 on the host, which needs no such capability.
 
+#### Runs as a non-root user
+
+The images run as a dedicated unprivileged user (default uid/gid 1000), not
+root — musefs mounts via the setuid `fusermount3` helper and needs no root of
+its own. Consequences for the commands above:
+
+- The bind-mounted **store** volume must be writable by that uid. Either
+  `chown 1000:1000 /path/to/store` on the host, or add `--user $(id -u):$(id -g)`
+  to run as your own uid. The **library** volume is mounted `:ro`, so its
+  ownership does not matter.
+- To bake an image whose user matches your host account (so no `chown` or
+  `--user` is needed), build from source with
+  `--build-arg MUSEFS_UID=$(id -u) --build-arg MUSEFS_GID=$(id -g)`.
+- The images include `user_allow_other` in `/etc/fuse.conf`, so a non-root
+  `--allow-other` / `--owner` / `--group` mount (used by the pod pattern below)
+  passes musefs's pre-flight check. See
+  [Ownership and permissions](#ownership-and-permissions).
+
 #### The mount-visibility gotcha (read this before sharing the mount)
 
 A FUSE mount made **inside** a container lives in that container's mount
@@ -306,7 +324,9 @@ world bits (e.g. `--file-mode 440 --dir-mode 550`) — only then does
 refuses an `allow_other` mount unless `/etc/fuse.conf` contains a line
 `user_allow_other`. musefs checks this before mounting and fails with an
 explanatory error if it is missing; add the line to `/etc/fuse.conf`, or run
-musefs as root. (This is libfuse/system policy, not a musefs restriction.)
+musefs as root. (This is libfuse/system policy, not a musefs restriction.) The
+published container images already include this line, so non-root `allow_other`
+mounts work out of the box there.
 
 ### Configuring with environment variables
 

--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -28,6 +28,31 @@ Enable the periodic re-scan too (edit the library path in
 systemctl --user enable --now musefs-scan.timer
 ```
 
+## Hardening
+
+These units run under the `--user` manager, which constrains what systemd
+sandboxing is possible. The two units differ sharply:
+
+- **`musefs-scan.service` is fully sandboxed.** The scanner creates no FUSE
+  mount, so it takes a strong sandbox (`ProtectSystem=true`, `SystemCallFilter=`,
+  plus namespace and seccomp restrictions). `ProtectSystem=true` (not `strict`)
+  keeps system directories read-only while leaving your library and `MUSEFS_DB`
+  writable, so a custom DB location needs no `ReadWritePaths=` edit. A few
+  directives that require capability-bounding-set drops
+  (`CapabilityBoundingSet=`, `PrivateDevices`, `ProtectKernelModules`,
+  `ProtectKernelLogs`, `ProtectClock`) are omitted: the unprivileged user
+  manager cannot apply them, and the process is already capability-less, so
+  nothing is lost. Inspect with
+  `systemd-analyze --user security musefs-scan.service`.
+
+- **`musefs.service` is intentionally *not* sandboxed, and cannot be.** musefs
+  mounts via the **setuid** `fusermount3` helper. `NoNewPrivileges=true` — and
+  nearly every other systemd hardening directive, since installing a seccomp
+  filter for an unprivileged process forces the kernel `no_new_privs` flag —
+  disables the setuid escalation, and the mount then fails with `fusermount3:
+  mount failed: Operation not permitted`. The unit comment explains this in
+  full.
+
 ## Notes
 
 - **Binary location.** The `--user` manager does not inherit your shell's

--- a/contrib/systemd/musefs-scan.service
+++ b/contrib/systemd/musefs-scan.service
@@ -8,3 +8,40 @@ EnvironmentFile=-%h/.config/musefs/musefs.conf
 Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
 # Scan target(s) are not env-configurable; set your library path here.
 ExecStart=musefs scan %h/Music --revalidate
+
+# --- Sandbox -------------------------------------------------------------
+# The scanner creates no FUSE mount, so it can take a strong systemd sandbox
+# (unlike musefs.service). None of these directives needs to know where your
+# library or DB live: ProtectSystem=true keeps system dirs read-only while
+# leaving $HOME and data volumes writable, so a custom MUSEFS_DB path works
+# with no ReadWritePaths= edit.
+#
+# NOTE: these run under the --user manager (see README). Directives that drop
+# capability-bounding-set bits fail there with 218/CAPABILITIES — the
+# unprivileged user manager cannot manipulate the bounding set. So the following
+# are deliberately OMITTED: CapabilityBoundingSet=, PrivateDevices,
+# ProtectKernelModules, ProtectKernelLogs, ProtectClock. They lose nothing here:
+# the process is already capability-less (unprivileged + NoNewPrivileges), so it
+# cannot exercise CAP_MKNOD / CAP_SYS_MODULE / CAP_SYSLOG / CAP_SYS_TIME anyway.
+NoNewPrivileges=true
+ProtectSystem=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+# ProtectHostname is omitted too: under --user it is a no-op and logs a
+# "UTS namespace setup is prohibited" warning on every run.
+# ProcSubset=pid hides non-pid /proc; a future parser reading /proc/cpuinfo for
+# SIMD detection would need this relaxed.
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=true
+# AF_UNIX is REQUIRED for journald logging; do NOT drop to none.
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+UMask=077

--- a/contrib/systemd/musefs.service
+++ b/contrib/systemd/musefs.service
@@ -15,10 +15,19 @@ ExecStart=musefs mount
 #ExecStop=-fusermount3 -u ${MUSEFS_MOUNTPOINT}
 Restart=on-failure
 RestartSec=5
-# NoNewPrivileges is safe for a FUSE mount. Do NOT add ProtectHome=,
-# PrivateMounts=, or MountFlags=private: they place the mount in a private
-# namespace and hide it from the rest of your session.
-NoNewPrivileges=true
+# This unit is deliberately NOT sandboxed, and that cannot be changed without
+# breaking the mount. musefs mounts via the *setuid* fusermount3 helper, and
+# NoNewPrivileges=true disables the setuid escalation, so the mount fails with
+# "fusermount3: mount failed: Operation not permitted". Crucially, nearly every
+# systemd hardening directive (SystemCallFilter=, Restrict*, LockPersonality=,
+# MemoryDenyWriteExecute=, ProtectKernel*, ProtectControlGroups=, ...) forces
+# the kernel no_new_privs flag — it is required to install a seccomp filter for
+# an unprivileged process — which breaks the mount the same way, *even with*
+# NoNewPrivileges=no. So none of them can be added here.
+# Do NOT add ProtectHome=, PrivateMounts=, or MountFlags=private either: those
+# place the mount in a private namespace and hide it from the rest of your
+# session.
+# (The scanner, musefs-scan.service, creates no mount and IS fully sandboxed.)
 
 [Install]
 WantedBy=default.target

--- a/docker/Dockerfile.glibc
+++ b/docker/Dockerfile.glibc
@@ -6,9 +6,23 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends fuse3 \
  && rm -rf /var/lib/apt/lists/*
 
+# Run as a dedicated unprivileged user. musefs mounts via the setuid fusermount3
+# helper and needs no root. The uid/gid default to 1000 but are build-arg
+# configurable: build with `--build-arg MUSEFS_UID=$(id -u) --build-arg
+# MUSEFS_GID=$(id -g)` to match your host owner and skip the store chown.
+# A bind-mounted store volume must be writable by the chosen uid.
+# user_allow_other lets a non-root --allow-other / --owner mount pass musefs's
+# /etc/fuse.conf pre-flight check (needed for the multi-container pod pattern).
+ARG MUSEFS_UID=1000
+ARG MUSEFS_GID=1000
+RUN groupadd -g "${MUSEFS_GID}" musefs \
+ && useradd -u "${MUSEFS_UID}" -g "${MUSEFS_GID}" -M -s /usr/sbin/nologin musefs \
+ && echo 'user_allow_other' >> /etc/fuse.conf
+
 # TARGETARCH is auto-populated by buildx per platform (amd64 / arm64); the build
 # context root holds <arch>/musefs for each.
 ARG TARGETARCH
 COPY ${TARGETARCH}/musefs /usr/local/bin/musefs
 
+USER musefs
 ENTRYPOINT ["musefs"]

--- a/docker/Dockerfile.musl
+++ b/docker/Dockerfile.musl
@@ -4,9 +4,23 @@ FROM alpine:3.20
 # fuse3 provides the setuid `fusermount3` helper musefs execs at mount/unmount.
 RUN apk add --no-cache fuse3
 
+# Run as a dedicated unprivileged user. musefs mounts via the setuid fusermount3
+# helper and needs no root. The uid/gid default to 1000 but are build-arg
+# configurable: build with `--build-arg MUSEFS_UID=$(id -u) --build-arg
+# MUSEFS_GID=$(id -g)` to match your host owner and skip the store chown.
+# A bind-mounted store volume must be writable by the chosen uid.
+# user_allow_other lets a non-root --allow-other / --owner mount pass musefs's
+# /etc/fuse.conf pre-flight check (needed for the multi-container pod pattern).
+ARG MUSEFS_UID=1000
+ARG MUSEFS_GID=1000
+RUN addgroup -g "${MUSEFS_GID}" musefs \
+ && adduser -u "${MUSEFS_UID}" -G musefs -H -D -s /sbin/nologin musefs \
+ && echo 'user_allow_other' >> /etc/fuse.conf
+
 # TARGETARCH is auto-populated by buildx per platform (amd64 / arm64); the build
 # context root holds <arch>/musefs for each.
 ARG TARGETARCH
 COPY ${TARGETARCH}/musefs /usr/local/bin/musefs
 
+USER musefs
 ENTRYPOINT ["musefs"]

--- a/docs/superpowers/plans/2026-06-12-deployment-asset-hardening.md
+++ b/docs/superpowers/plans/2026-06-12-deployment-asset-hardening.md
@@ -40,7 +40,7 @@ Files created or modified by this plan:
 - `contrib/systemd/musefs-scan.service` — **modify**: append the full sandbox block (Task 1).
 - `contrib/systemd/musefs.service` — **modify**: extend the do-NOT-add comment, append safe directives + commented opt-in block (Task 2).
 - `contrib/systemd/README.md` — **modify**: add a `## Hardening` section (Task 3).
-- `docker/Dockerfile.glibc` — **modify**: add non-root user, `user_allow_other`, `USER` (Task 4).
+- `docker/Dockerfile.glibc` — **modify**: add non-root user (`MUSEFS_UID`/`MUSEFS_GID` args, default 1000), `user_allow_other`, `USER` (Task 4).
 - `docker/Dockerfile.musl` — **modify**: same, Alpine flavour (Task 4).
 - `README.md` — **modify**: non-root container note + `user_allow_other` cross-ref (Task 4).
 
@@ -66,25 +66,37 @@ systemctl --user is-system-running
 Expected: either "no existing musefs user units", or a list you will leave
 untouched. The manager state should print `running` (or `degraded` — fine).
 
-- [ ] **Step 2: Point at the real library and create scratch dirs**
+- [ ] **Step 2: Write the shared env file and create scratch dirs**
+
+**Critical:** each `Run:` block in this plan executes in a *fresh shell* — shell
+variables do **not** persist between steps. So all scratch paths live in one
+sourced env file that every later block reads with
+`source "$HOME/.musefs-harden-env.sh"`. Edit `LIB` in this file *once* to narrow
+the corpus; the narrowing then persists across every step.
 
 The dedicated server has a real music library at `/data/media/music`. The
 scanner reads it directly — AppArmor only gates FUSE *mounts* under `/data`, not
 reads, and `ProtectSystem=true` leaves `/data` readable. A full scan of the
-whole library can be slow (HDD); for a sandbox smoke test, narrow `LIB` to a
-single artist/album.
+whole library is slow (HDD); narrow `LIB` to a single artist/album for the smoke
+test.
 
 Run:
 ```bash
+mkdir -p "$HOME/.cache/musefs-harden-test"/{db,custom-db,mnt}
+cat > "$HOME/.musefs-harden-env.sh" <<EOF
 export HARDEN="$HOME/.cache/musefs-harden-test"
-export LIB="/data/media/music"          # for speed: set to one album, e.g. "$LIB/<artist>/<album>"
-rm -rf "$HARDEN"
-mkdir -p "$HARDEN"/{db,custom-db,mnt}
+export LIB="/data/media/music"          # EDIT to one album for a faster test, e.g. /data/media/music/<artist>/<album>
+export BIN="$PWD/target/release/musefs"
+export MUSL_BIN="$PWD/target/x86_64-unknown-linux-musl/release/musefs"
+export CTX="/tmp/musefs-harden-ctx"
+export STORE="/tmp/musefs-harden-store"
+EOF
+source "$HOME/.musefs-harden-env.sh"
 test -r "$LIB" && find "$LIB" -type f \( -iname '*.flac' -o -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.ogg' -o -iname '*.wav' \) | head -3
+echo "env: HARDEN=$HARDEN LIB=$LIB"
 ```
 Expected: `$LIB` is readable and at least one audio file is listed. (If
-`/data/media/music` is unavailable, fall back to a scratch lib:
-`mkdir -p "$HARDEN/lib" && cp musefs-format/tests/fixtures/sample.m4a "$HARDEN/lib/" && export LIB="$HARDEN/lib"`.)
+`/data/media/music` is unavailable, fall back: `mkdir -p "$HOME/.cache/musefs-harden-test/lib" && cp musefs-format/tests/fixtures/sample.m4a "$HOME/.cache/musefs-harden-test/lib/"`, then edit `LIB` in the env file to that dir.)
 
 - [ ] **Step 3: Build the host (glibc) binary for the systemd tests**
 
@@ -119,9 +131,9 @@ in a temp context so the repo tree stays clean.
 
 Run:
 ```bash
-export CTX=/tmp/musefs-harden-ctx
+source "$HOME/.musefs-harden-env.sh"
 rm -rf "$CTX"; mkdir -p "$CTX/amd64"
-cp target/x86_64-unknown-linux-musl/release/musefs "$CTX/amd64/musefs"
+cp "$MUSL_BIN" "$CTX/amd64/musefs"
 chmod +x "$CTX/amd64/musefs"
 ls -l "$CTX/amd64/"
 ```
@@ -184,9 +196,7 @@ directives under test come verbatim from the edited file*.
 
 Run:
 ```bash
-export HARDEN="$HOME/.cache/musefs-harden-test"
-export LIB="${LIB:-/data/media/music}"
-export BIN="$PWD/target/release/musefs"
+source "$HOME/.musefs-harden-env.sh"
 install -Dm644 contrib/systemd/musefs-scan.service \
   ~/.config/systemd/user/musefs-harden-scan.service
 mkdir -p ~/.config/systemd/user/musefs-harden-scan.service.d
@@ -205,6 +215,7 @@ Expected: no error from `daemon-reload`.
 
 Run:
 ```bash
+source "$HOME/.musefs-harden-env.sh"
 systemctl --user start musefs-harden-scan.service
 systemctl --user status musefs-harden-scan.service --no-pager | sed -n '1,6p'
 ls -l "$HARDEN/db/"
@@ -225,14 +236,19 @@ broken — `$HARDEN/custom-db` is nowhere near `~/.local/share/musefs`.
 
 Run:
 ```bash
+source "$HOME/.musefs-harden-env.sh"
 sed -i "s#--db $HARDEN/db/library.db#--db $HARDEN/custom-db/lib.db#" \
   ~/.config/systemd/user/musefs-harden-scan.service.d/override.conf
 systemctl --user daemon-reload
 systemctl --user start musefs-harden-scan.service
 ls -l "$HARDEN/custom-db/"
+# restore the override to the default DB so Task 2's mount finds it:
+sed -i "s#--db $HARDEN/custom-db/lib.db#--db $HARDEN/db/library.db#" \
+  ~/.config/systemd/user/musefs-harden-scan.service.d/override.conf
 ```
 Expected: `$HARDEN/custom-db/lib.db` written, exit 0 — confirming
-`ProtectSystem=true` needs no per-path config.
+`ProtectSystem=true` needs no per-path config. (The restore keeps
+`$HARDEN/db/library.db` from Step 3 as the canonical DB for Task 2.)
 
 - [ ] **Step 5: Record the exposure score as evidence**
 
@@ -317,14 +333,16 @@ SystemCallArchitectures=native
 
 - [ ] **Step 2: Install the mount unit under a test name with a scratch drop-in**
 
-This reuses the DB built in Task 1. The mountpoint is under `$HOME`, which the
-AppArmor `fusermount3` profile permits (mounting under `/data` would be denied —
-that is an AppArmor policy, not a musefs bug).
+This **depends on `$HARDEN/db/library.db` built in Task 1 Step 3** — `mount`
+hard-rejects a missing DB (the merged #309 fix), so do not run this task after a
+fresh Task 0 without re-running Task 1 Step 3 first. The mountpoint is under
+`$HOME`, which the AppArmor `fusermount3` profile permits (mounting under `/data`
+would be denied — that is an AppArmor policy, not a musefs bug).
 
 Run:
 ```bash
-export HARDEN="$HOME/.cache/musefs-harden-test"
-export BIN="$PWD/target/release/musefs"
+source "$HOME/.musefs-harden-env.sh"
+test -f "$HARDEN/db/library.db" || { echo "MISSING DB — run Task 1 Step 3 first"; exit 1; }
 install -Dm644 contrib/systemd/musefs.service \
   ~/.config/systemd/user/musefs-harden-mount.service
 mkdir -p ~/.config/systemd/user/musefs-harden-mount.service.d
@@ -337,12 +355,13 @@ ExecStart=$BIN mount $HARDEN/mnt --db $HARDEN/db/library.db
 EOF
 systemctl --user daemon-reload
 ```
-Expected: `daemon-reload` succeeds.
+Expected: the DB check passes and `daemon-reload` succeeds.
 
 - [ ] **Step 3: Start the mount and verify it is visible in the session**
 
 Run:
 ```bash
+source "$HOME/.musefs-harden-env.sh"
 systemctl --user start musefs-harden-mount.service
 sleep 1
 mountpoint "$HARDEN/mnt" && echo "MOUNT VISIBLE"
@@ -362,6 +381,7 @@ the comment's "uncomment one at a time" guidance is real.
 
 Run:
 ```bash
+source "$HOME/.musefs-harden-env.sh"
 systemctl --user stop musefs-harden-mount.service
 fusermount3 -u "$HARDEN/mnt" 2>/dev/null || true
 cat > ~/.config/systemd/user/musefs-harden-mount.service.d/optin.conf <<'EOF'
@@ -372,9 +392,14 @@ systemctl --user daemon-reload
 systemctl --user start musefs-harden-mount.service
 sleep 1
 mountpoint "$HARDEN/mnt" && echo "OPT-IN MOUNT OK"
+# tear down the opt-in spot-check (leave the mount unit installed for Step 5):
+systemctl --user stop musefs-harden-mount.service
+fusermount3 -u "$HARDEN/mnt" 2>/dev/null || true
+rm ~/.config/systemd/user/musefs-harden-mount.service.d/optin.conf
+systemctl --user daemon-reload
 ```
 Expected: `OPT-IN MOUNT OK` (validates `@mount` works on kernel 7.0 / systemd
-259). Then tear down: `systemctl --user stop musefs-harden-mount.service; fusermount3 -u "$HARDEN/mnt" 2>/dev/null || true; rm ~/.config/systemd/user/musefs-harden-mount.service.d/optin.conf; systemctl --user daemon-reload`.
+259), then a clean teardown of the opt-in drop-in.
 
 - [ ] **Step 5: Record the exposure score as evidence**
 
@@ -460,7 +485,7 @@ EOF
 
 ---
 
-## Task 4: #319 — Non-root container images (uid 1000)
+## Task 4: #319 — Non-root container images (default uid 1000, build-arg configurable)
 
 **Files:**
 - Modify: `docker/Dockerfile.glibc`
@@ -480,13 +505,17 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends fuse3 \
  && rm -rf /var/lib/apt/lists/*
 
-# Run as a dedicated unprivileged user (uid/gid 1000). musefs mounts via the
-# setuid fusermount3 helper and needs no root, so a bind-mounted store volume
-# must be writable by uid 1000 (or pass `--user $(id -u):$(id -g)`).
+# Run as a dedicated unprivileged user. musefs mounts via the setuid fusermount3
+# helper and needs no root. The uid/gid default to 1000 but are build-arg
+# configurable: build with `--build-arg MUSEFS_UID=$(id -u) --build-arg
+# MUSEFS_GID=$(id -g)` to match your host owner and skip the store chown.
+# A bind-mounted store volume must be writable by the chosen uid.
 # user_allow_other lets a non-root --allow-other / --owner mount pass musefs's
 # /etc/fuse.conf pre-flight check (needed for the multi-container pod pattern).
-RUN groupadd -g 1000 musefs \
- && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs \
+ARG MUSEFS_UID=1000
+ARG MUSEFS_GID=1000
+RUN groupadd -g "${MUSEFS_GID}" musefs \
+ && useradd -u "${MUSEFS_UID}" -g "${MUSEFS_GID}" -M -s /usr/sbin/nologin musefs \
  && echo 'user_allow_other' >> /etc/fuse.conf
 
 # TARGETARCH is auto-populated by buildx per platform (amd64 / arm64); the build
@@ -509,13 +538,17 @@ FROM alpine:3.20
 # fuse3 provides the setuid `fusermount3` helper musefs execs at mount/unmount.
 RUN apk add --no-cache fuse3
 
-# Run as a dedicated unprivileged user (uid/gid 1000). musefs mounts via the
-# setuid fusermount3 helper and needs no root, so a bind-mounted store volume
-# must be writable by uid 1000 (or pass `--user $(id -u):$(id -g)`).
+# Run as a dedicated unprivileged user. musefs mounts via the setuid fusermount3
+# helper and needs no root. The uid/gid default to 1000 but are build-arg
+# configurable: build with `--build-arg MUSEFS_UID=$(id -u) --build-arg
+# MUSEFS_GID=$(id -g)` to match your host owner and skip the store chown.
+# A bind-mounted store volume must be writable by the chosen uid.
 # user_allow_other lets a non-root --allow-other / --owner mount pass musefs's
 # /etc/fuse.conf pre-flight check (needed for the multi-container pod pattern).
-RUN addgroup -g 1000 musefs \
- && adduser -u 1000 -G musefs -H -D -s /sbin/nologin musefs \
+ARG MUSEFS_UID=1000
+ARG MUSEFS_GID=1000
+RUN addgroup -g "${MUSEFS_GID}" musefs \
+ && adduser -u "${MUSEFS_UID}" -G musefs -H -D -s /sbin/nologin musefs \
  && echo 'user_allow_other' >> /etc/fuse.conf
 
 # TARGETARCH is auto-populated by buildx per platform (amd64 / arm64); the build
@@ -531,24 +564,28 @@ ENTRYPOINT ["musefs"]
 
 Run:
 ```bash
-export CTX=/tmp/musefs-harden-ctx
+source "$HOME/.musefs-harden-env.sh"
 cp docker/Dockerfile.glibc docker/Dockerfile.musl "$CTX/"
 podman build -f "$CTX/Dockerfile.glibc" --build-arg TARGETARCH=amd64 -t musefs-harden:glibc "$CTX"
 podman build -f "$CTX/Dockerfile.musl"  --build-arg TARGETARCH=amd64 -t musefs-harden:musl  "$CTX"
+# build-arg override: an image whose user matches a custom uid
+podman build -f "$CTX/Dockerfile.glibc" --build-arg TARGETARCH=amd64 \
+  --build-arg MUSEFS_UID=1234 --build-arg MUSEFS_GID=1234 -t musefs-harden:uid1234 "$CTX"
 ```
-Expected: both builds succeed. (If the glibc image errors on `useradd`/`nologin`,
-those are in `bookworm-slim` by default — re-check the RUN line.)
+Expected: all three builds succeed. (If the glibc image errors on
+`useradd`/`nologin`, those ship in `bookworm-slim` — re-check the RUN line.)
 
-- [ ] **Step 4: Verify the entrypoint runs as uid 1000 (both images)**
+- [ ] **Step 4: Verify the entrypoint runs as the expected uid (default + override)**
 
 Run:
 ```bash
 for tag in glibc musl; do
-  echo "== $tag =="
-  podman run --rm --entrypoint id "musefs-harden:$tag" -u
+  printf '%s -> ' "$tag"; podman run --rm --entrypoint id "musefs-harden:$tag" -u
 done
+printf 'uid1234 -> '; podman run --rm --entrypoint id musefs-harden:uid1234 -u
 ```
-Expected: each prints `1000`.
+Expected: `glibc -> 1000`, `musl -> 1000`, `uid1234 -> 1234` (the last proves
+the `MUSEFS_UID` build arg takes effect).
 
 - [ ] **Step 5: Verify a non-root `scan` writes the store (ownership friction)**
 
@@ -557,8 +594,8 @@ store must be made writable for that mapping — the real-world ownership step.
 
 Run:
 ```bash
-export STORE=/tmp/musefs-harden-store; rm -rf "$STORE"; mkdir -p "$STORE"
-export LIB="${LIB:-/data/media/music}"         # narrow to one album for a fast container scan
+source "$HOME/.musefs-harden-env.sh"
+rm -rf "$STORE"; mkdir -p "$STORE"
 podman unshare chown 1000:1000 "$STORE"        # "make the store writable by uid 1000"
 podman run --rm \
   -v "$LIB":/library:ro \
@@ -572,29 +609,39 @@ store-ownership requirement and that a non-root scan works.)
 - [ ] **Step 6: Verify the `/etc/fuse.conf` pre-flight check both ways**
 
 The baked `user_allow_other` must satisfy musefs's pre-flight; masking
-`/etc/fuse.conf` with an empty file must trigger the explicit error. The
-pre-flight runs *before* the privileged `mount()` syscall, so this validates the
-fuse.conf plumbing without needing a successful in-container mount.
+`/etc/fuse.conf` with `/dev/null` (read as an empty string, so `user_allow_other`
+is absent) must trigger the explicit error. The pre-flight runs *before* the
+privileged `mount()` syscall, so this validates the fuse.conf plumbing without
+needing a successful in-container mount. Both images are checked — Alpine's
+`fusermount3` honouring `/etc/fuse.conf` is the musl-specific regression risk.
+
+The exact error substring musefs emits when the line is missing is
+`does not enable 'user_allow_other'` (from `ALLOW_OTHER_HELP` in
+`musefs-fuse/src/platform/mount.rs`); the assertions grep for it rather than
+eyeballing output.
 
 Run:
 ```bash
-echo "== WITH baked user_allow_other (expect: past pre-flight) =="
-podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
-  -v /tmp/musefs-harden-store:/store --entrypoint sh musefs-harden:glibc \
-  -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db --allow-other 2>&1 | head -5' || true
+source "$HOME/.musefs-harden-env.sh"
+ERR="does not enable 'user_allow_other'"
+for tag in glibc musl; do
+  echo "== $tag : WITH baked user_allow_other (pre-flight should PASS) =="
+  out=$(podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+    -v "$STORE":/store --entrypoint sh "musefs-harden:$tag" \
+    -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db --allow-other 2>&1' || true)
+  echo "$out" | grep -qF "$ERR" && echo "  FAIL: pre-flight wrongly fired" || echo "  OK: past pre-flight"
 
-echo "== WITHOUT user_allow_other (mask fuse.conf; expect: explicit error) =="
-podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
-  -v /dev/null:/etc/fuse.conf:ro \
-  -v /tmp/musefs-harden-store:/store --entrypoint sh musefs-harden:glibc \
-  -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db --allow-other 2>&1 | head -5' || true
+  echo "== $tag : WITHOUT user_allow_other (mask /etc/fuse.conf; pre-flight should FIRE) =="
+  out=$(podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+    -v /dev/null:/etc/fuse.conf:ro -v "$STORE":/store --entrypoint sh "musefs-harden:$tag" \
+    -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db --allow-other 2>&1' || true)
+  echo "$out" | grep -qF "$ERR" && echo "  OK: pre-flight fired" || echo "  FAIL: error missing"
+done
 ```
-Expected: the WITH run does **not** print the "add `user_allow_other` to
-`/etc/fuse.conf`" error (it gets past the check; any later failure is the
-unprivileged-mount step, acceptable here). The WITHOUT run prints exactly that
-pre-flight error. Repeat the WITH run with `musefs-harden:musl` to confirm
-Alpine's `fusermount3` honours `/etc/fuse.conf` identically (the musl-specific
-regression risk).
+Expected: every WITH line prints `OK: past pre-flight` and every WITHOUT line
+prints `OK: pre-flight fired` — for **both** glibc and musl. (In the WITH case
+the mount may then fail at the unprivileged `mount()` step in rootless Podman;
+that is irrelevant — the assertion is only that the pre-flight did not fire.)
 
 - [ ] **Step 7: (Optional) Full in-container mount under rootful Podman**
 
@@ -602,12 +649,14 @@ A real mount needs unnamespaced `CAP_SYS_ADMIN`; rootless Podman cannot grant
 it (see the project's FUSE/CAP_SYS_ADMIN note). Skip unless you want end-to-end
 confirmation:
 ```bash
+source "$HOME/.musefs-harden-env.sh"
 sudo podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
-  -v /tmp/musefs-harden-store:/store --entrypoint sh musefs-harden:glibc \
+  -v "$STORE":/store --entrypoint sh musefs-harden:glibc \
   -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db & sleep 1; mountpoint /tmp/m'
 ```
-Expected (if run): `/tmp/m is a mountpoint`. Note: running under `sudo` writes
-the store as root, so do this *after* Step 5's ownership assertion, not before.
+Expected (if run): `/tmp/m is a mountpoint`. The mount only *reads* `/store`
+(the `--rm` container's mountpoint is in-container and ephemeral), so this leaves
+no root-owned files on the host. Run it *after* Step 5's ownership assertion.
 
 - [ ] **Step 8: Update `README.md` — non-root container note**
 
@@ -619,14 +668,17 @@ before the `#### The mount-visibility gotcha` heading), insert:
 
 #### Runs as a non-root user
 
-The images run as a dedicated unprivileged user (uid/gid 1000), not root —
-musefs mounts via the setuid `fusermount3` helper and needs no root of its own.
-Two consequences for the commands above:
+The images run as a dedicated unprivileged user (default uid/gid 1000), not
+root — musefs mounts via the setuid `fusermount3` helper and needs no root of
+its own. Consequences for the commands above:
 
-- The bind-mounted **store** volume must be writable by uid 1000. Either
+- The bind-mounted **store** volume must be writable by that uid. Either
   `chown 1000:1000 /path/to/store` on the host, or add `--user $(id -u):$(id -g)`
   to run as your own uid. The **library** volume is mounted `:ro`, so its
   ownership does not matter.
+- To bake an image whose user matches your host account (so no `chown` or
+  `--user` is needed), build from source with
+  `--build-arg MUSEFS_UID=$(id -u) --build-arg MUSEFS_GID=$(id -g)`.
 - The images include `user_allow_other` in `/etc/fuse.conf`, so a non-root
   `--allow-other` / `--owner` / `--group` mount (used by the pod pattern below)
   passes musefs's pre-flight check. See
@@ -649,15 +701,17 @@ that paragraph (after "...not a musefs restriction.)"):
 ```bash
 git add docker/Dockerfile.glibc docker/Dockerfile.musl README.md
 git commit -m "$(cat <<'EOF'
-feat(docker): run the musefs container as non-root uid 1000 (#319)
+feat(docker): run the musefs container as a non-root user (#319)
 
-Both images create a dedicated uid/gid 1000 user and USER it, and bake
+Both images create a dedicated non-root user (default uid/gid 1000,
+overridable via MUSEFS_UID/MUSEFS_GID build args) and USER it, and bake
 user_allow_other into /etc/fuse.conf so a non-root --allow-other mount
 passes musefs's post-#339 pre-flight check (the multi-container pod
-pattern). Documents the store-volume ownership requirement. Verified
-live: entrypoint runs as 1000, non-root scan writes a 1000-owned DB,
-fuse.conf pre-flight passes with the baked line and fails cleanly when
-masked, on both glibc and musl images.
+pattern). Documents the store-volume ownership requirement and the
+build-arg escape hatch. Verified live: entrypoint runs as the default
+and an overridden uid, non-root scan writes a 1000-owned DB, fuse.conf
+pre-flight passes with the baked line and fails cleanly when masked, on
+both glibc and musl images.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
 EOF
@@ -674,12 +728,16 @@ Leaves no test units, mounts, images, or scratch dirs behind. **No commit.**
 
 Run:
 ```bash
+source "$HOME/.musefs-harden-env.sh"
 systemctl --user stop musefs-harden-mount.service musefs-harden-scan.service 2>/dev/null || true
-fusermount3 -u "$HOME/.cache/musefs-harden-test/mnt" 2>/dev/null || true
+fusermount3 -u "$HARDEN/mnt" 2>/dev/null || true
 rm -rf ~/.config/systemd/user/musefs-harden-scan.service ~/.config/systemd/user/musefs-harden-scan.service.d
 rm -rf ~/.config/systemd/user/musefs-harden-mount.service ~/.config/systemd/user/musefs-harden-mount.service.d
 systemctl --user daemon-reload
-rm -rf "$HOME/.cache/musefs-harden-test" /tmp/musefs-harden-ctx /tmp/musefs-harden-store
+# $STORE was chowned to a mapped subuid (Task 4 Step 5), so remove it inside the
+# user namespace; the rest is plain-owned.
+podman unshare rm -rf "$STORE" 2>/dev/null || true
+rm -rf "$HARDEN" "$CTX" "$HOME/.musefs-harden-env.sh"
 ```
 Expected: no errors; `ls ~/.config/systemd/user/ | grep harden` returns nothing.
 
@@ -687,7 +745,7 @@ Expected: no errors; `ls ~/.config/systemd/user/ | grep harden` returns nothing.
 
 Run:
 ```bash
-podman rmi musefs-harden:glibc musefs-harden:musl 2>/dev/null || true
+podman rmi musefs-harden:glibc musefs-harden:musl musefs-harden:uid1234 2>/dev/null || true
 ```
 
 - [ ] **Step 3: Confirm the tree is clean and on-branch**
@@ -707,17 +765,21 @@ on top of the rebased branch.
 **Spec coverage:**
 - #317 full path-agnostic scanner sandbox → Task 1 (directive block matches the spec's #317 block exactly, `ProtectSystem=true`, no `ReadWritePaths`).
 - #318 mount-visible subset + commented opt-in → Task 2 (matches the spec's safe set + the four opt-in directives).
-- #319 non-root uid 1000 + `user_allow_other` → Task 4.
-- Doc updates: `contrib/systemd/README.md` → Task 3; `README.md` Docker + ownership → Task 4 Steps 8–9; inline unit/Dockerfile comments → Tasks 1, 2, 4.
-- Verification (live, dedi): scanner default+custom DB path + journald (Task 1), mount visibility + opt-in spot-check + exposure scores (Task 2), uid 1000 + store ownership + fuse.conf pre-flight both ways on both images (Task 4).
+- #319 non-root user (default uid/gid 1000, `MUSEFS_UID`/`MUSEFS_GID` build args) + `user_allow_other` → Task 4.
+- Doc updates: `contrib/systemd/README.md` → Task 3; `README.md` central "Runs as a non-root user" note (build arg + store ownership) + ownership cross-ref → Task 4 Steps 8–9; inline unit/Dockerfile comments → Tasks 1, 2, 4. (Per the spec, the two inline `docker run` examples are covered by the adjacent central note, not edited individually.)
+- Verification (live, dedi): scanner default+custom DB path + journald (Task 1), mount visibility + opt-in spot-check + exposure scores (Task 2), default+overridden uid + store ownership + fuse.conf pre-flight both ways on both images (Task 4).
 - "Known sharp edges" (`ProcSubset=pid`, `ProtectControlGroups` on `--user`) → captured as inline comments in Task 1.
 
 **Placeholder scan:** none — every edit shows full file/block content; every verification step has an exact command and expected output.
 
-**Consistency:** the scratch env vars (`HARDEN`, `BIN`, `CTX`, `STORE`) and test
-unit names (`musefs-harden-scan`, `musefs-harden-mount`) and image tags
-(`musefs-harden:glibc|musl`) are used identically across Tasks 0–5. Task 5 cleans
-up exactly what Tasks 0–4 create.
+**Shell-state safety:** each `Run:` block executes in a fresh shell (env vars do
+not persist), so Task 0 Step 2 writes `$HOME/.musefs-harden-env.sh` and every
+later block begins with `source "$HOME/.musefs-harden-env.sh"`. Narrowing the
+corpus is a one-time edit to `LIB` in that file. Scratch vars (`HARDEN`, `LIB`,
+`BIN`, `MUSL_BIN`, `CTX`, `STORE`), test unit names (`musefs-harden-scan`,
+`musefs-harden-mount`), and image tags (`musefs-harden:glibc|musl|uid1234`) are
+used identically across Tasks 0–5. Task 5 cleans up exactly what Tasks 0–4
+create (including the subuid-owned `$STORE` via `podman unshare rm`).
 
 **Scope:** deployment-asset config only; no source/schema/FUSE-path changes, no
 CI harness (per the spec's explicit live-test-not-CI decision).

--- a/docs/superpowers/plans/2026-06-12-deployment-asset-hardening.md
+++ b/docs/superpowers/plans/2026-06-12-deployment-asset-hardening.md
@@ -1,0 +1,723 @@
+# Deployment-Asset Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden musefs's shipped deployment assets — sandbox the two systemd user units and run the container images as a non-root user — without breaking the FUSE mount or imposing path-configuration friction.
+
+**Architecture:** Three independent, ascending-risk edits, each gated by a *live* run on the dedicated server (there are no unit tests for a systemd directive — the verification IS the gate). The mount-less scanner takes a full path-agnostic sandbox; the mount unit takes only directives that keep the FUSE mount visible (the riskier ones ship commented-out/opt-in); the containers drop to a fixed uid/gid 1000 with `user_allow_other` baked in so the post-#339 `/etc/fuse.conf` pre-flight check still passes for non-root `allow_other` mounts.
+
+**Tech Stack:** systemd user units (`systemctl --user`, `systemd-analyze security`), FUSE/`fusermount3`, Podman (rootless + `podman unshare`), Cargo (host + `x86_64-unknown-linux-musl` static target).
+
+**Spec:** `docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md`
+
+**Issues:** #317 (scanner unit), #318 (mount unit), #319 (container user). Tracking: #280.
+
+---
+
+## Pre-commit note (read once)
+
+Per `CLAUDE.md`, the pre-commit hook skips the cargo gate *only* when every
+staged path is under `docs/` or is a `*.md` file. Commits that stage a
+`.service` file or a `Dockerfile` are **not** docs-only, so they run the full
+workspace test suite. We change no Rust, so those tests pass — but expect each
+such commit to take a few minutes. The `.service`/`Dockerfile` content is not
+linted by shellcheck/yamllint/ruff. Do **not** use `--no-verify`.
+
+## Safety note (read once)
+
+The live tests install systemd user units and build container images. To avoid
+clobbering any real musefs deployment on this machine, **every** test unit uses
+a `musefs-harden-*` name and a scratch directory under
+`$HOME/.cache/musefs-harden-test`. Never touch `~/.config/systemd/user/musefs.service`
+or `musefs-scan.service` directly. The Task 5 cleanup removes all test artifacts.
+
+---
+
+## File Structure
+
+Files created or modified by this plan:
+
+- `contrib/systemd/musefs-scan.service` — **modify**: append the full sandbox block (Task 1).
+- `contrib/systemd/musefs.service` — **modify**: extend the do-NOT-add comment, append safe directives + commented opt-in block (Task 2).
+- `contrib/systemd/README.md` — **modify**: add a `## Hardening` section (Task 3).
+- `docker/Dockerfile.glibc` — **modify**: add non-root user, `user_allow_other`, `USER` (Task 4).
+- `docker/Dockerfile.musl` — **modify**: same, Alpine flavour (Task 4).
+- `README.md` — **modify**: non-root container note + `user_allow_other` cross-ref (Task 4).
+
+No source files change. No new committed files (the live-test harness is inline, per the spec's "no CI smoke harness" scope decision).
+
+---
+
+## Task 0: Live-test harness setup
+
+Sets up the scratch fixtures and the two binaries every later task reuses. This
+task produces **no commit** — it builds throwaway artifacts under `$HOME/.cache`
+and `/tmp`.
+
+**Files:** none (scratch only).
+
+- [ ] **Step 1: Confirm no name collision with a real deployment**
+
+Run:
+```bash
+ls ~/.config/systemd/user/ 2>/dev/null | grep -i musefs || echo "no existing musefs user units"
+systemctl --user is-system-running
+```
+Expected: either "no existing musefs user units", or a list you will leave
+untouched. The manager state should print `running` (or `degraded` — fine).
+
+- [ ] **Step 2: Point at the real library and create scratch dirs**
+
+The dedicated server has a real music library at `/data/media/music`. The
+scanner reads it directly — AppArmor only gates FUSE *mounts* under `/data`, not
+reads, and `ProtectSystem=true` leaves `/data` readable. A full scan of the
+whole library can be slow (HDD); for a sandbox smoke test, narrow `LIB` to a
+single artist/album.
+
+Run:
+```bash
+export HARDEN="$HOME/.cache/musefs-harden-test"
+export LIB="/data/media/music"          # for speed: set to one album, e.g. "$LIB/<artist>/<album>"
+rm -rf "$HARDEN"
+mkdir -p "$HARDEN"/{db,custom-db,mnt}
+test -r "$LIB" && find "$LIB" -type f \( -iname '*.flac' -o -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.ogg' -o -iname '*.wav' \) | head -3
+```
+Expected: `$LIB` is readable and at least one audio file is listed. (If
+`/data/media/music` is unavailable, fall back to a scratch lib:
+`mkdir -p "$HARDEN/lib" && cp musefs-format/tests/fixtures/sample.m4a "$HARDEN/lib/" && export LIB="$HARDEN/lib"`.)
+
+- [ ] **Step 3: Build the host (glibc) binary for the systemd tests**
+
+Run:
+```bash
+cargo build --release
+ls -l target/release/musefs
+```
+Expected: `target/release/musefs` exists. This native binary is what the
+systemd user units exec in Tasks 1–2.
+
+- [ ] **Step 4: Build the static musl binary for the container tests**
+
+The host glibc is newer than `bookworm`/`alpine`, so a host-built glibc binary
+will not start inside either image. A static musl binary runs in both.
+
+Run:
+```bash
+rustup target add x86_64-unknown-linux-musl
+# libsqlite3-sys (bundled) compiles C; musl needs a musl C toolchain:
+command -v musl-gcc || sudo apt-get install -y musl-tools
+cargo build --release --target x86_64-unknown-linux-musl
+file target/x86_64-unknown-linux-musl/release/musefs
+```
+Expected: `file` reports `statically linked` (or `static-pie`). If the build
+fails on the C toolchain, that is the `musl-tools` step — install it and retry.
+
+- [ ] **Step 5: Stage a clean Podman build context**
+
+The Dockerfiles `COPY ${TARGETARCH}/musefs`; stage the musl binary as `amd64/musefs`
+in a temp context so the repo tree stays clean.
+
+Run:
+```bash
+export CTX=/tmp/musefs-harden-ctx
+rm -rf "$CTX"; mkdir -p "$CTX/amd64"
+cp target/x86_64-unknown-linux-musl/release/musefs "$CTX/amd64/musefs"
+chmod +x "$CTX/amd64/musefs"
+ls -l "$CTX/amd64/"
+```
+Expected: `$CTX/amd64/musefs` present and executable. (Dockerfiles are copied
+into `$CTX` in Task 4, after they are edited.)
+
+---
+
+## Task 1: #317 — Full path-agnostic sandbox on `musefs-scan.service`
+
+**Files:**
+- Modify: `contrib/systemd/musefs-scan.service`
+
+- [ ] **Step 1: Append the sandbox block to the unit**
+
+Append the following block to the end of the `[Service]` section of
+`contrib/systemd/musefs-scan.service` (after the existing `ExecStart=` line, so
+the file's `[Service]` section ends with this):
+
+```ini
+
+# --- Sandbox -------------------------------------------------------------
+# The scanner creates no FUSE mount, so it can take the full systemd sandbox
+# (unlike musefs.service). None of these directives needs to know where your
+# library or DB live: ProtectSystem=true keeps system dirs read-only while
+# leaving $HOME and data volumes writable, so a custom MUSEFS_DB path works
+# with no ReadWritePaths= edit.
+NoNewPrivileges=true
+ProtectSystem=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+# ProcSubset=pid hides non-pid /proc; a future parser reading /proc/cpuinfo for
+# SIMD detection would need this relaxed.
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=true
+# AF_UNIX is REQUIRED for journald logging; do NOT drop to none.
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+UMask=077
+```
+
+- [ ] **Step 2: Install the unit under a test name with a scratch drop-in**
+
+The drop-in overrides only `ExecStart`/`PATH`/`EnvironmentFile` so the *sandbox
+directives under test come verbatim from the edited file*.
+
+Run:
+```bash
+export HARDEN="$HOME/.cache/musefs-harden-test"
+export LIB="${LIB:-/data/media/music}"
+export BIN="$PWD/target/release/musefs"
+install -Dm644 contrib/systemd/musefs-scan.service \
+  ~/.config/systemd/user/musefs-harden-scan.service
+mkdir -p ~/.config/systemd/user/musefs-harden-scan.service.d
+cat > ~/.config/systemd/user/musefs-harden-scan.service.d/override.conf <<EOF
+[Service]
+EnvironmentFile=
+Environment=PATH=$(dirname "$BIN"):/usr/bin
+ExecStart=
+ExecStart=$BIN scan $LIB --db $HARDEN/db/library.db --revalidate
+EOF
+systemctl --user daemon-reload
+```
+Expected: no error from `daemon-reload`.
+
+- [ ] **Step 3: Run the sandboxed scan and verify the DB was written**
+
+Run:
+```bash
+systemctl --user start musefs-harden-scan.service
+systemctl --user status musefs-harden-scan.service --no-pager | sed -n '1,6p'
+ls -l "$HARDEN/db/"
+journalctl --user -u musefs-harden-scan.service --no-pager | tail -15
+```
+Expected: status shows `Deactivated successfully` / `code=exited, status=0`;
+`$HARDEN/db/library.db` exists (with `-wal`/`-shm` siblings during the run);
+the journal shows scan log lines (proves `RestrictAddressFamilies=AF_UNIX`
+still reaches journald). If the unit failed with a syscall/permission error,
+that is a directive the sandbox got wrong — drop the offending directive, add an
+inline `# dropped: <reason>` comment, `daemon-reload`, and retry (the
+empirical-fallback discipline from the spec).
+
+- [ ] **Step 4: Verify a custom (non-default) DB path also works**
+
+This is the case the dropped `ProtectSystem=strict`+`ReadWritePaths` would have
+broken — `$HARDEN/custom-db` is nowhere near `~/.local/share/musefs`.
+
+Run:
+```bash
+sed -i "s#--db $HARDEN/db/library.db#--db $HARDEN/custom-db/lib.db#" \
+  ~/.config/systemd/user/musefs-harden-scan.service.d/override.conf
+systemctl --user daemon-reload
+systemctl --user start musefs-harden-scan.service
+ls -l "$HARDEN/custom-db/"
+```
+Expected: `$HARDEN/custom-db/lib.db` written, exit 0 — confirming
+`ProtectSystem=true` needs no per-path config.
+
+- [ ] **Step 5: Record the exposure score as evidence**
+
+Run:
+```bash
+systemd-analyze --user security musefs-harden-scan.service --no-pager | tail -3
+```
+Expected: an `Overall exposure level` line with a low score (the scanner is the
+unit chasing a low score). Note it in the commit message or PR.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/systemd/musefs-scan.service
+git commit -m "$(cat <<'EOF'
+feat(contrib): sandbox the musefs-scan.service systemd unit (#317)
+
+The scanner creates no FUSE mount, so it takes the full systemd
+sandbox. Uses ProtectSystem=true (not strict) so a custom MUSEFS_DB
+path needs no ReadWritePaths edit. Verified live: sandboxed scan
+writes the DB at both default and custom paths, journald logging
+intact.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+(The cargo gate runs here — no Rust changed, so it passes.)
+
+---
+
+## Task 2: #318 — Mount-visible hardening on `musefs.service`
+
+**Files:**
+- Modify: `contrib/systemd/musefs.service`
+
+- [ ] **Step 1: Replace the trailing comment + `NoNewPrivileges` block**
+
+In `contrib/systemd/musefs.service`, replace this existing block:
+
+```ini
+# NoNewPrivileges is safe for a FUSE mount. Do NOT add ProtectHome=,
+# PrivateMounts=, or MountFlags=private: they place the mount in a private
+# namespace and hide it from the rest of your session.
+NoNewPrivileges=true
+```
+
+with:
+
+```ini
+# NoNewPrivileges is safe for a FUSE mount. Do NOT add ProtectHome=,
+# ProtectSystem=, ReadOnlyPaths=, PrivateTmp=, PrivateMounts=, or
+# MountFlags=private: they remount the path the FUSE mount lives under, or
+# sever mount propagation, hiding the mount from the rest of your session.
+#
+# The directives below are safe: they do not touch the mountpoint's path and
+# rely on systemd's default MountFlags=shared, which propagates the FUSE mount
+# back to your session. (ProtectKernel*/ProtectControlGroups DO create a mount
+# namespace, but only over /proc and /sys, so the $HOME mount still propagates.)
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_UNIX
+SystemCallArchitectures=native
+#
+# Opt-in (commented): these CAN trap the mount on a kernel/systemd older than
+# the maintainer's test box (kernel 7.0 / systemd 259). Uncomment one at a time
+# and confirm `mountpoint <your mountpoint>` still succeeds after a restart
+# before keeping it.
+#SystemCallFilter=@system-service @mount
+#RestrictNamespaces=true
+#CapabilityBoundingSet=
+#MemoryDenyWriteExecute=true
+```
+
+- [ ] **Step 2: Install the mount unit under a test name with a scratch drop-in**
+
+This reuses the DB built in Task 1. The mountpoint is under `$HOME`, which the
+AppArmor `fusermount3` profile permits (mounting under `/data` would be denied —
+that is an AppArmor policy, not a musefs bug).
+
+Run:
+```bash
+export HARDEN="$HOME/.cache/musefs-harden-test"
+export BIN="$PWD/target/release/musefs"
+install -Dm644 contrib/systemd/musefs.service \
+  ~/.config/systemd/user/musefs-harden-mount.service
+mkdir -p ~/.config/systemd/user/musefs-harden-mount.service.d
+cat > ~/.config/systemd/user/musefs-harden-mount.service.d/override.conf <<EOF
+[Service]
+EnvironmentFile=
+Environment=PATH=$(dirname "$BIN"):/usr/bin
+ExecStart=
+ExecStart=$BIN mount $HARDEN/mnt --db $HARDEN/db/library.db
+EOF
+systemctl --user daemon-reload
+```
+Expected: `daemon-reload` succeeds.
+
+- [ ] **Step 3: Start the mount and verify it is visible in the session**
+
+Run:
+```bash
+systemctl --user start musefs-harden-mount.service
+sleep 1
+mountpoint "$HARDEN/mnt" && echo "MOUNT VISIBLE"
+ls -R "$HARDEN/mnt" | head
+# read a served file end-to-end:
+find "$HARDEN/mnt" -type f | head -1 | xargs -r -I{} sh -c 'head -c 16 "{}" | xxd | head -1'
+```
+Expected: `mountpoint` prints `is a mountpoint` and `MOUNT VISIBLE`; the tree
+lists synthesized entries; the file read returns bytes. **This is the gate** —
+if the mount is not visible, a directive severed propagation; bisect by
+commenting directives, record the cause inline, and retry.
+
+- [ ] **Step 4: Spot-check one opt-in directive (document the opt-in path)**
+
+Confirm the strictest opt-in directive still mounts on *this* (recent) box, so
+the comment's "uncomment one at a time" guidance is real.
+
+Run:
+```bash
+systemctl --user stop musefs-harden-mount.service
+fusermount3 -u "$HARDEN/mnt" 2>/dev/null || true
+cat > ~/.config/systemd/user/musefs-harden-mount.service.d/optin.conf <<'EOF'
+[Service]
+SystemCallFilter=@system-service @mount
+EOF
+systemctl --user daemon-reload
+systemctl --user start musefs-harden-mount.service
+sleep 1
+mountpoint "$HARDEN/mnt" && echo "OPT-IN MOUNT OK"
+```
+Expected: `OPT-IN MOUNT OK` (validates `@mount` works on kernel 7.0 / systemd
+259). Then tear down: `systemctl --user stop musefs-harden-mount.service; fusermount3 -u "$HARDEN/mnt" 2>/dev/null || true; rm ~/.config/systemd/user/musefs-harden-mount.service.d/optin.conf; systemctl --user daemon-reload`.
+
+- [ ] **Step 5: Record the exposure score as evidence**
+
+Run:
+```bash
+systemd-analyze --user security musefs-harden-mount.service --no-pager | tail -3
+```
+Expected: an `Overall exposure level` line. It will be **higher** (worse) than
+the scanner's — that is correct, the mount unit intentionally omits the
+mount-hiding directives. It is evidence, not a pass/fail gate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add contrib/systemd/musefs.service
+git commit -m "$(cat <<'EOF'
+feat(contrib): add mount-visible hardening to musefs.service (#318)
+
+Adds the systemd directives that do not sever the FUSE mount's
+propagation to the session (ProtectKernel*, ProtectControlGroups,
+LockPersonality, Restrict*, RestrictAddressFamilies=AF_UNIX). The four
+directives that can trap the mount on older kernels ship commented-out
+as opt-in. Verified live: mount visible in session, served file reads;
+opt-in @mount confirmed on kernel 7.0 / systemd 259.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Document the systemd hardening
+
+**Files:**
+- Modify: `contrib/systemd/README.md`
+
+- [ ] **Step 1: Insert a `## Hardening` section**
+
+In `contrib/systemd/README.md`, insert the following section immediately before
+the existing `## Notes` heading:
+
+```markdown
+## Hardening
+
+Both units ship sandboxed; no per-user path edits are required. The scanner uses
+`ProtectSystem=true` (not `strict`), so a custom `MUSEFS_DB` location works
+without a `ReadWritePaths=` change.
+
+- `musefs-scan.service` takes the **full** systemd sandbox — it creates no FUSE
+  mount, so namespace and mount-hiding directives are safe there.
+- `musefs.service` takes only the directives that keep the FUSE mount visible in
+  your session. A handful of stricter directives (`SystemCallFilter`,
+  `RestrictNamespaces`, `CapabilityBoundingSet=`, `MemoryDenyWriteExecute`) ship
+  **commented out** at the bottom of the unit — they can trap the mount on
+  kernels older than the maintainer's test box. Uncomment them one at a time and
+  confirm `mountpoint <your mountpoint>` still succeeds after a restart.
+
+Inspect the result with `systemd-analyze --user security musefs-scan.service`.
+
+```
+
+- [ ] **Step 2: Verify the file still reads coherently**
+
+Run:
+```bash
+sed -n '/## Hardening/,/## Notes/p' contrib/systemd/README.md
+```
+Expected: the new section prints, directly followed by the `## Notes` heading.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add contrib/systemd/README.md
+git commit -m "$(cat <<'EOF'
+docs(contrib): document systemd unit hardening (#317 #318)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+(Docs-only `*.md` commit — cargo gate skipped.)
+
+---
+
+## Task 4: #319 — Non-root container images (uid 1000)
+
+**Files:**
+- Modify: `docker/Dockerfile.glibc`
+- Modify: `docker/Dockerfile.musl`
+- Modify: `README.md`
+
+- [ ] **Step 1: Edit `docker/Dockerfile.glibc`**
+
+Replace the whole file with:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim
+
+# fuse3 provides the setuid `fusermount3` helper musefs execs at mount/unmount.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fuse3 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Run as a dedicated unprivileged user (uid/gid 1000). musefs mounts via the
+# setuid fusermount3 helper and needs no root, so a bind-mounted store volume
+# must be writable by uid 1000 (or pass `--user $(id -u):$(id -g)`).
+# user_allow_other lets a non-root --allow-other / --owner mount pass musefs's
+# /etc/fuse.conf pre-flight check (needed for the multi-container pod pattern).
+RUN groupadd -g 1000 musefs \
+ && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs \
+ && echo 'user_allow_other' >> /etc/fuse.conf
+
+# TARGETARCH is auto-populated by buildx per platform (amd64 / arm64); the build
+# context root holds <arch>/musefs for each.
+ARG TARGETARCH
+COPY ${TARGETARCH}/musefs /usr/local/bin/musefs
+
+USER musefs
+ENTRYPOINT ["musefs"]
+```
+
+- [ ] **Step 2: Edit `docker/Dockerfile.musl`**
+
+Replace the whole file with:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM alpine:3.20
+
+# fuse3 provides the setuid `fusermount3` helper musefs execs at mount/unmount.
+RUN apk add --no-cache fuse3
+
+# Run as a dedicated unprivileged user (uid/gid 1000). musefs mounts via the
+# setuid fusermount3 helper and needs no root, so a bind-mounted store volume
+# must be writable by uid 1000 (or pass `--user $(id -u):$(id -g)`).
+# user_allow_other lets a non-root --allow-other / --owner mount pass musefs's
+# /etc/fuse.conf pre-flight check (needed for the multi-container pod pattern).
+RUN addgroup -g 1000 musefs \
+ && adduser -u 1000 -G musefs -H -D -s /sbin/nologin musefs \
+ && echo 'user_allow_other' >> /etc/fuse.conf
+
+# TARGETARCH is auto-populated by buildx per platform (amd64 / arm64); the build
+# context root holds <arch>/musefs for each.
+ARG TARGETARCH
+COPY ${TARGETARCH}/musefs /usr/local/bin/musefs
+
+USER musefs
+ENTRYPOINT ["musefs"]
+```
+
+- [ ] **Step 3: Build both images from the staged context**
+
+Run:
+```bash
+export CTX=/tmp/musefs-harden-ctx
+cp docker/Dockerfile.glibc docker/Dockerfile.musl "$CTX/"
+podman build -f "$CTX/Dockerfile.glibc" --build-arg TARGETARCH=amd64 -t musefs-harden:glibc "$CTX"
+podman build -f "$CTX/Dockerfile.musl"  --build-arg TARGETARCH=amd64 -t musefs-harden:musl  "$CTX"
+```
+Expected: both builds succeed. (If the glibc image errors on `useradd`/`nologin`,
+those are in `bookworm-slim` by default — re-check the RUN line.)
+
+- [ ] **Step 4: Verify the entrypoint runs as uid 1000 (both images)**
+
+Run:
+```bash
+for tag in glibc musl; do
+  echo "== $tag =="
+  podman run --rm --entrypoint id "musefs-harden:$tag" -u
+done
+```
+Expected: each prints `1000`.
+
+- [ ] **Step 5: Verify a non-root `scan` writes the store (ownership friction)**
+
+Rootless Podman remaps container uid 1000 to a host subuid, so the bind-mounted
+store must be made writable for that mapping — the real-world ownership step.
+
+Run:
+```bash
+export STORE=/tmp/musefs-harden-store; rm -rf "$STORE"; mkdir -p "$STORE"
+export LIB="${LIB:-/data/media/music}"         # narrow to one album for a fast container scan
+podman unshare chown 1000:1000 "$STORE"        # "make the store writable by uid 1000"
+podman run --rm \
+  -v "$LIB":/library:ro \
+  -v "$STORE":/store \
+  musefs-harden:glibc scan /library --db /store/library.db --revalidate
+podman unshare ls -ln "$STORE"
+```
+Expected: scan exits 0; `library.db` listed with owner `1000`. (This proves the
+store-ownership requirement and that a non-root scan works.)
+
+- [ ] **Step 6: Verify the `/etc/fuse.conf` pre-flight check both ways**
+
+The baked `user_allow_other` must satisfy musefs's pre-flight; masking
+`/etc/fuse.conf` with an empty file must trigger the explicit error. The
+pre-flight runs *before* the privileged `mount()` syscall, so this validates the
+fuse.conf plumbing without needing a successful in-container mount.
+
+Run:
+```bash
+echo "== WITH baked user_allow_other (expect: past pre-flight) =="
+podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+  -v /tmp/musefs-harden-store:/store --entrypoint sh musefs-harden:glibc \
+  -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db --allow-other 2>&1 | head -5' || true
+
+echo "== WITHOUT user_allow_other (mask fuse.conf; expect: explicit error) =="
+podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+  -v /dev/null:/etc/fuse.conf:ro \
+  -v /tmp/musefs-harden-store:/store --entrypoint sh musefs-harden:glibc \
+  -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db --allow-other 2>&1 | head -5' || true
+```
+Expected: the WITH run does **not** print the "add `user_allow_other` to
+`/etc/fuse.conf`" error (it gets past the check; any later failure is the
+unprivileged-mount step, acceptable here). The WITHOUT run prints exactly that
+pre-flight error. Repeat the WITH run with `musefs-harden:musl` to confirm
+Alpine's `fusermount3` honours `/etc/fuse.conf` identically (the musl-specific
+regression risk).
+
+- [ ] **Step 7: (Optional) Full in-container mount under rootful Podman**
+
+A real mount needs unnamespaced `CAP_SYS_ADMIN`; rootless Podman cannot grant
+it (see the project's FUSE/CAP_SYS_ADMIN note). Skip unless you want end-to-end
+confirmation:
+```bash
+sudo podman run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
+  -v /tmp/musefs-harden-store:/store --entrypoint sh musefs-harden:glibc \
+  -c 'mkdir -p /tmp/m && musefs mount /tmp/m --db /store/library.db & sleep 1; mountpoint /tmp/m'
+```
+Expected (if run): `/tmp/m is a mountpoint`. Note: running under `sudo` writes
+the store as root, so do this *after* Step 5's ownership assertion, not before.
+
+- [ ] **Step 8: Update `README.md` — non-root container note**
+
+In `README.md`, immediately after the `CAP_SYS_ADMIN` paragraph that ends with
+"...prefer running musefs on the host, which needs no such capability." (just
+before the `#### The mount-visibility gotcha` heading), insert:
+
+```markdown
+
+#### Runs as a non-root user
+
+The images run as a dedicated unprivileged user (uid/gid 1000), not root —
+musefs mounts via the setuid `fusermount3` helper and needs no root of its own.
+Two consequences for the commands above:
+
+- The bind-mounted **store** volume must be writable by uid 1000. Either
+  `chown 1000:1000 /path/to/store` on the host, or add `--user $(id -u):$(id -g)`
+  to run as your own uid. The **library** volume is mounted `:ro`, so its
+  ownership does not matter.
+- The images include `user_allow_other` in `/etc/fuse.conf`, so a non-root
+  `--allow-other` / `--owner` / `--group` mount (used by the pod pattern below)
+  passes musefs's pre-flight check. See
+  [Ownership and permissions](#ownership-and-permissions).
+```
+
+- [ ] **Step 9: Update `README.md` — cross-reference from the ownership note**
+
+In `README.md`, in the "**Non-root mounts need `user_allow_other`**" paragraph
+(in the *Ownership and permissions* section), append this sentence to the end of
+that paragraph (after "...not a musefs restriction.)"):
+
+```markdown
+ The published container images already include this line, so non-root
+`allow_other` mounts work out of the box there.
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add docker/Dockerfile.glibc docker/Dockerfile.musl README.md
+git commit -m "$(cat <<'EOF'
+feat(docker): run the musefs container as non-root uid 1000 (#319)
+
+Both images create a dedicated uid/gid 1000 user and USER it, and bake
+user_allow_other into /etc/fuse.conf so a non-root --allow-other mount
+passes musefs's post-#339 pre-flight check (the multi-container pod
+pattern). Documents the store-volume ownership requirement. Verified
+live: entrypoint runs as 1000, non-root scan writes a 1000-owned DB,
+fuse.conf pre-flight passes with the baked line and fails cleanly when
+masked, on both glibc and musl images.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Tear down the live-test harness
+
+Leaves no test units, mounts, images, or scratch dirs behind. **No commit.**
+
+- [ ] **Step 1: Stop and remove test units + scratch**
+
+Run:
+```bash
+systemctl --user stop musefs-harden-mount.service musefs-harden-scan.service 2>/dev/null || true
+fusermount3 -u "$HOME/.cache/musefs-harden-test/mnt" 2>/dev/null || true
+rm -rf ~/.config/systemd/user/musefs-harden-scan.service ~/.config/systemd/user/musefs-harden-scan.service.d
+rm -rf ~/.config/systemd/user/musefs-harden-mount.service ~/.config/systemd/user/musefs-harden-mount.service.d
+systemctl --user daemon-reload
+rm -rf "$HOME/.cache/musefs-harden-test" /tmp/musefs-harden-ctx /tmp/musefs-harden-store
+```
+Expected: no errors; `ls ~/.config/systemd/user/ | grep harden` returns nothing.
+
+- [ ] **Step 2: (Optional) Remove the test images**
+
+Run:
+```bash
+podman rmi musefs-harden:glibc musefs-harden:musl 2>/dev/null || true
+```
+
+- [ ] **Step 3: Confirm the tree is clean and on-branch**
+
+Run:
+```bash
+git status -sb
+git log --oneline -4
+```
+Expected: clean working tree; the four feature commits (#317, #318, docs, #319)
+on top of the rebased branch.
+
+---
+
+## Self-Review (completed during planning)
+
+**Spec coverage:**
+- #317 full path-agnostic scanner sandbox → Task 1 (directive block matches the spec's #317 block exactly, `ProtectSystem=true`, no `ReadWritePaths`).
+- #318 mount-visible subset + commented opt-in → Task 2 (matches the spec's safe set + the four opt-in directives).
+- #319 non-root uid 1000 + `user_allow_other` → Task 4.
+- Doc updates: `contrib/systemd/README.md` → Task 3; `README.md` Docker + ownership → Task 4 Steps 8–9; inline unit/Dockerfile comments → Tasks 1, 2, 4.
+- Verification (live, dedi): scanner default+custom DB path + journald (Task 1), mount visibility + opt-in spot-check + exposure scores (Task 2), uid 1000 + store ownership + fuse.conf pre-flight both ways on both images (Task 4).
+- "Known sharp edges" (`ProcSubset=pid`, `ProtectControlGroups` on `--user`) → captured as inline comments in Task 1.
+
+**Placeholder scan:** none — every edit shows full file/block content; every verification step has an exact command and expected output.
+
+**Consistency:** the scratch env vars (`HARDEN`, `BIN`, `CTX`, `STORE`) and test
+unit names (`musefs-harden-scan`, `musefs-harden-mount`) and image tags
+(`musefs-harden:glibc|musl`) are used identically across Tasks 0–5. Task 5 cleans
+up exactly what Tasks 0–4 create.
+
+**Scope:** deployment-asset config only; no source/schema/FUSE-path changes, no
+CI harness (per the spec's explicit live-test-not-CI decision).

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -30,13 +30,20 @@ not face, while the riskiest ones can **break the FUSE mount** or impose
 user-visible friction. This spec keeps only directives that are *both* worth the
 risk and friction-free, and moves the rest to an explicit opt-in bucket.
 
-Two of the three issues also intersect an **in-flight PR** touching FUSE
-`allow_other` / `default_permissions`:
+The FUSE `allow_other` / `default_permissions` PR (**#339**, merged) has now
+landed and this branch is rebased on it. What shipped changes #319's rationale:
 
-- **#318 (mount unit)** and **#319 (`/etc/fuse.conf` + container)** are **parked**
-  until that PR lands, to avoid conflicting on the same surface.
-- **#317 (scanner)** is independent of `allow_other`/`default_permissions` and
-  can proceed on its own.
+- An explicit `--allow-other` flag (implied by `--owner`/`--group`) and a
+  `MUSEFS_ALLOW_OTHER` env var.
+- musefs now **pre-flight-checks `/etc/fuse.conf` for `user_allow_other`** and
+  fails with an explanatory error when a non-root `allow_other` mount lacks it
+  (`musefs-fuse/src/platform/mount.rs`).
+
+Consequence: switching the container to non-root (**#319**) makes the
+`user_allow_other` line in the image **required** to preserve the documented
+multi-container pod pattern (a non-root `--allow-other` mount now hard-fails the
+pre-flight without it), not the optional polish the earlier draft treated it as.
+All three issues are now unblocked.
 
 ## Guiding principle
 
@@ -53,7 +60,7 @@ friction and without risking the mount**. This yields three proportionate tiers:
    mount-capable / namespace / syscall-filter directives are **opt-in**, because
    they can trap the mount on kernels older than the dev box.
 3. **Container** — drop from root to a fixed unprivileged uid/gid 1000. Mostly a
-   docs change (volume ownership). Parked behind the `allow_other` PR.
+   docs change (volume ownership), plus the now-required `user_allow_other` line.
 
 ## Facts grounding the design
 
@@ -168,11 +175,12 @@ known-recent platform can uncomment them after confirming the mount still
 appears. We do not ship them on, because the dedi (kernel 7.0 / systemd 259) is
 not representative — "works here" does not generalize to Debian 12.
 
-### #319 — Dockerfiles: non-root uid 1000 (parked behind the `allow_other` PR)
+### #319 — Dockerfiles: non-root uid 1000
 
 Both images: create a `musefs` group+user at gid/uid **1000**, add
-`user_allow_other` to `/etc/fuse.conf` (so the multi-container pod pattern's
-`allow_other` still works without root), then `USER musefs`.
+`user_allow_other` to `/etc/fuse.conf` (now **required** for the non-root pod
+pattern — post-#339 musefs pre-flight-checks for it and hard-fails an
+`allow_other`/`--owner`/`--group` mount without it), then `USER musefs`.
 
 - **glibc / Debian:**
   `groupadd -g 1000 musefs && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs`
@@ -190,29 +198,35 @@ change as much as an image change. Confirm no base image / compose default
 injects `NoNewPrivileges` (would block the setuid escalation the container
 relies on).
 
-**This issue is parked** until the in-flight `allow_other`/`default_permissions`
-PR lands, since both edit `/etc/fuse.conf` and the FUSE permission surface.
+A plain single-container mount read only by uid 1000 itself needs **no**
+`allow_other`; the `user_allow_other` line matters only for the
+cross-container / owner-presenting case, and is harmless when unused.
 
 ## Documentation updates
 
 - `contrib/systemd/README.md` — short "Hardening" note: the units ship
   sandboxed; no per-user path edits are required (the scanner uses
   `ProtectSystem=true`, not `strict`). Mention the opt-in mount-unit directives.
-- `README.md` Docker section — the image runs as uid 1000; the bind-mounted
-  store dir must be owned by / writable to 1000 (or pass `--user`). Update the
-  `docker run` example (`README.md:116-120`) and the pod example
-  (`README.md:142-149`) so uid-1000 guidance does not contradict their existing
-  `--security-opt apparmor=unconfined` lines. (Deferred with #319.)
+- `README.md` Docker section (post-#339 line numbers) — the image runs as uid
+  1000; the bind-mounted store dir must be owned by / writable to 1000 (or pass
+  `--user`). Update the `docker run` example (`README.md:116-120`) and the
+  "mount-visibility gotcha" pod example (`README.md:145-148`) so uid-1000
+  guidance does not contradict their `--security-opt apparmor=unconfined` lines.
+  Cross-reference the new "Non-root mounts need `user_allow_other`" note
+  (`README.md:297-302`) from the pod example, since the non-root image now
+  relies on the image-baked `user_allow_other` for that pattern.
 - Inline comments in each unit / Dockerfile justifying the non-obvious
   directives.
 
 ## Implementation ordering
 
-1. **#317 (scanner)** — independent of the `allow_other` PR; do this now. Single
-   live `scan --revalidate` validates it.
-2. **#318 (mount unit)** and **#319 (container)** — after the `allow_other` PR
-   lands. #318 is a single edit (no prune loop now that the risky directives are
-   opt-in/commented). #319 is image + docs.
+All three are unblocked (#339 is merged). Suggested order by ascending risk:
+
+1. **#317 (scanner)** — simplest; a single live `scan --revalidate` validates it.
+2. **#318 (mount unit)** — a single edit (no prune loop now that the risky
+   directives are opt-in/commented).
+3. **#319 (container)** — image + docs; exercise the non-root `allow_other` pod
+   path against the now-merged pre-flight check.
 
 **Rollback:** each asset's pre-hardening version is recoverable from git. The
 pre-commit cargo gate is **skipped** for these (docs/config-only paths) and the
@@ -228,16 +242,18 @@ is the manual live run; do not commit an untested directive set.
    the case the dropped `ReadWritePaths` would have broken. Confirm the scanner
    spawns no namespace-cloning helper (probe workers are plain threads, so
    `RestrictNamespaces` is safe).
-2. **#318 (post-PR):** install the unit; assert the mount is visible in the
-   session and a served file reads back correctly. `systemd-analyze` score is
-   *evidence, not a gate* — the mount unit intentionally scores higher than the
-   scanner. Spot-check that uncommenting one opt-in directive and restarting
-   still mounts, to document the opt-in path.
-3. **#319 (post-PR):** build **both** images; for each assert uid 1000 can open
+2. **#318:** install the unit; assert the mount is visible in the session and a
+   served file reads back correctly. `systemd-analyze` score is *evidence, not a
+   gate* — the mount unit intentionally scores higher than the scanner.
+   Spot-check that uncommenting one opt-in directive and restarting still mounts,
+   to document the opt-in path.
+3. **#319:** build **both** images; for each assert uid 1000 can open
    `/dev/fuse`, run `scan` + `mount` non-root with
-   `--cap-add SYS_ADMIN --device /dev/fuse`, and confirm the store write is
-   uid-1000-owned and `allow_other` works non-root (musl-specific regression
-   risk).
+   `--cap-add SYS_ADMIN --device /dev/fuse`. Confirm the store write is
+   uid-1000-owned, and that a non-root `--allow-other` (or `--owner`) mount
+   passes the merged `/etc/fuse.conf` pre-flight check thanks to the image-baked
+   `user_allow_other` — and fails cleanly if that line is removed (musl-specific
+   regression risk).
 
 ## Out of scope (YAGNI)
 

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -12,70 +12,82 @@ already-privileged contexts.
 
 - `contrib/systemd/musefs-scan.service` runs the oneshot scanner — which parses
   adversarial media bytes — with **zero** sandboxing directives, even though it
-  creates no FUSE mount and can therefore take the full systemd sandbox.
-- `contrib/systemd/musefs.service` sets only `NoNewPrivileges=true`. Several
+  creates no FUSE mount and can therefore take a strong sandbox.
+- `contrib/systemd/musefs.service` sets only `NoNewPrivileges=true`. A few
   hardening directives that do **not** sever the FUSE mount's propagation to the
-  session are absent, so the unit does not enforce the README's "no root, no
-  `CAP_SYS_ADMIN`" posture.
+  session are absent.
 - `docker/Dockerfile.glibc` and `docker/Dockerfile.musl` set no `USER`, so
   `ENTRYPOINT ["musefs"]` runs as **root** inside a container that already needs
   `--cap-add SYS_ADMIN` + `--device /dev/fuse` — a larger blast radius than
-  necessary, contradicting the systemd units' non-root guidance.
+  necessary.
+
+## Scope decision: right-sized, not a full checklist sweep
+
+An earlier draft applied every systemd directive each asset could technically
+take. That was over-built: most of the marginal directives defend an
+already-unprivileged, socket-less, network-less daemon against threats it does
+not face, while the riskiest ones can **break the FUSE mount** or impose
+user-visible friction. This spec keeps only directives that are *both* worth the
+risk and friction-free, and moves the rest to an explicit opt-in bucket.
+
+Two of the three issues also intersect an **in-flight PR** touching FUSE
+`allow_other` / `default_permissions`:
+
+- **#318 (mount unit)** and **#319 (`/etc/fuse.conf` + container)** are **parked**
+  until that PR lands, to avoid conflicting on the same surface.
+- **#317 (scanner)** is independent of `allow_other`/`default_permissions` and
+  can proceed on its own.
 
 ## Guiding principle
 
-Apply the strictest sandbox each asset's mount-visibility constraint allows.
-This yields three tiers:
+Apply the strongest sandbox each asset can take **without path-configuration
+friction and without risking the mount**. This yields three proportionate tiers:
 
-1. **Scanner** — no FUSE mount → full sandbox, *including* namespace /
-   mount-hiding directives.
-2. **Mount unit** — only directives that do not remount the path the FUSE mount
-   lives under, nor sever mount propagation to the session.
-3. **Container** — drop from root to a fixed unprivileged uid/gid 1000.
-
-`SystemCallFilter` uses systemd's curated `@system-service` group (maintained
-across kernels) rather than a handcrafted allowlist (fragile across
-distros/libc), plus the minimal extra group a given unit provably needs.
+1. **Scanner** — no FUSE mount → full *path-agnostic* sandbox. The justified
+   one: it is the sole component ingesting adversarial bytes, so containing a
+   parser RCE has real value. Deliberately omits write-path confinement
+   (`ProtectSystem=strict` + `ReadWritePaths=`), whose only marginal gain is
+   confining writes the scanner already restricts to the DB by design — at the
+   cost of every custom-`MUSEFS_DB` user silently failing their scan.
+2. **Mount unit** — only the safe-anywhere, friction-free directives. The
+   mount-capable / namespace / syscall-filter directives are **opt-in**, because
+   they can trap the mount on kernels older than the dev box.
+3. **Container** — drop from root to a fixed unprivileged uid/gid 1000. Mostly a
+   docs change (volume ownership). Parked behind the `allow_other` PR.
 
 ## Facts grounding the design
 
-- musefs touches no network: local SQLite + positioned file reads. No sockets
-  beyond journald's `AF_UNIX`.
-- Documented DB convention (`contrib/systemd/musefs.conf.example:20`):
-  `~/.local/share/musefs/library.db`. There is no hardcoded default in the CLI;
-  the DB is supplied via `MUSEFS_DB`/flag.
-- The library may live outside `$HOME` (e.g. `/data`); reads remain permitted
-  under `ProtectSystem=strict` (read-only ≠ inaccessible).
+- musefs touches no network: local SQLite + positioned file reads. The only
+  socket need is journald's `AF_UNIX`.
+- The library may live outside `$HOME` (e.g. `/data`); `ProtectSystem=true`
+  leaves `/home` and arbitrary data paths writable/readable, so no path config
+  is required (unlike `strict`).
 - On the **host**, `/dev/fuse` is mode `0666`; an unprivileged uid can open it.
   Inside a container the device node is created by `--device /dev/fuse` as
   `root:root` with the host's mode — it is the *in-container* perms that govern
   uid 1000's access, so the live test must assert `/dev/fuse` is openable by the
-  non-root user as a named check (see Verification).
+  non-root user.
 - `fusermount3` is setuid-root, so the **container** mount works without
-  `NoNewPrivileges` blocking the setuid escalation (the container is the one
-  context where the setuid path is actually exercised). The **systemd** units
-  keep `NoNewPrivileges=true`, which *does* neutralize that setuid — they rely
-  instead on **unprivileged FUSE** (kernel ≥ 4.18 + fusermount3 ≥ 3.x mounting
-  in the caller's own user/mount context). This is the version floor: on an
-  older kernel/fusermount3 the existing `NNP=true` mount unit would itself not
-  work. Dedi baseline (verified): systemd 259, fusermount3 3.18.2, kernel 7.0.
-- musefs is Rust with no JIT → `MemoryDenyWriteExecute=true` is safe. The
-  scanner crates pull in no `mmap`-exec path; the only `memmap2` user is
-  `musefs-fuse` (not the scanner). The SQLite WAL `-shm` mapping is
-  `MAP_SHARED` read/write, not anonymous W+X, so it survives `MDWE`.
+  `NoNewPrivileges` blocking the setuid escalation. The **systemd** units keep
+  `NoNewPrivileges=true`, which *does* neutralize that setuid — they rely
+  instead on **unprivileged FUSE** (kernel ≥ 4.18 + fusermount3 ≥ 3.x). Dedi
+  baseline (verified): systemd 259, fusermount3 3.18.2, kernel 7.0 — newer than
+  most users, which is exactly why the mount unit's risky directives are opt-in
+  rather than shipped on.
+- musefs is Rust with no JIT → `MemoryDenyWriteExecute=true` is safe where used
+  (the scanner pulls in no `mmap`-exec path; `memmap2` lives only in
+  `musefs-fuse`).
 
 ## Design
 
-### #317 — `musefs-scan.service`: full sandbox
+### #317 — `musefs-scan.service`: full path-agnostic sandbox
 
-Add the complete sandbox. The scanner reads the library (read-only, anywhere)
-and writes only the DB directory.
+The scanner reads the library (anywhere) and writes the DB. None of these
+directives needs to know where either lives:
 
 ```ini
 NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=%h/.local/share/musefs   # the DB *directory*; ADJUST if MUSEFS_DB lives elsewhere
+ProtectSystem=true                       # /usr,/boot,/etc read-only; /home & data stay writable — no path config
 PrivateTmp=true
 PrivateDevices=true
 ProtectKernelTunables=true
@@ -87,7 +99,7 @@ ProtectHostname=true
 ProtectProc=invisible
 ProcSubset=pid
 RestrictNamespaces=true
-RestrictAddressFamilies=AF_UNIX          # REQUIRED for journald (/run/systemd/journal/socket); do NOT drop to none — it silently kills logs
+RestrictAddressFamilies=AF_UNIX          # REQUIRED for journald; do NOT drop to none (silently kills logs)
 RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
@@ -99,183 +111,149 @@ SystemCallErrorNumber=EPERM
 UMask=077
 ```
 
-**Friction (documented inline):** `ReadWritePaths` must name the DB's
-**directory, not the file** — SQLite in WAL mode (confirmed:
-`musefs-db/src/lib.rs:86`) writes `library.db-wal` and `library.db-shm` as
-*siblings* in that directory, so a file-scoped RW path would silently break WAL
-creation. A DB outside `~/.local/share/musefs` requires editing this line; the
-library path needs no entry (reads are always allowed under
-`ProtectSystem=strict`, including a library on `/data`). `PrivateTmp=true` gives
-SQLite a private `/tmp` for any temp-store spill.
+**Dropped from the earlier draft (friction):** `ProtectSystem=strict`,
+`ProtectHome=read-only`, `ReadWritePaths=%h/.local/share/musefs`. Those confine
+writes to a single declared directory — which forces every user with a custom
+`MUSEFS_DB` to edit a *second*, non-obvious line or hit a confusing read-only
+error. The scanner already only writes the DB by design, so the lost
+confinement is low-value; `ProtectSystem=true` keeps system dirs read-only with
+zero path coupling.
 
-**Empirical-fallback discipline (same as the mount unit):** the `@system-service`
-filter + `SystemCallErrorNumber=EPERM` combination can return `EPERM` (not
-`ENOSYS`) for a filtered syscall, which some libc paths handle poorly. The live
-test runs a real `scan --revalidate`; any directive that breaks the scan is
-dropped with an inline comment recording the failure, exactly as for #318.
+**Empirical-fallback discipline:** `@system-service` + `SystemCallErrorNumber=
+EPERM` can return `EPERM` (not `ENOSYS`) for a filtered syscall, which some libc
+paths handle poorly. The live test runs a real `scan --revalidate`; any
+directive that breaks the scan is dropped with an inline comment recording why.
 
-### #318 — `musefs.service`: mount-visible hardening
+### #318 — `musefs.service`: safe-anywhere subset (the rest opt-in)
 
-Keep `NoNewPrivileges=true` and the existing "do NOT add" comment; **extend**
-that comment to state which new directives are safe and why. Add only
-directives that do not create a private mount namespace over the mountpoint path
-or sever propagation:
+Keep `NoNewPrivileges=true` and the existing "do NOT add" comment; extend it to
+state which new directives are safe and why. Add only directives that cannot
+trap the mount on any supported kernel:
 
 ```ini
-CapabilityBoundingSet=
-RestrictAddressFamilies=AF_UNIX
-RestrictNamespaces=true
-LockPersonality=true
-MemoryDenyWriteExecute=true
-RestrictRealtime=true
-RestrictSUIDSGID=true
-ProtectClock=true
-ProtectHostname=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_UNIX
 SystemCallArchitectures=native
-SystemCallFilter=@system-service @mount   # @mount: fusermount3 needs mount/umount2
 ```
 
-**Forbidden (still):** `Protect{System,Home}=`, `ReadOnlyPaths=`,
-`ReadWritePaths=`, `PrivateTmp=`, `PrivateMounts=`, `MountFlags=private` — each
-either remounts the home path the FUSE mount lives under or severs propagation,
-hiding the mount from the session.
+**Why these are safe:** `ProtectKernel*` / `ProtectControlGroups` *do* place the
+unit in a private mount namespace (they bind-mount `/proc/sys`, `/sys`,
+`/sys/fs/cgroup` read-only), but a FUSE mount the service later makes under
+`$HOME` is **still visible in the session** because of systemd's default
+`MountFlags=shared`: the mount propagates back to the host. The existing
+Forbidden list (`Protect{System,Home}=`, `PrivateMounts=`, `MountFlags=private`)
+is forbidden precisely because it severs that propagation or remounts the
+mountpoint's parent.
 
-**Rationale for the boundary (the load-bearing invariant):**
-`ProtectKernel*` / `ProtectControlGroups` *do* place the unit in a private mount
-namespace (they bind-mount `/proc/sys`, `/sys`, `/sys/fs/cgroup` read-only). The
-reason a FUSE mount the service later creates under `$HOME` is **still visible
-in the session** is systemd's default `MountFlags=shared`: mounts the unit makes
-propagate *back* to the host via shared propagation. The Forbidden list is
-forbidden precisely because it severs that — `MountFlags=private` /
-`PrivateMounts=` switch propagation to private/slave and trap the mount, and
-`Protect{System,Home}=` remount the very path the mount lives under. **This
-spec's entire mount-unit hardening depends on default shared propagation; if any
-future edit sets `MountFlags=private`, every "safe" directive above instantly
-becomes mount-hiding.**
+**Opt-in / deferred (documented in the unit comment, commented out):**
 
-The directives that could *still* break the mount on this kernel —
-`SystemCallFilter=@system-service @mount` (over-restrictive `@mount`),
-`RestrictNamespaces`, `CapabilityBoundingSet=`, `MemoryDenyWriteExecute` — are
-resolved empirically by the live test. On the dedi, `@mount` was verified to
-include the new mount-API syscalls (`fsopen`/`fsmount`/`move_mount`/
-`open_tree_attr`) that unprivileged FUSE uses on recent kernels; an *older*
-systemd's `@mount` predates them, so a `@mount`-caused failure is a distinct
-branch from a `RestrictNamespaces`-caused one. Any directive that breaks the
-mount is dropped with an inline comment recording why, turning the failure into
-documentation.
+```ini
+#SystemCallFilter=@system-service @mount   # @mount can be stale on older systemd → mount fails
+#RestrictNamespaces=true                    # unprivileged-FUSE path may need a namespace on some kernels
+#CapabilityBoundingSet=                     # NNP already neuters fusermount3 setuid; net gain marginal
+#MemoryDenyWriteExecute=true                # read-only mmap is safe in principle, unverified across platforms
+```
 
-### #319 — Dockerfiles: non-root uid 1000
+These four are the ones that can break the mount on a kernel/systemd older than
+the dev box. They are shipped **commented out**, with a note that a user on a
+known-recent platform can uncomment them after confirming the mount still
+appears. We do not ship them on, because the dedi (kernel 7.0 / systemd 259) is
+not representative — "works here" does not generalize to Debian 12.
+
+### #319 — Dockerfiles: non-root uid 1000 (parked behind the `allow_other` PR)
 
 Both images: create a `musefs` group+user at gid/uid **1000**, add
-`user_allow_other` to `/etc/fuse.conf` (so the documented multi-container pod
-pattern's `allow_other` still works without root), then `USER musefs` before
-`ENTRYPOINT`.
+`user_allow_other` to `/etc/fuse.conf` (so the multi-container pod pattern's
+`allow_other` still works without root), then `USER musefs`.
 
 - **glibc / Debian:**
   `groupadd -g 1000 musefs && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs`
 - **musl / Alpine:**
   `addgroup -g 1000 musefs && adduser -u 1000 -G musefs -H -D -s /sbin/nologin musefs`
-- `RUN echo 'user_allow_other' >> /etc/fuse.conf` (file created if absent).
-  **Musl caveat:** confirm Alpine's `fusermount3` reads `/etc/fuse.conf` from
-  the same path and honours `user_allow_other` identically — this is verified in
-  the live test, not assumed, since the `allow_other` pod pattern is the one
-  thing the non-root switch could regress.
+- `RUN echo 'user_allow_other' >> /etc/fuse.conf` (created if absent). **Musl
+  caveat:** confirm Alpine's `fusermount3` reads `/etc/fuse.conf` and honours
+  `user_allow_other` — verified in the live test, not assumed.
 - `USER musefs`
 
-The store volume must be writable by uid 1000 — documented, not enforced in the
-image (the chosen UID strategy: fixed 1000 + doc note, not a build arg).
+The store volume must be writable by uid 1000 — **this is the real friction**:
+the existing copy-paste `docker run -v /store …` breaks unless the host store
+dir is owned by 1000 or `--user $(id -u):$(id -g)` is passed. This is a docs
+change as much as an image change. Confirm no base image / compose default
+injects `NoNewPrivileges` (would block the setuid escalation the container
+relies on).
 
-`/dev/fuse` access is governed by the **in-container** device-node perms (Docker
-creates it `root:root` with the host mode under `--device`), not the host's
-`0666` — so the live test asserts uid 1000 can open it explicitly. Confirm no
-base image / compose default injects `NoNewPrivileges` into the container, which
-would block the `fusermount3` setuid escalation the container path relies on.
+**This issue is parked** until the in-flight `allow_other`/`default_permissions`
+PR lands, since both edit `/etc/fuse.conf` and the FUSE permission surface.
 
 ## Documentation updates
 
-- `contrib/systemd/README.md` — add a short "Hardening" note: units ship
-  sandboxed; the scanner's `ReadWritePaths` is the one line to adjust for a
-  non-default DB path.
-- `README.md` Docker section — the image now runs as uid 1000; the bind-mounted
-  store dir must be owned by / writable to 1000 (or pass
-  `--user $(id -u):$(id -g)`). Update the `docker run` example block
-  (`README.md:116-120`) and the multi-container pod example (`README.md:142-149`)
-  so the uid-1000 guidance does not contradict their existing
-  `--security-opt apparmor=unconfined` lines.
+- `contrib/systemd/README.md` — short "Hardening" note: the units ship
+  sandboxed; no per-user path edits are required (the scanner uses
+  `ProtectSystem=true`, not `strict`). Mention the opt-in mount-unit directives.
+- `README.md` Docker section — the image runs as uid 1000; the bind-mounted
+  store dir must be owned by / writable to 1000 (or pass `--user`). Update the
+  `docker run` example (`README.md:116-120`) and the pod example
+  (`README.md:142-149`) so uid-1000 guidance does not contradict their existing
+  `--security-opt apparmor=unconfined` lines. (Deferred with #319.)
 - Inline comments in each unit / Dockerfile justifying the non-obvious
   directives.
 
-## Implementation ordering & rollback
+## Implementation ordering
 
-The three edits are independent *as files* but #317 and #318 are not atomic —
-each is an **edit → live-test → prune-failed-directive → re-test** loop (the
-spec expects some mount-unit directives to be dropped mid-test). Order:
+1. **#317 (scanner)** — independent of the `allow_other` PR; do this now. Single
+   live `scan --revalidate` validates it.
+2. **#318 (mount unit)** and **#319 (container)** — after the `allow_other` PR
+   lands. #318 is a single edit (no prune loop now that the risky directives are
+   opt-in/commented). #319 is image + docs.
 
-1. **#319 (Dockerfiles)** first — no propagation subtlety, fastest to validate,
-   unblocks the container doc update.
-2. **#317 (scanner)** next — full sandbox, single live `scan` validates it; its
-   prune loop is independent of the mount unit.
-3. **#318 (mount unit)** last — the riskiest, with the empirical prune loop.
-
-**Rollback / partial failure:** each unit/Dockerfile's pre-hardening version is
-recoverable from git; a failed mount-unit live test must leave the **committed**
-unit in its last-known-good directive set, never the in-flight experimental one.
-The pre-commit cargo gate is **skipped** for these (docs/config-only paths), and
-the shell/YAML legs do not lint `.service`/`Dockerfile` content — so the real
-gate is the manual live run, and each commit must represent a directive set that
-actually passed it. Do not commit an untested directive set.
+**Rollback:** each asset's pre-hardening version is recoverable from git. The
+pre-commit cargo gate is **skipped** for these (docs/config-only paths) and the
+shell/YAML legs do not lint `.service`/`Dockerfile` content — so the real gate
+is the manual live run; do not commit an untested directive set.
 
 ## Verification (live, on the dedicated server)
 
-1. `systemd-analyze --user security musefs.service` and
-   `musefs-scan.service` — record before/after exposure scores **as evidence,
-   not a pass/fail gate**. The mount unit deliberately omits the mount-hiding
-   directives, so its score is *expected* to stay higher than the scanner's;
-   that is correct, not a regression. The scanner is the unit chasing a low
-   score.
-2. Install both user units (mount under `$HOME` per the AppArmor-fusermount3
-   constraint — `/data` mounts are denied by the host profile, not a musefs
-   bug). Run a real `musefs-scan.service`; assert the DB **and its `-wal`/`-shm`
-   siblings** are written. Start `musefs.service`; assert the mount is visible
-   in the session and a served file reads back correctly. The `musefs-scan.timer`
-   is unchanged (hardening lives on the service); confirm it still triggers.
-3. Build **both** `Dockerfile.glibc` and `Dockerfile.musl`. For each: assert
-   uid 1000 can open `/dev/fuse`; run `scan` (DB write) and `mount` as the
-   non-root uid with `--cap-add SYS_ADMIN --device /dev/fuse`; assert both
-   succeed, the store write lands owned by uid 1000, and `allow_other` works
-   non-root (the `user_allow_other` path — the musl-specific regression risk).
+1. **#317:** `systemd-analyze --user security musefs-scan.service` (record the
+   exposure score as evidence). Install the unit, run a real
+   `musefs-scan.service`; assert the DB (and `-wal`/`-shm` siblings) are written
+   for a DB both at the default location and at a **custom `MUSEFS_DB` path** —
+   the case the dropped `ReadWritePaths` would have broken. Confirm the scanner
+   spawns no namespace-cloning helper (probe workers are plain threads, so
+   `RestrictNamespaces` is safe).
+2. **#318 (post-PR):** install the unit; assert the mount is visible in the
+   session and a served file reads back correctly. `systemd-analyze` score is
+   *evidence, not a gate* — the mount unit intentionally scores higher than the
+   scanner. Spot-check that uncommenting one opt-in directive and restarting
+   still mounts, to document the opt-in path.
+3. **#319 (post-PR):** build **both** images; for each assert uid 1000 can open
+   `/dev/fuse`, run `scan` + `mount` non-root with
+   `--cap-add SYS_ADMIN --device /dev/fuse`, and confirm the store write is
+   uid-1000-owned and `allow_other` works non-root (musl-specific regression
+   risk).
 
 ## Out of scope (YAGNI)
 
-- CI smoke harness — verification is the live dedi run, not a committed CI test.
-- Build-arg-configurable container UID — fixed 1000 + doc note was chosen.
-- Any change to the binary, the FUSE/read path, or the store schema. This is
-  deployment-asset config only.
+- CI smoke harness — verification is the live dedi run.
+- Build-arg-configurable container UID — fixed 1000 + doc note.
+- Write-path confinement on the scanner (`ProtectSystem=strict` +
+  `ReadWritePaths`) — dropped for friction; revisit only if a concrete
+  parser-write threat appears.
+- Aggressive mount-unit syscall/namespace hardening — shipped opt-in, not on.
+- Any change to the binary, the FUSE/read path, or the store schema.
 
-## Risks
+## Known sharp edges (inline-comment level)
 
-- A `SystemCallFilter` / `RestrictNamespaces` / `CapabilityBoundingSet` choice
-  silently breaks the FUSE mount. **Mitigation:** these surface only at runtime,
-  so the live test on the mount unit is mandatory, not optional; failures are
-  recorded inline as documentation.
-- The non-root container regresses the multi-container `allow_other` pod
-  pattern. **Mitigation:** `user_allow_other` in the image; the pod pattern is
-  exercised in the container live test if feasible.
-- Distro-specific user-creation flag drift (Debian `useradd` vs Alpine
-  `adduser`). **Mitigation:** both image builds are exercised in the live test.
-
-**Known sharp edges (carry into inline comments, not blockers):**
-
-- `ProcSubset=pid` + `ProtectProc=invisible` on the scanner hide non-pid `/proc`
-  entries. Safe today, but a future media parser that reads `/proc/cpuinfo` for
-  SIMD detection would break — note it in the unit comment.
+- `ProcSubset=pid` + `ProtectProc=invisible` on the scanner hide non-pid
+  `/proc`. Safe today; a future parser reading `/proc/cpuinfo` for SIMD
+  detection would break — note it in the comment.
 - `ProtectControlGroups=true` on a `--user` unit remounts `/sys/fs/cgroup`
   read-only in the namespace; confirm it does not interfere with the user
-  manager's own cgroup bookkeeping for the unit (expected harmless).
-- `RestrictNamespaces=true` on the scanner is safe only because the scanner
-  spawns no namespace-cloning helper (probe workers are plain threads) — verify
-  during the live scan.
+  manager's cgroup bookkeeping (expected harmless).

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -46,11 +46,23 @@ distros/libc), plus the minimal extra group a given unit provably needs.
   the DB is supplied via `MUSEFS_DB`/flag.
 - The library may live outside `$HOME` (e.g. `/data`); reads remain permitted
   under `ProtectSystem=strict` (read-only ≠ inaccessible).
-- `/dev/fuse` is mode `0666`; an unprivileged uid can open it. `fusermount3` is
-  setuid-root, so the **container** mount works without `NoNewPrivileges`
-  blocking the setuid escalation (the container is the one context where the
-  setuid path is actually exercised).
-- musefs is Rust with no JIT → `MemoryDenyWriteExecute=true` is safe.
+- On the **host**, `/dev/fuse` is mode `0666`; an unprivileged uid can open it.
+  Inside a container the device node is created by `--device /dev/fuse` as
+  `root:root` with the host's mode — it is the *in-container* perms that govern
+  uid 1000's access, so the live test must assert `/dev/fuse` is openable by the
+  non-root user as a named check (see Verification).
+- `fusermount3` is setuid-root, so the **container** mount works without
+  `NoNewPrivileges` blocking the setuid escalation (the container is the one
+  context where the setuid path is actually exercised). The **systemd** units
+  keep `NoNewPrivileges=true`, which *does* neutralize that setuid — they rely
+  instead on **unprivileged FUSE** (kernel ≥ 4.18 + fusermount3 ≥ 3.x mounting
+  in the caller's own user/mount context). This is the version floor: on an
+  older kernel/fusermount3 the existing `NNP=true` mount unit would itself not
+  work. Dedi baseline (verified): systemd 259, fusermount3 3.18.2, kernel 7.0.
+- musefs is Rust with no JIT → `MemoryDenyWriteExecute=true` is safe. The
+  scanner crates pull in no `mmap`-exec path; the only `memmap2` user is
+  `musefs-fuse` (not the scanner). The SQLite WAL `-shm` mapping is
+  `MAP_SHARED` read/write, not anonymous W+X, so it survives `MDWE`.
 
 ## Design
 
@@ -63,7 +75,7 @@ and writes only the DB directory.
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=%h/.local/share/musefs   # DB dir; ADJUST if MUSEFS_DB lives elsewhere
+ReadWritePaths=%h/.local/share/musefs   # the DB *directory*; ADJUST if MUSEFS_DB lives elsewhere
 PrivateTmp=true
 PrivateDevices=true
 ProtectKernelTunables=true
@@ -75,7 +87,7 @@ ProtectHostname=true
 ProtectProc=invisible
 ProcSubset=pid
 RestrictNamespaces=true
-RestrictAddressFamilies=AF_UNIX          # journald; tighten to none if logging survives
+RestrictAddressFamilies=AF_UNIX          # REQUIRED for journald (/run/systemd/journal/socket); do NOT drop to none — it silently kills logs
 RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
@@ -88,9 +100,19 @@ UMask=077
 ```
 
 **Friction (documented inline):** `ReadWritePaths` must name the DB's
-directory. A DB outside `~/.local/share/musefs` requires editing this line; the
+**directory, not the file** — SQLite in WAL mode (confirmed:
+`musefs-db/src/lib.rs:86`) writes `library.db-wal` and `library.db-shm` as
+*siblings* in that directory, so a file-scoped RW path would silently break WAL
+creation. A DB outside `~/.local/share/musefs` requires editing this line; the
 library path needs no entry (reads are always allowed under
-`ProtectSystem=strict`).
+`ProtectSystem=strict`, including a library on `/data`). `PrivateTmp=true` gives
+SQLite a private `/tmp` for any temp-store spill.
+
+**Empirical-fallback discipline (same as the mount unit):** the `@system-service`
+filter + `SystemCallErrorNumber=EPERM` combination can return `EPERM` (not
+`ENOSYS`) for a filtered syscall, which some libc paths handle poorly. The live
+test runs a real `scan --revalidate`; any directive that breaks the scan is
+dropped with an inline comment recording the failure, exactly as for #318.
 
 ### #318 — `musefs.service`: mount-visible hardening
 
@@ -122,13 +144,29 @@ SystemCallFilter=@system-service @mount   # @mount: fusermount3 needs mount/umou
 either remounts the home path the FUSE mount lives under or severs propagation,
 hiding the mount from the session.
 
-**Rationale for the boundary:** `ProtectKernel*` / `ProtectControlGroups` touch
-`/proc` and `/sys`, not the home path under which the mount sits, so they do not
-break propagation. The four directives that *could* break the mount —
-`@mount` (could be over-restrictive), `RestrictNamespaces`,
-`CapabilityBoundingSet=`, `MemoryDenyWriteExecute` — are resolved empirically by
-the live test. Any that breaks the mount is dropped with an inline comment
-recording why, turning the failure into documentation.
+**Rationale for the boundary (the load-bearing invariant):**
+`ProtectKernel*` / `ProtectControlGroups` *do* place the unit in a private mount
+namespace (they bind-mount `/proc/sys`, `/sys`, `/sys/fs/cgroup` read-only). The
+reason a FUSE mount the service later creates under `$HOME` is **still visible
+in the session** is systemd's default `MountFlags=shared`: mounts the unit makes
+propagate *back* to the host via shared propagation. The Forbidden list is
+forbidden precisely because it severs that — `MountFlags=private` /
+`PrivateMounts=` switch propagation to private/slave and trap the mount, and
+`Protect{System,Home}=` remount the very path the mount lives under. **This
+spec's entire mount-unit hardening depends on default shared propagation; if any
+future edit sets `MountFlags=private`, every "safe" directive above instantly
+becomes mount-hiding.**
+
+The directives that could *still* break the mount on this kernel —
+`SystemCallFilter=@system-service @mount` (over-restrictive `@mount`),
+`RestrictNamespaces`, `CapabilityBoundingSet=`, `MemoryDenyWriteExecute` — are
+resolved empirically by the live test. On the dedi, `@mount` was verified to
+include the new mount-API syscalls (`fsopen`/`fsmount`/`move_mount`/
+`open_tree_attr`) that unprivileged FUSE uses on recent kernels; an *older*
+systemd's `@mount` predates them, so a `@mount`-caused failure is a distinct
+branch from a `RestrictNamespaces`-caused one. Any directive that breaks the
+mount is dropped with an inline comment recording why, turning the failure into
+documentation.
 
 ### #319 — Dockerfiles: non-root uid 1000
 
@@ -141,11 +179,21 @@ pattern's `allow_other` still works without root), then `USER musefs` before
   `groupadd -g 1000 musefs && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs`
 - **musl / Alpine:**
   `addgroup -g 1000 musefs && adduser -u 1000 -G musefs -H -D -s /sbin/nologin musefs`
-- `RUN echo 'user_allow_other' >> /etc/fuse.conf` (file created if absent)
+- `RUN echo 'user_allow_other' >> /etc/fuse.conf` (file created if absent).
+  **Musl caveat:** confirm Alpine's `fusermount3` reads `/etc/fuse.conf` from
+  the same path and honours `user_allow_other` identically — this is verified in
+  the live test, not assumed, since the `allow_other` pod pattern is the one
+  thing the non-root switch could regress.
 - `USER musefs`
 
 The store volume must be writable by uid 1000 — documented, not enforced in the
 image (the chosen UID strategy: fixed 1000 + doc note, not a build arg).
+
+`/dev/fuse` access is governed by the **in-container** device-node perms (Docker
+creates it `root:root` with the host mode under `--device`), not the host's
+`0666` — so the live test asserts uid 1000 can open it explicitly. Confirm no
+base image / compose default injects `NoNewPrivileges` into the container, which
+would block the `fusermount3` setuid escalation the container path relies on.
 
 ## Documentation updates
 
@@ -154,22 +202,52 @@ image (the chosen UID strategy: fixed 1000 + doc note, not a build arg).
   non-default DB path.
 - `README.md` Docker section — the image now runs as uid 1000; the bind-mounted
   store dir must be owned by / writable to 1000 (or pass
-  `--user $(id -u):$(id -g)`).
+  `--user $(id -u):$(id -g)`). Update the `docker run` example block
+  (`README.md:116-120`) and the multi-container pod example (`README.md:142-149`)
+  so the uid-1000 guidance does not contradict their existing
+  `--security-opt apparmor=unconfined` lines.
 - Inline comments in each unit / Dockerfile justifying the non-obvious
   directives.
+
+## Implementation ordering & rollback
+
+The three edits are independent *as files* but #317 and #318 are not atomic —
+each is an **edit → live-test → prune-failed-directive → re-test** loop (the
+spec expects some mount-unit directives to be dropped mid-test). Order:
+
+1. **#319 (Dockerfiles)** first — no propagation subtlety, fastest to validate,
+   unblocks the container doc update.
+2. **#317 (scanner)** next — full sandbox, single live `scan` validates it; its
+   prune loop is independent of the mount unit.
+3. **#318 (mount unit)** last — the riskiest, with the empirical prune loop.
+
+**Rollback / partial failure:** each unit/Dockerfile's pre-hardening version is
+recoverable from git; a failed mount-unit live test must leave the **committed**
+unit in its last-known-good directive set, never the in-flight experimental one.
+The pre-commit cargo gate is **skipped** for these (docs/config-only paths), and
+the shell/YAML legs do not lint `.service`/`Dockerfile` content — so the real
+gate is the manual live run, and each commit must represent a directive set that
+actually passed it. Do not commit an untested directive set.
 
 ## Verification (live, on the dedicated server)
 
 1. `systemd-analyze --user security musefs.service` and
-   `musefs-scan.service` — record before/after exposure scores as evidence.
+   `musefs-scan.service` — record before/after exposure scores **as evidence,
+   not a pass/fail gate**. The mount unit deliberately omits the mount-hiding
+   directives, so its score is *expected* to stay higher than the scanner's;
+   that is correct, not a regression. The scanner is the unit chasing a low
+   score.
 2. Install both user units (mount under `$HOME` per the AppArmor-fusermount3
    constraint — `/data` mounts are denied by the host profile, not a musefs
-   bug). Run a real `musefs-scan.service`; assert the DB is updated. Start
-   `musefs.service`; assert the mount is visible in the session and a served
-   file reads back correctly.
-3. Build `Dockerfile.glibc`; run `scan` (DB write) and `mount` as the non-root
-   uid with `--cap-add SYS_ADMIN --device /dev/fuse`; assert both succeed and
-   the store write lands owned by uid 1000.
+   bug). Run a real `musefs-scan.service`; assert the DB **and its `-wal`/`-shm`
+   siblings** are written. Start `musefs.service`; assert the mount is visible
+   in the session and a served file reads back correctly. The `musefs-scan.timer`
+   is unchanged (hardening lives on the service); confirm it still triggers.
+3. Build **both** `Dockerfile.glibc` and `Dockerfile.musl`. For each: assert
+   uid 1000 can open `/dev/fuse`; run `scan` (DB write) and `mount` as the
+   non-root uid with `--cap-add SYS_ADMIN --device /dev/fuse`; assert both
+   succeed, the store write lands owned by uid 1000, and `allow_other` works
+   non-root (the `user_allow_other` path — the musl-specific regression risk).
 
 ## Out of scope (YAGNI)
 
@@ -189,3 +267,15 @@ image (the chosen UID strategy: fixed 1000 + doc note, not a build arg).
   exercised in the container live test if feasible.
 - Distro-specific user-creation flag drift (Debian `useradd` vs Alpine
   `adduser`). **Mitigation:** both image builds are exercised in the live test.
+
+**Known sharp edges (carry into inline comments, not blockers):**
+
+- `ProcSubset=pid` + `ProtectProc=invisible` on the scanner hide non-pid `/proc`
+  entries. Safe today, but a future media parser that reads `/proc/cpuinfo` for
+  SIMD detection would break — note it in the unit comment.
+- `ProtectControlGroups=true` on a `--user` unit remounts `/sys/fs/cgroup`
+  read-only in the namespace; confirm it does not interfere with the user
+  manager's own cgroup bookkeeping for the unit (expected harmless).
+- `RestrictNamespaces=true` on the scanner is safe only because the scanner
+  spawns no namespace-cloning helper (probe workers are plain threads) — verify
+  during the live scan.

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -59,8 +59,9 @@ friction and without risking the mount**. This yields three proportionate tiers:
 2. **Mount unit** — only the safe-anywhere, friction-free directives. The
    mount-capable / namespace / syscall-filter directives are **opt-in**, because
    they can trap the mount on kernels older than the dev box.
-3. **Container** — drop from root to a fixed unprivileged uid/gid 1000. Mostly a
-   docs change (volume ownership), plus the now-required `user_allow_other` line.
+3. **Container** — drop from root to an unprivileged user (default uid/gid 1000,
+   build-arg configurable). Mostly a docs change (volume ownership), plus the
+   now-required `user_allow_other` line.
 
 ## Facts grounding the design
 
@@ -175,26 +176,30 @@ known-recent platform can uncomment them after confirming the mount still
 appears. We do not ship them on, because the dedi (kernel 7.0 / systemd 259) is
 not representative — "works here" does not generalize to Debian 12.
 
-### #319 — Dockerfiles: non-root uid 1000
+### #319 — Dockerfiles: non-root user (default uid/gid 1000, build-arg configurable)
 
-Both images: create a `musefs` group+user at gid/uid **1000**, add
-`user_allow_other` to `/etc/fuse.conf` (now **required** for the non-root pod
-pattern — post-#339 musefs pre-flight-checks for it and hard-fails an
-`allow_other`/`--owner`/`--group` mount without it), then `USER musefs`.
+Both images: create a `musefs` group+user at a **build-arg-configurable** uid/gid
+(`ARG MUSEFS_UID=1000` / `MUSEFS_GID=1000`), add `user_allow_other` to
+`/etc/fuse.conf` (now **required** for the non-root pod pattern — post-#339
+musefs pre-flight-checks for it and hard-fails an `allow_other`/`--owner`/
+`--group` mount without it), then `USER musefs`.
 
 - **glibc / Debian:**
-  `groupadd -g 1000 musefs && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs`
+  `groupadd -g "$MUSEFS_GID" musefs && useradd -u "$MUSEFS_UID" -g "$MUSEFS_GID" -M -s /usr/sbin/nologin musefs`
 - **musl / Alpine:**
-  `addgroup -g 1000 musefs && adduser -u 1000 -G musefs -H -D -s /sbin/nologin musefs`
+  `addgroup -g "$MUSEFS_GID" musefs && adduser -u "$MUSEFS_UID" -G musefs -H -D -s /sbin/nologin musefs`
 - `RUN echo 'user_allow_other' >> /etc/fuse.conf` (created if absent). **Musl
   caveat:** confirm Alpine's `fusermount3` reads `/etc/fuse.conf` and honours
   `user_allow_other` — verified in the live test, not assumed.
-- `USER musefs`
+- `USER musefs` (by name — works regardless of the chosen numeric uid).
 
-The store volume must be writable by uid 1000 — **this is the real friction**:
-the existing copy-paste `docker run -v /store …` breaks unless the host store
-dir is owned by 1000 or `--user $(id -u):$(id -g)` is passed. This is a docs
-change as much as an image change. Confirm no base image / compose default
+The store volume must be writable by the chosen uid — **this is the real
+friction**: the existing copy-paste `docker run -v /store …` breaks unless the
+host store dir is owned by that uid, or `--user $(id -u):$(id -g)` is passed.
+The build arg is the friction-reducer for self-builders: `--build-arg
+MUSEFS_UID=$(id -u) --build-arg MUSEFS_GID=$(id -g)` bakes an image whose user
+matches the host owner, so no chown or `--user` is needed at run time (the
+published image defaults to 1000). Confirm no base image / compose default
 injects `NoNewPrivileges` (would block the setuid escalation the container
 relies on).
 
@@ -247,7 +252,8 @@ is the manual live run; do not commit an untested directive set.
    gate* — the mount unit intentionally scores higher than the scanner.
    Spot-check that uncommenting one opt-in directive and restarting still mounts,
    to document the opt-in path.
-3. **#319:** build **both** images; for each assert uid 1000 can open
+3. **#319:** build **both** images at the default uid and confirm a build-arg
+   override (`--build-arg MUSEFS_UID=…`) takes effect; for each assert the uid can open
    `/dev/fuse`, run `scan` + `mount` non-root with
    `--cap-add SYS_ADMIN --device /dev/fuse`. Confirm the store write is
    uid-1000-owned, and that a non-root `--allow-other` (or `--owner`) mount
@@ -258,7 +264,6 @@ is the manual live run; do not commit an untested directive set.
 ## Out of scope (YAGNI)
 
 - CI smoke harness — verification is the live dedi run.
-- Build-arg-configurable container UID — fixed 1000 + doc note.
 - Write-path confinement on the scanner (`ProtectSystem=strict` +
   `ReadWritePaths`) — dropped for friction; revisit only if a concrete
   parser-write threat appears.

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -212,13 +212,14 @@ cross-container / owner-presenting case, and is harmless when unused.
 - `contrib/systemd/README.md` — short "Hardening" note: the units ship
   sandboxed; no per-user path edits are required (the scanner uses
   `ProtectSystem=true`, not `strict`). Mention the opt-in mount-unit directives.
-- `README.md` Docker section (post-#339 line numbers) — the image runs as uid
-  1000; the bind-mounted store dir must be owned by / writable to 1000 (or pass
-  `--user`). Update the `docker run` example (`README.md:116-120`) and the
-  "mount-visibility gotcha" pod example (`README.md:145-148`) so uid-1000
-  guidance does not contradict their `--security-opt apparmor=unconfined` lines.
-  Cross-reference the new "Non-root mounts need `user_allow_other`" note
-  (`README.md:297-302`) from the pod example, since the non-root image now
+- `README.md` Docker section — the image runs as a non-root user (default uid
+  1000); the bind-mounted store dir must be owned by / writable to that uid (or
+  pass `--user`, or build with `--build-arg MUSEFS_UID=$(id -u)`). Add this as a
+  single central "Runs as a non-root user" note inserted between the `docker run`
+  example and the pod example (rather than editing each example inline — keeps
+  the examples copy-pasteable and the guidance in one place). Cross-reference the
+  "Non-root mounts need `user_allow_other`" note (`README.md:297-302`), since the
+  non-root image now
   relies on the image-baked `user_allow_other` for that pattern.
 - Inline comments in each unit / Dockerfile justifying the non-obvious
   directives.

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -4,6 +4,32 @@
 **Issues:** #317 (scanner unit), #318 (mount unit), #319 (container user)
 **Tracking:** #280 · Audit: Task 29 (`docker-systemd-assets`)
 
+## Outcome (what live testing changed)
+
+This section records where implementation diverged from the design below; the
+design text is left intact as the original intent. Verified on the dev box
+(systemd 259, setuid fusermount3 3.18.2, kernel 7.0).
+
+- **#317 (scanner) — landed, with a `--user` trim.** The full sandbox below
+  assumed a system-manager-grade capability set. Under the **`--user` manager**
+  (where these units run) any directive needing a capability-bounding-set drop
+  fails with `218/CAPABILITIES`: `CapabilityBoundingSet=`, `PrivateDevices`,
+  `ProtectKernelModules`, `ProtectKernelLogs`, `ProtectClock` were dropped (no
+  loss — the process is already capability-less). `ProtectHostname` was dropped
+  as a no-op that warns. Result: a still-strong sandbox, `systemd-analyze --user
+  security` ≈ **5.3 MEDIUM**.
+- **#318 (mount unit) — inverted into a fix; issue closed, not implemented.**
+  The premise (the mount unit can take "mount-visible" directives) is false for
+  a `--user` FUSE mount: musefs mounts via the **setuid** `fusermount3`, and
+  `NoNewPrivileges=true` — plus *every* directive that implies it (any seccomp
+  filter forces the kernel `no_new_privs` flag, even with `NoNewPrivileges=no`)
+  — disables the setuid escalation, so the mount fails `Operation not permitted`.
+  The shipped unit's existing `NoNewPrivileges=true` was itself a latent,
+  never-tested mount-breaker. Resolution: **remove `NoNewPrivileges`**, document
+  why a `--user` FUSE mount unit cannot be sandboxed, and close #318.
+- **#319 (containers) — landed as designed**, including the build-arg UID.
+  Verified non-root mount end-to-end (rootless podman) on both glibc and musl.
+
 ## Problem
 
 The shipped deployment assets carry defense-in-depth hardening gaps. None is a

--- a/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-12-deployment-asset-hardening-design.md
@@ -1,0 +1,191 @@
+# Deployment-asset hardening: systemd units + container images
+
+**Date:** 2026-06-12
+**Issues:** #317 (scanner unit), #318 (mount unit), #319 (container user)
+**Tracking:** #280 · Audit: Task 29 (`docker-systemd-assets`)
+
+## Problem
+
+The shipped deployment assets carry defense-in-depth hardening gaps. None is a
+live exploit; all are hardening of assets that handle untrusted media or run in
+already-privileged contexts.
+
+- `contrib/systemd/musefs-scan.service` runs the oneshot scanner — which parses
+  adversarial media bytes — with **zero** sandboxing directives, even though it
+  creates no FUSE mount and can therefore take the full systemd sandbox.
+- `contrib/systemd/musefs.service` sets only `NoNewPrivileges=true`. Several
+  hardening directives that do **not** sever the FUSE mount's propagation to the
+  session are absent, so the unit does not enforce the README's "no root, no
+  `CAP_SYS_ADMIN`" posture.
+- `docker/Dockerfile.glibc` and `docker/Dockerfile.musl` set no `USER`, so
+  `ENTRYPOINT ["musefs"]` runs as **root** inside a container that already needs
+  `--cap-add SYS_ADMIN` + `--device /dev/fuse` — a larger blast radius than
+  necessary, contradicting the systemd units' non-root guidance.
+
+## Guiding principle
+
+Apply the strictest sandbox each asset's mount-visibility constraint allows.
+This yields three tiers:
+
+1. **Scanner** — no FUSE mount → full sandbox, *including* namespace /
+   mount-hiding directives.
+2. **Mount unit** — only directives that do not remount the path the FUSE mount
+   lives under, nor sever mount propagation to the session.
+3. **Container** — drop from root to a fixed unprivileged uid/gid 1000.
+
+`SystemCallFilter` uses systemd's curated `@system-service` group (maintained
+across kernels) rather than a handcrafted allowlist (fragile across
+distros/libc), plus the minimal extra group a given unit provably needs.
+
+## Facts grounding the design
+
+- musefs touches no network: local SQLite + positioned file reads. No sockets
+  beyond journald's `AF_UNIX`.
+- Documented DB convention (`contrib/systemd/musefs.conf.example:20`):
+  `~/.local/share/musefs/library.db`. There is no hardcoded default in the CLI;
+  the DB is supplied via `MUSEFS_DB`/flag.
+- The library may live outside `$HOME` (e.g. `/data`); reads remain permitted
+  under `ProtectSystem=strict` (read-only ≠ inaccessible).
+- `/dev/fuse` is mode `0666`; an unprivileged uid can open it. `fusermount3` is
+  setuid-root, so the **container** mount works without `NoNewPrivileges`
+  blocking the setuid escalation (the container is the one context where the
+  setuid path is actually exercised).
+- musefs is Rust with no JIT → `MemoryDenyWriteExecute=true` is safe.
+
+## Design
+
+### #317 — `musefs-scan.service`: full sandbox
+
+Add the complete sandbox. The scanner reads the library (read-only, anywhere)
+and writes only the DB directory.
+
+```ini
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%h/.local/share/musefs   # DB dir; ADJUST if MUSEFS_DB lives elsewhere
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_UNIX          # journald; tighten to none if logging survives
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+CapabilityBoundingSet=                    # empty
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+UMask=077
+```
+
+**Friction (documented inline):** `ReadWritePaths` must name the DB's
+directory. A DB outside `~/.local/share/musefs` requires editing this line; the
+library path needs no entry (reads are always allowed under
+`ProtectSystem=strict`).
+
+### #318 — `musefs.service`: mount-visible hardening
+
+Keep `NoNewPrivileges=true` and the existing "do NOT add" comment; **extend**
+that comment to state which new directives are safe and why. Add only
+directives that do not create a private mount namespace over the mountpoint path
+or sever propagation:
+
+```ini
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+ProtectClock=true
+ProtectHostname=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service @mount   # @mount: fusermount3 needs mount/umount2
+```
+
+**Forbidden (still):** `Protect{System,Home}=`, `ReadOnlyPaths=`,
+`ReadWritePaths=`, `PrivateTmp=`, `PrivateMounts=`, `MountFlags=private` — each
+either remounts the home path the FUSE mount lives under or severs propagation,
+hiding the mount from the session.
+
+**Rationale for the boundary:** `ProtectKernel*` / `ProtectControlGroups` touch
+`/proc` and `/sys`, not the home path under which the mount sits, so they do not
+break propagation. The four directives that *could* break the mount —
+`@mount` (could be over-restrictive), `RestrictNamespaces`,
+`CapabilityBoundingSet=`, `MemoryDenyWriteExecute` — are resolved empirically by
+the live test. Any that breaks the mount is dropped with an inline comment
+recording why, turning the failure into documentation.
+
+### #319 — Dockerfiles: non-root uid 1000
+
+Both images: create a `musefs` group+user at gid/uid **1000**, add
+`user_allow_other` to `/etc/fuse.conf` (so the documented multi-container pod
+pattern's `allow_other` still works without root), then `USER musefs` before
+`ENTRYPOINT`.
+
+- **glibc / Debian:**
+  `groupadd -g 1000 musefs && useradd -u 1000 -g 1000 -M -s /usr/sbin/nologin musefs`
+- **musl / Alpine:**
+  `addgroup -g 1000 musefs && adduser -u 1000 -G musefs -H -D -s /sbin/nologin musefs`
+- `RUN echo 'user_allow_other' >> /etc/fuse.conf` (file created if absent)
+- `USER musefs`
+
+The store volume must be writable by uid 1000 — documented, not enforced in the
+image (the chosen UID strategy: fixed 1000 + doc note, not a build arg).
+
+## Documentation updates
+
+- `contrib/systemd/README.md` — add a short "Hardening" note: units ship
+  sandboxed; the scanner's `ReadWritePaths` is the one line to adjust for a
+  non-default DB path.
+- `README.md` Docker section — the image now runs as uid 1000; the bind-mounted
+  store dir must be owned by / writable to 1000 (or pass
+  `--user $(id -u):$(id -g)`).
+- Inline comments in each unit / Dockerfile justifying the non-obvious
+  directives.
+
+## Verification (live, on the dedicated server)
+
+1. `systemd-analyze --user security musefs.service` and
+   `musefs-scan.service` — record before/after exposure scores as evidence.
+2. Install both user units (mount under `$HOME` per the AppArmor-fusermount3
+   constraint — `/data` mounts are denied by the host profile, not a musefs
+   bug). Run a real `musefs-scan.service`; assert the DB is updated. Start
+   `musefs.service`; assert the mount is visible in the session and a served
+   file reads back correctly.
+3. Build `Dockerfile.glibc`; run `scan` (DB write) and `mount` as the non-root
+   uid with `--cap-add SYS_ADMIN --device /dev/fuse`; assert both succeed and
+   the store write lands owned by uid 1000.
+
+## Out of scope (YAGNI)
+
+- CI smoke harness — verification is the live dedi run, not a committed CI test.
+- Build-arg-configurable container UID — fixed 1000 + doc note was chosen.
+- Any change to the binary, the FUSE/read path, or the store schema. This is
+  deployment-asset config only.
+
+## Risks
+
+- A `SystemCallFilter` / `RestrictNamespaces` / `CapabilityBoundingSet` choice
+  silently breaks the FUSE mount. **Mitigation:** these surface only at runtime,
+  so the live test on the mount unit is mandatory, not optional; failures are
+  recorded inline as documentation.
+- The non-root container regresses the multi-container `allow_other` pod
+  pattern. **Mitigation:** `user_allow_other` in the image; the pod pattern is
+  exercised in the container live test if feasible.
+- Distro-specific user-creation flag drift (Debian `useradd` vs Alpine
+  `adduser`). **Mitigation:** both image builds are exercised in the live test.


### PR DESCRIPTION
## Summary

Deployment-asset hardening from the Task 29 / #280 audit, scoped to what live testing showed is actually achievable.

- **#317 — sandbox `musefs-scan.service`.** The mount-less scanner (which parses adversarial media) now takes a strong systemd sandbox, scoped to what the `--user` manager permits — directives needing a capability-bounding-set drop (`CapabilityBoundingSet=`, `PrivateDevices`, `ProtectKernelModules`/`Logs`, `ProtectClock`) fail there with `218/CAPABILITIES` and are omitted (the process is already capability-less). Uses `ProtectSystem=true` (not `strict`) so a custom `MUSEFS_DB` path needs no `ReadWritePaths=` edit. `systemd-analyze --user security` ≈ 5.3 MEDIUM.
- **#318 — a fix, not the proposed feature (issue closed).** Live testing showed a `--user` FUSE mount unit fundamentally cannot be sandboxed: musefs mounts via the **setuid** `fusermount3`, and `NoNewPrivileges=true` — which the shipped unit already carried with an untested "safe for a FUSE mount" comment — disables the setuid escalation, so the mount fails `Operation not permitted`. Every systemd seccomp/namespace directive forces the kernel `no_new_privs` flag (even with `NoNewPrivileges=no`), so none can be added. Resolution: **remove the mount-breaking `NoNewPrivileges`** and document the constraint.
- **#319 — non-root containers.** Both images run as a dedicated unprivileged user (default uid/gid 1000, configurable via `--build-arg MUSEFS_UID/MUSEFS_GID`) with `user_allow_other` baked into `/etc/fuse.conf` so a non-root `--allow-other`/`--owner` mount passes musefs's post-#339 pre-flight check. README documents the store-ownership requirement and the build-arg escape hatch.

The design spec and implementation plan are included under `docs/superpowers/`.

## Test Plan

All live-verified on the dev box (systemd 259, setuid fusermount3 3.18.2, kernel 7.0, rootless podman):

- [x] **scanner**: sandboxed scan via `systemctl --user` succeeds at both the default and a custom `MUSEFS_DB` path; journald logging intact; no warnings
- [x] **mount unit**: after removing `NoNewPrivileges`, the `--user` unit mounts and a served file reads back (`fLaC` magic)
- [x] **containers (glibc + musl)**: entrypoint runs as uid 1000 (and 1234 via build arg); non-root scan writes a 1000-owned store; fuse.conf pre-flight passes with the baked line and fires when `/etc/fuse.conf` is masked; non-root container mounts end-to-end and serves the synthesized tree
- [x] full `cargo test --workspace` green (no Rust changed)

Closes #317
Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)