### PR TITLE
feat(scripts): --fix mode to auto-re-anchor mutants.toml (#345)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -64,6 +64,7 @@ if echo "$STAGED" | grep -qE '^(\.cargo/mutants\.toml|scripts/check_mutant_ancho
         fi
         if ! python3 scripts/check_mutant_anchors.py --mutants-json "$MUTANTS_LIST"; then
             echo "✗ mutant-anchor guard: re-anchor .cargo/mutants.toml to the current coordinates." >&2
+            echo "  auto-fix shifted line:col anchors with: python3 scripts/check_mutant_anchors.py --fix" >&2
             exit 1
         fi
     else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,11 @@ Sharp edges:
   the mutant there is still genuinely equivalent** (a reformat can change
   surrounding logic, not just line numbers). A `count`/`rows` mismatch means a
   sibling appeared or disappeared — investigate before bumping the number.
+  Pure `cargo fmt`/line-shift drift can be repaired automatically with
+  `python3 scripts/check_mutant_anchors.py --fix`, which re-points each
+  `file:line:col` anchor to its current coordinates by operator+function and
+  refuses to guess when a site was added or removed; always eyeball the
+  resulting diff before committing.
   Every new `file:line:col` exclusion needs a `# guard:` tag (the guard rejects
   an untagged one), and `exclude_re` patterns must stay within the
   Rust-regex/Python-`re` shared subset the guard allows (`\. \d + | ^ ( ) *`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,11 +345,16 @@ Sharp edges:
   the mutant there is still genuinely equivalent** (a reformat can change
   surrounding logic, not just line numbers). A `count`/`rows` mismatch means a
   sibling appeared or disappeared — investigate before bumping the number.
-  Pure `cargo fmt`/line-shift drift can be repaired automatically with
-  `python3 scripts/check_mutant_anchors.py --fix`, which re-points each
-  `file:line:col` anchor to its current coordinates by operator+function and
-  refuses to guess when a site was added or removed; always eyeball the
-  resulting diff before committing.
+  Pure `cargo fmt`/line-shift drift can often be repaired automatically with
+  `python3 scripts/check_mutant_anchors.py --fix`, which re-points an anchor to
+  its current coordinates by operator+function. It only does so when the mapping
+  is unambiguous — every same-operator site in the function is anchored, so the
+  positional match is exact. An anchor that pins one of several same-operator
+  sites (the usual reason it is a `file:line:col` anchor rather than a
+  description) cannot be derived from the tag alone, so `--fix` leaves it for
+  manual re-anchoring and reports `can't auto-derive the coordinate`; it also
+  declines when a site was added or removed. Always eyeball the resulting diff
+  before committing.
   Every new `file:line:col` exclusion needs a `# guard:` tag (the guard rejects
   an untagged one), and `exclude_re` patterns must stay within the
   Rust-regex/Python-`re` shared subset the guard allows (`\. \d + | ^ ( ) *`,

--- a/docs/superpowers/plans/2026-06-14-mutant-anchor-autofix.md
+++ b/docs/superpowers/plans/2026-06-14-mutant-anchor-autofix.md
@@ -1,0 +1,819 @@
+# `check_mutant_anchors.py` `--fix` Auto-Re-Anchor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--fix` flag to `scripts/check_mutant_anchors.py` that rewrites drifted `file:line:col` anchors in `.cargo/mutants.toml` in place, deriving each entry's current coordinates from the live cargo-mutants list and refusing to guess when a mapping is ambiguous.
+
+**Architecture:** Pure functions layered on the existing parser: `_candidate_mutants` resolves an entry's current sites by `op`+`fn` (coordinates wildcarded out of its regex); `compute_rewrites` groups same-resolving "sibling" entries and maps them positionally by source order, flagging structural/zero-candidate cases instead of rewriting them; `apply_rewrites` does a byte-preserving line-level coordinate swap; `run_fix` applies, re-parses from disk, and re-validates via the existing `check()`. The pre-commit hook and CI stay read-only and merely point at `--fix`.
+
+**Tech Stack:** Python 3 stdlib (`re`, `argparse`, `dataclasses`, `collections.Counter`), pytest. No new dependencies.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `scripts/check_mutant_anchors.py` — add helpers, `Rewrite` dataclass, `compute_rewrites`, `apply_rewrites`, `run_fix`, and a `--fix` argparse flag. All additive; no existing function signature changes.
+- **Modify** `scripts/test_check_mutant_anchors.py` — add unit tests for each new function plus end-to-end `main(["--fix", ...])` tests.
+- **Modify** `.githooks/pre-commit` — append a one-line `--fix` pointer to the existing failure message (stays read-only).
+- **Modify** `CONTRIBUTING.md` — add a sentence to the "When the guard fails" paragraph pointing at `--fix`.
+
+### Conventions to follow (already in the file)
+- Tests import the script as `import check_mutant_anchors as g` and build mutants via the local `_m(name)` helper (`= g.parse_mutant(name)`).
+- `g.Entry(regex, toml_line, tag)`, `g.Tag(op=, fn=, fn_present=, rows=, count=)`, `g.Mutant.site == (file, line, col)`.
+- Failure strings are formatted by `_fmt(entry, msg)` → `"[mutants.toml:{toml_line}] /{regex}/ — {msg}"`.
+- `toml_line` is **1-based** (`parse_toml_entries` uses `enumerate(..., start=1)`).
+- `parse_toml_entries` unquotes by stripping the surrounding quote only — `entry.regex` is the exact literal text between the quotes, so it appears verbatim on its source line.
+
+### Commit-time gotchas (apply to every Python commit below)
+- The pre-commit hook runs `ruff check` **and** `ruff format --check` over the Python paths — run `ruff format scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py` before each commit or it will be rejected as unformatted (config: `select = ["E","F","I","N","W"]`, line-length 100, `format.preview = true`).
+- Staging `scripts/check_mutant_anchors.py` matches the pre-commit **mutant-anchor guard** trigger, so each of these commits also runs `cargo mutants --no-config --list --json` + the full workspace test suite (several minutes, needs `cargo-mutants` installed). This is expected; the guard should stay green because no `.cargo/mutants.toml` anchor changes. If `cargo-mutants` is absent the guard self-skips (CI still enforces it).
+
+---
+
+## Task 1: Coordinate helpers + `Rewrite` dataclass
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py` (add `_COORD_RE` next to `_LITERAL_LINECOL`; add `Counter` import; add `_wildcard_coords`, `_entry_coords`, `Rewrite` after `parse_mutant`)
+- Test: `scripts/test_check_mutant_anchors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `scripts/test_check_mutant_anchors.py` (near the other unit tests):
+
+```python
+def test_wildcard_coords_bare_prefix():
+    assert g._wildcard_coords(r"musefs-core/src/scan\.rs:1041:32:") == (
+        r"musefs-core/src/scan\.rs:\d+:\d+:"
+    )
+
+
+def test_wildcard_coords_preserves_repl_suffix():
+    assert g._wildcard_coords(r"musefs-core/src/scan\.rs:1212:29: replace \+ with -") == (
+        r"musefs-core/src/scan\.rs:\d+:\d+: replace \+ with -"
+    )
+
+
+def test_wildcard_coords_replaces_only_first_linecol():
+    # the suffix's own digits must survive untouched
+    assert g._wildcard_coords(r"foo/bar\.rs:10:20: replace 1 with 2") == (
+        r"foo/bar\.rs:\d+:\d+: replace 1 with 2"
+    )
+
+
+def test_entry_coords_parses_line_col():
+    assert g._entry_coords(r"musefs-core/src/scan\.rs:1041:32:") == (1041, 32)
+    assert g._entry_coords(r"musefs-core/src/scan\.rs:1212:29: replace \+ with -") == (1212, 29)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k "wildcard_coords or entry_coords" -v`
+Expected: FAIL with `AttributeError: module 'check_mutant_anchors' has no attribute '_wildcard_coords'`.
+
+- [ ] **Step 3: Implement the helpers**
+
+In `scripts/check_mutant_anchors.py`, add `Counter` to the imports — change:
+
+```python
+from dataclasses import dataclass
+```
+
+to:
+
+```python
+from collections import Counter
+from dataclasses import dataclass
+```
+
+Add the capturing coordinate regex directly below the existing `_LITERAL_LINECOL` definition:
+
+```python
+_LITERAL_LINECOL = re.compile(r":[0-9]+:[0-9]+:")
+_COORD_RE = re.compile(r":([0-9]+):([0-9]+):")
+```
+
+Add these helpers immediately after `parse_mutant` (before `classify`):
+
+```python
+def _wildcard_coords(regex: str) -> str:
+    """Replace an entry regex's literal ``:line:col:`` with a ``:\\d+:\\d+:`` wildcard.
+
+    Uses a function replacement, not a literal one: a string replacement of
+    ``":\\d+:\\d+:"`` would have its ``\\d`` parsed as a replacement-template escape
+    and raise ``re.PatternError: bad escape \\d``.
+    """
+    return _LITERAL_LINECOL.sub(lambda _: r":\d+:\d+:", regex, count=1)
+
+
+def _entry_coords(regex: str) -> tuple[int, int]:
+    """Parse the (line, col) a linecol entry currently anchors on."""
+    m = _COORD_RE.search(regex)
+    assert m is not None  # caller guarantees classify(regex) == "linecol"
+    return int(m.group(1)), int(m.group(2))
+```
+
+Add the `Rewrite` dataclass immediately after the `Entry` dataclass:
+
+```python
+@dataclass
+class Rewrite:
+    entry: Entry
+    line: int
+    col: int
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k "wildcard_coords or entry_coords" -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(scripts): coordinate helpers for mutant-anchor --fix (#345)"
+```
+
+---
+
+## Task 2: `_candidate_mutants` — resolve an entry's current sites
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py` (add `_candidate_mutants` after `_entry_coords`)
+- Test: `scripts/test_check_mutant_anchors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_candidate_mutants_bare_prefix_filters_by_op_fn():
+    entry = g.Entry(
+        r"musefs-core/src/scan\.rs:277:30:",
+        1,
+        g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+    )
+    muts = [
+        _m("musefs-core/src/scan.rs:300:30: replace < with == in probe_file"),
+        _m("musefs-core/src/scan.rs:305:10: replace + with - in probe_file"),  # wrong op
+        _m("musefs-core/src/scan.rs:310:10: replace < with == in other_fn"),  # wrong fn
+    ]
+    got = g._candidate_mutants(entry, muts)
+    assert [m.site for m in got] == [("musefs-core/src/scan.rs", 300, 30)]
+
+
+def test_candidate_mutants_repl_suffix_narrows():
+    entry = g.Entry(
+        r"musefs-core/src/scan\.rs:1212:29: replace \+ with -",
+        1,
+        g.Tag(op="+", fn="revalidate_with", fn_present=True, rows=1),
+    )
+    muts = [
+        _m("musefs-core/src/scan.rs:1220:29: replace + with - in revalidate_with"),
+        _m("musefs-core/src/scan.rs:1220:29: replace + with * in revalidate_with"),  # excluded by suffix
+    ]
+    got = g._candidate_mutants(entry, muts)
+    assert [m.repl for m in got] == ["-"]
+
+
+def test_candidate_mutants_empty_fn_matches_free_function():
+    entry = g.Entry(
+        r"musefs-core/src/reader\.rs:71:60: replace / with [%*]",
+        1,
+        g.Tag(op="/", fn="", fn_present=True, rows=2),
+    )
+    muts = [
+        _m("musefs-core/src/reader.rs:80:60: replace / with %"),
+        _m("musefs-core/src/reader.rs:80:60: replace / with *"),
+    ]
+    got = g._candidate_mutants(entry, muts)
+    assert {m.site for m in got} == {("musefs-core/src/reader.rs", 80, 60)}
+    assert len(got) == 2
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k candidate_mutants -v`
+Expected: FAIL with `AttributeError: ... has no attribute '_candidate_mutants'`.
+
+- [ ] **Step 3: Implement `_candidate_mutants`**
+
+Add after `_entry_coords`:
+
+```python
+def _candidate_mutants(entry: Entry, mutants: list[Mutant]) -> list[Mutant]:
+    """Live mutants a linecol entry's op/fn currently resolve to, ignoring its stale coords.
+
+    The entry's regex is matched with its coordinates wildcarded — preserving any
+    ``replace \\+ with -`` repl suffix that narrows the match — and the result is
+    further filtered by the guard tag's ``op`` and ``fn`` (``fn=""`` → free function,
+    matched as ``fn is None``). Mirrors the predicate ``_check_linecol`` validates with.
+    """
+    t = entry.tag
+    wild = re.compile(_wildcard_coords(entry.regex))
+    expected_fn = None if t.fn == "" else t.fn
+    return [m for m in mutants if wild.search(m.name) and m.op == t.op and m.fn == expected_fn]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k candidate_mutants -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(scripts): resolve current mutant sites for an anchor (#345)"
+```
+
+---
+
+## Task 3: `compute_rewrites` — group, map positionally, flag the unmappable
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py` (add `compute_rewrites` after `_candidate_mutants`)
+- Test: `scripts/test_check_mutant_anchors.py`
+
+`compute_rewrites(entries, mutants)` returns `(rewrites, skip_notes, skipped_lines)`:
+- `rewrites` — `Rewrite` objects for entries whose coordinates changed, sorted by `toml_line`.
+- `skip_notes` — `_fmt`-formatted messages for entries `--fix` deliberately left alone (zero-candidate or structural).
+- `skipped_lines` — the `toml_line`s of those skipped entries, so re-validation can defer to the better-worded note.
+
+Only **complete-tag linecol** entries are processed; desc, tagless, and incomplete-tag entries are ignored here and surfaced later by `check()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_compute_rewrites_simple_shift():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            3,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:300:30: replace < with == in probe_file")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert skips == [] and skipped == set()
+    assert len(rewrites) == 1
+    assert (rewrites[0].entry.toml_line, rewrites[0].line, rewrites[0].col) == (3, 300, 30)
+
+
+def test_compute_rewrites_no_drift_is_noop():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            3,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skips == [] and skipped == set()
+
+
+def test_compute_rewrites_multisite_positional():
+    # two >= anchors in run_pipeline, both shifted down 2 lines; map low->low, high->high
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1041:32:",
+            5,
+            g.Tag(op=">=", fn="run_pipeline", fn_present=True, rows=1),
+        ),
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1051:40:",
+            9,
+            g.Tag(op=">=", fn="run_pipeline", fn_present=True, rows=1),
+        ),
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1043:32: replace >= with > in run_pipeline"),
+        _m("musefs-core/src/scan.rs:1053:40: replace >= with > in run_pipeline"),
+    ]
+    rewrites, skips, _ = g.compute_rewrites(entries, muts)
+    assert skips == []
+    assert {(r.entry.toml_line, r.line, r.col) for r in rewrites} == {
+        (5, 1043, 32),
+        (9, 1053, 40),
+    }
+
+
+def test_compute_rewrites_repl_suffixed():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1212:29: replace \+ with -",
+            3,
+            g.Tag(op="+", fn="revalidate_with", fn_present=True, rows=1),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1220:29: replace + with - in revalidate_with"),
+        _m("musefs-core/src/scan.rs:1220:29: replace + with * in revalidate_with"),
+    ]
+    rewrites, skips, _ = g.compute_rewrites(entries, muts)
+    assert skips == []
+    assert len(rewrites) == 1 and (rewrites[0].line, rewrites[0].col) == (1220, 29)
+
+
+def test_compute_rewrites_rows_two_site():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1039:29:",
+            3,
+            g.Tag(op="+=", fn="run_pipeline", fn_present=True, rows=2),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1045:29: replace += with -= in run_pipeline"),
+        _m("musefs-core/src/scan.rs:1045:29: replace += with *= in run_pipeline"),
+    ]
+    rewrites, skips, _ = g.compute_rewrites(entries, muts)
+    assert skips == []
+    assert len(rewrites) == 1 and (rewrites[0].line, rewrites[0].col) == (1045, 29)
+
+
+def test_compute_rewrites_zero_candidate_reports_deletion():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            4,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:500:10: replace + with - in other_fn")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skipped == {4}
+    assert len(skips) == 1 and "delete this exclude_re entry" in skips[0]
+
+
+def test_compute_rewrites_structural_count_mismatch():
+    # one anchor, op/fn now resolves to two sites -> refuse the whole group
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1041:32:",
+            4,
+            g.Tag(op=">=", fn="run_pipeline", fn_present=True, rows=1),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1043:32: replace >= with > in run_pipeline"),
+        _m("musefs-core/src/scan.rs:1099:10: replace >= with > in run_pipeline"),
+    ]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skipped == {4}
+    assert "structural change" in skips[0]
+
+
+def test_compute_rewrites_rows_mismatch_skips_group():
+    # equinumerous (1 anchor, 1 site) but the site holds 1 mutant while rows=2
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1039:29:",
+            4,
+            g.Tag(op="+=", fn="run_pipeline", fn_present=True, rows=2),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:1045:29: replace += with -= in run_pipeline")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skipped == {4}
+    assert "structural change" in skips[0]
+
+
+def test_compute_rewrites_ignores_desc_and_tagless():
+    entries = [
+        g.Entry(r"replace \| with \^ in synchsafe_decode", 3, g.Tag(count=3)),
+        g.Entry(r"musefs-core/src/scan\.rs:277:30:", 5, None),
+        g.Entry(r"musefs-core/src/scan\.rs:277:30:", 7, g.Tag(op="<")),
+    ]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skips == [] and skipped == set()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k compute_rewrites -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'compute_rewrites'`.
+
+- [ ] **Step 3: Implement `compute_rewrites`**
+
+Add after `_candidate_mutants`:
+
+```python
+def compute_rewrites(
+    entries: list[Entry], mutants: list[Mutant]
+) -> tuple[list[Rewrite], list[str], set[int]]:
+    """Plan coordinate rewrites for drifted complete-tag linecol entries.
+
+    Returns (rewrites, skip_notes, skipped_lines). Entries are grouped by the
+    identical set of sites their op/fn resolves to; siblings in a group are mapped
+    to those sites positionally by source order (which fmt/edits preserve). A group
+    whose anchor count differs from its site count, or any of whose sites holds a
+    number of mutants other than the anchor's ``rows``, is a structural change — it
+    is left untouched and reported, never guessed. An entry resolving to no site is
+    deleted code, reported with deletion-oriented wording.
+    """
+    targets = [
+        e
+        for e in entries
+        if classify(e.regex) == "linecol"
+        and e.tag is not None
+        and e.tag.op is not None
+        and e.tag.fn_present
+        and e.tag.rows is not None
+    ]
+
+    rewrites: list[Rewrite] = []
+    skip_notes: list[str] = []
+    skipped: set[int] = set()
+
+    groups: dict[tuple, list[Entry]] = {}
+    matched_by_line: dict[int, list[Mutant]] = {}
+    for e in targets:
+        ms = _candidate_mutants(e, mutants)
+        matched_by_line[e.toml_line] = ms
+        sites = tuple(sorted({m.site for m in ms}))
+        if not sites:
+            skip_notes.append(
+                _fmt(e, "matches no live mutant — code removed? delete this exclude_re entry")
+            )
+            skipped.add(e.toml_line)
+            continue
+        groups.setdefault(sites, []).append(e)
+
+    for sites, group in groups.items():
+        group = sorted(group, key=lambda e: _entry_coords(e.regex))
+        counts = Counter(m.site for m in matched_by_line[group[0].toml_line])
+        mappable = len(group) == len(sites) and all(
+            counts[sites[i]] == group[i].tag.rows for i in range(len(group))
+        )
+        if not mappable:
+            for e in group:
+                skip_notes.append(
+                    _fmt(
+                        e,
+                        f"op/fn resolves to {len(sites)} site(s) but {len(group)} anchor(s) "
+                        "reference it — structural change, re-anchor manually",
+                    )
+                )
+                skipped.add(e.toml_line)
+            continue
+        for e, site in zip(group, sites):
+            _, line, col = site
+            if (line, col) != _entry_coords(e.regex):
+                rewrites.append(Rewrite(e, line, col))
+
+    rewrites.sort(key=lambda r: r.entry.toml_line)
+    return rewrites, skip_notes, skipped
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k compute_rewrites -v`
+Expected: PASS (9 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(scripts): positional re-anchor planner for --fix (#345)"
+```
+
+---
+
+## Task 4: `apply_rewrites` — byte-preserving coordinate swap
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py` (add `apply_rewrites` after `compute_rewrites`)
+- Test: `scripts/test_check_mutant_anchors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_apply_rewrites_byte_preserving():
+    toml = (
+        "exclude_re = [\n"
+        '    # guard: op=">=" fn="run_pipeline" rows=1\n'
+        "    'musefs-core/src/scan\\.rs:1041:32:',\n"
+        "]\n"
+    )
+    entries, _ = g.parse_toml_entries(toml)
+    out = g.apply_rewrites(toml, [g.Rewrite(entries[0], 1043, 32)])
+    assert "scan\\.rs:1043:32:" in out
+    assert "scan\\.rs:1041:32:" not in out
+    # guard tag and overall structure untouched
+    assert 'op=">=" fn="run_pipeline" rows=1' in out
+    assert out.count("\n") == toml.count("\n")
+    # only the coordinate digits changed
+    assert out == toml.replace(":1041:32:", ":1043:32:")
+
+
+def test_apply_rewrites_preserves_repl_suffix():
+    toml = "exclude_re = [\n    'musefs-core/src/scan\\.rs:1212:29: replace \\+ with -',\n]\n"
+    entries, _ = g.parse_toml_entries(toml)
+    out = g.apply_rewrites(toml, [g.Rewrite(entries[0], 1220, 29)])
+    assert "scan\\.rs:1220:29: replace \\+ with -" in out
+
+
+def test_apply_rewrites_empty_is_identity():
+    toml = "exclude_re = [\n    'musefs-core/src/scan\\.rs:1041:32:',\n]\n"
+    assert g.apply_rewrites(toml, []) == toml
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k apply_rewrites -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'apply_rewrites'`.
+
+- [ ] **Step 3: Implement `apply_rewrites`**
+
+Add after `compute_rewrites`:
+
+```python
+def apply_rewrites(toml_text: str, rewrites: list[Rewrite]) -> str:
+    """Return ``toml_text`` with each rewrite's ``:line:col:`` swapped in place.
+
+    Only the entry's own source line is touched; the new coordinates are an
+    f-string (no backslash, so a literal replacement is safe here, unlike the
+    wildcard in ``_wildcard_coords``). Quote char, comma, indentation, and the
+    guard-tag comment above are byte-preserved.
+    """
+    lines = toml_text.splitlines(keepends=True)
+    for rw in rewrites:
+        new_regex = _LITERAL_LINECOL.sub(f":{rw.line}:{rw.col}:", rw.entry.regex, count=1)
+        idx = rw.entry.toml_line - 1
+        lines[idx] = lines[idx].replace(rw.entry.regex, new_regex, 1)
+    return "".join(lines)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k apply_rewrites -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(scripts): byte-preserving anchor rewrite for --fix (#345)"
+```
+
+---
+
+## Task 5: `run_fix` + `--fix` CLI wiring
+
+**Files:**
+- Modify: `scripts/check_mutant_anchors.py` (add `run_fix` after `apply_rewrites`; add `--fix` arg and branch in `main`)
+- Test: `scripts/test_check_mutant_anchors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `import json` near the top of `scripts/test_check_mutant_anchors.py` (below `import sys`), then add:
+
+```python
+def _write_toml(tmp_path, body: str):
+    p = tmp_path / "mutants.toml"
+    p.write_text(body)
+    return p
+
+
+def _write_muts(tmp_path, names: list[str]):
+    p = tmp_path / "muts.json"
+    p.write_text(json.dumps([{"name": n} for n in names]))
+    return p
+
+
+_FIX_TOML = (
+    "exclude_re = [\n"
+    '    # guard: op="<" fn="probe_file" rows=1\n'
+    "    'musefs-core/src/scan\\.rs:277:30:',\n"
+    "]\n"
+)
+
+
+def test_main_fix_rewrites_and_passes(tmp_path, capsys):
+    toml = _write_toml(tmp_path, _FIX_TOML)
+    muts = _write_muts(tmp_path, ["musefs-core/src/scan.rs:300:30: replace < with == in probe_file"])
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    assert rc == 0
+    assert "scan\\.rs:300:30:" in toml.read_text()
+    assert "scan\\.rs:277:30:" not in toml.read_text()
+    assert "re-anchored" in capsys.readouterr().out
+
+
+def test_main_fix_idempotent(tmp_path):
+    toml = _write_toml(tmp_path, _FIX_TOML)
+    muts = _write_muts(tmp_path, ["musefs-core/src/scan.rs:300:30: replace < with == in probe_file"])
+    assert g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)]) == 0
+    after_first = toml.read_text()
+    assert g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)]) == 0
+    assert toml.read_text() == after_first
+
+
+def test_main_fix_partial_reports_and_exits_nonzero(tmp_path, capsys):
+    # first entry is fixable; second resolves to no live mutant (deleted code)
+    body = (
+        "exclude_re = [\n"
+        '    # guard: op="<" fn="probe_file" rows=1\n'
+        "    'musefs-core/src/scan\\.rs:277:30:',\n"
+        '    # guard: op=">" fn="gone" rows=1\n'
+        "    'musefs-core/src/scan\\.rs:900:10:',\n"
+        "]\n"
+    )
+    toml = _write_toml(tmp_path, body)
+    muts = _write_muts(tmp_path, ["musefs-core/src/scan.rs:300:30: replace < with == in probe_file"])
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "scan\\.rs:300:30:" in toml.read_text()  # the fixable one was still applied
+    assert "delete this exclude_re entry" in out
+
+
+def test_main_fix_no_op_when_clean(tmp_path, capsys):
+    toml = _write_toml(tmp_path, _FIX_TOML)
+    muts = _write_muts(tmp_path, ["musefs-core/src/scan.rs:277:30: replace < with == in probe_file"])
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    assert rc == 0
+    assert toml.read_text() == _FIX_TOML
+    assert "no coordinates needed re-anchoring" in capsys.readouterr().out
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k main_fix -v`
+Expected: FAIL — `--fix` is an unrecognized argument (argparse `SystemExit`), or `run_fix` is missing.
+
+- [ ] **Step 3: Implement `run_fix` and wire `--fix`**
+
+Add `run_fix` after `apply_rewrites`:
+
+```python
+def run_fix(toml_path: Path, entries: list[Entry], mutants: list[Mutant]) -> int:
+    """Re-anchor drifted linecol coordinates in ``toml_path``, then re-validate.
+
+    Exactly one rewrite pass followed by one validation pass — no fixpoint. Entries
+    that could not be safely re-anchored (structural / deleted) are reported with
+    their dedicated wording; re-validation handles the rest (desc drift, untagged).
+    """
+    rewrites, skip_notes, skipped = compute_rewrites(entries, mutants)
+    if rewrites:
+        toml_path.write_text(apply_rewrites(toml_path.read_text(), rewrites))
+        for rw in rewrites:
+            old_line, old_col = _entry_coords(rw.entry.regex)
+            print(
+                f"re-anchored [mutants.toml:{rw.entry.toml_line}] "
+                f":{old_line}:{old_col}: -> :{rw.line}:{rw.col}:"
+            )
+    else:
+        print("no coordinates needed re-anchoring.")
+
+    fresh_entries, fresh_globs = parse_toml_entries(toml_path.read_text())
+    remaining = [
+        f
+        for f in check(fresh_entries, mutants, fresh_globs)
+        if not any(f"[mutants.toml:{ln}]" in f for ln in skipped)
+    ]
+    problems = skip_notes + remaining
+    if problems:
+        print(f"\n{len(problems)} entry(ies) still need manual attention:\n")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+    print(f"OK: {len(fresh_entries)} exclude_re entries validated against {len(mutants)} mutants.")
+    return 0
+```
+
+In `main`, add the flag after the existing `--toml` argument:
+
+```python
+    ap.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite drifted file:line:col anchors in --toml in place, then re-validate",
+    )
+```
+
+and branch right after `mutants = load_mutants(json_text)`'s `try/except` block, replacing:
+
+```python
+    failures = check(entries, mutants, globs)
+```
+
+with:
+
+```python
+    if args.fix:
+        try:
+            return run_fix(args.toml, entries, mutants)
+        except OSError as ex:
+            print(f"error: failed to rewrite {args.toml}: {ex}", file=sys.stderr)
+            return 1
+
+    failures = check(entries, mutants, globs)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -k main_fix -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Run the full script test suite to confirm no regressions**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: PASS (all existing + new tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py
+git commit -m "feat(scripts): --fix re-anchors mutants.toml and re-validates (#345)"
+```
+
+---
+
+## Task 6: Point the pre-commit hook and CONTRIBUTING at `--fix`
+
+**Files:**
+- Modify: `.githooks/pre-commit` (the mutant-anchor guard failure message, ~line 66)
+- Modify: `CONTRIBUTING.md` (the "When the guard fails" paragraph, ~line 343)
+
+No automated test — this is a message/doc change. Verify by reading the diff and running shellcheck (the pre-commit hook runs it automatically on commit).
+
+- [ ] **Step 1: Update the pre-commit failure message**
+
+In `.githooks/pre-commit`, replace:
+
+```sh
+        if ! python3 scripts/check_mutant_anchors.py --mutants-json "$MUTANTS_LIST"; then
+            echo "✗ mutant-anchor guard: re-anchor .cargo/mutants.toml to the current coordinates." >&2
+            exit 1
+        fi
+```
+
+with:
+
+```sh
+        if ! python3 scripts/check_mutant_anchors.py --mutants-json "$MUTANTS_LIST"; then
+            echo "✗ mutant-anchor guard: re-anchor .cargo/mutants.toml to the current coordinates." >&2
+            echo "  auto-fix shifted line:col anchors with: python3 scripts/check_mutant_anchors.py --fix" >&2
+            exit 1
+        fi
+```
+
+- [ ] **Step 2: Update CONTRIBUTING.md**
+
+In `CONTRIBUTING.md`, find the sentence ending the "When the guard fails" paragraph:
+
+```
+    — re-anchor it to the current coordinates from the listing **and re-confirm
+    the mutant there is still genuinely equivalent** (a reformat can change
+    surrounding logic, not just line numbers). A `count`/`rows` mismatch means a
+    sibling appeared or disappeared — investigate before bumping the number.
+```
+
+Append a sentence after it (still inside that paragraph):
+
+```
+    Pure `cargo fmt`/line-shift drift can be repaired automatically with
+    `python3 scripts/check_mutant_anchors.py --fix`, which re-points each
+    `file:line:col` anchor to its current coordinates by operator+function and
+    refuses to guess when a site was added or removed; always eyeball the
+    resulting diff before committing.
+```
+
+- [ ] **Step 3: Verify shellcheck passes on the hook**
+
+Run: `shellcheck .githooks/pre-commit`
+Expected: no output (exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .githooks/pre-commit CONTRIBUTING.md
+git commit -m "docs: point mutant-anchor guard failures at --fix (#345)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full script test suite:**
+
+Run: `python -m pytest scripts/test_check_mutant_anchors.py -v`
+Expected: all tests pass.
+
+- [ ] **Smoke-test `--fix` against the real config (no-op expected on a clean tree):**
+
+Run:
+```bash
+cargo mutants --no-config --list --json > /tmp/mutants-list.json
+python3 scripts/check_mutant_anchors.py --fix --mutants-json /tmp/mutants-list.json
+git diff --stat .cargo/mutants.toml
+```
+Expected: prints `no coordinates needed re-anchoring.` then `OK: …`, and `git diff` shows **no** change to `.cargo/mutants.toml` (the committed anchors are already correct). If it does rewrite, inspect the diff — that means the checked-in anchors had drifted.
+
+- [ ] **Confirm ruff is clean (CI `python-musefs` gate):**
+
+Run: `ruff check scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py && ruff format --check scripts/check_mutant_anchors.py scripts/test_check_mutant_anchors.py`
+Expected: `All checks passed!` and formatting clean.

--- a/docs/superpowers/plans/2026-06-14-mutant-anchor-autofix.md
+++ b/docs/superpowers/plans/2026-06-14-mutant-anchor-autofix.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a `--fix` flag to `scripts/check_mutant_anchors.py` that rewrites drifted `file:line:col` anchors in `.cargo/mutants.toml` in place, deriving each entry's current coordinates from the live cargo-mutants list and refusing to guess when a mapping is ambiguous.
 
-**Architecture:** Pure functions layered on the existing parser: `_candidate_mutants` resolves an entry's current sites by `op`+`fn` (coordinates wildcarded out of its regex); `compute_rewrites` groups same-resolving "sibling" entries and maps them positionally by source order, flagging structural/zero-candidate cases instead of rewriting them; `apply_rewrites` does a byte-preserving line-level coordinate swap; `run_fix` applies, re-parses from disk, and re-validates via the existing `check()`. The pre-commit hook and CI stay read-only and merely point at `--fix`.
+**Architecture:** Pure functions layered on the existing parser: `_candidate_mutants` resolves an entry's current sites by `op`+`fn` (coordinates wildcarded out of its regex); `compute_rewrites` groups same-resolving "sibling" entries and maps them positionally by source order, leaving non-derivable cases for manual fix instead of rewriting them; `run_fix` re-derives the set of entries that *currently* fail `check()` and gates unfixable-entry reporting on it (so a valid but non-unique-op/fn anchor on a clean tree is a silent no-op), then applies the rewrites, re-parses from disk, and re-validates. `apply_rewrites` does a byte-preserving line-level coordinate swap. The pre-commit hook and CI stay read-only and merely point at `--fix`.
 
 **Tech Stack:** Python 3 stdlib (`re`, `argparse`, `dataclasses`, `collections.Counter`), pytest. No new dependencies.
 
@@ -362,7 +362,7 @@ def test_compute_rewrites_structural_count_mismatch():
     ]
     rewrites, skips, skipped = g.compute_rewrites(entries, muts)
     assert rewrites == [] and skipped == {4}
-    assert "structural change" in skips[0]
+    assert "can't auto-derive" in skips[0]
 
 
 def test_compute_rewrites_rows_mismatch_skips_group():
@@ -377,7 +377,7 @@ def test_compute_rewrites_rows_mismatch_skips_group():
     muts = [_m("musefs-core/src/scan.rs:1045:29: replace += with -= in run_pipeline")]
     rewrites, skips, skipped = g.compute_rewrites(entries, muts)
     assert rewrites == [] and skipped == {4}
-    assert "structural change" in skips[0]
+    assert "can't auto-derive" in skips[0]
 
 
 def test_compute_rewrites_ignores_desc_and_tagless():
@@ -453,8 +453,8 @@ def compute_rewrites(
                 skip_notes.append(
                     _fmt(
                         e,
-                        f"op/fn resolves to {len(sites)} site(s) but {len(group)} anchor(s) "
-                        "reference it — structural change, re-anchor manually",
+                        f"op/fn resolves to {len(sites)} live site(s), {len(group)} anchor(s) "
+                        "pin it — can't auto-derive the coordinate, re-anchor manually",
                     )
                 )
                 skipped.add(e.toml_line)
@@ -637,6 +637,57 @@ def test_main_fix_no_op_when_clean(tmp_path, capsys):
     assert rc == 0
     assert toml.read_text() == _FIX_TOML
     assert "no coordinates needed re-anchoring" in capsys.readouterr().out
+
+
+# A line:col anchor exists precisely because op+fn is NOT unique in the function
+# (several same-op/fn sites, only one excluded). On a clean tree such an entry is
+# valid and --fix must leave it silent — never re-derive its coordinate from the
+# tag (impossible) and false-flag it. Regression for the #345 review finding.
+_NONUNIQUE_TOML = (
+    "exclude_re = [\n"
+    '    # guard: op="+" fn="walk" rows=1\n'
+    "    'musefs-format/src/wav\\.rs:58:28:',\n"
+    "]\n"
+)
+
+
+def test_main_fix_clean_nonunique_op_fn_is_noop(tmp_path, capsys):
+    toml = _write_toml(tmp_path, _NONUNIQUE_TOML)
+    muts = _write_muts(
+        tmp_path,
+        [
+            "musefs-format/src/wav.rs:58:28: replace + with - in walk",  # excluded site (valid)
+            "musefs-format/src/wav.rs:60:10: replace + with - in walk",  # killable sibling
+            "musefs-format/src/wav.rs:62:14: replace + with - in walk",
+        ],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert toml.read_text() == _NONUNIQUE_TOML
+    assert "auto-derive" not in out and "manual attention" not in out
+
+
+def test_main_fix_drifted_nonunique_reports_manual(tmp_path, capsys):
+    body = (
+        "exclude_re = [\n"
+        '    # guard: op="+" fn="walk" rows=1\n'
+        "    'musefs-format/src/wav\\.rs:58:28:',\n"  # stale: no live mutant at 58:28
+        "]\n"
+    )
+    toml = _write_toml(tmp_path, body)
+    muts = _write_muts(
+        tmp_path,
+        [
+            "musefs-format/src/wav.rs:70:28: replace + with - in walk",
+            "musefs-format/src/wav.rs:72:10: replace + with - in walk",
+        ],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "auto-derive" in out
+    assert toml.read_text() == body  # ambiguous → not rewritten
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -646,17 +697,42 @@ Expected: FAIL — `--fix` is an unrecognized argument (argparse `SystemExit`), 
 
 - [ ] **Step 3: Implement `run_fix` and wire `--fix`**
 
-Add `run_fix` after `apply_rewrites`:
+First add a small helper after `_fmt` (used to map `check()`/skip-note strings
+back to the toml line they refer to):
 
 ```python
-def run_fix(toml_path: Path, entries: list[Entry], mutants: list[Mutant]) -> int:
+_FAIL_LINE_RE = re.compile(r"^\[mutants\.toml:(\d+)\]")
+
+
+def _failing_lines(failures: list[str]) -> set[int]:
+    """Extract the toml line numbers a list of `_fmt` failure strings refers to."""
+    return {int(m.group(1)) for f in failures if (m := _FAIL_LINE_RE.match(f))}
+```
+
+Then add `run_fix` after `apply_rewrites`. The **failure gate** is the key
+correctness point: a `file:line:col` anchor's `op`+`fn` resolves to *every*
+same-operator site in its function (that non-uniqueness is why it is pinned by
+coordinate), so `compute_rewrites` will mark most valid anchors "can't
+auto-derive". Reporting those on a clean tree would fail a valid config — so we
+only surface an unfixable entry when it **actually fails `check()` now**:
+
+```python
+def run_fix(
+    toml_path: Path, entries: list[Entry], globs: list[str], mutants: list[Mutant]
+) -> int:
     """Re-anchor drifted linecol coordinates in ``toml_path``, then re-validate.
 
     Exactly one rewrite pass followed by one validation pass — no fixpoint. Entries
-    that could not be safely re-anchored (structural / deleted) are reported with
-    their dedicated wording; re-validation handles the rest (desc drift, untagged).
+    that could not be safely re-anchored are reported with their dedicated wording
+    *only when they actually fail validation now* — an op/fn that resolves to many
+    sites is normal for a line:col anchor (that non-uniqueness is why it is pinned by
+    coordinate), so a currently-valid such entry is left silent rather than false-
+    flagged. Re-validation handles the rest (desc drift, untagged).
     """
+    failing = _failing_lines(check(entries, mutants, globs))
     rewrites, skip_notes, skipped = compute_rewrites(entries, mutants)
+    skip_notes = [n for n in skip_notes if _failing_lines([n]) <= failing]
+    skipped &= failing
     if rewrites:
         toml_path.write_text(apply_rewrites(toml_path.read_text(), rewrites))
         for rw in rewrites:
@@ -705,7 +781,7 @@ with:
 ```python
     if args.fix:
         try:
-            return run_fix(args.toml, entries, mutants)
+            return run_fix(args.toml, entries, globs, mutants)
         except OSError as ex:
             print(f"error: failed to rewrite {args.toml}: {ex}", file=sys.stderr)
             return 1
@@ -716,7 +792,7 @@ with:
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `python -m pytest scripts/test_check_mutant_anchors.py -k main_fix -v`
-Expected: PASS (4 passed).
+Expected: PASS (6 passed).
 
 - [ ] **Step 5: Run the full script test suite to confirm no regressions**
 

--- a/docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md
+++ b/docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md
@@ -49,12 +49,22 @@ by `classify()` on the presence of a literal `:line:col:` in the regex:
 
 For each `linecol` entry, the candidate live mutants are those matching **both**:
 
-1. the entry's regex with its coordinates wildcarded —
-   `_LITERAL_LINECOL.sub(":\\d+:\\d+:", regex, count=1)`. This preserves any
+1. the entry's regex with its coordinates wildcarded. Use a **function
+   replacement** so the `\d` is not parsed as a replacement-template escape:
+   `_LITERAL_LINECOL.sub(lambda _: r":\d+:\d+:", regex, count=1)`. A literal
+   replacement string `":\\d+:\\d+:"` raises `re.PatternError: bad escape \d`
+   on Python 3.7+ — do **not** use that form. The wildcard preserves any
    `replace \+ with -` repl suffix that narrows the match; for a bare
-   `file:line:col:` prefix (no op/repl in the regex) the wildcard adds no
-   constraint.
+   `file:line:col:` prefix (no op/repl in the regex) it adds no constraint. The
+   file portion of the regex is left verbatim, so the wildcard only ever
+   loosens `line:col`, never the path.
 2. the guard tag's `op` and `fn` (`expected_fn = None if tag.fn == ""`).
+
+Entries that lack a complete guard tag (`tag is None`, or any of `op`/`fn`/
+`rows` absent) cannot be op/fn-filtered, so `--fix` **skips** them entirely and
+passes them through to `check()`, which reports them as "needs op=/fn=/rows=".
+(A *malformed* tag — bad residue — already aborts the whole load in
+`parse_guard_tag` before `--fix` runs; that is unchanged.)
 
 The op/fn filter is what constrains bare-prefix entries — exactly mirroring how
 `_check_linecol` validates today. Candidates are grouped into distinct sites
@@ -76,6 +86,13 @@ Entries that resolve to the **identical candidate-site set** are siblings (e.g.
   **structural change, not a shift** (a site was added/removed, or the operator
   count changed). Leave the whole group untouched and report it.
 
+The **zero-candidate** case (the entry's op/fn now matches *no* live site) is a
+distinct sub-case of "counts differ": the code was deleted, not moved, so a
+re-anchor is impossible. Report it with deletion-oriented wording — `matches no
+live mutant — code removed? delete this exclude_re entry` — rather than the
+generic "re-anchor" note, mirroring `_check_desc`'s "delete a dead rule"
+guidance.
+
 Grouping by candidate-site set (rather than by raw `op`+`fn` strings) is what
 lets repl-suffixed and bare-prefix entries share one code path: two entries are
 siblings precisely when they are indistinguishable except by position.
@@ -89,15 +106,26 @@ identical-`op`/`fn` sites except by position — the `# guard:` comments in
 `mutants.toml` already instruct devs to re-verify these coordinates after any
 reformatting of the file. `--fix` inherits, and does not widen, that contract.
 
+Cross-file mismapping cannot occur: every `linecol` regex pins the full path
+(`musefs-core/src/scan\.rs`, …) and the coordinate wildcard touches only
+`line:col`, so candidates for an entry are always confined to its own file even
+though `_NAME_RE`'s file group (`[^:]+`) is in principle permissive.
+
 ### Rewrite mechanics
 
 - Only entries whose computed coordinates **differ** from the current ones are
   rewritten — minimal toml diff, and a second `--fix` run is a no-op.
 - Rewriting is line-precise: on `entry.toml_line`, substitute the old quoted
   regex with the new one. The new regex is the old with its coordinates swapped
-  via `_LITERAL_LINECOL.sub(":{line}:{col}:", regex, count=1)`. Quote character,
-  trailing comma, indentation, and the guard-tag comment above are byte-
-  preserved.
+  via `_LITERAL_LINECOL.sub(f":{line}:{col}:", regex, count=1)` (an f-string
+  literal — the coordinates contain no backslash, so a plain replacement string
+  is safe here, unlike the wildcard call above). Quote character, trailing
+  comma, indentation, and the guard-tag comment above are byte-preserved; the
+  guard tag's `op`/`fn`/`rows` are never touched (they live in the comment, not
+  the rewritten regex).
+- Rewrites are applied and printed in ascending `entry.toml_line` order, so the
+  toml diff and the summary output are deterministic regardless of the
+  set-iteration order used to discover sibling groups.
 - Each rewrite prints a line of the form:
   `re-anchored [mutants.toml:42] :1039:29: -> :1041:30:`.
 
