### PR TITLE
fix(scan): log silently-dropped art, binary tags, and unparseable files (#284)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:448:31:',
+    'musefs-core/src/scan\.rs:449:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:455:30:',
+    'musefs-core/src/scan\.rs:456:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,18 +127,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:466:21:',
+    'musefs-core/src/scan\.rs:467:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:471:17:',
+    'musefs-core/src/scan\.rs:472:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:837:46:',
+    'musefs-core/src/scan\.rs:863:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -147,25 +147,25 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `+=` and `>=`/`||` repeat in
-    # run_pipeline (e.g. the killable `*scanned += 1` at 902), so these cannot be
+    # run_pipeline (e.g. the killable `*scanned += 1` at 936), so these cannot be
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:924:29:',
+    'musefs-core/src/scan\.rs:958:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:926:32:',
+    'musefs-core/src/scan\.rs:960:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:926:47:',
+    'musefs-core/src/scan\.rs:960:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:926:62:',
+    'musefs-core/src/scan\.rs:960:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:934:37:',
+    'musefs-core/src/scan\.rs:968:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:936:40:',
+    'musefs-core/src/scan\.rs:970:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:936:55:',
+    'musefs-core/src/scan\.rs:970:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:936:70:',
+    'musefs-core/src/scan\.rs:970:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -173,11 +173,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1049:25:',
+    'musefs-core/src/scan\.rs:1086:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1053:25:',
+    'musefs-core/src/scan\.rs:1094:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1089:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1131:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -339,7 +339,11 @@ offset/length, tags, pictures, structural blocks) on a parallel probe
 pipeline feeding a single DB writer, committing in batches. Probing reads
 are bounded — the scanner never slurps whole files — and ingestion caps
 per-item sizes (`MAX_ART_BYTES`, `MAX_BINARY_TAG_BYTES`) so a crafted file
-cannot balloon the store.
+cannot balloon the store. An over-cap picture or binary tag is dropped and
+logged (`RUST_LOG=warn`) rather than vanishing silently, so a track that
+appears to have lost its cover art has an explanation in the logs; a
+supported-extension file that fails to parse, or errors mid-probe, is
+likewise logged with the reason and counted `failed`.
 
 Symlinks are **not followed by default**: a symlinked file or directory is
 logged (`RUST_LOG=info`/`warn`) and skipped, which keeps the walk immune to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Scanner no longer drops files and embedded art silently:** embedded cover
+  art over `MAX_ART_BYTES` (and binary tags over `MAX_BINARY_TAG_BYTES`) were
+  filtered out at ingest with no log line, so a track whose art exceeded the cap
+  appeared to simply have none — indistinguishable from a scan bug. The drop is
+  now logged (`RUST_LOG=warn`). Likewise, a supported-extension file that fails
+  to parse or errors mid-probe was counted `failed` with the underlying error
+  discarded; the reason is now logged. Note: oversized art in `.m4a`/`.m4b`
+  files is dropped earlier, inside the format layer, and is not yet logged
+  (#284, #343).
 - **Lidarr custom-script env var casing:** Lidarr stores custom-script
   environment variables in a .NET `StringDictionary`, which lowercases every key,
   so a Linux script actually receives `lidarr_sourcepath` / `lidarr_eventtype`

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -403,9 +403,7 @@ fn probe_body(
         let scan = match mp4::read_structure_from(&mut f, file_len) {
             Ok(s) => s,
             Err(e) => {
-                if matches!(e, mp4::Mp4ScanError::MetadataTooLarge { .. }) {
-                    log::warn!("skipping {}: {e}", path.display());
-                }
+                log::warn!("skipping {}: {e}", path.display());
                 return Ok(None);
             }
         };
@@ -436,7 +434,10 @@ fn probe_body(
     for _ in 0..MAX_WIDEN_RETRIES {
         match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
             Probe::Done(p) => return Ok(Some(p)),
-            Probe::Skip => return Ok(None),
+            Probe::Skip => {
+                log::warn!("skipping {}: no parseable audio metadata", path.display());
+                return Ok(None);
+            }
             Probe::NeedMore(up_to) => {
                 // Read everything we're willing to probe? Widening can't help.
                 if want as u64 >= probe_cap {
@@ -473,6 +474,8 @@ fn probe_body(
             "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
             path.display()
         );
+    } else {
+        log::warn!("skipping {}: no parseable audio metadata", path.display());
     }
     Ok(None)
 }
@@ -619,6 +622,53 @@ fn key_passes_floor(key: &str) -> bool {
     !key.is_empty() && key.bytes().all(|b| b >= 0x20)
 }
 
+/// Drops embedded pictures over [`MAX_ART_BYTES`], logging each so a cover that
+/// vanishes from the synthesized view is explained rather than silent (#284).
+/// Filtering here, before the caller enumerates, keeps stored art ordinals
+/// gap-free. Note: the mp4 `covr` path caps oversize art earlier, inside
+/// `mp4::read_pictures`, so those drops never reach this filter.
+fn accept_pictures(abs_path: &str, pictures: Vec<EmbeddedPicture>) -> Vec<EmbeddedPicture> {
+    pictures
+        .into_iter()
+        .filter(|p| {
+            if p.data.len() > MAX_ART_BYTES {
+                log::warn!(
+                    "{abs_path}: dropping embedded {} art ({} bytes), over the {MAX_ART_BYTES}-byte cap",
+                    p.mime,
+                    p.data.len(),
+                );
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
+/// Filters embedded binary tags to those worth storing, logging oversize drops
+/// (#284). Empty payloads carry nothing to serve, so they are dropped silently;
+/// payloads over [`MAX_BINARY_TAG_BYTES`] are a lossy drop and get a warning.
+fn accept_binary_tags(abs_path: &str, tags: Vec<EmbeddedBinaryTag>) -> Vec<musefs_db::BinaryTag> {
+    tags.into_iter()
+        .filter(|b| {
+            if b.payload.len() > MAX_BINARY_TAG_BYTES {
+                log::warn!(
+                    "{abs_path}: dropping binary tag {} ({} bytes), over the {MAX_BINARY_TAG_BYTES}-byte cap",
+                    b.key,
+                    b.payload.len(),
+                );
+                return false;
+            }
+            !b.payload.is_empty()
+        })
+        .enumerate()
+        .map(|(ordinal, b)| musefs_db::BinaryTag {
+            key: b.key,
+            payload: b.payload,
+            ordinal: ordinal as u64,
+        })
+        .collect()
+}
+
 /// Upsert a track from a probed backing file: write the track row, replace its
 /// seeded tags, and ingest its embedded art (capped, deduped, clamped).
 fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
@@ -645,17 +695,7 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     }
     db.replace_tags(track_id, &tags)?;
 
-    let binary_tags: Vec<musefs_db::BinaryTag> = probed
-        .binary_tags
-        .into_iter()
-        .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
-        .enumerate()
-        .map(|(ordinal, b)| musefs_db::BinaryTag {
-            key: b.key,
-            payload: b.payload,
-            ordinal: ordinal as u64,
-        })
-        .collect();
+    let binary_tags = accept_binary_tags(abs_path, probed.binary_tags);
     db.set_binary_tags(track_id, &binary_tags)?;
 
     let mut sb_ordinals: HashMap<String, u64> = HashMap::new();
@@ -676,13 +716,10 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
     db.set_structural_blocks(track_id, &structural_blocks)?;
 
     let mut track_arts = Vec::new();
-    // Filter before enumerating so skipped (oversized) art doesn't leave gaps
-    // in the stored ordinals.
-    let accepted = probed
-        .pictures
+    for (ordinal, pic) in accept_pictures(abs_path, probed.pictures)
         .into_iter()
-        .filter(|p| p.data.len() <= MAX_ART_BYTES);
-    for (ordinal, pic) in accepted.enumerate() {
+        .enumerate()
+    {
         let art_id = db.upsert_art(&NewArt {
             mime: pic.mime,
             width: (pic.width != 0).then_some(pic.width),
@@ -731,17 +768,7 @@ fn ingest_bulk(
     }
     bw.replace_tags(track_id, &tags)?;
 
-    let binary_tags: Vec<musefs_db::BinaryTag> = probed
-        .binary_tags
-        .into_iter()
-        .filter(|b| !b.payload.is_empty() && b.payload.len() <= MAX_BINARY_TAG_BYTES)
-        .enumerate()
-        .map(|(ordinal, b)| musefs_db::BinaryTag {
-            key: b.key,
-            payload: b.payload,
-            ordinal: ordinal as u64,
-        })
-        .collect();
+    let binary_tags = accept_binary_tags(abs_path, probed.binary_tags);
     bw.set_binary_tags(track_id, &binary_tags)?;
 
     let mut sb_ordinals: HashMap<String, u64> = HashMap::new();
@@ -762,11 +789,10 @@ fn ingest_bulk(
     bw.set_structural_blocks(track_id, &structural_blocks)?;
 
     let mut track_arts = Vec::new();
-    let accepted = probed
-        .pictures
+    for (ordinal, pic) in accept_pictures(abs_path, probed.pictures)
         .into_iter()
-        .filter(|p| p.data.len() <= MAX_ART_BYTES);
-    for (ordinal, pic) in accepted.enumerate() {
+        .enumerate()
+    {
         let art_id = bw.upsert_art(&NewArt {
             mime: pic.mime,
             width: (pic.width != 0).then_some(pic.width),
@@ -849,9 +875,13 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                 let Some(path) = next else { break };
                 match probe_file(&path, window) {
                     Ok(ProbeOutcome::Probed(probed, stamp)) => {
-                        let Ok(abs) = std::fs::canonicalize(&path) else {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            continue;
+                        let abs = match std::fs::canonicalize(&path) {
+                            Ok(abs) => abs,
+                            Err(e) => {
+                                log::warn!("skipping {}: {e}", path.display());
+                                failed.fetch_add(1, Ordering::Relaxed);
+                                continue;
+                            }
                         };
                         let weight = payload_weight(&probed);
                         budget.acquire(weight); // backpressure on in-flight art bytes
@@ -866,7 +896,11 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                             break;
                         }
                     }
-                    Ok(ProbeOutcome::Unparseable) | Err(_) => {
+                    Ok(ProbeOutcome::Unparseable) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        log::warn!("skipping {}: {e}", path.display());
                         failed.fetch_add(1, Ordering::Relaxed);
                     }
                     Ok(ProbeOutcome::Raced) => {
@@ -1045,13 +1079,21 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
     let mut skip_failed = 0u64;
     let mut changed: Vec<PathBuf> = Vec::new();
     for path in files {
-        let Ok(meta) = std::fs::metadata(&path) else {
-            skip_failed += 1;
-            continue;
+        let meta = match std::fs::metadata(&path) {
+            Ok(meta) => meta,
+            Err(e) => {
+                log::warn!("skipping {}: {e}", path.display());
+                skip_failed += 1;
+                continue;
+            }
         };
-        let Ok(abs) = std::fs::canonicalize(&path) else {
-            skip_failed += 1;
-            continue;
+        let abs = match std::fs::canonicalize(&path) {
+            Ok(abs) => abs,
+            Err(e) => {
+                log::warn!("skipping {}: {e}", path.display());
+                skip_failed += 1;
+                continue;
+            }
         };
         let key = abs.to_string_lossy().into_owned();
         if let Some((stamp, id, format)) = existing.get(&key).copied() {

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -2023,6 +2023,37 @@ mod hardening_tests {
         assert_eq!(rows[0].byte_len, 3);
     }
 
+    #[test]
+    fn accept_pictures_keeps_at_cap_and_drops_over_cap() {
+        let mk = |len: usize| EmbeddedPicture {
+            mime: "image/jpeg".to_string(),
+            picture_type: musefs_format::PictureType::new(3).unwrap(),
+            description: String::new(),
+            width: 0,
+            height: 0,
+            data: vec![0u8; len],
+        };
+        // A picture exactly at the cap is kept; one byte over is dropped. The
+        // boundary pins `>` against `>=` (an at-cap drop would be silent loss).
+        let kept = accept_pictures("/x.flac", vec![mk(MAX_ART_BYTES), mk(MAX_ART_BYTES + 1)]);
+        assert_eq!(kept.len(), 1, "exactly the at-cap picture survives");
+        assert_eq!(kept[0].data.len(), MAX_ART_BYTES);
+    }
+
+    #[test]
+    fn accept_binary_tags_keeps_at_cap_and_drops_over_cap() {
+        let mk = |len: usize| EmbeddedBinaryTag {
+            key: "PRIV".to_string(),
+            payload: vec![0u8; len],
+        };
+        let kept = accept_binary_tags(
+            "/x.mp3",
+            vec![mk(MAX_BINARY_TAG_BYTES), mk(MAX_BINARY_TAG_BYTES + 1)],
+        );
+        assert_eq!(kept.len(), 1, "exactly the at-cap binary tag survives");
+        assert_eq!(kept[0].payload.len(), MAX_BINARY_TAG_BYTES);
+    }
+
     fn probed_with_text_tags(tags: &[(&str, &str)]) -> Probed {
         Probed {
             format: musefs_db::Format::Mp3,


### PR DESCRIPTION
## What

Closes #284. The scanner dropped several things silently, with no way for a user to tell intended behavior from a bug. This surfaces them in the logs.

- **Oversized embedded art (#284):** pictures over `MAX_ART_BYTES` were filtered out at ingest with no log line, so a track whose cover art exceeded the cap appeared to simply have no art. Both ingest paths (`ingest`, `ingest_bulk`) now `warn!` on each oversized drop, via shared `accept_pictures` / `accept_binary_tags` helpers.
- **Oversized binary tags:** the same silent filter applied to opaque binary tags (Serato analysis blobs, etc.) — now logged too. (Empty payloads stay silent — nothing to serve.)
- **Unparseable / errored files:** a supported-extension file that failed to parse, an I/O error mid-probe, or a `canonicalize` failure only bumped the `failed` counter and *discarded the underlying error*. `probe_body` is now the single source of the "why unparseable" log (parse failure, mp4 scan error, no-parseable-metadata fallback), and the `run_pipeline` / `revalidate_with` workers log the propagated error instead of swallowing it.

## Notes

- Unparseable files log at `warn` to match the existing skip-site convention; on a library with supported-extension-but-unparseable files this is intentionally more verbose than before.
- `.cargo/mutants.toml`: re-anchored the shifted `scan.rs` `file:line:col` mutant-exclude entries (the line shifts moved them); the pre-commit drift guard passes.
- **Out of scope / follow-ups filed:** oversized art in `.m4a`/`.m4b` is dropped earlier, inside `musefs-format` (which has no logging facade), so it's not covered here — filed as #343. The manual mutant re-anchoring this required motivated #345 (auto-fix mode for `check_mutant_anchors.py`).

## Testing

- `cargo clippy --all-targets` clean; full workspace test suite green (via pre-commit hook).
- `cargo test -p musefs-core` incl. `scan_counters` and `probe_equivalence` integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)