### PR TITLE
fix(ci): correct cargo-zigbuild download URL in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,11 @@ jobs:
           set -euo pipefail
           curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar -xJ
           echo "$PWD/zig-linux-x86_64-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          curl -fsSL "https://github.com/rust-cross/cargo-zigbuild/releases/download/v${CARGO_ZIGBUILD_VERSION}/cargo-zigbuild-v${CARGO_ZIGBUILD_VERSION}.x86_64-unknown-linux-musl.tar.gz" \
-            | tar -xz -C "$HOME/.cargo/bin" cargo-zigbuild
+          # The release assets are cargo-dist-named (no version in the filename,
+          # .tar.xz, binary nested under a <triple>/ dir), so strip that dir and
+          # select just the binary into ~/.cargo/bin.
+          curl -fsSL "https://github.com/rust-cross/cargo-zigbuild/releases/download/v${CARGO_ZIGBUILD_VERSION}/cargo-zigbuild-x86_64-unknown-linux-musl.tar.xz" \
+            | tar -xJ --strip-components=1 -C "$HOME/.cargo/bin" cargo-zigbuild-x86_64-unknown-linux-musl/cargo-zigbuild
       - name: Add Rust target
         run: rustup target add ${{ matrix.triple }}
       - name: Build


### PR DESCRIPTION
## Problem

With the gate fixed (#351), the v1.0.0 release reached the `build` matrix, where all 4 jobs failed in *Install Zig and cargo-zigbuild*:

```
curl: (22) The requested URL returned error: 404
gzip: stdin: unexpected end of file
tar: Child returned status 1
```

The workflow requested `cargo-zigbuild-v0.22.3.x86_64-unknown-linux-musl.tar.gz`, but the project now ships **cargo-dist-named** assets: no version in the filename, `.tar.xz` (not `.tar.gz`), and the binary nested under a `<triple>/` directory. The 404's empty body broke the piped `tar -xz`, failing every build and skipping smoke/publish/images.

## Fix

```
cargo-zigbuild-x86_64-unknown-linux-musl.tar.xz
… | tar -xJ --strip-components=1 -C "$HOME/.cargo/bin" cargo-zigbuild-x86_64-unknown-linux-musl/cargo-zigbuild
```

Verified the URL resolves (200) and the extraction lands a runnable `cargo-zigbuild 0.22.3` binary. The Zig 0.13.0 download is unaffected (URL checked, 200).

After merge, `v1.0.0` will be re-pointed to the new commit to re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)