### PR TITLE
refactor(db): collapse migrations into a single v1 baseline schema

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,46 +111,30 @@ represents the spliced bytes, so passthrough never applies.
 
 ## The SQLite store
 
-`musefs-db/src/schema.rs` defines the schema as an append-only list of
-migrations (`MIGRATIONS`); `user_version` records how many have been applied.
+`musefs-db/src/schema.rs` defines the schema as a single baseline migration
+(`MIGRATIONS`); `user_version` records the schema version (1).
 The store is the **interface external tools write to** — the beets and Picard
 plugins under `contrib/` write tags and art here out-of-band.
 
-- **V1** — the core tables: `tracks` (one row per backing file: path, format,
-  audio byte range, size/nanosecond-mtime/ctime stamps, `content_version`), `tags` (multi-value
-  key/value rows ordered by `ordinal`), `art` (content-addressed by sha256,
-  deduplicated image blobs), and `track_art` (per-track art links with
-  picture type and ordering). Deleting a track cascades to its `tags` and
-  `track_art` rows. Triggers bump the owning track's `content_version` and
-  `updated_at` on any `tags`/`track_art` insert/update/delete.
-- **V2** — binary tags and structural blocks: `tags.value_blob` (a row is
-  binary iff `value_blob IS NOT NULL`) and the `structural_blocks` table —
-  read-only, derived-from-file metadata (FLAC `STREAMINFO`/`SEEKTABLE`) that
-  is **not** part of the editable contract.
-- **V3** — the `track_changes` changelog: a bounded, self-pruning ring
-  (capacity 8192, `CHANGELOG_CAP`) fed by triggers on `tracks`. Every
-  metadata edit funnels through an `UPDATE` on the tracks row (the V1
-  triggers), so triggers on `tracks` alone capture all writers — this relies
-  on SQLite's nested trigger activation (on by default). Writers maintain the
-  ring via the pruning trigger; the mount's read-only connections never need
-  to.
-- **V4** — `CHECK` constraints on `tracks`, `tags`, `art`, and `track_art`
-  that move the contract invariants below from convention to commit-time
-  enforcement. SQLite cannot add a constraint in place, so V4 rebuilds the
-  four tables (stashing rows past the FK cascade) and recreates their
-  triggers after the bulk refill so the rebuild does not pump the
-  `track_changes` ring. A pre-existing violating row aborts the migration.
-- **V5** — freshness-superset triggers that make `content_version` cover every
-  DB-knowable input to synthesized bytes, not only tag/`track_art` edits:
-  `art_reject_content_update` (rejects in-place mutation of an `art` row's
-  content columns — art is content-addressed, so a changed image is a new row),
-  `art_ad` (bumps every track referencing a deleted `art` row, so an orphaned
-  reference rebuilds to a clean serve-time error rather than streaming stale
-  bytes), `tracks_geometry_au` (bumps when scanner-owned geometry — `format`,
-  audio bounds, backing size/nanosecond-mtime — changes; keys on
-  `backing_mtime_ns` only — `backing_ctime_ns` is pure freshness identity, not a
-  served-byte input), and `structural_blocks_ai`/`_ad`
-  (bump when FLAC structural blocks change).
+- The **baseline schema** (`MIGRATION_V1`): the core tables — `tracks` (one row
+  per backing file: path, format, audio byte range, size/nanosecond-mtime/ctime
+  stamps, `content_version`), `tags` (multi-value key/value rows ordered by
+  `ordinal`, with an optional `value_blob` for binary tags), `art`
+  (content-addressed, deduplicated image blobs), `track_art` (per-track art
+  links with picture type and ordering), and `structural_blocks` (read-only,
+  derived-from-file FLAC `STREAMINFO`/`SEEKTABLE` metadata, **not** part of the
+  editable contract). Deleting a track cascades to its `tags` and `track_art`
+  rows. Triggers bump the owning track's `content_version`/`updated_at` on any
+  `tags`/`track_art` edit; `CHECK` constraints enforce the contract invariants
+  below at commit time. A bounded, self-pruning `track_changes` ring (capacity
+  8192, `CHANGELOG_CAP`) fed by triggers on `tracks` gives O(changed) refresh —
+  every metadata edit funnels through an `UPDATE` on the tracks row, relying on
+  SQLite's nested trigger activation (on by default). Freshness-superset
+  triggers make `content_version` cover every DB-knowable input to synthesized
+  bytes: `art_reject_content_update` (art is content-addressed and immutable),
+  `art_ad` (a deleted art row bumps referencing tracks so an orphan rebuilds to
+  a clean serve-time error), `tracks_geometry_au` (scanner-owned geometry
+  changes), and `structural_blocks_ai`/`_ad`.
 
 ### The external-writer contract
 
@@ -161,7 +145,7 @@ plugins under `contrib/` write tags and art here out-of-band.
 all of `structural_blocks`: those are derived from probing the file, and
 external tools must run `musefs scan` rather than compute them.
 
-**What the store enforces.** As of V4, SQLite `CHECK` constraints reject the
+**What the store enforces.** SQLite `CHECK` constraints reject the
 malformed *shapes* at commit, so an external writer cannot persist them:
 
 - an unknown `format` string, or a negative length/offset/size/version;
