### PR TITLE
docs: document extension-only probe dispatch (#190) and OggFLAC PICTURE description padding (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,12 @@ counts every file that isn't a supported audio format — cover art, `.cue` /
 `.log` / `.nfo` sidecars, and anything else non-audio — so a large `skipped`
 number (hundreds or thousands on a big library) is expected, not an error.
 `failed` is the one to watch: those are audio files musefs recognised by
-extension but could not parse.
+extension but could not parse. Format dispatch is by **extension only** —
+there is no content sniffing and no fallback to another parser, so a file
+whose contents don't match its extension (e.g. a FLAC named `.mp3`) is handed
+to the wrong parser, fails, and is counted here rather than retried. Renaming
+files across formats makes them vanish from the mount; fix the extension and
+rescan.
 
 `--revalidate` is the maintenance pass: it skips unchanged files —
 **preserving any tag edits you made in the store** — prunes tracks whose

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -47,6 +47,17 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
   upper-cased on synthesis.
 - Ogg carries no binary-tag slot: only text comments and pictures exist, so
   there is nothing else to preserve.
+- **Embedded picture descriptions are right-padded with up to two trailing
+  spaces.** The FLAC PICTURE block body is built with its description padded so
+  the body length is a multiple of 3 (`picture_prefix`,
+  `musefs-format/src/ogg/mod.rs`), which is what makes
+  `base64(prefix ++ image) == base64(prefix) ++ base64(image)` and lets the
+  image's base64 be served as an independent, incrementally-streamable
+  substring (the [art split](#how-synthesis-works) above). Padding the
+  description is the safe place to do it — the MIME type must stay a valid
+  type. So a synthesized picture's description can differ from the original by
+  up to two trailing spaces; this applies to Opus/Vorbis and OggFLAC alike,
+  since both build the block body the same way.
 
 ## How synthesis works
 


### PR DESCRIPTION
Two documentation-only fixes for open `documentation` issues.

## #190 — format probe dispatch is extension-only
`README.md`: the scan-summary paragraph now states that format dispatch is by **extension only** — no content sniffing, no fallback to another parser — so a file whose contents don't match its extension (e.g. a FLAC named `.mp3`) is handed to the wrong parser, fails, and is counted as `failed` rather than retried. Notes that renaming files across formats makes them vanish until the extension is fixed and rescanned.

## #361 — OggFLAC PICTURE description trailing-space padding
`docs/OGG.md` (Lossy edges): documents that embedded picture descriptions are right-padded with up to two trailing spaces so the FLAC PICTURE block body length is a multiple of 3 — the alignment that makes `base64(prefix ++ image) == base64(prefix) ++ base64(image)` and lets the image's base64 be served as an independent, incrementally-streamable substring. Applies to Opus/Vorbis and OggFLAC alike, since both build the block body the same way.

Verified against `picture_prefix` (`musefs-format/src/ogg/mod.rs`) and the extension-based dispatch in `scan.rs`. No code changes.

Closes #190
Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)