### PR TITLE
docs: state the hash-stability/seeding guarantee in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ from the database, spliced in front of your original, untouched audio.
 - **Lossless-by-construction experimentation.** Change your tags, try a different
   organization scheme, new cover art — the originals are physically
   read-only to the mount. Backing up a current library is as easy as copying the db file.
+- **Hash-stable by construction.** The mount never rewrites a byte, so each
+  backing file's checksum is exactly what it was the day it arrived — anything
+  verified by hash keeps verifying, and anything you're seeding keeps seeding,
+  however aggressively you retag and reorganize the view on top.
 
 > [!NOTE]
 > This project was built with AI. The general workflow was to use the [superpowers](https://github.com/obra/superpowers) skills to provide a framework. Claude Opus was used to write plans and specs which were then implemented by another model, primarily MiMo v2.5.


### PR DESCRIPTION
Adds one bullet to **What it's for** making the integrity forcing function explicit.

Because the mount never rewrites a byte, every backing file's checksum is unchanged — so hash-verified archives and actively-seeded files stay valid no matter how aggressively the *view* is retagged and reorganized. That property was implicit in the design but never stated; this surfaces it in vocabulary the data-integrity / selfhosted / `*arr` audience actually searches on, without leaning on loaded terminology.

Docs-only change (+4 lines); pre-commit skipped the cargo gate accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated to clarify that the FUSE mount is hash-stable: file checksums remain unchanged and persistently valid even as tags or the presented library view are modified, ensuring consistent integrity verification for stored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->