### PR TITLE
fix(ci): run image smoke as root so ffmpeg install + FUSE work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,11 @@ jobs:
       - name: Smoke the built image (amd64, native)
         run: |
           set -euo pipefail
-          docker run --rm \
+          # --user 0:0: the image runs as a non-root user by default (hardening),
+          # but the smoke installs ffmpeg at runtime and mounts FUSE, both of
+          # which need root. This overrides only the smoke run; the pushed image
+          # keeps its non-root default.
+          docker run --rm --user 0:0 \
             --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor=unconfined \
             -v "$PWD/scripts":/scripts:ro --entrypoint sh \
             "musefs-smoke:${{ matrix.variant }}" \


### PR DESCRIPTION
## Problem

With build+smoke green, the v1.0.0 release reached the final stage. Two independent jobs failed:

**`publish`** — crates.io returned `400: A verified email address is required to publish crates`. Account-side, not code; the maintainer has since verified the email at https://crates.io/settings/profile. No change needed here.

**`images`** (both glibc + musl) failed at *Smoke the built image*:

```
glibc: E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
musl:  ERROR: Unable to lock database: Permission denied   (apk)
```

The images run as `USER musefs` (non-root, by hardening design), but the smoke step installs ffmpeg at runtime and mounts FUSE — both need root.

## Fix

Run the smoke container with `--user 0:0`. This overrides only the smoke invocation; the pushed image keeps its non-root default (verified both Dockerfiles set `USER musefs`).

After merge, `v1.0.0` re-points to the new commit. With the email now verified, `publish` and `images` should both go green and `release-assets` will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)