### PR TITLE
perf(db): collapse serve/write-path SQLite inefficiencies (#367, #362)

### DIFF
--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -979,14 +979,15 @@ impl Musefs {
         };
         let (size, mtime_secs) = self.pool.with(|db| {
             // Cheap, indexed: the current content_version drives lazy invalidation.
-            let track = db
-                .get_track(track_id)?
+            // Only the two columns the validation needs — no full-row materialization.
+            let (content_version, backing_path) = db
+                .track_version_and_path(track_id)?
                 .ok_or(CoreError::TrackNotFound(track_id))?;
             // `.map(|e| *e)` copies the SizeEntry (Copy) so the shard Ref drops
             // before the miss-path insert below — same key → same shard, and
             // holding the Ref across the re-lock would deadlock.
             if let Some(e) = self.size_cache.get(&track_id).map(|e| *e)
-                && e.content_version == track.content_version
+                && e.content_version == content_version
             {
                 // Hit: re-stat the backing file (no synthesis) and compare to
                 // the stamp the cached attrs were built from. An on-disk change
@@ -994,9 +995,9 @@ impl Musefs {
                 // getattr advertise stale attrs — the one metadata surface that
                 // could outrun a backing change (read/open already re-stat).
                 crate::metrics::on_stat();
-                let meta = std::fs::metadata(&track.backing_path)?;
+                let meta = std::fs::metadata(&backing_path)?;
                 if BackingStamp::from_metadata(&meta) != e.stamp {
-                    return Err(CoreError::BackingChanged(track.backing_path.clone()));
+                    return Err(CoreError::BackingChanged(backing_path));
                 }
                 return Ok((e.total_len, e.mtime_secs));
             }
@@ -1005,7 +1006,7 @@ impl Musefs {
             self.size_cache.insert(
                 track_id,
                 SizeEntry {
-                    content_version: track.content_version,
+                    content_version,
                     total_len: resolved.total_len,
                     mtime_secs: resolved.mtime_secs,
                     stamp: resolved.stamp,

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -36,12 +36,12 @@ pub(crate) fn tags_to_fields(tags: &[Tag]) -> BTreeMap<String, &str> {
 /// the bytes are streamed at read time.
 pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<ArtInput>> {
     let mut inputs = Vec::new();
-    for ta in db.get_track_art(track_id)? {
+    for (ta, meta) in db.get_track_art_with_meta(track_id)? {
         // `track_art.art_id` is a foreign key into `art`, but SQLite FK
         // enforcement is per-connection and external writers can disable it or
         // import a partial DB. A missing `art` row is a contract violation we
         // surface (the read fails) rather than silently dropping the art.
-        let Some(meta) = db.get_art_meta(ta.art_id)? else {
+        let Some(meta) = meta else {
             return Err(crate::error::CoreError::OrphanedArt {
                 track_id,
                 art_id: ta.art_id,

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -40,9 +40,9 @@ impl<M> Db<M> {
     /// Art row metadata without loading the image blob — used to build synthesis
     /// inputs at resolve time without materializing art in memory.
     pub fn get_art_meta(&self, id: i64) -> Result<Option<ArtMeta>> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT length(mime), mime, width, height, byte_len FROM art WHERE id = ?1")?;
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT length(mime), mime, width, height, byte_len FROM art WHERE id = ?1",
+        )?;
         let mut rows = stmt.query(params![id])?;
         match rows.next()? {
             Some(r) => {
@@ -76,7 +76,7 @@ impl<M> Db<M> {
     }
 
     pub fn get_track_art(&self, track_id: i64) -> Result<Vec<TrackArt>> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT length(description), art_id, picture_type, description, ordinal
              FROM track_art WHERE track_id = ?1 ORDER BY ordinal",
         )?;
@@ -95,6 +95,58 @@ impl<M> Db<M> {
                 description: r.get(3)?,
                 ordinal: r.get(4)?,
             });
+            check_art_count(track_id, out.len())?;
+        }
+        Ok(out)
+    }
+
+    /// A track's `track_art` links joined with their `art` row metadata (no
+    /// image blob), in one query — collapses the former N+1 (`get_track_art`
+    /// plus one `get_art_meta` per row) on the resolve hot path. The `art` side
+    /// is `None` for an orphaned link: SQLite FK enforcement is per-connection,
+    /// so an external writer can leave a `track_art` row dangling, and the
+    /// caller surfaces that rather than silently dropping the art.
+    pub fn get_track_art_with_meta(
+        &self,
+        track_id: i64,
+    ) -> Result<Vec<(TrackArt, Option<ArtMeta>)>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT length(ta.description), ta.art_id, ta.picture_type, ta.description, ta.ordinal, \
+             length(a.mime), a.mime, a.width, a.height, a.byte_len \
+             FROM track_art ta LEFT JOIN art a ON a.id = ta.art_id \
+             WHERE ta.track_id = ?1 ORDER BY ta.ordinal",
+        )?;
+        let mut rows = stmt.query(params![track_id])?;
+        let mut out = Vec::new();
+        while let Some(r) = rows.next()? {
+            check_field_len(
+                "track_art",
+                "description",
+                r.get(0)?,
+                MAX_ART_DESCRIPTION_LEN,
+            )?;
+            let track_art = TrackArt {
+                art_id: r.get(1)?,
+                picture_type: r.get(2)?,
+                description: r.get(3)?,
+                ordinal: r.get(4)?,
+            };
+            // A NULL `mime` means the LEFT JOIN found no `art` row (orphaned
+            // link); `mime` is NOT NULL in the schema, so it is a reliable
+            // presence sentinel.
+            let meta = match r.get::<_, Option<String>>(6)? {
+                Some(mime) => {
+                    check_field_len("art", "mime", r.get(5)?, MAX_ART_MIME_LEN)?;
+                    Some(ArtMeta {
+                        mime,
+                        width: r.get(7)?,
+                        height: r.get(8)?,
+                        byte_len: r.get(9)?,
+                    })
+                }
+                None => None,
+            };
+            out.push((track_art, meta));
             check_art_count(track_id, out.len())?;
         }
         Ok(out)

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -131,14 +131,16 @@ impl<M> Db<M> {
                 description: r.get(3)?,
                 ordinal: r.get(4)?,
             };
-            // A NULL `mime` means the LEFT JOIN found no `art` row (orphaned
-            // link); `mime` is NOT NULL in the schema, so it is a reliable
-            // presence sentinel.
-            let meta = match r.get::<_, Option<String>>(6)? {
-                Some(mime) => {
-                    check_field_len("art", "mime", r.get(5)?, MAX_ART_MIME_LEN)?;
+            // A NULL `length(a.mime)` means the LEFT JOIN found no `art` row
+            // (orphaned link); `mime` is NOT NULL in the schema, so the length
+            // column is a reliable presence sentinel — and checking it lets us
+            // reject an over-cap mime before the string is ever materialized
+            // (the allocation-free guarantee, spec N13).
+            let meta = match r.get::<_, Option<i64>>(5)? {
+                Some(mime_len) => {
+                    check_field_len("art", "mime", mime_len, MAX_ART_MIME_LEN)?;
                     Some(ArtMeta {
-                        mime,
+                        mime: r.get(6)?,
                         width: r.get(7)?,
                         height: r.get(8)?,
                         byte_len: r.get(9)?,

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -37,7 +37,7 @@ pub struct BulkWriter<'c> {
 
 impl BulkWriter<'_> {
     pub fn upsert_track(&mut self, t: &NewTrack) -> Result<i64> {
-        self.tx.execute(
+        Ok(self.tx.query_row(
             "INSERT INTO tracks
                 (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime_ns, backing_ctime_ns, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
@@ -46,12 +46,9 @@ impl BulkWriter<'_> {
                 audio_length=excluded.audio_length, backing_size=excluded.backing_size,
                 backing_mtime_ns=excluded.backing_mtime_ns,
                 backing_ctime_ns=excluded.backing_ctime_ns,
-                updated_at=CAST(strftime('%s','now') AS INTEGER)",
+                updated_at=CAST(strftime('%s','now') AS INTEGER)
+             RETURNING id",
             params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime_ns, t.backing_ctime_ns],
-        )?;
-        Ok(self.tx.query_row(
-            "SELECT id FROM tracks WHERE backing_path = ?1",
-            params![t.backing_path],
             |r| r.get(0),
         )?)
     }
@@ -75,7 +72,7 @@ impl BulkWriter<'_> {
             "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
             params![track_id],
         )?;
-        let mut stmt = self.tx.prepare(
+        let mut stmt = self.tx.prepare_cached(
             "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
              VALUES (?1, ?2, '', ?3, ?4)",
         )?;
@@ -94,7 +91,7 @@ impl BulkWriter<'_> {
             "DELETE FROM structural_blocks WHERE track_id = ?1",
             params![track_id],
         )?;
-        let mut stmt = self.tx.prepare(
+        let mut stmt = self.tx.prepare_cached(
             "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
              VALUES (?1, ?2, ?3, ?4)",
         )?;

--- a/musefs-db/src/structural.rs
+++ b/musefs-db/src/structural.rs
@@ -18,7 +18,7 @@ impl<M> Db<M> {
     /// FLAC track has not been (re)scanned under V2 — callers fall back to a
     /// front read in that case.
     pub fn get_structural_blocks(&self, track_id: i64) -> Result<Vec<StructuralBlock>> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT kind, ordinal, length(body), body FROM structural_blocks \
              WHERE track_id = ?1 ORDER BY kind, ordinal",
         )?;

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -16,7 +16,7 @@ fn check_tag_lengths(key_len: i64, value_len: i64) -> Result<()> {
 
 impl<M> Db<M> {
     pub fn get_tags(&self, track_id: i64) -> Result<Vec<Tag>> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT length(key), length(value), key, value, ordinal FROM tags \
              WHERE track_id = ?1 AND value_blob IS NULL ORDER BY key, ordinal",
         )?;

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -88,6 +88,21 @@ impl<M> Db<M> {
         )?)
     }
 
+    /// The two columns `getattr` needs to validate cached attrs — the freshness
+    /// stamp (`content_version`) and the path to re-stat (`backing_path`) —
+    /// without materializing a full `Track` (no `format` parse, no
+    /// `TrackBounds`) on the hottest metadata op. `None` if the id is unknown.
+    pub fn track_version_and_path(&self, id: i64) -> Result<Option<(i64, String)>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT content_version, backing_path FROM tracks WHERE id = ?1")?;
+        let mut rows = stmt.query(params![id])?;
+        match rows.next()? {
+            Some(r) => Ok(Some((r.get(0)?, r.get(1)?))),
+            None => Ok(None),
+        }
+    }
+
     /// Begin a deferred (read) transaction: subsequent reads on this connection see
     /// a single consistent snapshot until `end_read`. Used to make a binary-tag
     /// read's content_version check and its blob reads mutually consistent.

--- a/musefs-db/tests/art.rs
+++ b/musefs-db/tests/art.rs
@@ -48,6 +48,35 @@ fn set_and_get_track_art() {
 }
 
 #[test]
+fn get_track_art_with_meta_joins_the_art_row() {
+    let db = Db::open_in_memory().unwrap();
+    let track = db.upsert_track(&new_track("/m/a.flac")).unwrap();
+    let art_id = db.upsert_art(&jpeg(vec![1, 2, 3])).unwrap();
+
+    db.set_track_art(
+        track,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: "front".to_string(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+
+    let got = db.get_track_art_with_meta(track).unwrap();
+    assert_eq!(got.len(), 1);
+    let (ta, meta) = &got[0];
+    assert_eq!(ta.art_id, art_id);
+    assert_eq!(ta.picture_type, 3);
+    assert_eq!(ta.description, "front");
+    assert_eq!(ta.ordinal, 0);
+    let meta = meta.as_ref().expect("joined art metadata must be present");
+    assert_eq!(meta.mime, "image/jpeg");
+    assert_eq!(meta.byte_len, 3);
+}
+
+#[test]
 fn linking_art_bumps_content_version() {
     let db = Db::open_in_memory().unwrap();
     let track = db.upsert_track(&new_track("/m/a.flac")).unwrap();

--- a/musefs-db/tests/tracks.rs
+++ b/musefs-db/tests/tracks.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::new_track;
+use common::{jpeg, new_track};
 use musefs_db::{Db, Format, NewArt, NewTrack, Tag, TrackArt};
 
 #[test]
@@ -19,6 +19,36 @@ fn insert_then_get_by_id_and_path() {
         .unwrap()
         .expect("track by path");
     assert_eq!(by_path.id, id);
+}
+
+#[test]
+fn track_version_and_path_returns_stamp_and_path() {
+    let db = Db::open_in_memory().unwrap();
+    let id = db.upsert_track(&new_track("/music/a.flac")).unwrap();
+    // Link art so content_version is bumped off its 0 default, pinning the
+    // returned stamp to a real, non-default value.
+    let art_id = db.upsert_art(&jpeg(vec![1, 2, 3])).unwrap();
+    db.set_track_art(
+        id,
+        &[TrackArt {
+            art_id,
+            picture_type: 3,
+            description: String::new(),
+            ordinal: 0,
+        }],
+    )
+    .unwrap();
+
+    let cv = db.track_content_version(id).unwrap();
+    assert!(
+        cv > 0,
+        "linking art must bump content_version above the default"
+    );
+    assert_eq!(
+        db.track_version_and_path(id).unwrap(),
+        Some((cv, "/music/a.flac".to_string())),
+    );
+    assert!(db.track_version_and_path(999_999).unwrap().is_none());
 }
 
 #[test]


### PR DESCRIPTION
Two independent DB-efficiency passes, no behaviour change.

## #367 — metadata/serve hot path (HeaderCache miss + getattr)
- **N+1 art-meta collapsed.** New `Db::get_track_art_with_meta` does a single `track_art ⋈ art` query; `track_art_to_inputs` consumes it, replacing the per-art-row `get_art_meta` round-trip (front/back/disc art was N extra trips per resolve). Implemented as a **LEFT JOIN** so an orphaned `track_art` link still surfaces as `OrphanedArt` rather than being silently dropped (inner join would drop it) — the existing `track_art_to_inputs_errors_on_orphaned_row` test stays green. Description/mime length and per-track art-count guards are carried over.
- **`prepare_cached` on fixed-SQL hot readers:** `get_tags`, `get_art_meta`, `get_track_art`, `get_structural_blocks`. The dynamic `IN (...)` tag builders are left on `prepare` (uncacheable), as the issue notes.
- **Lean getattr hit path.** New `Db::track_version_and_path` (`prepare_cached`, returns only `(content_version, backing_path)`); `getattr` uses it instead of `get_track` → `row_to_track`, dropping the discarded `format` parse, `TrackBounds`, and full-row alloc on every attr-TTL refresh. The DB round-trip itself stays (must read `content_version` to detect change).

## #362 — bulk write path (`bulk.rs`)
- `upsert_track`: `INSERT … ON CONFLICT DO UPDATE` + separate `SELECT id` folded into one statement via `RETURNING id` (SQLite 3.35+, bundled build). Returns the id for both insert and update branches.
- `set_binary_tags` / `set_structural_blocks`: `prepare` → `prepare_cached`, matching `replace_tags` / `set_track_art`.

## Verification
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean
- Full workspace test suite (pre-commit) — green on both commits
- `cargo test -p musefs-core --features metrics` — 400 passed (getattr stat/open counters unchanged)
- `check_mutant_anchors.py` — OK (51 entries / 3025 mutants)

Closes #367
Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Optimization**
  * Improved database efficiency by reusing prepared statements and streamlining metadata lookups, reducing extra round-trips for tag, track, and artwork retrieval.
  * Added a more direct way to fetch track artwork together with its associated metadata in one pass, while preserving behavior for missing metadata.
  * Added a lightweight track metadata helper to avoid heavy row processing during validation.
* **Tests**
  * Added unit coverage for the new joined artwork retrieval and the track metadata helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->