### PR TITLE
fix(ci): build jemalloc on FreeBSD + widen freebsd path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,12 @@ jobs:
             echo "src=false" >> "$GITHUB_OUTPUT"
           fi
           # The FreeBSD VM e2e is far too slow for every PR: run it only when the
-          # FUSE/mount surface or its harness changes. Release tags run it
-          # unconditionally (gated in the job's `if`, not here).
-          if printf '%s\n' "$changed" | grep -qE '^(musefs-fuse/|scripts/freebsd-vm/|\.github/workflows/ci\.yml$)'; then
+          # FUSE/mount surface or its harness changes. The `musefs/` binary crate
+          # and `Cargo.lock` are included too: allocator/dependency changes there
+          # (e.g. the jemalloc global allocator) can break the FreeBSD build
+          # without touching the FUSE surface. Release tags run it unconditionally
+          # (gated in the job's `if`, not here).
+          if printf '%s\n' "$changed" | grep -qE '^(musefs/|musefs-fuse/|scripts/freebsd-vm/|Cargo\.lock$|\.github/workflows/ci\.yml$)'; then
             echo "fuse=true" >> "$GITHUB_OUTPUT"
           else
             echo "fuse=false" >> "$GITHUB_OUTPUT"

--- a/scripts/freebsd-vm/provision.sh
+++ b/scripts/freebsd-vm/provision.sh
@@ -17,7 +17,10 @@ cd "$ROOT"
 # flac-in-ogg fixtures — both shell out to `ffmpeg` and SILENTLY SKIP if it is
 # absent (a vacuous pass). The default FreeBSD `ffmpeg` package ships the
 # needed decoders/encoders (flac, opus, vorbis, aac, mp3, pcm/wav).
-pkg install -y git ffmpeg rustup-init
+# gmake is REQUIRED to build the bundled jemalloc: the `musefs` binary's default
+# `jemalloc` feature pulls tikv-jemalloc-sys, whose build.rs invokes `gmake` (not
+# base `make`) on BSD hosts — without it the build panics with os error 2.
+pkg install -y git ffmpeg gmake rustup-init
 
 # Install the current stable toolchain (cargo + rustc) into ~/.cargo. run-e2e.sh
 # puts ~/.cargo/bin on PATH. `-y` makes it non-interactive / idempotent.


### PR DESCRIPTION
## What

The FreeBSD VM e2e was failing to build because `tikv-jemalloc-sys` (pulled in by the `musefs` binary's default `jemalloc` feature, added in #395) builds the bundled jemalloc by invoking `gmake` on BSD hosts — and the VM provisioning never installed it. The build panicked with:

```
thread 'main' panicked at .../tikv-jemalloc-sys-0.7.1/build.rs:437:
failed to execute command: No such file or directory (os error 2)
```

(`build.rs` selects `gmake` over base `make` for freebsd/netbsd/openbsd/dragonfly/etc.)

## Why it slipped through

#395 touched only `musefs/` and Cargo files, none of which matched the `freebsd` job's path filter (`musefs-fuse/|scripts/freebsd-vm/|ci.yml`). The FreeBSD e2e was skipped on that PR, so the break went unnoticed until a later PR happened to edit `ci.yml` and re-triggered the job.

## Changes

- **`scripts/freebsd-vm/provision.sh`**: add `gmake` to the `pkg install` list.
- **`.github/workflows/ci.yml`**: widen the `freebsd` path filter to include `musefs/` and `Cargo.lock`, so allocator/dependency changes to the binary re-run the FreeBSD job instead of slipping past it.

Editing `provision.sh` + `ci.yml` here means the `freebsd` job runs on this PR and verifies the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced FreeBSD build infrastructure by improving continuous integration detection of dependency changes that may affect FreeBSD compatibility
  * Added required build tools to the FreeBSD development environment for reliable builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->