### PR TITLE
docs(systemd): correct boolean env-var accepted values (#366)

### DIFF
--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -9,8 +9,9 @@
 #   - leave optional settings COMMENTED. A bare `KEY=` means "set to empty",
 #     which is treated as a value and breaks path/boolean settings.
 #
-# Booleans accept (case-insensitive): true/false, yes/no, on/off, 1/0.
-# Any other value is a hard error that stops the unit from starting.
+# Booleans accept only the literal lowercase `true` or `false`. Any other
+# value (including 1/0, yes/no, on/off, or capitalised True/False) is a hard
+# error that stops the unit from starting.
 
 # --- Required ---------------------------------------------------------------
 


### PR DESCRIPTION
## What

Corrects `contrib/systemd/musefs.conf.example` to document the boolean env-var values the CLI actually accepts.

## Why

The config example claimed booleans accept `true/false, yes/no, on/off, 1/0`, but the clap bool args have no `BoolishValueParser` attached, so they fall back to clap's default `bool` parser — which accepts **only** the literal lowercase `true`/`false`. An operator following the documented guidance (e.g. `MUSEFS_KEEP_CACHE=1` or `MUSEFS_ALLOW_OTHER=yes`) gets a unit that fails to start with `invalid value '1' for '--keep-cache' [possible values: true, false]`, a message that doesn't point back to the config file.

Fixes #366.

## Verification

Empirically tested every value against the built binary's env parsing:

| value | `MUSEFS_KEEP_CACHE` (SetTrue) | `MUSEFS_CASE_INSENSITIVE` (Set) |
| --- | --- | --- |
| `true` / `false` | accepted | accepted |
| `True` / `False` | rejected | — |
| `1` / `0` | rejected | rejected |
| `yes` / `no` | rejected | rejected |
| `on` / `off` | rejected | rejected |

## Follow-up

Wiring up `BoolishValueParser` so the fuller set works as originally specified (it was in the design plan but never attached) is tracked in #370; that change will revert this doc correction and add the missing CLI tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated systemd configuration example documentation to require boolean values to be strictly lowercase `true` or `false`. Previously accepted case-insensitive variants (1/0, yes/no, on/off) are no longer supported and will cause configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->