### PR TITLE
feat(cli): boolish env bools, --version flag, packaged-binary scan tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
           # unpacked into the repo root.
           mkdir -p bin
           tar -xzf dist/musefs-*-${{ matrix.triple }}.tar.gz -C bin
-          ./bin/musefs --help || true   # glibc/musl host may differ; real check is the smoke
+          ./bin/musefs --version || true   # glibc/musl host may differ; real check is the smoke
       - name: Smoke (host)
         if: matrix.mode == 'host'
         run: |

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ the original bytes, just through the daemon instead of the kernel.
 
 ## Usage
 
+`musefs --version` (or `-V`) prints the build version; `--help` on the root or
+any subcommand lists its flags.
+
 ### Scan
 
 ```bash
@@ -409,7 +412,11 @@ Every scalar `mount` and `scan` flag can also be set with a `MUSEFS_*`
 environment variable — uppercase the long flag and turn dashes into
 underscores (e.g. `--poll-interval-ms` → `MUSEFS_POLL_INTERVAL_MS`, the
 `mount` mountpoint → `MUSEFS_MOUNTPOINT`). An explicit flag always overrides
-its env var, which overrides the default. The repeatable `--fallback` and the
+its env var, which overrides the default. Boolean flags (`MUSEFS_KEEP_CACHE`,
+`MUSEFS_REVALIDATE`, `MUSEFS_FOLLOW_SYMLINKS`, `MUSEFS_QUIET`,
+`MUSEFS_ALLOW_OTHER`, `MUSEFS_CASE_INSENSITIVE`) accept a case-insensitive
+boolish value — `true`/`false`, `yes`/`no`, `on`/`off`, `1`/`0` — and reject
+anything else. The repeatable `--fallback` and the
 `scan` targets are command-line only. See
 [`contrib/systemd/musefs.conf.example`](contrib/systemd/musefs.conf.example)
 for the full, canonical list.

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -9,9 +9,8 @@
 #   - leave optional settings COMMENTED. A bare `KEY=` means "set to empty",
 #     which is treated as a value and breaks path/boolean settings.
 #
-# Booleans accept only the literal lowercase `true` or `false`. Any other
-# value (including 1/0, yes/no, on/off, or capitalised True/False) is a hard
-# error that stops the unit from starting.
+# Booleans accept (case-insensitive): true/false, yes/no, on/off, 1/0.
+# Any other value is a hard error that stops the unit from starting.
 
 # --- Required ---------------------------------------------------------------
 

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -31,6 +31,8 @@ impl From<CliMode> for musefs_core::Mode {
 #[derive(Parser, Debug)]
 #[command(
     name = "musefs",
+    version,
+    propagate_version = true,
     about = "Read-only re-tagging FUSE view of a music library"
 )]
 pub struct Cli {
@@ -86,13 +88,13 @@ pub struct MountArgs {
     /// Keep the kernel page cache across opens. External re-tags auto-invalidate
     /// the affected inodes on refresh, so cached bytes are dropped when content
     /// changes.
-    #[arg(long, env = "MUSEFS_KEEP_CACHE")]
+    #[arg(long, env = "MUSEFS_KEEP_CACHE", value_parser = clap::builder::BoolishValueParser::new())]
     pub keep_cache: bool,
     /// Compare filenames case-insensitively: case-variant directories merge and
     /// case-variant files are disambiguated. Defaults to true on macOS (whose
     /// volumes are usually case-insensitive), false on Linux/FreeBSD. Override
     /// with `--case-insensitive false` (e.g. a case-sensitive APFS volume).
-    #[arg(long, env = "MUSEFS_CASE_INSENSITIVE", default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set)]
+    #[arg(long, env = "MUSEFS_CASE_INSENSITIVE", default_value_t = cfg!(target_os = "macos"), action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new())]
     pub case_insensitive: bool,
     /// Owning user for every entry: a username or numeric uid. Defaults to the
     /// launching process's uid.
@@ -113,7 +115,7 @@ pub struct MountArgs {
     /// the mounting user can reach the mount and the presented owner/mode bits
     /// are kernel-enforced. Implied by `--owner`/`--group`. Non-root mounts also
     /// require `user_allow_other` in `/etc/fuse.conf`.
-    #[arg(long, env = "MUSEFS_ALLOW_OTHER")]
+    #[arg(long, env = "MUSEFS_ALLOW_OTHER", value_parser = clap::builder::BoolishValueParser::new())]
     pub allow_other: bool,
 }
 
@@ -130,18 +132,18 @@ pub enum Command {
         db: PathBuf,
         /// Re-validate: skip unchanged files, prune tracks whose backing file is
         /// gone, and garbage-collect orphaned art.
-        #[arg(long, env = "MUSEFS_REVALIDATE")]
+        #[arg(long, env = "MUSEFS_REVALIDATE", value_parser = clap::builder::BoolishValueParser::new())]
         revalidate: bool,
         /// Probe worker threads (0 = available parallelism). 1 = sequential.
         #[arg(long, env = "MUSEFS_JOBS", default_value_t = 0)]
         jobs: usize,
         /// Follow symlinks while walking directories. Off by default: symlinked
         /// files and directories are logged and skipped.
-        #[arg(long, env = "MUSEFS_FOLLOW_SYMLINKS")]
+        #[arg(long, env = "MUSEFS_FOLLOW_SYMLINKS", value_parser = clap::builder::BoolishValueParser::new())]
         follow_symlinks: bool,
         /// Suppress the per-target summary on stdout (failures still surface via
         /// the `log` facade on stderr; raise detail with `RUST_LOG=info`).
-        #[arg(long, short, env = "MUSEFS_QUIET")]
+        #[arg(long, short, env = "MUSEFS_QUIET", value_parser = clap::builder::BoolishValueParser::new())]
         quiet: bool,
     },
     /// Mount a read-only FUSE view of the store.
@@ -466,7 +468,17 @@ mod tests {
     #[test]
     fn case_insensitive_is_overridable() {
         use clap::Parser;
-        for (val, want) in [("true", true), ("false", false)] {
+        // The boolish set (1/0, yes/no, on/off, t/f) parses, not just true/false.
+        for (val, want) in [
+            ("true", true),
+            ("false", false),
+            ("1", true),
+            ("0", false),
+            ("yes", true),
+            ("no", false),
+            ("on", true),
+            ("off", false),
+        ] {
             let cli = Cli::try_parse_from([
                 "musefs",
                 "mount",

--- a/musefs/tests/cli_process.rs
+++ b/musefs/tests/cli_process.rs
@@ -1,0 +1,221 @@
+//! Process-boundary coverage for the packaged `musefs` binary: clap dispatch,
+//! exit codes, stderr, `--version`, and `scan`/`revalidate` wiring. The
+//! library-level `musefs-cli` tests call `run_scan` directly and never exercise
+//! `main`'s arg-parse → error-format → exit-status contract; these do, by
+//! spawning the real binary (`CARGO_BIN_EXE_musefs`). All cases are non-FUSE, so
+//! they run in the default suite without `/dev/fuse`.
+
+use std::process::Command;
+
+fn musefs() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_musefs"));
+    // No MUSEFS_* should leak in from the developer's shell.
+    cmd.env_clear();
+    cmd
+}
+
+fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
+    let len = body.len();
+    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
+    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
+    out.push(u8::try_from(len & 0xFF).unwrap());
+    out.extend_from_slice(body);
+    out
+}
+
+fn streaminfo_body() -> Vec<u8> {
+    let mut b = vec![
+        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
+        0x00, 0x00, 0x00,
+    ];
+    b.extend_from_slice(&[0u8; 16]);
+    b
+}
+
+fn vorbis_comment_body(comments: &[&str]) -> Vec<u8> {
+    let vendor = "orig";
+    let mut out = Vec::new();
+    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
+    out.extend_from_slice(vendor.as_bytes());
+    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
+    for c in comments {
+        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
+        out.extend_from_slice(c.as_bytes());
+    }
+    out
+}
+
+fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body(comments), true));
+    out.extend_from_slice(audio);
+    out
+}
+
+/// A directory holding one ingestible FLAC, plus the DB path to scan it into.
+fn library_with_one_flac() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("library");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::write(
+        target.join("a.flac"),
+        make_flac(&["ARTIST=Alice", "TITLE=Song"], &[0xAB; 32]),
+    )
+    .unwrap();
+    let db = dir.path().join("library.db");
+    (dir, target, db)
+}
+
+#[test]
+fn version_flag_reports_the_package_version() {
+    for flag in ["--version", "-V"] {
+        let out = musefs().arg(flag).output().unwrap();
+        assert!(
+            out.status.success(),
+            "`musefs {flag}` should exit 0, stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains(env!("CARGO_PKG_VERSION")),
+            "`musefs {flag}` should print {}, stdout: {stdout}",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+}
+
+#[test]
+fn version_flag_propagates_to_subcommands() {
+    // propagate_version: `musefs scan --version` reports the same version rather
+    // than erroring on an unexpected argument.
+    let out = musefs().args(["scan", "--version"]).output().unwrap();
+    assert!(
+        out.status.success(),
+        "`musefs scan --version` should exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains(env!("CARGO_PKG_VERSION")),
+        "stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn scan_succeeds_and_ingests_through_the_binary() {
+    let (_dir, target, db) = library_with_one_flac();
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .arg("--db")
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "scan should exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The DB landed at the --db path (db-path wiring) ...
+    assert!(db.exists(), "scan should create the DB at --db");
+    // ... and the library target was actually walked and ingested (the summary
+    // reports one scanned file).
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("1 file(s)"),
+        "expected one ingested file in the summary, stdout: {stdout}"
+    );
+}
+
+#[test]
+fn scan_with_revalidate_flag_runs_the_revalidate_pass() {
+    let (_dir, target, db) = library_with_one_flac();
+    // Seed the store first so revalidate has something to re-check.
+    let seed = musefs()
+        .arg("scan")
+        .arg(&target)
+        .arg("--db")
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(seed.status.success());
+
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .arg("--db")
+        .arg(&db)
+        .arg("--revalidate")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "revalidate should exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("revalidated"),
+        "the --revalidate flag should select the revalidate summary, stdout: {stdout}"
+    );
+}
+
+#[test]
+fn scan_missing_target_fails_with_nonzero_exit_and_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("scan.db");
+    let missing = dir.path().join("does-not-exist");
+    let out = musefs()
+        .arg("scan")
+        .arg(&missing)
+        .arg("--db")
+        .arg(&db)
+        .output()
+        .unwrap();
+    // A runtime failure (not a usage error) exits 1 and explains itself on
+    // stderr via `main`'s `musefs: {e:#}` formatting.
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("musefs:"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&missing.display().to_string()),
+        "stderr should name the failing target, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn scan_without_targets_is_a_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("scan.db");
+    let out = musefs().arg("scan").arg("--db").arg(&db).output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "missing required targets should be a usage error, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !db.exists(),
+        "a usage error must not create the DB, it never reached run_scan"
+    );
+}
+
+#[test]
+fn unknown_subcommand_is_a_usage_error() {
+    let out = musefs().arg("frobnicate").output().unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("unrecognized") || stderr.contains("unexpected"),
+        "stderr: {stderr}"
+    );
+}

