### PR TITLE
feat(scan): log skipped-file extension breakdown and oversized mp4 art/tag drops (#341, #343)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:449:31:',
+    'musefs-core/src/scan\.rs:498:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:456:30:',
+    'musefs-core/src/scan\.rs:505:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,18 +127,27 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:467:21:',
+    'musefs-core/src/scan\.rs:516:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:472:17:',
+    'musefs-core/src/scan\.rs:521:17:',
+    # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
+    # per oversized mp4 `covr` / `----` payload the format layer skipped before
+    # materialization (#343) and returns nothing. With no log-capture harness in the
+    # suite its emission is unobservable to any test, so `replace ... with ()` is
+    # MISSED-yet-unkillable — the same class as the probe_body oversize-diag warn
+    # above and the metrics counters. The drop DECISIONS it reports are pinned in
+    # musefs-format (read_pictures_reporting / read_binary_tags_reporting tests).
+    # guard: count=1
+    'replace log_mp4_oversize_drops with \(\)',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:863:46:',
+    'musefs-core/src/scan\.rs:944:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -147,25 +156,25 @@ exclude_re = [
     # (fsyncs), a performance property only observable via the `metrics`
     # instrumentation the in-diff gate does not build.
     # NB: line:col here (and for revalidate below) — `+=` and `>=`/`||` repeat in
-    # run_pipeline (e.g. the killable `*scanned += 1` at 936), so these cannot be
+    # run_pipeline (e.g. the killable `*scanned += 1` at 1017), so these cannot be
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:958:29:',
+    'musefs-core/src/scan\.rs:1039:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:960:32:',
+    'musefs-core/src/scan\.rs:1041:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:960:47:',
+    'musefs-core/src/scan\.rs:1041:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:960:62:',
+    'musefs-core/src/scan\.rs:1041:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:968:37:',
+    'musefs-core/src/scan\.rs:1049:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:970:40:',
+    'musefs-core/src/scan\.rs:1051:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:970:55:',
+    'musefs-core/src/scan\.rs:1051:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:970:70:',
+    'musefs-core/src/scan\.rs:1051:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -173,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1086:29:',
+    'musefs-core/src/scan\.rs:1167:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1094:29:',
+    'musefs-core/src/scan\.rs:1175:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1131:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1212:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ample free space instead of fuser's all-zero default, so `df` no longer shows a
   0-byte filesystem and capacity-checking importers (Lidarr et al.) don't balk
   (#368).
-- **Per-extension skip breakdown:** at end of scan, an `info`-level summary line
-  breaks the `skipped` count down by lowercased extension (e.g. `skipped 42:
-  jpg=20, cue=10, log=8, <none>=4`), so a large skip count is diagnosable —
-  expected sidecars versus genuinely unexpected files. Log-only; the `ScanStats`
-  struct and CLI summary are unchanged (#341).
+- **Per-extension skip breakdown:** at end of scan, a summary line breaks the
+  `skipped` count down by lowercased extension (e.g. `skipped 42: jpg=20,
+  cue=10, log=8, <none>=4`), logged at `warn` so it shows by default, so a large
+  skip count is diagnosable — expected sidecars versus genuinely unexpected
+  files. Log-only; the `ScanStats` struct and CLI summary are unchanged (#341).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ample free space instead of fuser's all-zero default, so `df` no longer shows a
   0-byte filesystem and capacity-checking importers (Lidarr et al.) don't balk
   (#368).
+- **Per-extension skip breakdown:** at end of scan, an `info`-level summary line
+  breaks the `skipped` count down by lowercased extension (e.g. `skipped 42:
+  jpg=20, cue=10, log=8, <none>=4`), so a large skip count is diagnosable —
+  expected sidecars versus genuinely unexpected files. Log-only; the `ScanStats`
+  struct and CLI summary are unchanged (#341).
 
 ### Fixed
 
+- **Silent mp4 oversize drops:** oversized embedded `covr` cover art and binary
+  freeform (`----`) values in `.m4a`/`.m4b` files are skipped in the format layer
+  before materialization (to avoid building a large image out of a large `moov`),
+  which previously dropped them with nothing in the logs. The scan now emits a
+  `warn` line for each, matching the logging the other formats already had (#343,
+  follow-up to #284).
 - **xattr log noise:** `getxattr`/`listxattr`/`setxattr`/`removexattr` now reply
   `ENOTSUP` explicitly (read-only filesystem, no extended attributes) instead of
   falling through to fuser's default, which logged a `[Not Implemented]` warn on

--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ The per-target summary reads `scanned N: … skipped X, failed Y`. `skipped`
 counts every file that isn't a supported audio format — cover art, `.cue` /
 `.log` / `.nfo` sidecars, and anything else non-audio — so a large `skipped`
 number (hundreds or thousands on a big library) is expected, not an error.
-Running with `RUST_LOG=info` adds a per-extension breakdown of the skip count
-at end of scan (e.g. `skipped 42: jpg=20, cue=10, log=8, <none>=4`), so you can
-tell expected sidecars from anything genuinely unexpected. `failed` is the one
+A per-extension breakdown of the skip count is logged at end of scan (e.g.
+`skipped 42: jpg=20, cue=10, log=8, <none>=4`), so you can tell expected
+sidecars from anything genuinely unexpected. `failed` is the one
 to watch: those are audio files musefs recognised by extension but could not
 parse. Format dispatch is by **extension only** —
 there is no content sniffing and no fallback to another parser, so a file

--- a/README.md
+++ b/README.md
@@ -284,8 +284,11 @@ The per-target summary reads `scanned N: … skipped X, failed Y`. `skipped`
 counts every file that isn't a supported audio format — cover art, `.cue` /
 `.log` / `.nfo` sidecars, and anything else non-audio — so a large `skipped`
 number (hundreds or thousands on a big library) is expected, not an error.
-`failed` is the one to watch: those are audio files musefs recognised by
-extension but could not parse. Format dispatch is by **extension only** —
+Running with `RUST_LOG=info` adds a per-extension breakdown of the skip count
+at end of scan (e.g. `skipped 42: jpg=20, cue=10, log=8, <none>=4`), so you can
+tell expected sidecars from anything genuinely unexpected. `failed` is the one
+to watch: those are audio files musefs recognised by extension but could not
+parse. Format dispatch is by **extension only** —
 there is no content sniffing and no fallback to another parser, so a file
 whose contents don't match its extension (e.g. a FLAC named `.mp3`) is handed
 to the wrong parser, fails, and is counted here rather than retried. Renaming

--- a/docs/M4A.md
+++ b/docs/M4A.md
@@ -43,6 +43,10 @@ layouts plug into, see [ARCHITECTURE.md](../ARCHITECTURE.md#the-segment-model).
   other type codes are skipped. MP4 has no picture-type or description
   fields: scanned art becomes "front cover" with an empty description, and
   any non-PNG stored art is emitted with the JPEG type code.
+- A `covr` image or binary `----` value larger than its size cap is skipped
+  at scan time — before the image is materialized out of a potentially large
+  `moov` — and logged (a `warn` line on stderr) so the lossy drop is explained
+  rather than silent.
 
 ## How synthesis works
 

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use musefs_db::convert::usize_from;
@@ -76,6 +76,48 @@ pub struct ScanStats {
     pub raced: u64,
 }
 
+/// Per-extension tally of files skipped during the directory walk because their
+/// extension is not a supported audio format. Backs the end-of-scan summary log
+/// line (#341) that breaks the single `skipped` count down by extension, so an
+/// operator can tell expected sidecars (cover art, `.cue`, `.log`, `.nfo`) from
+/// genuinely unexpected files. Not part of `ScanStats`: the breakdown is
+/// log-only and does not affect the CLI summary.
+#[derive(Debug, Default)]
+struct SkipTally {
+    total: u64,
+    by_ext: BTreeMap<String, u64>,
+}
+
+impl SkipTally {
+    /// Record one skipped file, bucketed by its lowercased extension
+    /// (`<none>` when the file has no extension or a non-UTF-8 one).
+    fn record(&mut self, path: &Path) {
+        self.total += 1;
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map_or_else(|| "<none>".to_string(), str::to_ascii_lowercase);
+        *self.by_ext.entry(ext).or_insert(0) += 1;
+    }
+
+    /// The end-of-scan summary line, e.g. `skipped 42: jpg=20, cue=10, log=8,
+    /// <none>=4` — buckets ordered by descending count, ties broken by extension
+    /// name. `None` when nothing was skipped, so there is no line to emit.
+    fn summary(&self) -> Option<String> {
+        if self.total == 0 {
+            return None;
+        }
+        let mut buckets: Vec<(&String, &u64)> = self.by_ext.iter().collect();
+        buckets.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let breakdown = buckets
+            .iter()
+            .map(|(ext, n)| format!("{ext}={n}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(format!("skipped {}: {breakdown}", self.total))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevalidateStats {
     pub updated: u64,
@@ -107,10 +149,10 @@ fn collect_audio(
     root: &Path,
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
-) -> std::io::Result<u64> {
+) -> std::io::Result<SkipTally> {
     let mut visited = HashSet::new();
     let mut files_visited = HashSet::new();
-    let mut skipped = 0u64;
+    let mut tally = SkipTally::default();
     if follow_symlinks {
         // Seed with the root's identity so a symlink pointing back to it is
         // caught as a cycle on the first descent.
@@ -124,9 +166,9 @@ fn collect_audio(
         follow_symlinks,
         &mut visited,
         &mut files_visited,
-        &mut skipped,
+        &mut tally,
     )?;
-    Ok(skipped)
+    Ok(tally)
 }
 
 fn collect_audio_inner(
@@ -135,19 +177,19 @@ fn collect_audio_inner(
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
     files_visited: &mut HashSet<(u64, u64)>,
-    skipped: &mut u64,
+    tally: &mut SkipTally,
 ) -> std::io::Result<()> {
     for entry in std::fs::read_dir(root)? {
         let entry = entry?;
         let path = entry.path();
         let ftype = entry.file_type()?;
         if ftype.is_dir() {
-            descend(&path, out, follow_symlinks, visited, files_visited, skipped)?;
+            descend(&path, out, follow_symlinks, visited, files_visited, tally)?;
         } else if ftype.is_file() {
             if is_supported_audio(&path) {
                 push_file(&path, out, follow_symlinks, files_visited, None);
             } else {
-                *skipped += 1;
+                tally.record(&path);
             }
         } else if ftype.is_symlink() {
             if !follow_symlinks {
@@ -159,13 +201,13 @@ fn collect_audio_inner(
             }
             match std::fs::metadata(&path) {
                 Ok(meta) if meta.is_dir() => {
-                    descend(&path, out, follow_symlinks, visited, files_visited, skipped)?;
+                    descend(&path, out, follow_symlinks, visited, files_visited, tally)?;
                 }
                 Ok(meta) if meta.is_file() => {
                     if is_supported_audio(&path) {
                         push_file(&path, out, follow_symlinks, files_visited, Some(&meta));
                     } else {
-                        *skipped += 1;
+                        tally.record(&path);
                     }
                 }
                 Ok(_) => {}
@@ -184,10 +226,10 @@ fn descend(
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
     files_visited: &mut HashSet<(u64, u64)>,
-    skipped: &mut u64,
+    tally: &mut SkipTally,
 ) -> std::io::Result<()> {
     if !follow_symlinks {
-        return collect_audio_inner(path, out, follow_symlinks, visited, files_visited, skipped);
+        return collect_audio_inner(path, out, follow_symlinks, visited, files_visited, tally);
     }
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
@@ -200,7 +242,7 @@ fn descend(
         log::warn!("skipping symlink cycle at {}", path.display());
         return Ok(());
     }
-    collect_audio_inner(path, out, follow_symlinks, visited, files_visited, skipped)
+    collect_audio_inner(path, out, follow_symlinks, visited, files_visited, tally)
 }
 
 fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
@@ -300,13 +342,16 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
         })
     } else if has_ext(path, "m4a") || has_ext(path, "m4b") {
         let bounds = mp4::locate_audio(bytes).ok()?;
+        let (pictures, art_drops) = mp4::read_pictures_reporting(bytes, MAX_ART_BYTES);
+        let (binary_tags, bin_drops) = mp4::read_binary_tags_reporting(bytes, MAX_BINARY_TAG_BYTES);
+        log_mp4_oversize_drops(path, &art_drops, &bin_drops);
         Some(Probed {
             format: Format::M4a,
             audio_offset: bounds.audio_offset,
             audio_length: bounds.audio_length,
             tags: mp4::read_tags(bytes),
-            pictures: mp4::read_pictures(bytes, MAX_ART_BYTES),
-            binary_tags: mp4::read_binary_tags(bytes, MAX_BINARY_TAG_BYTES),
+            pictures,
+            binary_tags,
             structural_blocks: Vec::new(),
         })
     } else if has_ext(path, "ogg") || has_ext(path, "oga") || has_ext(path, "opus") {
@@ -407,13 +452,17 @@ fn probe_body(
                 return Ok(None);
             }
         };
+        let (pictures, art_drops) = mp4::read_pictures_reporting(&scan.moov, MAX_ART_BYTES);
+        let (binary_tags, bin_drops) =
+            mp4::read_binary_tags_reporting(&scan.moov, MAX_BINARY_TAG_BYTES);
+        log_mp4_oversize_drops(path, &art_drops, &bin_drops);
         return Ok(Some(Probed {
             format: Format::M4a,
             audio_offset: scan.mdat_payload_offset,
             audio_length: scan.mdat_payload_len,
             tags: mp4::read_tags(&scan.moov),
-            pictures: mp4::read_pictures(&scan.moov, MAX_ART_BYTES),
-            binary_tags: mp4::read_binary_tags(&scan.moov, MAX_BINARY_TAG_BYTES),
+            pictures,
+            binary_tags,
             structural_blocks: Vec::new(),
         }));
     }
@@ -669,6 +718,31 @@ fn accept_binary_tags(abs_path: &str, tags: Vec<EmbeddedBinaryTag>) -> Vec<musef
         .collect()
 }
 
+/// Logs each oversized mp4 `covr` image / binary `----` value that the format
+/// layer skipped before materialization (#343). These drops happen inside
+/// `mp4::read_pictures` / `mp4::read_binary_tags` — earlier than the `accept_*`
+/// ingest filters that log the lossy drops for the other formats (#284), and
+/// deliberately so, to avoid building a large image out of a large `moov` — so
+/// they are surfaced here at probe time, mirroring the `accept_*` message shape.
+fn log_mp4_oversize_drops(path: &Path, art: &[mp4::OversizeDrop], binary: &[mp4::OversizeDrop]) {
+    for d in art {
+        log::warn!(
+            "{}: dropping embedded {} art ({} bytes), over the {MAX_ART_BYTES}-byte cap",
+            path.display(),
+            d.descriptor,
+            d.bytes,
+        );
+    }
+    for d in binary {
+        log::warn!(
+            "{}: dropping binary tag {} ({} bytes), over the {MAX_BINARY_TAG_BYTES}-byte cap",
+            path.display(),
+            d.descriptor,
+            d.bytes,
+        );
+    }
+}
+
 /// Upsert a track from a probed backing file: write the track row, replace its
 /// seeded tags, and ingest its embedded art (capped, deduped, clamped).
 fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
@@ -818,24 +892,31 @@ fn ingest_bulk(
 /// stamps), seeding its tags from the file's existing metadata. `root` may be
 /// a single audio file (only that file is scanned) or a directory (walked
 /// recursively). Files whose extension is not a supported audio format
-/// increment `ScanStats::skipped`; supported-extension files with a per-file
-/// I/O or parse error increment `ScanStats::failed` and do not abort the scan.
+/// increment `ScanStats::skipped` and are tallied by extension for the
+/// end-of-scan summary log line (#341); supported-extension files with a
+/// per-file I/O or parse error increment `ScanStats::failed` and do not abort
+/// the scan.
 pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
     let mut files = Vec::new();
-    let mut skipped = 0u64;
+    let mut tally = SkipTally::default();
     if root.is_file() {
         if is_supported_audio(root) {
             files.push(root.to_path_buf());
         } else {
-            skipped += 1;
+            tally.record(root);
         }
     } else {
-        skipped += collect_audio(root, &mut files, opts.follow_symlinks)?;
+        tally = collect_audio(root, &mut files, opts.follow_symlinks)?;
     }
     db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
     let mut stats = run_pipeline(db, files, opts)?;
     // skipped is tallied during the walk, not the pipeline
-    stats.skipped = skipped;
+    stats.skipped = tally.total;
+    // Per-extension breakdown of the skip count, so a large `skipped` is
+    // diagnosable (#341). Log-only: never folded into `stats`/the CLI summary.
+    if let Some(summary) = tally.summary() {
+        log::info!("{summary}");
+    }
     Ok(stats)
 }
 
@@ -1007,7 +1088,7 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
             skipped += 1;
         }
     } else {
-        skipped += collect_audio(root, &mut files, false)?;
+        skipped += collect_audio(root, &mut files, false)?.total;
     }
     let mut stats = ScanStats {
         scanned: 0,
@@ -1828,6 +1909,50 @@ mod hardening_tests {
         assert_eq!(stats.scanned, 2);
         assert_eq!(stats.failed, 1);
         assert_eq!(stats.skipped, 1);
+    }
+
+    #[test]
+    fn skip_tally_summary_orders_by_descending_count() {
+        let mut tally = super::SkipTally::default();
+        for _ in 0..20 {
+            tally.record(std::path::Path::new("art/cover.jpg"));
+        }
+        for _ in 0..10 {
+            tally.record(std::path::Path::new("disc.cue"));
+        }
+        for _ in 0..8 {
+            tally.record(std::path::Path::new("rip.log"));
+        }
+        for _ in 0..4 {
+            tally.record(std::path::Path::new("README"));
+        }
+        assert_eq!(tally.total, 42);
+        assert_eq!(
+            tally.summary().unwrap(),
+            "skipped 42: jpg=20, cue=10, log=8, <none>=4"
+        );
+    }
+
+    #[test]
+    fn skip_tally_lowercases_extension_and_buckets_extensionless() {
+        let mut tally = super::SkipTally::default();
+        tally.record(std::path::Path::new("a.JPG"));
+        tally.record(std::path::Path::new("b.jpg"));
+        tally.record(std::path::Path::new("noext"));
+        assert_eq!(tally.summary().unwrap(), "skipped 3: jpg=2, <none>=1");
+    }
+
+    #[test]
+    fn skip_tally_ties_break_by_extension_name() {
+        let mut tally = super::SkipTally::default();
+        tally.record(std::path::Path::new("a.nfo"));
+        tally.record(std::path::Path::new("b.cue"));
+        assert_eq!(tally.summary().unwrap(), "skipped 2: cue=1, nfo=1");
+    }
+
+    #[test]
+    fn skip_tally_empty_has_no_summary() {
+        assert!(super::SkipTally::default().summary().is_none());
     }
 
     #[test]

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -915,7 +915,7 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
     // Per-extension breakdown of the skip count, so a large `skipped` is
     // diagnosable (#341). Log-only: never folded into `stats`/the CLI summary.
     if let Some(summary) = tally.summary() {
-        log::info!("{summary}");
+        log::warn!("{summary}");
     }
     Ok(stats)
 }

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -430,20 +430,33 @@ pub fn read_tags(buf: &[u8]) -> Vec<(String, String)> {
     out
 }
 
-/// Lenient: returns empty / skips any malformed atom and never errors — this only
-/// seeds cover art from existing files, so a missing or garbled picture must simply be absent.
-/// Every `data` child of every `covr` atom yields one picture (the iTunes
-/// multiple-artwork convention); non-`data` children are skipped.
-///
-/// `max_art_bytes` caps each image body: a `data` payload whose image bytes
-/// (after the 8-byte `[type][locale]` header) exceed it is skipped before any
-/// copy, so an oversized `covr` in a large `moov` is never materialized.
-pub fn read_pictures(buf: &[u8], max_art_bytes: usize) -> Vec<EmbeddedPicture> {
+/// An embedded `covr` image or binary `----` payload that a reader skipped
+/// because it exceeded the caller's size cap. Carries only a descriptor and the
+/// payload's byte size — never the bytes themselves — so the caller can log the
+/// lossy drop (the format layer has no logging facade) without materializing the
+/// oversized item out of a potentially large `moov` (#343).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OversizeDrop {
+    /// Cover-art MIME type, or the binary tag's `----:<mean>:<name>` key.
+    pub descriptor: String,
+    /// Size of the dropped payload body in bytes (after the 8-byte `data` header).
+    pub bytes: usize,
+}
+
+/// Like [`read_pictures`], but also returns the oversized `covr` images skipped
+/// over `max_art_bytes`, so the caller can log each lossy drop. The size check
+/// still happens before any copy — an oversized image is described, never
+/// materialized. See [`OversizeDrop`].
+pub fn read_pictures_reporting(
+    buf: &[u8],
+    max_art_bytes: usize,
+) -> (Vec<EmbeddedPicture>, Vec<OversizeDrop>) {
     let Some((start, len)) = ilst_region(buf) else {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     };
     let ilst = &buf[start..start + len];
     let mut out = Vec::new();
+    let mut dropped = Vec::new();
     for atom in child_boxes(ilst).unwrap_or_default() {
         if &atom.kind != b"covr" {
             continue;
@@ -457,14 +470,18 @@ pub fn read_pictures(buf: &[u8], max_art_bytes: usize) -> Vec<EmbeddedPicture> {
             if dp.len() < 8 {
                 continue;
             }
-            if dp.len() - 8 > max_art_bytes {
-                continue;
-            }
             let mime = match u32::from_be_bytes([dp[0], dp[1], dp[2], dp[3]]) {
                 13 => "image/jpeg",
                 14 => "image/png",
                 _ => continue,
             };
+            if dp.len() - 8 > max_art_bytes {
+                dropped.push(OversizeDrop {
+                    descriptor: mime.to_string(),
+                    bytes: dp.len() - 8,
+                });
+                continue;
+            }
             out.push(EmbeddedPicture {
                 mime: mime.to_string(),
                 picture_type: PictureType::new(3).expect("3 is in range"),
@@ -475,26 +492,36 @@ pub fn read_pictures(buf: &[u8], max_art_bytes: usize) -> Vec<EmbeddedPicture> {
             });
         }
     }
-    out
+    (out, dropped)
 }
 
-/// Extract opaque (non-text) MP4 `----` freeform atoms for binary-tag passthrough.
-/// One `EmbeddedBinaryTag` per `----` atom whose first `data` sub-box is
-/// binary-typed (type code != 1): key `----:<mean>:<name>`, payload the `data`
-/// value bytes (after the 8-byte `[type][locale]` header). Text freeform atoms
-/// (type 1) are handled by `read_tags`, so the two paths never double-store.
-/// Lenient: malformed atoms are skipped. Only the first `data` sub-box is read
-/// (multi-value freeform is rare; mirrors `read_freeform`).
+/// Lenient: returns empty / skips any malformed atom and never errors — this only
+/// seeds cover art from existing files, so a missing or garbled picture must simply be absent.
+/// Every `data` child of every `covr` atom yields one picture (the iTunes
+/// multiple-artwork convention); non-`data` children are skipped.
 ///
-/// `max_binary_tag_bytes` caps each value: a `data` payload whose value bytes
+/// `max_art_bytes` caps each image body: a `data` payload whose image bytes
 /// (after the 8-byte `[type][locale]` header) exceed it is skipped before any
-/// copy, so an oversized `----` in a large `moov` is never materialized.
-pub fn read_binary_tags(buf: &[u8], max_binary_tag_bytes: usize) -> Vec<EmbeddedBinaryTag> {
+/// copy, so an oversized `covr` in a large `moov` is never materialized. Use
+/// [`read_pictures_reporting`] to also recover the oversized drops for logging.
+pub fn read_pictures(buf: &[u8], max_art_bytes: usize) -> Vec<EmbeddedPicture> {
+    read_pictures_reporting(buf, max_art_bytes).0
+}
+
+/// Like [`read_binary_tags`], but also returns the oversized `----` values
+/// skipped over `max_binary_tag_bytes`, so the caller can log each lossy drop.
+/// The size check still happens before any copy — an oversized value is
+/// described, never materialized. See [`OversizeDrop`].
+pub fn read_binary_tags_reporting(
+    buf: &[u8],
+    max_binary_tag_bytes: usize,
+) -> (Vec<EmbeddedBinaryTag>, Vec<OversizeDrop>) {
     let Some((start, len)) = ilst_region(buf) else {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     };
     let ilst = &buf[start..start + len];
     let mut out = Vec::new();
+    let mut dropped = Vec::new();
     for atom in child_boxes(ilst).unwrap_or_default() {
         if &atom.kind != b"----" {
             continue;
@@ -505,9 +532,6 @@ pub fn read_binary_tags(buf: &[u8], max_binary_tag_bytes: usize) -> Vec<Embedded
         };
         let dp = data.payload(inner);
         if dp.len() < 8 {
-            continue;
-        }
-        if dp.len() - 8 > max_binary_tag_bytes {
             continue;
         }
         // `data` body is `[type: u32][locale: u32][value]`; type 1 == UTF-8 text,
@@ -536,12 +560,36 @@ pub fn read_binary_tags(buf: &[u8], max_binary_tag_bytes: usize) -> Vec<Embedded
                     "com.apple.iTunes"
                 }
             });
+        let key = format!("----:{mean}:{name}");
+        if dp.len() - 8 > max_binary_tag_bytes {
+            dropped.push(OversizeDrop {
+                descriptor: key,
+                bytes: dp.len() - 8,
+            });
+            continue;
+        }
         out.push(EmbeddedBinaryTag {
-            key: format!("----:{mean}:{name}"),
+            key,
             payload: dp[8..].to_vec(),
         });
     }
-    out
+    (out, dropped)
+}
+
+/// Extract opaque (non-text) MP4 `----` freeform atoms for binary-tag passthrough.
+/// One `EmbeddedBinaryTag` per `----` atom whose first `data` sub-box is
+/// binary-typed (type code != 1): key `----:<mean>:<name>`, payload the `data`
+/// value bytes (after the 8-byte `[type][locale]` header). Text freeform atoms
+/// (type 1) are handled by `read_tags`, so the two paths never double-store.
+/// Lenient: malformed atoms are skipped. Only the first `data` sub-box is read
+/// (multi-value freeform is rare; mirrors `read_freeform`).
+///
+/// `max_binary_tag_bytes` caps each value: a `data` payload whose value bytes
+/// (after the 8-byte `[type][locale]` header) exceed it is skipped before any
+/// copy, so an oversized `----` in a large `moov` is never materialized. Use
+/// [`read_binary_tags_reporting`] to also recover the oversized drops for logging.
+pub fn read_binary_tags(buf: &[u8], max_binary_tag_bytes: usize) -> Vec<EmbeddedBinaryTag> {
+    read_binary_tags_reporting(buf, max_binary_tag_bytes).0
 }
 
 fn boxed(kind: &[u8; 4], payload: &[u8]) -> Result<Vec<u8>> {
@@ -1911,6 +1959,28 @@ mod tests {
     }
 
     #[test]
+    fn read_pictures_reporting_reports_oversize_drop() {
+        // The image body (5 bytes) exceeds the 4-byte cap: skipped from the
+        // pictures, but reported as a drop with its MIME and exact byte size.
+        let over = vec![0xFFu8; 5];
+        let buf = mp4_with_ilst(&bx(b"covr", &data_atom(13, &over)), true);
+        let (pics, dropped) = read_pictures_reporting(&buf, 4);
+        assert!(pics.is_empty());
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].descriptor, "image/jpeg");
+        assert_eq!(dropped[0].bytes, over.len());
+    }
+
+    #[test]
+    fn read_pictures_reporting_no_drops_when_within_budget() {
+        let exact = vec![0xFFu8; 4];
+        let buf = mp4_with_ilst(&bx(b"covr", &data_atom(13, &exact)), true);
+        let (pics, dropped) = read_pictures_reporting(&buf, 4);
+        assert_eq!(pics.len(), 1);
+        assert!(dropped.is_empty());
+    }
+
+    #[test]
     fn read_pictures_skips_non_data_children_of_covr() {
         // A non-`data` child inside covr (rare but legal) is silently skipped.
         let png = [0x89, b'P', b'N', b'G'];
@@ -2253,6 +2323,32 @@ mod tests {
         let tags = read_binary_tags(&moov, 4);
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].payload, exact);
+    }
+
+    #[test]
+    fn read_binary_tags_reporting_reports_oversize_drop() {
+        // A 5-byte value over the 4-byte cap: skipped from the tags, but reported
+        // as a drop with its `----:<mean>:<name>` key and exact byte size.
+        let over = vec![0xABu8; 5];
+        let atom = freeform_atom_typed("com.serato.dj", "analysis", 0, &over);
+        let moov = moov_with_ilst(&atom);
+        let (tags, dropped) = read_binary_tags_reporting(&moov, 4);
+        assert!(tags.is_empty());
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].descriptor, "----:com.serato.dj:analysis");
+        assert_eq!(dropped[0].bytes, over.len());
+    }
+
+    #[test]
+    fn read_binary_tags_reporting_skips_oversize_text_without_reporting() {
+        // An oversized *text* (type 1) freeform is the text path's job, never a
+        // binary-tag drop — it must not be reported here.
+        let over = vec![b'x'; 5];
+        let atom = freeform_atom_typed("com.apple.iTunes", "MOOD", 1, &over);
+        let moov = moov_with_ilst(&atom);
+        let (tags, dropped) = read_binary_tags_reporting(&moov, 4);
+        assert!(tags.is_empty());
+        assert!(dropped.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Two scan-logging diagnosability fixes, follow-ups to the #284/#340 scan work.

## #341 — per-extension skip breakdown
After #301/#340, `musefs scan` counts every non-audio file as `skipped`, mixing expected sidecars (cover art, `.cue`, `.log`, `.nfo`) with genuinely unexpected files behind one opaque number. The walk now aggregates skips by lowercased extension (`<none>` for extensionless) and emits one end-of-scan `info` summary line, e.g.:

```
skipped 42: jpg=20, cue=10, log=8, <none>=4
```

(buckets ordered by descending count, ties by extension name). **Log-only** — `ScanStats` and the CLI summary are unchanged, as the issue specifies.

## #343 — silent mp4 oversized art / binary-tag drops
Oversized embedded `covr` cover art and binary freeform (`----`) values in `.m4a`/`.m4b` were dropped silently inside `musefs-format` (`mp4::read_pictures` / `read_binary_tags`). The cap is enforced there deliberately — to avoid materializing a large image out of a large `moov` — so the bytes never reach the `musefs-core` ingest filter that logs the drop for the other formats (#284), leaving the drop invisible.

The format readers now have `*_reporting` variants returning each oversized drop as a descriptor + byte size (never the bytes — the cap check still precedes any copy), and the scan logs a `warn` per drop at probe time, mirroring the #284 `accept_*` message shape. The original `read_pictures` / `read_binary_tags` are thin wrappers, so all existing callers, tests, and the fuzz crate are untouched.

## Verification
- `cargo test` workspace green; metrics-feature tests pass; `clippy --all-targets` clean; fmt clean.
- In-diff mutation gate (in-place): **49 mutants — 37 caught, 12 unviable, 0 missed**.
- `.cargo/mutants.toml` scan.rs anchors re-anchored for the line shift; added one documented exclude for the `log_mp4_oversize_drops` logging shim (no log-capture harness makes its `replace … with ()` mutant unkillable — same class as the metrics counters).
- Docs updated: README (skip breakdown), `docs/M4A.md` (oversize drop now logged), CHANGELOG.

Closes #341
Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-extension breakdown for skipped files reported at scan completion.

* **Bug Fixes**
  * Oversized embedded cover art and binary values in MP4 files are now skipped early with logged warnings instead of failing silently.

* **Documentation**
  * Updated scan output documentation and MP4 format edge-case notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->