### PR TITLE
docs: clarify mount/allow_other/musl + systemd & lidarr integration gotchas (#381-#386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Each tagged release attaches static/portable Linux binaries for four targets:
 | `x86_64-unknown-linux-musl`  | musl | Fully static — runs on Alpine / scratch containers. |
 | `aarch64-unknown-linux-musl` | musl | Fully static, ARM64. |
 
+The `*-musl` build is statically linked, so it runs on **any** Linux host of
+that architecture regardless of libc — glibc distros (Debian/Ubuntu/Fedora)
+included, not just Alpine/musl. For mixed or containerized deployments it is the
+simplest choice: one binary you can drop onto a glibc host and an Alpine image
+alike.
+
 Download the tarball for your target from the
 [latest release](https://github.com/Sohex/musefs/releases/latest), verify it,
 and extract:
@@ -319,6 +325,14 @@ musefs mount /path/to/mountpoint --db library.db \
 `mount` blocks until the filesystem is unmounted (`fusermount -u`, or
 Ctrl-C).
 
+> **`mount` never creates the store** — unlike `scan`, it requires a populated
+> DB to already exist and exits non-zero otherwise. Interactively this is
+> invisible (the `scan` → `mount` quick start always seeds it first), but it
+> bites automation: a `mount` started at boot before anything has scanned
+> hard-fails (and crash-loops under `Restart=`). Seed the store with an initial
+> `scan`, or order the mount after it — see
+> [`contrib/systemd`](contrib/systemd/README.md).
+
 > **Mounting at an arbitrary path may be denied by AppArmor.** On distros that
 > ship an AppArmor profile for `fusermount3` (Ubuntu 24.04+ / libfuse ≥ 3.17),
 > unprivileged FUSE mounts are only allowed when the mountpoint is under a
@@ -420,6 +434,20 @@ explanatory error if it is missing; add the line to `/etc/fuse.conf`, or run
 musefs as root. (This is libfuse/system policy, not a musefs restriction.) The
 published container images already include this line, so non-root `allow_other`
 mounts work out of the box there.
+
+**`--allow-other` grants other users — but not root.** A FUSE mount made with
+`allow_other` (not `allow_root`) is reachable by other unprivileged users, yet
+**root specifically cannot traverse or stat it** when it is owned by another
+user. This surprises root-run tooling (Ansible, boot scripts):
+
+- `mountpoint -q <mnt>` / `stat <mnt>` run as root report it as *not a
+  mountpoint* — they try to stat *through* the mount and get EACCES. Detect the
+  mount from root with `findmnt <mnt>` or `/proc/mounts` instead, which read the
+  mount table rather than the filesystem.
+- Don't have root manage the mountpoint **directory** while it is mounted: a
+  root task that re-asserts the directory (e.g. Ansible `file: state=directory`)
+  fails with EACCES/EEXIST on every run after the first. Create the directory
+  before mounting, or run such tasks as the mounting user.
 
 ### Configuring with environment variables
 

--- a/contrib/lidarr/README.md
+++ b/contrib/lidarr/README.md
@@ -116,6 +116,34 @@ runs the doctor preflight first (skip with `--skip-lidarr-preflight`), then
 queries all Lidarr artists and syncs their known track files into the musefs
 DB.
 
+## Migrating an existing Lidarr library
+
+The forward path above (new import → import script symlink → sync) works
+cleanly on a fresh import. Re-homing a **pre-existing** Lidarr library onto the
+musefs symlink tree runs into several Lidarr behaviors; this is the working
+order (observed on Lidarr v1, lsio image). None of it is a musefs bug — these
+are Lidarr quirks an integrator only hits here.
+
+1. **Reassign the artists to the new (musefs) root folder.**
+2. **Clear the stale trackfile records before re-importing.** If the artists'
+   existing trackfiles still reference the *old* root, re-import fails with
+   `NotParentException` (`/old/root/... is not a child of /new/root`) —
+   Lidarr's `RemoveExistingTrackFiles` chokes computing the relative path.
+   Delete the stale trackfile records first.
+   - **The empty-root deletion guard:** Lidarr blocks trackfile deletion while
+     the new root folder is empty ("Artist's root folder is empty", a
+     mass-deletion safety guard) — a chicken-and-egg with the symlinks not
+     existing yet. Drop a placeholder file in the root until the first symlinks
+     land, then remove it.
+   - **Batch the bulk delete:** `DELETE /api/v1/trackfile/bulk` returns 500 on
+     large batches (~200 ids); send ~25 ids per call.
+3. **Re-import.** The import script creates the destination symlinks.
+4. **Backfill the store:** `musefs-lidarr-sync --all`.
+
+Point `musefs scan` at the **backing directory, not the symlink tree.** The
+default (`--follow-symlinks` off) is exactly right here: the store should key
+off the real files, while Lidarr's symlink tree is just its own tracking view.
+
 ## Doctor
 
 To verify your Lidarr settings are musefs-safe:
@@ -133,6 +161,15 @@ The doctor checks Lidarr's API for:
 If `MUSEFS_LIDARR_URL` and `MUSEFS_LIDARR_API_KEY` are not configured, `doctor`
 and sync fail because the integration cannot verify safe settings or build
 complete per-track metadata.
+
+`--doctor` is a **runtime / post-deploy** check, not an offline one: it makes a
+live Lidarr API call, so it needs `MUSEFS_LIDARR_URL` + `MUSEFS_LIDARR_API_KEY`
+and a reachable Lidarr instance. Run it after deployment, not at container
+**build** time — offline it fails with connection-refused even when the
+toolchain itself is wired up correctly. There is no offline "are the binary and
+plugins installed/wired" check; to confirm installation at build time, test that
+the `musefs-lidarr-import` / `musefs-lidarr-sync` scripts and the `musefs`
+binary are importable/on `PATH`.
 
 ## Smoke test
 

--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -55,6 +55,21 @@ sandboxing is possible. The two units differ sharply:
 
 ## Notes
 
+- **The store must exist before the mount starts.** `musefs mount` never
+  creates the DB — it requires a populated store and exits non-zero otherwise,
+  so a mount unit that starts before anything has scanned hard-fails and (with
+  `Restart=on-failure`) crash-loops. Seed the store with an initial
+  `musefs scan` before `enable --now musefs.service`. If you generate the store
+  from another unit, order this one after it with a drop-in
+  (`systemctl --user edit musefs`):
+
+  ```ini
+  [Unit]
+  After=musefs-initial-scan.service
+  Requires=musefs-initial-scan.service
+  ```
+
+  (The `musefs-scan.timer` is a periodic *re-scan*, not the initial seed.)
 - **Binary location.** The `--user` manager does not inherit your shell's
   `PATH`. The units set `PATH` for a `cargo install` binary in `~/.cargo/bin`;
   if musefs is elsewhere, edit the `Environment=PATH=` line (or make

--- a/contrib/systemd/musefs.service
+++ b/contrib/systemd/musefs.service
@@ -10,6 +10,11 @@ EnvironmentFile=-%h/.config/musefs/musefs.conf
 # replace ExecStart with an absolute path) to match where musefs is installed.
 Environment=PATH=%h/.cargo/bin:/usr/local/bin:/usr/bin
 ExecStart=musefs mount
+# Passing --template here? systemd expands `$word` in ExecStart as a (usually
+# undefined, hence empty) environment variable, so a bare `$albumartist/...`
+# reaches musefs garbled and the mount aborts (rc 2). Double the `$` so systemd
+# passes the literal template through:
+#ExecStart=musefs mount %h/mnt/music --db %h/.local/share/musefs/library.db --template '$$albumartist/$$album/$$title'
 # musefs unmounts cleanly on SIGTERM (systemd's default stop signal), so no
 # ExecStop is required. Uncomment as a fallback if a mount is ever left behind:
 #ExecStop=-fusermount3 -u ${MUSEFS_MOUNTPOINT}


### PR DESCRIPTION
Resolves six documentation-clarification reports (#381–#386) raised by an
infrastructure-as-code integrator (rootless Podman, `systemd --user`, Ansible,
Navidrome + Lidarr). None are musefs bugs — each is a place where the real
behavior was correct but undocumented where an integrator would look.

| # | Fix | Where |
|---|-----|-------|
| #381 | `mount` never creates the store; must be seeded/ordered after an initial `scan` (boot-time hard-fail / crash-loop) | `README.md` Mount, `contrib/systemd/README.md` (with `After=`/`Requires=` drop-in) |
| #382 | `--allow-other` uses `allow_other` (not `allow_root`), so root is blocked; detect via `findmnt`/`/proc/mounts`, don't let root manage the mountpoint dir while mounted | `README.md` Ownership and permissions |
| #383 | systemd expands `$word` in `ExecStart`; commented `$$`-escaped `--template` example | `contrib/systemd/musefs.service` |
| #384 | "Migrating an existing Lidarr library" playbook (reassign root → clear stale trackfiles w/ placeholder + ~25-id batches → re-import → `--all`; scan the backing dir) | `contrib/lidarr/README.md` |
| #385 | `--doctor` is a runtime/post-deploy check (live Lidarr API + env), not an offline toolchain check | `contrib/lidarr/README.md` |
| #386 | the musl-static build runs on glibc hosts too — the single-binary choice for mixed/container deploys | `README.md` Prebuilt binaries |

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)