--- a/musefs/tests/env_config.rs
+++ b/musefs/tests/env_config.rs
@@ -228,3 +228,116 @@ fn scan_help_lists_env_vars() {
     assert!(stdout.contains("MUSEFS_DB"), "stdout: {stdout}");
     assert!(stdout.contains("MUSEFS_JOBS"), "stdout: {stdout}");
 }
+
+// #370: the SetTrue bools parse the full boolish set from env (case-insensitive
+// true/false, t/f, yes/no, y/n, on/off, 1/0), not just literal `true`/`false`.
+// Each accepted value gets past clap parsing (exit != 2) and reaches the mount
+// runtime's missing-db guard.
+#[test]
+fn boolish_boolean_env_values_are_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = unopenable_db(dir.path(), "env.db");
+    for val in ["1", "0", "yes", "no", "on", "off", "t", "f", "TRUE", "Off"] {
+        let out = musefs()
+            .arg("mount")
+            .arg(dir.path())
+            .arg("--db")
+            .arg(&db)
+            .env("MUSEFS_KEEP_CACHE", val)
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert_ne!(
+            out.status.code(),
+            Some(2),
+            "MUSEFS_KEEP_CACHE={val} should parse, stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("database does not exist"),
+            "MUSEFS_KEEP_CACHE={val} should reach the missing-db guard, stderr: {stderr}"
+        );
+    }
+}
+
+// #370: a boolish MUSEFS_REVALIDATE actually flips scan into its revalidate
+// pass (observable on stdout), proving the parsed bool reaches run_scan — not
+// merely that parsing succeeds.
+#[test]
+fn boolish_revalidate_env_selects_the_revalidate_pass() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("library");
+    std::fs::create_dir(&target).unwrap();
+    let db = dir.path().join("reval.db");
+
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .env("MUSEFS_DB", &db)
+        .env("MUSEFS_REVALIDATE", "on")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("revalidated"), "stdout: {stdout}");
+
+    // Default (no env) takes the full-ingest path.
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .env("MUSEFS_DB", &db)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("scanned"), "stdout: {stdout}");
+}
+
+// #370: a boolish MUSEFS_QUIET (1/0) is honoured — `1` suppresses the summary,
+// `0` keeps it. The bare-`bool` parser would reject `0` outright, so this only
+// passes once BoolishValueParser is attached.
+#[test]
+fn boolish_quiet_env_toggles_the_summary() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("library");
+    std::fs::create_dir(&target).unwrap();
+    let db = dir.path().join("quiet.db");
+
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .env("MUSEFS_DB", &db)
+        .env("MUSEFS_QUIET", "1")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "MUSEFS_QUIET=1 should suppress the summary, stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .env("MUSEFS_DB", &db)
+        .env("MUSEFS_QUIET", "0")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("scanned"),
+        "MUSEFS_QUIET=0 should keep the summary, stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 echo "smoke: musefs = $MUSEFS"
 
 # Validate the binary actually runs before doing any FUSE work.
