### PR TITLE
fix(ci): release smoke unpacked binary onto the musefs/ crate dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,14 +219,18 @@ jobs:
       - name: Extract binary
         run: |
           set -euo pipefail
-          tar -xzf dist/musefs-*-${{ matrix.triple }}.tar.gz -C .
-          ./musefs --version || true   # glibc/musl host may differ; real check is the smoke
+          # Extract into a dedicated dir: the binary is named `musefs`, which
+          # would collide with the checked-out `musefs/` crate directory if
+          # unpacked into the repo root.
+          mkdir -p bin
+          tar -xzf dist/musefs-*-${{ matrix.triple }}.tar.gz -C bin
+          ./bin/musefs --version || true   # glibc/musl host may differ; real check is the smoke
       - name: Smoke (host)
         if: matrix.mode == 'host'
         run: |
           set -euo pipefail
           sudo apt-get update && sudo apt-get install -y fuse3 ffmpeg
-          ./scripts/smoke-binary.sh ./musefs
+          ./scripts/smoke-binary.sh ./bin/musefs
       - name: Smoke (Alpine container)
         if: matrix.mode == 'alpine'
         run: |
@@ -235,7 +239,7 @@ jobs:
             --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
             -v "$PWD":/w -w /w \
             alpine:3.20 \
-            sh -c 'apk add --no-cache fuse3 ffmpeg >/dev/null && sh scripts/smoke-binary.sh ./musefs'
+            sh -c 'apk add --no-cache fuse3 ffmpeg >/dev/null && sh scripts/smoke-binary.sh ./bin/musefs'
 
   images:
     needs: smoke


### PR DESCRIPTION
## Problem

With the build matrix fixed (#352), the v1.0.0 release reached `smoke`, where all 4 jobs failed in *Extract binary*:

```
tar: musefs: Cannot open: File exists
tar: Exiting with failure status due to previous errors
```

The step ran `tar -xzf … -C .` into the repo checkout, but the binary is named `musefs` and collides with the checked-out `musefs/` crate **directory**. `images`/`publish`/`release-assets` then skipped. (Latent bug — this job never ran successfully before, since v0.2.0 was released manually.)

## Fix

Extract into a dedicated `bin/` dir and point the smoke script at `./bin/musefs` (host + Alpine). The `images` job already unpacks into its own `ctx/<arch>` dir, so it's unaffected.

Pre-checked the remaining stages so this is hopefully the last round: all 6 publishable crates carry `description` + `license`, and `CARGO_REGISTRY_TOKEN` is configured — so `publish`/`images`/`release-assets` should be clear.

After merge, `v1.0.0` will be re-pointed to the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)