### PR TITLE
fix(ci): lidarr-e2e chowned backing file, tripping the freshness guard

### DIFF
--- a/scripts/lidarr-e2e/run-e2e.sh
+++ b/scripts/lidarr-e2e/run-e2e.sh
@@ -110,8 +110,12 @@ done
 [ -n "$IMPORTED" ] || { echo "--- lidarr log ---"; "$DOCKER" exec "$CID" sh -c 'tail -n 40 /config/logs/lidarr.txt'|grep -iE 'import|reject|script|sync'|tail -15; fail "import did not complete"; }
 
 # The in-container sync/import (root under rootful Docker) wrote the store +
-# library symlinks; chown the tree so the host musefs read/mount/assert path works.
-reown "$W"
+# library symlinks; chown those back so the host musefs read/mount/assert path
+# works. Deliberately NOT $W/downloads: the backing file is host-created and only
+# read in-container, so chowning it would bump its ctime after the store recorded
+# its freshness stamp — tripping the (size, mtime, ctime) backing-changed guard
+# (musefs-core freshness, #276) and failing the serve with an I/O error.
+reown "$W/store" "$LIB" "$W/config"
 echo "=== assertions ==="
 LIBFILE="$LIB/Komiku/01 - The calling.flac"
 [ -L "$LIBFILE" ] || fail "library entry is not a symlink (import script didn't run): $(ls -l "$LIBFILE")"


### PR DESCRIPTION
## Problem

The `py-v1.0.0` release was blocked by the `lidarr-e2e` gate. It failed three times — once on an intermittent `Importing 0 tracks` import-timing flake, then **deterministically** on the serve:

```
[ok] library entry is a symlink -> …/downloads/Komiku/01 - The calling.flac
[ok] store artist tags: ['Komiku']
[ok] backing bytes unchanged
[ok] backing file has no albumartist/date
WARN musefs_fuse: lookup failed: backing file changed since scan: …/downloads/Komiku/01 - The calling.flac
…/mnt/…/The calling.flac: Input/output error
KeyError: 'format'
FAIL: served file does not carry Lidarr's metadata
```

## Root cause

The harness reowns the rootful-Docker-written tree back to the runner before the host mount/assert pass: `reown "$W"` ran `chown -R` over **all** of `$W`, including `$W/downloads`. But the backing file there is host-created and only *read* in-container — chowning it (even to the same owner) bumps its **ctime** *after* the store recorded the track's freshness stamp.

musefs's backing-changed guard is `(size, mtime, ctime)` since #276 (ctime is the adversarial backstop against an mtime-reset rewrite), so the post-chown ctime mismatch correctly rejects the serve with an I/O error — and the assertion's `ffprobe` on the unreadable served file gets no `"format"`. Latent until #276; the import-timing flake had been masking it.

## Fix

Reown only the container-written subtrees (`$W/store`, `$LIB`, `$W/config`), leaving `$W/downloads` — and the backing file's ctime — untouched.

Verified the mechanism locally with the real binary: a scan→serve reads fine (`fLaC`) with the backing left alone, and fails with an I/O error once the backing is chowned post-scan.

Note: the separate intermittent `Importing 0 tracks` import-timing flake is not addressed here.

After merge, re-run the Python release (`gh run rerun <py-release-run> --failed`) to publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)