### PR TITLE
fix(ci): smoke fixture tags didn't match default tree template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
           # unpacked into the repo root.
           mkdir -p bin
           tar -xzf dist/musefs-*-${{ matrix.triple }}.tar.gz -C bin
-          ./bin/musefs --version || true   # glibc/musl host may differ; real check is the smoke
+          ./bin/musefs --help || true   # glibc/musl host may differ; real check is the smoke
       - name: Smoke (host)
         if: matrix.mode == 'host'
         run: |

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -25,16 +25,18 @@ fi
 
 mkdir -p "$WORK/backing" "$WORK/mnt"
 
-# 1s tagged FLAC fixture.
+# 1s tagged FLAC fixture. Tags must cover the default virtual-tree template
+# ($albumartist/$album/$title) or the served path falls back to "Unknown ...".
 ffmpeg -hide_banner -loglevel error -f lavfi -i "sine=frequency=440:duration=1" \
-  -metadata artist=Alice -metadata title=Song "$WORK/backing/a.flac"
+  -metadata album_artist=Alice -metadata album=Greatest -metadata title=Song \
+  "$WORK/backing/a.flac"
 
 "$MUSEFS" scan "$WORK/backing" --db "$WORK/smoke.db"
 
 "$MUSEFS" mount "$WORK/mnt" --db "$WORK/smoke.db" &
 PID=$!
 
-SONG="$WORK/mnt/Alice/Song.flac"
+SONG="$WORK/mnt/Alice/Greatest/Song.flac"
 i=0
 while [ ! -f "$SONG" ]; do
   i=$((i + 1))


### PR DESCRIPTION
## Problem

With the extract collision fixed (#353), the v1.0.0 smoke jobs got further but still failed:

```
scanned …/backing: 1 file(s), skipped 0, failed 0
FAIL: mount did not come up
```

The mount was actually fine — the **expected path was wrong**. The smoke FLAC fixture set only `artist`+`title` and looked for `Alice/Song.flac`, but musefs's default virtual-tree template is `$albumartist/$album/$title`, so the file materialised at `Unknown Artist/Unknown Album/Song.flac`. The script waited 30s for a path that never existed. (The harness had never been run to completion — the release job is the first place it ran.)

Reproduced locally; confirmed the tree renders `Alice/Greatest/Song.flac` once the fixture carries `album_artist`/`album`/`title`.

## Fix

- Tag the fixture with `album_artist=Alice album=Greatest title=Song` and look for `Alice/Greatest/Song.flac`. Verified end-to-end locally: scan → mount → read (`fLaC` OK, 12173 bytes) → SIGTERM unmount → **PASS** (exit 0).
- Swap the extract-step `musefs --version` (no such flag; emitted a spurious "unexpected argument") for `--help`.

After merge, `v1.0.0` will be re-pointed to the new commit. Remaining stages (`publish`/`images`/`release-assets`) were pre-validated earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)