@@ -191,7 +175,7 @@ foreign_key_check`, rejecting anything that is not the canonical latest schema
 with a message telling the user to run `musefs scan`.
 
 **Art is immutable once written.** `art` rows are content-addressed by
-`sha256`; as of V5 a trigger rejects any in-place `UPDATE` of an art row's
+`sha256`; a trigger rejects any in-place `UPDATE` of an art row's
 content columns (`data`, `sha256`, `mime`, `byte_len`, `width`, `height`) with
 `RAISE(ABORT)` — a multi-row `UPDATE art` touching any content column aborts the
 whole statement. To change a track's art, insert a new content-addressed row
@@ -207,7 +191,7 @@ from the actual file's stat, or audio bounds that fit the stored
 `backing_size` but overrun the file once it has shrunk. musefs re-stats the
 backing file on every resolve and treats such rows as untrusted input,
 degrading to a controlled
-`BackingChanged`/layout error, never undefined behavior. The store's V4
+`BackingChanged`/layout error, never undefined behavior. The store's
 `CHECK` rejects art over `MAX_ART_BYTES` (16 MiB − 64 KiB) at write time;
 resolve also re-checks it (`ArtTooLarge`, all formats) to backstop a writer
 that disables check enforcement, and the scanner's ingest-time drop is
@@ -265,7 +249,7 @@ Two distinct counters drive correctness; they answer different questions.
 bytes change?"*. The DB triggers increment it on any input the database can see that changes
 synthesized bytes: tag and `track_art` edits, `art`-row deletes that orphan a
 reference, scanner-owned geometry changes (`format`, audio bounds, backing
-size/nanosecond-mtime), and FLAC structural-block changes (V5). It is
+size/nanosecond-mtime), and FLAC structural-block changes. It is
 therefore a superset key — the one input it cannot cover is an on-disk backing
 change with no DB write, which `resolve` (and, since #279, a size-cache
 `getattr` hit) catches by re-statting the backing file and degrading to

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -8,148 +8,21 @@
 SCHEMA_SQL = """\
 -- ── MIGRATION_V1 ──
 CREATE TABLE tracks (
-    id              INTEGER PRIMARY KEY,
-    backing_path    TEXT NOT NULL UNIQUE,
-    format          TEXT NOT NULL,
-    audio_offset    INTEGER NOT NULL,
-    audio_length    INTEGER NOT NULL,
-    backing_size    INTEGER NOT NULL,
-    backing_mtime   INTEGER NOT NULL,
-    content_version INTEGER NOT NULL DEFAULT 0,
-    updated_at      INTEGER NOT NULL
-);
-
-CREATE TABLE tags (
-    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    key      TEXT NOT NULL,
-    value    TEXT NOT NULL,
-    ordinal  INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (track_id, key, ordinal)
-);
-
-CREATE TABLE art (
-    id       INTEGER PRIMARY KEY,
-    sha256   TEXT NOT NULL UNIQUE,
-    mime     TEXT NOT NULL,
-    width    INTEGER,
-    height   INTEGER,
-    byte_len INTEGER NOT NULL,
-    data     BLOB NOT NULL
-);
-
-CREATE TABLE track_art (
-    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    art_id       INTEGER NOT NULL REFERENCES art(id),
-    picture_type INTEGER NOT NULL DEFAULT 3,
-    description  TEXT NOT NULL DEFAULT '',
-    ordinal      INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (track_id, ordinal)
-);
-
-CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = OLD.track_id;
-END;
-
-CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = OLD.track_id;
-END;
-PRAGMA user_version = 1;
-
--- ── MIGRATION_V2 ──
--- Binary tag payloads live alongside text tags. A row is binary iff
--- value_blob IS NOT NULL; binary rows store '' in value.
-ALTER TABLE tags ADD COLUMN value_blob BLOB;
-
--- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
--- NOT part of the editable `tags` contract: external tools never touch it.
-CREATE TABLE structural_blocks (
-    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    kind     TEXT NOT NULL,
-    ordinal  INTEGER NOT NULL DEFAULT 0,
-    body     BLOB NOT NULL,
-    PRIMARY KEY (track_id, kind, ordinal)
-);
-PRAGMA user_version = 2;
-
--- ── MIGRATION_V3 ──
--- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
--- through an UPDATE on the tracks row (the V1 tags/track_art triggers), so
--- triggers on tracks alone capture all writers. Relies on SQLite nested
--- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
-CREATE TABLE track_changes (
-    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
-    track_id INTEGER NOT NULL
-);
-
-CREATE TRIGGER tracks_changelog_ai AFTER INSERT ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (NEW.id);
-END;
-CREATE TRIGGER tracks_changelog_au AFTER UPDATE ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (NEW.id);
-END;
-CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (OLD.id);
-END;
-
--- Self-pruning ring: writers maintain it; the mount's read-only connections
--- never need to. Deletes only from the old end, so retained seqs stay contiguous.
-CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
-    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
-END;
-PRAGMA user_version = 3;
-
--- ── MIGRATION_V4 ──
-CREATE TEMP TABLE _m4_tracks AS SELECT * FROM tracks;
-CREATE TEMP TABLE _m4_tags AS SELECT * FROM tags;
-CREATE TEMP TABLE _m4_art AS SELECT * FROM art;
-CREATE TEMP TABLE _m4_track_art AS SELECT * FROM track_art;
-CREATE TEMP TABLE _m4_structural AS SELECT * FROM structural_blocks;
-
-DROP TABLE track_art;
-DROP TABLE tags;
-DROP TABLE art;
-DROP TABLE structural_blocks;
-DROP TABLE tracks;
-
-CREATE TABLE tracks (
-    id              INTEGER PRIMARY KEY,
-    backing_path    TEXT NOT NULL UNIQUE,
-    format          TEXT NOT NULL,
-    audio_offset    INTEGER NOT NULL,
-    audio_length    INTEGER NOT NULL,
-    backing_size    INTEGER NOT NULL,
-    backing_mtime   INTEGER NOT NULL,
-    content_version INTEGER NOT NULL DEFAULT 0,
-    updated_at      INTEGER NOT NULL,
+    id               INTEGER PRIMARY KEY,
+    backing_path     TEXT NOT NULL UNIQUE,
+    format           TEXT NOT NULL,
+    audio_offset     INTEGER NOT NULL,
+    audio_length     INTEGER NOT NULL,
+    backing_size     INTEGER NOT NULL,
+    backing_mtime_ns INTEGER NOT NULL,
+    content_version  INTEGER NOT NULL DEFAULT 0,
+    updated_at       INTEGER NOT NULL,
+    backing_ctime_ns INTEGER NOT NULL DEFAULT 0 CHECK (backing_ctime_ns >= 0),
     CHECK (format IN ('flac','mp3','m4a','opus','vorbis','oggflac','wav')),
     CHECK (audio_offset >= 0),
     CHECK (audio_length >= 0),
     CHECK (backing_size >= 0),
-    CHECK (backing_mtime >= 0),
+    CHECK (backing_mtime_ns >= 0),
     CHECK (content_version >= 0),
     CHECK (updated_at >= 0),
     CHECK (audio_offset + audio_length <= backing_size)
@@ -199,6 +72,8 @@ CREATE TABLE track_art (
     CHECK (length(description) <= 1024)
 );
 
+-- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
+-- NOT part of the editable `tags` contract: external tools never touch it.
 CREATE TABLE structural_blocks (
     track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
     kind     TEXT NOT NULL,
@@ -210,17 +85,18 @@ CREATE TABLE structural_blocks (
     CHECK (length(body) <= 16777215)
 );
 
-INSERT INTO tracks SELECT * FROM _m4_tracks;
-INSERT INTO art SELECT * FROM _m4_art;
-INSERT INTO tags SELECT * FROM _m4_tags;
-INSERT INTO track_art SELECT * FROM _m4_track_art;
-INSERT INTO structural_blocks SELECT * FROM _m4_structural;
+-- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
+-- through an UPDATE on the tracks row (the tags/track_art triggers), so
+-- triggers on tracks alone capture all writers. Relies on SQLite nested
+-- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
+CREATE TABLE track_changes (
+    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id INTEGER NOT NULL
+);
 
-DROP TABLE _m4_track_art;
-DROP TABLE _m4_tags;
-DROP TABLE _m4_art;
-DROP TABLE _m4_structural;
-DROP TABLE _m4_tracks;
+-- Index the reverse art -> track_art edge so bulk orphan-GC and the art delete
+-- trigger below do not scan the whole join table per deleted row.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
 
 CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
     UPDATE tracks SET content_version = content_version + 1,
@@ -263,20 +139,18 @@ END;
 CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
     INSERT INTO track_changes (track_id) VALUES (OLD.id);
 END;
-PRAGMA user_version = 4;
 
--- ── MIGRATION_V5 ──
-ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
-ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0
-    CHECK (backing_ctime_ns >= 0);
-
+-- Self-pruning ring: writers maintain it; the mount's read-only connections
+-- never need to. Deletes only from the old end, so retained seqs stay contiguous.
+CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
+    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
+END;
 
 -- art rows are content-addressed by sha256: once written, their content
 -- columns are immutable. A writer needing different bytes/metadata inserts a
 -- NEW row and relinks via track_art (which bumps content_version through the
--- V1 track_art triggers). This closes #271, where an in-place art edit changed
--- served bytes without bumping any referencing track. width/height use IS NOT
--- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
+-- track_art triggers). width/height use IS NOT (NULL-safe) because they are
+-- nullable; the NOT NULL columns use <>.
 CREATE TRIGGER art_reject_content_update
 BEFORE UPDATE ON art
 WHEN NEW.data   <> OLD.data
@@ -289,12 +163,6 @@ BEGIN
     SELECT RAISE(ABORT,
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
-
--- Index the reverse art -> track_art edge. track_art is keyed (track_id,
--- ordinal), so without this both the art_ad trigger below and SQLite's own
--- REFERENCES art(id) check on art deletes scan the whole join table per
--- deleted row, which makes bulk orphan-GC O(deletes * rows).
-CREATE INDEX track_art_art_id_idx ON track_art(art_id);
 
 -- Deleting an art row that still has track_art references (an orphan an
 -- external writer can produce with foreign_keys OFF) bumps every referencing
@@ -309,9 +177,9 @@ END;
 
 -- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
 -- not touch content_version. Bump it whenever a geometry column actually
--- changes, making content_version a true superset of served-byte inputs
--- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
--- content_version changes), so the recursion terminates after exactly one bump.
+-- changes, making content_version a true superset of served-byte inputs. The
+-- WHEN guard is false on this trigger's own nested UPDATE (only content_version
+-- changes), so the recursion terminates after exactly one bump.
 CREATE TRIGGER tracks_geometry_au
 AFTER UPDATE ON tracks
 WHEN NEW.format        <> OLD.format
@@ -334,7 +202,7 @@ END;
 CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
 END;
-PRAGMA user_version = 5;
+PRAGMA user_version = 1;
 """
 
-USER_VERSION = 5
+USER_VERSION = 1

--- a/contrib/picard/tests/test_conftest_sanity.py
+++ b/contrib/picard/tests/test_conftest_sanity.py
@@ -5,7 +5,7 @@ def test_db_path_has_schema(db_path):
     conn = connect(db_path)
     try:
         # user_version applied from the fixture SQL.
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 5
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
     finally:
         conn.close()
 

--- a/contrib/python-musefs/README.md
+++ b/contrib/python-musefs/README.md
@@ -132,7 +132,7 @@ that bite plugin authors:
 
 - **Write only `tags`, `art`, and `track_art`.** The scanner owns the structural
   columns of `tracks` and all of `structural_blocks`; never compute them — run
-  `musefs scan` (i.e. `run_scan`). V4 `CHECK` constraints reject malformed
+  `musefs scan` (i.e. `run_scan`). `CHECK` constraints reject malformed
   structural shapes at commit, so you cannot persist them anyway.
 - **Binary tags survive a sync.** `merge_tags` / `replace_tags` scope their
   deletes to text rows (`value_blob IS NULL`), so the write loop never wipes
@@ -141,7 +141,7 @@ that bite plugin authors:
   `CHECK` on the row).
 - **Content-address art** through `upsert_art` (sha256 de-dup) rather than
   inserting `art` rows by hand; `sync_files` does this for you.
-- **Art rows are immutable.** As of V5 a trigger rejects in-place updates of an
+- **Art rows are immutable.** A trigger rejects in-place updates of an
   `art` row's content columns (`data`, `sha256`, `mime`, `byte_len`, `width`,
   `height`). To change a track's art, insert a new content-addressed row via
   `upsert_art` and relink it via `replace_track_art`.

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -5,148 +5,21 @@
 SCHEMA_SQL = """\
 -- ── MIGRATION_V1 ──
 CREATE TABLE tracks (
-    id              INTEGER PRIMARY KEY,
-    backing_path    TEXT NOT NULL UNIQUE,
-    format          TEXT NOT NULL,
-    audio_offset    INTEGER NOT NULL,
-    audio_length    INTEGER NOT NULL,
-    backing_size    INTEGER NOT NULL,
-    backing_mtime   INTEGER NOT NULL,
-    content_version INTEGER NOT NULL DEFAULT 0,
-    updated_at      INTEGER NOT NULL
-);
-
-CREATE TABLE tags (
-    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    key      TEXT NOT NULL,
-    value    TEXT NOT NULL,
-    ordinal  INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (track_id, key, ordinal)
-);
-
-CREATE TABLE art (
-    id       INTEGER PRIMARY KEY,
-    sha256   TEXT NOT NULL UNIQUE,
-    mime     TEXT NOT NULL,
-    width    INTEGER,
-    height   INTEGER,
-    byte_len INTEGER NOT NULL,
-    data     BLOB NOT NULL
-);
-
-CREATE TABLE track_art (
-    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    art_id       INTEGER NOT NULL REFERENCES art(id),
-    picture_type INTEGER NOT NULL DEFAULT 3,
-    description  TEXT NOT NULL DEFAULT '',
-    ordinal      INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (track_id, ordinal)
-);
-
-CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = OLD.track_id;
-END;
-
-CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = OLD.track_id;
-END;
-PRAGMA user_version = 1;
-
--- ── MIGRATION_V2 ──
--- Binary tag payloads live alongside text tags. A row is binary iff
--- value_blob IS NOT NULL; binary rows store '' in value.
-ALTER TABLE tags ADD COLUMN value_blob BLOB;
-
--- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
--- NOT part of the editable `tags` contract: external tools never touch it.
-CREATE TABLE structural_blocks (
-    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    kind     TEXT NOT NULL,
-    ordinal  INTEGER NOT NULL DEFAULT 0,
-    body     BLOB NOT NULL,
-    PRIMARY KEY (track_id, kind, ordinal)
-);
-PRAGMA user_version = 2;
-
--- ── MIGRATION_V3 ──
--- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
--- through an UPDATE on the tracks row (the V1 tags/track_art triggers), so
--- triggers on tracks alone capture all writers. Relies on SQLite nested
--- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
-CREATE TABLE track_changes (
-    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
-    track_id INTEGER NOT NULL
-);
-
-CREATE TRIGGER tracks_changelog_ai AFTER INSERT ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (NEW.id);
-END;
-CREATE TRIGGER tracks_changelog_au AFTER UPDATE ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (NEW.id);
-END;
-CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (OLD.id);
-END;
-
--- Self-pruning ring: writers maintain it; the mount's read-only connections
--- never need to. Deletes only from the old end, so retained seqs stay contiguous.
-CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
-    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
-END;
-PRAGMA user_version = 3;
-
--- ── MIGRATION_V4 ──
-CREATE TEMP TABLE _m4_tracks AS SELECT * FROM tracks;
-CREATE TEMP TABLE _m4_tags AS SELECT * FROM tags;
-CREATE TEMP TABLE _m4_art AS SELECT * FROM art;
-CREATE TEMP TABLE _m4_track_art AS SELECT * FROM track_art;
-CREATE TEMP TABLE _m4_structural AS SELECT * FROM structural_blocks;
-
-DROP TABLE track_art;
-DROP TABLE tags;
-DROP TABLE art;
-DROP TABLE structural_blocks;
-DROP TABLE tracks;
-
-CREATE TABLE tracks (
-    id              INTEGER PRIMARY KEY,
-    backing_path    TEXT NOT NULL UNIQUE,
-    format          TEXT NOT NULL,
-    audio_offset    INTEGER NOT NULL,
-    audio_length    INTEGER NOT NULL,
-    backing_size    INTEGER NOT NULL,
-    backing_mtime   INTEGER NOT NULL,
-    content_version INTEGER NOT NULL DEFAULT 0,
-    updated_at      INTEGER NOT NULL,
+    id               INTEGER PRIMARY KEY,
+    backing_path     TEXT NOT NULL UNIQUE,
+    format           TEXT NOT NULL,
+    audio_offset     INTEGER NOT NULL,
+    audio_length     INTEGER NOT NULL,
+    backing_size     INTEGER NOT NULL,
+    backing_mtime_ns INTEGER NOT NULL,
+    content_version  INTEGER NOT NULL DEFAULT 0,
+    updated_at       INTEGER NOT NULL,
+    backing_ctime_ns INTEGER NOT NULL DEFAULT 0 CHECK (backing_ctime_ns >= 0),
     CHECK (format IN ('flac','mp3','m4a','opus','vorbis','oggflac','wav')),
     CHECK (audio_offset >= 0),
     CHECK (audio_length >= 0),
     CHECK (backing_size >= 0),
-    CHECK (backing_mtime >= 0),
+    CHECK (backing_mtime_ns >= 0),
     CHECK (content_version >= 0),
     CHECK (updated_at >= 0),
     CHECK (audio_offset + audio_length <= backing_size)
@@ -196,6 +69,8 @@ CREATE TABLE track_art (
     CHECK (length(description) <= 1024)
 );
 
+-- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
+-- NOT part of the editable `tags` contract: external tools never touch it.
 CREATE TABLE structural_blocks (
     track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
     kind     TEXT NOT NULL,
@@ -207,17 +82,18 @@ CREATE TABLE structural_blocks (
     CHECK (length(body) <= 16777215)
 );
 
-INSERT INTO tracks SELECT * FROM _m4_tracks;
-INSERT INTO art SELECT * FROM _m4_art;
-INSERT INTO tags SELECT * FROM _m4_tags;
-INSERT INTO track_art SELECT * FROM _m4_track_art;
-INSERT INTO structural_blocks SELECT * FROM _m4_structural;
+-- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
+-- through an UPDATE on the tracks row (the tags/track_art triggers), so
+-- triggers on tracks alone capture all writers. Relies on SQLite nested
+-- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
+CREATE TABLE track_changes (
+    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id INTEGER NOT NULL
+);
 
-DROP TABLE _m4_track_art;
-DROP TABLE _m4_tags;
-DROP TABLE _m4_art;
-DROP TABLE _m4_structural;
-DROP TABLE _m4_tracks;
+-- Index the reverse art -> track_art edge so bulk orphan-GC and the art delete
+-- trigger below do not scan the whole join table per deleted row.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
 
 CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
     UPDATE tracks SET content_version = content_version + 1,
@@ -260,20 +136,18 @@ END;
 CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
     INSERT INTO track_changes (track_id) VALUES (OLD.id);
 END;
-PRAGMA user_version = 4;
 
--- ── MIGRATION_V5 ──
-ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
-ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0
-    CHECK (backing_ctime_ns >= 0);
-
+-- Self-pruning ring: writers maintain it; the mount's read-only connections
+-- never need to. Deletes only from the old end, so retained seqs stay contiguous.
+CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
+    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
+END;
 
 -- art rows are content-addressed by sha256: once written, their content
 -- columns are immutable. A writer needing different bytes/metadata inserts a
 -- NEW row and relinks via track_art (which bumps content_version through the
--- V1 track_art triggers). This closes #271, where an in-place art edit changed
--- served bytes without bumping any referencing track. width/height use IS NOT
--- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
+-- track_art triggers). width/height use IS NOT (NULL-safe) because they are
+-- nullable; the NOT NULL columns use <>.
 CREATE TRIGGER art_reject_content_update
 BEFORE UPDATE ON art
 WHEN NEW.data   <> OLD.data
@@ -286,12 +160,6 @@ BEGIN
     SELECT RAISE(ABORT,
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
-
--- Index the reverse art -> track_art edge. track_art is keyed (track_id,
--- ordinal), so without this both the art_ad trigger below and SQLite's own
--- REFERENCES art(id) check on art deletes scan the whole join table per
--- deleted row, which makes bulk orphan-GC O(deletes * rows).
-CREATE INDEX track_art_art_id_idx ON track_art(art_id);
 
 -- Deleting an art row that still has track_art references (an orphan an
 -- external writer can produce with foreign_keys OFF) bumps every referencing
@@ -306,9 +174,9 @@ END;
 
 -- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
 -- not touch content_version. Bump it whenever a geometry column actually
--- changes, making content_version a true superset of served-byte inputs
--- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
--- content_version changes), so the recursion terminates after exactly one bump.
+-- changes, making content_version a true superset of served-byte inputs. The
+-- WHEN guard is false on this trigger's own nested UPDATE (only content_version
+-- changes), so the recursion terminates after exactly one bump.
 CREATE TRIGGER tracks_geometry_au
 AFTER UPDATE ON tracks
 WHEN NEW.format        <> OLD.format
@@ -331,7 +199,7 @@ END;
 CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
     UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
 END;
-PRAGMA user_version = 5;
+PRAGMA user_version = 1;
 """
 
-USER_VERSION = 5
+USER_VERSION = 1

--- a/contrib/python-musefs/tests/test_constants.py
+++ b/contrib/python-musefs/tests/test_constants.py
@@ -2,7 +2,7 @@ from musefs_common import constants
 
 
 def test_expected_user_version_matches_rust_migrations():
-    assert constants.EXPECTED_USER_VERSION == 5
+    assert constants.EXPECTED_USER_VERSION == 1
 
 
 def test_max_art_bytes_is_16mib_minus_64kib():

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -82,7 +82,7 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
    `OggArtSlice` runs, no base64); the last metadata packet's last-block
    flag and packet 0's 16-bit following-packet count are recomputed to
    match. Art exceeding `MAX_ART_BYTES` (16 MiB − 64 KiB) is rejected by the
-   store's V4 `CHECK`, with a resolve-time cap backstopping a writer that
+   store's `CHECK`, with a resolve-time cap backstopping a writer that
    disables check enforcement.
 3. `OggAudio` — one compact segment covering all original audio pages, with
    the page-count delta to apply to every sequence number.

--- a/docs/superpowers/plans/2026-06-12-schema-v1-reset.md
+++ b/docs/superpowers/plans/2026-06-12-schema-v1-reset.md
@@ -1,0 +1,816 @@
+# Schema v1 reset (collapse migrations) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the five historical SQLite migrations (`MIGRATION_V1`..`V5`) into a single baseline `MIGRATION_V1` so a fresh database stamps `user_version = 1`, in preparation for the v1.0.0 release.
+
+**Architecture:** Keep the migration framework (`MIGRATIONS` array + `migrate()` loop) but reduce it to one element holding the current post-V5 schema as plain `CREATE` statements. The collapsed schema is *semantically* identical to a DB that ran all five migrations — verified by a throwaway PRAGMA-level A/B diff and by the retained CHECK/trigger/identity tests. Regenerate the vendored Python schema mirror and flip the two hardcoded `user_version == 5` expectations.
+
+**Tech Stack:** Rust (rusqlite, SQLite `PRAGMA`), Python (pytest, ruff), the project's pre-commit gate (fmt, clippy `-D warnings`, full workspace test suite, ruff).
+
+---
+
+## ⚠️ Atomicity — read before starting
+
+This change is **one self-consistent commit, created only in the final task.** Do **not** commit at intermediate task boundaries:
+
+- After Task 2 the `musefs-db` *test target* will not compile (tests still reference removed constants) — Task 3 fixes it.
+- Between Task 3 and Task 5 the tree is intentionally red: `schema_py_fixture_is_fresh` and the contrib `== 5` tests fail until the mirror is regenerated and the asserts flipped.
+
+The pre-commit hook runs the full workspace suite and rejects red commits, so everything must be green together. The `MUSEFS_REGEN_SCHEMA_PY=1` regen + re-vendor (Task 5) must run **before** staging. The reference spec is `docs/superpowers/specs/2026-06-12-schema-v1-reset-design.md`.
+
+> **Per the repo owner's standing instruction, do not run `git commit` until the user explicitly approves.** Task 7 prepares the commit; confirm before executing it.
+
+---
+
+## Task 1: Capture the pre-collapse semantic schema (A/B baseline)
+
+A throwaway harness that dumps the *semantic* schema (column shape/order, foreign keys, indexes) of a fully-migrated DB. Run it now (on the current 5-migration code) to capture the baseline, then again after the collapse (Task 3) — the diff must be empty. We dump PRAGMAs, **not** raw `sqlite_master.sql` table text, because the old form (V4 `CREATE` + V5 `ALTER`) legitimately differs textually from one clean `CREATE`.
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs` (add a `#[cfg(test)]` module at end of file)
+
+- [ ] **Step 1: Add the throwaway dump test**
+
+Insert this module at the very end of `musefs-db/src/schema.rs` (after `migration_v5_tests`):
+
+```rust
+// THROWAWAY: A/B harness for the v1 schema collapse. Dumps the semantic schema
+// (PRAGMA-level) of a fully-migrated DB so the collapsed baseline can be proven
+// equivalent to the 5-migration schema. Remove in the final task of the plan.
+#[cfg(test)]
+mod ab_dump {
+    use rusqlite::Connection;
+    use rusqlite::types::Value;
+
+    #[test]
+    #[ignore = "throwaway A/B harness for the schema collapse; remove before commit"]
+    fn dump_semantic_schema() {
+        let path = std::env::var("MUSEFS_AB_DUMP").expect("set MUSEFS_AB_DUMP to an output path");
+        let mut conn = Connection::open_in_memory().unwrap();
+        super::migrate(&mut conn).unwrap();
+        let mut out = String::new();
+        for t in [
+            "tracks",
+            "tags",
+            "art",
+            "track_art",
+            "structural_blocks",
+            "track_changes",
+        ] {
+            // (pragma, skip_leading_cols): index_list's first column is a volatile
+            // creation-order `seq`; drop it so creation order does not cause a
+            // false diff. table_info's `cid` (column 0) IS kept — it pins order.
+            for (pragma, skip) in [("table_info", 0usize), ("foreign_key_list", 0), ("index_list", 1)] {
+                let mut stmt = conn.prepare(&format!("PRAGMA {pragma}('{t}')")).unwrap();
+                let ncol = stmt.column_count();
+                let mut rows = stmt.query([]).unwrap();
+                let mut lines: Vec<String> = Vec::new();
+                while let Some(r) = rows.next().unwrap() {
+                    let cells: Vec<String> = (skip..ncol)
+                        .map(|i| format!("{:?}", r.get::<_, Value>(i).unwrap()))
+                        .collect();
+                    lines.push(cells.join("|"));
+                }
+                lines.sort();
+                out.push_str(&format!("== {t}.{pragma} ==\n"));
+                out.push_str(&lines.join("\n"));
+                out.push('\n');
+            }
+        }
+        // Trigger and explicit-index bodies, copied verbatim from the old
+        // literals: a typo in a copied body would diverge HERE (the only check
+        // that compares against the pre-collapse text — identity_tests is
+        // self-referential post-collapse). Autoindexes have NULL sql and are
+        // covered by index_list above.
+        let mut stmt = conn
+            .prepare(
+                "SELECT type, name, sql FROM sqlite_master \
+                 WHERE type IN ('trigger','index') AND sql IS NOT NULL \
+                 AND name NOT LIKE 'sqlite_%' ORDER BY type, name",
+            )
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let mut lines: Vec<String> = Vec::new();
+        while let Some(r) = rows.next().unwrap() {
+            lines.push(format!(
+                "{}|{}|{}",
+                r.get::<_, String>(0).unwrap(),
+                r.get::<_, String>(1).unwrap(),
+                r.get::<_, String>(2).unwrap()
+            ));
+        }
+        lines.sort();
+        out.push_str("== triggers+indexes ==\n");
+        out.push_str(&lines.join("\n"));
+        out.push('\n');
+        std::fs::write(&path, out).unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Run the dump on the current (5-migration) schema**
+
+Run: `MUSEFS_AB_DUMP=/tmp/schema_before.txt cargo test -p musefs-db ab_dump::dump_semantic_schema -- --ignored --exact`
+Expected: PASS. Then `test -s /tmp/schema_before.txt && echo OK` prints `OK` (non-empty file written).
+
+- [ ] **Step 3: Sanity-check the captured baseline**
+
+Run: `grep -c '== ' /tmp/schema_before.txt`
+Expected: `19` (6 tables × 3 PRAGMAs, plus one `== triggers+indexes ==` section). Do **not** commit.
+
+---
+
+## Task 2: Collapse the migration constants
+
+Replace the five migration constants with a single `MIGRATION_V1` holding the current post-V5 schema, and reduce `MIGRATIONS` to one element. Every table/trigger/index except `tracks` is copied verbatim from the existing literals; `tracks` is hand-assembled from V4's `CREATE` + V5's two `ALTER`s.
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs:4-364` (the constants and the `MIGRATIONS` array)
+
+- [ ] **Step 1: Replace the five `MIGRATION_V*` constants with one**
+
+Delete `MIGRATION_V1`, `MIGRATION_V2`, `MIGRATION_V3`, `MIGRATION_V4`, `MIGRATION_V5` (lines 4–356, keeping the `CHANGELOG_CAP` const at 93–96) and replace the whole constant block with:
+
+```rust
+/// Ring capacity of the `track_changes` changelog. Must match the literal in
+/// MIGRATION_V1 (guarded by `changelog_cap_constant_matches_migration_sql`).
+#[allow(dead_code)]
+pub const CHANGELOG_CAP: i64 = 8192;
+
+// The complete v1.0.0 baseline schema. Collapsed from the five historical
+// migrations: there are no pre-1.0 databases to upgrade, so the step-by-step
+// path was removed. Semantically equivalent to applying the old V1..V5 in
+// sequence (verified by the PRAGMA-level A/B check in the schema-reset plan and
+// by the CHECK/trigger/identity tests below).
+const MIGRATION_V1: &str = r"
+CREATE TABLE tracks (
+    id               INTEGER PRIMARY KEY,
+    backing_path     TEXT NOT NULL UNIQUE,
+    format           TEXT NOT NULL,
+    audio_offset     INTEGER NOT NULL,
+    audio_length     INTEGER NOT NULL,
+    backing_size     INTEGER NOT NULL,
+    backing_mtime_ns INTEGER NOT NULL,
+    content_version  INTEGER NOT NULL DEFAULT 0,
+    updated_at       INTEGER NOT NULL,
+    backing_ctime_ns INTEGER NOT NULL DEFAULT 0 CHECK (backing_ctime_ns >= 0),
+    CHECK (format IN ('flac','mp3','m4a','opus','vorbis','oggflac','wav')),
+    CHECK (audio_offset >= 0),
+    CHECK (audio_length >= 0),
+    CHECK (backing_size >= 0),
+    CHECK (backing_mtime_ns >= 0),
+    CHECK (content_version >= 0),
+    CHECK (updated_at >= 0),
+    CHECK (audio_offset + audio_length <= backing_size)
+);
+
+CREATE TABLE tags (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(value) <= 262144),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+
+CREATE TABLE art (
+    id       INTEGER PRIMARY KEY,
+    sha256   TEXT NOT NULL UNIQUE,
+    mime     TEXT NOT NULL,
+    width    INTEGER,
+    height   INTEGER,
+    byte_len INTEGER NOT NULL,
+    data     BLOB NOT NULL,
+    CHECK (byte_len = length(data)),
+    CHECK (length(sha256) = 64),
+    CHECK (width IS NULL OR width >= 0),
+    CHECK (height IS NULL OR height >= 0),
+    CHECK (length(mime) <= 255),
+    CHECK (byte_len <= 16711680)
+);
+
+CREATE TABLE track_art (
+    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    art_id       INTEGER NOT NULL REFERENCES art(id),
+    picture_type INTEGER NOT NULL DEFAULT 3,
+    description  TEXT NOT NULL DEFAULT '',
+    ordinal      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (track_id, ordinal),
+    CHECK (picture_type BETWEEN 0 AND 20),
+    CHECK (ordinal >= 0),
+    CHECK (length(description) <= 1024)
+);
+
+-- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
+-- NOT part of the editable `tags` contract: external tools never touch it.
+CREATE TABLE structural_blocks (
+    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    kind     TEXT NOT NULL,
+    ordinal  INTEGER NOT NULL DEFAULT 0,
+    body     BLOB NOT NULL,
+    PRIMARY KEY (track_id, kind, ordinal),
+    CHECK (kind IN ('STREAMINFO','SEEKTABLE')),
+    CHECK (ordinal >= 0),
+    CHECK (length(body) <= 16777215)
+);
+
+-- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
+-- through an UPDATE on the tracks row (the tags/track_art triggers), so
+-- triggers on tracks alone capture all writers. Relies on SQLite nested
+-- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
+CREATE TABLE track_changes (
+    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id INTEGER NOT NULL
+);
+
+-- Index the reverse art -> track_art edge so bulk orphan-GC and the art delete
+-- trigger below do not scan the whole join table per deleted row.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER tracks_changelog_ai AFTER INSERT ON tracks BEGIN
+    INSERT INTO track_changes (track_id) VALUES (NEW.id);
+END;
+CREATE TRIGGER tracks_changelog_au AFTER UPDATE ON tracks BEGIN
+    INSERT INTO track_changes (track_id) VALUES (NEW.id);
+END;
+CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
+    INSERT INTO track_changes (track_id) VALUES (OLD.id);
+END;
+
+-- Self-pruning ring: writers maintain it; the mount's read-only connections
+-- never need to. Deletes only from the old end, so retained seqs stay contiguous.
+CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
+    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
+END;
+
+-- art rows are content-addressed by sha256: once written, their content
+-- columns are immutable. A writer needing different bytes/metadata inserts a
+-- NEW row and relinks via track_art (which bumps content_version through the
+-- track_art triggers). width/height use IS NOT (NULL-safe) because they are
+-- nullable; the NOT NULL columns use <>.
+CREATE TRIGGER art_reject_content_update
+BEFORE UPDATE ON art
+WHEN NEW.data   <> OLD.data
+  OR NEW.sha256 <> OLD.sha256
+  OR NEW.mime   <> OLD.mime
+  OR NEW.byte_len <> OLD.byte_len
+  OR NEW.width  IS NOT OLD.width
+  OR NEW.height IS NOT OLD.height
+BEGIN
+    SELECT RAISE(ABORT,
+        'art rows are immutable; insert a new content-addressed row and relink via track_art');
+END;
+
+-- Deleting an art row that still has track_art references (an orphan an
+-- external writer can produce with foreign_keys OFF) bumps every referencing
+-- track, so the mount rebuilds and serves a clean EIO on the orphan rather
+-- than streaming stale bytes from an old cached layout. Inert on the normal
+-- gc_orphan_art path, where the deleted row has no references.
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+
+-- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
+-- not touch content_version. Bump it whenever a geometry column actually
+-- changes, making content_version a true superset of served-byte inputs. The
+-- WHEN guard is false on this trigger's own nested UPDATE (only content_version
+-- changes), so the recursion terminates after exactly one bump.
+CREATE TRIGGER tracks_geometry_au
+AFTER UPDATE ON tracks
+WHEN NEW.format        <> OLD.format
+  OR NEW.audio_offset  <> OLD.audio_offset
+  OR NEW.audio_length  <> OLD.audio_length
+  OR NEW.backing_size  <> OLD.backing_size
+  OR NEW.backing_mtime_ns <> OLD.backing_mtime_ns
+BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.id;
+END;
+
+-- FLAC structural blocks feed synthesized headers and flip the synthesis path
+-- (legacy front-read fallback vs streamed fast path), so a change must bump.
+-- set_structural_blocks is DELETE-then-INSERT (no UPDATE path exists), so these
+-- fire on every rewrite; the resulting over-bump on a byte-identical re-probe
+-- is harmless monotone churn (content_version is compared only for equality).
+CREATE TRIGGER structural_blocks_ai AFTER INSERT ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
+    UPDATE tracks SET content_version = content_version + 1 WHERE id = OLD.track_id;
+END;
+";
+```
+
+- [ ] **Step 2: Reduce the `MIGRATIONS` array to one element**
+
+Replace the `MIGRATIONS` const (was lines 357–364):
+
+```rust
+const MIGRATIONS: &[&str] = &[MIGRATION_V1];
+```
+
+Leave `migrate()` and everything below it (`reference_objects`, `read_schema_objects`, `schema_mismatch`, `validate_identity`) unchanged.
+
+- [ ] **Step 3: Verify the library compiles (test target will not yet — that is Task 3)**
+
+Run: `cargo build -p musefs-db`
+Expected: PASS (the `src` lib has no references to the removed constants). Do **not** commit.
+
+---
+
+## Task 3: Reorganize the `schema.rs` test modules
+
+Delete the upgrade-path tests, fix the `MIGRATION_Vn`/`MIGRATIONS[n]` references and `uv == 5` asserts, and consolidate the surviving final-schema tests into purpose-named modules. After this task the crate test target compiles and the A/B diff is run.
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs` (the `#[cfg(test)]` modules: `migration_v2_tests`, `migration_v3_tests`, `migration_v4_tests`, `migration_v5_tests`; leave `schema_py_tests`, `identity_tests`, and the `ab_dump` harness alone)
+
+- [ ] **Step 1: Delete the five upgrade-path tests**
+
+Delete these test functions entirely (they reference removed constants / the old `backing_mtime` column and no longer have meaning):
+
+- `migration_v2_tests::v1_rows_survive_v2_migration_with_null_value_blob`
+- `migration_v3_tests::v2_db_upgrades_to_v3_preserving_rows`
+- `migration_v4_tests::v4_rebuild_preserves_fk_children`
+- `migration_v4_tests::v4_rebuild_does_not_pump_changelog_ring`
+- `migration_v4_tests::v4_rebuild_preserves_structural_blocks`
+
+Also delete the now-unused helper `migration_v4_tests::insert_track_v3` (only the deleted rebuild tests used the old `backing_mtime` column).
+
+- [ ] **Step 2: Rename the four `migration_vN_tests` modules to purpose-named modules**
+
+Rename in place (keep each module's surviving tests and the helpers they use):
+
+- `mod migration_v3_tests` → `mod changelog_tests`
+- `mod migration_v4_tests` → `mod constraint_tests`
+- `mod migration_v5_tests` → `mod art_immutability_tests`
+- `mod migration_v2_tests` → `mod baseline_tests`
+
+Then move three tests so each module holds only its kind of invariant:
+
+- Move `v4_metadata_edit_bumps_version_and_appends_one_changelog_row` from `constraint_tests` into `changelog_tests`. **Rewrite its setup** — its body calls `fresh(&mut conn)`, but `fresh` lives only in `constraint_tests` (the old `migration_v4_tests`); the assertion doesn't need `foreign_keys` ON, so replace the `fresh(&mut conn)` call with `super::migrate(&mut conn).unwrap()`. `changelog_tests` already has its own `insert_track` and `count_changes`, so no helper duplication is needed. The exact rewritten body is given in Step 4.
+- Move `changelog_cap_constant_matches_migration_sql` from `changelog_tests` into `baseline_tests`.
+- Move `v4_check_literals_match_limits_constants` from `constraint_tests` into `baseline_tests` (renamed `check_literals_match_limits_constants` — see Step 3).
+
+**Delete the now-orphaned `count_changes` helper from `constraint_tests`** (schema.rs:1256). Its only two callers were `v4_rebuild_does_not_pump_changelog_ring` (deleted in Step 1) and `v4_metadata_edit...` (moved out, above); leaving it would trip clippy `dead_code` under `-D warnings` and fail the pre-commit hook. `changelog_tests` keeps its own separate `count_changes` (schema.rs:561).
+
+(Other helper fns — `insert_track`, `fresh`, `rejected`, `seed_track_and_art` — stay in the modules whose surviving tests use them. After the moves/deletes, confirm no helper is left unused: `cargo clippy --all-targets` in Step 6 of Task 7 is the backstop, but a missed orphan is the most likely reorg bug.)
+
+- [ ] **Step 3: Fix the constant/index references in the moved drift guards**
+
+In `baseline_tests`, update the two moved guards:
+
+```rust
+/// The SQL literal and the exported constant must not drift.
+#[test]
+fn changelog_cap_constant_matches_migration_sql() {
+    assert!(super::MIGRATION_V1.contains(&format!("NEW.seq - {}", super::CHANGELOG_CAP)));
+}
+```
+
+```rust
+#[test]
+fn check_literals_match_limits_constants() {
+    use crate::limits::*;
+    let sql = super::MIGRATION_V1;
+    assert!(sql.contains(&format!("length(key) <= {MAX_TAG_KEY_LEN}")));
+    assert!(sql.contains(&format!("length(value) <= {MAX_TAG_VALUE_LEN}")));
+    assert!(sql.contains(&format!("length(value_blob) <= {MAX_BINARY_TAG_BYTES}")));
+    assert!(sql.contains(&format!("length(mime) <= {MAX_ART_MIME_LEN}")));
+    assert!(sql.contains(&format!("byte_len <= {MAX_ART_BYTES}")));
+    assert!(sql.contains(&format!("length(description) <= {MAX_ART_DESCRIPTION_LEN}")));
+    assert!(sql.contains(&format!("length(body) <= {MAX_STRUCTURAL_BODY_LEN}")));
+    let kinds = STRUCTURAL_KINDS
+        .iter()
+        .map(|k| format!("'{k}'"))
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(sql.contains(&format!("kind IN ({kinds})")));
+}
+```
+
+- [ ] **Step 4: Flip every `assert_eq!(uv, 5)` to `1` in the surviving tests**
+
+In the renamed modules, the following tests assert the migrated `user_version`; change each `assert_eq!(uv, 5)` (and the `uv2` re-run assert) to `1`:
+
+- `constraint_tests::v4_valid_rows_migrate_and_read_cleanly`
+- `changelog_tests::v3_changelog_records_insert_update_delete`
+- (`v2_db_upgrades_to_v3_preserving_rows` also asserted `5` but was deleted in Step 1.)
+
+Place the moved `v4_metadata_edit_bumps_version_and_appends_one_changelog_row` into `changelog_tests` with this exact body (the only change from the original is `fresh(&mut conn)` → `super::migrate(&mut conn).unwrap()`):
+
+```rust
+#[test]
+fn v4_metadata_edit_bumps_version_and_appends_one_changelog_row() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    super::migrate(&mut conn).unwrap();
+    insert_track(&conn, "/a.flac");
+    let cv_before: i64 = conn
+        .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let changes_before = count_changes(&conn);
+
+    conn.execute(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','A',0)",
+        [],
+    )
+    .unwrap();
+
+    let cv_after: i64 = conn
+        .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(cv_after, cv_before + 1, "content_version must bump by one");
+    assert_eq!(
+        count_changes(&conn),
+        changes_before + 1,
+        "exactly one changelog row from the edit (nested trigger)"
+    );
+}
+```
+
+Also retarget the two version-naming tests in `baseline_tests`:
+
+Replace `baseline_tests::v2_adds_value_blob_and_structural_blocks_and_is_idempotent` with this rewrite (single migration, asserts `user_version == 1`):
+
+```rust
+#[test]
+fn baseline_creates_value_blob_and_structural_blocks_and_is_idempotent() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    super::migrate(&mut conn).unwrap();
+    let uv: i64 = conn
+        .pragma_query_value(None, "user_version", |r| r.get(0))
+        .unwrap();
+    assert_eq!(uv, 1);
+
+    // value_blob exists on tags and defaults to NULL.
+    conn.execute(
+        "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+         backing_size, backing_mtime_ns, updated_at) \
+         VALUES ('/a.flac','flac',0,1,1,0,0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','A',0)",
+        [],
+    )
+    .unwrap();
+    let blob_is_null: bool = conn
+        .query_row(
+            "SELECT value_blob IS NULL FROM tags WHERE track_id=1 AND key='artist'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(blob_is_null);
+
+    // structural_blocks table accepts a row.
+    conn.execute(
+        "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
+         VALUES (1,'STREAMINFO',0,X'00')",
+        [],
+    )
+    .unwrap();
+
+    // Re-running migrate is a no-op (idempotent).
+    super::migrate(&mut conn).unwrap();
+    let uv2: i64 = conn
+        .pragma_query_value(None, "user_version", |r| r.get(0))
+        .unwrap();
+    assert_eq!(uv2, 1);
+}
+```
+
+Rename `art_immutability_tests::migration_reaches_user_version_5` → `migration_reaches_user_version_1` and change its assert to `assert_eq!(uv, 1)`.
+
+- [ ] **Step 5: Rewrite the trigger-presence test to assert the full 15-trigger set**
+
+In `constraint_tests`, replace `v4_recreates_all_destroyed_triggers` with a fresh-DB invariant covering **all 15** baseline triggers (the old list omitted the five V5 triggers):
+
+```rust
+#[test]
+fn fresh_db_has_all_baseline_triggers() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    fresh(&mut conn);
+    let names: Vec<String> = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name")
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
+        .unwrap();
+    for expected in [
+        "tags_ai",
+        "tags_au",
+        "tags_ad",
+        "track_art_ai",
+        "track_art_au",
+        "track_art_ad",
+        "tracks_changelog_ai",
+        "tracks_changelog_au",
+        "tracks_changelog_ad",
+        "track_changes_prune",
+        "art_reject_content_update",
+        "art_ad",
+        "tracks_geometry_au",
+        "structural_blocks_ai",
+        "structural_blocks_ad",
+    ] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "missing trigger on fresh DB: {expected}"
+        );
+    }
+    assert_eq!(names.len(), 15, "unexpected trigger count: {names:?}");
+}
+```
+
+- [ ] **Step 6: Compile the test target**
+
+Run: `cargo test -p musefs-db --no-run`
+Expected: PASS (compiles). If it fails, it is almost always a leftover reference to `MIGRATION_V2`/`V3`/`V4`/`V5` or `MIGRATIONS[1]`/`[2]` — grep and fix:
+Run: `grep -nE 'MIGRATION_V[2-5]|MIGRATIONS\[[1-9]' musefs-db/src/schema.rs`
+Expected: no matches.
+
+- [ ] **Step 7: Run the A/B diff — the collapse must be semantically equivalent**
+
+Run: `MUSEFS_AB_DUMP=/tmp/schema_after.txt cargo test -p musefs-db ab_dump::dump_semantic_schema -- --ignored --exact && diff /tmp/schema_before.txt /tmp/schema_after.txt && echo EQUIVALENT`
+Expected: prints `EQUIVALENT` (empty diff). A non-empty diff means a column/type/default/FK/index drifted — fix the `MIGRATION_V1` DDL before continuing.
+
+- [ ] **Step 8: Run the `musefs-db` suite (one known failure expected)**
+
+Run: `cargo test -p musefs-db`
+Expected: all pass **except** `schema_py_tests::schema_py_fixture_is_fresh` (the vendored mirror is still the old 5-migration text — fixed in Task 5). Confirm that is the *only* failure. Do **not** commit.
+
+---
+
+## Task 4: Fix the remaining Rust references
+
+Two small fixes outside `schema.rs`.
+
+**Files:**
+- Modify: `musefs-db/src/limits.rs:3`
+- Modify: `musefs-db/tests/schema.rs:6,15,20`
+
+- [ ] **Step 1: Fix the `limits.rs` doc reference**
+
+In `musefs-db/src/limits.rs`, the module doc comment reads `... in [`crate::schema`] (`MIGRATION_V4`) ...`. Change `MIGRATION_V4` to `MIGRATION_V1`.
+
+- [ ] **Step 2: Fix the integration-test `user_version` asserts**
+
+In `musefs-db/tests/schema.rs`, change the three `user_version` assertions from `5` to `1` (lines ~6, ~15, ~20). Leave the `== 0` unmigrated-`Default` test (line ~29) unchanged.
+
+Run: `grep -n ', 5)' musefs-db/tests/schema.rs`
+Expected: no matches after the edit (the three `assert_eq!(..., 5)` sites are now `1`; the `== 0` unmigrated test on line ~29 is unaffected).
+
+- [ ] **Step 3: Re-run the `musefs-db` suite**
+
+Run: `cargo test -p musefs-db`
+Expected: still only `schema_py_fixture_is_fresh` fails. Do **not** commit.
+
+---
+
+## Task 5: Regenerate and re-vendor the Python schema mirror
+
+Regenerate `schema.py` from the collapsed `MIGRATIONS`, re-vendor it into Picard, and flip the two hardcoded `== 5` expectations.
+
+**Files:**
+- Regenerate: `contrib/python-musefs/src/musefs_common/schema.py`
+- Re-vendor: `contrib/picard/musefs/_common/schema.py`
+- Modify: `contrib/python-musefs/tests/test_constants.py`
+- Modify: `contrib/picard/tests/test_conftest_sanity.py`
+
+- [ ] **Step 1: Regenerate the mirror**
+
+Run: `MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py`
+Expected: PASS. Then verify the regenerated file:
+Run: `grep -nE 'MIGRATION_V|USER_VERSION' contrib/python-musefs/src/musefs_common/schema.py`
+Expected: exactly one `-- ── MIGRATION_V1 ──` banner, one `PRAGMA user_version = 1;`, and `USER_VERSION = 1`.
+
+- [ ] **Step 2: Re-vendor into Picard**
+
+Run: `python contrib/python-musefs/vendor_to_picard.py`
+Expected: rewrites `contrib/picard/musefs/_common/schema.py`. Verify:
+Run: `grep -nE 'MIGRATION_V|USER_VERSION' contrib/picard/musefs/_common/schema.py`
+Expected: same single-`MIGRATION_V1` / `USER_VERSION = 1` result.
+
+- [ ] **Step 3: Flip the python-musefs constant expectation**
+
+In `contrib/python-musefs/tests/test_constants.py`, change:
+
+```python
+    assert constants.EXPECTED_USER_VERSION == 1
+```
+
+(was `== 5`).
+
+- [ ] **Step 4: Flip the Picard conftest sanity expectation**
+
+In `contrib/picard/tests/test_conftest_sanity.py`, change the assert (line ~8) from `== 5` to:
+
+```python
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+```
+
+- [ ] **Step 5: Confirm `schema_py_fixture_is_fresh` now passes**
+
+Run: `cargo test -p musefs-db schema_py`
+Expected: PASS (no failures).
+
+- [ ] **Step 6: Run the python-musefs test suite**
+
+Run: `cd contrib/python-musefs && python -m pytest -q ; cd -`
+Expected: PASS. (`test_errors.py`'s `SchemaMismatch(5)` and `test_public_api.py`'s `"0.1.0" != "1"` are independent of the expected version and still pass without edits.)
+
+- [ ] **Step 7: Run the beets and Picard suites**
+
+Run (beets, needs its venv): `contrib/beets/.venv/bin/python -m pytest contrib/beets -q`
+Expected: PASS (conftest rebuilds from the regenerated `SCHEMA_SQL`).
+
+Run (real Picard, or it silently skips): `PYTHONPATH=/usr/lib/picard /usr/bin/python3 -m pytest contrib/picard -q`
+Expected: PASS. Do **not** commit.
+
+---
+
+## Task 6: Rewrite the migration-version documentation
+
+Collapse the V1–V5 narrative in `ARCHITECTURE.md` and drop the stray "As of V5" qualifier in the python-musefs README. Preserve all feature/contract prose.
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (the "The SQLite store" section, ~lines 112–201, plus lines 210 and 268)
+- Modify: `contrib/python-musefs/README.md:135,144`
+- Modify: `docs/OGG.md:85`
+
+- [ ] **Step 1: Collapse the `ARCHITECTURE.md` schema narrative**
+
+In `ARCHITECTURE.md`:
+
+1. Line ~114–115: change "defines the schema as an append-only list of migrations (`MIGRATIONS`); `user_version` records how many have been applied." to "defines the schema as a single baseline migration (`MIGRATIONS`); `user_version` records the schema version (1)."
+2. Replace the five bullets (`- **V1** — ...` through the end of the `- **V5** — ...` bullet) with one bullet that retains the feature prose, e.g.:
+
+```markdown
+- The **baseline schema** (`MIGRATION_V1`): the core tables — `tracks` (one row
+  per backing file: path, format, audio byte range, size/nanosecond-mtime/ctime
+  stamps, `content_version`), `tags` (multi-value key/value rows ordered by
+  `ordinal`, with an optional `value_blob` for binary tags), `art`
+  (content-addressed, deduplicated image blobs), `track_art` (per-track art
+  links with picture type and ordering), and `structural_blocks` (read-only,
+  derived-from-file FLAC `STREAMINFO`/`SEEKTABLE` metadata, **not** part of the
+  editable contract). Deleting a track cascades to its `tags` and `track_art`
+  rows. Triggers bump the owning track's `content_version`/`updated_at` on any
+  `tags`/`track_art` edit; `CHECK` constraints enforce the contract invariants
+  below at commit time. A bounded, self-pruning `track_changes` ring (capacity
+  8192, `CHANGELOG_CAP`) fed by triggers on `tracks` gives O(changed) refresh —
+  every metadata edit funnels through an `UPDATE` on the tracks row, relying on
+  SQLite's nested trigger activation (on by default). Freshness-superset
+  triggers make `content_version` cover every DB-knowable input to synthesized
+  bytes: `art_reject_content_update` (art is content-addressed and immutable),
+  `art_ad` (a deleted art row bumps referencing tracks so an orphan rebuilds to
+  a clean serve-time error), `tracks_geometry_au` (scanner-owned geometry
+  changes), and `structural_blocks_ai`/`_ad`.
+```
+
+3. Line ~164: change "**What the store enforces.** As of V4, SQLite `CHECK` constraints reject..." to "**What the store enforces.** SQLite `CHECK` constraints reject...".
+4. Line ~194: change "as of V5 a trigger rejects any in-place `UPDATE`..." to "a trigger rejects any in-place `UPDATE`...".
+5. Line ~210: change "The store's V4 `CHECK` rejects art over `MAX_ART_BYTES`..." to "The store's `CHECK` rejects art over `MAX_ART_BYTES`...".
+6. Line ~268: change "...and FLAC structural-block changes (V5)." to "...and FLAC structural-block changes." (drop the trailing `(V5)`).
+
+Leave the "external-writer contract" bullet list, the "Schema identity" paragraph, and everything not version-stamped verbatim.
+
+- [ ] **Step 2: Drop the version qualifiers in the python-musefs README**
+
+In `contrib/python-musefs/README.md`:
+- Line ~135: change "run `musefs scan` (i.e. `run_scan`). V4 `CHECK` constraints reject malformed" to "run `musefs scan` (i.e. `run_scan`). `CHECK` constraints reject malformed".
+- Line ~144: change "**Art rows are immutable.** As of V5 a trigger rejects in-place updates of an" to "**Art rows are immutable.** A trigger rejects in-place updates of an".
+
+- [ ] **Step 3: Drop the "V4" qualifier in OGG.md**
+
+In `docs/OGG.md:85`, change "is rejected by the store's V4 `CHECK`, with a resolve-time cap" to "is rejected by the store's `CHECK`, with a resolve-time cap".
+
+- [ ] **Step 4: Confirm no live doc still cites a removed migration version**
+
+Run: `grep -rnE 'MIGRATION_V[2-5]|\bV[2-5]\b' ARCHITECTURE.md CONTRIBUTING.md README.md contrib/*/README.md docs/*.md 2>/dev/null`
+Expected: no matches (matches inside `docs/superpowers/specs|plans/` are out of scope and not searched here). Do **not** commit.
+
+---
+
+## Task 7: Remove the A/B harness, run the full gate, and commit
+
+**Files:**
+- Modify: `musefs-db/src/schema.rs` (delete the `ab_dump` module)
+
+- [ ] **Step 1: Delete the throwaway A/B harness**
+
+Remove the entire `mod ab_dump { ... }` module (and its leading `// THROWAWAY` comment) added in Task 1.
+
+Run: `grep -n 'ab_dump\|MUSEFS_AB_DUMP' musefs-db/src/schema.rs`
+Expected: no matches.
+
+- [ ] **Step 2: Format and lint**
+
+Run: `cargo fmt --all && cargo fmt --all --check && cargo clippy --all-targets`
+Expected: clippy clean (no warnings; the workspace denies them).
+
+- [ ] **Step 3: Full workspace test suite**
+
+Run: `cargo test`
+Expected: PASS (all crates; FUSE e2e excluded as usual).
+
+- [ ] **Step 4: Metrics-feature tests (separate from the default run)**
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: PASS. (These assert exact getattr/read stat counts and are not in the default workspace run; the schema change does not touch the read path, but the gate's `check` job runs them.)
+
+- [ ] **Step 5: Re-run the contrib Python suites**
+
+Run: `cd contrib/python-musefs && python -m pytest -q ; cd -`
+Run: `contrib/beets/.venv/bin/python -m pytest contrib/beets -q`
+Run: `PYTHONPATH=/usr/lib/picard /usr/bin/python3 -m pytest contrib/picard -q`
+Expected: all PASS.
+
+- [ ] **Step 6: Review the diff, then commit (only after user approval)**
+
+Run: `git status && git diff --stat`
+Expected staged set (by name — do not `git add -A`): `musefs-db/src/schema.rs`, `musefs-db/src/limits.rs`, `musefs-db/tests/schema.rs`, `contrib/python-musefs/src/musefs_common/schema.py`, `contrib/picard/musefs/_common/schema.py`, `contrib/python-musefs/tests/test_constants.py`, `contrib/picard/tests/test_conftest_sanity.py`, `ARCHITECTURE.md`, `contrib/python-musefs/README.md`, `docs/OGG.md`, and the spec/plan docs under `docs/superpowers/`.
+
+Confirm with the user, then:
+
+```bash
+git add musefs-db/src/schema.rs musefs-db/src/limits.rs musefs-db/tests/schema.rs \
+  contrib/python-musefs/src/musefs_common/schema.py \
+  contrib/picard/musefs/_common/schema.py \
+  contrib/python-musefs/tests/test_constants.py \
+  contrib/picard/tests/test_conftest_sanity.py \
+  ARCHITECTURE.md contrib/python-musefs/README.md docs/OGG.md \
+  docs/superpowers/specs/2026-06-12-schema-v1-reset-design.md \
+  docs/superpowers/plans/2026-06-12-schema-v1-reset.md
+git commit -m "$(cat <<'EOF'
+refactor(db): collapse migrations into a single v1 baseline schema
+
+Reset the SQLite schema version to 1 for the v1.0.0 release. musefs is
+pre-release, so there are no databases to upgrade: the V1..V5 migration
+path is collapsed into one MIGRATION_V1 holding the current schema. The
+collapsed schema is semantically identical to the post-V5 result
+(verified via a PRAGMA-level A/B diff and the retained CHECK/trigger/
+identity tests). Regenerates and re-vendors the Python schema mirror and
+updates the docs that narrated the migration history.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+The pre-commit hook re-runs fmt/clippy/full-suite/ruff; if it rejects, fix the reported issue, re-stage by name, and create a **new** commit (never `--amend`, never `--no-verify`).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §1 collapse → Task 2; §2 in-tree fixups → Tasks 3–4; §3 docs → Task 6; §4 test surgery → Task 3; §5 Python regen → Task 5; semantic A/B + atomic-commit verification → Tasks 1/3/7. All spec sections map to a task.
+- **No placeholders:** every code/SQL block is concrete; relocations name exact source/destination modules and the exact assert edits.
+- **Naming consistency:** `MIGRATION_V1`, `MIGRATIONS`, `CHANGELOG_CAP`, the new module names (`constraint_tests`, `changelog_tests`, `art_immutability_tests`, `baseline_tests`), and the renamed tests (`check_literals_match_limits_constants`, `baseline_creates_value_blob_and_structural_blocks_and_is_idempotent`, `migration_reaches_user_version_1`, `fresh_db_has_all_baseline_triggers`) are used consistently across tasks.

--- a/docs/superpowers/specs/2026-06-12-schema-v1-reset-design.md
+++ b/docs/superpowers/specs/2026-06-12-schema-v1-reset-design.md
@@ -1,0 +1,233 @@
+# Schema v1 reset (collapse migrations for v1.0.0)
+
+## Goal
+
+In preparation for the v1.0.0 release, reset the SQLite store's schema version
+to **1** and collapse the five historical migrations (`MIGRATION_V1`..`V5`) into
+a single baseline migration representing the current (post-V5) schema. musefs is
+pre-release, so there are no deployed databases to upgrade — the historical
+step-by-step migration path carries no value and only adds surface area.
+
+This is a mechanical reset, not a schema change. The collapsed baseline is
+**semantically equivalent** to a DB that has run all five migrations: identical
+tables, columns (and column order), constraints, triggers, and index, and
+identical accept/reject/trigger *behavior*. The stored `sqlite_master.sql`
+*text* may differ from the old form — V4 rebuilt tables with inline CHECKs and
+V5 then `ALTER`-appended a column, whereas the baseline is a single clean
+`CREATE` — and that is fine: nothing compares against the old text.
+`validate_identity()` checks a live DB against a reference that, after this
+change, is **also** built from the new `MIGRATION_V1` (so it is self-consistent),
+and the external plugins only check `user_version`, not DDL text.
+
+## Mechanism (decided)
+
+Keep the migration framework. `MIGRATIONS` stays an array and `migrate()` keeps
+its per-step `user_version`-stamping loop, so a post-1.0 schema change is added
+by appending `MIGRATION_V2`. After this reset the array holds a single element,
+so `migrate()` stamps `user_version` to **1**.
+
+## Changes
+
+### 1. Collapse the migrations — `musefs-db/src/schema.rs`
+
+Replace `MIGRATION_V1`..`MIGRATION_V5` with a single `MIGRATION_V1` holding the
+final post-V5 schema as plain `CREATE` statements — no `ALTER`, no V4-style
+table-rebuild/stash dance.
+
+**Assembly rule (to avoid hand-formatting drift):** copy the `CREATE TABLE`
+statements for `tags`/`art`/`track_art`/`structural_blocks`, the
+`track_changes` table, the `track_art_art_id_idx` index, and **all** triggers
+verbatim from the existing V3/V4/V5 literals — they are already clean `CREATE`
+statements and carry the exact constraint/trigger text. Only `tracks` is
+hand-assembled, because its final form is V4's `CREATE TABLE` *plus* V5's two
+`ALTER`s (rename `backing_mtime` -> `backing_mtime_ns`, which also rewrites the
+`backing_mtime >= 0` CHECK; and append `backing_ctime_ns`). Its exact target
+DDL is:
+
+```sql
+CREATE TABLE tracks (
+    id               INTEGER PRIMARY KEY,
+    backing_path     TEXT NOT NULL UNIQUE,
+    format           TEXT NOT NULL,
+    audio_offset     INTEGER NOT NULL,
+    audio_length     INTEGER NOT NULL,
+    backing_size     INTEGER NOT NULL,
+    backing_mtime_ns INTEGER NOT NULL,
+    content_version  INTEGER NOT NULL DEFAULT 0,
+    updated_at       INTEGER NOT NULL,
+    backing_ctime_ns INTEGER NOT NULL DEFAULT 0 CHECK (backing_ctime_ns >= 0),
+    CHECK (format IN ('flac','mp3','m4a','opus','vorbis','oggflac','wav')),
+    CHECK (audio_offset >= 0),
+    CHECK (audio_length >= 0),
+    CHECK (backing_size >= 0),
+    CHECK (backing_mtime_ns >= 0),
+    CHECK (content_version >= 0),
+    CHECK (updated_at >= 0),
+    CHECK (audio_offset + audio_length <= backing_size)
+);
+```
+
+`backing_ctime_ns` is the last column with its CHECK attached at the column
+level (matching V5's `ALTER ... ADD COLUMN ... CHECK`). Nothing in the Rust code
+depends on `tracks` column order — `tracks.rs:14` selects an explicit column
+list, and the only `SELECT *` on `tracks` is inside V4's rebuild (being deleted)
+— so this ordering is for fidelity, not correctness.
+
+The full baseline thus contains:
+
+- **Tables:** `tracks` (above), `tags` (`value_blob` + V4 CHECKs), `art`
+  (V4 CHECKs), `track_art` (V4 CHECKs), `structural_blocks` (V4 CHECKs),
+  `track_changes`.
+- **Index:** `track_art_art_id_idx`.
+- **Triggers (15):** `tags_ai`/`au`/`ad`, `track_art_ai`/`au`/`ad`,
+  `tracks_changelog_ai`/`au`/`ad`, `track_changes_prune`,
+  `art_reject_content_update`, `art_ad`, `tracks_geometry_au`,
+  `structural_blocks_ai`/`ad`.
+
+`MIGRATIONS` becomes `&[MIGRATION_V1]`. `migrate()`, `reference_objects()`,
+`read_schema_objects()`, `schema_mismatch()`, and `validate_identity()` are
+unchanged. `CHANGELOG_CAP` stays (it now guards the `MIGRATION_V1` literal).
+
+### 2. In-tree reference fixups
+
+- `musefs-db/src/schema.rs` `CHANGELOG_CAP` rustdoc (currently "Must match the
+  literal in MIGRATION_V3"): `MIGRATION_V3` -> `MIGRATION_V1`.
+- `changelog_cap_constant_matches_migration_sql`: `MIGRATIONS[2]` -> `MIGRATION_V1`.
+- `v4_check_literals_match_limits_constants`: `MIGRATION_V4` -> `MIGRATION_V1`.
+- `musefs-db/src/limits.rs:3` doc comment: `MIGRATION_V4` -> `MIGRATION_V1`.
+- `musefs-db/tests/schema.rs`: the three `user_version == 5` asserts -> `== 1`.
+  The `== 0` unmigrated-`Default` test is unchanged (its "always-migrated 1"
+  comment already describes the new state).
+
+### 3. Documentation rewrites (in scope)
+
+- **`ARCHITECTURE.md` "The SQLite store" section (~lines 112–201).** The V1–V5
+  bullet narrative (`- V1 — ...` through `- V5 — ...`) and the "append-only list
+  of migrations" framing describe history that no longer exists. Collapse the
+  five bullets into one "the baseline schema" description that **retains the
+  feature prose** (core tables + cascade/version triggers, binary tags +
+  structural blocks, the self-pruning `track_changes` changelog ring, the CHECK
+  constraints, the freshness-superset triggers), and reword the contract
+  section's version-stamped phrasings: "As of V4, SQLite `CHECK` constraints…"
+  (line 164) -> "The store enforces…"; "as of V5 a trigger rejects…" (lines
+  143/194) -> drop the "as of V5" qualifier. Keep it minimal — preserve the
+  external-writer-contract content verbatim where it is not version-stamped.
+- **`contrib/python-musefs/README.md`** — drop the version qualifiers at line
+  135 ("V4 `CHECK` constraints…") and line 144 ("As of V5 a trigger rejects…").
+- **`docs/OGG.md:85`** — drop the "V4" qualifier ("the store's V4 `CHECK`" ->
+  "the store's `CHECK`").
+- A `grep -rnE 'MIGRATION_V[2-5]|\bV[2-5]\b'` over the tracked non-historical
+  docs (ARCHITECTURE, CONTRIBUTING, READMEs, `docs/*.md`) must come back empty
+  after the rewrites.
+- Historical plan docs under `docs/superpowers/plans/` (e.g. the
+  backing-freshness plan referencing `MIGRATION_V5`) are **left as-is** — the
+  repo treats `plans/` as a historical record.
+
+### 4. Test surgery — `schema.rs` test modules
+
+Delete the upgrade-path tests (they validate `Vn -> Vn+1` transitions that no
+longer exist; they are exactly the tests referencing `MIGRATIONS[1]`/`[2]` and
+the old-`backing_mtime` `insert_track_v3` helper, so they would not even
+compile):
+
+- `v1_rows_survive_v2_migration_with_null_value_blob`
+- `v2_db_upgrades_to_v3_preserving_rows`
+- `v4_rebuild_preserves_fk_children`
+- `v4_rebuild_does_not_pump_changelog_ring`
+- `v4_rebuild_preserves_structural_blocks`
+
+Keep every final-schema invariant test, fixing any `uv == 5` -> `uv == 1`, and
+reorganize the version-named modules into purpose-named ones. Target layout
+(every surviving test gets an explicit home):
+
+- **`constraint_tests`** — all CHECK rejection/acceptance tests for
+  `tracks`/`tags`/`art`/`track_art`/`structural_blocks` (the bulk of
+  `migration_v4_tests`), plus `v4_valid_rows_migrate_and_read_cleanly` and the
+  trigger-presence test (see below).
+- **`changelog_tests`** — `v3_changelog_records_insert_update_delete`,
+  `v3_bare_tag_insert_produces_changelog_row_via_nested_trigger`,
+  `v3_prune_keeps_ring_bounded_and_contiguous`.
+- **`art_immutability_tests`** — `art_content_update_is_rejected`,
+  `art_noop_update_is_allowed`, `deleting_referenced_art_bumps_tracks`,
+  `deleting_unreferenced_art_bumps_nothing`.
+- **`baseline_tests`** — the migrate-idempotency + `value_blob`/structural
+  existence test (rewritten from `v2_adds_value_blob_and_structural_blocks_and_is_idempotent`
+  against the single migration, asserting `user_version == 1`), the
+  `migration_reaches_user_version_5` test (renamed/retargeted to assert
+  `user_version == 1`), and the two SQL-literal drift guards
+  (`changelog_cap_constant_matches_migration_sql`,
+  `v4_check_literals_match_limits_constants`, with the constant-name fixups from
+  §2).
+- **`identity_tests`** and **`schema_py_tests`** — unchanged (already generic
+  over `MIGRATIONS`).
+
+The `v4_recreates_all_destroyed_triggers` test is rewritten as a plain
+"fresh DB has all expected triggers" invariant in `constraint_tests`, asserting
+the **full 15-trigger set** above — including the five V5 triggers
+(`art_reject_content_update`, `art_ad`, `tracks_geometry_au`,
+`structural_blocks_ai`/`ad`), which the current 10-name list omits. This
+preserves coverage that the collapse did not silently drop a trigger.
+
+No invariant coverage is lost in the delete-set: the FK-cascade-survival and
+changelog-not-pumped behaviors those tests proved were V4-rebuild-specific and
+genuinely no longer exist.
+
+### 5. Regenerate + re-vendor the Python mirror
+
+`MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py` rewrites
+`contrib/python-musefs/src/musefs_common/schema.py` (single
+`-- ── MIGRATION_V1 ──` banner, `USER_VERSION = 1`). Then
+`python contrib/python-musefs/vendor_to_picard.py` re-vendors the Picard copy
+(`contrib/picard/musefs/_common/schema.py`). Then flip the two hardcoded
+expectations:
+
+- `contrib/python-musefs/tests/test_constants.py`: `== 5` -> `== 1`.
+- `contrib/picard/tests/test_conftest_sanity.py`: `== 5` -> `== 1`.
+
+No change needed to `test_errors.py` (`SchemaMismatch(5)` is a literal `found`
+value, independent of the expected version) or `test_public_api.py`
+(`"0.1.0" != "1"` still holds). beets/lidarr/picard conftests build from
+`SCHEMA_SQL` and get the regenerated (semantically identical) schema; the
+`PRAGMA user_version = 99` mismatch tests are unaffected.
+
+## Verification
+
+- `cargo test` (full workspace) + `cargo clippy --all-targets` + `cargo fmt --check`.
+- `cargo test -p musefs-core --features metrics` (CI `check` job; not in the
+  default workspace run).
+- Contrib Python suites: beets venv (`contrib/beets/.venv/bin/python`),
+  system-Picard (`/usr/bin/python3` + `PYTHONPATH` to `/usr/lib/picard` and
+  dist-packages PyQt5), python-musefs.
+- **One-shot semantic A/B** to replace the lost cross-version guard (the
+  retained `schema_sql_matches_migrate` only proves render == `migrate()`, and
+  after collapse both sides are the new `MIGRATION_V1`): build a DB from the
+  pre-collapse schema (the five migrations on `main`/HEAD) and a DB from the
+  collapsed baseline, then diff their *semantic* schema — per-table
+  `PRAGMA table_info`, `PRAGMA foreign_key_list`, `PRAGMA index_list`/`index_info`,
+  and the set of trigger `{name, sql}` from `sqlite_master`. These must be
+  identical. Do **not** diff raw `sqlite_master.sql` table text — it will
+  legitimately differ (V4 CREATE + V5 ALTER vs one clean CREATE). Table-level
+  CHECK constraints are not enumerable via PRAGMA; they are covered by the
+  retained CHECK-rejection tests. This is a throwaway implementation-time check,
+  not a committed test (the old `MIGRATION_V2`..`V5` literals no longer exist).
+
+**Atomicity.** The schema collapse, the in-tree reference fixups, the mirror
+regen + re-vendor, and all `== 5` assert flips form one self-consistent change:
+deleting the migrations makes `schema_py_fixture_is_fresh` and the contrib
+`== 5` tests red until the regen/re-vendor/flips land. The pre-commit hook runs
+the full workspace suite and rejects red commits, so these must be staged
+together as one commit, and the `MUSEFS_REGEN_SCHEMA_PY=1` regen + re-vendor
+must run *before* staging.
+
+`sqlite_sequence` is a non-issue: `read_schema_objects` filters
+`name NOT LIKE 'sqlite_%'`, so the AUTOINCREMENT-created table never enters the
+identity reference; the collapse does not change this.
+
+## Out of scope
+
+- No behavioral schema change — served bytes and accepted/rejected rows are
+  unchanged from today.
+- No new migration-version doc; no unrelated refactoring or cleanup beyond the
+  documentation rewrites in §3.
+- The `fuzz/` crate (out of workspace) is unaffected — no format-layer API
+  changes here.

--- a/musefs-db/src/limits.rs
+++ b/musefs-db/src/limits.rs
@@ -1,6 +1,6 @@
 //! Size and identity caps enforced at the DB boundary (#267/#269/#278).
 //!
-//! The `CHECK` constraints in [`crate::schema`] (`MIGRATION_V4`) enforce these
+//! The `CHECK` constraints in [`crate::schema`] (`MIGRATION_V1`) enforce these
 //! at write time for honest writers; the reader guards in [`crate::tags`],
 //! [`crate::art`] and [`crate::structural`] re-enforce them at read time,
 //! because a crafted DB can carry the canonical schema yet smuggle a

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -3,172 +3,21 @@ use rusqlite::{Connection, TransactionBehavior};
 
 const MIGRATION_V1: &str = r"
 CREATE TABLE tracks (
-    id              INTEGER PRIMARY KEY,
-    backing_path    TEXT NOT NULL UNIQUE,
-    format          TEXT NOT NULL,
-    audio_offset    INTEGER NOT NULL,
-    audio_length    INTEGER NOT NULL,
-    backing_size    INTEGER NOT NULL,
-    backing_mtime   INTEGER NOT NULL,
-    content_version INTEGER NOT NULL DEFAULT 0,
-    updated_at      INTEGER NOT NULL
-);
-
-CREATE TABLE tags (
-    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    key      TEXT NOT NULL,
-    value    TEXT NOT NULL,
-    ordinal  INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (track_id, key, ordinal)
-);
-
-CREATE TABLE art (
-    id       INTEGER PRIMARY KEY,
-    sha256   TEXT NOT NULL UNIQUE,
-    mime     TEXT NOT NULL,
-    width    INTEGER,
-    height   INTEGER,
-    byte_len INTEGER NOT NULL,
-    data     BLOB NOT NULL
-);
-
-CREATE TABLE track_art (
-    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    art_id       INTEGER NOT NULL REFERENCES art(id),
-    picture_type INTEGER NOT NULL DEFAULT 3,
-    description  TEXT NOT NULL DEFAULT '',
-    ordinal      INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (track_id, ordinal)
-);
-
-CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = OLD.track_id;
-END;
-
-CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = NEW.track_id;
-END;
-CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
-    UPDATE tracks SET content_version = content_version + 1,
-                      updated_at = CAST(strftime('%s','now') AS INTEGER)
-    WHERE id = OLD.track_id;
-END;
-";
-
-const MIGRATION_V2: &str = r"
--- Binary tag payloads live alongside text tags. A row is binary iff
--- value_blob IS NOT NULL; binary rows store '' in value.
-ALTER TABLE tags ADD COLUMN value_blob BLOB;
-
--- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
--- NOT part of the editable `tags` contract: external tools never touch it.
-CREATE TABLE structural_blocks (
-    track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
-    kind     TEXT NOT NULL,
-    ordinal  INTEGER NOT NULL DEFAULT 0,
-    body     BLOB NOT NULL,
-    PRIMARY KEY (track_id, kind, ordinal)
-);
-";
-
-/// Ring capacity of the `track_changes` changelog. Must match the literal in
-/// MIGRATION_V3 (guarded by `changelog_cap_constant_matches_migration_sql`).
-#[allow(dead_code)]
-pub const CHANGELOG_CAP: i64 = 8192;
-
-const MIGRATION_V3: &str = r"
--- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
--- through an UPDATE on the tracks row (the V1 tags/track_art triggers), so
--- triggers on tracks alone capture all writers. Relies on SQLite nested
--- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
-CREATE TABLE track_changes (
-    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
-    track_id INTEGER NOT NULL
-);
-
-CREATE TRIGGER tracks_changelog_ai AFTER INSERT ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (NEW.id);
-END;
-CREATE TRIGGER tracks_changelog_au AFTER UPDATE ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (NEW.id);
-END;
-CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
-    INSERT INTO track_changes (track_id) VALUES (OLD.id);
-END;
-
--- Self-pruning ring: writers maintain it; the mount's read-only connections
--- never need to. Deletes only from the old end, so retained seqs stay contiguous.
-CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
-    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
-END;
-";
-
-// V4 adds CHECK constraints to the four editable/contract tables. SQLite
-// cannot ALTER ADD CONSTRAINT, so each table is rebuilt. Order is load-bearing:
-//   1. Stash every row into a TEMP table (TEMP tables carry no FK, so the
-//      drops below cannot cascade through them).
-//   2. DROP the four real tables. This is done with foreign_keys ON (the
-//      migrate() transaction cannot toggle the pragma), so dropping a parent
-//      would ON DELETE CASCADE its children — but the children are dropped
-//      first and their data already lives in the stash, so nothing is lost.
-//   3. CREATE the four tables WITH the CHECK constraints.
-//   4. Refill from the stash. The INSERT..SELECT copies enforce every new
-//      CHECK, so any pre-existing violating row aborts the migration.
-//   5. Recreate the triggers AFTER the refill. Dropping/renaming a table
-//      destroys triggers defined ON it: the V1 tags_ai/au/ad, the V1
-//      track_art_ai/au/ad, and the V3 tracks_changelog_ai/au/ad. Recreating
-//      them only after step 4 means the bulk refill of `tracks` does NOT fire
-//      tracks_changelog_ai and pump the self-pruning track_changes ring.
-//      track_changes_prune (ON track_changes) is NOT rebuilt. structural_blocks
-//      IS now rebuilt — its rows are stashed before the tracks DROP so they
-//      survive the cascade, then restored with the new CHECK constraints.
-const MIGRATION_V4: &str = r"
-CREATE TEMP TABLE _m4_tracks AS SELECT * FROM tracks;
-CREATE TEMP TABLE _m4_tags AS SELECT * FROM tags;
-CREATE TEMP TABLE _m4_art AS SELECT * FROM art;
-CREATE TEMP TABLE _m4_track_art AS SELECT * FROM track_art;
-CREATE TEMP TABLE _m4_structural AS SELECT * FROM structural_blocks;
-
-DROP TABLE track_art;
-DROP TABLE tags;
-DROP TABLE art;
-DROP TABLE structural_blocks;
-DROP TABLE tracks;
-
-CREATE TABLE tracks (
-    id              INTEGER PRIMARY KEY,
-    backing_path    TEXT NOT NULL UNIQUE,
-    format          TEXT NOT NULL,
-    audio_offset    INTEGER NOT NULL,
-    audio_length    INTEGER NOT NULL,
-    backing_size    INTEGER NOT NULL,
-    backing_mtime   INTEGER NOT NULL,
-    content_version INTEGER NOT NULL DEFAULT 0,
-    updated_at      INTEGER NOT NULL,
+    id               INTEGER PRIMARY KEY,
+    backing_path     TEXT NOT NULL UNIQUE,
+    format           TEXT NOT NULL,
+    audio_offset     INTEGER NOT NULL,
+    audio_length     INTEGER NOT NULL,
+    backing_size     INTEGER NOT NULL,
+    backing_mtime_ns INTEGER NOT NULL,
+    content_version  INTEGER NOT NULL DEFAULT 0,
+    updated_at       INTEGER NOT NULL,
+    backing_ctime_ns INTEGER NOT NULL DEFAULT 0 CHECK (backing_ctime_ns >= 0),
     CHECK (format IN ('flac','mp3','m4a','opus','vorbis','oggflac','wav')),
     CHECK (audio_offset >= 0),
     CHECK (audio_length >= 0),
     CHECK (backing_size >= 0),
-    CHECK (backing_mtime >= 0),
+    CHECK (backing_mtime_ns >= 0),
     CHECK (content_version >= 0),
     CHECK (updated_at >= 0),
     CHECK (audio_offset + audio_length <= backing_size)
@@ -218,6 +67,8 @@ CREATE TABLE track_art (
     CHECK (length(description) <= 1024)
 );
 
+-- Read-only, derived-from-file structural metadata (FLAC STREAMINFO/SEEKTABLE).
+-- NOT part of the editable `tags` contract: external tools never touch it.
 CREATE TABLE structural_blocks (
     track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
     kind     TEXT NOT NULL,
@@ -229,17 +80,18 @@ CREATE TABLE structural_blocks (
     CHECK (length(body) <= 16777215)
 );
 
-INSERT INTO tracks SELECT * FROM _m4_tracks;
-INSERT INTO art SELECT * FROM _m4_art;
-INSERT INTO tags SELECT * FROM _m4_tags;
-INSERT INTO track_art SELECT * FROM _m4_track_art;
-INSERT INTO structural_blocks SELECT * FROM _m4_structural;
+-- Bounded changelog ring for O(changed) refresh. Every metadata edit funnels
+-- through an UPDATE on the tracks row (the tags/track_art triggers), so
+-- triggers on tracks alone capture all writers. Relies on SQLite nested
+-- trigger activation (on by default; distinct from PRAGMA recursive_triggers).
+CREATE TABLE track_changes (
+    seq      INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id INTEGER NOT NULL
+);
 
-DROP TABLE _m4_track_art;
-DROP TABLE _m4_tags;
-DROP TABLE _m4_art;
-DROP TABLE _m4_structural;
-DROP TABLE _m4_tracks;
+-- Index the reverse art -> track_art edge so bulk orphan-GC and the art delete
+-- trigger below do not scan the whole join table per deleted row.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
 
 CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
     UPDATE tracks SET content_version = content_version + 1,
@@ -282,20 +134,18 @@ END;
 CREATE TRIGGER tracks_changelog_ad AFTER DELETE ON tracks BEGIN
     INSERT INTO track_changes (track_id) VALUES (OLD.id);
 END;
-";
 
-const MIGRATION_V5: &str = r"
-ALTER TABLE tracks RENAME COLUMN backing_mtime TO backing_mtime_ns;
-ALTER TABLE tracks ADD COLUMN backing_ctime_ns INTEGER NOT NULL DEFAULT 0
-    CHECK (backing_ctime_ns >= 0);
-
+-- Self-pruning ring: writers maintain it; the mount's read-only connections
+-- never need to. Deletes only from the old end, so retained seqs stay contiguous.
+CREATE TRIGGER track_changes_prune AFTER INSERT ON track_changes BEGIN
+    DELETE FROM track_changes WHERE seq <= NEW.seq - 8192;
+END;
 
 -- art rows are content-addressed by sha256: once written, their content
 -- columns are immutable. A writer needing different bytes/metadata inserts a
 -- NEW row and relinks via track_art (which bumps content_version through the
--- V1 track_art triggers). This closes #271, where an in-place art edit changed
--- served bytes without bumping any referencing track. width/height use IS NOT
--- (NULL-safe) because they are nullable; the NOT NULL columns use <>.
+-- track_art triggers). width/height use IS NOT (NULL-safe) because they are
+-- nullable; the NOT NULL columns use <>.
 CREATE TRIGGER art_reject_content_update
 BEFORE UPDATE ON art
 WHEN NEW.data   <> OLD.data
@@ -308,12 +158,6 @@ BEGIN
     SELECT RAISE(ABORT,
         'art rows are immutable; insert a new content-addressed row and relink via track_art');
 END;
-
--- Index the reverse art -> track_art edge. track_art is keyed (track_id,
--- ordinal), so without this both the art_ad trigger below and SQLite's own
--- REFERENCES art(id) check on art deletes scan the whole join table per
--- deleted row, which makes bulk orphan-GC O(deletes * rows).
-CREATE INDEX track_art_art_id_idx ON track_art(art_id);
 
 -- Deleting an art row that still has track_art references (an orphan an
 -- external writer can produce with foreign_keys OFF) bumps every referencing
@@ -328,9 +172,9 @@ END;
 
 -- Scanner-owned geometry feeds the synthesized layout, but upsert_track does
 -- not touch content_version. Bump it whenever a geometry column actually
--- changes, making content_version a true superset of served-byte inputs
--- (#272). The WHEN guard is false on this trigger's own nested UPDATE (only
--- content_version changes), so the recursion terminates after exactly one bump.
+-- changes, making content_version a true superset of served-byte inputs. The
+-- WHEN guard is false on this trigger's own nested UPDATE (only content_version
+-- changes), so the recursion terminates after exactly one bump.
 CREATE TRIGGER tracks_geometry_au
 AFTER UPDATE ON tracks
 WHEN NEW.format        <> OLD.format
@@ -355,13 +199,12 @@ CREATE TRIGGER structural_blocks_ad AFTER DELETE ON structural_blocks BEGIN
 END;
 ";
 
-const MIGRATIONS: &[&str] = &[
-    MIGRATION_V1,
-    MIGRATION_V2,
-    MIGRATION_V3,
-    MIGRATION_V4,
-    MIGRATION_V5,
-];
+/// Ring capacity of the `track_changes` changelog. Must match the literal in
+/// MIGRATION_V1 (guarded by `changelog_cap_constant_matches_migration_sql`).
+#[allow(dead_code)]
+pub const CHANGELOG_CAP: i64 = 8192;
+
+const MIGRATIONS: &[&str] = &[MIGRATION_V1];
 
 pub fn migrate(conn: &mut Connection) -> Result<()> {
     let latest = i64::try_from(MIGRATIONS.len()).expect("MIGRATIONS count must fit i64");
@@ -451,18 +294,17 @@ pub(crate) fn validate_identity(conn: &Connection) -> crate::Result<()> {
 }
 
 #[cfg(test)]
-mod migration_v2_tests {
+mod baseline_tests {
     use rusqlite::Connection;
 
     #[test]
-    fn v2_adds_value_blob_and_structural_blocks_and_is_idempotent() {
+    fn baseline_creates_value_blob_and_structural_blocks_and_is_idempotent() {
         let mut conn = Connection::open_in_memory().unwrap();
         super::migrate(&mut conn).unwrap();
-        // user_version reflects the number of migrations applied.
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 5);
+        assert_eq!(uv, 1);
 
         // value_blob exists on tags and defaults to NULL.
         conn.execute(
@@ -499,63 +341,37 @@ mod migration_v2_tests {
         let uv2: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv2, 5);
+        assert_eq!(uv2, 1);
+    }
+
+    /// The SQL literal and the exported constant must not drift.
+    #[test]
+    fn changelog_cap_constant_matches_migration_sql() {
+        assert!(super::MIGRATION_V1.contains(&format!("NEW.seq - {}", super::CHANGELOG_CAP)));
     }
 
     #[test]
-    fn v1_rows_survive_v2_migration_with_null_value_blob() {
-        let mut conn = Connection::open_in_memory().unwrap();
-        // Apply ONLY V1, then stamp the version so migrate() resumes at V2.
-        conn.execute_batch(super::MIGRATIONS[0]).unwrap();
-        conn.pragma_update(None, "user_version", 1i64).unwrap();
-
-        // Insert under the V1 schema (no value_blob column exists yet).
-        conn.execute(
-            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
-             VALUES ('/legacy.flac','flac',10,20,30,0,0)",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','Legacy',0)",
-            [],
-        )
-        .unwrap();
-
-        // Upgrade V1 -> V2 -> V3.
-        super::migrate(&mut conn).unwrap();
-        let uv: i64 = conn
-            .pragma_query_value(None, "user_version", |r| r.get(0))
-            .unwrap();
-        assert_eq!(uv, 5);
-
-        // The pre-existing row survived unchanged, with value_blob defaulted NULL.
-        let (value, blob_is_null): (String, bool) = conn
-            .query_row(
-                "SELECT value, value_blob IS NULL FROM tags WHERE track_id=1 AND key='artist'",
-                [],
-                |r| Ok((r.get(0)?, r.get(1)?)),
-            )
-            .unwrap();
-        assert_eq!(value, "Legacy");
-        assert!(
-            blob_is_null,
-            "existing tag rows must default value_blob to NULL"
-        );
-
-        // The track row survived too.
-        let offset: i64 = conn
-            .query_row("SELECT audio_offset FROM tracks WHERE id=1", [], |r| {
-                r.get(0)
-            })
-            .unwrap();
-        assert_eq!(offset, 10);
+    fn check_literals_match_limits_constants() {
+        use crate::limits::*;
+        let sql = super::MIGRATION_V1;
+        assert!(sql.contains(&format!("length(key) <= {MAX_TAG_KEY_LEN}")));
+        assert!(sql.contains(&format!("length(value) <= {MAX_TAG_VALUE_LEN}")));
+        assert!(sql.contains(&format!("length(value_blob) <= {MAX_BINARY_TAG_BYTES}")));
+        assert!(sql.contains(&format!("length(mime) <= {MAX_ART_MIME_LEN}")));
+        assert!(sql.contains(&format!("byte_len <= {MAX_ART_BYTES}")));
+        assert!(sql.contains(&format!("length(description) <= {MAX_ART_DESCRIPTION_LEN}")));
+        assert!(sql.contains(&format!("length(body) <= {MAX_STRUCTURAL_BODY_LEN}")));
+        let kinds = STRUCTURAL_KINDS
+            .iter()
+            .map(|k| format!("'{k}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        assert!(sql.contains(&format!("kind IN ({kinds})")));
     }
 }
 
 #[cfg(test)]
-mod migration_v3_tests {
+mod changelog_tests {
     use rusqlite::Connection;
 
     fn count_changes(conn: &Connection) -> i64 {
@@ -580,7 +396,7 @@ mod migration_v3_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 5);
+        assert_eq!(uv, 1);
 
         insert_track(&conn, "/a.flac"); // tracks AI -> 1 row
         assert_eq!(count_changes(&conn), 1);
@@ -660,38 +476,34 @@ mod migration_v3_tests {
     }
 
     #[test]
-    fn v2_db_upgrades_to_v3_preserving_rows() {
+    fn v4_metadata_edit_bumps_version_and_appends_one_changelog_row() {
         let mut conn = Connection::open_in_memory().unwrap();
-        // Apply V1+V2 only, stamp version 2, insert under the V2 schema.
-        conn.execute_batch(super::MIGRATIONS[0]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[1]).unwrap();
-        conn.pragma_update(None, "user_version", 2i64).unwrap();
-        // V2 schema has `backing_mtime` (pre-rename); use it directly.
+        super::migrate(&mut conn).unwrap();
+        insert_track(&conn, "/a.flac");
+        let cv_before: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let changes_before = count_changes(&conn);
+
         conn.execute(
-            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
-             VALUES ('/legacy.flac','flac',0,1,1,0,0)",
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','A',0)",
             [],
         )
         .unwrap();
 
-        super::migrate(&mut conn).unwrap();
-        let uv: i64 = conn
-            .pragma_query_value(None, "user_version", |r| r.get(0))
+        let cv_after: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
+                r.get(0)
+            })
             .unwrap();
-        assert_eq!(uv, 5);
-        // Pre-migration rows produce no retroactive changelog entries...
-        assert_eq!(count_changes(&conn), 0);
-        // ...but post-migration edits do.
-        conn.execute("UPDATE tracks SET backing_mtime_ns = 9 WHERE id = 1", [])
-            .unwrap();
-        assert_eq!(count_changes(&conn), 2);
-    }
-
-    /// The SQL literal and the exported constant must not drift.
-    #[test]
-    fn changelog_cap_constant_matches_migration_sql() {
-        assert!(super::MIGRATIONS[2].contains(&format!("NEW.seq - {}", super::CHANGELOG_CAP)));
+        assert_eq!(cv_after, cv_before + 1, "content_version must bump by one");
+        assert_eq!(
+            count_changes(&conn),
+            changes_before + 1,
+            "exactly one changelog row from the edit (nested trigger)"
+        );
     }
 }
 
@@ -800,7 +612,7 @@ mod schema_py_tests {
 }
 
 #[cfg(test)]
-mod migration_v4_tests {
+mod constraint_tests {
     use rusqlite::Connection;
 
     /// A fresh, fully-migrated DB with foreign_keys ON — mirrors how
@@ -808,16 +620,6 @@ mod migration_v4_tests {
     fn fresh(conn: &mut Connection) {
         conn.pragma_update(None, "foreign_keys", true).unwrap();
         super::migrate(conn).unwrap();
-    }
-
-    fn insert_track_v3(conn: &Connection, path: &str) {
-        conn.execute(
-            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
-             backing_size, backing_mtime, updated_at) \
-             VALUES (?1,'flac',0,1,1,0,0)",
-            [path],
-        )
-        .unwrap();
     }
 
     fn insert_track(conn: &Connection, path: &str) {
@@ -838,7 +640,7 @@ mod migration_v4_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 5);
+        assert_eq!(uv, 1);
 
         insert_track(&conn, "/a.flac");
         conn.execute(
@@ -875,74 +677,6 @@ mod migration_v4_tests {
             )
             .unwrap();
         assert_eq!(pic, 3);
-    }
-
-    /// The `tracks` rebuild drops the table while foreign_keys is ON, which
-    /// would cascade-delete `tags`/`track_art` if the rows were not stashed
-    /// first. Prove the children survive a fresh upgrade carrying real rows.
-    #[test]
-    fn v4_rebuild_preserves_fk_children() {
-        let mut conn = Connection::open_in_memory().unwrap();
-        conn.pragma_update(None, "foreign_keys", true).unwrap();
-        // Apply V1+V2+V3 only, stamp version 3, insert under the V3 schema.
-        conn.execute_batch(super::MIGRATIONS[0]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[1]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[2]).unwrap();
-        conn.pragma_update(None, "user_version", 3i64).unwrap();
-
-        insert_track_v3(&conn, "/legacy.flac");
-        conn.execute(
-            "INSERT INTO art (sha256, mime, byte_len, data) VALUES (?1,'image/png',1,X'00')",
-            [&"b".repeat(64)],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','Legacy',0)",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO track_art (track_id, art_id, picture_type, ordinal) \
-             VALUES (1,1,3,0)",
-            [],
-        )
-        .unwrap();
-
-        // Upgrade V3 -> V4.
-        super::migrate(&mut conn).unwrap();
-        let uv: i64 = conn
-            .pragma_query_value(None, "user_version", |r| r.get(0))
-            .unwrap();
-        assert_eq!(uv, 5);
-
-        // Children survived the parent rebuild (no cascade-delete).
-        let tags: i64 = conn
-            .query_row("SELECT COUNT(*) FROM tags", [], |r| r.get(0))
-            .unwrap();
-        let track_art: i64 = conn
-            .query_row("SELECT COUNT(*) FROM track_art", [], |r| r.get(0))
-            .unwrap();
-        let art: i64 = conn
-            .query_row("SELECT COUNT(*) FROM art", [], |r| r.get(0))
-            .unwrap();
-        assert_eq!((tags, track_art, art), (1, 1, 1));
-        assert_eq!(
-            Vec::<(i64, String, Option<String>)>::new(),
-            conn.prepare("PRAGMA foreign_key_check")
-                .unwrap()
-                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(3)?)))
-                .unwrap()
-                .collect::<rusqlite::Result<Vec<_>>>()
-                .unwrap(),
-            "no orphaned FK rows after rebuild"
-        );
-
-        // FK is still enforced after the rebuild: an orphan tag is rejected.
-        let orphan = conn.execute(
-            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (999,'x','y',0)",
-            [],
-        );
-        assert!(orphan.is_err(), "FK must still reject orphan child rows");
     }
 
     fn rejected(conn: &Connection, sql: &str) {
@@ -1253,62 +987,6 @@ mod migration_v4_tests {
         );
     }
 
-    fn count_changes(conn: &Connection) -> i64 {
-        conn.query_row("SELECT COUNT(*) FROM track_changes", [], |r| r.get(0))
-            .unwrap()
-    }
-
-    #[test]
-    fn v4_rebuild_does_not_pump_changelog_ring() {
-        let mut conn = Connection::open_in_memory().unwrap();
-        conn.pragma_update(None, "foreign_keys", true).unwrap();
-        conn.execute_batch(super::MIGRATIONS[0]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[1]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[2]).unwrap();
-        conn.pragma_update(None, "user_version", 3i64).unwrap();
-        insert_track_v3(&conn, "/a.flac");
-        insert_track_v3(&conn, "/b.flac");
-        conn.execute("DELETE FROM track_changes", []).unwrap();
-
-        super::migrate(&mut conn).unwrap();
-        assert_eq!(
-            count_changes(&conn),
-            0,
-            "the V4 bulk refill must not fire tracks_changelog_ai"
-        );
-    }
-
-    #[test]
-    fn v4_metadata_edit_bumps_version_and_appends_one_changelog_row() {
-        let mut conn = Connection::open_in_memory().unwrap();
-        fresh(&mut conn);
-        insert_track(&conn, "/a.flac");
-        let cv_before: i64 = conn
-            .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
-                r.get(0)
-            })
-            .unwrap();
-        let changes_before = count_changes(&conn);
-
-        conn.execute(
-            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','A',0)",
-            [],
-        )
-        .unwrap();
-
-        let cv_after: i64 = conn
-            .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
-                r.get(0)
-            })
-            .unwrap();
-        assert_eq!(cv_after, cv_before + 1, "content_version must bump by one");
-        assert_eq!(
-            count_changes(&conn),
-            changes_before + 1,
-            "exactly one changelog row from the edit (nested trigger)"
-        );
-    }
-
     #[test]
     fn v4_tags_rejects_oversize_key() {
         let mut conn = Connection::open_in_memory().unwrap();
@@ -1421,58 +1099,7 @@ mod migration_v4_tests {
     }
 
     #[test]
-    fn v4_rebuild_preserves_structural_blocks() {
-        let mut conn = Connection::open_in_memory().unwrap();
-        conn.pragma_update(None, "foreign_keys", true).unwrap();
-        conn.execute_batch(super::MIGRATIONS[0]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[1]).unwrap();
-        conn.execute_batch(super::MIGRATIONS[2]).unwrap();
-        conn.pragma_update(None, "user_version", 3i64).unwrap();
-
-        insert_track_v3(&conn, "/legacy.flac");
-        conn.execute(
-            "INSERT INTO structural_blocks (track_id, kind, ordinal, body) VALUES (1, 'STREAMINFO', 0, X'AABB')",
-            [],
-        )
-        .unwrap();
-
-        super::migrate(&mut conn).unwrap();
-
-        let n: i64 = conn
-            .query_row("SELECT COUNT(*) FROM structural_blocks", [], |r| r.get(0))
-            .unwrap();
-        assert_eq!(n, 1, "structural_blocks must survive the V4 tracks rebuild");
-        let body: Vec<u8> = conn
-            .query_row(
-                "SELECT body FROM structural_blocks WHERE track_id = 1",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(body, vec![0xAA, 0xBB]);
-    }
-
-    #[test]
-    fn v4_check_literals_match_limits_constants() {
-        use crate::limits::*;
-        let v4 = super::MIGRATION_V4;
-        assert!(v4.contains(&format!("length(key) <= {MAX_TAG_KEY_LEN}")));
-        assert!(v4.contains(&format!("length(value) <= {MAX_TAG_VALUE_LEN}")));
-        assert!(v4.contains(&format!("length(value_blob) <= {MAX_BINARY_TAG_BYTES}")));
-        assert!(v4.contains(&format!("length(mime) <= {MAX_ART_MIME_LEN}")));
-        assert!(v4.contains(&format!("byte_len <= {MAX_ART_BYTES}")));
-        assert!(v4.contains(&format!("length(description) <= {MAX_ART_DESCRIPTION_LEN}")));
-        assert!(v4.contains(&format!("length(body) <= {MAX_STRUCTURAL_BODY_LEN}")));
-        let kinds = STRUCTURAL_KINDS
-            .iter()
-            .map(|k| format!("'{k}'"))
-            .collect::<Vec<_>>()
-            .join(",");
-        assert!(v4.contains(&format!("kind IN ({kinds})")));
-    }
-
-    #[test]
-    fn v4_recreates_all_destroyed_triggers() {
+    fn fresh_db_has_all_baseline_triggers() {
         let mut conn = Connection::open_in_memory().unwrap();
         fresh(&mut conn);
         let names: Vec<String> = conn
@@ -1493,12 +1120,18 @@ mod migration_v4_tests {
             "tracks_changelog_au",
             "tracks_changelog_ad",
             "track_changes_prune",
+            "art_reject_content_update",
+            "art_ad",
+            "tracks_geometry_au",
+            "structural_blocks_ai",
+            "structural_blocks_ad",
         ] {
             assert!(
                 names.iter().any(|n| n == expected),
-                "missing trigger after V4: {expected}"
+                "missing trigger on fresh DB: {expected}"
             );
         }
+        assert_eq!(names.len(), 15, "unexpected trigger count: {names:?}");
     }
 
     #[test]
@@ -1668,7 +1301,7 @@ mod identity_tests {
 }
 
 #[cfg(test)]
-mod migration_v5_tests {
+mod art_immutability_tests {
     use rusqlite::{Connection, params};
 
     /// A fresh, fully-migrated DB with `foreign_keys` OFF — that is what lets
@@ -1702,12 +1335,12 @@ mod migration_v5_tests {
     }
 
     #[test]
-    fn migration_reaches_user_version_5() {
+    fn migration_reaches_user_version_1() {
         let conn = migrated();
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 5);
+        assert_eq!(uv, 1);
     }
 
     #[test]

--- a/musefs-db/tests/schema.rs
+++ b/musefs-db/tests/schema.rs
@@ -3,7 +3,7 @@ use musefs_db::Db;
 #[test]
 fn open_in_memory_runs_migration_to_latest() {
     let db = Db::open_in_memory().expect("open");
-    assert_eq!(db.user_version().expect("user_version"), 5);
+    assert_eq!(db.user_version().expect("user_version"), 1);
 }
 
 #[test]
@@ -12,12 +12,12 @@ fn migration_is_idempotent_across_reopen() {
     let path = dir.path().join("musefs.db");
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 5);
+    assert_eq!(db.user_version().unwrap(), 1);
     drop(db);
 
     // Reopening must not error and must not advance the version.
     let db2 = Db::open(&path).unwrap();
-    assert_eq!(db2.user_version().unwrap(), 5);
+    assert_eq!(db2.user_version().unwrap(), 1);
 }
 
 #[cfg(feature = "mutants")]


### PR DESCRIPTION
## What

In preparation for the v1.0.0 release, reset the SQLite schema version to **1** by collapsing the five historical migrations (`MIGRATION_V1`..`V5`) into a single baseline `MIGRATION_V1`. musefs is pre-release, so there are no deployed databases to upgrade — the step-by-step path was dead weight.

The migration framework is **kept** (`MIGRATIONS` array + `migrate()` loop); it just holds one element now. Post-1.0 schema changes append `MIGRATION_V2`.

## Semantic equivalence

The collapsed schema is **semantically identical** to a DB that ran all five migrations — verified two ways:

- A throwaway PRAGMA-level A/B diff during development (column shape/order, FKs, indexes, trigger/index bodies) — empty diff, only `user_version` flips 5→1.
- The retained `CHECK` / trigger / `identity` tests.

The `tracks` table is hand-assembled from V4's `CREATE` + V5's two `ALTER`s (preserving `backing_ctime_ns`-last column order); every other table/trigger/index is copied verbatim from the existing literals.

## Changes

- **`musefs-db/src/schema.rs`** — five constants → one `MIGRATION_V1`; `MIGRATIONS = &[MIGRATION_V1]`. `migrate()`/`validate_identity()` unchanged.
- **Test surgery** — deleted the five upgrade-path tests (no longer meaningful), consolidated the survivors into purpose-named modules (`baseline_tests`, `changelog_tests`, `constraint_tests`, `art_immutability_tests`), and rewrote the trigger-presence test to assert all 15 baseline triggers on a fresh DB.
- **`limits.rs` / `tests/schema.rs`** — `MIGRATION_V4`→`V1` doc ref; `user_version` asserts 5→1.
- **Python mirror** — regenerated `schema.py`, re-vendored into Picard, flipped the two `EXPECTED_USER_VERSION == 5` expectations.
- **Docs** — collapsed the V1–V5 narrative in `ARCHITECTURE.md` and dropped stray `V4`/`V5` qualifiers in the python-musefs README and `docs/OGG.md` (all feature/contract prose preserved).

## Verification

`cargo fmt --check`, `cargo clippy --all-targets`, full workspace `cargo test`, `cargo test -p musefs-core --features metrics`, and the python-musefs / beets / real-Picard suites all pass. Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified database schema into a single, streamlined baseline configuration with improved organization.
  * Enhanced file metadata timestamp precision by switching to nanosecond granularity for better accuracy.
  * Implemented automatic changelog ring pruning to maintain optimal database performance.

* **Documentation**
  * Updated architecture, design specifications, and contributor documentation to clarify database schema structure, enforcement mechanisms, and consistency guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->