### PR TITLE
fix(fuse): add statfs + xattr handlers to stop log noise and 0-byte df

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`statfs` reply:** the mount now reports a non-zero synthetic capacity with
+  ample free space instead of fuser's all-zero default, so `df` no longer shows a
+  0-byte filesystem and capacity-checking importers (Lidarr et al.) don't balk
+  (#368).
+
+### Fixed
+
+- **xattr log noise:** `getxattr`/`listxattr`/`setxattr`/`removexattr` now reply
+  `ENOTSUP` explicitly (read-only filesystem, no extended attributes) instead of
+  falling through to fuser's default, which logged a `[Not Implemented]` warn on
+  every xattr probe (`ls -l`, indexers, backup tools). The caller-visible result
+  is unchanged (#364).
+
 ## [1.0.0] - 2026-06-12
 
 First stable release.

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -23,6 +23,7 @@ fuser = { version = "0.17", features = ["macos-no-mount"] }
 
 [dev-dependencies]
 tempfile = "3"
+rustix = { version = "1", features = ["fs"] }
 metaflac = "0.2"
 musefs-db = { path = "../musefs-db" }
 musefs-format = { path = "../musefs-format" }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -15,7 +15,7 @@ use crate::convert::{assemble_dir_listing, to_file_attr};
 use fuser::{
     BackgroundSession, Config, FileHandle, FileType, Filesystem, FopenFlags, Generation, INodeNo,
     InitFlags, KernelConfig, LockOwner, Notifier, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory,
-    ReplyEmpty, ReplyEntry, ReplyOpen, Request, Session,
+    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyXattr, Request, Session,
 };
 use musefs_core::CoreError;
 use musefs_core::Fh;
@@ -93,6 +93,33 @@ fn open_flags(keep_cache: bool) -> FopenFlags {
     } else {
         FopenFlags::empty()
     }
+}
+
+/// Synthetic `statfs` reply values (#368). musefs is a read-only passthrough
+/// with no single backing volume to mirror (backing files are per-track and may
+/// span devices), so we advertise a large, fully-free synthetic capacity rather
+/// than fuser's default all-zero reply — which makes `df` report a 0-byte
+/// filesystem and can make capacity-checking importers (Lidarr et al.) refuse to
+/// operate. Returns the `ReplyStatfs::statfs` argument tuple:
+/// `(blocks, bfree, bavail, files, ffree, bsize, namelen, frsize)`.
+fn statfs_params() -> (u64, u64, u64, u64, u64, u32, u32, u32) {
+    const BSIZE: u32 = 512;
+    const NAMELEN: u32 = 255;
+    // 1 TiB advertised capacity, reported entirely free — read-only, so nothing
+    // is "used" in a writable sense, and 1 TiB clears typical free-space checks.
+    const CAPACITY_BYTES: u64 = 1 << 40;
+    const TOTAL_INODES: u64 = 1 << 32;
+    let blocks = CAPACITY_BYTES / u64::from(BSIZE);
+    (
+        blocks,
+        blocks,
+        blocks,
+        TOTAL_INODES,
+        TOTAL_INODES,
+        BSIZE,
+        NAMELEN,
+        BSIZE,
+    )
 }
 
 /// Map a core error onto a POSIX errno for the FUSE reply. `Io` errors carry the
@@ -537,6 +564,51 @@ impl Filesystem for MusefsFs {
         reply.ok();
     }
 
+    fn statfs(&self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
+        let (blocks, bfree, bavail, files, ffree, bsize, namelen, frsize) = statfs_params();
+        reply.statfs(blocks, bfree, bavail, files, ffree, bsize, namelen, frsize);
+    }
+
+    fn getxattr(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _name: &OsStr,
+        _size: u32,
+        reply: ReplyXattr,
+    ) {
+        // Read-only filesystem with no extended attributes. Reply ENOTSUP
+        // explicitly so fuser's default doesn't log a `[Not Implemented]` warn on
+        // every probe (#364); callers see the same "Operation not supported"
+        // result the default's ENOSYS already collapses to.
+        reply.error(fuser::Errno::ENOTSUP);
+    }
+
+    fn listxattr(&self, _req: &Request, _ino: INodeNo, _size: u32, reply: ReplyXattr) {
+        // See `getxattr`: no xattrs, reply ENOTSUP quietly to suppress the warn.
+        reply.error(fuser::Errno::ENOTSUP);
+    }
+
+    fn setxattr(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _name: &OsStr,
+        _value: &[u8],
+        _flags: i32,
+        _position: u32,
+        reply: ReplyEmpty,
+    ) {
+        // Read-only: setting an xattr is unsupported. Replied explicitly for
+        // symmetry with get/listxattr so no `[Not Implemented]` warn is logged.
+        reply.error(fuser::Errno::ENOTSUP);
+    }
+
+    fn removexattr(&self, _req: &Request, _ino: INodeNo, _name: &OsStr, reply: ReplyEmpty) {
+        // Read-only: removing an xattr is unsupported. See `setxattr`.
+        reply.error(fuser::Errno::ENOTSUP);
+    }
+
     fn read(
         &self,
         _req: &Request,
@@ -797,6 +869,24 @@ mod tests {
     fn open_flags_sets_keep_cache_bit_only_when_enabled() {
         assert_eq!(open_flags(false), FopenFlags::empty());
         assert_eq!(open_flags(true), FopenFlags::FOPEN_KEEP_CACHE);
+    }
+
+    #[test]
+    fn statfs_params_reports_nonzero_capacity_with_ample_free() {
+        let (blocks, bfree, bavail, files, ffree, bsize, namelen, frsize) = statfs_params();
+        // The whole point of #368: a non-zero total so capacity-checking
+        // clients (Lidarr et al.) don't read the mount as a full/empty 0-byte fs.
+        assert!(blocks > 0, "blocks must be non-zero");
+        assert!(bavail > 0 && bfree > 0, "must advertise free space");
+        assert!(
+            bavail <= blocks && bfree <= blocks,
+            "free cannot exceed total"
+        );
+        assert!(ffree <= files, "free inodes cannot exceed total");
+        // bsize/namelen were already fine in fuser's default; keep them.
+        assert_eq!(bsize, 512);
+        assert_eq!(frsize, 512);
+        assert_eq!(namelen, 255);
     }
 
     fn test_fs() -> (tempfile::TempDir, MusefsFs) {

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -249,3 +249,63 @@ fn large_directory_lists_fully_across_paginated_readdir() {
     drop(session);
     drop(backing);
 }
+
+#[test]
+#[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse -- --ignored"]
+fn statfs_reports_nonzero_capacity(/* #368 */) {
+    let backing = tempfile::tempdir().unwrap();
+    let flac = make_flac(&["ARTIST=Alice", "TITLE=Song"], &[0xAB; 64]);
+    std::fs::write(backing.path().join("a.flac"), &flac).unwrap();
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-statfs").unwrap();
+
+    // `df` over the mount must not see a 0-byte filesystem.
+    let stat = rustix::fs::statvfs(mountpoint.path()).unwrap();
+    assert!(stat.f_blocks > 0, "total blocks must be non-zero");
+    assert!(stat.f_bavail > 0, "available blocks must be non-zero");
+
+    drop(session);
+    drop(backing);
+}
+
+#[test]
+#[cfg(target_os = "linux")] // xattr probing semantics are Linux-specific here
+#[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse -- --ignored"]
+fn xattr_ops_reply_enotsup_quietly(/* #364 */) {
+    let backing = tempfile::tempdir().unwrap();
+    let flac = make_flac(&["ARTIST=Alice", "TITLE=Song"], &[0xAB; 64]);
+    std::fs::write(backing.path().join("a.flac"), &flac).unwrap();
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-xattr").unwrap();
+
+    let song = mountpoint.path().join("Alice").join("Song.flac");
+    let mut buf = [0u8; 64];
+
+    // getxattr a missing attribute → ENOTSUP (same caller-visible result as the
+    // suppressed default, without the per-probe `[Not Implemented]` warn).
+    let err = rustix::fs::getxattr(&song, "user.test", &mut buf).unwrap_err();
+    assert_eq!(
+        err.raw_os_error(),
+        libc::ENOTSUP,
+        "getxattr should be ENOTSUP"
+    );
+
+    // listxattr likewise.
+    let err = rustix::fs::listxattr(&song, &mut buf).unwrap_err();
+    assert_eq!(
+        err.raw_os_error(),
+        libc::ENOTSUP,
+        "listxattr should be ENOTSUP"
+    );
+
+    drop(session);
+    drop(backing);
+}


### PR DESCRIPTION
## What

musefs implemented no `statfs` or xattr operations, so fuser's default trait methods ran:

- **`df` reported a 0-byte filesystem** at 0% used (fuser's all-zero `statfs` reply). A capacity-checking importer (Lidarr and similar — a primary musefs target) may refuse to operate against a filesystem it believes is empty/full (#368).
- **Every xattr probe logged a `[Not Implemented]` WARN** — `ls -l` (ACL probe → `listxattr`), file managers/thumbnailers, backup tools, indexers. Log noise, not a functional defect, but it recurs continuously (#364).

## Changes

- **`statfs`**: reply a synthetic 1 TiB capacity reported fully free. There is no single backing volume to mirror (backing files are per-track and may span devices), so synthetic-with-ample-free — the option the issue explicitly accepts — is used. Values come from a pure `statfs_params()` helper. `bsize`/`namelen` keep their (already-fine) defaults.
- **`getxattr`/`listxattr`/`setxattr`/`removexattr`**: reply `ENOTSUP` explicitly instead of falling through to fuser's default, mirroring the existing `flush` remedy. The caller-visible result is unchanged (fuser's default `ENOSYS` already collapses to `EOPNOTSUPP`/`ENOTSUP`); the warns stop.

## Tests

- `statfs_params` unit test (runs in the pre-commit/full suite).
- e2e mount tests in `musefs-fuse/tests/mount.rs` (`#[ignore]`, need `/dev/fuse`) verified against a real mount: `statvfs` returns non-zero blocks/avail; `getxattr`/`listxattr` return `ENOTSUP`. They use `rustix` safe wrappers since the workspace denies `unsafe_code` (added the `fs` dev-dep feature).
- Full workspace `cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check` all green.

Closes #364
Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filesystem capacity reporting now shows non-zero available space, so tools like `df` and other capacity checks no longer see a 0-byte filesystem.
  * Extended attribute operations now return a clearer “not supported” result on read-only filesystems, reducing noisy warnings during access checks.

* **Tests**
  * Added coverage for filesystem capacity reporting and extended attribute behavior on mounted filesystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->