### PR TITLE
feat(musefs): jemalloc global allocator to bound RSS under churn (#360)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -762,3 +762,29 @@ consistent across HDD and NFS. This is the only tunable worth changing for slow 
   latency is never hidden by prefetch. The real lever for slow backing would be a
   **concurrent backing-prefetch pipeline in the daemon** (issue several `BackingAudio`
   reads ahead in parallel), an architectural change tracked separately.
+
+---
+
+## Global allocator — steady-state RSS (#360)
+
+Long-lived high-churn FUSE load fragments glibc malloc, growing daemon RSS over
+days without a true leak. The `musefs` binary now defaults to the jemalloc
+global allocator with a background purge thread. Measured with
+`scripts/rss-churn-bench.sh` (Linux; median `VmRSS` over the flattened tail —
+steady state, not peak).
+
+**Parameters:** WORKERS=8 (nproc), FILES=500, CYCLES=200, WARMUP=20, no
+REFRESH_CMD. DB = a freshly-scanned 4427-track store on tmpfs (`/tmp`); backing
+audio on `/data` (HDD). Concurrent `cat`-to-`/dev/null` churn drives the
+open/read/release handle-table and read-synthesis allocation path.
+
+| Allocator      | Steady-state RSS      |
+| -------------- | --------------------- |
+| system malloc  | ~74.7 MiB (76496 kiB) |
+| jemalloc       | ~28.7 MiB (29368 kiB) |
+
+**Decision: SHIP jemalloc.** Steady-state RSS is ~62% lower (jemalloc ≤ system
+malloc, the §4 ship rule). Under identical churn glibc retained ~46 MiB of dirty
+pages that jemalloc's decay + background purge return to the OS — the #360
+fragmentation failure mode, reproduced and fixed. The gap is far outside
+run-to-run noise, so no within-noise tie-break was needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,11 @@ cargo clippy --all-targets               # lint (policy: see below)
 cargo fmt                                # format
 ```
 
+The `musefs` binary enables the default-on `jemalloc` feature (jemalloc global
+allocator + background purge thread). Build the system-allocator variant with
+`cargo build -p musefs --no-default-features` — used for the RSS comparison
+(`scripts/rss-churn-bench.sh`) and by packagers that forbid vendored C libs.
+
 The FUSE end-to-end tests perform real mounts and are `#[ignore]`d:
 
 ```bash
@@ -576,6 +581,19 @@ and is the source of truth; this checklist is the human side.
    `ci-ok` and `coverage-ok` to be green on the tagged commit** before anything
    builds or publishes — a red tree blocks the release automatically.
 3. `CARGO_REGISTRY_TOKEN` is present in repo secrets.
+4. Smoke-build every cross target so `jemalloc-sys` is known to compile under
+   zig before tagging (the release matrix builds with the `jemalloc` feature on):
+
+   ```bash
+   for t in x86_64-unknown-linux-gnu.2.17 aarch64-unknown-linux-gnu.2.17 \
+            x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+     cargo zigbuild --release -p musefs --target "$t"
+   done
+   ```
+
+   If a target cannot build `jemalloc-sys`, add `--no-default-features` to that
+   matrix entry in `release.yml` **and** its matching Docker image, rather than
+   blocking the release.
 
 **Version bump (do this in one commit before tagging).**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -592,8 +592,9 @@ and is the source of truth; this checklist is the human side.
    ```
 
    If a target cannot build `jemalloc-sys`, add `--no-default-features` to that
-   matrix entry in `release.yml` **and** its matching Docker image, rather than
-   blocking the release.
+   matrix entry's `cargo zigbuild` in `release.yml`, rather than blocking the
+   release. The Docker images `COPY` the binary this step produces (they don't
+   run cargo), so the matching container inherits the opt-out automatically.
 
 **Version bump (do this in one commit before tagging).**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ version = "1.0.0"
 dependencies = [
  "clap",
  "env_logger",
+ "log",
  "musefs-cli",
  "rustix",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,8 @@ dependencies = [
  "musefs-cli",
  "rustix",
  "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1141,6 +1143,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -1727,6 +1735,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ cargo install --git https://github.com/Sohex/musefs musefs
 
 The same `fuse3` runtime requirement as the prebuilt binaries applies.
 
+The binary uses **jemalloc** as its global allocator by default (it bounds
+resident memory for the long-lived mount daemon under heavy concurrent reads).
+Distribution packagers or anyone debugging memory with valgrind/heaptrack can
+build against the system allocator instead with
+`cargo build -p musefs --no-default-features` (or `cargo install musefs
+--no-default-features`).
+
 ### Container images
 
 Each tagged release also publishes multi-arch images to the GitHub Container

--- a/docs/superpowers/plans/2026-06-14-jemalloc-global-allocator.md
+++ b/docs/superpowers/plans/2026-06-14-jemalloc-global-allocator.md
@@ -39,7 +39,7 @@ Insert a `[features]` block immediately after the `[[bin]]` block (before `[depe
 ```toml
 [features]
 default = ["jemalloc"]
-jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "tikv-jemalloc-ctl/stats"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -49,7 +49,7 @@ tikv-jemallocator = { version = "0.7", optional = true }
 tikv-jemalloc-ctl = { version = "0.7", optional = true }
 ```
 
-(jemalloc's stats and `background_threads_runtime_support` are on by default via `tikv-jemalloc-sys`; no extra cargo feature is required.)
+(`background_threads_runtime_support` is on by default via `tikv-jemalloc-sys`, so the background thread needs no extra feature. The `stats` module of `tikv-jemalloc-ctl` is **not** a default feature, though — the `tikv-jemalloc-ctl/stats` entry above turns it on so `stats::allocated::read()` in the Step 2 test compiles. `epoch::advance()` and `background_thread` are ungated and need no feature.)
 
 - [ ] **Step 2: Write the failing test in `musefs/src/main.rs`**
 
@@ -127,7 +127,7 @@ git commit -m "feat(musefs): jemalloc global allocator behind default-on feature
 In `musefs/Cargo.toml`, extend the feature and add the dep:
 
 ```toml
-jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "dep:log"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "tikv-jemalloc-ctl/stats", "dep:log"]
 ```
 
 ```toml
@@ -279,8 +279,7 @@ run_variant() {
   mkdir -p "$MOUNT"
   "$bin" mount "$DB" "$MOUNT" &
   local mpid=$!
-  local i
-  for i in $(seq 1 50); do
+  for _ in $(seq 1 50); do
     mountpoint -q "$MOUNT" && break
     sleep 0.1
   done
@@ -295,7 +294,7 @@ run_variant() {
   stop="$(mktemp)"
   rm -f "$stop"
   local pids=()
-  for i in $(seq 1 "$WORKERS"); do
+  for _ in $(seq 1 "$WORKERS"); do
     (
       while [ ! -e "$stop" ]; do
         for f in "${targets[@]}"; do
@@ -318,7 +317,7 @@ run_variant() {
     rpid=$!
   fi
   local samples=()
-  for i in $(seq 1 "$CYCLES"); do
+  for _ in $(seq 1 "$CYCLES"); do
     sleep 1
     samples+=("$(awk '/^VmRSS:/ { print $2 }' "/proc/$mpid/status" 2>/dev/null || echo 0)")
   done
@@ -556,10 +555,11 @@ Add a per-entry flag in the matrix (add `no_default: true` to the failing
         run: cargo zigbuild --release -p musefs --target ${{ matrix.zig_target }} ${{ matrix.no_default && '--no-default-features' || '' }}
 ```
 
-Then apply the same `--no-default-features` to that arch's Docker image build
-(`docker/Dockerfile` / `docker/Dockerfile.musl` cargo invocation) so the tarball
-and container for that arch ship the same allocator. Document the dropped target
-in `CONTRIBUTING.md` under the release section.
+No Docker edit is needed: the image variants `COPY` the prebuilt binary emitted
+by this same `build` job (they do not invoke cargo), so the build-step flag
+propagates to that arch's container automatically — the tarball and image stay
+in sync for free. Just document the dropped target in `CONTRIBUTING.md` under the
+release section.
 
 - [ ] **Step 4: If all four built, no workflow change is needed**
 
@@ -569,7 +569,7 @@ cleanly, so the conditional fallback was not triggered.
 - [ ] **Step 5: Commit (only if Step 3 changed files)**
 
 ```bash
-git add .github/workflows/release.yml docker/ CONTRIBUTING.md
+git add .github/workflows/release.yml CONTRIBUTING.md
 git commit -m "ci(release): opt the <triple> target out of jemalloc (jemalloc-sys cross-build) (#360)"
 ```
 

--- a/docs/superpowers/plans/2026-06-14-jemalloc-global-allocator.md
+++ b/docs/superpowers/plans/2026-06-14-jemalloc-global-allocator.md
@@ -1,0 +1,592 @@
+# jemalloc Global Allocator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `musefs` binary use jemalloc as its global allocator (with a background purge thread) to bound RSS under long-lived, high-churn FUSE load, behind a default-on `jemalloc` feature that packagers/debuggers can disable.
+
+**Architecture:** The allocator override lives only in the binary crate (`musefs/src/main.rs`); library crates, tests, benches, and the sanitizer CI jobs are untouched. jemalloc comes from `tikv-jemallocator`; the background purge thread is turned on at startup via the safe `tikv-jemalloc-ctl` API (no `unsafe`, so the workspace `unsafe_code = "deny"` lint is satisfied). A committed Linux churn benchmark measures steady-state RSS to gate the change; docs and the release pipeline are updated for the new dependency.
+
+**Tech Stack:** Rust 2024, `tikv-jemallocator` + `tikv-jemalloc-ctl` 0.7, `cargo-zigbuild` (release cross-builds), Bash + `/proc` (RSS bench).
+
+**Source spec:** `docs/superpowers/specs/2026-06-14-jemalloc-global-allocator-design.md` (issue #360 part A; telemetry part B is a separate spec, out of scope).
+
+**Pre-commit note:** every non-docs commit runs `cargo fmt`, `cargo clippy --all-targets -D warnings`, the **full workspace test suite**, and `shellcheck` over tracked shell files. Each code/script commit below must be green. Docs-only commits skip the cargo legs. No `.cargo/mutants.toml` re-anchoring is needed — its anchors live in `musefs-core`/`musefs-format`, which this plan never edits.
+
+---
+
+## File Structure
+
+- `musefs/Cargo.toml` — **modify**: add the `jemalloc` feature (default-on) and the three optional deps.
+- `musefs/src/main.rs` — **modify**: add `#[global_allocator]`, the background-thread helper, the startup call, and unit tests proving jemalloc is wired and the purge thread is enabled.
+- `scripts/rss-churn-bench.sh` — **create**: Linux steady-state RSS churn benchmark comparing system-malloc vs jemalloc builds.
+- `BENCHMARKS.md` — **modify**: new allocator/RSS section recording methodology, parameters, numbers, and the ship decision.
+- `README.md` — **modify**: one line under "Building from source" on the default allocator + `--no-default-features` opt-out.
+- `CONTRIBUTING.md` — **modify**: note the `jemalloc` feature and the release smoke-build step.
+- `.github/workflows/release.yml` — **modify only if** a release target fails to cross-build `jemalloc-sys` (per-target `--no-default-features` fallback). Conditional; see Task 6.
+
+---
+
+## Task 1: Wire jemalloc as the global allocator
+
+**Files:**
+- Modify: `musefs/Cargo.toml`
+- Modify/Test: `musefs/src/main.rs`
+
+- [ ] **Step 1: Add the feature + optional deps to `musefs/Cargo.toml`**
+
+Insert a `[features]` block immediately after the `[[bin]]` block (before `[dependencies]`), and add the two optional deps to `[dependencies]`:
+
+```toml
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+env_logger = "0.11"
+musefs-cli = { path = "../musefs-cli", version = "1.0.0" }
+tikv-jemallocator = { version = "0.7", optional = true }
+tikv-jemalloc-ctl = { version = "0.7", optional = true }
+```
+
+(jemalloc's stats and `background_threads_runtime_support` are on by default via `tikv-jemalloc-sys`; no extra cargo feature is required.)
+
+- [ ] **Step 2: Write the failing test in `musefs/src/main.rs`**
+
+Append this module at the end of `musefs/src/main.rs`. The test allocates a 4 MiB buffer and asks jemalloc how much it has allocated; jemalloc only reports a large figure if it is actually serving the global allocator.
+
+```rust
+#[cfg(all(test, feature = "jemalloc"))]
+mod tests {
+    #[test]
+    fn jemalloc_is_the_global_allocator() {
+        // mallctl reads talk to the linked jemalloc runtime; `allocated` only
+        // climbs past a megabyte if jemalloc is serving #[global_allocator].
+        let buf: Vec<u8> = vec![0u8; 4 * 1024 * 1024];
+        std::hint::black_box(&buf);
+        tikv_jemalloc_ctl::epoch::advance().unwrap();
+        let allocated = tikv_jemalloc_ctl::stats::allocated::read().unwrap();
+        assert!(
+            allocated >= 1 << 20,
+            "jemalloc reports {allocated} bytes allocated; not wired as #[global_allocator]"
+        );
+        drop(buf);
+    }
+}
+```
+
+- [ ] **Step 3: Run the test and confirm it FAILS**
+
+Run: `cargo test -p musefs jemalloc_is_the_global_allocator`
+Expected: FAIL — `allocated` is ~0 because the system allocator is still serving the `Vec`, jemalloc is linked but unused. (The assertion message prints the tiny byte count.)
+
+- [ ] **Step 4: Add the global allocator to `musefs/src/main.rs`**
+
+Insert these lines between the `use` line and `fn main()`:
+
+```rust
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+```
+
+- [ ] **Step 5: Run the test and confirm it PASSES**
+
+Run: `cargo test -p musefs jemalloc_is_the_global_allocator`
+Expected: PASS — the 4 MiB `Vec` now flows through jemalloc, so `allocated >= 1 MiB`.
+
+- [ ] **Step 6: Confirm the opt-out still builds**
+
+Run: `cargo build -p musefs --no-default-features`
+Expected: builds cleanly (system malloc; the `#[cfg(feature = "jemalloc")]` items and the test module compile out).
+
+- [ ] **Step 7: Lint + format**
+
+Run: `cargo clippy -p musefs --all-targets -- -D warnings && cargo fmt`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs/Cargo.toml musefs/src/main.rs Cargo.lock
+git commit -m "feat(musefs): jemalloc global allocator behind default-on feature (#360)"
+```
+
+(The pre-commit hook runs the full workspace test suite under default features, exercising the new test.)
+
+---
+
+## Task 2: Enable the background purge thread at startup
+
+**Files:**
+- Modify: `musefs/Cargo.toml`
+- Modify/Test: `musefs/src/main.rs`
+
+- [ ] **Step 1: Add the `log` optional dep to the `jemalloc` feature**
+
+In `musefs/Cargo.toml`, extend the feature and add the dep:
+
+```toml
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "dep:log"]
+```
+
+```toml
+log = { version = "0.4", optional = true }
+```
+
+(Add the `log` line to `[dependencies]` alongside the other optional deps.)
+
+- [ ] **Step 2: Write the failing test in `musefs/src/main.rs`**
+
+Add these two tests inside the existing `#[cfg(all(test, feature = "jemalloc"))] mod tests` block (next to `jemalloc_is_the_global_allocator`):
+
+```rust
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn background_thread_enables_on_linux() {
+        super::enable_jemalloc_background_thread();
+        assert!(
+            tikv_jemalloc_ctl::background_thread::read().unwrap(),
+            "background_thread should be on after enable() on linux"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn enable_background_thread_does_not_panic_off_linux() {
+        // jemalloc lacks background-thread support on some platforms (macOS);
+        // the helper must swallow the error rather than panic.
+        super::enable_jemalloc_background_thread();
+    }
+```
+
+- [ ] **Step 3: Run the test and confirm it FAILS**
+
+Run: `cargo test -p musefs background_thread`
+Expected: FAIL to compile — `enable_jemalloc_background_thread` does not exist yet (`cannot find function ... in module super`).
+
+- [ ] **Step 4: Add the helper and call it from `main`**
+
+In `musefs/src/main.rs`, add the helper just below the `GLOBAL` static:
+
+```rust
+/// Enable jemalloc's background purge thread so an idle daemon returns dirty
+/// pages to the OS (the RSS-creep fix in #360). Best-effort: unsupported on some
+/// platforms (notably macOS), where it logs at debug and continues — jemalloc
+/// stays active and still purges on allocation activity.
+#[cfg(feature = "jemalloc")]
+fn enable_jemalloc_background_thread() {
+    if let Err(e) = tikv_jemalloc_ctl::background_thread::write(true) {
+        log::debug!("jemalloc background_thread unavailable: {e}");
+    }
+}
+```
+
+Then call it in `main`, right after `env_logger…init()` and before `run(...)`:
+
+```rust
+    #[cfg(feature = "jemalloc")]
+    enable_jemalloc_background_thread();
+```
+
+- [ ] **Step 5: Run the test and confirm it PASSES**
+
+Run: `cargo test -p musefs background_thread`
+Expected: PASS on Linux (`background_thread_enables_on_linux` asserts `true`).
+
+- [ ] **Step 6: Confirm the opt-out still builds**
+
+Run: `cargo build -p musefs --no-default-features`
+Expected: builds cleanly (helper + call compile out).
+
+- [ ] **Step 7: Lint + format**
+
+Run: `cargo clippy -p musefs --all-targets -- -D warnings && cargo fmt`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs/Cargo.toml musefs/src/main.rs Cargo.lock
+git commit -m "feat(musefs): enable jemalloc background purge thread at startup (#360)"
+```
+
+---
+
+## Task 3: RSS churn benchmark script
+
+**Files:**
+- Create: `scripts/rss-churn-bench.sh`
+
+- [ ] **Step 1: Create `scripts/rss-churn-bench.sh` with this exact content**
+
+```bash
+#!/usr/bin/env bash
+# Steady-state RSS churn benchmark for the musefs daemon (issue #360 part A).
+# Drives concurrent open/read/release churn against a mounted store and reports
+# the MEDIAN VmRSS over the flattened tail (steady state, NOT peak RSS), for the
+# system-malloc and jemalloc builds, then prints a ship/investigate decision.
+#
+# Linux-only: VmRSS comes from /proc/<pid>/status.
+#
+# Env knobs (defaults in parens):
+#   DB           musefs store path                         (required)
+#   MOUNT        mountpoint under $HOME                     ($HOME/.musefs-rss-mnt)
+#   WORKERS      concurrent reader threads                 (nproc)
+#   FILES        distinct files to churn                   (500)
+#   CYCLES       1-second RSS samples per variant          (200)
+#   WARMUP       leading samples discarded                 (20)
+#   REFRESH_CMD  shell command run every REFRESH_SECS      (none)
+#   REFRESH_SECS refresh cadence in seconds                (30)
+#   BINARIES     override builds: "sysmalloc=/p jemalloc=/p" (built from repo)
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "rss-churn-bench: Linux-only (needs /proc/<pid>/status VmRSS)" >&2
+  exit 1
+fi
+
+: "${DB:?set DB to a musefs store path}"
+MOUNT="${MOUNT:-$HOME/.musefs-rss-mnt}"
+WORKERS="${WORKERS:-$(nproc)}"
+FILES="${FILES:-500}"
+CYCLES="${CYCLES:-200}"
+WARMUP="${WARMUP:-20}"
+REFRESH_SECS="${REFRESH_SECS:-30}"
+
+build_variants() {
+  echo "building system-malloc and jemalloc release binaries..." >&2
+  cargo build --release -p musefs --no-default-features >&2
+  cp target/release/musefs /tmp/musefs-sysmalloc
+  cargo build --release -p musefs >&2
+  cp target/release/musefs /tmp/musefs-jemalloc
+  echo "sysmalloc=/tmp/musefs-sysmalloc jemalloc=/tmp/musefs-jemalloc"
+}
+
+# stdin: one integer per line -> median of the last 25% of lines.
+median_tail() {
+  local n tail_start
+  mapfile -t vals
+  n="${#vals[@]}"
+  tail_start=$(( n - n / 4 ))
+  printf '%s\n' "${vals[@]:tail_start}" | sort -n | awk '
+    { a[NR] = $1 }
+    END { if (NR % 2) print a[(NR + 1) / 2]; else print (a[NR / 2] + a[NR / 2 + 1]) / 2 }'
+}
+
+run_variant() {
+  local bin="$1"
+  mkdir -p "$MOUNT"
+  "$bin" mount "$DB" "$MOUNT" &
+  local mpid=$!
+  local i
+  for i in $(seq 1 50); do
+    mountpoint -q "$MOUNT" && break
+    sleep 0.1
+  done
+  local targets=()
+  mapfile -t targets < <(find "$MOUNT" -type f | head -n "$FILES")
+  if [ "${#targets[@]}" -eq 0 ]; then
+    echo "no files found under $MOUNT" >&2
+    fusermount3 -u "$MOUNT" 2>/dev/null || true
+    return 1
+  fi
+  local stop
+  stop="$(mktemp)"
+  rm -f "$stop"
+  local pids=()
+  for i in $(seq 1 "$WORKERS"); do
+    (
+      while [ ! -e "$stop" ]; do
+        for f in "${targets[@]}"; do
+          [ -e "$stop" ] && break
+          cat "$f" >/dev/null 2>&1 || true
+        done
+      done
+    ) &
+    pids+=("$!")
+  done
+  local rpid=""
+  if [ -n "${REFRESH_CMD:-}" ]; then
+    (
+      while [ ! -e "$stop" ]; do
+        sleep "$REFRESH_SECS"
+        # shellcheck disable=SC2086
+        eval $REFRESH_CMD >/dev/null 2>&1 || true
+      done
+    ) &
+    rpid=$!
+  fi
+  local samples=()
+  for i in $(seq 1 "$CYCLES"); do
+    sleep 1
+    samples+=("$(awk '/^VmRSS:/ { print $2 }' "/proc/$mpid/status" 2>/dev/null || echo 0)")
+  done
+  : > "$stop"
+  wait "${pids[@]}" 2>/dev/null || true
+  [ -n "$rpid" ] && { wait "$rpid" 2>/dev/null || true; }
+  rm -f "$stop"
+  fusermount3 -u "$MOUNT" 2>/dev/null || true
+  wait "$mpid" 2>/dev/null || true
+  printf '%s\n' "${samples[@]:$WARMUP}" | median_tail
+}
+
+main() {
+  local spec="${BINARIES:-$(build_variants)}"
+  echo "label,steady_state_rss_kib"
+  local sys_rss="" jem_rss="" pair label bin rss
+  # shellcheck disable=SC2086
+  for pair in $spec; do
+    label="${pair%%=*}"
+    bin="${pair#*=}"
+    rss="$(run_variant "$bin")"
+    echo "$label,$rss"
+    case "$label" in
+      *sys*) sys_rss="$rss" ;;
+      *jem*) jem_rss="$rss" ;;
+    esac
+  done
+  if [ -n "$sys_rss" ] && [ -n "$jem_rss" ]; then
+    if [ "$jem_rss" -le "$sys_rss" ]; then
+      echo "decision: SHIP jemalloc (steady-state ${jem_rss} kiB <= sysmalloc ${sys_rss} kiB)"
+    else
+      echo "decision: INVESTIGATE — jemalloc ${jem_rss} kiB > sysmalloc ${sys_rss} kiB"
+    fi
+  fi
+}
+
+main "$@"
+```
+
+- [ ] **Step 2: Make it executable and pass shellcheck**
+
+Run: `chmod +x scripts/rss-churn-bench.sh && shellcheck scripts/rss-churn-bench.sh`
+Expected: no findings (the two `eval`/word-split spots carry `# shellcheck disable` comments).
+
+- [ ] **Step 3: Smoke-run the script against the live-mount harness**
+
+Prep the harness DB once (the real store; copy to tmpfs so the bench isn't disk-bound):
+
+Run:
+```bash
+cp ~/musefs.db /tmp/musefs.db
+DB=/tmp/musefs.db MOUNT="$HOME/.musefs-rss-mnt" \
+  WORKERS=2 FILES=5 CYCLES=5 WARMUP=1 \
+  scripts/rss-churn-bench.sh
+```
+Expected: it builds both binaries, then prints a `label,steady_state_rss_kib` header, two data rows (`sysmalloc,<n>` and `jemalloc,<n>`), and a `decision:` line. (Numbers are tiny/noisy at these smoke parameters — this step only proves the harness runs end-to-end.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/rss-churn-bench.sh
+git commit -m "test(scripts): steady-state RSS churn benchmark for the allocator (#360)"
+```
+
+(The pre-commit `shellcheck` leg lints the new script.)
+
+---
+
+## Task 4: README + CONTRIBUTING documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Add the allocator note to `README.md`**
+
+In `README.md`, under `### Building from source`, after the line
+`The same `fuse3` runtime requirement as the prebuilt binaries applies.`
+add a new paragraph:
+
+```markdown
+The binary uses **jemalloc** as its global allocator by default (it bounds
+resident memory for the long-lived mount daemon under heavy concurrent reads).
+Distribution packagers or anyone debugging memory with valgrind/heaptrack can
+build against the system allocator instead with
+`cargo build -p musefs --no-default-features` (or `cargo install musefs
+--no-default-features`).
+```
+
+- [ ] **Step 2: Add the feature note to `CONTRIBUTING.md` Build & test**
+
+In `CONTRIBUTING.md`, under `## Build & test`, after the closing ``` of the
+first code block (the `cargo build … cargo fmt` block), add:
+
+```markdown
+The `musefs` binary enables the default-on `jemalloc` feature (jemalloc global
+allocator + background purge thread). Build the system-allocator variant with
+`cargo build -p musefs --no-default-features` — used for the RSS comparison
+(`scripts/rss-churn-bench.sh`) and by packagers that forbid vendored C libs.
+```
+
+- [ ] **Step 3: Add the release smoke-build step to `CONTRIBUTING.md`**
+
+In `CONTRIBUTING.md`, under `## Releasing the Rust crates and binaries` →
+`**Pre-flight.**`, add a new numbered item after item 3
+(`CARGO_REGISTRY_TOKEN is present…`):
+
+```markdown
+4. Smoke-build every cross target so `jemalloc-sys` is known to compile under
+   zig before tagging (the release matrix builds with the `jemalloc` feature on):
+
+   ```bash
+   for t in x86_64-unknown-linux-gnu.2.17 aarch64-unknown-linux-gnu.2.17 \
+            x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+     cargo zigbuild --release -p musefs --target "$t"
+   done
+   ```
+
+   If a target cannot build `jemalloc-sys`, add `--no-default-features` to that
+   matrix entry in `release.yml` **and** its matching Docker image, rather than
+   blocking the release.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CONTRIBUTING.md
+git commit -m "docs: document the jemalloc allocator and its opt-out (#360)"
+```
+
+(Docs-only commit — the cargo gate is skipped.)
+
+---
+
+## Task 5: Run the real benchmark and record results in BENCHMARKS.md
+
+**Files:**
+- Modify: `BENCHMARKS.md`
+
+- [ ] **Step 1: Run the full benchmark**
+
+Run (defaults: 500 files, nproc workers, 200 samples, 20 warmup — expect ~7 min/variant):
+```bash
+cp ~/musefs.db /tmp/musefs.db
+DB=/tmp/musefs.db scripts/rss-churn-bench.sh | tee /tmp/rss-bench.out
+```
+Expected: the two-row CSV plus a `decision:` line. Record the two `steady_state_rss_kib` values and the decision.
+
+- [ ] **Step 2: Add the results section to `BENCHMARKS.md`**
+
+Append a new section at the end of `BENCHMARKS.md` (fill the two RSS cells and the decision line from Step 1's output — these are measured runtime values):
+
+```markdown
+## Global allocator — steady-state RSS (#360)
+
+Long-lived high-churn FUSE load fragments glibc malloc, growing daemon RSS over
+days without a true leak. The `musefs` binary now defaults to the jemalloc
+global allocator with a background purge thread. Measured with
+`scripts/rss-churn-bench.sh` (Linux; median `VmRSS` over the flattened tail —
+steady state, not peak).
+
+**Parameters:** WORKERS=<nproc on this box>, FILES=500, CYCLES=200, WARMUP=20,
+no REFRESH_CMD; DB = the ~4427-track store on tmpfs (`/tmp`).
+
+| Allocator      | Steady-state RSS |
+| -------------- | ---------------- |
+| system malloc  | <measured> MiB   |
+| jemalloc       | <measured> MiB   |
+
+**Decision:** <SHIP / INVESTIGATE per the script's decision line> — ship rule is
+jemalloc steady-state RSS ≤ system malloc; a within-noise tie is recorded and
+decided explicitly here.
+```
+
+- [ ] **Step 3: Verify the decision is consistent with the spec gate**
+
+Confirm the recorded decision matches the §4 rule in the spec: ship only if
+jemalloc ≤ system malloc (or an explicit within-noise call). If jemalloc is
+meaningfully worse, **stop and escalate** — do not proceed to release; the
+change is blocked pending investigation (spec Risks table).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add BENCHMARKS.md
+git commit -m "docs(benchmarks): record allocator steady-state RSS comparison (#360)"
+```
+
+(Docs-only commit — the cargo gate is skipped.)
+
+---
+
+## Task 6: Verify release cross-builds (conditional fix)
+
+**Files:**
+- Modify **only if a target fails**: `.github/workflows/release.yml` (+ matching Docker image)
+
+- [ ] **Step 1: Install the cross toolchain (if not already present)**
+
+Run:
+```bash
+for t in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu \
+         x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+  rustup target add "$t"
+done
+cargo install cargo-zigbuild --version 0.22.3 || true   # zig must be on PATH (0.13.0)
+```
+Expected: targets added; `cargo-zigbuild --version` works and `zig version` prints `0.13.0`.
+
+- [ ] **Step 2: Cross-build all four release targets with the jemalloc feature on**
+
+Run:
+```bash
+for t in x86_64-unknown-linux-gnu.2.17 aarch64-unknown-linux-gnu.2.17 \
+         x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+  echo "=== $t ==="
+  cargo zigbuild --release -p musefs --target "$t"
+done
+```
+Expected: all four link `jemalloc-sys` and produce a binary. This is the spec's primary build-risk surface (jemalloc-sys C under zig cross-compilation).
+
+- [ ] **Step 3: If a target failed, apply the per-target opt-out**
+
+For each failing `<triple>` only, edit `.github/workflows/release.yml`: in the
+`build` job's `Build` step, the run line is currently:
+
+```yaml
+        run: cargo zigbuild --release -p musefs --target ${{ matrix.zig_target }}
+```
+
+Add a per-entry flag in the matrix (add `no_default: true` to the failing
+`include` entry) and make the build line honor it, e.g.:
+
+```yaml
+        run: cargo zigbuild --release -p musefs --target ${{ matrix.zig_target }} ${{ matrix.no_default && '--no-default-features' || '' }}
+```
+
+Then apply the same `--no-default-features` to that arch's Docker image build
+(`docker/Dockerfile` / `docker/Dockerfile.musl` cargo invocation) so the tarball
+and container for that arch ship the same allocator. Document the dropped target
+in `CONTRIBUTING.md` under the release section.
+
+- [ ] **Step 4: If all four built, no workflow change is needed**
+
+Record (in the PR description) that all four targets cross-built `jemalloc-sys`
+cleanly, so the conditional fallback was not triggered.
+
+- [ ] **Step 5: Commit (only if Step 3 changed files)**
+
+```bash
+git add .github/workflows/release.yml docker/ CONTRIBUTING.md
+git commit -m "ci(release): opt the <triple> target out of jemalloc (jemalloc-sys cross-build) (#360)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Crate wiring / default-on feature → Task 1 (+ `log` in Task 2). ✔
+- `#[global_allocator]`, no-`unsafe` → Task 1 Step 4. ✔
+- Background purge thread, best-effort, startup, default decay → Task 2. ✔
+- Sanitizers unaffected / native builds → no code action needed (verified in spec §3); release cross-build → Task 6. ✔
+- Verification harness (concurrency, file-set, refresh hook, duration, steady-state median, decision rule) → Task 3 (script) + Task 5 (run + record + gate). ✔
+- Docs: BENCHMARKS → Task 5; README + CONTRIBUTING (feature matrix + release smoke) → Task 4. ✔
+- Risks: jemalloc-sys cross-build → Task 6; background_thread unsupported → Task 2 best-effort + test; RSS no-improvement → Task 5 Step 3 gate. ✔
+- Acceptance criteria 1–6 all map to tasks (AC1/2 → T1/T2; AC3 → pre-commit workspace tests + `-p musefs --ignored` under default features; AC4 → T6; AC5 → T3+T5; AC6 → T4). ✔
+
+**Placeholder scan:** the only `<…>` placeholders are empirical benchmark numbers in Task 5 Step 2 (measured at runtime) and the failing-`<triple>` name in Task 6 (conditional, unknown until Step 2 runs) — both unavoidable and clearly marked. No logic/code placeholders.
+
+**Type/name consistency:** `enable_jemalloc_background_thread` (defined T2 Step 4, called T2 Step 4 main + tests T2 Step 2), `GLOBAL` static (T1 Step 4), feature name `jemalloc` and labels `sysmalloc`/`jemalloc` (consistent across Cargo.toml, script `case` arms, BENCHMARKS table). Crate versions pinned 0.7 throughout.

--- a/docs/superpowers/specs/2026-06-14-jemalloc-global-allocator-design.md
+++ b/docs/superpowers/specs/2026-06-14-jemalloc-global-allocator-design.md
@@ -62,12 +62,14 @@ default = ["jemalloc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 
 [dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
-tikv-jemalloc-ctl = { version = "0.6", optional = true }
+tikv-jemallocator = { version = "0.7", optional = true }
+tikv-jemalloc-ctl = { version = "0.7", optional = true }
 ```
 
-(`background_threads_runtime_support` is on by default in `tikv-jemallocator`;
-the plan pins exact versions.) The opt-out for packagers, memory-debuggers, and
+(`background_threads_runtime_support` is on by default via `tikv-jemalloc-sys`,
+so enabling the background thread at runtime needs no extra cargo feature; the
+plan pins exact versions and updates `Cargo.lock`.) The opt-out for packagers,
+memory-debuggers, and
 A/B benchmarking is `cargo build -p musefs --no-default-features`. A cargo
 feature is a build-time toggle, so end users running a prebuilt release binary
 are unaffected — only source builds can flip it, which is precisely who the
@@ -134,7 +136,10 @@ cross-cutting logic in `musefs-core`" layering rule.
   - Smoke-build all four targets locally with `cargo zigbuild --release -p
     musefs --target <zig_target>` before relying on the release.
   - If any target cannot build `jemalloc-sys`, set `--no-default-features` for
-    that matrix entry (and document it) rather than blocking the release.
+    that matrix entry (and document it) rather than blocking the release. The
+    Docker image variants consume the same triples, so a dropped target must
+    propagate to its matching image — otherwise the tarball and container for one
+    arch would ship different allocators.
 - **Mutants — no re-anchoring.** `mutants.toml` anchors live in `musefs-core` /
   `musefs-format` source, which this change does not touch.
 
@@ -149,16 +154,40 @@ backed by a committed, runnable harness:
      default build (jemalloc).
   2. Mounts each variant under `$HOME` (AppArmor permits FUSE there) against the
      test music corpus, with `/data`-backed files as needed.
-  3. Drives a churn loop: repeated open/read/release across many files plus
-     periodic refresh, to exercise the `im`-tree alloc/free bursts, the
-     `sharded_slab` handle-table churn, and the per-worker read path.
-  4. Samples `VmRSS` from `/proc/<pid>/status` over N cycles and reports
-     steady-state RSS for each variant.
+  3. Drives a **concurrent** churn loop — cross-thread alloc-here/free-there is
+     the exact mechanism jemalloc must win on, so a single-threaded loop would
+     show a false null. The script pins, as configurable parameters with stated
+     defaults:
+     - **Concurrency:** `WORKERS` reader threads (default = number of cores),
+       each independently opening/reading/releasing across the file set, so
+       allocations and frees land on different threads.
+     - **File set:** `FILES` distinct tracks (default ≥ 500) read end-to-end so
+       the read path, header cache, and handle table all churn.
+     - **Refresh cadence:** trigger a tree refresh every `REFRESH_SECS` (default
+       30 s) to exercise the `im`-tree alloc/free bursts.
+     - **Duration:** `CYCLES` churn cycles (default ≥ 200) after a discarded
+       `WARMUP` cycles (default 20).
+  4. Samples `VmRSS` from `/proc/<pid>/status` once per cycle and reports
+     **steady-state** RSS per variant: the median `VmRSS` over the last 25 % of
+     cycles, after warmup, once the curve has flattened (max-vs-median over that
+     window within a few percent). This is distinct from the *peak* RSS already
+     reported elsewhere in `BENCHMARKS.md`.
+- **Decision rule (the actual gate):** ship jemalloc only if its steady-state
+  RSS is **≤** the system-malloc baseline. If the two are within run-to-run
+  noise, record both and make an explicit ship/no-ship call in the spec/PR
+  rather than assuming a win. A jemalloc result meaningfully *worse* than
+  baseline blocks the change pending investigation.
 - **Record:** add a new allocator/RSS section to `BENCHMARKS.md` with the
-  methodology and measured numbers (system malloc vs jemalloc).
+  methodology, the parameters used, and the measured numbers (system malloc vs
+  jemalloc) plus the resulting decision.
 - **CI's role** is only to confirm the binary builds/links and all tests pass
   under jemalloc — already covered by `cargo test --workspace` and
-  `cargo test -p musefs -- --ignored`. CI does not run the RSS bench.
+  `cargo test -p musefs -- --ignored` (the latter spawns the real
+  default-feature binary, so it exercises jemalloc end-to-end). CI does not run
+  the RSS bench. The cross-built release targets get their first jemalloc
+  *runtime* exercise from the existing release smoke (`scripts/smoke-binary.sh`
+  on host + the Alpine/musl container smoke in `release.yml`), so a jemalloc
+  init failure under musl/aarch64 surfaces there, not in `cargo test`.
 
 ### 5. Documentation
 
@@ -187,6 +216,9 @@ backed by a committed, runnable harness:
    the default (jemalloc) build; the ASan/TSan jobs are unchanged.
 4. All four release targets build with `jemalloc-sys` under `cargo-zigbuild`
    (or are documented as `--no-default-features`).
-5. `scripts/rss-churn-bench.sh` runs and `BENCHMARKS.md` records the system
-   malloc vs jemalloc steady-state RSS comparison.
+5. `scripts/rss-churn-bench.sh` runs the concurrent churn workload and
+   `BENCHMARKS.md` records the system malloc vs jemalloc **steady-state** RSS
+   comparison (median over the flattened tail, not peak), together with the
+   explicit ship decision per the §4 rule — jemalloc steady-state RSS must be
+   ≤ baseline (or, if within noise, an explicit recorded call).
 6. `README.md` and `CONTRIBUTING.md` document the allocator and the opt-out.

--- a/docs/superpowers/specs/2026-06-14-jemalloc-global-allocator-design.md
+++ b/docs/superpowers/specs/2026-06-14-jemalloc-global-allocator-design.md
@@ -1,0 +1,192 @@
+# jemalloc global allocator for the `musefs` binary
+
+**Issue:** [#360](https://github.com/Sohex/musefs/issues/360) (part A only)
+**Date:** 2026-06-14
+**Status:** Approved design — ready for implementation plan
+
+## Problem
+
+The release binary sets no `#[global_allocator]`, so it uses the system
+allocator (glibc malloc on the main release targets). The hot path does heavy
+concurrent `Arc` cloning, `DashMap` sharding, and `sharded_slab` allocate/free
+churn, with periodic tree-refresh bursts — many small, uniformly-sized,
+short-to-medium-lived allocations, frequently allocated on one worker thread and
+freed on another. This is the canonical pattern under which glibc malloc
+accumulates dirty pages in per-thread arenas and never returns them to the OS,
+so a long-lived `musefs` daemon's RSS can creep upward over days or weeks
+without a true leak.
+
+Issue #360 also raises a runtime telemetry surface; that is a separate,
+independent subsystem and is **explicitly out of scope** for this spec. It will
+get its own spec/plan cycle.
+
+## Goal
+
+Replace the system allocator with jemalloc in the `musefs` binary, tuned to
+return idle memory to the OS, so steady-state RSS under sustained churn stays
+bounded. Provide a build-time opt-out for downstream packagers and
+memory-debugging, and a committed harness that measures the RSS effect.
+
+## Non-goals
+
+- Any runtime telemetry / observability surface (issue #360 part B).
+- Changing the allocator used by the library crates, benches, tests, or the
+  sanitizer CI jobs. The override lives in the binary crate only.
+- Per-call or per-arena allocator tuning beyond enabling background purging.
+
+## Why jemalloc
+
+The workload (small uniform objects, cross-thread alloc/free, periodic bursts)
+is exactly what jemalloc's per-size-class arenas absorb without fragmenting.
+Decay-based purging plus a background purge thread directly target the named
+RSS-creep failure mode by returning dirty pages to the OS during quiet periods.
+jemalloc is native to the project's most fragile non-Linux CI legs (FreeBSD test
+job; macOS clippy/test job) and to musl release builds, where it also sidesteps
+musl's weak built-in allocator. FUSE rules out Windows, so jemalloc's lack of
+MSVC support is irrelevant here. `tikv-jemalloc-ctl`'s stats API is additionally
+a head start on the parked telemetry work, though that is not built here.
+
+mimalloc (simpler, but coarser RSS-return control and no stats binding) and
+snmalloc (strong cross-thread-free story, but the least battle-tested binding
+and finickier on our FreeBSD/musl cross-targets) were considered and rejected.
+
+## Design
+
+### 1. Crate wiring (`musefs/Cargo.toml`)
+
+Add a **default-on** `jemalloc` feature gating two optional dependencies:
+
+```toml
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
+
+[dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
+tikv-jemalloc-ctl = { version = "0.6", optional = true }
+```
+
+(`background_threads_runtime_support` is on by default in `tikv-jemallocator`;
+the plan pins exact versions.) The opt-out for packagers, memory-debuggers, and
+A/B benchmarking is `cargo build -p musefs --no-default-features`. A cargo
+feature is a build-time toggle, so end users running a prebuilt release binary
+are unaffected — only source builds can flip it, which is precisely who the
+opt-out serves.
+
+### 2. Allocator + background thread (`musefs/src/main.rs`)
+
+Set the global allocator under the feature. No `unsafe` is required, so this
+does not trip the workspace `unsafe_code = "deny"` lint:
+
+```rust
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+```
+
+After `env_logger` is initialised in `main`, call a small
+`#[cfg(feature = "jemalloc")]` helper that enables jemalloc's background purge
+thread via the safe ctl API:
+
+```rust
+#[cfg(feature = "jemalloc")]
+fn enable_jemalloc_background_thread() {
+    if let Err(e) = tikv_jemalloc_ctl::background_thread::write(true) {
+        log::debug!("jemalloc background_thread unavailable: {e}");
+    }
+}
+```
+
+- **Best-effort:** on platforms where jemalloc does not support background
+  threads (notably macOS), `write(true)` returns `Err`; we log and continue.
+  jemalloc stays active and still purges on allocation activity; only the
+  timed-idle purge is absent there. The long-lived daemon target is Linux, where
+  it is supported.
+- **Unconditional at startup:** enabled before `run()` so it covers `mount`; it
+  is harmless for the short-lived `scan` path (one cheap jemalloc-managed
+  thread).
+- **Default decay otherwise:** jemalloc's default dirty/muzzy decay is sane; the
+  background thread is the missing piece that makes an *idle* daemon actually
+  return pages. No further `MALLOC_CONF` tuning. (Setting `malloc_conf` via an
+  exported symbol would require `#[unsafe(no_mangle)]` and is deliberately
+  avoided in favour of the runtime ctl call.)
+
+The allocator setup stays in the binary crate: setting a global allocator is
+binary-specific, so this does not violate the "keep the binary thin,
+cross-cutting logic in `musefs-core`" layering rule.
+
+### 3. Platform / CI behavior
+
+- **Sanitizers — unaffected, no gating needed.** The ASan job builds
+  `cargo +nightly test -p musefs-core --test concurrent_reads`; the TSan job
+  builds `-p musefs-core` and `-p musefs-fuse`. Neither builds the `musefs`
+  binary, so the `#[global_allocator]` is never compiled into a sanitizer test
+  binary. No `cfg(sanitize)` guard is required.
+- **Native builds everywhere clippy/tests run.** jemalloc compiles natively on
+  the Linux `check` job, the macOS job (`cargo clippy --all-targets` +
+  `cargo test --workspace`), and the FreeBSD in-VM job. No cross-compilation of
+  jemalloc C is performed for any clippy gate.
+- **Release pipeline — the real build risk.** `release.yml` builds four targets
+  with `cargo-zigbuild` (`x86_64`/`aarch64` × `gnu`/`musl`) plus Docker
+  musl/glibc images; all must build `jemalloc-sys` under zig cross-compilation.
+  Because the project's release workflow has a history of first-run breakage,
+  this is a checklist item, not an assumption:
+  - Smoke-build all four targets locally with `cargo zigbuild --release -p
+    musefs --target <zig_target>` before relying on the release.
+  - If any target cannot build `jemalloc-sys`, set `--no-default-features` for
+    that matrix entry (and document it) rather than blocking the release.
+- **Mutants — no re-anchoring.** `mutants.toml` anchors live in `musefs-core` /
+  `musefs-format` source, which this change does not touch.
+
+### 4. Verification (committed harness + `BENCHMARKS.md`)
+
+Days-scale RSS creep is not CI-testable, so verification is a manual/local gate
+backed by a committed, runnable harness:
+
+- **Script:** `scripts/rss-churn-bench.sh` (runnable, committed in-tree; any
+  large corpus stays gitignored). It:
+  1. Builds both variants: `--no-default-features` (system malloc) and the
+     default build (jemalloc).
+  2. Mounts each variant under `$HOME` (AppArmor permits FUSE there) against the
+     test music corpus, with `/data`-backed files as needed.
+  3. Drives a churn loop: repeated open/read/release across many files plus
+     periodic refresh, to exercise the `im`-tree alloc/free bursts, the
+     `sharded_slab` handle-table churn, and the per-worker read path.
+  4. Samples `VmRSS` from `/proc/<pid>/status` over N cycles and reports
+     steady-state RSS for each variant.
+- **Record:** add a new allocator/RSS section to `BENCHMARKS.md` with the
+  methodology and measured numbers (system malloc vs jemalloc).
+- **CI's role** is only to confirm the binary builds/links and all tests pass
+  under jemalloc — already covered by `cargo test --workspace` and
+  `cargo test -p musefs -- --ignored`. CI does not run the RSS bench.
+
+### 5. Documentation
+
+- `BENCHMARKS.md`: the RSS/allocator section above.
+- `README.md`: one line noting jemalloc is the default allocator and the
+  `--no-default-features` opt-out for source builds / packaging.
+- `CONTRIBUTING.md`: note the `jemalloc` feature in the build/feature matrix and
+  the release smoke-build step.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `jemalloc-sys` fails to build for a release target under zig cross | Smoke-build all four targets pre-release; fall back to `--no-default-features` per target |
+| `background_thread` unsupported on a platform (macOS) | Best-effort enable; log and continue, jemalloc still active |
+| Bigger binary / slightly slower tiny allocations | Accepted; the RSS-bounding win is the goal |
+| RSS bench shows no improvement on this workload | The bench is the gate: if jemalloc does not help, revisit before shipping |
+
+## Acceptance criteria
+
+1. The default `musefs` build sets jemalloc as the global allocator and enables
+   the background purge thread on Linux (best-effort elsewhere).
+2. `cargo build -p musefs --no-default-features` produces a working
+   system-malloc binary.
+3. `cargo test --workspace` and `cargo test -p musefs -- --ignored` pass under
+   the default (jemalloc) build; the ASan/TSan jobs are unchanged.
+4. All four release targets build with `jemalloc-sys` under `cargo-zigbuild`
+   (or are documented as `--no-default-features`).
+5. `scripts/rss-churn-bench.sh` runs and `BENCHMARKS.md` records the system
+   malloc vs jemalloc steady-state RSS comparison.
+6. `README.md` and `CONTRIBUTING.md` document the allocator and the opt-out.

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [features]
 default = ["jemalloc"]
-jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "tikv-jemalloc-ctl/stats"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "tikv-jemalloc-ctl/stats", "dep:log"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -23,6 +23,7 @@ env_logger = "0.11"
 musefs-cli = { path = "../musefs-cli", version = "1.0.0" }
 tikv-jemallocator = { version = "0.7", optional = true }
 tikv-jemalloc-ctl = { version = "0.7", optional = true }
+log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -13,10 +13,16 @@ categories = ["filesystem", "multimedia::audio", "command-line-utilities"]
 name = "musefs"
 path = "src/main.rs"
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "tikv-jemalloc-ctl/stats"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 musefs-cli = { path = "../musefs-cli", version = "1.0.0" }
+tikv-jemallocator = { version = "0.7", optional = true }
+tikv-jemalloc-ctl = { version = "0.7", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -1,6 +1,10 @@
 use clap::Parser;
 use musefs_cli::{Cli, run};
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() {
     // The library crates report serve-path failures through the `log` facade;
     // without a sink they vanish. Default to `warn` so they surface on stderr,
@@ -9,5 +13,21 @@ fn main() {
     if let Err(e) = run(Cli::parse()) {
         eprintln!("musefs: {e:#}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(all(test, feature = "jemalloc"))]
+mod tests {
+    #[test]
+    fn jemalloc_is_the_global_allocator() {
+        let buf: Vec<u8> = vec![0u8; 4 * 1024 * 1024];
+        std::hint::black_box(&buf);
+        tikv_jemalloc_ctl::epoch::advance().unwrap();
+        let allocated = tikv_jemalloc_ctl::stats::allocated::read().unwrap();
+        assert!(
+            allocated >= 1 << 20,
+            "jemalloc reports {allocated} bytes allocated; not wired as #[global_allocator]"
+        );
+        drop(buf);
     }
 }

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -5,11 +5,24 @@ use musefs_cli::{Cli, run};
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+/// Enable jemalloc's background purge thread so an idle daemon returns dirty
+/// pages to the OS (the RSS-creep fix in #360). Best-effort: unsupported on some
+/// platforms (notably macOS), where it logs at debug and continues — jemalloc
+/// stays active and still purges on allocation activity.
+#[cfg(feature = "jemalloc")]
+fn enable_jemalloc_background_thread() {
+    if let Err(e) = tikv_jemalloc_ctl::background_thread::write(true) {
+        log::debug!("jemalloc background_thread unavailable: {e}");
+    }
+}
+
 fn main() {
     // The library crates report serve-path failures through the `log` facade;
     // without a sink they vanish. Default to `warn` so they surface on stderr,
     // overridable via RUST_LOG.
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+    #[cfg(feature = "jemalloc")]
+    enable_jemalloc_background_thread();
     if let Err(e) = run(Cli::parse()) {
         eprintln!("musefs: {e:#}");
         std::process::exit(1);
@@ -18,6 +31,24 @@ fn main() {
 
 #[cfg(all(test, feature = "jemalloc"))]
 mod tests {
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn background_thread_enables_on_linux() {
+        super::enable_jemalloc_background_thread();
+        assert!(
+            tikv_jemalloc_ctl::background_thread::read().unwrap(),
+            "background_thread should be on after enable() on linux"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn enable_background_thread_does_not_panic_off_linux() {
+        // jemalloc lacks background-thread support on some platforms (macOS);
+        // the helper must swallow the error rather than panic.
+        super::enable_jemalloc_background_thread();
+    }
+
     #[test]
     fn jemalloc_is_the_global_allocator() {
         let buf: Vec<u8> = vec![0u8; 4 * 1024 * 1024];

--- a/scripts/rss-churn-bench.sh
+++ b/scripts/rss-churn-bench.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Steady-state RSS churn benchmark for the musefs daemon (issue #360 part A).
+# Drives concurrent open/read/release churn against a mounted store and reports
+# the MEDIAN VmRSS over the flattened tail (steady state, NOT peak RSS), for the
+# system-malloc and jemalloc builds, then prints a ship/investigate decision.
+#
+# Linux-only: VmRSS comes from /proc/<pid>/status.
+#
+# Env knobs (defaults in parens):
+#   DB           musefs store path                         (required)
+#   MOUNT        mountpoint under $HOME                     ($HOME/.musefs-rss-mnt)
+#   WORKERS      concurrent reader threads                 (nproc)
+#   FILES        distinct files to churn                   (500)
+#   CYCLES       1-second RSS samples per variant          (200)
+#   WARMUP       leading samples discarded                 (20)
+#   REFRESH_CMD  shell command run every REFRESH_SECS      (none)
+#   REFRESH_SECS refresh cadence in seconds                (30)
+#   BINARIES     override builds: "sysmalloc=/p jemalloc=/p" (built from repo)
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "rss-churn-bench: Linux-only (needs /proc/<pid>/status VmRSS)" >&2
+  exit 1
+fi
+
+: "${DB:?set DB to a musefs store path}"
+MOUNT="${MOUNT:-$HOME/.musefs-rss-mnt}"
+WORKERS="${WORKERS:-$(nproc)}"
+FILES="${FILES:-500}"
+CYCLES="${CYCLES:-200}"
+WARMUP="${WARMUP:-20}"
+REFRESH_SECS="${REFRESH_SECS:-30}"
+
+build_variants() {
+  echo "building system-malloc and jemalloc release binaries..." >&2
+  cargo build --release -p musefs --no-default-features >&2
+  cp target/release/musefs /tmp/musefs-sysmalloc
+  cargo build --release -p musefs >&2
+  cp target/release/musefs /tmp/musefs-jemalloc
+  echo "sysmalloc=/tmp/musefs-sysmalloc jemalloc=/tmp/musefs-jemalloc"
+}
+
+# stdin: one integer per line -> median of the last 25% of lines.
+median_tail() {
+  local n tail_start
+  mapfile -t vals
+  n="${#vals[@]}"
+  tail_start=$(( n - n / 4 ))
+  printf '%s\n' "${vals[@]:tail_start}" | sort -n | awk '
+    { a[NR] = $1 }
+    END { if (NR % 2) print a[(NR + 1) / 2]; else print (a[NR / 2] + a[NR / 2 + 1]) / 2 }'
+}
+
+run_variant() {
+  local bin="$1"
+  mkdir -p "$MOUNT"
+  "$bin" mount --db "$DB" "$MOUNT" &
+  local mpid=$!
+  for _ in $(seq 1 50); do
+    mountpoint -q "$MOUNT" && break
+    sleep 0.1
+  done
+  local targets=()
+  mapfile -t targets < <(find "$MOUNT" -type f | head -n "$FILES")
+  if [ "${#targets[@]}" -eq 0 ]; then
+    echo "no files found under $MOUNT" >&2
+    fusermount3 -u "$MOUNT" 2>/dev/null || true
+    return 1
+  fi
+  local stop
+  stop="$(mktemp)"
+  rm -f "$stop"
+  local pids=()
+  for _ in $(seq 1 "$WORKERS"); do
+    (
+      while [ ! -e "$stop" ]; do
+        for f in "${targets[@]}"; do
+          [ -e "$stop" ] && break
+          cat "$f" >/dev/null 2>&1 || true
+        done
+      done
+    ) &
+    pids+=("$!")
+  done
+  local rpid=""
+  if [ -n "${REFRESH_CMD:-}" ]; then
+    (
+      while [ ! -e "$stop" ]; do
+        sleep "$REFRESH_SECS"
+        # shellcheck disable=SC2086
+        eval $REFRESH_CMD >/dev/null 2>&1 || true
+      done
+    ) &
+    rpid=$!
+  fi
+  local samples=()
+  for _ in $(seq 1 "$CYCLES"); do
+    sleep 1
+    samples+=("$(awk '/^VmRSS:/ { print $2 }' "/proc/$mpid/status" 2>/dev/null || echo 0)")
+  done
+  : > "$stop"
+  wait "${pids[@]}" 2>/dev/null || true
+  [ -n "$rpid" ] && { wait "$rpid" 2>/dev/null || true; }
+  rm -f "$stop"
+  fusermount3 -u "$MOUNT" 2>/dev/null || true
+  wait "$mpid" 2>/dev/null || true
+  printf '%s\n' "${samples[@]:$WARMUP}" | median_tail
+}
+
+main() {
+  local spec="${BINARIES:-$(build_variants)}"
+  echo "label,steady_state_rss_kib"
+  local sys_rss="" jem_rss="" pair label bin rss
+  # shellcheck disable=SC2086
+  for pair in $spec; do
+    label="${pair%%=*}"
+    bin="${pair#*=}"
+    rss="$(run_variant "$bin")"
+    echo "$label,$rss"
+    case "$label" in
+      *sys*) sys_rss="$rss" ;;
+      *jem*) jem_rss="$rss" ;;
+    esac
+  done
+  if [ -n "$sys_rss" ] && [ -n "$jem_rss" ]; then
+    if [ "$jem_rss" -le "$sys_rss" ]; then
+      echo "decision: SHIP jemalloc (steady-state ${jem_rss} kiB <= sysmalloc ${sys_rss} kiB)"
+    else
+      echo "decision: INVESTIGATE — jemalloc ${jem_rss} kiB > sysmalloc ${sys_rss} kiB"
+    fi
+  fi
+}
+
+main "$@"

--- a/scripts/rss-churn-bench.sh
+++ b/scripts/rss-churn-bench.sh
@@ -42,10 +42,13 @@ build_variants() {
 
 # stdin: one integer per line -> median of the last 25% of lines.
 median_tail() {
-  local n tail_start
+  local n keep tail_start
   mapfile -t vals
   n="${#vals[@]}"
-  tail_start=$(( n - n / 4 ))
+  [ "$n" -eq 0 ] && return 0
+  keep=$(( n / 4 ))
+  [ "$keep" -lt 1 ] && keep=1
+  tail_start=$(( n - keep ))
   printf '%s\n' "${vals[@]:tail_start}" | sort -n | awk '
     { a[NR] = $1 }
     END { if (NR % 2) print a[(NR + 1) / 2]; else print (a[NR / 2] + a[NR / 2 + 1]) / 2 }'
@@ -60,7 +63,7 @@ run_variant() {
     mountpoint -q "$MOUNT" && break
     sleep 0.1
   done
-  trap 'kill "$mpid" 2>/dev/null; kill "${pids[@]}" 2>/dev/null; [ -n "${rpid:-}" ] && kill "$rpid" 2>/dev/null; fusermount3 -u "$MOUNT" 2>/dev/null; rm -f "$stop"' EXIT INT TERM
+  trap 'kill "$mpid" 2>/dev/null; kill "${pids[@]:-}" 2>/dev/null; [ -n "${rpid:-}" ] && kill "$rpid" 2>/dev/null; fusermount3 -u "$MOUNT" 2>/dev/null; rm -f "${stop:-}"' EXIT INT TERM
   local targets=()
   mapfile -t targets < <(find "$MOUNT" -type f | head -n "$FILES")
   if [ "${#targets[@]}" -eq 0 ]; then

--- a/scripts/rss-churn-bench.sh
+++ b/scripts/rss-churn-bench.sh
@@ -63,7 +63,7 @@ run_variant() {
     mountpoint -q "$MOUNT" && break
     sleep 0.1
   done
-  trap 'kill "$mpid" 2>/dev/null; kill "${pids[@]:-}" 2>/dev/null; [ -n "${rpid:-}" ] && kill "$rpid" 2>/dev/null; fusermount3 -u "$MOUNT" 2>/dev/null; rm -f "${stop:-}"' EXIT INT TERM
+  trap 'kill "${mpid:-}" 2>/dev/null; kill "${pids[@]:-}" 2>/dev/null; [ -n "${rpid:-}" ] && kill "$rpid" 2>/dev/null; fusermount3 -u "$MOUNT" 2>/dev/null; rm -f "${stop:-}"' EXIT INT TERM
   local targets=()
   mapfile -t targets < <(find "$MOUNT" -type f | head -n "$FILES")
   if [ "${#targets[@]}" -eq 0 ]; then

--- a/scripts/rss-churn-bench.sh
+++ b/scripts/rss-churn-bench.sh
@@ -64,6 +64,13 @@ run_variant() {
     sleep 0.1
   done
   trap 'kill "${mpid:-}" 2>/dev/null; kill "${pids[@]:-}" 2>/dev/null; [ -n "${rpid:-}" ] && kill "$rpid" 2>/dev/null; fusermount3 -u "$MOUNT" 2>/dev/null; rm -f "${stop:-}"' EXIT INT TERM
+  # Confirm the mount actually came up: a failed mount would leave $MOUNT as a
+  # plain host dir, so find/cat below would silently churn host files instead of
+  # the synthesized FS and the RSS numbers would be garbage.
+  if ! mountpoint -q "$MOUNT"; then
+    echo "mount did not come up at $MOUNT" >&2
+    return 1
+  fi
   local targets=()
   mapfile -t targets < <(find "$MOUNT" -type f | head -n "$FILES")
   if [ "${#targets[@]}" -eq 0 ]; then

--- a/scripts/rss-churn-bench.sh
+++ b/scripts/rss-churn-bench.sh
@@ -60,6 +60,7 @@ run_variant() {
     mountpoint -q "$MOUNT" && break
     sleep 0.1
   done
+  trap 'kill "$mpid" 2>/dev/null; kill "${pids[@]}" 2>/dev/null; [ -n "${rpid:-}" ] && kill "$rpid" 2>/dev/null; fusermount3 -u "$MOUNT" 2>/dev/null; rm -f "$stop"' EXIT INT TERM
   local targets=()
   mapfile -t targets < <(find "$MOUNT" -type f | head -n "$FILES")
   if [ "${#targets[@]}" -eq 0 ]; then


### PR DESCRIPTION
## What

Make the `musefs` binary use **jemalloc** as its global allocator, with a background purge thread, to bound resident memory under long-lived high-churn FUSE load. The hot path's concurrent `Arc` cloning, `DashMap` sharding, and `sharded_slab` allocate/free churn is the pattern glibc malloc fragments under — RSS creeps over days without a true leak. This is **part A** of #360.

## How

- `#[global_allocator]` set to `tikv_jemallocator::Jemalloc` in `musefs/src/main.rs`, behind a **default-on `jemalloc` cargo feature**. No `unsafe` (satisfies the workspace `unsafe_code = "deny"`).
- Background purge thread enabled at startup via the safe `tikv-jemalloc-ctl` API — best-effort (logs and continues where unsupported, e.g. macOS), so an idle daemon returns dirty pages to the OS.
- Opt-out for packagers (no vendored C libs) and memory-debugging (valgrind/heaptrack): `cargo build -p musefs --no-default-features`.
- Scoped to the binary crate only — libraries, tests, benches, and the ASan/TSan CI jobs (which build `-p musefs-core`/`-p musefs-fuse`, never the binary) are untouched.

## Result

Steady-state RSS under the churn bench (`scripts/rss-churn-bench.sh`, 500 files × 8 workers × 200 samples against a real 4427-track corpus; median `VmRSS` over the flattened tail):

| Allocator | Steady-state RSS |
|---|---|
| system malloc | ~74.7 MiB |
| jemalloc | ~28.7 MiB |

**~62% lower** — the #360 fragmentation mode reproduced and fixed. Methodology + numbers in `BENCHMARKS.md`.

## Verification

- Both jemalloc unit tests pass (allocator is wired; background thread enabled on Linux); `--no-default-features` opt-out builds.
- Full workspace test suite + `clippy -D warnings` + shellcheck green (pre-commit on every commit).
- All four release targets (x86_64/aarch64 × gnu/musl) cross-build `jemalloc-sys` cleanly under `cargo-zigbuild`, jemalloc confirmed embedded — no `release.yml` change needed.

## Scope

Closes #360. The telemetry half (runtime observability of handle table / queue depth / allocator state) is split out to #394 for its own design.

Design + plan: `docs/superpowers/specs/2026-06-14-jemalloc-global-allocator-design.md`, `docs/superpowers/plans/2026-06-14-jemalloc-global-allocator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * musefs binary now defaults to jemalloc allocator with opt-out capability
  * New memory usage benchmark script added

* **Documentation**
  * README and CONTRIBUTING updated with allocator configuration details
  * New benchmarking documentation and implementation specifications added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->