### PR TITLE
ci: performance-regression gating for the read path (#211)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,9 @@ jobs:
   perf-ab:
     name: Read A/B (warn-only)
     needs: changes
-    if: needs.changes.outputs.perf == 'true'
+    # PR-only: on push/tag events `pull_request.base.sha` is empty, so the A/B
+    # script has no base to bench against. The job is informational anyway.
+    if: needs.changes.outputs.perf == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       src: ${{ steps.filter.outputs.src }}
       fuse: ${{ steps.filter.outputs.fuse }}
       lidarr: ${{ steps.filter.outputs.lidarr }}
+      perf: ${{ steps.filter.outputs.perf }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -48,6 +49,7 @@ jobs:
             echo "src=true" >> "$GITHUB_OUTPUT"
             echo "fuse=true" >> "$GITHUB_OUTPUT"
             echo "lidarr=true" >> "$GITHUB_OUTPUT"
+            echo "perf=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           changed="$(git diff --name-only "$base...HEAD")"
@@ -74,6 +76,14 @@ jobs:
             echo "lidarr=true" >> "$GITHUB_OUTPUT"
           else
             echo "lidarr=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Read/synthesis surface only: the A/B wall-clock job is expensive
+          # (builds criterion twice), so gate it to changes that can actually
+          # move read latency. tests/ and benches/ are excluded by the anchors.
+          if printf '%s\n' "$changed" | grep -qE '^(musefs-core/src/|musefs-format/src/)'; then
+            echo "perf=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "perf=false" >> "$GITHUB_OUTPUT"
           fi
 
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,10 @@ jobs:
       - uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a
         with:
           usesh: true
+          # Pass/fail e2e gate — we keep no build artifacts, so skip the rsync
+          # sync-back of the large target/ tree, which has filled the host
+          # runner's disk ("No space left on device") at the end of a green run.
+          copyback: false
           prepare: sh scripts/freebsd-vm/provision.sh
           run: sh scripts/freebsd-vm/run-e2e.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,35 @@ jobs:
     if: needs.changes.outputs.lidarr == 'true'
     uses: ./.github/workflows/lidarr-smoke.yml
 
+  perf-ab:
+    name: Read A/B (warn-only)
+    needs: changes
+    if: needs.changes.outputs.perf == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Install libfuse3
+        run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
+      - name: Install critcmp
+        run: cargo install critcmp --locked --version 0.1.8
+      - name: Run A/B
+        run: scripts/perf-ab.sh "${{ github.event.pull_request.base.sha }}" "$RUNNER_TEMP/perf-ab.md"
+      - name: Comment (same-repo PRs)
+        if: github.event.pull_request.head.repo.fork == false
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
+        with:
+          header: perf-ab
+          path: ${{ runner.temp }}/perf-ab.md
+      - name: Job summary (fallback / forks)
+        if: always()
+        run: cat "$RUNNER_TEMP/perf-ab.md" >> "$GITHUB_STEP_SUMMARY"
+
   # Single required status check for branch protection. Always runs (even when
   # the heavy jobs were skipped on a docs-only change) so the check is always
   # reported; green when every needed job either succeeded or was skipped, red

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,3 +385,23 @@ jobs:
               --notes "Prebuilt binaries for ${GITHUB_REF_NAME}. Verify with: sha256sum -c <file>.sha256"
           fi
           gh release upload "$GITHUB_REF_NAME" dist/*.tar.gz dist/*.sha256 --clobber
+
+  benchmarks:
+    name: Benchmark snapshot
+    runs-on: ubuntu-latest
+    continue-on-error: true # record-only; never blocks a release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Install libfuse3
+        run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
+      - name: Run benchmarks
+        run: scripts/perf-release-bench.sh "$RUNNER_TEMP/bench-snapshot.txt"
+      - name: Upload snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: benchmark-snapshot-${{ github.ref_name }}
+          path: ${{ runner.temp }}/bench-snapshot.txt

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -65,6 +65,23 @@ deployment-representative tier.
 
 ---
 
+## CI regression gating
+
+`BENCHMARKS.md` records hand-run absolute numbers; CI guards against regressions
+in three lanes:
+
+1. **Counter gate (every non-doc PR, hard).** `perf_counters.rs` +
+   `tree.rs` golden work-counter assertions under `--features metrics`. Catches
+   algorithmic regressions (extra copy, whole-file slurp, O(N) tree rebuild).
+2. **A/B wall-clock (warn-only, core `src` PRs).** The `perf-ab` job benches the
+   base and PR commits back-to-back on one runner and posts a `critcmp` delta as
+   a PR comment. Never blocks.
+3. **Release record.** The `benchmarks` job runs the full bench suite at the
+   `ci` tier on a tag and uploads the numbers as an artifact for curation here.
+
+The fsync-storm (403→0) signal needs a real FUSE mount and lives only in the
+release lane / the `#[ignore]` `bench_scan_under_latency`, not the per-PR gate.
+
 ## Methodology
 
 ### Machine

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -82,6 +82,9 @@ in three lanes:
 The fsync-storm (403→0) signal needs a real FUSE mount and lives only in the
 release lane / the `#[ignore]` `bench_scan_under_latency`, not the per-PR gate.
 
+The release artifact is named `benchmark-snapshot-<tag>`; download it from the
+tag's workflow run and fold the numbers into the per-pass tables here.
+
 ## Methodology
 
 ### Machine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,6 +360,17 @@ Sharp edges:
   Rust-regex/Python-`re` shared subset the guard allows (`\. \d + | ^ ( ) *`,
   no inline `(?...)` groups).
 
+### Performance regression gating
+
+`cargo test -p musefs-core --features metrics` includes
+`tests/perf_counters.rs`: golden assertions on deterministic work counters
+(`preads`, `pread_bytes`, `scan_bytes_read`, art/binary-tag chunks) for the
+read/serve and ingest paths, plus a `tree.rs` unit test pinning the refresh
+rebuild count as size-invariant. These are a hard gate — a legitimate change to
+read/ingest/refresh work must update the golden numbers in the same PR. They run
+on every non-doc PR via CI's `check` job. Constant-factor (wall-clock) changes
+are surfaced separately by the warn-only `perf-ab` job (below).
+
 ### Concurrency + sanitizers
 
 Concurrent-reader coverage exists at two levels:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,6 +371,12 @@ read/ingest/refresh work must update the golden numbers in the same PR. They run
 on every non-doc PR via CI's `check` job. Constant-factor (wall-clock) changes
 are surfaced separately by the warn-only `perf-ab` job (below).
 
+The `perf-ab` job runs only when `musefs-core/src/**` or `musefs-format/src/**`
+change. It benches the base and PR commits back-to-back on one runner and posts a
+`critcmp` delta as a sticky PR comment. It is **warn-only** and not a required
+check — GH runner noise makes wall-clock unfit for hard gating. Reproduce locally
+with `scripts/perf-ab.sh <base-sha> out.md`.
+
 ### Concurrency + sanitizers
 
 Concurrent-reader coverage exists at two levels:

--- a/docs/superpowers/plans/2026-06-14-ci-perf-regression-gating.md
+++ b/docs/superpowers/plans/2026-06-14-ci-perf-regression-gating.md
@@ -1,0 +1,800 @@
+# CI Performance-Regression Gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give musefs CI a regression signal for the read/serve, ingest, and refresh paths without flaky wall-clock gating.
+
+**Architecture:** Three independently-shippable PRs. PR1 is a hard, zero-flake gate of deterministic work *counters* (reusing the existing `metrics` feature — no production code). PR2 adds a warn-only same-runner A/B wall-clock job that runs only when read/synthesis `src` changes. PR3 records a full bench snapshot at release time as an artifact.
+
+**Tech Stack:** Rust, `cargo test --features metrics`, criterion (`read_throughput` bench), `critcmp`, GitHub Actions, bash.
+
+**Source spec:** `docs/superpowers/specs/2026-06-14-ci-perf-regression-gating-design.md`
+
+---
+
+## File structure
+
+| File | PR | Responsibility |
+| ---- | -- | -------------- |
+| `musefs-core/tests/perf_counters.rs` | 1 | New `--features metrics` test module: per-format golden read counters + ingest slurp-window counters. |
+| `musefs-core/src/tree.rs` | 1 | One new unit test appended to the existing `#[cfg(test)] mod` asserting `apply_changes` rebuild count is size-invariant. |
+| `CONTRIBUTING.md`, `BENCHMARKS.md` | 1 | Document the counter gate + (PR2) the A/B job. |
+| `scripts/perf-ab.sh` | 2 | Same-runner base-vs-PR criterion A/B + critcmp; emits a markdown table. |
+| `.github/workflows/ci.yml` | 2 | New `perf` output on the `changes` job; new `perf-ab` job. |
+| `scripts/perf-release-bench.sh` | 3 | Run the full read bench + `ci`-tier ingest/refresh benches, capture output. |
+| `.github/workflows/release.yml` | 3 | New `benchmarks` job uploading the snapshot artifact. |
+
+**Key existing APIs (verified, do not re-derive):**
+- `common::corpus::{ALL_FORMATS, Format, CorpusParams, prepare_format, format_token, Target}` — `prepare_format(&params, base, fmt) -> Target { corpus_dir, .. }` generates a single-format corpus under `base/<token>/`.
+- `musefs_core::{Musefs, MountConfig, Mode, VirtualTree, scan_directory, metrics}`; `metrics::{reset, snapshot, Snapshot}`. `Snapshot` fields: `opens, stats, preads, pread_bytes, art_chunks, binary_tag_chunks, scan_opens, scan_preads, scan_bytes_read`.
+- `fs.readdir(ino) -> Vec<(String, u64, bool)>` (name, inode, is_dir); `fs.getattr(ino).size`; `fs.read(ino, None, off, len) -> Vec<u8>`; `VirtualTree::ROOT`.
+- In `tree.rs` test module: `VirtualTree::build_with(&[(i64,String)], &mut alloc)`, `InodeAllocator::new(false)`, `trs(path) -> TrackRenderState`, `apply_changes(&new_paths, changed, added, removed, &mut alloc) -> Result<usize, RebuildError>` where `usize` is the rebuild-subtree count.
+- `metrics` counters are process-global; serialize cases with a `static METRICS_LOCK: Mutex<()>` and `metrics::reset()` before each measured region (pattern: `musefs-core/tests/metrics.rs`).
+
+---
+
+# PR 1 — Lane 1: deterministic counter gate (no production code)
+
+Runs in the existing `check` job's "Core metrics-feature tests" step
+(`cargo test -p musefs-core --features metrics`) — no workflow change. Must land
+green (the pre-commit hook runs the full workspace suite).
+
+### Task 1.1: read-counter module scaffold + sequential-read goldens
+
+**Files:**
+- Create: `musefs-core/tests/perf_counters.rs`
+
+- [ ] **Step 1: Write the module skeleton with the shared fixture + lock**
+
+```rust
+#![cfg(feature = "metrics")]
+
+mod common;
+use common::corpus::{ALL_FORMATS, CorpusParams, Format, format_token, prepare_format};
+use musefs_core::{Mode, MountConfig, Musefs, VirtualTree, metrics, scan_directory};
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+/// The `metrics` counters are global statics; serialize every measured region.
+static METRICS_LOCK: Mutex<()> = Mutex::new(());
+
+/// Audio payload size for every read golden (4 MiB, matching `read_throughput`).
+const AUDIO_BYTES: u64 = 4 * 1024 * 1024;
+/// 128 KiB read chunk (matching `read_throughput`).
+const CHUNK: u64 = 128 * 1024;
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$album/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
+    }
+}
+
+/// Recursively collect every file inode (non-FLAC corpus tracks render under
+/// the `Unknown/` fallback, so we discover by a format-agnostic tree walk).
+fn collect_file_inodes(fs: &Musefs, dir: u64, out: &mut Vec<u64>) {
+    for (_, ino, is_dir) in fs.readdir(dir).unwrap() {
+        if is_dir {
+            collect_file_inodes(fs, ino, out);
+        } else {
+            out.push(ino);
+        }
+    }
+}
+
+/// Generate a single-format corpus (audio-only, fixed seed/size), scan + mount,
+/// and return (fs, first-file-inode, tempdir-guard).
+fn mount_one(fmt: Format, bytes_per_track: usize, art_bytes_per_track: usize)
+    -> (Musefs, u64, tempfile::TempDir)
+{
+    let base = tempfile::tempdir().unwrap();
+    let params = CorpusParams {
+        albums: 1,
+        tracks_per_album: 1,
+        bytes_per_track,
+        art_bytes_per_track,
+        format_mix: vec![fmt],
+        seed: 42,
+    };
+    let target = prepare_format(&params, base.path(), fmt);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+    let mut inodes = Vec::new();
+    collect_file_inodes(&fs, VirtualTree::ROOT, &mut inodes);
+    assert!(!inodes.is_empty(), "no file inodes for {fmt:?}");
+    (fs, inodes[0], base)
+}
+
+fn read_whole(fs: &Musefs, inode: u64) {
+    let size = fs.getattr(inode).unwrap().size;
+    let mut off = 0u64;
+    while off < size {
+        let got = fs.read(inode, None, off, CHUNK).unwrap();
+        if got.is_empty() {
+            break;
+        }
+        off += got.len() as u64;
+    }
+}
+```
+
+- [ ] **Step 2: Add the sequential-read golden test (audio read exactly once, no art/tags)**
+
+```rust
+/// Whole-file sequential read of an audio-only file: the audio payload is read
+/// exactly once (no slurp / no over-read), and no art or binary-tag chunks are
+/// emitted. `pread_bytes` is the load-bearing slurp guard.
+#[test]
+fn sequential_read_audio_read_exactly_once() {
+    let _g = METRICS_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    for &fmt in ALL_FORMATS {
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize, 0);
+        metrics::reset();
+        read_whole(&fs, inode);
+        let s = metrics::snapshot();
+        assert_eq!(
+            s.pread_bytes, AUDIO_BYTES,
+            "{}: audio body must be read exactly once (slurp/over-read guard)",
+            format_token(fmt),
+        );
+        assert_eq!(s.art_chunks, 0, "{}: audio-only must emit no art chunks", format_token(fmt));
+        assert_eq!(
+            s.binary_tag_chunks, 0,
+            "{}: audio-only must emit no binary-tag chunks", format_token(fmt),
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Run the test, expect PASS**
+
+Run: `cargo test -p musefs-core --features metrics --test perf_counters sequential_read_audio_read_exactly_once -- --nocapture`
+Expected: PASS. (If `pread_bytes` differs for a format, that is a real finding — investigate before adjusting; the audio payload is read once by construction.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add musefs-core/tests/perf_counters.rs
+git commit -m "test(core): golden sequential-read counters per format (#211)"
+```
+
+### Task 1.2: freeze per-format `preads` + seek goldens (characterization)
+
+`preads` (syscall count) and the seek read's `pread_bytes` are deterministic but
+format-specific; observe them once and pin them as constants.
+
+**Files:**
+- Modify: `musefs-core/tests/perf_counters.rs`
+
+- [ ] **Step 1: Add a per-format expected-constants table and the seek fixture, using sentinel `0`s to be filled in Step 3**
+
+```rust
+/// Frozen per-format goldens. `(seq_preads, seek_preads, seek_pread_bytes)`.
+/// seek = one 128 KiB read near EOF; it must touch a BOUNDED window, never the
+/// whole file/index. Filled by the characterization run in Step 3 — a change
+/// here means real read-path work changed; update in the same PR.
+fn goldens(fmt: Format) -> (u64, u64, u64) {
+    match fmt {
+        Format::Flac => (0, 0, 0),
+        Format::Mp3 => (0, 0, 0),
+        Format::M4aMoovFirst => (0, 0, 0),
+        Format::M4aMoovLast => (0, 0, 0),
+        Format::Ogg => (0, 0, 0),
+        Format::Wav => (0, 0, 0),
+    }
+}
+
+const SEEK_OFF: u64 = 3_500_000;
+
+#[test]
+fn read_preads_and_seek_match_goldens() {
+    let _g = METRICS_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    for &fmt in ALL_FORMATS {
+        let (exp_seq_preads, exp_seek_preads, exp_seek_bytes) = goldens(fmt);
+
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize, 0);
+        metrics::reset();
+        read_whole(&fs, inode);
+        let seq = metrics::snapshot();
+        assert_eq!(seq.preads, exp_seq_preads, "{}: sequential preads", format_token(fmt));
+
+        // Fresh mount → cold cache → single deep read.
+        let (fs2, inode2, _dir2) = mount_one(fmt, AUDIO_BYTES as usize, 0);
+        metrics::reset();
+        let _ = fs2.read(inode2, None, SEEK_OFF, CHUNK).unwrap();
+        let seek = metrics::snapshot();
+        assert_eq!(seek.preads, exp_seek_preads, "{}: seek preads", format_token(fmt));
+        assert_eq!(
+            seek.pread_bytes, exp_seek_bytes,
+            "{}: seek must read a bounded window, not the whole file/index", format_token(fmt),
+        );
+        assert!(
+            seek.pread_bytes < AUDIO_BYTES / 4,
+            "{}: seek read {} bytes — not a bounded window", format_token(fmt), seek.pread_bytes,
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to characterize — it will FAIL and print actual vs expected**
+
+Run: `cargo test -p musefs-core --features metrics --test perf_counters read_preads_and_seek_match_goldens -- --nocapture`
+Expected: FAIL. Each panic line prints the actual value, e.g. `flac: sequential preads ... left: 33, right: 0`. Record the actual `seq.preads`, `seek.preads`, and `seek.pread_bytes` for every format.
+
+- [ ] **Step 3: Replace the sentinel `0`s in `goldens()` with the observed values**
+
+Edit `goldens()` so each arm holds the `(seq_preads, seek_preads, seek_pread_bytes)` triple you recorded. Example shape (your numbers will differ):
+
+```rust
+        Format::Flac => (33, 1, 131072),
+```
+
+- [ ] **Step 4: Re-run, expect PASS**
+
+Run: `cargo test -p musefs-core --features metrics --test perf_counters read_preads_and_seek_match_goldens -- --nocapture`
+Expected: PASS for all six formats. Confirm every `seek_pread_bytes` is well under `AUDIO_BYTES/4` (the bounded-window invariant).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/perf_counters.rs
+git commit -m "test(core): freeze per-format read preads + bounded-seek goldens (#211)"
+```
+
+### Task 1.3: ingest slurp-window golden
+
+A corpus whose files exceed the ~1 MiB bounded metadata window, so a reintroduced
+whole-file slurp inflates `scan_bytes_read`.
+
+**Files:**
+- Modify: `musefs-core/tests/perf_counters.rs`
+
+- [ ] **Step 1: Add the ingest test (FLAC, 2 MiB/track > window), sentinel `0`s**
+
+```rust
+/// Ingest of files LARGER than the ~1 MiB bounded metadata window: the scanner
+/// reads only a bounded prefix, never the whole file. A reintroduced slurp shows
+/// up as `scan_bytes_read` jumping toward `tracks * 2 MiB`. Counts frozen below.
+#[test]
+fn ingest_reads_bounded_prefix_not_whole_file() {
+    let _g = METRICS_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    const TRACKS: usize = 3;
+    const BYTES_PER_TRACK: usize = 2 * 1024 * 1024; // > 1 MiB scan window
+    // (scan_opens, scan_preads, scan_bytes_read) — filled in Step 3.
+    let (exp_opens, exp_preads, exp_bytes): (u64, u64, u64) = (0, 0, 0);
+
+    let base = tempfile::tempdir().unwrap();
+    let params = CorpusParams {
+        albums: 1,
+        tracks_per_album: TRACKS,
+        bytes_per_track: BYTES_PER_TRACK,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 42,
+    };
+    let target = prepare_format(&params, base.path(), Format::Flac);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    metrics::reset();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let s = metrics::snapshot();
+
+    assert_eq!(s.scan_opens, exp_opens, "scan_opens");
+    assert_eq!(s.scan_preads, exp_preads, "scan_preads");
+    assert_eq!(s.scan_bytes_read, exp_bytes, "scan_bytes_read");
+    // Hard upper bound independent of the frozen number: must be far below a slurp.
+    assert!(
+        s.scan_bytes_read < (TRACKS as u64) * BYTES_PER_TRACK as u64 / 2,
+        "scan read {} bytes — looks like a whole-file slurp", s.scan_bytes_read,
+    );
+}
+```
+
+- [ ] **Step 2: Run to characterize — FAIL prints actuals**
+
+Run: `cargo test -p musefs-core --features metrics --test perf_counters ingest_reads_bounded_prefix_not_whole_file -- --nocapture`
+Expected: FAIL printing actual `scan_opens` (expect 3), `scan_preads`, `scan_bytes_read`. Record them.
+
+- [ ] **Step 3: Replace the `(0, 0, 0)` tuple with the observed values**
+
+```rust
+    let (exp_opens, exp_preads, exp_bytes): (u64, u64, u64) = (3, /*…*/, /*…*/);
+```
+
+- [ ] **Step 4: Re-run, expect PASS; confirm `scan_bytes_read` ≪ slurp bound**
+
+Run: `cargo test -p musefs-core --features metrics --test perf_counters ingest_reads_bounded_prefix_not_whole_file -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/tests/perf_counters.rs
+git commit -m "test(core): ingest bounded-prefix scan_bytes golden (#211)"
+```
+
+### Task 1.4: refresh size-invariance unit test (in `tree.rs`)
+
+`apply_changes` is `pub(crate)`, so this lives in the in-module test suite.
+**Append at the very end of the `#[cfg(test)] mod` (before its closing `}`)** so
+no line shifts above the `InodeAllocator` mutants anchors.
+
+**Files:**
+- Modify: `musefs-core/src/tree.rs` (end of the test module)
+
+- [ ] **Step 1: Confirm the current `.cargo/mutants.toml` anchors pass (baseline)**
+
+Run: `python3 scripts/check_mutant_anchors.py` (or the path the pre-commit hook uses — `grep -n mutant_anchors .pre-commit-config.yaml` to find it)
+Expected: exits 0 (anchors valid before the edit).
+
+- [ ] **Step 2: Append the test at the end of the test module**
+
+Insert immediately before the final closing `}` of `mod tests` (after `dot_and_dotdot_plain_components_are_dropped`):
+
+```rust
+    /// Builds a many-album library, re-tags ONE track (renaming its leaf within
+    /// its own album dir), and asserts `apply_changes` rebuilds exactly one
+    /// subtree — *regardless of library size*. A reintroduced full reconstruction
+    /// would rebuild every album dir, so the count would scale with size.
+    fn library(albums: usize) -> Vec<(i64, String)> {
+        let mut e = Vec::new();
+        for a in 0..albums {
+            for t in 0..3 {
+                let id = (a * 3 + t) as i64;
+                e.push((id, format!("Album{a:04}/t{t}.flac")));
+            }
+        }
+        e
+    }
+
+    fn rebuilds_for_one_retag(albums: usize) -> usize {
+        let entries = library(albums);
+        let mut alloc = InodeAllocator::new(false);
+        let mut t = VirtualTree::build_with(&entries, &mut alloc);
+        // Re-tag track id 1 (Album0000/t1.flac) → renamed leaf in the SAME dir.
+        let changed_id: i64 = 1;
+        let mut new_entries = entries.clone();
+        for (id, path) in &mut new_entries {
+            if *id == changed_id {
+                *path = "Album0000/renamed.flac".to_string();
+            }
+        }
+        let new_paths: std::collections::HashMap<i64, TrackRenderState> =
+            new_entries.iter().map(|&(id, ref p)| (id, trs(p))).collect();
+        t.apply_changes(&new_paths, &[changed_id], &[], &[], &mut alloc)
+            .unwrap()
+    }
+
+    #[test]
+    fn apply_changes_rebuild_count_is_size_invariant() {
+        let small = rebuilds_for_one_retag(43); // 129 tracks
+        let large = rebuilds_for_one_retag(683); // 2049 tracks
+        assert_eq!(small, 1, "one re-tag must rebuild exactly its own album dir");
+        assert_eq!(
+            small, large,
+            "rebuild count must not grow with library size (O(changed), not O(N))",
+        );
+    }
+```
+
+- [ ] **Step 3: Run the new test, expect PASS**
+
+Run: `cargo test -p musefs-core apply_changes_rebuild_count_is_size_invariant -- --nocapture`
+Expected: PASS. (If `small != 1`, the re-tag is touching more than its dir — investigate; do not loosen the assertion to match.)
+
+- [ ] **Step 4: Re-check mutants anchors are still valid**
+
+Run: `python3 scripts/check_mutant_anchors.py`
+Expected: exits 0. If it fails, re-anchor the shifted `.cargo/mutants.toml` entries (each via its `# guard:` tag) in this same change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/tree.rs
+git commit -m "test(core): assert refresh rebuild count is size-invariant (#211)"
+```
+
+### Task 1.5: documentation
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (test-tiers section)
+- Modify: `BENCHMARKS.md` (new subsection)
+
+- [ ] **Step 1: Find the CONTRIBUTING test-tiers anchor**
+
+Run: `grep -nE "^#+ .*[Tt]est|mutation gate|test tiers" CONTRIBUTING.md | head`
+Expected: a heading under which the test tiers (fuzzing, interop, mutation gate) are described.
+
+- [ ] **Step 2: Add a "Performance regression gating" paragraph under that section**
+
+```markdown
+### Performance regression gating
+
+`cargo test -p musefs-core --features metrics` includes
+`tests/perf_counters.rs`: golden assertions on deterministic work counters
+(`preads`, `pread_bytes`, `scan_bytes_read`, art/binary-tag chunks) for the
+read/serve and ingest paths, plus a `tree.rs` unit test pinning the refresh
+rebuild count as size-invariant. These are a hard gate — a legitimate change to
+read/ingest/refresh work must update the golden numbers in the same PR. They run
+on every non-doc PR via CI's `check` job. Constant-factor (wall-clock) changes
+are surfaced separately by the warn-only `perf-ab` job (below).
+```
+
+- [ ] **Step 3: Add a "CI regression gating" subsection to BENCHMARKS.md**
+
+Run: `grep -nE "^## |^### " BENCHMARKS.md | head` to find a home near the Methodology section, then add:
+
+```markdown
+## CI regression gating
+
+`BENCHMARKS.md` records hand-run absolute numbers; CI guards against regressions
+in three lanes:
+
+1. **Counter gate (every non-doc PR, hard).** `perf_counters.rs` +
+   `tree.rs` golden work-counter assertions under `--features metrics`. Catches
+   algorithmic regressions (extra copy, whole-file slurp, O(N) tree rebuild).
+2. **A/B wall-clock (warn-only, core `src` PRs).** The `perf-ab` job benches the
+   base and PR commits back-to-back on one runner and posts a `critcmp` delta as
+   a PR comment. Never blocks.
+3. **Release record.** The `benchmarks` job runs the full bench suite at the
+   `ci` tier on a tag and uploads the numbers as an artifact for curation here.
+
+The fsync-storm (403→0) signal needs a real FUSE mount and lives only in the
+release lane / the `#[ignore]` `bench_scan_under_latency`, not the per-PR gate.
+```
+
+- [ ] **Step 4: Verify the full metrics-feature leg is green**
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: PASS (all perf_counters tests + existing metrics tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CONTRIBUTING.md BENCHMARKS.md
+git commit -m "docs: document the perf counter gate + CI gating lanes (#211)"
+```
+
+PR1 is complete: open it, confirm the `check` job is green.
+
+---
+
+# PR 2 — Lane 2: same-runner A/B wall-clock (warn-only)
+
+### Task 2.1: `perf` path-filter output on the `changes` job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (`changes` job, lines ~22-77)
+
+- [ ] **Step 1: Add `perf` to the job `outputs` map**
+
+In the `changes:` job's `outputs:` block (alongside `src`/`fuse`/`lidarr`), add:
+
+```yaml
+      perf: ${{ steps.filter.outputs.perf }}
+```
+
+- [ ] **Step 2: Emit `perf` in the filter step**
+
+In the `no usable base ref` early-exit block, add `echo "perf=true" >> "$GITHUB_OUTPUT"` next to the other `true` writes. Then, after the `lidarr` block, add:
+
+```bash
+          # Read/synthesis surface only: the A/B wall-clock job is expensive
+          # (builds criterion twice), so gate it to changes that can actually
+          # move read latency. tests/ and benches/ are excluded by the anchors.
+          if printf '%s\n' "$changed" | grep -qE '^(musefs-core/src/|musefs-format/src/)'; then
+            echo "perf=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "perf=false" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+- [ ] **Step 3: Lint the workflow YAML**
+
+Run: `yamllint .github/workflows/ci.yml`
+Expected: no errors (warnings consistent with the rest of the file are fine).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add perf path-filter output to the changes job (#211)"
+```
+
+### Task 2.2: the A/B harness script
+
+**Files:**
+- Create: `scripts/perf-ab.sh`
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Same-runner A/B wall-clock comparison of the read_throughput criterion bench.
+# Benches the base ref and HEAD back-to-back on ONE machine (robust to
+# runner-to-runner variance), then diffs with critcmp. Warn-only: always exits 0.
+#
+# Usage: scripts/perf-ab.sh <base-sha> <out-markdown-file>
+# Requires: cargo, critcmp on PATH. Run from the repo root with a clean tree.
+set -euo pipefail
+
+BASE_SHA="${1:?base sha required}"
+OUT="${2:?output markdown path required}"
+BENCH=(cargo bench -p musefs-core --bench read_throughput --)
+
+head_sha="$(git rev-parse HEAD)"
+
+run_baseline() {
+  local name="$1"
+  "${BENCH[@]}" --save-baseline "$name" >/dev/null 2>&1
+}
+
+echo "Benching base ($BASE_SHA)…" >&2
+git checkout --quiet --detach "$BASE_SHA"
+run_baseline base
+
+echo "Benching head ($head_sha)…" >&2
+git checkout --quiet --detach "$head_sha"
+run_baseline pr
+
+{
+  echo "### Read-path A/B (same-runner, warn-only)"
+  echo
+  echo "Base \`${BASE_SHA:0:12}\` vs PR \`${head_sha:0:12}\`. Wall-clock on a"
+  echo "shared GH runner — treat <10% moves as noise."
+  echo
+  base_n="$(critcmp --list 2>/dev/null | grep -c '^base' || true)"
+  pr_n="$(critcmp --list 2>/dev/null | grep -c '^pr' || true)"
+  common="$(critcmp base pr 2>/dev/null | tail -n +2 | grep -c . || true)"
+  if [ "$common" -eq 0 ]; then
+    echo "> ⚠️ No comparable benchmarks (benchmark IDs differ between base and PR"
+    echo "> — a harness/bench rename?). Nothing to compare."
+  else
+    echo '```'
+    critcmp base pr
+    echo '```'
+    echo
+    echo "_base benches: ${base_n}, pr benches: ${pr_n}, compared: ${common}._"
+  fi
+} > "$OUT"
+
+echo "Wrote $OUT" >&2
+```
+
+- [ ] **Step 2: Make it executable and shellcheck it**
+
+Run: `chmod +x scripts/perf-ab.sh && shellcheck scripts/perf-ab.sh`
+Expected: no findings.
+
+- [ ] **Step 3: Dry-run locally against the merge-base**
+
+Run: `scripts/perf-ab.sh "$(git rev-parse HEAD~1)" /tmp/perf-ab.md && cat /tmp/perf-ab.md`
+Expected: completes (two bench runs — minutes), `/tmp/perf-ab.md` holds a critcmp table. Afterward run `git checkout perf-regression` (the script leaves a detached HEAD).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/perf-ab.sh
+git commit -m "ci: add same-runner read A/B harness script (#211)"
+```
+
+### Task 2.3: the `perf-ab` workflow job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the job (after an existing job; copy the libfuse3 install step verbatim from the `check` job)**
+
+Resolve the pins first:
+- `marocchino/sticky-pull-request-comment` — `gh api repos/marocchino/sticky-pull-request-comment/commits/v2 --jq .sha` (pin to the **commit** SHA, not the tag).
+- `critcmp` version — pick the current `cargo search critcmp` version; pin it.
+
+```yaml
+  perf-ab:
+    name: Read A/B (warn-only)
+    needs: changes
+    if: needs.changes.outputs.perf == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # base merge-base must be present for the A/B checkout
+      - name: Install libfuse3
+        run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
+      - name: Install critcmp
+        run: cargo install critcmp --locked --version <PINNED>
+      - name: Run A/B
+        run: scripts/perf-ab.sh "${{ github.event.pull_request.base.sha }}" "$RUNNER_TEMP/perf-ab.md"
+      - name: Comment (same-repo PRs)
+        if: github.event.pull_request.head.repo.fork == false
+        uses: marocchino/sticky-pull-request-comment@<PINNED_COMMIT_SHA>
+        with:
+          header: perf-ab
+          path: ${{ runner.temp }}/perf-ab.md
+      - name: Job summary (fallback / forks)
+        if: always()
+        run: cat "$RUNNER_TEMP/perf-ab.md" >> "$GITHUB_STEP_SUMMARY"
+```
+
+- [ ] **Step 2: Confirm `perf-ab` is NOT added to any required-checks aggregator**
+
+Run: `grep -nE "ci-ok|needs:.*perf-ab|aggregat" .github/workflows/ci.yml`
+Expected: `perf-ab` appears only as its own job — never in the `needs:` list of the `ci-ok`/aggregator job (it must never block merge). If an aggregator lists every job, leave `perf-ab` out of it.
+
+- [ ] **Step 3: Lint**
+
+Run: `yamllint .github/workflows/ci.yml`
+Expected: clean.
+
+- [ ] **Step 4: Commit and push the PR; verify behavior on the PR itself**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: warn-only same-runner read A/B job (#211)"
+```
+
+Because this PR touches `.github/workflows/` (not `musefs-*/src/`), `perf=false`,
+so `perf-ab` will be **skipped** on its own PR — expected. Validate it by either
+(a) a follow-up trivial `musefs-core/src/` no-op PR, or (b) temporarily widening
+the `perf` filter on a scratch branch. Confirm the comment posts and the job is
+green/non-required.
+
+### Task 2.4: document the A/B job
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Extend the gating paragraph from Task 1.5**
+
+Append to the "Performance regression gating" section:
+
+```markdown
+The `perf-ab` job runs only when `musefs-core/src/**` or `musefs-format/src/**`
+change. It benches the base and PR commits back-to-back on one runner and posts a
+`critcmp` delta as a sticky PR comment. It is **warn-only** and not a required
+check — GH runner noise makes wall-clock unfit for hard gating. Reproduce locally
+with `scripts/perf-ab.sh <base-sha> out.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs: document the perf-ab warn-only job (#211)"
+```
+
+---
+
+# PR 3 — Lane 3: release full-bench record
+
+### Task 3.1: the release bench script
+
+**Files:**
+- Create: `scripts/perf-release-bench.sh`
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Run the full read bench plus the ci-tier ingest/refresh benches and capture
+# all output to a single artifact file. Record-only; never gates a release.
+#
+# Usage: scripts/perf-release-bench.sh <out-file>
+set -euo pipefail
+OUT="${1:?output file required}"
+
+{
+  echo "# musefs release benchmark snapshot"
+  echo "commit: $(git rev-parse HEAD)"
+  echo
+
+  echo "## read_throughput (criterion)"
+  cargo bench -p musefs-core --bench read_throughput -- 2>&1 || true
+
+  echo "## bench_ingest (ci tier)"
+  MUSEFS_BENCH_TIER=ci cargo test --release -p musefs-core --features metrics \
+    --test bench_ingest -- --ignored --nocapture 2>&1 || true
+
+  echo "## bench_refresh (ci tier)"
+  MUSEFS_BENCH_TIER=ci cargo test --release -p musefs-core \
+    --test bench_refresh -- --ignored --nocapture 2>&1 || true
+} | tee "$OUT"
+```
+
+- [ ] **Step 2: Make executable and shellcheck**
+
+Run: `chmod +x scripts/perf-release-bench.sh && shellcheck scripts/perf-release-bench.sh`
+Expected: no findings.
+
+- [ ] **Step 3: Smoke-run only the ingest leg locally (full read bench is slow)**
+
+Run: `MUSEFS_BENCH_TIER=ci cargo test --release -p musefs-core --features metrics --test bench_ingest -- --ignored --nocapture 2>&1 | tail -20`
+Expected: the ci-tier ingest bench runs and prints timings (confirms the command is valid).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/perf-release-bench.sh
+git commit -m "ci: add release benchmark-record script (#211)"
+```
+
+### Task 3.2: the `benchmarks` release job
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add the job (copy the checkout + libfuse3 install steps from an existing release job; pin `actions/upload-artifact` to the SHA already used elsewhere in the repo)**
+
+Run first: `grep -rn "upload-artifact@" .github/workflows/ | head -1` to reuse the existing pinned SHA.
+
+```yaml
+  benchmarks:
+    name: Benchmark snapshot
+    runs-on: ubuntu-latest
+    continue-on-error: true # record-only; never blocks a release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Install libfuse3
+        run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
+      - name: Run benchmarks
+        run: scripts/perf-release-bench.sh "$RUNNER_TEMP/bench-snapshot.txt"
+      - name: Upload snapshot
+        uses: actions/upload-artifact@<PINNED_SHA>
+        with:
+          name: benchmark-snapshot-${{ github.ref_name }}
+          path: ${{ runner.temp }}/bench-snapshot.txt
+```
+
+- [ ] **Step 2: Confirm it is not wired into any release gate**
+
+Run: `grep -nE "needs:.*benchmarks" .github/workflows/release.yml`
+Expected: no match (no other job depends on `benchmarks`; it cannot block `publish`/`build`/`release-assets`).
+
+- [ ] **Step 3: Lint**
+
+Run: `yamllint .github/workflows/release.yml`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: record a benchmark snapshot artifact on release (#211)"
+```
+
+### Task 3.3: close the loop in docs
+
+**Files:**
+- Modify: `BENCHMARKS.md`
+
+- [ ] **Step 1: Note the artifact source in the "CI regression gating" subsection**
+
+Append: "The release artifact is named `benchmark-snapshot-<tag>`; download it from the tag's workflow run and fold the numbers into the per-pass tables here."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add BENCHMARKS.md
+git commit -m "docs: point BENCHMARKS.md at the release snapshot artifact (#211)"
+```
+
+---
+
+## Self-review notes (resolved during authoring)
+
+- **Spec coverage:** Lane 1 read goldens → 1.1/1.2; ingest slurp guard → 1.3; refresh O(changed) via existing `apply_changes` return (no new counter) → 1.4; fsync==0 explicitly release-only → 3.1 (ci-tier `bench_ingest`) + noted in docs. Lane 2 path filter/job/script/fork-fallback/pin → 2.1–2.4. Lane 3 record-only artifact + ci tier → 3.1–3.3.
+- **No production code in PR1** — every asserted counter already exists; the only `tree.rs` change is an appended test (mutants anchors re-checked in 1.4).
+- **Characterization steps** (1.2, 1.3) discover format-specific exact constants via a shown command + a shown edit, not a vague "TODO" — the load-bearing invariants (`pread_bytes == AUDIO_BYTES`, bounded-seek/slurp upper bounds) are asserted independently of the frozen numbers.
+- **Pins** (`critcmp` version, sticky-comment commit SHA, `upload-artifact` SHA) are resolved by the explicit commands in 2.3/3.2, honoring the commit-not-tag pin rule.

--- a/docs/superpowers/plans/2026-06-14-ci-perf-regression-gating.md
+++ b/docs/superpowers/plans/2026-06-14-ci-perf-regression-gating.md
@@ -86,17 +86,15 @@ fn collect_file_inodes(fs: &Musefs, dir: u64, out: &mut Vec<u64>) {
     }
 }
 
-/// Generate a single-format corpus (audio-only, fixed seed/size), scan + mount,
+/// Generate a single-format AUDIO-ONLY corpus (fixed seed/size), scan + mount,
 /// and return (fs, first-file-inode, tempdir-guard).
-fn mount_one(fmt: Format, bytes_per_track: usize, art_bytes_per_track: usize)
-    -> (Musefs, u64, tempfile::TempDir)
-{
+fn mount_one(fmt: Format, bytes_per_track: usize) -> (Musefs, u64, tempfile::TempDir) {
     let base = tempfile::tempdir().unwrap();
     let params = CorpusParams {
         albums: 1,
         tracks_per_album: 1,
         bytes_per_track,
-        art_bytes_per_track,
+        art_bytes_per_track: 0,
         format_mix: vec![fmt],
         seed: 42,
     };
@@ -123,25 +121,26 @@ fn read_whole(fs: &Musefs, inode: u64) {
 }
 ```
 
-- [ ] **Step 2: Add the sequential-read golden test (audio read exactly once, no art/tags)**
+- [ ] **Step 2: Add the format-agnostic invariant test (audio-only emits no art/tag chunks)**
+
+These two are computable a-priori (the corpus is audio-only with `art_bytes=0`,
+and the non-FLAC corpus carries no embedded art/tags), so they are green
+immediately — no characterization. The exact `pread_bytes`/`preads` (which differ
+per format — MP3 prepends sync bytes, M4A wraps audio in an `mdat` box) are pinned
+in Task 1.2.
 
 ```rust
-/// Whole-file sequential read of an audio-only file: the audio payload is read
-/// exactly once (no slurp / no over-read), and no art or binary-tag chunks are
-/// emitted. `pread_bytes` is the load-bearing slurp guard.
+/// A whole-file sequential read of an audio-only file must emit zero art and
+/// zero binary-tag chunks (guards against accidental art/tag re-emission on the
+/// hot read path). Per-format byte/pread goldens live in Task 1.2.
 #[test]
-fn sequential_read_audio_read_exactly_once() {
+fn audio_only_read_emits_no_art_or_tag_chunks() {
     let _g = METRICS_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     for &fmt in ALL_FORMATS {
-        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize, 0);
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize);
         metrics::reset();
         read_whole(&fs, inode);
         let s = metrics::snapshot();
-        assert_eq!(
-            s.pread_bytes, AUDIO_BYTES,
-            "{}: audio body must be read exactly once (slurp/over-read guard)",
-            format_token(fmt),
-        );
         assert_eq!(s.art_chunks, 0, "{}: audio-only must emit no art chunks", format_token(fmt));
         assert_eq!(
             s.binary_tag_chunks, 0,
@@ -153,14 +152,14 @@ fn sequential_read_audio_read_exactly_once() {
 
 - [ ] **Step 3: Run the test, expect PASS**
 
-Run: `cargo test -p musefs-core --features metrics --test perf_counters sequential_read_audio_read_exactly_once -- --nocapture`
-Expected: PASS. (If `pread_bytes` differs for a format, that is a real finding — investigate before adjusting; the audio payload is read once by construction.)
+Run: `cargo test -p musefs-core --features metrics --test perf_counters audio_only_read_emits_no_art_or_tag_chunks -- --nocapture`
+Expected: PASS. (If a format emits art/tag chunks for an audio-only file, that is a real finding — investigate before adjusting.)
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add musefs-core/tests/perf_counters.rs
-git commit -m "test(core): golden sequential-read counters per format (#211)"
+git commit -m "test(core): scaffold perf counters + no-art/tag read invariant (#211)"
 ```
 
 ### Task 1.2: freeze per-format `preads` + seek goldens (characterization)
@@ -173,19 +172,26 @@ format-specific; observe them once and pin them as constants.
 
 - [ ] **Step 1: Add a per-format expected-constants table and the seek fixture, using sentinel `0`s to be filled in Step 3**
 
+`pread_bytes` is per-format because the corpus generator frames audio differently
+(MP3 prepends `0xFF 0xFB`; M4A wraps the payload in an `mdat` box; FLAC/OGG/WAV
+append it verbatim). So the audio-read-once guard is a pinned per-format
+`seq_pread_bytes`, not a single `AUDIO_BYTES` constant.
+
 ```rust
-/// Frozen per-format goldens. `(seq_preads, seek_preads, seek_pread_bytes)`.
-/// seek = one 128 KiB read near EOF; it must touch a BOUNDED window, never the
-/// whole file/index. Filled by the characterization run in Step 3 — a change
-/// here means real read-path work changed; update in the same PR.
-fn goldens(fmt: Format) -> (u64, u64, u64) {
+/// Frozen per-format read goldens:
+/// `(seq_preads, seq_pread_bytes, seek_preads, seek_pread_bytes)`.
+/// seq = whole-file sequential read (audio read exactly once).
+/// seek = one 128 KiB read near EOF — must touch a BOUNDED window, never the
+/// whole file/index. Filled by the characterization run in Step 3; a change here
+/// means real read-path work changed — update in the same PR.
+fn goldens(fmt: Format) -> (u64, u64, u64, u64) {
     match fmt {
-        Format::Flac => (0, 0, 0),
-        Format::Mp3 => (0, 0, 0),
-        Format::M4aMoovFirst => (0, 0, 0),
-        Format::M4aMoovLast => (0, 0, 0),
-        Format::Ogg => (0, 0, 0),
-        Format::Wav => (0, 0, 0),
+        Format::Flac => (0, 0, 0, 0),
+        Format::Mp3 => (0, 0, 0, 0),
+        Format::M4aMoovFirst => (0, 0, 0, 0),
+        Format::M4aMoovLast => (0, 0, 0, 0),
+        Format::Ogg => (0, 0, 0, 0),
+        Format::Wav => (0, 0, 0, 0),
     }
 }
 
@@ -195,16 +201,22 @@ const SEEK_OFF: u64 = 3_500_000;
 fn read_preads_and_seek_match_goldens() {
     let _g = METRICS_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     for &fmt in ALL_FORMATS {
-        let (exp_seq_preads, exp_seek_preads, exp_seek_bytes) = goldens(fmt);
+        let (exp_seq_preads, exp_seq_bytes, exp_seek_preads, exp_seek_bytes) = goldens(fmt);
 
-        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize, 0);
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize);
         metrics::reset();
         read_whole(&fs, inode);
         let seq = metrics::snapshot();
         assert_eq!(seq.preads, exp_seq_preads, "{}: sequential preads", format_token(fmt));
+        assert_eq!(seq.pread_bytes, exp_seq_bytes, "{}: sequential pread_bytes (audio read once)", format_token(fmt));
+        // Format-agnostic slurp guard, independent of the frozen number.
+        assert!(
+            seq.pread_bytes < AUDIO_BYTES * 2,
+            "{}: sequential read {} bytes — looks like a double-read/slurp", format_token(fmt), seq.pread_bytes,
+        );
 
         // Fresh mount → cold cache → single deep read.
-        let (fs2, inode2, _dir2) = mount_one(fmt, AUDIO_BYTES as usize, 0);
+        let (fs2, inode2, _dir2) = mount_one(fmt, AUDIO_BYTES as usize);
         metrics::reset();
         let _ = fs2.read(inode2, None, SEEK_OFF, CHUNK).unwrap();
         let seek = metrics::snapshot();
@@ -224,20 +236,20 @@ fn read_preads_and_seek_match_goldens() {
 - [ ] **Step 2: Run the test to characterize — it will FAIL and print actual vs expected**
 
 Run: `cargo test -p musefs-core --features metrics --test perf_counters read_preads_and_seek_match_goldens -- --nocapture`
-Expected: FAIL. Each panic line prints the actual value, e.g. `flac: sequential preads ... left: 33, right: 0`. Record the actual `seq.preads`, `seek.preads`, and `seek.pread_bytes` for every format.
+Expected: FAIL. Each panic line prints the actual value, e.g. `flac: sequential preads ... left: 33, right: 0`. Record the actual `seq.preads`, `seq.pread_bytes`, `seek.preads`, and `seek.pread_bytes` for every format. (Sanity-check each `seq.pread_bytes` ≈ 4 MiB and each `seek.pread_bytes` ≪ 1 MiB before pinning — a value near the whole file size means a real over-read, not a golden to freeze.)
 
 - [ ] **Step 3: Replace the sentinel `0`s in `goldens()` with the observed values**
 
-Edit `goldens()` so each arm holds the `(seq_preads, seek_preads, seek_pread_bytes)` triple you recorded. Example shape (your numbers will differ):
+Edit `goldens()` so each arm holds the `(seq_preads, seq_pread_bytes, seek_preads, seek_pread_bytes)` tuple you recorded. Example shape (your numbers will differ):
 
 ```rust
-        Format::Flac => (33, 1, 131072),
+        Format::Flac => (33, 4_194_304, 1, 131_072),
 ```
 
 - [ ] **Step 4: Re-run, expect PASS**
 
 Run: `cargo test -p musefs-core --features metrics --test perf_counters read_preads_and_seek_match_goldens -- --nocapture`
-Expected: PASS for all six formats. Confirm every `seek_pread_bytes` is well under `AUDIO_BYTES/4` (the bounded-window invariant).
+Expected: PASS for all six formats. Confirm every `seek_pread_bytes` is well under `AUDIO_BYTES/4` (the bounded-window invariant) and every `seq_pread_bytes` is under `AUDIO_BYTES*2` (the slurp guard).
 
 - [ ] **Step 5: Commit**
 
@@ -336,10 +348,14 @@ Expected: exits 0 (anchors valid before the edit).
 Insert immediately before the final closing `}` of `mod tests` (after `dot_and_dotdot_plain_components_are_dropped`):
 
 ```rust
-    /// Builds a many-album library, re-tags ONE track (renaming its leaf within
-    /// its own album dir), and asserts `apply_changes` rebuilds exactly one
-    /// subtree — *regardless of library size*. A reintroduced full reconstruction
-    /// would rebuild every album dir, so the count would scale with size.
+    /// Builds a many-album library and re-tags ONE track (renaming its leaf
+    /// within its own album dir, no rendered-name collision). The
+    /// `apply_changes` rebuild-subtree count for such a change is 0 — it is
+    /// handled by remove+insert — and must stay 0 *regardless of library size*.
+    /// A regression that over-dirties (rebuilding album subtrees on every change)
+    /// would make the count scale with album count, tripping this gate. (This
+    /// guards `apply_changes`'s O(changed) contract; it does NOT guard the
+    /// facade's choice to call `apply_changes` vs a full `build_with`.)
     fn library(albums: usize) -> Vec<(i64, String)> {
         let mut e = Vec::new();
         for a in 0..albums {
@@ -371,12 +387,16 @@ Insert immediately before the final closing `}` of `mod tests` (after `dot_and_d
 
     #[test]
     fn apply_changes_rebuild_count_is_size_invariant() {
+        // Characterized: a collision-free single re-tag dirties nothing, at any
+        // size. Pinned exactly so ANY change (a constant shift to 1, or scaling
+        // with album count) trips the gate.
+        const EXPECTED_REBUILDS: usize = 0;
         let small = rebuilds_for_one_retag(43); // 129 tracks
         let large = rebuilds_for_one_retag(683); // 2049 tracks
-        assert_eq!(small, 1, "one re-tag must rebuild exactly its own album dir");
+        assert_eq!(small, EXPECTED_REBUILDS, "small-library rebuild count");
         assert_eq!(
-            small, large,
-            "rebuild count must not grow with library size (O(changed), not O(N))",
+            large, EXPECTED_REBUILDS,
+            "large-library rebuild count must not scale with size (O(changed), not O(N))",
         );
     }
 ```
@@ -384,7 +404,7 @@ Insert immediately before the final closing `}` of `mod tests` (after `dot_and_d
 - [ ] **Step 3: Run the new test, expect PASS**
 
 Run: `cargo test -p musefs-core apply_changes_rebuild_count_is_size_invariant -- --nocapture`
-Expected: PASS. (If `small != 1`, the re-tag is touching more than its dir — investigate; do not loosen the assertion to match.)
+Expected: PASS — the count is 0 at both sizes (verified against the current tree). If it is nonzero, the re-tag is tripping a collision path; switch the changed leaf to a guaranteed-unique name (it must not collide with any sibling) rather than loosening the assertion.
 
 - [ ] **Step 4: Re-check mutants anchors are still valid**
 
@@ -796,5 +816,11 @@ git commit -m "docs: point BENCHMARKS.md at the release snapshot artifact (#211)
 
 - **Spec coverage:** Lane 1 read goldens → 1.1/1.2; ingest slurp guard → 1.3; refresh O(changed) via existing `apply_changes` return (no new counter) → 1.4; fsync==0 explicitly release-only → 3.1 (ci-tier `bench_ingest`) + noted in docs. Lane 2 path filter/job/script/fork-fallback/pin → 2.1–2.4. Lane 3 record-only artifact + ci tier → 3.1–3.3.
 - **No production code in PR1** — every asserted counter already exists; the only `tree.rs` change is an appended test (mutants anchors re-checked in 1.4).
-- **Characterization steps** (1.2, 1.3) discover format-specific exact constants via a shown command + a shown edit, not a vague "TODO" — the load-bearing invariants (`pread_bytes == AUDIO_BYTES`, bounded-seek/slurp upper bounds) are asserted independently of the frozen numbers.
+- **Characterization steps** (1.2, 1.3) discover format-specific exact constants via a shown command + a shown edit, not a vague "TODO" — the load-bearing invariants (bounded-seek `< AUDIO_BYTES/4`, slurp `< AUDIO_BYTES*2`) are asserted independently of the frozen numbers.
 - **Pins** (`critcmp` version, sticky-comment commit SHA, `upload-artifact` SHA) are resolved by the explicit commands in 2.3/3.2, honoring the commit-not-tag pin rule.
+
+**Spec-plan-reviewer pass 2 — corrections applied (all verified against the live code):**
+- **Refresh count is 0, not 1** (probed: `clean_rename small=0 large=0`). Task 1.4 now pins `EXPECTED_REBUILDS = 0` exactly at both sizes — a collision-free single re-tag is handled by remove+insert and rebuilds nothing; the gate trips on any scaling or constant shift. (A `== 1` assertion would have been red at its own commit, which the pre-commit hook rejects.)
+- **`pread_bytes` is per-format** (MP3 prepends sync bytes, M4A wraps audio in `mdat`), so Task 1.1 no longer asserts `pread_bytes == AUDIO_BYTES` for all formats; the exact per-format `seq_pread_bytes` is pinned in Task 1.2's `goldens()`.
+- **No dead code in `perf_counters.rs`**: dropped `mount_one`'s unused `art_bytes` param (the spec's exact-art-chunk golden is already covered relationally by `flac_art_serve_increments_art_chunks` in `metrics.rs`); every helper/const in the new file is used, so `clippy --all-targets -D warnings` stays green.
+- **Verified-OK by the reviewer (no change needed):** all PR1 APIs compile against real signatures; cross-binary metrics global state is per-process (no flake); no PR1 commit boundary is red after the 1.4 fix; PR2/PR3 workflow wiring (`ci-ok` excludes `perf-ab`, `release.yml` tag trigger + `github.ref_name`, fork context expression, `critcmp --list`) is correct.

--- a/docs/superpowers/plans/2026-06-14-ci-perf-regression-gating.md
+++ b/docs/superpowers/plans/2026-06-14-ci-perf-regression-gating.md
@@ -4,7 +4,7 @@
 
 **Goal:** Give musefs CI a regression signal for the read/serve, ingest, and refresh paths without flaky wall-clock gating.
 
-**Architecture:** Three independently-shippable PRs. PR1 is a hard, zero-flake gate of deterministic work *counters* (reusing the existing `metrics` feature — no production code). PR2 adds a warn-only same-runner A/B wall-clock job that runs only when read/synthesis `src` changes. PR3 records a full bench snapshot at release time as an artifact.
+**Delivery:** A **single PR**, landed as a series of commits grouped into three parts. Part 1 is a hard, zero-flake gate of deterministic work *counters* (reusing the existing `metrics` feature — no production code). Part 2 adds a warn-only same-runner A/B wall-clock job that runs only when read/synthesis `src` changes. Part 3 records a full bench snapshot at release time as an artifact. (The spec's "Sequencing" section sketches these as three PRs; per the user they ship as one PR / one commit series. Because the PR touches `musefs-core/src/**`, the Part-2 `perf-ab` job self-validates on this very PR.)
 
 **Tech Stack:** Rust, `cargo test --features metrics`, criterion (`read_throughput` bench), `critcmp`, GitHub Actions, bash.
 
@@ -14,11 +14,11 @@
 
 ## File structure
 
-| File | PR | Responsibility |
-| ---- | -- | -------------- |
+| File | Part | Responsibility |
+| ---- | ---- | -------------- |
 | `musefs-core/tests/perf_counters.rs` | 1 | New `--features metrics` test module: per-format golden read counters + ingest slurp-window counters. |
 | `musefs-core/src/tree.rs` | 1 | One new unit test appended to the existing `#[cfg(test)] mod` asserting `apply_changes` rebuild count is size-invariant. |
-| `CONTRIBUTING.md`, `BENCHMARKS.md` | 1 | Document the counter gate + (PR2) the A/B job. |
+| `CONTRIBUTING.md`, `BENCHMARKS.md` | 1 | Document the counter gate + (Part 2) the A/B job. |
 | `scripts/perf-ab.sh` | 2 | Same-runner base-vs-PR criterion A/B + critcmp; emits a markdown table. |
 | `.github/workflows/ci.yml` | 2 | New `perf` output on the `changes` job; new `perf-ab` job. |
 | `scripts/perf-release-bench.sh` | 3 | Run the full read bench + `ci`-tier ingest/refresh benches, capture output. |
@@ -33,11 +33,12 @@
 
 ---
 
-# PR 1 — Lane 1: deterministic counter gate (no production code)
+# Part 1 — Lane 1: deterministic counter gate (no production code)
 
 Runs in the existing `check` job's "Core metrics-feature tests" step
-(`cargo test -p musefs-core --features metrics`) — no workflow change. Must land
-green (the pre-commit hook runs the full workspace suite).
+(`cargo test -p musefs-core --features metrics`) — no workflow change. Every
+commit must be green (the pre-commit hook runs the full workspace suite, so a red
+commit is rejected).
 
 ### Task 1.1: read-counter module scaffold + sequential-read goldens
 
@@ -479,11 +480,12 @@ git add CONTRIBUTING.md BENCHMARKS.md
 git commit -m "docs: document the perf counter gate + CI gating lanes (#211)"
 ```
 
-PR1 is complete: open it, confirm the `check` job is green.
+Part 1 complete — the counter gate is in place; the metrics-feature `check` leg
+stays green. Continue committing on the same branch.
 
 ---
 
-# PR 2 — Lane 2: same-runner A/B wall-clock (warn-only)
+# Part 2 — Lane 2: same-runner A/B wall-clock (warn-only)
 
 ### Task 2.1: `perf` path-filter output on the `changes` job
 
@@ -654,18 +656,19 @@ Expected: `perf-ab` appears only as its own job — never in the `needs:` list o
 Run: `yamllint .github/workflows/ci.yml`
 Expected: clean.
 
-- [ ] **Step 4: Commit and push the PR; verify behavior on the PR itself**
+- [ ] **Step 4: Commit; the job self-validates on this PR**
 
 ```bash
 git add .github/workflows/ci.yml
 git commit -m "ci: warn-only same-runner read A/B job (#211)"
 ```
 
-Because this PR touches `.github/workflows/` (not `musefs-*/src/`), `perf=false`,
-so `perf-ab` will be **skipped** on its own PR — expected. Validate it by either
-(a) a follow-up trivial `musefs-core/src/` no-op PR, or (b) temporarily widening
-the `perf` filter on a scratch branch. Confirm the comment posts and the job is
-green/non-required.
+Because this single PR also contains the Part 1 `musefs-core/src/**` changes, the
+`changes` job sets `perf=true`, so `perf-ab` **runs on this PR** (GitHub uses the
+PR branch's workflow file for same-repo `pull_request` events). It benches base
+(`main`) vs HEAD — read logic is unchanged, so expect a no-regression table.
+Confirm: the sticky comment posts, and the job is green and **not** a required
+check (does not block merge).
 
 ### Task 2.4: document the A/B job
 
@@ -693,7 +696,7 @@ git commit -m "docs: document the perf-ab warn-only job (#211)"
 
 ---
 
-# PR 3 — Lane 3: release full-bench record
+# Part 3 — Lane 3: release full-bench record
 
 ### Task 3.1: the release bench script
 
@@ -810,12 +813,24 @@ git add BENCHMARKS.md
 git commit -m "docs: point BENCHMARKS.md at the release snapshot artifact (#211)"
 ```
 
+### Finish: open the single PR
+
+- [ ] **Step 1: Verify the whole suite is green (the pre-commit hook already ran it per commit, but confirm the metrics leg explicitly)**
+
+Run: `cargo test -p musefs-core --features metrics && cargo test --workspace`
+Expected: PASS.
+
+- [ ] **Step 2: Open ONE PR for the full commit series**
+
+Run: `gh pr create --base main --title "ci: performance-regression gating for the read path (#211)" --body "<summary of the three lanes; closes #211>"`
+Expected: a single PR containing all Part 1–3 commits. Confirm on the PR that the `check` job (counter gate) is green and the `perf-ab` job ran, posted its comment, and is non-blocking.
+
 ---
 
 ## Self-review notes (resolved during authoring)
 
 - **Spec coverage:** Lane 1 read goldens → 1.1/1.2; ingest slurp guard → 1.3; refresh O(changed) via existing `apply_changes` return (no new counter) → 1.4; fsync==0 explicitly release-only → 3.1 (ci-tier `bench_ingest`) + noted in docs. Lane 2 path filter/job/script/fork-fallback/pin → 2.1–2.4. Lane 3 record-only artifact + ci tier → 3.1–3.3.
-- **No production code in PR1** — every asserted counter already exists; the only `tree.rs` change is an appended test (mutants anchors re-checked in 1.4).
+- **No production code in Part 1** — every asserted counter already exists; the only `tree.rs` change is an appended test (mutants anchors re-checked in 1.4).
 - **Characterization steps** (1.2, 1.3) discover format-specific exact constants via a shown command + a shown edit, not a vague "TODO" — the load-bearing invariants (bounded-seek `< AUDIO_BYTES/4`, slurp `< AUDIO_BYTES*2`) are asserted independently of the frozen numbers.
 - **Pins** (`critcmp` version, sticky-comment commit SHA, `upload-artifact` SHA) are resolved by the explicit commands in 2.3/3.2, honoring the commit-not-tag pin rule.
 
@@ -823,4 +838,4 @@ git commit -m "docs: point BENCHMARKS.md at the release snapshot artifact (#211)
 - **Refresh count is 0, not 1** (probed: `clean_rename small=0 large=0`). Task 1.4 now pins `EXPECTED_REBUILDS = 0` exactly at both sizes — a collision-free single re-tag is handled by remove+insert and rebuilds nothing; the gate trips on any scaling or constant shift. (A `== 1` assertion would have been red at its own commit, which the pre-commit hook rejects.)
 - **`pread_bytes` is per-format** (MP3 prepends sync bytes, M4A wraps audio in `mdat`), so Task 1.1 no longer asserts `pread_bytes == AUDIO_BYTES` for all formats; the exact per-format `seq_pread_bytes` is pinned in Task 1.2's `goldens()`.
 - **No dead code in `perf_counters.rs`**: dropped `mount_one`'s unused `art_bytes` param (the spec's exact-art-chunk golden is already covered relationally by `flac_art_serve_increments_art_chunks` in `metrics.rs`); every helper/const in the new file is used, so `clippy --all-targets -D warnings` stays green.
-- **Verified-OK by the reviewer (no change needed):** all PR1 APIs compile against real signatures; cross-binary metrics global state is per-process (no flake); no PR1 commit boundary is red after the 1.4 fix; PR2/PR3 workflow wiring (`ci-ok` excludes `perf-ab`, `release.yml` tag trigger + `github.ref_name`, fork context expression, `critcmp --list`) is correct.
+- **Verified-OK by the reviewer (no change needed):** all Part 1 APIs compile against real signatures; cross-binary metrics global state is per-process (no flake); no Part 1 commit boundary is red after the 1.4 fix; Part 2/3 workflow wiring (`ci-ok` excludes `perf-ab`, `release.yml` tag trigger + `github.ref_name`, fork context expression, `critcmp --list`) is correct.

--- a/docs/superpowers/specs/2026-06-14-ci-perf-regression-gating-design.md
+++ b/docs/superpowers/specs/2026-06-14-ci-perf-regression-gating-design.md
@@ -1,0 +1,152 @@
+# CI performance-regression gating (issue #211)
+
+## Problem
+
+musefs's product is read latency, yet the only performance signals are
+criterion wall-clock benches (`musefs-core/benches/read_throughput.rs`) and the
+ignored `bench_ingest`/`bench_refresh` tests, all run by hand and recorded
+manually in `BENCHMARKS.md`. No CI job runs `cargo bench` or compares against a
+baseline, so a latency/throughput regression in the splice/read, ingest, or
+refresh path can merge with the suite fully green.
+
+GitHub Actions shared `ubuntu-latest` runners vary run-to-run, so naive
+wall-clock micro-gating against a stored baseline is famously flaky. The project
+already treats **deterministic work counters** (preads, bytes read, fsync count,
+copy counts) as its "portable signal" — see `BENCHMARKS.md` (fsync 403→0;
+`bytes_read` equal both sides) — and already asserts exact getattr/read/open
+counts in `musefs-core/tests/metrics.rs` under the `metrics` feature.
+
+## Goals
+
+- A hard, zero-flake CI gate that catches **algorithmic** regressions on the
+  read/serve, ingest, and refresh paths (an extra copy, a reintroduced per-file
+  fsync/slurp, a reintroduced O(N) tree rebuild).
+- Per-PR visibility into **constant-factor** wall-clock regressions on the
+  read/synthesis surface, without flaky pass/fail.
+- A recorded full-bench snapshot at release time for hand-curation into
+  `BENCHMARKS.md`.
+
+## Non-goals
+
+- Hard-blocking any PR or release on wall-clock numbers (GHA noise makes this
+  dishonest).
+- Auto-committing benchmark results into `BENCHMARKS.md` (it is hand-curated by
+  design; see its preamble).
+- Self-hosted or dedicated bench runners.
+
+## Design — three lanes
+
+### Lane 1 — Deterministic counter gate (hard, every non-doc PR)
+
+The real regression guard. A new test module
+`musefs-core/tests/perf_counters.rs`, compiled under `--features metrics`, run
+by the existing `check` job's "Core metrics-feature tests" step
+(`cargo test -p musefs-core --features metrics`). No new CI job. In-memory,
+deterministic, sub-second.
+
+Golden exact-equality assertions on the portable signals (a regression flips a
+count → hard fail):
+
+- **Read/serve** — for each `bench_formats()` format (flac, mp3, m4a, ogg, wav),
+  a fixed-size synthesized single-track corpus. Assert exact
+  `(preads, pread_bytes, art_chunks, binary_tag_chunks)` from
+  `metrics::snapshot()` for:
+  - a whole-file sequential read (`fh = None`, 128 KiB chunks),
+  - a cold-first read (fresh mount, read once),
+  - a deep seek read (one 128 KiB read near EOF) — guards the SP4 invariant that
+    a seek scans a bounded backward window, not the whole page index
+    (→ bounded `preads`/`pread_bytes`, not file-size-proportional).
+- **Ingest** — scan a fixed `ci`-tier corpus (single format, fixed seed/size).
+  Assert exact `(scan_opens, scan_preads, scan_bytes_read)`, and **fsync count
+  == 0** through the latency-FS path (the 403→0 guard against a reintroduced
+  per-file-commit / whole-file slurp). Reuses the `bench_scan_under_latency`
+  fsync-counting mechanism already exercised by `bench_ingest.rs`.
+- **Refresh** — a single-track re-tag at two library sizes (e.g. 128 and 2048
+  tracks). Assert the **node-touch count is bounded and identical across both
+  sizes** (O(changed), not O(N)) — catches reintroduction of the full
+  `VirtualTree::build_with` reconstruction that `apply_changes` replaced.
+
+**New production code (the only piece):** a node-touch counter under
+`#[cfg(feature = "metrics")]`, incremented once per node mutated in
+`VirtualTree::apply_changes` (`musefs-core/src/tree.rs:642`), surfaced via a new
+field on `metrics::Snapshot` with a no-op stub in the non-`metrics` build (mirror
+the existing counter pattern in `musefs-core/src/metrics.rs`).
+
+Legitimate strategy changes update the golden numbers in the same PR — the same
+intended friction as today's getattr/read-count assertions.
+
+### Lane 2 — Same-runner A/B wall-clock (warn-only, path-gated)
+
+Per-PR constant-factor visibility, robust to runner variance by benching both
+commits on the **same** runner.
+
+- **Path filter:** a new `perf` output on the existing `changes` job, set `true`
+  when `git diff --name-only "$base...HEAD"` matches
+  `^(musefs-core/src/|musefs-format/src/)` (the read/synthesis surface; crate
+  `tests/` and `benches/` dirs are excluded by the glob). Mirrors the existing
+  `fuse`/`lidarr` output pattern.
+- **Job:** new `perf-ab` job in `ci.yml`, `if: needs.changes.outputs.perf ==
+  'true'`, `permissions: { contents: read, pull-requests: write }`. Full-history
+  checkout (base merge-base must be present). Installs libfuse3. Drives an
+  in-tree `scripts/perf-ab.sh`:
+  1. `cargo bench -p musefs-core --bench read_throughput -- --save-baseline base`
+     on the base SHA,
+  2. checkout PR HEAD, same with `--save-baseline pr`,
+  3. `critcmp base pr` → delta table.
+- **Surface:** a **sticky PR comment** (e.g. `marocchino/sticky-pull-request-comment`,
+  SHA-pinned) with the critcmp table, a header flagging any bench regressed
+  >10%. **Never blocks** — informational only, not a required check. On fork PRs
+  the write token is absent, so the comment step is guarded and the table falls
+  back to `$GITHUB_STEP_SUMMARY`.
+
+Cost: builds criterion twice. Bounded because the job only runs on
+core/format `src/**` changes.
+
+### Lane 3 — Full bench record (release tags)
+
+A recorded snapshot, not a gate.
+
+- **Job:** new `benchmarks` job in `release.yml`, on tag push. Runs the full
+  `read_throughput` criterion suite plus the ignored `bench_ingest` /
+  `bench_refresh` at a representative tier (`MUSEFS_BENCH_TIER`), `--nocapture`,
+  via an in-tree `scripts/perf-release-bench.sh`.
+- **Output:** uploads captured results as a release **artifact**
+  (`actions/upload-artifact`) for hand-curation into `BENCHMARKS.md`. No
+  auto-commit. **Non-blocking** — a slow/noisy bench must never block a release.
+
+## Documentation & harness
+
+- `scripts/perf-ab.sh` and `scripts/perf-release-bench.sh` live in-tree and run
+  locally; CI only invokes them.
+- `CONTRIBUTING.md` test-tiers section: document the Lane 1 counter gate and the
+  Lane 2 A/B job (when it runs, that it is warn-only).
+- `BENCHMARKS.md`: a short "CI regression gating" subsection describing the
+  three lanes and the manual-vs-CI split.
+
+## Risks & tradeoffs
+
+- **Algorithmic-only hard gate.** Lane 1 catches changes in work *counts*, not
+  constant-factor slowdowns; the latter are surfaced only by Lane 2, only on
+  core-`src` PRs, only as a warning. This is the honest limit of gating on noisy
+  GHA runners.
+- **Mutants anchors.** Adding the touch counter in `tree.rs` shifts line numbers
+  → re-anchor `.cargo/mutants.toml` in the same commit (the
+  `check_mutant_anchors.py` pre-commit guard fails otherwise).
+- **Golden-number maintenance.** Exact counter assertions must be updated
+  whenever read/ingest/refresh work legitimately changes — intentional friction.
+- **Fork PRs.** Lane 2's PR comment degrades to a job summary (no write token).
+- **Pre-commit gate.** The new `perf_counters.rs` runs under
+  `cargo test -p musefs-core --features metrics`, which the workspace default
+  `cargo test` skips — ensure the metrics-feature leg is green before pushing
+  (the full workspace pre-commit hook covers it; bare `cargo test` does not).
+
+## Affected files
+
+- `musefs-core/src/metrics.rs` — new touch counter + `Snapshot` field (+ stub).
+- `musefs-core/src/tree.rs` — increment touch counter in `apply_changes`.
+- `musefs-core/tests/perf_counters.rs` — new golden-counter test module.
+- `.cargo/mutants.toml` — re-anchor after `tree.rs` line shift.
+- `.github/workflows/ci.yml` — `perf` output on `changes`; new `perf-ab` job.
+- `.github/workflows/release.yml` — new `benchmarks` job.
+- `scripts/perf-ab.sh`, `scripts/perf-release-bench.sh` — new harness scripts.
+- `CONTRIBUTING.md`, `BENCHMARKS.md` — docs.

--- a/docs/superpowers/specs/2026-06-14-ci-perf-regression-gating-design.md
+++ b/docs/superpowers/specs/2026-06-14-ci-perf-regression-gating-design.md
@@ -19,8 +19,9 @@ counts in `musefs-core/tests/metrics.rs` under the `metrics` feature.
 ## Goals
 
 - A hard, zero-flake CI gate that catches **algorithmic** regressions on the
-  read/serve, ingest, and refresh paths (an extra copy, a reintroduced per-file
-  fsync/slurp, a reintroduced O(N) tree rebuild).
+  read/serve, ingest, and refresh paths (an extra copy, a reintroduced whole-file
+  slurp, a reintroduced O(N) tree rebuild). The fsync-storm signal needs a real
+  FUSE mount and is recorded at release rather than per-PR (see Lane 1 ingest).
 - Per-PR visibility into **constant-factor** wall-clock regressions on the
   read/synthesis surface, without flaky pass/fail.
 - A recorded full-bench snapshot at release time for hand-curation into
@@ -38,39 +39,58 @@ counts in `musefs-core/tests/metrics.rs` under the `metrics` feature.
 
 ### Lane 1 — Deterministic counter gate (hard, every non-doc PR)
 
-The real regression guard. A new test module
-`musefs-core/tests/perf_counters.rs`, compiled under `--features metrics`, run
-by the existing `check` job's "Core metrics-feature tests" step
-(`cargo test -p musefs-core --features metrics`). No new CI job. In-memory,
-deterministic, sub-second.
+The real regression guard. **No new production code** — every counter it asserts
+already exists. Two homes, both run today on every non-doc PR:
+
+- Read/serve + ingest: a new test module `musefs-core/tests/perf_counters.rs`,
+  compiled under `--features metrics`, run by the existing `check` job's "Core
+  metrics-feature tests" step (`cargo test -p musefs-core --features metrics`).
+  In-memory, deterministic, sub-second.
+- Refresh: a new `#[cfg(test)]` unit test **appended to the end of the existing
+  test module in `musefs-core/src/tree.rs`** (so no line shift above the
+  `InodeAllocator` mutants anchors — no `.cargo/mutants.toml` re-anchor needed).
+  `apply_changes` is `pub(crate)`, so the assertion must be in-module, not an
+  integration test.
 
 Golden exact-equality assertions on the portable signals (a regression flips a
-count → hard fail):
+count → hard fail). Every corpus parameter that moves a counter is pinned so the
+goldens are reproducible:
 
-- **Read/serve** — for each `bench_formats()` format (flac, mp3, m4a, ogg, wav),
-  a fixed-size synthesized single-track corpus. Assert exact
+- **Read/serve** — iterate a **fixed format list** (`[Flac, Mp3, M4a, Ogg, Wav]`
+  written literally, NOT the env-overridable `bench_formats()`, so
+  `MUSEFS_BENCH_FORMAT_MIX` can't silently narrow the gate). Per format a single
+  pinned corpus: `albums=1, tracks_per_album=1, seed=42`, `bytes_per_track`
+  fixed (4 MiB), and **two art variants** — `art_bytes_per_track=0` for the
+  audio-only counter goldens and one fixed nonzero size (e.g. 64 KiB) for an
+  `art_chunks` assertion. Read chunk size pinned at 128 KiB. Assert exact
   `(preads, pread_bytes, art_chunks, binary_tag_chunks)` from
   `metrics::snapshot()` for:
   - a whole-file sequential read (`fh = None`, 128 KiB chunks),
   - a cold-first read (fresh mount, read once),
   - a deep seek read (one 128 KiB read near EOF) — guards the SP4 invariant that
-    a seek scans a bounded backward window, not the whole page index
-    (→ bounded `preads`/`pread_bytes`, not file-size-proportional).
-- **Ingest** — scan a fixed `ci`-tier corpus (single format, fixed seed/size).
-  Assert exact `(scan_opens, scan_preads, scan_bytes_read)`, and **fsync count
-  == 0** through the latency-FS path (the 403→0 guard against a reintroduced
-  per-file-commit / whole-file slurp). Reuses the `bench_scan_under_latency`
-  fsync-counting mechanism already exercised by `bench_ingest.rs`.
-- **Refresh** — a single-track re-tag at two library sizes (e.g. 128 and 2048
-  tracks). Assert the **node-touch count is bounded and identical across both
-  sizes** (O(changed), not O(N)) — catches reintroduction of the full
-  `VirtualTree::build_with` reconstruction that `apply_changes` replaced.
+    a seek scans a bounded backward window, not the whole page index. Asserted as
+    a **concrete expected number** per format (frozen TDD-style: write the test,
+    observe the count, pin it), not a relation.
+- **Ingest** — scan a corpus whose `bytes_per_track` is **larger than the ~1 MiB
+  bounded metadata window** (e.g. 2 MiB × a few tracks, fixed seed) so a
+  reintroduced whole-file slurp shows up as inflated `scan_bytes_read` (below the
+  window, bounded and slurp read the same bytes — SP1 §4 — so the corpus must
+  straddle it). Assert exact `(scan_opens, scan_preads, scan_bytes_read)`.
+  **The fsync 403→0 guard is NOT in this in-memory lane** — fsync counting needs
+  the real `musefs-latencyfs` mount (requires `/dev/fuse`), which would make the
+  lane neither in-memory nor sub-second. It stays where it already lives: the
+  `#[ignore]` `bench_scan_under_latency` test, run at release (Lane 3).
+- **Refresh** — a single-track re-tag applied at two library sizes (e.g. 128 and
+  2048 tracks). Assert the value `apply_changes` **already returns** — the count
+  of `rebuild_subtree` calls (`tree.rs:752`, documented as the O(changed)
+  observability) — is **identical across both sizes**. That count, not "nodes
+  mutated," is the size-invariant signal (a `rebuild_subtree` is itself
+  O(subtree); only the *number of rebuilds* is O(changed)). Catches
+  reintroduction of the full `VirtualTree::build_with` reconstruction.
 
-**New production code (the only piece):** a node-touch counter under
-`#[cfg(feature = "metrics")]`, incremented once per node mutated in
-`VirtualTree::apply_changes` (`musefs-core/src/tree.rs:642`), surfaced via a new
-field on `metrics::Snapshot` with a no-op stub in the non-`metrics` build (mirror
-the existing counter pattern in `musefs-core/src/metrics.rs`).
+`metrics` counters are process-global; the read/ingest test module must
+serialize its cases and `metrics::reset()` between them (mirror the
+`METRICS_LOCK` mutex in `musefs-core/tests/metrics.rs`).
 
 Legitimate strategy changes update the golden numbers in the same PR — the same
 intended friction as today's getattr/read-count assertions.
@@ -85,19 +105,36 @@ commits on the **same** runner.
   `^(musefs-core/src/|musefs-format/src/)` (the read/synthesis surface; crate
   `tests/` and `benches/` dirs are excluded by the glob). Mirrors the existing
   `fuse`/`lidarr` output pattern.
+- **Trigger event — stays on `pull_request`.** The job checks out **and builds**
+  PR HEAD, so it must NOT use `pull_request_target` (that pairs a writable token
+  with untrusted-code execution). On `pull_request`, fork PRs get a read-only
+  token — handled below.
 - **Job:** new `perf-ab` job in `ci.yml`, `if: needs.changes.outputs.perf ==
   'true'`, `permissions: { contents: read, pull-requests: write }`. Full-history
-  checkout (base merge-base must be present). Installs libfuse3. Drives an
-  in-tree `scripts/perf-ab.sh`:
+  checkout (base merge-base must be present). Installs libfuse3. Installs
+  `critcmp` (not present in the repo today) via a SHA/version-pinned step —
+  prefer a pinned prebuilt binary or `cargo install critcmp --locked --version
+  <pinned>` with a cargo-bin cache to avoid a multi-minute build each run. Drives
+  an in-tree `scripts/perf-ab.sh`:
   1. `cargo bench -p musefs-core --bench read_throughput -- --save-baseline base`
      on the base SHA,
   2. checkout PR HEAD, same with `--save-baseline pr`,
   3. `critcmp base pr` → delta table.
-- **Surface:** a **sticky PR comment** (e.g. `marocchino/sticky-pull-request-comment`,
-  SHA-pinned) with the critcmp table, a header flagging any bench regressed
-  >10%. **Never blocks** — informational only, not a required check. On fork PRs
-  the write token is absent, so the comment step is guarded and the table falls
-  back to `$GITHUB_STEP_SUMMARY`.
+- **Harness/ID drift.** Each side builds the bench from **its own** checkout, so
+  a PR that renames/adds/removes benchmark IDs (or edits the shared
+  `tests/common` harness) produces a base/PR set that only partially overlaps.
+  `critcmp` compares only common IDs; the script must detect a shrunken/empty
+  common set and say so in the comment rather than silently reporting "no
+  regressions." (Note: a harness-only PR won't trigger this job — the path filter
+  excludes `tests/`/`benches/` — but a `src` PR that also touches the harness
+  will, hence the guard.)
+- **Surface:** a **sticky PR comment** via a specific SHA-pinned action
+  (`marocchino/sticky-pull-request-comment`, pinned to a **commit** SHA per the
+  annotated-tag pin trap) with the critcmp table and a header flagging any bench
+  regressed >10%. **Never blocks** — informational only, not a required check.
+  The comment step is guarded with `if: github.event.pull_request.head.repo.fork
+  == false` (fork PRs have no write token); on a fork the table is written to
+  `$GITHUB_STEP_SUMMARY` instead.
 
 Cost: builds criterion twice. Bounded because the job only runs on
 core/format `src/**` changes.
@@ -108,11 +145,17 @@ A recorded snapshot, not a gate.
 
 - **Job:** new `benchmarks` job in `release.yml`, on tag push. Runs the full
   `read_throughput` criterion suite plus the ignored `bench_ingest` /
-  `bench_refresh` at a representative tier (`MUSEFS_BENCH_TIER`), `--nocapture`,
-  via an in-tree `scripts/perf-release-bench.sh`.
+  `bench_refresh` pinned to the **`ci` tier** (`MUSEFS_BENCH_TIER=ci`, ~200
+  tracks — small enough for a shared GHA runner; the `bandwidth` 30 MiB×1k and
+  `large-compute` 100k tiers risk multi-hour runs / OOM and are explicitly
+  excluded), `--nocapture`, via an in-tree `scripts/perf-release-bench.sh`. This
+  records absolute numbers and the in-process ingest counters; it is the home of
+  the latency-FS fsync==0 signal (`bench_scan_under_latency`) only if `/dev/fuse`
+  is available on the runner, otherwise that leg is skipped and noted.
 - **Output:** uploads captured results as a release **artifact**
-  (`actions/upload-artifact`) for hand-curation into `BENCHMARKS.md`. No
-  auto-commit. **Non-blocking** — a slow/noisy bench must never block a release.
+  (`actions/upload-artifact`, SHA-pinned) for hand-curation into `BENCHMARKS.md`.
+  No auto-commit. **Non-blocking** (`continue-on-error` / not a required check) —
+  a slow/noisy bench must never block a release.
 
 ## Documentation & harness
 
@@ -129,23 +172,43 @@ A recorded snapshot, not a gate.
   constant-factor slowdowns; the latter are surfaced only by Lane 2, only on
   core-`src` PRs, only as a warning. This is the honest limit of gating on noisy
   GHA runners.
-- **Mutants anchors.** Adding the touch counter in `tree.rs` shifts line numbers
-  → re-anchor `.cargo/mutants.toml` in the same commit (the
-  `check_mutant_anchors.py` pre-commit guard fails otherwise).
+- **No fsync==0 in the PR gate.** The 403→0 ingest signal needs the latency-FS
+  mount (`/dev/fuse`), so it lives only in the release lane / the existing
+  `#[ignore]` bench, not the per-PR gate. A reintroduced *slurp* is still caught
+  per-PR via `scan_bytes_read` (Lane 1 ingest); a reintroduced *per-file fsync
+  storm* is caught only at release.
 - **Golden-number maintenance.** Exact counter assertions must be updated
   whenever read/ingest/refresh work legitimately changes — intentional friction.
+- **Refresh test edits `tree.rs`.** Even appended at the end of the test module,
+  confirm `check_mutant_anchors.py` passes before committing; if any
+  `.cargo/mutants.toml` anchor shifts, re-anchor in the same commit.
 - **Fork PRs.** Lane 2's PR comment degrades to a job summary (no write token).
 - **Pre-commit gate.** The new `perf_counters.rs` runs under
   `cargo test -p musefs-core --features metrics`, which the workspace default
   `cargo test` skips — ensure the metrics-feature leg is green before pushing
   (the full workspace pre-commit hook covers it; bare `cargo test` does not).
 
+## Sequencing
+
+Three independently-shippable PRs, in order:
+
+1. **Lane 1 — counter gate.** Pure tests: `perf_counters.rs` + the `tree.rs`
+   refresh unit test. Touches no production code or workflows; must land green
+   under the metrics-feature leg (pre-commit runs the full suite).
+2. **Lane 2 — A/B job.** Workflow + `scripts/perf-ab.sh` + the `perf` filter
+   output. Pure CI/scripts.
+3. **Lane 3 — release record.** Workflow job + `scripts/perf-release-bench.sh`.
+
+Keeping Lane 1 separate prevents a churny golden-number test from blocking the
+CI-only work in Lanes 2–3.
+
 ## Affected files
 
-- `musefs-core/src/metrics.rs` — new touch counter + `Snapshot` field (+ stub).
-- `musefs-core/src/tree.rs` — increment touch counter in `apply_changes`.
-- `musefs-core/tests/perf_counters.rs` — new golden-counter test module.
-- `.cargo/mutants.toml` — re-anchor after `tree.rs` line shift.
+- `musefs-core/tests/perf_counters.rs` — new golden read/ingest counter module
+  (reuses existing `metrics` counters; no production change).
+- `musefs-core/src/tree.rs` — new refresh unit test appended to the existing
+  `#[cfg(test)]` module asserting the `apply_changes` rebuild count is
+  size-invariant (no production-body change).
 - `.github/workflows/ci.yml` — `perf` output on `changes`; new `perf-ab` job.
 - `.github/workflows/release.yml` — new `benchmarks` job.
 - `scripts/perf-ab.sh`, `scripts/perf-release-bench.sh` — new harness scripts.

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1912,4 +1912,55 @@ mod tests {
         assert!(t.lookup(VirtualTree::ROOT, "Song.flac").is_some());
         assert!(t.lookup(VirtualTree::ROOT, "Tune.flac").is_some());
     }
+
+    /// Builds a many-album library and re-tags ONE track (renaming its leaf
+    /// within its own album dir, no rendered-name collision). The
+    /// `apply_changes` rebuild-subtree count for such a change is 0 — it is
+    /// handled by remove+insert — and must stay 0 *regardless of library size*.
+    /// A regression that over-dirties (rebuilding album subtrees on every change)
+    /// would make the count scale with album count, tripping this gate. (This
+    /// guards `apply_changes`'s O(changed) contract; it does NOT guard the
+    /// facade's choice to call `apply_changes` vs a full `build_with`.)
+    fn library(albums: usize) -> Vec<(i64, String)> {
+        let mut e = Vec::new();
+        for a in 0..albums {
+            for t in 0..3 {
+                let id = i64::try_from(a * 3 + t).unwrap();
+                e.push((id, format!("Album{a:04}/t{t}.flac")));
+            }
+        }
+        e
+    }
+
+    fn rebuilds_for_one_retag(albums: usize) -> usize {
+        let entries = library(albums);
+        let mut alloc = InodeAllocator::new(false);
+        let mut t = VirtualTree::build_with(&entries, &mut alloc);
+        // Re-tag track id 1 (Album0000/t1.flac) → renamed leaf in the SAME dir.
+        let changed_id: i64 = 1;
+        let mut new_entries = entries.clone();
+        for (id, path) in &mut new_entries {
+            if *id == changed_id {
+                *path = "Album0000/renamed.flac".to_string();
+            }
+        }
+        let new_paths: std::collections::HashMap<i64, TrackRenderState> = new_entries
+            .iter()
+            .map(|&(id, ref p)| (id, trs(p)))
+            .collect();
+        t.apply_changes(&new_paths, &[changed_id], &[], &[], &mut alloc)
+            .unwrap()
+    }
+
+    #[test]
+    fn apply_changes_rebuild_count_is_size_invariant() {
+        const EXPECTED_REBUILDS: usize = 0;
+        let small = rebuilds_for_one_retag(43); // 129 tracks
+        let large = rebuilds_for_one_retag(683); // 2049 tracks
+        assert_eq!(small, EXPECTED_REBUILDS, "small-library rebuild count");
+        assert_eq!(
+            large, EXPECTED_REBUILDS,
+            "large-library rebuild count must not scale with size (O(changed), not O(N))",
+        );
+    }
 }

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -1,0 +1,100 @@
+#![cfg(feature = "metrics")]
+
+mod common;
+use common::corpus::{ALL_FORMATS, CorpusParams, Format, format_token, prepare_format};
+use musefs_core::{Mode, MountConfig, Musefs, VirtualTree, metrics, scan_directory};
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+/// The `metrics` counters are global statics; serialize every measured region.
+static METRICS_LOCK: Mutex<()> = Mutex::new(());
+
+/// Audio payload size for every read golden (4 MiB, matching `read_throughput`).
+const AUDIO_BYTES: u64 = 4 * 1024 * 1024;
+/// 128 KiB read chunk (matching `read_throughput`).
+const CHUNK: u64 = 128 * 1024;
+
+fn config() -> MountConfig {
+    MountConfig {
+        template: "$artist/$album/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
+    }
+}
+
+/// Recursively collect every file inode (non-FLAC corpus tracks render under
+/// the `Unknown/` fallback, so we discover by a format-agnostic tree walk).
+fn collect_file_inodes(fs: &Musefs, dir: u64, out: &mut Vec<u64>) {
+    for (_, ino, is_dir) in fs.readdir(dir).unwrap() {
+        if is_dir {
+            collect_file_inodes(fs, ino, out);
+        } else {
+            out.push(ino);
+        }
+    }
+}
+
+/// Generate a single-format AUDIO-ONLY corpus (fixed seed/size), scan + mount,
+/// and return (fs, first-file-inode, tempdir-guard).
+fn mount_one(fmt: Format, bytes_per_track: usize) -> (Musefs, u64, tempfile::TempDir) {
+    let base = tempfile::tempdir().unwrap();
+    let params = CorpusParams {
+        albums: 1,
+        tracks_per_album: 1,
+        bytes_per_track,
+        art_bytes_per_track: 0,
+        format_mix: vec![fmt],
+        seed: 42,
+    };
+    let target = prepare_format(&params, base.path(), fmt);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+    let mut inodes = Vec::new();
+    collect_file_inodes(&fs, VirtualTree::ROOT, &mut inodes);
+    assert!(!inodes.is_empty(), "no file inodes for {fmt:?}");
+    (fs, inodes[0], base)
+}
+
+fn read_whole(fs: &Musefs, inode: u64) {
+    let size = fs.getattr(inode).unwrap().size;
+    let mut off = 0u64;
+    while off < size {
+        let got = fs.read(inode, None, off, CHUNK).unwrap();
+        if got.is_empty() {
+            break;
+        }
+        off += got.len() as u64;
+    }
+}
+
+/// A whole-file sequential read of an audio-only file must emit zero art and
+/// zero binary-tag chunks (guards against accidental art/tag re-emission on the
+/// hot read path). Per-format byte/pread goldens live in Task 1.2.
+#[test]
+fn audio_only_read_emits_no_art_or_tag_chunks() {
+    let _g = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    for &fmt in ALL_FORMATS {
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize);
+        metrics::reset();
+        read_whole(&fs, inode);
+        let s = metrics::snapshot();
+        assert_eq!(
+            s.art_chunks,
+            0,
+            "{}: audio-only must emit no art chunks",
+            format_token(fmt)
+        );
+        assert_eq!(
+            s.binary_tag_chunks,
+            0,
+            "{}: audio-only must emit no binary-tag chunks",
+            format_token(fmt),
+        );
+    }
+}

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -172,3 +172,41 @@ fn read_preads_and_seek_match_goldens() {
         );
     }
 }
+
+/// Ingest of files LARGER than the ~1 MiB bounded metadata window: the scanner
+/// reads only a bounded prefix, never the whole file. A reintroduced slurp shows
+/// up as `scan_bytes_read` jumping toward `tracks * 2 MiB`. Counts frozen below.
+#[test]
+fn ingest_reads_bounded_prefix_not_whole_file() {
+    let _g = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    const TRACKS: usize = 3;
+    const BYTES_PER_TRACK: usize = 2 * 1024 * 1024; // > 1 MiB scan window
+    let (exp_opens, exp_preads, exp_bytes): (u64, u64, u64) = (3, 3, 3_145_728);
+
+    let base = tempfile::tempdir().unwrap();
+    let params = CorpusParams {
+        albums: 1,
+        tracks_per_album: TRACKS,
+        bytes_per_track: BYTES_PER_TRACK,
+        art_bytes_per_track: 0,
+        format_mix: vec![Format::Flac],
+        seed: 42,
+    };
+    let target = prepare_format(&params, base.path(), Format::Flac);
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    metrics::reset();
+    scan_directory(&db, &target.corpus_dir).unwrap();
+    let s = metrics::snapshot();
+
+    assert_eq!(s.scan_opens, exp_opens, "scan_opens");
+    assert_eq!(s.scan_preads, exp_preads, "scan_preads");
+    assert_eq!(s.scan_bytes_read, exp_bytes, "scan_bytes_read");
+    // Hard upper bound independent of the frozen number: must be far below a slurp.
+    assert!(
+        s.scan_bytes_read < (TRACKS as u64) * BYTES_PER_TRACK as u64,
+        "scan read {} bytes — looks like a whole-file slurp",
+        s.scan_bytes_read,
+    );
+}

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -203,9 +203,12 @@ fn ingest_reads_bounded_prefix_not_whole_file() {
     assert_eq!(s.scan_opens, exp_opens, "scan_opens");
     assert_eq!(s.scan_preads, exp_preads, "scan_preads");
     assert_eq!(s.scan_bytes_read, exp_bytes, "scan_bytes_read");
-    // Hard upper bound independent of the frozen number: must be far below a slurp.
+    // Hard upper bound independent of the frozen number: a slurp reads the whole
+    // 2 MiB/track (6 MiB total); the bounded prefix is ~1 MiB/track (3 MiB). Sit
+    // the bound between them so any drift toward a slurp trips even if the golden
+    // is updated.
     assert!(
-        s.scan_bytes_read < (TRACKS as u64) * BYTES_PER_TRACK as u64,
+        s.scan_bytes_read < (TRACKS as u64) * BYTES_PER_TRACK as u64 * 3 / 4,
         "scan read {} bytes — looks like a whole-file slurp",
         s.scan_bytes_read,
     );

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -138,18 +138,16 @@ fn read_preads_and_seek_match_goldens() {
         assert_eq!(
             seq.pread_bytes,
             exp_seq_bytes,
-            "{}: sequential pread_bytes (audio read once)",
+            "{}: sequential pread_bytes",
             format_token(fmt)
         );
-        // Format-agnostic slurp guard, independent of the frozen number.
         assert!(
             seq.pread_bytes < AUDIO_BYTES_USIZE as u64 * 2,
-            "{}: sequential read {} bytes — looks like a double-read/slurp",
+            "{}: sequential read {} bytes — slurp?",
             format_token(fmt),
-            seq.pread_bytes,
+            seq.pread_bytes
         );
 
-        // Fresh mount → cold cache → single deep read.
         let (fs2, inode2, _dir2) = mount_one(fmt, AUDIO_BYTES_USIZE);
         metrics::reset();
         let _ = fs2.read(inode2, None, SEEK_OFF, CHUNK).unwrap();
@@ -163,14 +161,14 @@ fn read_preads_and_seek_match_goldens() {
         assert_eq!(
             seek.pread_bytes,
             exp_seek_bytes,
-            "{}: seek must read a bounded window, not the whole file/index",
-            format_token(fmt),
+            "{}: seek pread_bytes",
+            format_token(fmt)
         );
         assert!(
             seek.pread_bytes < AUDIO_BYTES_USIZE as u64 / 4,
-            "{}: seek read {} bytes — not a bounded window",
+            "{}: seek read {} bytes — not bounded",
             format_token(fmt),
-            seek.pread_bytes,
+            seek.pread_bytes
         );
     }
 }

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -98,3 +98,79 @@ fn audio_only_read_emits_no_art_or_tag_chunks() {
         );
     }
 }
+
+/// Frozen per-format read goldens:
+/// `(seq_preads, seq_pread_bytes, seek_preads, seek_pread_bytes)`.
+/// seq = whole-file sequential read (audio read exactly once).
+/// seek = one 128 KiB read near EOF — must touch a BOUNDED window, never the
+/// whole file/index. Filled by the characterization run in Step 3; a change here
+/// means real read-path work changed — update in the same PR.
+fn goldens(fmt: Format) -> (u64, u64, u64, u64) {
+    match fmt {
+        Format::Mp3 => (33, 4_194_306, 1, 131_072),
+        Format::Ogg => (194, 4_221_658, 9, 262_250),
+        Format::Flac | Format::M4aMoovFirst | Format::M4aMoovLast | Format::Wav => {
+            (33, 4_194_304, 1, 131_072)
+        }
+    }
+}
+
+const SEEK_OFF: u64 = 3_500_000;
+
+#[test]
+fn read_preads_and_seek_match_goldens() {
+    let _g = METRICS_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    for &fmt in ALL_FORMATS {
+        let (exp_seq_preads, exp_seq_bytes, exp_seek_preads, exp_seek_bytes) = goldens(fmt);
+
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES_USIZE);
+        metrics::reset();
+        read_whole(&fs, inode);
+        let seq = metrics::snapshot();
+        assert_eq!(
+            seq.preads,
+            exp_seq_preads,
+            "{}: sequential preads",
+            format_token(fmt)
+        );
+        assert_eq!(
+            seq.pread_bytes,
+            exp_seq_bytes,
+            "{}: sequential pread_bytes (audio read once)",
+            format_token(fmt)
+        );
+        // Format-agnostic slurp guard, independent of the frozen number.
+        assert!(
+            seq.pread_bytes < AUDIO_BYTES_USIZE as u64 * 2,
+            "{}: sequential read {} bytes — looks like a double-read/slurp",
+            format_token(fmt),
+            seq.pread_bytes,
+        );
+
+        // Fresh mount → cold cache → single deep read.
+        let (fs2, inode2, _dir2) = mount_one(fmt, AUDIO_BYTES_USIZE);
+        metrics::reset();
+        let _ = fs2.read(inode2, None, SEEK_OFF, CHUNK).unwrap();
+        let seek = metrics::snapshot();
+        assert_eq!(
+            seek.preads,
+            exp_seek_preads,
+            "{}: seek preads",
+            format_token(fmt)
+        );
+        assert_eq!(
+            seek.pread_bytes,
+            exp_seek_bytes,
+            "{}: seek must read a bounded window, not the whole file/index",
+            format_token(fmt),
+        );
+        assert!(
+            seek.pread_bytes < AUDIO_BYTES_USIZE as u64 / 4,
+            "{}: seek read {} bytes — not a bounded window",
+            format_token(fmt),
+            seek.pread_bytes,
+        );
+    }
+}

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -9,8 +9,8 @@ use std::sync::Mutex;
 /// The `metrics` counters are global statics; serialize every measured region.
 static METRICS_LOCK: Mutex<()> = Mutex::new(());
 
-/// Audio payload size for every read golden (4 MiB, matching `read_throughput`).
-const AUDIO_BYTES: u64 = 4 * 1024 * 1024;
+/// `AUDIO_BYTES` as `usize` for `CorpusParams::bytes_per_track`.
+const AUDIO_BYTES_USIZE: usize = 4 * 1024 * 1024;
 /// 128 KiB read chunk (matching `read_throughput`).
 const CHUNK: u64 = 128 * 1024;
 
@@ -80,7 +80,7 @@ fn audio_only_read_emits_no_art_or_tag_chunks() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     for &fmt in ALL_FORMATS {
-        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES as usize);
+        let (fs, inode, _dir) = mount_one(fmt, AUDIO_BYTES_USIZE);
         metrics::reset();
         read_whole(&fs, inode);
         let s = metrics::snapshot();

--- a/scripts/perf-ab.sh
+++ b/scripts/perf-ab.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Same-runner A/B wall-clock comparison of the read_throughput criterion bench.
 # Benches the base ref and HEAD back-to-back on ONE machine (robust to
-# runner-to-runner variance), then diffs with critcmp. Warn-only: always exits 0.
+# runner-to-runner variance), then diffs with critcmp. The job that invokes this
+# is informational (excluded from the ci-ok gate); a build/bench failure here
+# surfaces as a red job rather than being swallowed.
 #
 # Usage: scripts/perf-ab.sh <base-sha> <out-markdown-file>
 # Requires: cargo, critcmp on PATH. Run from the repo root with a clean tree.

--- a/scripts/perf-ab.sh
+++ b/scripts/perf-ab.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Same-runner A/B wall-clock comparison of the read_throughput criterion bench.
+# Benches the base ref and HEAD back-to-back on ONE machine (robust to
+# runner-to-runner variance), then diffs with critcmp. Warn-only: always exits 0.
+#
+# Usage: scripts/perf-ab.sh <base-sha> <out-markdown-file>
+# Requires: cargo, critcmp on PATH. Run from the repo root with a clean tree.
+set -euo pipefail
+
+BASE_SHA="${1:?base sha required}"
+OUT="${2:?output markdown path required}"
+BENCH=(cargo bench -p musefs-core --bench read_throughput --)
+
+head_sha="$(git rev-parse HEAD)"
+
+run_baseline() {
+  local name="$1"
+  "${BENCH[@]}" --save-baseline "$name" >/dev/null 2>&1
+}
+
+echo "Benching base ($BASE_SHA)…" >&2
+git checkout --quiet --detach "$BASE_SHA"
+run_baseline base
+
+echo "Benching head ($head_sha)…" >&2
+git checkout --quiet --detach "$head_sha"
+run_baseline pr
+
+{
+  echo "### Read-path A/B (same-runner, warn-only)"
+  echo
+  echo "Base \`${BASE_SHA:0:12}\` vs PR \`${head_sha:0:12}\`. Wall-clock on a"
+  echo "shared GH runner — treat <10% moves as noise."
+  echo
+  base_n="$(critcmp --list 2>/dev/null | grep -c '^base' || true)"
+  pr_n="$(critcmp --list 2>/dev/null | grep -c '^pr' || true)"
+  common="$(critcmp base pr 2>/dev/null | tail -n +2 | grep -c . || true)"
+  if [ "$common" -eq 0 ]; then
+    echo "> ⚠️ No comparable benchmarks (benchmark IDs differ between base and PR"
+    echo "> — a harness/bench rename?). Nothing to compare."
+  else
+    echo '```'
+    critcmp base pr
+    echo '```'
+    echo
+    echo "_base benches: ${base_n}, pr benches: ${pr_n}, compared: ${common}._"
+  fi
+} > "$OUT"
+
+echo "Wrote $OUT" >&2

--- a/scripts/perf-release-bench.sh
+++ b/scripts/perf-release-bench.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run the full read bench plus the ci-tier ingest/refresh benches and capture
+# all output to a single artifact file. Record-only; never gates a release.
+#
+# Usage: scripts/perf-release-bench.sh <out-file>
+set -euo pipefail
+OUT="${1:?output file required}"
+
+{
+  echo "# musefs release benchmark snapshot"
+  echo "commit: $(git rev-parse HEAD)"
+  echo
+
+  echo "## read_throughput (criterion)"
+  cargo bench -p musefs-core --bench read_throughput -- 2>&1 || true
+
+  echo "## bench_ingest (ci tier)"
+  MUSEFS_BENCH_TIER=ci cargo test --release -p musefs-core --features metrics \
+    --test bench_ingest -- --ignored --nocapture 2>&1 || true
+
+  echo "## bench_refresh (ci tier)"
+  MUSEFS_BENCH_TIER=ci cargo test --release -p musefs-core \
+    --test bench_refresh -- --ignored --nocapture 2>&1 || true
+} | tee "$OUT"


### PR DESCRIPTION
Closes #211.

Adds a three-lane regression signal for the read/serve, ingest, and refresh paths without flaky wall-clock gating. Delivered as one commit series in three parts.

## Part 1 — deterministic counter gate (hard, every non-doc PR)
No production code — reuses the existing `metrics` feature counters.
- `musefs-core/tests/perf_counters.rs`: per-format golden read counters (`preads`/`pread_bytes`, art/binary-tag chunks), a bounded-seek invariant, and an ingest slurp-window golden (`scan_bytes_read` stays a bounded prefix, never a whole-file slurp).
- `musefs-core/src/tree.rs`: one appended unit test pinning the `apply_changes` rebuild-subtree count as **size-invariant** (O(changed), not O(N)).
- Runs in the existing `check` job's `--features metrics` step. A legitimate work change updates the goldens in the same PR.

## Part 2 — same-runner A/B wall-clock (warn-only)
- New `perf` path-filter output on the `changes` job; new `perf-ab` job that runs **only** on `pull_request` events touching `musefs-core/src/**` or `musefs-format/src/**`.
- `scripts/perf-ab.sh` benches base vs HEAD back-to-back on one runner and posts a `critcmp` delta as a sticky PR comment. **Never blocks** (excluded from `ci-ok`); degrades to a job summary on forks.

## Part 3 — release full-bench record
- `scripts/perf-release-bench.sh` + a `benchmarks` job in `release.yml` (`continue-on-error`) uploading a snapshot artifact for hand-curation into `BENCHMARKS.md`.

The fsync-storm (403→0) signal needs a real FUSE mount and stays in the release lane / `#[ignore]` bench, not the per-PR gate.

Docs: `CONTRIBUTING.md` test-tiers + `BENCHMARKS.md` "CI regression gating" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
