### PR TITLE
refactor(db): hex-encode digests via base16ct::HexDisplay (#153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +942,7 @@ dependencies = [
 name = "musefs-db"
 version = "1.0.0"
 dependencies = [
+ "base16ct",
  "rusqlite",
  "sha2",
  "strum",

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+# HexDisplay is the RustCrypto-recommended way to hex-format a digest since
+# sha2 0.11 swapped GenericArray (LowerHex) for hybrid_array::Array (no fmt).
+base16ct = "0.2"
 # fallible_uint enables the checked FromSql/ToSql impls for u64/usize, which
 # validate non-negative row columns at the boundary (the cast-convention spec).
 rusqlite = { version = "0.40", features = ["bundled", "blob", "fallible_uint"] }

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -5,16 +5,8 @@ use crate::{Db, ReadWrite, Result};
 use rusqlite::params;
 use sha2::{Digest, Sha256};
 
-// Hand-encoded: sha2 0.11's digest output (hybrid_array::Array) has no
-// LowerHex impl, so `format!("{:x}", ..)` does not compile. Revisit on the
-// next sha2 bump (RustCrypto/hybrid-array#201).
 pub(crate) fn sha256_hex(data: &[u8]) -> String {
-    let mut s = String::with_capacity(64);
-    for b in Sha256::digest(data) {
-        use std::fmt::Write;
-        let _ = write!(s, "{b:02x}");
-    }
-    s
+    format!("{:x}", base16ct::HexDisplay(&Sha256::digest(data)))
 }
 
 impl<M> Db<M> {


### PR DESCRIPTION
## Summary

`sha256_hex` (`musefs-db/src/art.rs`) hand-encoded the digest with a per-byte `write!` loop because sha2 0.11 swapped its digest output from `GenericArray` (which impls `LowerHex`) to `hybrid_array::Array`, which has no `fmt` impls (RustCrypto/hybrid-array#201).

This adopts the RustCrypto-recommended fix from the upstream issue comment: [`base16ct::HexDisplay`](https://docs.rs/base16ct/latest/base16ct/struct.HexDisplay.html), a `&[u8]` wrapper that implements `LowerHex`, so the idiomatic `format!("{:x}", ..)` works again.

```rust
format!("{:x}", base16ct::HexDisplay(&Sha256::digest(data)))
```

This is the upstream-endorsed, permanent approach — not a stopgap awaiting a `hybrid-array` `fmt` impl, so the previous "revisit on next sha2 bump" caveat is dropped.

- Adds `base16ct = "0.2"` to `musefs-db` (resolves to 0.2.0).

## Testing

- Existing NIST `sha256("abc")` guard test (`sha256_hex_matches_known_digest`) still passes.
- `cargo clippy -p musefs-db --all-targets -- -D warnings` clean.
- Full workspace test suite green (pre-commit gate).

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)