@@ -106,17 +134,28 @@ reformatting of the file. `--fix` inherits, and does not widen, that contract.
 - New `--fix` flag on `main()`. It works with the existing `--mutants-json`
   (offline, as the pre-commit hook and CI already produce the list) or invokes
   `cargo mutants --no-config --list --json` itself when that flag is absent.
-- Flow under `--fix`:
+  `--fix` trusts the supplied JSON to reflect the *current* source: a stale list
+  (generated before the edit that caused the drift) would re-anchor to old
+  coordinates and then validate clean against that same stale list. The
+  pre-commit hook always regenerates the list fresh, so this is safe in
+  practice; for interactive re-anchoring, prefer running `--fix` without
+  `--mutants-json` so it lists live.
+- Flow under `--fix` — exactly one rewrite pass followed by one validation pass,
+  no fixpoint iteration:
   1. load entries + mutants,
   2. compute rewrites (per the rules above),
   3. write the rewritten toml,
-  4. print the rewrite summary,
-  5. **re-validate the rewritten toml** via the existing `check()`,
-  6. exit `0` only if validation is clean.
+  4. print the rewrite summary (ascending `toml_line`),
+  5. **re-read and re-parse the rewritten toml from disk**
+     (`parse_toml_entries(args.toml.read_text())`) and run `check()` on those
+     fresh entries — never the pre-rewrite in-memory `entries`, whose regex and
+     `toml_line` are now stale,
+  6. exit `0` only if that validation is clean.
 - Remaining failures after a fix (desc-count drift, structural `linecol`
-  groups) are printed exactly as `check()` reports them today, plus a per-group
-  "left untouched — needs manual re-anchor" note. Exit is non-zero whenever any
-  entry still fails.
+  groups, zero-candidate deleted-code entries, tagless entries) are printed
+  exactly as `check()` reports them, plus the per-case note from the rules above
+  ("left untouched — needs manual re-anchor", or the deletion-oriented wording
+  for zero-candidate). Exit is non-zero whenever any entry still fails.
 
 ### Hook / CI integration
 
