### PR TITLE
fix(ci): release gate combined gh --slurp with -q, never parsed checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,17 @@ jobs:
           echo "Gating on check-runs started at/after ${SINCE} (the tag trigger)."
           deadline=$(( $(date +%s) + 45 * 60 ))   # 45 min covers the full matrix
           while :; do
-            # --slurp collects all pages into one JSON array; the jq filter then
-            # flattens every page's check_runs into a single {check_runs: [...]}
-            # object (plain --paginate would emit one object per page, which is
-            # not valid single-document JSON).
+            # --slurp collects all pages into one JSON array; a standalone jq
+            # then flattens every page's check_runs into a single
+            # {check_runs: [...]} object (plain --paginate would emit one object
+            # per page, which is not valid single-document JSON). gh forbids
+            # combining --slurp with its built-in -q/--jq, so the flatten runs as
+            # a separate jq process (preinstalled on ubuntu-latest).
             # `|| true`: tolerate a transient gh/API failure — release_gate.py
             # treats an empty/garbled checks.json as "wait", so the loop retries
             # rather than aborting the release on a single blip.
             gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
-              --paginate --slurp -q '{check_runs: [.[].check_runs[]]}' > checks.json || true
+              --paginate --slurp | jq '{check_runs: [.[].check_runs[]]}' > checks.json || true
             set +e
             python scripts/release_gate.py --names ci-ok coverage-ok --since "$SINCE" < checks.json
             rc=$?


### PR DESCRIPTION
## Problem

The v1.0.0 release run stalled at the `gate` job. The gate polls the Checks API with:

```
gh api .../check-runs --paginate --slurp -q '{check_runs: [.[].check_runs[]]}'
```

`gh` forbids combining `--slurp` with its built-in `-q`/`--jq` ("the --slurp option is not supported with --jq or --template"), so the command errored every iteration and `checks.json` was empty. `release_gate.py` then reported "Could not parse check-runs JSON; will retry," so the gate spun until its 45-minute deadline and failed the release **even though `ci-ok` and `coverage-ok` were green**.

Nothing was published — `build`/`smoke`/`publish`/`images` are all gated behind `gate`.

## Fix

Flatten the slurped pages with a standalone `jq` process (preinstalled on `ubuntu-latest`) instead of gh's `-q`. `release_gate.py` is unchanged.

After merge, the `v1.0.0` tag will be moved to the fixed commit so the release re-runs with a working gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)