### PR TITLE
feat(db): refuse a store newer than the binary's schema (#210)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,7 +172,11 @@ malformed *shapes* at commit, so an external writer cannot persist them:
 **Schema identity.** On open, musefs also validates schema identity: a
 `sqlite_master` comparison against a freshly-migrated reference plus `PRAGMA
 foreign_key_check`, rejecting anything that is not the canonical latest schema
-with a message telling the user to run `musefs scan`.
+with a message telling the user to run `musefs scan`. A store whose
+`user_version` is *newer* than this binary's latest migration (a future or
+third-party tool bumped the schema) is refused up front with a distinct
+"store is newer than this binary" error rather than silently treated as
+already-migrated — an older binary must not risk misreading a newer contract.
 
 **Art is immutable once written.** `art` rows are content-addressed by
 `sha256`; a trigger rejects any in-place `UPDATE` of an art row's

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -25,6 +25,9 @@ mutants = []
 fuzzing = []
 
 [dev-dependencies]
+# Used to plant a future `user_version` on a file-backed store, exercising the
+# "store is newer than this binary" guard the public API cannot otherwise reach.
+rusqlite = { version = "0.40", features = ["bundled"] }
 tempfile = "3"
 
 [lints]

--- a/musefs-db/src/error.rs
+++ b/musefs-db/src/error.rs
@@ -17,6 +17,11 @@ pub enum DbError {
          regenerate the store by running `musefs scan` against the library"
     )]
     SchemaMismatch { object: String },
+    #[error(
+        "store schema version {found} is newer than this musefs build supports \
+         (max {supported}); upgrade musefs to read this store"
+    )]
+    StoreTooNew { found: i64, supported: i64 },
     #[error("{table}.{field} length {len} exceeds the {max} cap (crafted or corrupt DB)")]
     FieldTooLarge {
         table: &'static str,

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -208,8 +208,19 @@ const MIGRATIONS: &[&str] = &[MIGRATION_V1];
 
 pub fn migrate(conn: &mut Connection) -> Result<()> {
     let latest = i64::try_from(MIGRATIONS.len()).expect("MIGRATIONS count must fit i64");
+    let current = conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))?;
+    // A store at a user_version past anything this binary knows about was written
+    // by a newer (or third-party) tool that bumped the schema. Refuse it loudly
+    // rather than treating it as already-migrated and silently misreading the
+    // external-writer contract.
+    if current > latest {
+        return Err(crate::error::DbError::StoreTooNew {
+            found: current,
+            supported: latest,
+        });
+    }
     // Fast path: already at the latest version, no transaction needed.
-    if conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))? >= latest {
+    if current >= latest {
         return Ok(());
     }
     // Use an IMMEDIATE transaction so the write lock is acquired up front. The

--- a/musefs-db/tests/schema.rs
+++ b/musefs-db/tests/schema.rs
@@ -20,6 +20,34 @@ fn migration_is_idempotent_across_reopen() {
     assert_eq!(db2.user_version().unwrap(), 1);
 }
 
+#[test]
+fn opening_a_store_newer_than_the_binary_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("musefs.db");
+
+    // Create a normal store, then simulate a future/third-party tool bumping the
+    // schema past what this binary knows about (the issue's "V2" scenario).
+    Db::open(&path).unwrap();
+    {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.pragma_update(None, "user_version", 2).unwrap();
+    }
+
+    // Reopening must refuse the store instead of silently treating it as
+    // already-migrated and risking a misread of the external-writer contract.
+    let err = Db::open(&path).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            musefs_db::DbError::StoreTooNew {
+                found: 2,
+                supported: 1
+            }
+        ),
+        "expected StoreTooNew {{ found: 2, supported: 1 }}, got {err:?}"
+    );
+}
+
 #[cfg(feature = "mutants")]
 #[test]
 fn default_db_is_unmigrated_version_zero() {


### PR DESCRIPTION
Closes #210.

## Problem

`migrate()` took the "already-migrated" fast path whenever `user_version >= latest`, so a store bumped *past* what this binary knows — a future or third-party tool advancing the schema — was silently treated as current and opened. With the store now an external-writer contract, an older binary could misread a newer store rather than failing clearly. There was no "store is newer than this binary" guard and no test pinning a defined outcome for that case.

## Change

- `migrate()` reads `user_version` once and, when it exceeds the latest migration, returns a distinct `DbError::StoreTooNew { found, supported }` up front instead of opening the store. The existing fast-path/transaction logic is unchanged below the guard.
- New error variant with a clear "store schema version N is newer than this musefs build supports … upgrade musefs" message.
- Integration test `opening_a_store_newer_than_the_binary_fails_loudly` plants `user_version = 2` (the issue's "V2 written by a future tool" scenario) on a file-backed store and asserts `Db::open` fails with `StoreTooNew { found: 2, supported: 1 }`. Adds `rusqlite` as a dev-dep to set the pragma the public API can't reach.
- Documented the guard under the external-writer contract's "Schema identity" note in `ARCHITECTURE.md`.

The SQL schema is unchanged (error + control-flow only), so no `schema_py` regeneration is needed.

## Verification

- TDD: test written first and watched fail (missing variant) before implementing.
- Full workspace tests pass; `cargo test -p musefs-db --features mutants` passes; clippy `--all-targets` and `fmt --check` clean.
- In-diff mutation gate (local): all 5 mutants on the changed lines caught. Mutant-anchor check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