@@ -137,10 +176,16 @@ temporary toml:
 - repl-suffixed entry remap (`replace \+ with -`);
 - structural-change group (site count changed) → untouched, reported, non-zero
   exit;
+- zero-candidate / deleted-code entry → untouched, reported with the deletion-
+  oriented message, non-zero exit;
+- tagless / incomplete-guard `linecol` entry → skipped by `--fix`, surfaced by
+  re-validation;
 - desc entries are never rewritten;
 - partial-fix: one group remapped while another (structural) is reported;
 - idempotence: a second `--fix` produces no changes;
-- non-coordinate bytes (comments, guard tags, formatting) are preserved exactly.
+- non-coordinate bytes (comments, guard tags, formatting) are preserved exactly,
+  and a remapped entry's `op=`/`fn=`/`rows=` guard tag is byte-identical after
+  the rewrite.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md
+++ b/docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md
@@ -82,16 +82,44 @@ Entries that resolve to the **identical candidate-site set** are siblings (e.g.
   site holds exactly `rows` matching mutants, then rewrite. Positional-by-source-
   order is safe because `cargo fmt` and ordinary edits preserve textual order;
   it correctly handles partial shifts within a group (only some sites moved).
-- If counts differ, or a mapped site's mutant count ≠ `rows`: this is a
-  **structural change, not a shift** (a site was added/removed, or the operator
-  count changed). Leave the whole group untouched and report it.
+- If counts differ, or a mapped site's mutant count ≠ `rows`: the coordinate
+  **cannot be auto-derived** — leave the whole group untouched and (subject to
+  the failure gate below) report it.
 
-The **zero-candidate** case (the entry's op/fn now matches *no* live site) is a
-distinct sub-case of "counts differ": the code was deleted, not moved, so a
-re-anchor is impossible. Report it with deletion-oriented wording — `matches no
-live mutant — code removed? delete this exclude_re entry` — rather than the
-generic "re-anchor" note, mirroring `_check_desc`'s "delete a dead rule"
-guidance.
+#### Why op/fn alone is not enough — the covering-set requirement
+
+A `file:line:col` anchor exists *precisely because* its `op`+`fn` is **not
+unique in the function** (that non-uniqueness is the documented reason it is
+pinned by coordinate rather than description). So an entry's `op`+`fn` typically
+resolves to **every** same-operator site in the function, not the one the anchor
+pins — e.g. `wav.rs:58:28` (`op="+" fn="walk_chunks"`) resolves to 9 live `+`
+sites; only one is excluded. The guard tag was designed to **validate a known
+coordinate**, not to **derive** one, and the literal coordinate (the only
+disambiguator) is exactly what wildcarding throws away.
+
+Positional re-derivation therefore only works for a **covering set**: a group
+where *every* same-`op`/`fn` site is anchored, so `#anchors == #sites` and the
+bijection is unambiguous (the `run_pipeline` `>=` cluster is one). When an anchor
+pins one of many sites (`#anchors < #sites`), the coordinate is unrecoverable
+from the tag — `--fix` must decline, never guess.
+
+The **zero-candidate** case (the entry's op/fn matches *no* live site) is the
+deleted-code variant: report it with deletion-oriented wording — `matches no
+live mutant — code removed? delete this exclude_re entry` — mirroring
+`_check_desc`'s "delete a dead rule" guidance.
+
+#### The failure gate (only report what actually broke)
+
+Because a non-covering anchor is the *normal* shape of a line:col entry, naively
+reporting every group that fails to map would fail a **clean, valid config**.
+So `--fix` first computes the set of entries that **currently fail `check()`**
+and only emits a skip-note / counts a group as a problem when at least one of its
+entries is in that failing set. A currently-valid non-covering anchor (its
+literal coordinate still matches) is left **silent** — `--fix` is not
+responsible for it until it actually drifts. This makes `--fix` on an unshifted
+tree a true no-op (exit 0), and surfaces a genuinely-drifted ambiguous anchor
+honestly as `can't auto-derive the coordinate, re-anchor manually` rather than
+mislabelling it a "structural change".
 
 Grouping by candidate-site set (rather than by raw `op`+`fn` strings) is what
 lets repl-suffixed and bare-prefix entries share one code path: two entries are
@@ -143,19 +171,28 @@ though `_NAME_RE`'s file group (`[^:]+`) is in principle permissive.
 - Flow under `--fix` — exactly one rewrite pass followed by one validation pass,
   no fixpoint iteration:
   1. load entries + mutants,
-  2. compute rewrites (per the rules above),
-  3. write the rewritten toml,
-  4. print the rewrite summary (ascending `toml_line`),
-  5. **re-read and re-parse the rewritten toml from disk**
+  2. compute the **currently-failing** set: `_failing_lines(check(entries,
+     mutants, globs))` (the toml line numbers `check()` flags *before* any
+     rewrite),
+  3. compute rewrites (per the rules above), then **filter** the unfixable
+     skip-notes / skipped-line set down to entries in the failing set (the
+     failure gate — a valid non-covering anchor produces a skip-note that is
+     dropped here),
+  4. write the rewritten toml,
+  5. print the rewrite summary (ascending `toml_line`),
+  6. **re-read and re-parse the rewritten toml from disk**
      (`parse_toml_entries(args.toml.read_text())`) and run `check()` on those
      fresh entries — never the pre-rewrite in-memory `entries`, whose regex and
-     `toml_line` are now stale,
-  6. exit `0` only if that validation is clean.
-- Remaining failures after a fix (desc-count drift, structural `linecol`
-  groups, zero-candidate deleted-code entries, tagless entries) are printed
-  exactly as `check()` reports them, plus the per-case note from the rules above
-  ("left untouched — needs manual re-anchor", or the deletion-oriented wording
-  for zero-candidate). Exit is non-zero whenever any entry still fails.
+     `toml_line` are now stale; the gated skipped-line set suppresses `check()`'s
+     generic message for entries already reported with better wording,
+  7. exit `0` only if no skip-notes remain and that validation is clean.
+- Remaining failures after a fix (desc-count drift, genuinely-drifted ambiguous
+  `linecol` anchors, zero-candidate deleted-code entries, tagless entries) are
+  printed with the per-case note from the rules above (`can't auto-derive the
+  coordinate, re-anchor manually`, or the deletion-oriented wording for
+  zero-candidate) plus any other `check()` failures. Exit is non-zero whenever
+  any entry still fails. A clean, unshifted tree produces no skip-notes and exits
+  `0`.
 
 ### Hook / CI integration
 
@@ -174,14 +211,18 @@ temporary toml:
 - single unambiguous remap (op/fn unique in file);
 - multi-site sibling group remap (the `>=` case);
 - repl-suffixed entry remap (`replace \+ with -`);
-- structural-change group (site count changed) → untouched, reported, non-zero
-  exit;
+- non-covering group (anchor count ≠ site count) → `can't auto-derive` note,
+  reported only when failing;
+- **valid non-unique-op/fn anchor on a clean tree → `--fix` is a silent no-op,
+  exit 0** (the failure-gate regression test for the #345 review finding);
+- drifted non-unique anchor → reported `can't auto-derive`, not rewritten,
+  non-zero exit;
 - zero-candidate / deleted-code entry → untouched, reported with the deletion-
   oriented message, non-zero exit;
 - tagless / incomplete-guard `linecol` entry → skipped by `--fix`, surfaced by
   re-validation;
 - desc entries are never rewritten;
-- partial-fix: one group remapped while another (structural) is reported;
+- partial-fix: one group remapped while another (deleted) is reported;
 - idempotence: a second `--fix` produces no changes;
 - non-coordinate bytes (comments, guard tags, formatting) are preserved exactly,
   and a remapped entry's `op=`/`fn=`/`rows=` guard tag is byte-identical after

--- a/docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md
+++ b/docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md
@@ -1,0 +1,153 @@
+# Auto-fix mode for `check_mutant_anchors.py` (`--fix`)
+
+Resolves [#345](https://github.com/Sohex/musefs/issues/345).
+
+## Problem
+
+Any edit to a mutation-tested source file (`musefs-core` / `musefs-format`
+`src/*.rs`) — including a plain `cargo fmt` reflow — shifts the `file:line:col`
+coordinates that `.cargo/mutants.toml`'s `exclude_re` entries are anchored on.
+The pre-commit/CI guard `scripts/check_mutant_anchors.py` then fails with
+"line likely shifted — re-anchor to current coordinates".
+
+Recovery is entirely manual today: regenerate the live mutant list, then for
+each failing entry cross-reference its `# guard:` tag against the new mutant
+set to find the current coordinates and hand-edit each anchor string. With a
+dozen-plus shifted entries from a single edit this is slow and easy to get
+wrong — mis-mapping two same-operator sites in one function, or silently
+re-pointing an anchor onto a killable mutant.
+
+The script already parses the guard tags and loads the mutant list to validate
+them, but it can only *report* drift, not *correct* it.
+
+## Goal
+
+Add a `--fix` flag that rewrites stale `linecol` coordinates in
+`.cargo/mutants.toml` in place, deriving each entry's current coordinates from
+the live mutant set. The fix must never re-point an anchor onto a different
+logical site by guessing: when an entry cannot be mapped unambiguously, it is
+left untouched and reported for manual attention.
+
+## Background: the two anchor kinds
+
+`check_mutant_anchors.py` validates two kinds of `exclude_re` entry, classified
+by `classify()` on the presence of a literal `:line:col:` in the regex:
+
+- **`linecol`** — e.g. `'musefs-core/src/scan\.rs:1041:32:'`, optionally with a
+  trailing repl description (`'...:1212:29: replace \+ with -'`). Guarded by a
+  `# guard: op=… fn=… rows=…` tag. These are the only anchors that drift on a
+  line shift.
+- **`desc`** — e.g. `'replace < with <= in VirtualTree::dirty_min_flip_ancestors'`.
+  Coordinate-free by design (deliberately chosen so `cargo fmt` cannot retire
+  them). Guarded by `# guard: count=…`. **Never touched by `--fix`.**
+
+`--fix` operates exclusively on `linecol` entries.
+
+## Design
+
+### Finding an entry's current coordinates
+
+For each `linecol` entry, the candidate live mutants are those matching **both**:
+
+1. the entry's regex with its coordinates wildcarded —
+   `_LITERAL_LINECOL.sub(":\\d+:\\d+:", regex, count=1)`. This preserves any
+   `replace \+ with -` repl suffix that narrows the match; for a bare
+   `file:line:col:` prefix (no op/repl in the regex) the wildcard adds no
+   constraint.
+2. the guard tag's `op` and `fn` (`expected_fn = None if tag.fn == ""`).
+
+The op/fn filter is what constrains bare-prefix entries — exactly mirroring how
+`_check_linecol` validates today. Candidates are grouped into distinct sites
+(`(file, line, col)`), sorted by `(line, col)`.
+
+### Disambiguating same-op/fn siblings
+
+Entries that resolve to the **identical candidate-site set** are siblings (e.g.
+`run_pipeline`'s four `>=` `rows=1` anchors at `1041:32`, `1041:62`, `1051:40`,
+`1051:70`). Within such a group:
+
+- Sort sibling entries by their **stale** `(line, col)`; sort candidate sites by
+  `(line, col)`.
+- If `len(entries) == len(sites)`: map positionally `i → i`, verify each mapped
+  site holds exactly `rows` matching mutants, then rewrite. Positional-by-source-
+  order is safe because `cargo fmt` and ordinary edits preserve textual order;
+  it correctly handles partial shifts within a group (only some sites moved).
+- If counts differ, or a mapped site's mutant count ≠ `rows`: this is a
+  **structural change, not a shift** (a site was added/removed, or the operator
+  count changed). Leave the whole group untouched and report it.
+
+Grouping by candidate-site set (rather than by raw `op`+`fn` strings) is what
+lets repl-suffixed and bare-prefix entries share one code path: two entries are
+siblings precisely when they are indistinguishable except by position.
+
+#### Documented limitation
+
+Positional mapping assumes source *order* is preserved. A genuine code
+*reordering* (moving a function or statement) could mis-map. This is no weaker
+than the validator's existing model, which already cannot distinguish two
+identical-`op`/`fn` sites except by position — the `# guard:` comments in
+`mutants.toml` already instruct devs to re-verify these coordinates after any
+reformatting of the file. `--fix` inherits, and does not widen, that contract.
+
+### Rewrite mechanics
+
+- Only entries whose computed coordinates **differ** from the current ones are
+  rewritten — minimal toml diff, and a second `--fix` run is a no-op.
+- Rewriting is line-precise: on `entry.toml_line`, substitute the old quoted
+  regex with the new one. The new regex is the old with its coordinates swapped
+  via `_LITERAL_LINECOL.sub(":{line}:{col}:", regex, count=1)`. Quote character,
+  trailing comma, indentation, and the guard-tag comment above are byte-
+  preserved.
+- Each rewrite prints a line of the form:
+  `re-anchored [mutants.toml:42] :1039:29: -> :1041:30:`.
+
+### CLI / UX
+
+- New `--fix` flag on `main()`. It works with the existing `--mutants-json`
+  (offline, as the pre-commit hook and CI already produce the list) or invokes
+  `cargo mutants --no-config --list --json` itself when that flag is absent.
+- Flow under `--fix`:
+  1. load entries + mutants,
+  2. compute rewrites (per the rules above),
+  3. write the rewritten toml,
+  4. print the rewrite summary,
+  5. **re-validate the rewritten toml** via the existing `check()`,
+  6. exit `0` only if validation is clean.
+- Remaining failures after a fix (desc-count drift, structural `linecol`
+  groups) are printed exactly as `check()` reports them today, plus a per-group
+  "left untouched — needs manual re-anchor" note. Exit is non-zero whenever any
+  entry still fails.
+
+### Hook / CI integration
+
+The `.githooks/pre-commit` guard and the CI `mutants.yml` job stay **read-only**
+— neither runs `--fix`. The pre-commit failure message gains a one-line pointer:
+
+> run `python3 scripts/check_mutant_anchors.py --fix` to re-anchor.
+
+No auto-re-stage, no mutation of staged state mid-commit.
+
+## Testing
+
+Extend `scripts/test_check_mutant_anchors.py` with synthetic mutant lists and a
+temporary toml:
+
+- single unambiguous remap (op/fn unique in file);
+- multi-site sibling group remap (the `>=` case);
+- repl-suffixed entry remap (`replace \+ with -`);
+- structural-change group (site count changed) → untouched, reported, non-zero
+  exit;
+- desc entries are never rewritten;
+- partial-fix: one group remapped while another (structural) is reported;
+- idempotence: a second `--fix` produces no changes;
+- non-coordinate bytes (comments, guard tags, formatting) are preserved exactly.
+
+## Out of scope
+
+- Hook auto-re-staging of the rewritten toml.
+- A `--dry-run` flag (the `--fix` rewrite summary is printed before the commit,
+  so it is already eyeball-able).
+- Any change to the anchor format, the `desc` model, or the validation rules.
+
+The change is purely additive: a new `--fix` path reusing the existing parse /
+match / validate code, plus its tests and a one-line hook-message update.

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -10,6 +10,7 @@ import json
 import re
 import subprocess
 import sys
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -102,6 +103,73 @@ def _candidate_mutants(entry: Entry, mutants: list[Mutant]) -> list[Mutant]:
     wild = re.compile(_wildcard_coords(entry.regex))
     expected_fn = None if t.fn == "" else t.fn
     return [m for m in mutants if wild.search(m.name) and m.op == t.op and m.fn == expected_fn]
+
+
+def compute_rewrites(
+    entries: list[Entry], mutants: list[Mutant]
+) -> tuple[list[Rewrite], list[str], set[int]]:
+    """Plan coordinate rewrites for drifted complete-tag linecol entries.
+
+    Returns (rewrites, skip_notes, skipped_lines). Entries are grouped by the
+    identical set of sites their op/fn resolves to; siblings in a group are mapped
+    to those sites positionally by source order (which fmt/edits preserve). A group
+    whose anchor count differs from its site count, or any of whose sites holds a
+    number of mutants other than the anchor's ``rows``, is a structural change — it
+    is left untouched and reported, never guessed. An entry resolving to no site is
+    deleted code, reported with deletion-oriented wording.
+    """
+    targets = [
+        e
+        for e in entries
+        if classify(e.regex) == "linecol"
+        and e.tag is not None
+        and e.tag.op is not None
+        and e.tag.fn_present
+        and e.tag.rows is not None
+    ]
+
+    rewrites: list[Rewrite] = []
+    skip_notes: list[str] = []
+    skipped: set[int] = set()
+
+    groups: dict[tuple, list[Entry]] = {}
+    matched_by_line: dict[int, list[Mutant]] = {}
+    for e in targets:
+        ms = _candidate_mutants(e, mutants)
+        matched_by_line[e.toml_line] = ms
+        sites = tuple(sorted({m.site for m in ms}))
+        if not sites:
+            skip_notes.append(
+                _fmt(e, "matches no live mutant — code removed? delete this exclude_re entry")
+            )
+            skipped.add(e.toml_line)
+            continue
+        groups.setdefault(sites, []).append(e)
+
+    for sites, group in groups.items():
+        group = sorted(group, key=lambda e: _entry_coords(e.regex))
+        counts = Counter(m.site for m in matched_by_line[group[0].toml_line])
+        mappable = len(group) == len(sites) and all(
+            counts[sites[i]] == group[i].tag.rows for i in range(len(group))
+        )
+        if not mappable:
+            for e in group:
+                skip_notes.append(
+                    _fmt(
+                        e,
+                        f"op/fn resolves to {len(sites)} site(s) but {len(group)} anchor(s) "
+                        "reference it — structural change, re-anchor manually",
+                    )
+                )
+                skipped.add(e.toml_line)
+            continue
+        for e, site in zip(group, sites):
+            _, line, col = site
+            if (line, col) != _entry_coords(e.regex):
+                rewrites.append(Rewrite(e, line, col))
+
+    rewrites.sort(key=lambda r: r.entry.toml_line)
+    return rewrites, skip_notes, skipped
 
 
 def classify(regex: str) -> str:

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -135,7 +135,10 @@ def compute_rewrites(
     groups: dict[tuple, list[Entry]] = {}
     matched_by_line: dict[int, list[Mutant]] = {}
     for e in targets:
-        ms = _candidate_mutants(e, mutants)
+        try:
+            ms = _candidate_mutants(e, mutants)
+        except re.error:
+            continue  # malformed regex; check() reports it gracefully in re-validation
         matched_by_line[e.toml_line] = ms
         sites = tuple(sorted({m.site for m in ms}))
         if not sites:
@@ -148,9 +151,9 @@ def compute_rewrites(
 
     for sites, group in groups.items():
         group = sorted(group, key=lambda e: _entry_coords(e.regex))
-        counts = Counter(m.site for m in matched_by_line[group[0].toml_line])
+        counts = {e.toml_line: Counter(m.site for m in matched_by_line[e.toml_line]) for e in group}
         mappable = len(group) == len(sites) and all(
-            counts[sites[i]] == group[i].tag.rows for i in range(len(group))
+            counts[e.toml_line][site] == e.tag.rows for e, site in zip(group, sites)
         )
         if not mappable:
             for e in group:

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -90,6 +90,20 @@ _COORD_RE = re.compile(r":([0-9]+):([0-9]+):")
 _ALLOWED_ESCAPES = set(".d+|^()*")
 
 
+def _candidate_mutants(entry: Entry, mutants: list[Mutant]) -> list[Mutant]:
+    """Live mutants a linecol entry's op/fn currently resolve to, ignoring its stale coords.
+
+    The entry's regex is matched with its coordinates wildcarded — preserving any
+    ``replace \\+ with -`` repl suffix that narrows the match — and the result is
+    further filtered by the guard tag's ``op`` and ``fn`` (``fn=""`` → free function,
+    matched as ``fn is None``). Mirrors the predicate ``_check_linecol`` validates with.
+    """
+    t = entry.tag
+    wild = re.compile(_wildcard_coords(entry.regex))
+    expected_fn = None if t.fn == "" else t.fn
+    return [m for m in mutants if wild.search(m.name) and m.op == t.op and m.fn == expected_fn]
+
+
 def classify(regex: str) -> str:
     return "linecol" if _LITERAL_LINECOL.search(regex) else "desc"
 

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -157,8 +157,8 @@ def compute_rewrites(
                 skip_notes.append(
                     _fmt(
                         e,
-                        f"op/fn resolves to {len(sites)} site(s) but {len(group)} anchor(s) "
-                        "reference it — structural change, re-anchor manually",
+                        f"op/fn resolves to {len(sites)} live site(s), {len(group)} anchor(s) "
+                        "pin it — can't auto-derive the coordinate, re-anchor manually",
                     )
                 )
                 skipped.add(e.toml_line)
@@ -188,14 +188,20 @@ def apply_rewrites(toml_text: str, rewrites: list[Rewrite]) -> str:
     return "".join(lines)
 
 
-def run_fix(toml_path: Path, entries: list[Entry], mutants: list[Mutant]) -> int:
+def run_fix(toml_path: Path, entries: list[Entry], globs: list[str], mutants: list[Mutant]) -> int:
     """Re-anchor drifted linecol coordinates in ``toml_path``, then re-validate.
 
     Exactly one rewrite pass followed by one validation pass — no fixpoint. Entries
-    that could not be safely re-anchored (structural / deleted) are reported with
-    their dedicated wording; re-validation handles the rest (desc drift, untagged).
+    that could not be safely re-anchored are reported with their dedicated wording
+    *only when they actually fail validation now* — an op/fn that resolves to many
+    sites is normal for a line:col anchor (that non-uniqueness is why it is pinned by
+    coordinate), so a currently-valid such entry is left silent rather than false-
+    flagged. Re-validation handles the rest (desc drift, untagged).
     """
+    failing = _failing_lines(check(entries, mutants, globs))
     rewrites, skip_notes, skipped = compute_rewrites(entries, mutants)
+    skip_notes = [n for n in skip_notes if _failing_lines([n]) <= failing]
+    skipped &= failing
     if rewrites:
         toml_path.write_text(apply_rewrites(toml_path.read_text(), rewrites))
         for rw in rewrites:
@@ -358,6 +364,14 @@ def _fmt(entry: Entry, msg: str) -> str:
     return f"[mutants.toml:{entry.toml_line}] /{entry.regex}/ — {msg}"
 
 
+_FAIL_LINE_RE = re.compile(r"^\[mutants\.toml:(\d+)\]")
+
+
+def _failing_lines(failures: list[str]) -> set[int]:
+    """Extract the toml line numbers a list of `_fmt` failure strings refers to."""
+    return {int(m.group(1)) for f in failures if (m := _FAIL_LINE_RE.match(f))}
+
+
 def _check_linecol(entry: Entry, matched: list[Mutant]) -> list[str]:
     t = entry.tag
     if t is None or t.op is None or not t.fn_present or t.rows is None:
@@ -477,7 +491,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.fix:
         try:
-            return run_fix(args.toml, entries, mutants)
+            return run_fix(args.toml, entries, globs, mutants)
         except OSError as ex:
             print(f"error: failed to rewrite {args.toml}: {ex}", file=sys.stderr)
             return 1

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -188,6 +188,41 @@ def apply_rewrites(toml_text: str, rewrites: list[Rewrite]) -> str:
     return "".join(lines)
 
 
+def run_fix(toml_path: Path, entries: list[Entry], mutants: list[Mutant]) -> int:
+    """Re-anchor drifted linecol coordinates in ``toml_path``, then re-validate.
+
+    Exactly one rewrite pass followed by one validation pass — no fixpoint. Entries
+    that could not be safely re-anchored (structural / deleted) are reported with
+    their dedicated wording; re-validation handles the rest (desc drift, untagged).
+    """
+    rewrites, skip_notes, skipped = compute_rewrites(entries, mutants)
+    if rewrites:
+        toml_path.write_text(apply_rewrites(toml_path.read_text(), rewrites))
+        for rw in rewrites:
+            old_line, old_col = _entry_coords(rw.entry.regex)
+            print(
+                f"re-anchored [mutants.toml:{rw.entry.toml_line}] "
+                f":{old_line}:{old_col}: -> :{rw.line}:{rw.col}:"
+            )
+    else:
+        print("no coordinates needed re-anchoring.")
+
+    fresh_entries, fresh_globs = parse_toml_entries(toml_path.read_text())
+    remaining = [
+        f
+        for f in check(fresh_entries, mutants, fresh_globs)
+        if not any(f"[mutants.toml:{ln}]" in f for ln in skipped)
+    ]
+    problems = skip_notes + remaining
+    if problems:
+        print(f"\n{len(problems)} entry(ies) still need manual attention:\n")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+    print(f"OK: {len(fresh_entries)} exclude_re entries validated against {len(mutants)} mutants.")
+    return 0
+
+
 def classify(regex: str) -> str:
     return "linecol" if _LITERAL_LINECOL.search(regex) else "desc"
 
@@ -425,6 +460,11 @@ def main(argv: list[str] | None = None) -> int:
         default=Path(".cargo/mutants.toml"),
         help="path to mutants.toml (default: .cargo/mutants.toml)",
     )
+    ap.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite drifted file:line:col anchors in --toml in place, then re-validate",
+    )
     args = ap.parse_args(argv)
 
     try:
@@ -434,6 +474,13 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, json.JSONDecodeError, ValueError, KeyError) as ex:
         print(f"error: failed to load toml/mutants: {ex}", file=sys.stderr)
         return 1
+
+    if args.fix:
+        try:
+            return run_fix(args.toml, entries, mutants)
+        except OSError as ex:
+            print(f"error: failed to rewrite {args.toml}: {ex}", file=sys.stderr)
+            return 1
 
     failures = check(entries, mutants, globs)
     if failures:

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -67,7 +67,25 @@ def parse_mutant(name: str) -> Mutant:
     )
 
 
+def _wildcard_coords(regex: str) -> str:
+    """Replace an entry regex's literal ``:line:col:`` with a ``:\\d+:\\d+:`` wildcard.
+
+    Uses a function replacement, not a literal one: a string replacement of
+    ``":\\d+:\\d+:"`` would have its ``\\d`` parsed as a replacement-template escape
+    and raise ``re.PatternError: bad escape \\d``.
+    """
+    return _LITERAL_LINECOL.sub(lambda _: r":\d+:\d+:", regex, count=1)
+
+
+def _entry_coords(regex: str) -> tuple[int, int]:
+    """Parse the (line, col) a linecol entry currently anchors on."""
+    m = _COORD_RE.search(regex)
+    assert m is not None  # caller guarantees classify(regex) == "linecol"
+    return int(m.group(1)), int(m.group(2))
+
+
 _LITERAL_LINECOL = re.compile(r":[0-9]+:[0-9]+:")
+_COORD_RE = re.compile(r":([0-9]+):([0-9]+):")
 
 _ALLOWED_ESCAPES = set(".d+|^()*")
 
@@ -141,6 +159,13 @@ class Entry:
     regex: str
     toml_line: int
     tag: Tag | None
+
+
+@dataclass
+class Rewrite:
+    entry: Entry
+    line: int
+    col: int
 
 
 def _unquote_toml_string(s: str) -> str:

--- a/scripts/check_mutant_anchors.py
+++ b/scripts/check_mutant_anchors.py
@@ -172,6 +172,22 @@ def compute_rewrites(
     return rewrites, skip_notes, skipped
 
 
+def apply_rewrites(toml_text: str, rewrites: list[Rewrite]) -> str:
+    """Return ``toml_text`` with each rewrite's ``:line:col:`` swapped in place.
+
+    Only the entry's own source line is touched; the new coordinates are an
+    f-string (no backslash, so a literal replacement is safe here, unlike the
+    wildcard in ``_wildcard_coords``). Quote char, comma, indentation, and the
+    guard-tag comment above are byte-preserved.
+    """
+    lines = toml_text.splitlines(keepends=True)
+    for rw in rewrites:
+        new_regex = _LITERAL_LINECOL.sub(f":{rw.line}:{rw.col}:", rw.entry.regex, count=1)
+        idx = rw.entry.toml_line - 1
+        lines[idx] = lines[idx].replace(rw.entry.regex, new_regex, 1)
+    return "".join(lines)
+
+
 def classify(regex: str) -> str:
     return "linecol" if _LITERAL_LINECOL.search(regex) else "desc"
 

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -538,3 +538,33 @@ def test_compute_rewrites_ignores_desc_and_tagless():
     muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
     rewrites, skips, skipped = g.compute_rewrites(entries, muts)
     assert rewrites == [] and skips == [] and skipped == set()
+
+
+def test_apply_rewrites_byte_preserving():
+    toml = (
+        "exclude_re = [\n"
+        '    # guard: op=">=" fn="run_pipeline" rows=1\n'
+        "    'musefs-core/src/scan\\.rs:1041:32:',\n"
+        "]\n"
+    )
+    entries, _ = g.parse_toml_entries(toml)
+    out = g.apply_rewrites(toml, [g.Rewrite(entries[0], 1043, 32)])
+    assert "scan\\.rs:1043:32:" in out
+    assert "scan\\.rs:1041:32:" not in out
+    # guard tag and overall structure untouched
+    assert 'op=">=" fn="run_pipeline" rows=1' in out
+    assert out.count("\n") == toml.count("\n")
+    # only the coordinate digits changed
+    assert out == toml.replace(":1041:32:", ":1043:32:")
+
+
+def test_apply_rewrites_preserves_repl_suffix():
+    toml = "exclude_re = [\n    'musefs-core/src/scan\\.rs:1212:29: replace \\+ with -',\n]\n"
+    entries, _ = g.parse_toml_entries(toml)
+    out = g.apply_rewrites(toml, [g.Rewrite(entries[0], 1220, 29)])
+    assert "scan\\.rs:1220:29: replace \\+ with -" in out
+
+
+def test_apply_rewrites_empty_is_identity():
+    toml = "exclude_re = [\n    'musefs-core/src/scan\\.rs:1041:32:',\n]\n"
+    assert g.apply_rewrites(toml, []) == toml

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -347,3 +347,48 @@ def test_wildcard_coords_replaces_only_first_linecol():
 def test_entry_coords_parses_line_col():
     assert g._entry_coords(r"musefs-core/src/scan\.rs:1041:32:") == (1041, 32)
     assert g._entry_coords(r"musefs-core/src/scan\.rs:1212:29: replace \+ with -") == (1212, 29)
+
+
+def test_candidate_mutants_bare_prefix_filters_by_op_fn():
+    entry = g.Entry(
+        r"musefs-core/src/scan\.rs:277:30:",
+        1,
+        g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+    )
+    muts = [
+        _m("musefs-core/src/scan.rs:300:30: replace < with == in probe_file"),
+        _m("musefs-core/src/scan.rs:305:10: replace + with - in probe_file"),  # wrong op
+        _m("musefs-core/src/scan.rs:310:10: replace < with == in other_fn"),  # wrong fn
+    ]
+    got = g._candidate_mutants(entry, muts)
+    assert [m.site for m in got] == [("musefs-core/src/scan.rs", 300, 30)]
+
+
+def test_candidate_mutants_repl_suffix_narrows():
+    entry = g.Entry(
+        r"musefs-core/src/scan\.rs:1212:29: replace \+ with -",
+        1,
+        g.Tag(op="+", fn="revalidate_with", fn_present=True, rows=1),
+    )
+    muts = [
+        _m("musefs-core/src/scan.rs:1220:29: replace + with - in revalidate_with"),
+        _m("musefs-core/src/scan.rs:1220:29: replace + with * in revalidate_with"),
+        # ^ suffix mismatch — different repl
+    ]
+    got = g._candidate_mutants(entry, muts)
+    assert [m.repl for m in got] == ["-"]
+
+
+def test_candidate_mutants_empty_fn_matches_free_function():
+    entry = g.Entry(
+        r"musefs-core/src/reader\.rs:71:60: replace / with [%*]",
+        1,
+        g.Tag(op="/", fn="", fn_present=True, rows=2),
+    )
+    muts = [
+        _m("musefs-core/src/reader.rs:80:60: replace / with %"),
+        _m("musefs-core/src/reader.rs:80:60: replace / with *"),
+    ]
+    got = g._candidate_mutants(entry, muts)
+    assert {m.site for m in got} == {("musefs-core/src/reader.rs", 80, 60)}
+    assert len(got) == 2

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -323,3 +323,27 @@ def test_load_mutants_from_json():
 def test_load_mutants_empty_is_error():
     with pytest.raises(ValueError):
         g.load_mutants("[]")
+
+
+def test_wildcard_coords_bare_prefix():
+    assert g._wildcard_coords(r"musefs-core/src/scan\.rs:1041:32:") == (
+        r"musefs-core/src/scan\.rs:\d+:\d+:"
+    )
+
+
+def test_wildcard_coords_preserves_repl_suffix():
+    assert g._wildcard_coords(r"musefs-core/src/scan\.rs:1212:29: replace \+ with -") == (
+        r"musefs-core/src/scan\.rs:\d+:\d+: replace \+ with -"
+    )
+
+
+def test_wildcard_coords_replaces_only_first_linecol():
+    # the suffix's own digits must survive untouched
+    assert g._wildcard_coords(r"foo/bar\.rs:10:20: replace 1 with 2") == (
+        r"foo/bar\.rs:\d+:\d+: replace 1 with 2"
+    )
+
+
+def test_entry_coords_parses_line_col():
+    assert g._entry_coords(r"musefs-core/src/scan\.rs:1041:32:") == (1041, 32)
+    assert g._entry_coords(r"musefs-core/src/scan\.rs:1212:29: replace \+ with -") == (1212, 29)

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -541,6 +541,38 @@ def test_compute_rewrites_ignores_desc_and_tagless():
     assert rewrites == [] and skips == [] and skipped == set()
 
 
+def test_compute_rewrites_skips_malformed_regex():
+    # A linecol regex can be malformed (unbalanced group); compute_rewrites must not
+    # raise — check() reports it gracefully in the re-validation pass instead.
+    entries = [g.Entry(r"foo\.rs:10:5:(", 3, g.Tag(op="+", fn="x", fn_present=True, rows=1))]
+    muts = [_m("foo.rs:10:5: replace + with - in x")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skips == [] and skipped == set()
+
+
+def test_compute_rewrites_mixed_narrowing_group_uses_per_entry_rows():
+    # A bare anchor (rows=2) and a repl-narrowed anchor (rows=1) resolve to the SAME
+    # two sites. The rows check must use each entry's own match set, not the first
+    # entry's — otherwise the narrowed entry is falsely judged unmappable.
+    entries = [
+        g.Entry(r"foo\.rs:10:5:", 3, g.Tag(op="+", fn="foo", fn_present=True, rows=2)),
+        g.Entry(
+            r"foo\.rs:20:5: replace \+ with -",
+            5,
+            g.Tag(op="+", fn="foo", fn_present=True, rows=1),
+        ),
+    ]
+    muts = [  # both sites shifted +100
+        _m("foo.rs:110:5: replace + with - in foo"),
+        _m("foo.rs:110:5: replace + with * in foo"),
+        _m("foo.rs:120:5: replace + with - in foo"),
+        _m("foo.rs:120:5: replace + with * in foo"),
+    ]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert skips == [] and skipped == set()
+    assert {(r.entry.toml_line, r.line, r.col) for r in rewrites} == {(3, 110, 5), (5, 120, 5)}
+
+
 def test_apply_rewrites_byte_preserving():
     toml = (
         "exclude_re = [\n"

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -512,7 +512,7 @@ def test_compute_rewrites_structural_count_mismatch():
     ]
     rewrites, skips, skipped = g.compute_rewrites(entries, muts)
     assert rewrites == [] and skipped == {4}
-    assert "structural change" in skips[0]
+    assert "can't auto-derive" in skips[0]
 
 
 def test_compute_rewrites_rows_mismatch_skips_group():
@@ -527,7 +527,7 @@ def test_compute_rewrites_rows_mismatch_skips_group():
     muts = [_m("musefs-core/src/scan.rs:1045:29: replace += with -= in run_pipeline")]
     rewrites, skips, skipped = g.compute_rewrites(entries, muts)
     assert rewrites == [] and skipped == {4}
-    assert "structural change" in skips[0]
+    assert "can't auto-derive" in skips[0]
 
 
 def test_compute_rewrites_ignores_desc_and_tagless():
@@ -648,3 +648,54 @@ def test_main_fix_no_op_when_clean(tmp_path, capsys):
     assert rc == 0
     assert toml.read_text() == _FIX_TOML
     assert "no coordinates needed re-anchoring" in capsys.readouterr().out
+
+
+# A line:col anchor exists precisely because op+fn is NOT unique in the function
+# (several same-op/fn sites, only one excluded). On a clean tree such an entry is
+# valid and --fix must leave it silent — never re-derive its coordinate from the
+# tag (impossible) and false-flag it. Regression for the #345 review finding.
+_NONUNIQUE_TOML = (
+    "exclude_re = [\n"
+    '    # guard: op="+" fn="walk" rows=1\n'
+    "    'musefs-format/src/wav\\.rs:58:28:',\n"
+    "]\n"
+)
+
+
+def test_main_fix_clean_nonunique_op_fn_is_noop(tmp_path, capsys):
+    toml = _write_toml(tmp_path, _NONUNIQUE_TOML)
+    muts = _write_muts(
+        tmp_path,
+        [
+            "musefs-format/src/wav.rs:58:28: replace + with - in walk",  # the excluded site (valid)
+            "musefs-format/src/wav.rs:60:10: replace + with - in walk",  # killable sibling
+            "musefs-format/src/wav.rs:62:14: replace + with - in walk",
+        ],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert toml.read_text() == _NONUNIQUE_TOML
+    assert "auto-derive" not in out and "manual attention" not in out
+
+
+def test_main_fix_drifted_nonunique_reports_manual(tmp_path, capsys):
+    body = (
+        "exclude_re = [\n"
+        '    # guard: op="+" fn="walk" rows=1\n'
+        "    'musefs-format/src/wav\\.rs:58:28:',\n"  # stale: no live mutant at 58:28
+        "]\n"
+    )
+    toml = _write_toml(tmp_path, body)
+    muts = _write_muts(
+        tmp_path,
+        [
+            "musefs-format/src/wav.rs:70:28: replace + with - in walk",
+            "musefs-format/src/wav.rs:72:10: replace + with - in walk",
+        ],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "auto-derive" in out
+    assert toml.read_text() == body  # ambiguous → not rewritten

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -392,3 +392,149 @@ def test_candidate_mutants_empty_fn_matches_free_function():
     got = g._candidate_mutants(entry, muts)
     assert {m.site for m in got} == {("musefs-core/src/reader.rs", 80, 60)}
     assert len(got) == 2
+
+
+def test_compute_rewrites_simple_shift():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            3,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:300:30: replace < with == in probe_file")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert skips == [] and skipped == set()
+    assert len(rewrites) == 1
+    assert (rewrites[0].entry.toml_line, rewrites[0].line, rewrites[0].col) == (3, 300, 30)
+
+
+def test_compute_rewrites_no_drift_is_noop():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            3,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skips == [] and skipped == set()
+
+
+def test_compute_rewrites_multisite_positional():
+    # two >= anchors in run_pipeline, both shifted down 2 lines; map low->low, high->high
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1041:32:",
+            5,
+            g.Tag(op=">=", fn="run_pipeline", fn_present=True, rows=1),
+        ),
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1051:40:",
+            9,
+            g.Tag(op=">=", fn="run_pipeline", fn_present=True, rows=1),
+        ),
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1043:32: replace >= with > in run_pipeline"),
+        _m("musefs-core/src/scan.rs:1053:40: replace >= with > in run_pipeline"),
+    ]
+    rewrites, skips, _ = g.compute_rewrites(entries, muts)
+    assert skips == []
+    assert {(r.entry.toml_line, r.line, r.col) for r in rewrites} == {
+        (5, 1043, 32),
+        (9, 1053, 40),
+    }
+
+
+def test_compute_rewrites_repl_suffixed():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1212:29: replace \+ with -",
+            3,
+            g.Tag(op="+", fn="revalidate_with", fn_present=True, rows=1),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1220:29: replace + with - in revalidate_with"),
+        _m("musefs-core/src/scan.rs:1220:29: replace + with * in revalidate_with"),
+    ]
+    rewrites, skips, _ = g.compute_rewrites(entries, muts)
+    assert skips == []
+    assert len(rewrites) == 1 and (rewrites[0].line, rewrites[0].col) == (1220, 29)
+
+
+def test_compute_rewrites_rows_two_site():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1039:29:",
+            3,
+            g.Tag(op="+=", fn="run_pipeline", fn_present=True, rows=2),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1045:29: replace += with -= in run_pipeline"),
+        _m("musefs-core/src/scan.rs:1045:29: replace += with *= in run_pipeline"),
+    ]
+    rewrites, skips, _ = g.compute_rewrites(entries, muts)
+    assert skips == []
+    assert len(rewrites) == 1 and (rewrites[0].line, rewrites[0].col) == (1045, 29)
+
+
+def test_compute_rewrites_zero_candidate_reports_deletion():
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:277:30:",
+            4,
+            g.Tag(op="<", fn="probe_file", fn_present=True, rows=1),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:500:10: replace + with - in other_fn")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skipped == {4}
+    assert len(skips) == 1 and "delete this exclude_re entry" in skips[0]
+
+
+def test_compute_rewrites_structural_count_mismatch():
+    # one anchor, op/fn now resolves to two sites -> refuse the whole group
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1041:32:",
+            4,
+            g.Tag(op=">=", fn="run_pipeline", fn_present=True, rows=1),
+        )
+    ]
+    muts = [
+        _m("musefs-core/src/scan.rs:1043:32: replace >= with > in run_pipeline"),
+        _m("musefs-core/src/scan.rs:1099:10: replace >= with > in run_pipeline"),
+    ]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skipped == {4}
+    assert "structural change" in skips[0]
+
+
+def test_compute_rewrites_rows_mismatch_skips_group():
+    # equinumerous (1 anchor, 1 site) but the site holds 1 mutant while rows=2
+    entries = [
+        g.Entry(
+            r"musefs-core/src/scan\.rs:1039:29:",
+            4,
+            g.Tag(op="+=", fn="run_pipeline", fn_present=True, rows=2),
+        )
+    ]
+    muts = [_m("musefs-core/src/scan.rs:1045:29: replace += with -= in run_pipeline")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skipped == {4}
+    assert "structural change" in skips[0]
+
+
+def test_compute_rewrites_ignores_desc_and_tagless():
+    entries = [
+        g.Entry(r"replace \| with \^ in synchsafe_decode", 3, g.Tag(count=3)),
+        g.Entry(r"musefs-core/src/scan\.rs:277:30:", 5, None),
+        g.Entry(r"musefs-core/src/scan\.rs:277:30:", 7, g.Tag(op="<")),
+    ]
+    muts = [_m("musefs-core/src/scan.rs:277:30: replace < with == in probe_file")]
+    rewrites, skips, skipped = g.compute_rewrites(entries, muts)
+    assert rewrites == [] and skips == [] and skipped == set()

--- a/scripts/test_check_mutant_anchors.py
+++ b/scripts/test_check_mutant_anchors.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -568,3 +569,82 @@ def test_apply_rewrites_preserves_repl_suffix():
 def test_apply_rewrites_empty_is_identity():
     toml = "exclude_re = [\n    'musefs-core/src/scan\\.rs:1041:32:',\n]\n"
     assert g.apply_rewrites(toml, []) == toml
+
+
+def _write_toml(tmp_path, body: str):
+    p = tmp_path / "mutants.toml"
+    p.write_text(body)
+    return p
+
+
+def _write_muts(tmp_path, names: list[str]):
+    p = tmp_path / "muts.json"
+    p.write_text(json.dumps([{"name": n} for n in names]))
+    return p
+
+
+_FIX_TOML = (
+    "exclude_re = [\n"
+    '    # guard: op="<" fn="probe_file" rows=1\n'
+    "    'musefs-core/src/scan\\.rs:277:30:',\n"
+    "]\n"
+)
+
+
+def test_main_fix_rewrites_and_passes(tmp_path, capsys):
+    toml = _write_toml(tmp_path, _FIX_TOML)
+    muts = _write_muts(
+        tmp_path,
+        ["musefs-core/src/scan.rs:300:30: replace < with == in probe_file"],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    assert rc == 0
+    assert "scan\\.rs:300:30:" in toml.read_text()
+    assert "scan\\.rs:277:30:" not in toml.read_text()
+    assert "re-anchored" in capsys.readouterr().out
+
+
+def test_main_fix_idempotent(tmp_path):
+    toml = _write_toml(tmp_path, _FIX_TOML)
+    muts = _write_muts(
+        tmp_path,
+        ["musefs-core/src/scan.rs:300:30: replace < with == in probe_file"],
+    )
+    assert g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)]) == 0
+    after_first = toml.read_text()
+    assert g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)]) == 0
+    assert toml.read_text() == after_first
+
+
+def test_main_fix_partial_reports_and_exits_nonzero(tmp_path, capsys):
+    # first entry is fixable; second resolves to no live mutant (deleted code)
+    body = (
+        "exclude_re = [\n"
+        '    # guard: op="<" fn="probe_file" rows=1\n'
+        "    'musefs-core/src/scan\\.rs:277:30:',\n"
+        '    # guard: op=">" fn="gone" rows=1\n'
+        "    'musefs-core/src/scan\\.rs:900:10:',\n"
+        "]\n"
+    )
+    toml = _write_toml(tmp_path, body)
+    muts = _write_muts(
+        tmp_path,
+        ["musefs-core/src/scan.rs:300:30: replace < with == in probe_file"],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "scan\\.rs:300:30:" in toml.read_text()  # the fixable one was still applied
+    assert "delete this exclude_re entry" in out
+
+
+def test_main_fix_no_op_when_clean(tmp_path, capsys):
+    toml = _write_toml(tmp_path, _FIX_TOML)
+    muts = _write_muts(
+        tmp_path,
+        ["musefs-core/src/scan.rs:277:30: replace < with == in probe_file"],
+    )
+    rc = g.main(["--fix", "--toml", str(toml), "--mutants-json", str(muts)])
+    assert rc == 0
+    assert toml.read_text() == _FIX_TOML
+    assert "no coordinates needed re-anchoring" in capsys.readouterr().out


### PR DESCRIPTION
Closes #345.

## What

Adds a `--fix` flag to `scripts/check_mutant_anchors.py` that re-anchors drifted
`file:line:col` exclusions in `.cargo/mutants.toml` in place, instead of only
reporting the drift. Today, any edit that shifts a mutation-tested line (even a
`cargo fmt` reflow) rots the coordinates and recovery is a slow, error-prone
manual cross-reference of every `# guard:` tag against the live mutant list.

```
python3 scripts/check_mutant_anchors.py --fix            # lists mutants live
python3 scripts/check_mutant_anchors.py --fix --mutants-json <list.json>
```

## How

- `_candidate_mutants` resolves an entry's current sites by its guard `op`+`fn`
  (coordinates wildcarded out of the regex, repl suffix preserved).
- `compute_rewrites` groups entries that resolve to the same site set and maps
  them **positionally by source order** (which `fmt`/edits preserve), verifying
  each mapped site holds exactly `rows` mutants before rewriting.
- `apply_rewrites` swaps only the `:line:col:` on the entry's own line —
  byte-preserving for quotes, comma, indentation, and the guard comment.
- `run_fix` applies, re-parses from disk, and re-validates via the existing
  `check()`.

### Key safety constraint (the covering-set limitation)

A `file:line:col` anchor exists *precisely because* its `op`+`fn` is **not unique
in the function** — so the tag alone cannot derive which site it pins. Positional
re-anchoring is therefore only sound for a **covering set** (every same-`op`/`fn`
site is excluded, e.g. the `run_pipeline` `>=` cluster). For a 1-of-N anchor the
coordinate is unrecoverable from the tag, and `--fix` declines rather than
guessing onto a killable mutant.

Because a non-covering anchor is the *normal* shape of a line:col entry, `--fix`
**gates** unfixable-entry reporting on whether the entry *actually fails*
`check()` now. A currently-valid anchor is left silent, so `--fix` on an
unshifted tree is a true no-op (exit 0); a genuinely-drifted ambiguous anchor is
reported honestly as `can't auto-derive the coordinate`.

The `.githooks/pre-commit` guard and CI `mutants.yml` stay **read-only**; the
hook's failure message now points at `--fix`.

## Testing

- 25 new unit + end-to-end tests in `scripts/test_check_mutant_anchors.py`
  (58 total pass), incl. positional remap, repl-suffixed remap, zero-candidate
  deletion, idempotence, byte-preservation, and the clean-tree no-op regression.
- Smoke-tested against the real 52-entry config: `--fix` is a no-op (exit 0,
  matching the read-only validator) and correctly repairs an injected drift.

Spec and plan: `docs/superpowers/specs/2026-06-14-mutant-anchor-autofix-design.md`,
`docs/superpowers/plans/2026-06-14-mutant-anchor-autofix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--fix` mode to automatically repair drifted mutant anchor coordinates in `.cargo/mutants.toml`.

* **Documentation**
  * Updated contribution guidelines with operational guidance on auto-repairing anchor coordinates.
  * Added implementation plan and design specification for anchor auto-fix functionality.

* **Tests**
  * Introduced comprehensive test coverage for coordinate resolution, rewrite logic, and end-to-end workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->