### PR TITLE
refactor(core): remove dead partition_changes helper and stale dead_code allows (#363)

### DIFF
--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -108,7 +108,6 @@ impl<M> musefs_format::ogg::ArtSource for DbArtSource<'_, M> {
 /// Map a track's binary tag rows to `BinaryTagInput`s for synthesis. Never reads
 /// the payload bytes — only `(rowid, key, byte_len)`; the bytes stream at read
 /// time. Ordered by (key, ordinal), matching `get_binary_tags`.
-#[allow(dead_code)] // wired into the reader resolve arms in Task 2.9
 pub(crate) fn binary_tags_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<BinaryTagInput>> {
     Ok(db
         .get_binary_tags(track_id)?

--- a/musefs-core/src/refresh_diff.rs
+++ b/musefs-core/src/refresh_diff.rs
@@ -13,8 +13,7 @@ pub(crate) struct TrackRenderState {
     pub path: String,
 }
 
-/// The result of diffing the previous snapshot against a fresh render-key scan.
-#[allow(dead_code)]
+/// The result of partitioning a changelog read against the previous snapshot.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct ChangeSet {
     /// In both, render key differs (must re-render).
@@ -26,37 +25,9 @@ pub(crate) struct ChangeSet {
 }
 
 impl ChangeSet {
-    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.changed.is_empty() && self.added.is_empty() && self.removed.is_empty()
     }
-}
-
-/// Partition a fresh `(id, content_version, format)` scan against the previous
-/// snapshot. `scan` is ordered by id (as `list_render_keys` returns it); outputs
-/// are id-ascending so downstream rendering and tree assembly are deterministic.
-#[allow(dead_code)]
-pub(crate) fn partition_changes(
-    prev: &HashMap<i64, TrackRenderState>,
-    scan: &[(i64, i64, Format)],
-) -> ChangeSet {
-    let mut cs = ChangeSet::default();
-    let mut seen = std::collections::HashSet::with_capacity(scan.len());
-    for &(id, cv, fmt) in scan {
-        seen.insert(id);
-        match prev.get(&id) {
-            None => cs.added.push(id),
-            Some(s) if s.content_version != cv || s.format != fmt => cs.changed.push(id),
-            Some(_) => {}
-        }
-    }
-    for &id in prev.keys() {
-        if !seen.contains(&id) {
-            cs.removed.push(id);
-        }
-    }
-    cs.removed.sort_unstable();
-    cs
 }
 
 /// Partition a changelog read against the previous snapshot. `prev_states` holds
@@ -87,49 +58,6 @@ pub(crate) fn partition_changelog(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn st(cv: i64, fmt: Format, path: &str) -> TrackRenderState {
-        TrackRenderState {
-            content_version: cv,
-            format: fmt,
-            path: path.into(),
-        }
-    }
-
-    #[test]
-    fn partitions_changed_added_removed() {
-        let mut prev = HashMap::new();
-        prev.insert(1, st(0, Format::Flac, "A/1.flac"));
-        prev.insert(2, st(0, Format::Flac, "A/2.flac"));
-        prev.insert(3, st(0, Format::Flac, "A/3.flac"));
-        let scan = vec![
-            (1, 0, Format::Flac),
-            (2, 1, Format::Flac),
-            (4, 0, Format::Flac),
-        ];
-        let cs = partition_changes(&prev, &scan);
-        assert_eq!(cs.changed, vec![2]);
-        assert_eq!(cs.added, vec![4]);
-        assert_eq!(cs.removed, vec![3]);
-    }
-
-    #[test]
-    fn format_only_change_is_changed() {
-        let mut prev = HashMap::new();
-        prev.insert(1, st(5, Format::Flac, "A/1.flac"));
-        let scan = vec![(1, 5, Format::Mp3)];
-        let cs = partition_changes(&prev, &scan);
-        assert_eq!(cs.changed, vec![1]);
-        assert!(cs.added.is_empty() && cs.removed.is_empty());
-    }
-
-    #[test]
-    fn no_changes_is_empty() {
-        let mut prev = HashMap::new();
-        prev.insert(1, st(0, Format::Flac, "A/1.flac"));
-        let scan = vec![(1, 0, Format::Flac)];
-        assert!(partition_changes(&prev, &scan).is_empty());
-    }
 
     #[test]
     fn is_empty_false_when_any_single_category_is_nonempty() {


### PR DESCRIPTION
Closes #363.

## What

`partition_changes` in `musefs-core/src/refresh_diff.rs` was `#[allow(dead_code)]` and referenced only by its own unit tests. The live refresh path uses `partition_changelog` (the changelog-based incremental diff), so the snapshot-vs-scan partitioner is no longer wired into anything.

- Remove `partition_changes`, its exclusive `st` test helper, and its three tests (`partitions_changed_added_removed`, `format_only_change_is_changed`, `no_changes_is_empty`).

## Scope correction

The issue suggested also removing `ChangeSet` "and friends" — but `ChangeSet`, `ChangeSet::is_empty`, and `partition_changelog` are all **live** (used by the changelog refresh path and `facade.rs`). They stay. What was actually stale were their `#[allow(dead_code)]` attributes, now dropped; `ChangeSet`'s doc comment is updated to describe the changelog partitioner.

## Dead-code sweep

Triaged every `#[allow(dead_code)]` in non-test source. Found one other stale marker:

- `binary_tags_to_inputs` (`mapping.rs`) carried a "wired into the reader resolve arms in Task 2.9" allow, but it is now actually called from `reader.rs` — allow removed.

All other markers are legitimate and left untouched (`CHANGELOG_CAP` test-verified invariant, `FLAG_EOS` flag-bit triple, `metrics` RAII guard, `layout.rs` test/fuzz-only, `spotlight.rs` macOS-only, `latencyfs` bench fields). A clean `cargo build` confirms no un-suppressed dead code remains.

## Verification

`cargo clippy --all-targets` clean, `cargo fmt --check` clean, full workspace test suite passes (via pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)