### PR TITLE
chore: cut v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-12
+
+First stable release.
+
 ### Added
 
 - **Lidarr integration:** a new `contrib/lidarr/` package that drives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "musefs"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-cli"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-core"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "arc-swap",
  "base64",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-db"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "rusqlite",
  "sha2",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-format"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64",
  "crc",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-fuse"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64",
  "fuser",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-latencyfs"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "fuser",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["musefs-db", "musefs-format", "musefs-core", "musefs-fuse", "musefs-c
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Sohex/musefs"

--- a/contrib/CHANGELOG.md
+++ b/contrib/CHANGELOG.md
@@ -10,6 +10,10 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-12
+
+First stable release.
+
 ### Added
 
 - PyPI distribution: `python-musefs`, `beets-musefs`, and `lidarr-musefs` are

--- a/contrib/beets/pyproject.toml
+++ b/contrib/beets/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "beets-musefs"
-version = "0.1.0"
+version = "1.0.0"
 description = "Sync beets metadata into the musefs SQLite store"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Conor Futro" }]
-dependencies = ["python-musefs>=0.1.0", "beets>=1.6"]
+dependencies = ["python-musefs>=1.0.0", "beets>=1.6"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/contrib/lidarr/pyproject.toml
+++ b/contrib/lidarr/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lidarr-musefs"
-version = "0.1.0"
+version = "1.0.0"
 description = "Sync Lidarr metadata into the musefs SQLite store"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Conor Futro" }]
-dependencies = ["python-musefs>=0.1.0"]
+dependencies = ["python-musefs>=1.0.0"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/contrib/lidarr/src/musefs_lidarr/__init__.py
+++ b/contrib/lidarr/src/musefs_lidarr/__init__.py
@@ -1,3 +1,3 @@
 """Lidarr integration for syncing metadata into musefs."""
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"

--- a/contrib/lidarr/tests/test_smoke.py
+++ b/contrib/lidarr/tests/test_smoke.py
@@ -3,5 +3,5 @@ from musefs_lidarr.errors import MusefsLidarrError
 
 
 def test_package_imports():
-    assert __version__ == "0.1.0"
+    assert __version__ == "1.0.0"
     assert str(MusefsLidarrError("problem")) == "problem"

--- a/contrib/picard/musefs/__init__.py
+++ b/contrib/picard/musefs/__init__.py
@@ -38,7 +38,7 @@ PLUGIN_DESCRIPTION = (
     "Right-click a file/album → 'Sync to musefs' to push Picard's tags and "
     "cover images into a musefs SQLite store, without rewriting the audio file."
 )
-PLUGIN_VERSION = "0.1.0"
+PLUGIN_VERSION = "1.0.0"
 # Floor: 2.0 — all required APIs (BaseAction, register_*_action, OptionsPage,
 # register_options_page, config.TextOption/BoolOption, thread.run_task,
 # iterfiles, metadata.images, is_front_image) are present since Picard 2.0.0.

--- a/contrib/picard/musefs/_common/__init__.py
+++ b/contrib/picard/musefs/_common/__init__.py
@@ -26,7 +26,7 @@ from .store import (
 )
 from .sync import ArtImage, Record, SyncStats, sync_files, sync_one
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 __all__ = [
     "EXPECTED_USER_VERSION",

--- a/contrib/picard/pyproject.toml
+++ b/contrib/picard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "musefs-picard"
-version = "0.1.0"
+version = "1.0.0"
 description = "Sync MusicBrainz Picard metadata into the musefs SQLite store"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/contrib/python-musefs/pyproject.toml
+++ b/contrib/python-musefs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-musefs"
-version = "0.1.0"
+version = "1.0.0"
 description = "Shared musefs SQLite-store contract for the beets and Picard plugins"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/contrib/python-musefs/src/musefs_common/__init__.py
+++ b/contrib/python-musefs/src/musefs_common/__init__.py
@@ -23,7 +23,7 @@ from .store import (
 )
 from .sync import ArtImage, Record, SyncStats, sync_files, sync_one
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 __all__ = [
     "EXPECTED_USER_VERSION",

--- a/contrib/python-musefs/tests/test_public_api.py
+++ b/contrib/python-musefs/tests/test_public_api.py
@@ -2,7 +2,7 @@ import musefs_common
 
 
 def test_version_is_package_semver_not_schema_version():
-    assert musefs_common.__version__ == "0.1.0"
+    assert musefs_common.__version__ == "1.0.0"
     assert musefs_common.__version__ != str(musefs_common.EXPECTED_USER_VERSION)
 
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-core"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "arc-swap",
  "dashmap",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-db"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "rusqlite",
  "sha2",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-format"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64",
  "id3",

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["filesystem", "multimedia::audio", "command-line-utilities"]
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
-musefs-db = { path = "../musefs-db", version = "0.2.0" }
-musefs-core = { path = "../musefs-core", version = "0.2.0" }
-musefs-fuse = { path = "../musefs-fuse", version = "0.2.0" }
+musefs-db = { path = "../musefs-db", version = "1.0.0" }
+musefs-core = { path = "../musefs-core", version = "1.0.0" }
+musefs-fuse = { path = "../musefs-fuse", version = "1.0.0" }
 signal-hook = "0.4"
 uzers = "0.12"
 

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -14,8 +14,8 @@ arc-swap = "1"
 dashmap = "6"
 im = "15"
 log = "0.4"
-musefs-db = { path = "../musefs-db", version = "0.2.0" }
-musefs-format = { path = "../musefs-format", version = "0.2.0" }
+musefs-db = { path = "../musefs-db", version = "1.0.0" }
+musefs-format = { path = "../musefs-format", version = "1.0.0" }
 once_cell = "1"
 parking_lot = "0.12"
 quick_cache = "0.6.23"

--- a/musefs-format/Cargo.toml
+++ b/musefs-format/Cargo.toml
@@ -21,7 +21,7 @@ metaflac = "0.2"
 mp4 = "0.14"
 crc = "3"
 hound = "3"
-musefs-db = { path = "../musefs-db", version = "0.2.0" }
+musefs-db = { path = "../musefs-db", version = "1.0.0" }
 proptest = "1"
 # Self-dependency: turns the `fuzzing` feature on for this crate's own test
 # builds, so tests/ can use fuzz_check and the proptests run without an

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -15,7 +15,7 @@ fuser = { version = "0.17", default-features = false }
 libc = "0.2"
 log = "0.4"
 rustix = { version = "1", features = ["process"] }
-musefs-core = { path = "../musefs-core", version = "0.2.0" }
+musefs-core = { path = "../musefs-core", version = "1.0.0" }
 threadpool = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-musefs-cli = { path = "../musefs-cli", version = "0.2.0" }
+musefs-cli = { path = "../musefs-cli", version = "1.0.0" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Cuts the v1.0.0 release. Tag once merged.

## Rust workspace (closes #162)
- Workspace version `0.2.0` → `1.0.0` and all 7 internal `musefs-*` path-dependency constraints.
- `Cargo.lock` and the out-of-workspace `fuzz/Cargo.lock` resynced (fuzz lock kept minimal — only the 3 musefs entries, no transitive-dep churn).
- `CHANGELOG.md`: `[Unreleased]` content moved into `## [1.0.0] - 2026-06-12`.

## contrib/ Python packages (decoupled, were 0.1.0)
- Bumped python-musefs, beets, lidarr, and the Picard plugin to `1.0.0` via `scripts/bump_python_version.py` (pyproject versions, `__version__`, `python-musefs>=` dep floors, re-vendored python-musefs into Picard).
- Manually bumped Picard `PLUGIN_VERSION` and the two tests pinning the old version.
- `contrib/CHANGELOG.md`: `[Unreleased]` → `## [1.0.0] - 2026-06-12`.

## Verification
- `cargo build` clean; `cargo package --workspace` succeeds for all 7 crates at v1.0.0.
- Pre-commit gate green (fmt, clippy `-D warnings`, full workspace test suite, ruff).
- Version-pinning Python tests pass (python-musefs `test_public_api`, lidarr `test_smoke`, Picard `test_vendor_sync`).
- The `release.yml` tag-vs-workspace gate will match a `v1.0.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)