-if ! "$MUSEFS" scan --help >/dev/null 2>&1; then
+if ! "$MUSEFS" --version >/dev/null 2>&1; then
   echo "FAIL: $MUSEFS did not run"; exit 1
 fi
 


### PR DESCRIPTION
Closes #370, #372, #206.

## #370 — wire up `BoolishValueParser` for boolean env vars
Attaches `clap::builder::BoolishValueParser::new()` to every boolean arg — the
`SetTrue` bools (`MUSEFS_KEEP_CACHE`, `MUSEFS_ALLOW_OTHER`, `MUSEFS_REVALIDATE`,
`MUSEFS_FOLLOW_SYMLINKS`, `MUSEFS_QUIET`) and the `Set` bool
`MUSEFS_CASE_INSENSITIVE`. They now accept the documented case-insensitive
boolish set (`true/false`, `yes/no`, `on/off`, `1/0`, `t/f`) instead of only
literal lowercase `true`/`false`. Reverts the interim #366 doc correction in
`contrib/systemd/musefs.conf.example` and documents the set in `README.md`.

## #372 — add `--version` / `-V`
Adds `version` + `propagate_version` to the root command so `musefs --version`
(and the subcommands) report `CARGO_PKG_VERSION` (`musefs 1.0.0`).

## #206 — packaged-binary scan/revalidate process coverage
New `musefs/tests/cli_process.rs` exercises the real binary's process boundary
(clap dispatch, exit codes, stderr, wiring): scan success + ingestion,
`--revalidate` dispatch, a representative failure (exit 1 + `musefs:` stderr),
missing-targets / unknown-subcommand usage errors (exit 2), and `--version`.
Boolish-env observable-effect tests added to `env_config.rs`.

## Bonus: restore the version-flag smoke checks
The musl/glibc release plan specified `"$MUSEFS" --version` as the
binary-runs check, but v1.0.0 shipped with `scan --help` / `--help`
substitutes because the flag didn't exist yet. Restored both
(`scripts/smoke-binary.sh` and the `release.yml` extract step) now that
`--version` works.

## Verification
- Full workspace suite green (pre-commit gate: tests, clippy `-D warnings`,
  fmt, shellcheck, yamllint, ruff).
- New tests confirmed red before the fix, green after.
- `musefs --version`/`-V` → `musefs 1.0.0`; boolish env values verified to
  parse and take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)