### PR TITLE
feat(core): single-stream backing read-ahead to hide NFS/remote latency (#255)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -435,4 +435,37 @@ exclude_re = [
     # functionally by the fuzzing-gated accessor test in the same file.
     # guard: count=1
     'musefs-db/src/lib\.rs:\d+:\d+: replace Db<M>::with_raw_conn -> R with Default::default\(\)',
+
+    # --- #255 backing read-ahead pool: hang-class + boundary-equivalent ---
+    # The read-ahead pool is a transparent cache: these mutants change cache
+    # accounting/eviction internals, never the bytes served (the byte-differential
+    # tests guarantee correctness). They split into two unkillable classes.
+    #
+    # Hang-class (TIMEOUT-only, never a clean kill — these CANCEL the in-diff CI
+    # job, the SP3 non-terminating-loop precedent): `per_stream_cap` returning 0
+    # (or inverting its `budget == 0` guard so every live pool reports cap 0) caps
+    # every window at 0, and `evict_one_coldest` reporting `Some`/widening its
+    # `freed > 0` guard claims progress it didn't make — either way the
+    # evict-until-room loop in `permitted_window` spins forever. Each is the sole
+    # such site in its fn, so operator+function-anchored (line-agnostic).
+    'replace ReadAheadPool::per_stream_cap -> u64 with 0',
+    'replace == with != in ReadAheadPool::per_stream_cap',
+    'replace ReadAheadPool::evict_one_coldest -> Option<u64> with Some\(0\)',
+    'replace ReadAheadPool::evict_one_coldest -> Option<u64> with Some\(1\)',
+    'replace > with (==|>=) in ReadAheadPool::evict_one_coldest',
+    #
+    # Boundary-equivalent guards: at the `==` boundary both branches do the same
+    # no-op (`fetch_sub(0)`, `add(0)`, or `window = cap`), so charged total and
+    # served bytes are identical. The NON-boundary mutations of these same
+    # operators (e.g. `> with ==`/`< with >`) ARE caught by the reconcile-accounting,
+    # read-then-release-leak, and set_cap-clamp tests. Sole site per fn.
+    'replace > with >= in ReadAheadPool::deregister',
+    'replace > with >= in ReadAheadPool::reconcile',
+    'replace < with <= in ReadAheadPool::reconcile',
+    'replace > with >= in ReadAhead::set_cap',
+    #
+    # Phase-2 prefetch ring size (`depth + 1`), off by default and best-effort: a
+    # wrong ring size only changes how many speculative windows are retained, never
+    # the served bytes. Sole `+` in serve_backing.
+    'replace \+ with (-|\*) in Musefs::serve_backing',
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -468,4 +468,22 @@ exclude_re = [
     # wrong ring size only changes how many speculative windows are retained, never
     # the served bytes. Sole `+` in serve_backing.
     'replace \+ with (-|\*) in Musefs::serve_backing',
+    #
+    # More hang-class (TIMEOUT-only, CANCEL the in-diff job): `len() -> 1` /
+    # `clear() -> 1` force a constant resident size, so `evict_one_coldest` keeps
+    # reporting a non-zero freed amount it never actually freed and
+    # `permitted_window`'s evict loop never terminates. The `-> 0` variants ARE
+    # caught (the len/clear-sum test). Sole returns.
+    'replace ReadAhead::len -> u64 with 1',
+    'replace ReadAhead::clear -> u64 with 1',
+    # insert_window eviction-filter arithmetic `w.start + w.bytes.len() <= frontier`,
+    # `+`->`*`: only changes WHICH cached window is dropped in a contrived spanning
+    # case, never the served bytes (the byte-differential tests pin those) — cache
+    # eviction policy, not correctness. The `<=`->`>` at the same site IS caught by
+    # the ring-trim test. Sole `+` in insert_window.
+    'replace \+ with \* in ReadAhead::insert_window',
+    # PrefetchWorkers::request -> (): drops the speculative job instead of queuing
+    # it. Phase-2 is opt-in and best-effort — a dropped prefetch just means a later
+    # synchronous fill, identical served bytes. Sole site.
+    'replace PrefetchWorkers::request with \(\)',
 ]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,6 +80,24 @@ binary tags are flagged (`RegionLayout::has_binary_tag`) so the reader can
 wrap those reads in a transactional `content_version` guard — a concurrent
 retag cannot interleave bytes from two generations of a tag.
 
+### Backing read-ahead
+
+Every backing read — `BackingAudio` splices and the `serve_ogg_window` page walk
+alike — flows through a single `BackingReader::read_exact_at`
+(`musefs-core/src/readahead.rs`). It caches *raw backing-file bytes keyed by
+absolute backing offset* in a per-handle adaptive window: a sequential miss reads
+one large `pread` (geometric growth up to a per-stream cap) instead of the
+≤256 KiB FUSE chunk, so a high-latency backing client (NFS, remote) can pipeline
+the RPCs behind one syscall; a seek resets the window to the floor. All handles
+draw from one process-wide RAM budget (`--read-ahead-budget-mib`, default 64) with
+deadlock-free `try_lock` LRU eviction. Keying on the absolute backing offset (not
+the synthesized output) makes the cache retag-immune, and serving still flows
+through the per-read `validate_opened_backing` re-stat, so the cardinal
+audio-bytes invariant and freshness semantics are untouched. An optional Phase-2
+background-prefetch layer (`--read-ahead-prefetch`) exists but is off by default —
+read amplification carries the whole win (see
+[BENCHMARKS.md](BENCHMARKS.md#backing-read-ahead-255)).
+
 How each format builds its layout differs enough to warrant its own document:
 [FLAC](docs/FLAC.md), [MP3](docs/MP3.md), [M4A](docs/M4A.md),
 [Ogg](docs/OGG.md), [WAV](docs/WAV.md).

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -758,10 +758,74 @@ consistent across HDD and NFS. This is the only tunable worth changing for slow 
   (`max_readahead`, `max_background`, and by extension a per-medium combination of them)
   show no benefit; `max_readahead` ≥2048 KiB actively hurts on HDD. The only justified
   change — enable `--keep-cache` on HDD/NFS — does not need an abstraction.
-- **Latent finding (future work):** single-stream reads are serialized, so per-read
-  latency is never hidden by prefetch. The real lever for slow backing would be a
-  **concurrent backing-prefetch pipeline in the daemon** (issue several `BackingAudio`
-  reads ahead in parallel), an architectural change tracked separately.
+- **Single-stream latency hiding — addressed in #255 (next section).** The serialized
+  read path measured above (512 MiB ÷ 256 KiB × RTT) is exactly what backing read-ahead
+  now fixes.
+
+---
+
+## Backing read-ahead (#255)
+
+Each `--max-readahead-kib` row above exposed the real bottleneck: a single stream is
+served one ≤256 KiB FUSE chunk at a time, each paying the full backing RTT, so a
+200 ms-RTT NFS mount tops out at ~1.3 MB/s regardless of the *kernel* read-ahead window.
+The fix is **read amplification in the daemon** — `BackingReader` coalesces a stream's
+small reads into one large positioned `pread` (geometric window growth, global RAM budget
+with LRU eviction), so the backing client can pipeline/parallelize the RPCs behind one
+syscall. A background-prefetch-threads layer ("Phase 2") was also built but is **off by
+default** (see below).
+
+### Methodology
+
+Two harnesses. **Real kernel mount** (`benches/storage_tunables_bench.sh`): a real reader
+(`dd`) over a real FUSE mount, cold (`drop_caches`) each sample, median of 3. Local backing
+on a btrfs HDD; NFS via a loopback **NFSv4.2** export plus `tc netem` for RTT. **The corpus
+is real FLAC** (`MUSEFS_BENCH_CORPUS_SRC`) — a `/dev/zero` corpus on a compressing fs
+(btrfs `compress=zstd`) collapses to a cached extent and never touches the platter, which
+silently inverts the HDD numbers; real already-compressed audio is incompressible.
+**In-process** (`musefs-core/tests/bench_ingest.rs::bench_read_under_latency`): the core read
+path over `musefs-latencyfs` (per-op injected latency), isolating the daemon from the kernel
+FUSE layer. `off` = `--read-ahead-budget-mib 0`; `phase1` = the default (amplification only);
+`phase1+2` = `--read-ahead-prefetch`.
+
+### Single-stream cold throughput (MB/s)
+
+| backing | off | **phase 1 (default)** | phase 1+2 | passthrough |
+|--------:|----:|----------------------:|----------:|------------:|
+| local HDD (btrfs, real FLAC) | ~60 | ~62 | ~60 | ~58 |
+| NFS, tmpfs-backed, 200 ms RTT | 1.2 | **7.4** | 6.8 | 9.8 |
+
+On NFS read-ahead is a **~6× single-stream win** (1.2 → 7.4 MB/s, 75 % of the kernel-passthrough
+ceiling). On a real local HDD all four configs sit within run-to-run noise (~±15 %) — read-ahead
+is **neutral**, not a regression. (An earlier `/dev/zero` corpus showed a spurious −35 %; it was
+the zstd-compression artifact above, not read-ahead.)
+
+### Concurrent streams (8 × distinct tracks, aggregate MB/s, NFS 200 ms RTT)
+
+| off | **phase 1 (default)** | phase 1+2 | passthrough |
+|----:|----------------------:|----------:|------------:|
+| 1.6 | **13.6** | 12.1 | 16.3 |
+
+### In-process, per-op latency (16 MiB Ogg whole read; wall ms / backing preads)
+
+| profile | off | phase 1 (default) |
+|--------:|----:|------------------:|
+| ssd (80 µs/op) | 45 ms / 774 preads | **26 ms / 32 preads** |
+| nfs-ssd (600 µs/op) | 138 ms / 774 | **112 ms / 32** |
+
+Amplification collapses 774 backing round-trips to 32; the win scales with per-op latency and
+is already material at SSD speeds (1.7×).
+
+### Phase 2 is off by default
+
+Background prefetch threads (Phase 2) **never beat amplification alone** and cost a consistent
+~10 %: single-stream NFS 6.8 vs 7.4, concurrent NFS 12.1 vs 13.6, neutral on HDD. A single large
+`pread` already lets the NFS client pipeline its RPCs, so the threads add coordination overhead
+without overlap to exploit. Phase 2 is therefore opt-in (`--read-ahead-prefetch`), retained for
+hypothetical backends where one large read does not self-pipeline.
+
+**Defaults:** read-ahead on at `--read-ahead-budget-mib 64`, Phase-1 amplification only. Set
+`0` to disable on local-disk-only setups (no benefit there, though no harm either).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -388,17 +388,20 @@ default template is `$albumartist/$album/$title`.
 
 ### Tuning
 
-The defaults are sensible for most setups. On slow backing storage (HDD, NFS) the one
-flag worth changing is `--keep-cache`; the read-ahead / background knobs have little
-measurable effect on musefs (see [BENCHMARKS.md](BENCHMARKS.md#storage-tunables)
-for the methodology and numbers).
+The defaults are sensible for most setups. On slow or high-latency backing (NFS, remote,
+HDD), the two flags worth knowing are `--read-ahead-budget-mib` — the daemon-level backing
+read-ahead that hides per-read latency, the single biggest win for NFS/remote — and
+`--keep-cache`. The *kernel*-level read-ahead / background knobs have little measurable
+effect (see [BENCHMARKS.md](BENCHMARKS.md#storage-tunables) for the methodology and numbers).
 
 | Flag | Default | What it does |
 | ---- | ------- | ------------ |
 | `--poll-interval-ms` | `1000` | Debounce window for detecting external DB edits. |
+| `--read-ahead-budget-mib` | `64` | Per-mount RAM budget (MiB) for **backing read-ahead**: the daemon coalesces a stream's small FUSE reads into one large positioned read, so the backing client can pipeline/parallelize them. **The biggest lever for slow/high-latency backing** — ~5–6× single-stream throughput over a 200 ms-RTT NFS mount; neutral on local disk. Shared across all active streams with LRU eviction; `0` disables it. |
+| `--read-ahead-prefetch` | disabled | Advanced: add background prefetch threads on top of read amplification. Off by default — benchmarks found amplification alone delivers the entire read-ahead win, while the threads add ~10% overhead with no measured benefit. Enable only when profiling a backend where a single large read does not self-pipeline. |
 | `--keep-cache` | disabled | Keep the kernel page cache across opens. **Worth enabling on HDD/NFS:** repeat opens of a file are then served from cache instead of re-read over slow storage (~3× faster reopen in our benches). External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
 | `--attr-ttl-ms` | `1000` | How long the kernel may trust cached entry/attr lookups. Higher cuts `lookup`/`getattr` traffic — useful for metadata-heavy clients (library scanners) over high-latency backing — but bounds how fast external edits become visible. |
-| `--max-readahead-kib` | `512` | Kernel read-ahead window (clamped to the kernel maximum). In practice this does **not** speed up musefs streaming: reads reach the daemon in fixed FUSE-sized chunks and a single stream is served serially, so a larger window doesn't reduce per-read latency. On HDD, values well above the default can even hurt. Leave at the default unless your own profiling shows otherwise. |
+| `--max-readahead-kib` | `512` | *Kernel* read-ahead window (clamped to the kernel maximum). Distinct from `--read-ahead-budget-mib` (the daemon-level read-ahead, which is the effective one): this kernel knob does **not** speed up musefs streaming, since reads reach the daemon in fixed FUSE-sized chunks regardless. On HDD, values well above the default can even hurt. Leave at the default unless your own profiling shows otherwise. |
 | `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. Does **not** bound foreground reads (those scale with client concurrency), so it has little effect on read throughput; left for completeness. |
 | `--case-insensitive <true\|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files get a numeric suffix (e.g. `Song (2)`). Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
 

--- a/benches/storage_tunables_bench.sh
+++ b/benches/storage_tunables_bench.sh
@@ -59,7 +59,11 @@ gen_corpus() { # $1=backing-dir $2=size_mib $3=streams
   # reruns reuse the copy.
   if [ -n "${MUSEFS_BENCH_CORPUS_SRC:-}" ]; then
     # Already populated (a prior run)? Skip the rescan of the (large) source tree.
-    if find "$1" -maxdepth 1 -type f \( -iname '*.flac' -o -iname '*.mp3' \) 2>/dev/null | grep -q .; then
+    # `-print -quit` stops at the first match (no pipe, so pipefail-safe) and we
+    # check every copied extension, not just flac/mp3.
+    if [ -n "$(find "$1" -maxdepth 1 -type f \
+      \( -iname '*.flac' -o -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.ogg' \) \
+      -print -quit 2>/dev/null)" ]; then
       return 0
     fi
     local n=$(( $3 + 1 ))

--- a/benches/storage_tunables_bench.sh
+++ b/benches/storage_tunables_bench.sh
@@ -45,10 +45,41 @@ make_wav() { local p="$1" m="$2" d r; [ -f "$p" ] && return 0
   { printf 'RIFF'; printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((r&255)) $((r>>8&255)) $((r>>16&255)) $((r>>24&255)))"
     printf 'WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x44\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00data'
     printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' $((d&255)) $((d>>8&255)) $((d>>16&255)) $((d>>24&255)))"
-    dd if=/dev/zero bs=1M count="$m" 2>/dev/null; } >> "$p"; }
+    # Incompressible payload: a /dev/zero corpus on a compressing fs (btrfs
+    # compress=zstd) collapses to a tiny cached extent, so cold reads never hit
+    # the platter and the "HDD" rows measure decompression, not backing latency.
+    dd if=/dev/urandom bs=1M count="$m" 2>/dev/null; } >> "$p"; }
 
 gen_corpus() { # $1=backing-dir $2=size_mib $3=streams
   mkdir -p "$1"
+  # Real-file corpus: with MUSEFS_BENCH_CORPUS_SRC set, copy the largest audio
+  # files from that tree (biggest first, streams+1 of them) instead of synthetic
+  # WAVs. Real already-compressed audio is incompressible and representative, so
+  # a compressing backing fs can't collapse it into a cached extent. `cp -n` makes
+  # reruns reuse the copy.
+  if [ -n "${MUSEFS_BENCH_CORPUS_SRC:-}" ]; then
+    # Already populated (a prior run)? Skip the rescan of the (large) source tree.
+    if find "$1" -maxdepth 1 -type f \( -iname '*.flac' -o -iname '*.mp3' \) 2>/dev/null | grep -q .; then
+      return 0
+    fi
+    local n=$(( $3 + 1 ))
+    # Optional size cap (MiB): pick the biggest real tracks UNDER it. High-RTT NFS
+    # rows need a normal ~50 MiB track (a 1 GiB file would take ~15 min/sample);
+    # local rows leave it unset to get one large file for a long, stable read.
+    local maxb=0
+    [ -n "${MUSEFS_BENCH_CORPUS_MAX_MIB:-}" ] && maxb=$(( MUSEFS_BENCH_CORPUS_MAX_MIB * 1024 * 1024 ))
+    # Capture-then-copy: `head` closing the pipe early would SIGPIPE `find`/`sort`
+    # and trip `pipefail`, so collect the list in a substitution (|| true) first.
+    local list
+    list=$(find "$MUSEFS_BENCH_CORPUS_SRC" -type f \
+      \( -iname '*.flac' -o -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.ogg' \) \
+      -printf '%s\t%p\n' 2>/dev/null | awk -v m="$maxb" -F'\t' 'm==0 || $1<=m' |
+      sort -rn | head -n "$n" | cut -f2-) || true
+    while IFS= read -r f; do
+      [ -n "$f" ] && { cp -n "$f" "$1/" 2>/dev/null || true; }
+    done <<< "$list"
+    return 0
+  fi
   make_wav "$1/big.wav" "$2"
   local i; for i in $(seq 1 "$3"); do make_wav "$1/t$i.wav" 32; done
 }
@@ -76,8 +107,9 @@ rm -f "$DB"; "$BIN" scan "$SCANDIR" --db "$DB" >/dev/null   # scan before adding
 if [ "$MODE" = nfs ]; then tc qdisc add dev lo root netem delay "${NETEM_MS}ms"; NETEM=1; fi
 
 # shellcheck disable=SC2016  # '$title' is a musefs output-template literal, not a shell var
-mount_m() { "$BIN" mount "$MMNT" --db "$DB" --mode synthesis --template '$title' "$@" >/dev/null 2>&1 & MP=$!
+mount_mode() { local m="$1"; shift; "$BIN" mount "$MMNT" --db "$DB" --mode "$m" --template '$title' "$@" >/dev/null 2>&1 & MP=$!
   local f=""; for _ in $(seq 1 60); do f=$(find "$MMNT" -type f 2>/dev/null|head -1); [ -n "$f" ] && break; sleep 0.25; done; }
+mount_m() { mount_mode synthesis "$@"; }
 umount_m() { kill "$MP" 2>/dev/null||true; for _ in $(seq 1 20); do kill -0 "$MP" 2>/dev/null||break; sleep 0.25; done; MP=""; }
 drop() { sync; echo 3 > /proc/sys/vm/drop_caches; }
 biggest() { find "$MMNT" -type f -printf '%s\t%p\n'|sort -rn|head -1|cut -f2-; }
@@ -86,6 +118,18 @@ cold_mbps() { local v; v="$(biggest)"; local o
   o=$(for _ in 1 2 3; do drop
     dd if="$v" of=/dev/null bs=1M 2>&1|tail -1|awk '{b=$1}{for(i=1;i<=NF;i++) if($i=="copied,")s=$(i+1)}END{if(s>0)printf "%.1f\n",b/1e6/s}'
   done|sort -n|sed -n 2p); echo "${o:-0}"; }
+
+echo "## read_ahead_budget (cold single-stream MB/s; issue #255)"
+printf '%-24s %10s\n' config MBps
+# off (ra=0) vs the default Phase-1 read amplification (ra=64, prefetch off).
+for rb in 0 64; do mount_m --read-ahead-budget-mib "$rb"; printf '%-24s %10s\n' "synthesis ra=${rb}MiB" "$(cold_mbps)"; umount_m; done
+# Phase 1+2: opt into the background prefetch threads (off by default; #255 found
+# they add overhead without benefit, so this row should not beat ra=64 alone).
+mount_m --read-ahead-budget-mib 64 --read-ahead-prefetch
+printf '%-24s %10s\n' "synthesis ra=64 +prefetch" "$(cold_mbps)"; umount_m
+# Reference ceiling: structure-only triggers kernel FUSE passthrough when
+# privileged, serving the backing fd directly (no daemon, no daemon read-ahead).
+mount_mode structure-only; printf '%-24s %10s\n' "passthrough (kernel)" "$(cold_mbps)"; umount_m
 
 echo "## max_readahead-kib (cold single-stream MB/s)"
 printf '%-16s %10s\n' readahead MBps

--- a/benches/storage_tunables_bench.sh
+++ b/benches/storage_tunables_bench.sh
@@ -58,15 +58,17 @@ gen_corpus() { # $1=backing-dir $2=size_mib $3=streams
   # a compressing backing fs can't collapse it into a cached extent. `cp -n` makes
   # reruns reuse the copy.
   if [ -n "${MUSEFS_BENCH_CORPUS_SRC:-}" ]; then
-    # Already populated (a prior run)? Skip the rescan of the (large) source tree.
-    # `-print -quit` stops at the first match (no pipe, so pipefail-safe) and we
-    # check every copied extension, not just flac/mp3.
-    if [ -n "$(find "$1" -maxdepth 1 -type f \
+    local n=$(( $3 + 1 ))
+    # Already populated by a prior run with at least as many streams? Skip the
+    # rescan of the (large) source tree. Count via `-printf '.' | wc -c` (wc
+    # consumes all input, so no early pipe close under pipefail) across every
+    # copied extension, and require >= streams+1 distinct files so a rerun after
+    # a SMALLER bench still tops up the corpus.
+    if [ "$(find "$1" -maxdepth 1 -type f \
       \( -iname '*.flac' -o -iname '*.mp3' -o -iname '*.m4a' -o -iname '*.ogg' \) \
-      -print -quit 2>/dev/null)" ]; then
+      -printf '.' 2>/dev/null | wc -c)" -ge "$n" ]; then
       return 0
     fi
-    local n=$(( $3 + 1 ))
     # Optional size cap (MiB): pick the biggest real tracks UNDER it. High-RTT NFS
     # rows need a normal ~50 MiB track (a 1 GiB file would take ~15 min/sample);
     # local rows leave it unset to get one large file for a long, stable read.

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -40,6 +40,16 @@ MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
 #MUSEFS_ATTR_TTL_MS=1000
 # Kernel read-ahead window (KiB); clamped to the kernel maximum at mount.
 #MUSEFS_MAX_READAHEAD_KIB=512
+# Backing read-ahead RAM budget (MiB), shared across all active streams. This is
+# the single most effective tuning for slow/high-latency backing (NFS, remote):
+# one large backing read lets the client pipeline its RPCs and hide latency
+# (~5-6x single-stream over a 200 ms-RTT NFS mount). Neutral on local disk.
+# 0 disables read-ahead. Default: 64.
+#MUSEFS_READ_AHEAD_BUDGET_MIB=64
+# Enable Phase-2 background prefetch threads (advanced). Off by default: read
+# amplification alone carries the read-ahead win, and the threads add overhead
+# without benefit on tested backends (NFS, SSD). Default: false.
+#MUSEFS_READ_AHEAD_PREFETCH=false
 # Max outstanding background (readahead/async) requests the kernel queues.
 #MUSEFS_MAX_BACKGROUND=64
 # Keep the kernel page cache across opens.

--- a/docs/OGG.md
+++ b/docs/OGG.md
@@ -108,6 +108,17 @@ data is refused, not served. Synthesized page sequence numbers wrap modulo
 2³² (matching Ogg's `u32` sequence field), so files whose audio pages have
 very high sequence numbers serve correctly rather than failing the read.
 
+The forward page-walk reads (`serve_ogg_window`) flow through the shared backing
+read-ahead buffer (`BackingReader`, see
+[ARCHITECTURE.md](../ARCHITECTURE.md#backing-read-ahead)) just like PCM
+`BackingAudio` reads, so a sequential Ogg stream amortizes backing latency the
+same way. The read-ahead cache holds *raw backing bytes keyed by absolute
+offset*, so it is orthogonal to header patching: the algebraic CRC/sequence
+rewrite happens on the bytes after they are read, and the cache never sees a
+patched page. (The backward `find_page_start` scan and its CRC check stay on the
+raw fd — they are short, non-sequential probes that the forward-streaming window
+would not help.)
+
 ## CRC patching: the linear-CRC trick
 
 This is the neatest thing in the Ogg path. Every Ogg page carries a CRC-32 over

--- a/docs/superpowers/plans/2026-06-14-read-ahead-overlap.md
+++ b/docs/superpowers/plans/2026-06-14-read-ahead-overlap.md
@@ -1144,15 +1144,19 @@ let key = fh.slab_key();
 if !h.registered.swap(true, Ordering::AcqRel) {
     self.readahead_pool.register(key, Arc::clone(&h.readahead));
 }
-let backing_len = r.stamp.size; // backing file size from the validated stamp (u64 field)
+let backing_len = r.stamp.size; // BackingStamp.size is a public u64 field (freshness.rs:16)
 let br = crate::readahead::BackingReader::new(
     &h.file, &h.readahead, &self.readahead_pool, key, backing_len,
 );
 read_at_with_file_into(r, db, &br, offset, size, out)?;
 ```
    (Adjust `read_at_with_file_into`'s signature use: it now takes `&BackingReader`
-   per Task 5/6.) Determine the correct `backing_len` accessor on `BackingStamp`;
-   if it stores size as a field use `r.stamp.size` / add a `size()` getter.
+   per Task 5/6.) `r.stamp.size` is the right accessor — `BackingStamp`
+   (`musefs-core/src/freshness.rs`) exposes `size: u64` as a public field; no
+   getter needed.
+   > Forward reference: Task 13 adds an `epoch` argument to `BackingReader::new`;
+   > this exact call site is migrated to `BackingReader::new(&h.file, &h.readahead,
+   > &self.readahead_pool, &h.epoch, key, backing_len)` there. Leave it 5-arg here.
 
 5. On the generation-bump path in `read_into` (where `h.generation.store(cur, ...)`
    happens after a re-resolve), drop the buffer and bump the epoch:

--- a/docs/superpowers/plans/2026-06-14-read-ahead-overlap.md
+++ b/docs/superpowers/plans/2026-06-14-read-ahead-overlap.md
@@ -185,7 +185,11 @@ impl ReadAhead {
             bytes: Vec::new(),
             next_expected: u64::MAX,
             window: WINDOW_FLOOR,
-            cap: cap.max(WINDOW_FLOOR),
+            // Do NOT floor the cap here: when the pool grants a sub-floor budget
+            // share, forcing the cap up to WINDOW_FLOOR would let the window grow
+            // past the grant and push `charged` over `budget`. A small cap simply
+            // means small windows.
+            cap,
         }
     }
 
@@ -203,9 +207,10 @@ impl ReadAhead {
         freed
     }
 
-    /// Update the per-stream cap (when the active-stream count changes the share).
+    /// Update the per-stream cap (when the budget share changes). No floor — see
+    /// `new`: a sub-floor cap must shrink the window, not be silently raised.
     pub fn set_cap(&mut self, cap: u64) {
-        self.cap = cap.max(WINDOW_FLOOR);
+        self.cap = cap;
         if self.window > self.cap {
             self.window = self.cap;
         }
@@ -245,14 +250,23 @@ impl ReadAhead {
             return Ok((n, n));
         }
         let old_len = self.bytes.len() as u64;
-        // Sequential miss grows; a seek resets to floor.
+        // Sequential miss grows; a seek resets to floor (both clamped by cap).
         if off == self.next_expected {
             self.window = self.window.saturating_mul(2).min(self.cap);
         } else {
             self.window = WINDOW_FLOOR.min(self.cap);
         }
-        // The window must at least cover the request, and never overrun EOF.
-        let want = self.window.max(len as u64).min(backing_len - off);
+        // The window must cover at least the request, must not exceed the cap
+        // (except by the bounded amount needed to satisfy a request larger than
+        // the cap), and must never overrun EOF. For a valid backing segment
+        // `off + len <= backing_len` always holds; `saturating_sub` is a defensive
+        // guard against a malformed caller rather than an expected branch.
+        debug_assert!(off < backing_len && off + len as u64 <= backing_len);
+        let want = self
+            .window
+            .max(len as u64)
+            .min(self.cap.max(len as u64))
+            .min(backing_len.saturating_sub(off));
         let mut buf = vec![0u8; want as usize];
         fill(&mut buf, off)?;
         dst.copy_from_slice(&buf[..len]);
@@ -449,13 +463,20 @@ impl ReadAheadPool {
     /// Charge the budget by the ACTUAL window-size change `(old_len → new_len)`.
     /// Keeps the invariant `charged == Σ(registered buffers' bytes.len())`.
     /// `new < old` (shrink/clear) uncharges. A no-op when `old == new` (hit).
+    ///
+    /// Hard ceiling caveat: `charged` can transiently exceed `budget` only by the
+    /// bounded amount a single request forces beyond the per-stream cap (a request
+    /// larger than the cap must still be served from one window). That overshoot
+    /// is at most `Σ(in-flight request sizes)` — at most one FUSE chunk (~256 KiB)
+    /// or one Ogg payload per active reader — never the unbounded read-ahead
+    /// region, which `permitted_window` strictly bounds. No assertion here: a
+    /// blanket bound would either be wrong (too tight) or vacuous (too loose).
     pub fn reconcile(&self, old_len: u64, new_len: u64) {
         if new_len > old_len {
             self.charged.fetch_add(new_len - old_len, Ordering::Relaxed);
         } else if new_len < old_len {
             self.charged.fetch_sub(old_len - new_len, Ordering::Relaxed);
         }
-        debug_assert!(self.charged.load(Ordering::Relaxed) <= self.budget.max(1) * 2);
     }
 
     /// Uncharge `bytes` directly (window cleared on invalidation/release).
@@ -722,8 +743,10 @@ impl<'a> BackingReader<'a> {
         // ceiling holds. A hit changes nothing and skips eviction entirely.
         if !ra.covers(abs_offset, dst.len()) {
             crate::metrics::on_readahead_miss();
+            // Use the grant verbatim — do NOT raise it to WINDOW_FLOOR, or a
+            // sub-floor budget share would over-grow the window past `budget`.
             let cap = self.pool.permitted_window(self.key, ra.len(), self.pool.per_stream_cap());
-            ra.set_cap(cap.max(WINDOW_FLOOR));
+            ra.set_cap(cap);
         } else {
             crate::metrics::on_readahead_hit();
         }
@@ -866,14 +889,15 @@ let start = out.len();
 out.resize(start + n, 0);
 br.read_exact_at(&mut out[start..], bo + within)?;
 ```
-3. In the `Segment::OggAudio { .. }` arm, temporarily keep it compiling by
-   obtaining the raw file from the reader for now — Task 6 routes it properly.
-   Add an accessor to `BackingReader`:
+3. Add a permanent `file()` accessor to `BackingReader` (Task 6 uses it for the
+   Ogg raw-fd scan path; it is not temporary):
 ```rust
 // in readahead.rs, impl BackingReader
 pub fn file(&self) -> &std::fs::File { self.file }
 ```
-   and in the Ogg arm change `let f = file.expect(...)` → `let f = backing.expect("...").file();` (Task 6 replaces this).
+   In the `Segment::OggAudio { .. }` arm, keep it compiling against the *unchanged*
+   `serve_ogg_window(&File, ...)` signature for now by passing `backing.expect(..).file()`:
+   change `let f = file.expect(...)` → `let f = backing.expect("ogg-audio segment requires an open backing reader").file();`. Task 6 changes `serve_ogg_window` to take `&BackingReader` and updates this call site to pass `br` directly.
 4. Update callers `read_at_with_file_into` and `read_at_into` to build a
    `BackingReader`. For the non-handle `read_at_into` fallback (one-shot open, no
    persistent buffer) construct a throwaway pool-less reader:
@@ -882,12 +906,15 @@ pub fn file(&self) -> &std::fs::File { self.file }
 let pool = crate::readahead::ReadAheadPool::new(0); // disabled → plain preads
 let buf = std::sync::Arc::new(std::sync::Mutex::new(
     crate::readahead::ReadAhead::new(0)));
-let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+// backing_len MUST be the backing file size, not the virtual total_len: the
+// reader clamps the window by `backing_len - off` where off is a BACKING offset.
+let backing_len = file.metadata()?.len();
+let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, backing_len);
 read_segments_into(resolved, db, Some(&br), offset, size, out)
 ```
-   (`backing_len` for the fallback can be `resolved` audio bound; `total_len` is a
-   safe upper clamp because the splice never requests past it. If a stricter file
-   length is needed, `file.metadata()?.len()`.)
+   (The pool is disabled here, so `BackingReader` takes its plain-pread path and
+   never touches the window; `backing_len` is still passed for signature
+   uniformity and is correct regardless.)
 5. Make `read_at_with_file_into` / `read_at_with_file` take `&BackingReader`
    instead of `&std::fs::File` (callers in `facade.rs` updated in Task 7). Keep
    their bodies delegating to `read_segments_into(..., Some(br), ...)`.
@@ -953,36 +980,38 @@ builders):
 Run: `cargo test -p musefs-core readahead_differential_tests::ogg_bytes_identical_through_backing_reader 2>&1 | tail -20`
 Expected: PASS already (the temp `.file()` accessor serves correct bytes) — but it bypasses the read-ahead window. The point of this task is to route Ogg's preads through the buffer so they also benefit and are covered. Proceed to change the signatures.
 
-- [ ] **Step 3: Thread `&BackingReader` through `ogg_index.rs`**
+- [ ] **Step 3: Route only the forward serving walk through `BackingReader`**
 
-Change these signatures from `backing: &std::fs::File` / `f: &std::fs::File` to
-`backing: &crate::readahead::BackingReader`:
-- `serve_ogg_window`
-- `find_page_start`
-- `read_counted`
-- `page_crc_ok` (and any other `read_counted` caller)
+**Why selective:** `serve_ogg_window` (`ogg_index.rs`) has TWO kinds of backing
+read. The forward page-walk reads (the header read at `pos`, line ~173, and the
+payload read at `pos + header_len + within`, line ~230) are exact and sequential
+— the hot path that benefits from read-ahead. But `find_page_start`'s backward
+scan and `page_crc_ok` use a short-read-tolerant `read_at` (returning a count,
+tolerating EOF) to *locate* a page during a seek — they cannot route through the
+exact-or-error `read_exact_at` shim, and they are the cold scan path. So:
 
-Change `read_counted` body to route through the shim and drop its own
-`on_pread` (the shim's fill closure counts physical preads — Task 4):
-```rust
-fn read_counted(
-    backing: &crate::readahead::BackingReader,
-    buf: &mut [u8],
-    offset: u64,
-) -> std::io::Result<()> {
-    // The BackingReader's fill closure increments `preads`; do not double-count.
-    backing.read_exact_at(buf, offset)
-}
-```
-**Counting model (already established in Task 4):** `preads` counts *physical*
-backing preads, incremented only inside `BackingReader`'s fill closure (and its
-disabled-pool path). Neither the PCM `BackingAudio` arm nor `read_counted` calls
-`on_pread`. Verify no stray `crate::metrics::on_pread(` remains in `reader.rs` or
-`ogg_index.rs`:
+- `serve_ogg_window`: change its `backing: &std::fs::File` param to
+  `backing: &crate::readahead::BackingReader`. Replace its two forward-walk
+  `read_counted(backing, ...)` calls with `backing.read_exact_at(...)` directly
+  (these now flow through the window). Where it calls
+  `find_page_start(backing, ...)`, pass the raw fd via `backing.file()` instead
+  (Step 4 makes `file()` a permanent accessor).
+- `find_page_start`, `page_crc_ok`, `read_counted`: leave their signatures on
+  `&std::fs::File` and their bodies (and their own `on_pread`) UNCHANGED — the
+  scan path stays raw.
+
+**Counting model:** `on_pread` counts every *physical* positioned backing read,
+wherever it happens — inside `BackingReader`'s fill closure (serve hot path,
+deduplicated by the window) AND inside `read_counted`/`page_crc_ok` (cold scan
+path, always physical). This is consistent: a sequential serve does fewer
+physical preads (window hits), while seek-time page location still counts its
+real preads. Do NOT remove `on_pread` from `ogg_index.rs`'s scan helpers — only
+the PCM `BackingAudio` arm dropped its `on_pread` (Task 5), because that read now
+goes through the shim. Verify only the PCM arm changed:
 ```bash
-grep -rn "on_pread" musefs-core/src/reader.rs musefs-core/src/ogg_index.rs
+grep -n "on_pread" musefs-core/src/ogg_index.rs   # expect: read_counted + page_crc_ok still present
+grep -n "on_pread" musefs-core/src/reader.rs       # expect: no matches (PCM arm dropped it)
 ```
-Expected: no matches (all counting now lives in `readahead.rs`).
 
 - [ ] **Step 4: Update the `OggAudio` arm call site in `reader.rs`**
 
@@ -992,8 +1021,8 @@ Segment::OggAudio { offset: ao, seq_delta, len } => {
     serve_ogg_window(br, *ao, *len, *seq_delta, within, within + n as u64, &mut *out, Some(&resolved.last_page))?;
 }
 ```
-Remove the temporary `.file()` accessor usage. You may keep `BackingReader::file()`
-only if Phase 2 needs it; otherwise delete it to avoid a dead-code warning.
+Keep `BackingReader::file()` permanently — `serve_ogg_window` passes it to
+`find_page_start` for the raw-fd scan path (Step 3). It is not dead code.
 
 - [ ] **Step 5: Run the full differential suite + crate tests**
 
@@ -1045,9 +1074,8 @@ mod readahead_handle_tests {
 }
 ```
 
-> If `metrics::reset()` does not exist, add it under the `metrics` feature (a
-> helper that zeroes the static counters) — it is needed for deterministic count
-> assertions and mirrors the existing test usage pattern.
+> `metrics::reset()` already exists (`metrics.rs:213`, both feature cfgs); Task 8
+> extends it to also zero the new read-ahead counters. Use it as-is here.
 
 - [ ] **Step 2: Run to verify failure**
 
@@ -1071,8 +1099,10 @@ struct Handle {
     /// Whether this handle is registered in the pool's active-stream registry.
     registered: AtomicBool,
     /// Bumped on a refresh-generation change, a seek, or release; an in-flight
-    /// Phase-2 prefetch checks it before storing (see spec §"Phase 2").
-    epoch: AtomicU64,
+    /// Phase-2 prefetch checks it before storing (see spec §"Phase 2"). `Arc` so a
+    /// prefetch job can share it (Task 13); a plain `AtomicU64` would not be
+    /// shareable into the worker. Bumped in-place via deref.
+    epoch: Arc<AtomicU64>,
 }
 ```
 
@@ -1099,7 +1129,7 @@ fh_from_key(self.handles.insert(Arc::new(Handle {
         self.readahead_pool.per_stream_cap(),
     ))),
     registered: AtomicBool::new(false),
-    epoch: AtomicU64::new(0),
+    epoch: Arc::new(AtomicU64::new(0)),
 })))
 ```
 
@@ -1195,17 +1225,30 @@ fn readahead_counts_physical_preads_not_logical_reads() {
 }
 ```
 
-- [ ] **Step 3: Fix the pre-existing exact-count assertions**
+- [ ] **Step 3: Audit and reconcile the pre-existing exact-count assertions**
 
-Find every test that asserts `s.preads == N` on a read path:
+The exact-count assertions in this crate are few — enumerate them and confirm
+each:
 ```bash
-grep -rn "preads, " musefs-core/src | grep assert
+grep -rn "\.preads\|\.opens\|scan_preads" musefs-core/src --include=*.rs | grep assert
 ```
-Re-derive the expected counts under read-ahead semantics (`preads` is now
-*physical* backing preads; a sequential second read is a hit, not a pread). For
-single-read tests the count is unchanged (first read always misses → 1 pread).
-For multi-sequential-read tests, lower the expected count and add a
-`readahead_hits`/`readahead_misses` assertion. Update each.
+As of writing, the only matches are in `musefs-core/src/metrics.rs`:
+- `metrics.rs:305` `assert_eq!(s.opens, 2);` and `:306` `assert_eq!(s.preads, 1);`
+  — this is a **single-read** scenario. Under read-ahead the first (only) read is
+  always a miss → exactly 1 physical pread, and `opens` is unchanged. **These
+  assertions stay as-is.** Add `assert_eq!(s.readahead_misses, 1)` and
+  `assert_eq!(s.readahead_hits, 0)` alongside to lock the new semantics.
+- `metrics.rs:323` `assert_eq!(s.scan_preads, 2);` — the **scan** path
+  (`on_scan_*`), which does NOT route through `BackingReader`. Unchanged; leave it.
+
+Also check the FUSE passthrough e2e (`musefs-fuse`), which `metrics.rs:22` notes
+"asserts exactly this" for `on_pread`: it runs in StructureOnly/passthrough mode
+where the kernel serves audio bytes and `read_into` is never called, so read-ahead
+does not touch it. Confirm by reading the test; expect no change needed.
+
+If `grep` surfaces any assertion not in this list (added since), apply the rule:
+single-read → unchanged; multi-sequential-read → lower `preads` and assert
+`readahead_hits`/`misses`.
 
 - [ ] **Step 4: Run the metrics-feature suite**
 
@@ -1360,7 +1403,7 @@ Add to `readahead_differential_tests`:
 
 Run: `cargo test -p musefs-core readahead_differential_tests 2>&1 | tail -20`
 Expected: PASS. If `pcm_bytes_identical_under_forced_eviction` fails, the bug is
-in budget reconciliation (`acquire`/`uncharge`) or `covers()` after a `clear()`;
+in budget reconciliation (`permitted_window`/`reconcile`) or `covers()` after a `clear()`;
 fix in `readahead.rs` until green.
 
 - [ ] **Step 3: Commit**
@@ -1414,70 +1457,241 @@ git commit -m "chore(core): Phase 1 read-ahead verification fixups (#255)"
 
 ## PHASE 2 — parallel prefetch
 
-### Task 12: Generalize the window to a prefetch ring + epoch-checked store
+### Task 12: Refactor `ReadAhead` to a bounded window ring
+
+**Why:** Phase 2 must fill window *K+1* while the kernel still reads window *K*.
+The Phase-1 single-window model can't hold both: a prefetch that overwrote the
+single window would clobber the bytes being served and *regress* sequential
+throughput. This task refactors `ReadAhead` from one `(win_start, bytes)` window
+to a small bounded set of windows. `max_windows` defaults to **1**, so all
+Phase-1 behavior and tests are preserved unchanged; Phase 2 raises it (Task 14).
 
 **Files:**
 - Modify: `musefs-core/src/readahead.rs`
 
 - [ ] **Step 1: Write the failing tests**
 
-Add a `prefetch_tests` module:
+Add a `ring_tests` module:
 ```rust
 #[cfg(test)]
-mod prefetch_tests {
+mod ring_tests {
+    use super::*;
+
+    #[test]
+    fn default_ring_holds_one_window_like_phase1() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP); // max_windows defaults to 1
+        let data: Vec<u8> = (0..2 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        let blen = data.len() as u64;
+        let mut dst = vec![0u8; 4096];
+        // Fill window A at offset 0, then a far read evicts it (only 1 window).
+        ra.read_into(&mut dst, 0, blen, |b, o| { b.copy_from_slice(&data[o as usize..][..b.len()]); Ok(()) }).unwrap();
+        ra.read_into(&mut dst, 1_000_000, blen, |b, o| { b.copy_from_slice(&data[o as usize..][..b.len()]); Ok(()) }).unwrap();
+        assert!(!ra.covers(0, 4096), "single-window ring evicts the old window");
+        assert!(ra.covers(1_000_000, 4096));
+    }
+
+    #[test]
+    fn ring_of_two_keeps_current_and_prefetched_window() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_max_windows(2);
+        // Store a prefetched window ahead WITHOUT serving a read there.
+        ra.store_window(1024 * 1024, vec![9u8; 512 * 1024]);
+        // Fill the current window via a normal read at 0.
+        let data = vec![1u8; 4096];
+        ra.read_into(&mut vec![0u8; 4096], 0, 4 * 1024 * 1024, |b, _| { b.copy_from_slice(&data[..b.len()]); Ok(()) }).unwrap();
+        // BOTH windows coexist: the just-read one and the prefetched-ahead one.
+        assert!(ra.covers(0, 4096), "current window present");
+        assert!(ra.covers(1024 * 1024, 4096), "prefetched window NOT clobbered");
+    }
+
+    #[test]
+    fn len_sums_all_windows_and_clear_drops_all() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_max_windows(3);
+        ra.store_window(0, vec![0u8; 100]);
+        ra.store_window(1000, vec![0u8; 200]);
+        assert_eq!(ra.len(), 300);
+        assert_eq!(ra.clear(), 300);
+        assert_eq!(ra.len(), 0);
+    }
+}
+```
+Also add the epoch-checked store seam tests (carried over from the prior design):
+```rust
+#[cfg(test)]
+mod prefetch_store_tests {
     use super::*;
     use std::sync::{Arc, Mutex};
+    use std::sync::atomic::AtomicU64;
 
     #[test]
     fn store_with_stale_epoch_is_discarded() {
         let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
-        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        // Dispatch a prefetch at epoch 0.
-        let dispatched = epoch.load(std::sync::atomic::Ordering::Acquire);
-        // A seek/refresh bumps the epoch.
-        epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-        // Storing the prefetched window must be rejected.
-        let stored = try_store_prefetch(&ra, &epoch, dispatched, 0, vec![1, 2, 3]);
-        assert!(!stored, "stale-epoch prefetch must be discarded");
+        let epoch = AtomicU64::new(0);
+        let dispatched = 0;
+        epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel); // seek/refresh
+        assert!(!try_store_prefetch(&ra, &epoch, dispatched, 0, vec![1, 2, 3]));
         assert_eq!(ra.lock().unwrap().len(), 0);
     }
 
     #[test]
     fn store_with_current_epoch_is_accepted() {
         let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
-        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(5));
-        let stored = try_store_prefetch(&ra, &epoch, 5, 1000, vec![0u8; 4096]);
-        assert!(stored);
+        ra.lock().unwrap().set_max_windows(2);
+        let epoch = AtomicU64::new(5);
+        assert!(try_store_prefetch(&ra, &epoch, 5, 1000, vec![0u8; 4096]));
+        assert!(ra.lock().unwrap().covers(1000, 4096));
     }
 }
 ```
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `cargo test -p musefs-core readahead::prefetch_tests 2>&1 | tail -20`
-Expected: FAIL — `try_store_prefetch` and the prefetch-store path undefined.
+Run: `cargo test -p musefs-core readahead::ring_tests readahead::prefetch_store_tests 2>&1 | tail -20`
+Expected: FAIL — `set_max_windows` / `store_window` / `try_store_prefetch` / the
+multi-window representation do not exist.
 
-- [ ] **Step 3: Implement the prefetch-store seam + a `store_window` on `ReadAhead`**
+- [ ] **Step 3: Refactor `ReadAhead` to a window ring**
 
-Add to `ReadAhead`:
+Replace the single-window fields with a bounded, sorted, non-overlapping set:
 ```rust
-/// Adopt an externally prefetched window (Phase 2). Replaces the current window
-/// with `[start, start+bytes.len())`. Does not touch `next_expected` (the
-/// foreground reader owns the sequential predictor). Returns the byte delta
-/// `(old_len, new_len)` for budget reconciliation.
-pub fn store_window(&mut self, start: u64, bytes: Vec<u8>) -> (u64, u64) {
-    let old = self.bytes.len() as u64;
-    self.win_start = start;
-    self.bytes = bytes;
-    (old, self.bytes.len() as u64)
+struct Window {
+    start: u64,
+    bytes: Vec<u8>,
+}
+
+pub struct ReadAhead {
+    /// Cached windows, sorted by `start`, non-overlapping. Bounded by `max_windows`.
+    windows: Vec<Window>,
+    next_expected: u64,
+    window: u64,
+    cap: u64,
+    /// Ring capacity: 1 in Phase 1 (single window), `depth + 1` in Phase 2.
+    max_windows: usize,
 }
 ```
-Add a free function:
+Rewrite the methods so external behavior is identical when `max_windows == 1`:
+```rust
+impl ReadAhead {
+    pub fn new(cap: u64) -> Self {
+        ReadAhead { windows: Vec::new(), next_expected: u64::MAX, window: WINDOW_FLOOR, cap, max_windows: 1 }
+    }
+    pub fn set_max_windows(&mut self, n: usize) { self.max_windows = n.max(1); }
+    pub fn next_expected(&self) -> u64 { self.next_expected }
+
+    pub fn len(&self) -> u64 {
+        self.windows.iter().map(|w| w.bytes.len() as u64).sum()
+    }
+    pub fn clear(&mut self) -> u64 {
+        let freed = self.len();
+        self.windows.clear();
+        self.window = WINDOW_FLOOR.min(self.cap.max(1));
+        self.next_expected = u64::MAX;
+        freed
+    }
+    pub fn set_cap(&mut self, cap: u64) {
+        self.cap = cap;
+        if self.window > self.cap { self.window = self.cap; }
+    }
+
+    /// True if some window fully contains `[off, off+len)`.
+    pub fn covers(&self, off: u64, len: usize) -> bool {
+        let end = off.saturating_add(len as u64);
+        self.windows.iter().any(|w| {
+            off >= w.start && end <= w.start + w.bytes.len() as u64
+        })
+    }
+
+    fn window_containing(&self, off: u64, len: usize) -> Option<&Window> {
+        let end = off.saturating_add(len as u64);
+        self.windows.iter().find(|w| off >= w.start && end <= w.start + w.bytes.len() as u64)
+    }
+
+    /// Insert a window, keeping `windows` sorted and bounded. When at capacity,
+    /// evict the window whose start is furthest *behind* `next_expected` (the one
+    /// the sequential stream has most likely passed). Returns bytes freed by any
+    /// eviction (for budget reconciliation by the caller; `store_window` returns
+    /// the net delta itself).
+    fn insert_window(&mut self, w: Window) {
+        // Replace an existing window with the same start (idempotent prefetch).
+        if let Some(slot) = self.windows.iter_mut().find(|x| x.start == w.start) {
+            *slot = w;
+        } else {
+            self.windows.push(w);
+        }
+        self.windows.sort_by_key(|x| x.start);
+        while self.windows.len() > self.max_windows {
+            let frontier = self.next_expected;
+            // Prefer evicting a window the reader has fully passed (its end is at or
+            // behind the frontier); among those, the smallest-start (oldest). If
+            // none are behind (all are ahead — e.g. freshly prefetched), evict the
+            // smallest-start window (index 0, since `windows` is sorted by start).
+            // This keeps the windows just ahead of the reader, never clobbering a
+            // window still to be read.
+            let idx = self
+                .windows
+                .iter()
+                .enumerate()
+                .filter(|(_, w)| w.start + w.bytes.len() as u64 <= frontier)
+                .min_by_key(|(_, w)| w.start)
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            self.windows.remove(idx);
+        }
+    }
+
+    /// Adopt an externally prefetched window (Phase 2) WITHOUT disturbing existing
+    /// windows or `next_expected`. Returns `(old_total, new_total)` for budget
+    /// reconciliation.
+    pub fn store_window(&mut self, start: u64, bytes: Vec<u8>) -> (u64, u64) {
+        let old = self.len();
+        self.insert_window(Window { start, bytes });
+        (old, self.len())
+    }
+
+    pub fn read_into(
+        &mut self,
+        dst: &mut [u8],
+        off: u64,
+        backing_len: u64,
+        mut fill: impl FnMut(&mut [u8], u64) -> io::Result<()>,
+    ) -> io::Result<(u64, u64)> {
+        let len = dst.len();
+        if len == 0 {
+            let n = self.len();
+            return Ok((n, n));
+        }
+        if let Some(w) = self.window_containing(off, len) {
+            let lo = (off - w.start) as usize;
+            dst.copy_from_slice(&w.bytes[lo..lo + len]);
+            self.next_expected = off + len as u64;
+            let n = self.len();
+            return Ok((n, n));
+        }
+        let old = self.len();
+        if off == self.next_expected {
+            self.window = self.window.saturating_mul(2).min(self.cap);
+        } else {
+            self.window = WINDOW_FLOOR.min(self.cap);
+        }
+        debug_assert!(off < backing_len && off + len as u64 <= backing_len);
+        let want = self.window.max(len as u64).min(self.cap.max(len as u64)).min(backing_len.saturating_sub(off));
+        let mut buf = vec![0u8; want as usize];
+        fill(&mut buf, off)?;
+        dst.copy_from_slice(&buf[..len]);
+        self.insert_window(Window { start: off, bytes: buf });
+        self.next_expected = off + len as u64;
+        Ok((old, self.len()))
+    }
+}
+```
+Add the epoch-checked store seam:
 ```rust
 use std::sync::atomic::{AtomicU64 as Epoch, Ordering as O};
 
-/// Store a prefetched window only if `dispatched_epoch` still matches `epoch`
-/// (no seek/refresh/release happened since dispatch). Returns whether stored.
+/// Store a prefetched window into `buf` only if `dispatched_epoch` still matches
+/// `epoch` (no seek/refresh/release since dispatch). Returns whether stored. The
+/// caller reconciles the budget with the returned delta on success.
 pub fn try_store_prefetch(
     buf: &Arc<Mutex<ReadAhead>>,
     epoch: &Epoch,
@@ -1494,17 +1708,23 @@ pub fn try_store_prefetch(
 }
 ```
 
-- [ ] **Step 4: Run to verify pass**
+> This refactor touches every `ReadAhead` method, so re-run the EARLIER unit tests
+> (`window_tests`, `backing_reader_tests`, the differentials) — they must all stay
+> green because `max_windows` defaults to 1. If `first_read_misses_then_sequential_reads_hit`
+> or the differentials break, the single-window-equivalence is wrong; fix
+> `insert_window`'s eviction until they pass.
 
-Run: `cargo test -p musefs-core readahead::prefetch_tests 2>&1 | tail -20`
-Expected: PASS.
+- [ ] **Step 4: Run to verify pass (new + all prior readahead tests)**
+
+Run: `cargo test -p musefs-core readahead 2>&1 | tail -30`
+Expected: PASS — ring tests, store tests, AND all Phase-1 readahead tests.
 
 - [ ] **Step 5: Re-anchor + commit**
 
 ```bash
 python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
 git add musefs-core/src/readahead.rs .cargo/mutants.toml
-git commit -m "feat(core): epoch-checked prefetch window store seam (#255)"
+git commit -m "refactor(core): ReadAhead window ring (non-clobbering prefetch) (#255)"
 ```
 
 ---
@@ -1535,13 +1755,12 @@ mod prefetch_worker_tests {
         let file = Arc::new(std::fs::File::open(&path).unwrap());
 
         let pool = Arc::new(ReadAheadPool::new(64 * 1024 * 1024));
-        let prefetch = PrefetchWorkers::new(2);
         let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
         let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
         pool.register(1, Arc::clone(&buf));
 
-        // Foreground reads window 0; request a prefetch of window 1.
-        prefetch.request(PrefetchJob {
+        // Run the prefetch of window 1 synchronously (deterministic; no threads).
+        PrefetchWorkers::run_job(PrefetchJob {
             file: Arc::clone(&file),
             buf: Arc::clone(&buf),
             epoch: Arc::clone(&epoch),
@@ -1550,11 +1769,9 @@ mod prefetch_worker_tests {
             len: 1024 * 1024,
             backing_len: data.len() as u64,
         });
-        prefetch.drain_for_test();
-        // The window now holds [1 MiB, 2 MiB).
+        // The window now holds [1 MiB, 2 MiB) and serves without a fill closure call.
         let mut out = vec![0u8; 4096];
         let mut ra = buf.lock().unwrap();
-        // covers() true → served without a fill closure call.
         let mut fills = 0;
         ra.read_into(&mut out, 1024 * 1024, data.len() as u64, |_, _| { fills += 1; Ok(()) }).unwrap();
         assert_eq!(fills, 0, "prefetched window should serve without a pread");
@@ -1562,6 +1779,9 @@ mod prefetch_worker_tests {
     }
 }
 ```
+> `run_job` must be callable as an associated fn (`PrefetchWorkers::run_job(job)`)
+> — it already is in Step 3. Make it `pub(crate)` or `#[cfg(test)] pub` so the test
+> can call it.
 
 - [ ] **Step 2: Run to verify failure**
 
@@ -1642,41 +1862,125 @@ impl PrefetchWorkers {
         let _ = self.tx.try_send(job);
     }
 
+    /// Test-only: run any queued jobs synchronously and deterministically (no
+    /// sleep). The production path uses the background threads via `request`.
     #[cfg(test)]
-    pub fn drain_for_test(&self) {
-        // Give workers a moment; jobs are tiny. For determinism, run synchronously
-        // instead in the test build:
-        std::thread::sleep(std::time::Duration::from_millis(50));
+    pub fn run_pending_for_test(&self, rx_jobs: Vec<PrefetchJob>) {
+        for job in rx_jobs {
+            Self::run_job(job);
+        }
     }
 }
 ```
 
-> If the 50 ms sleep is too flaky for CI, make `run_job` callable directly and
-> have the test call `PrefetchWorkers::run_job(job)` synchronously instead of
-> `request` + `drain_for_test`. Prefer the synchronous form for the unit test.
+> Use the synchronous form in unit tests: build `PrefetchJob`s and call
+> `PrefetchWorkers::run_job(job)` directly — do NOT rely on thread timing. The
+> background threads exist for production; the test asserts the *logic* (window
+> filled, epoch honored), not the scheduler. The `prefetch_fills_next_window...`
+> test in Step 1 should call `PrefetchWorkers::run_job(job)` directly rather than
+> `request` + a sleep; update it to do so.
 
-- [ ] **Step 4: Trigger prefetch from `BackingReader` on a serving advance**
+- [ ] **Step 4: Make the backing fd shareable and add the prefetch worker to `Musefs`**
 
-In `facade.rs` `read_into`, after a successful `read_at_with_file_into`, if the
-pool is enabled and the read was sequential, enqueue a prefetch of the next
-window. Add a `Musefs` field `prefetch: crate::readahead::PrefetchWorkers`
-(initialize in `open` with e.g. `PrefetchWorkers::new(2)` only when budget > 0;
-when disabled, skip requests). Build the job from `h.file` (wrap the fd in an
-`Arc` once at `open` — change `Handle.file` to `Arc<std::fs::File>`), `h.readahead`,
-`h.epoch`, the current epoch value, the next window `start = next_expected`, and
-`len = per_stream_cap`. Gate the request on the buffer reporting a recent
-sequential serve (expose `ReadAhead::next_expected()` and only prefetch when the
-just-served read ended at the window tail).
+Prefetch jobs need an owned fd reference, so change `Handle.file` from
+`std::fs::File` to `Arc<std::fs::File>`. Update the call sites:
+- `open_handle`: `file: Arc::new(file)`.
+- `validate_opened_backing(&h.file, ...)` → `validate_opened_backing(&h.file, ...)`
+  still works via `Arc` deref, but make the param `&std::fs::File` and pass
+  `&h.file` (Arc derefs); confirm `passthrough_fd`'s `AsFd` impl uses `&*self.0.file`.
+- `BackingReader::new(&h.file, ...)` → `BackingReader::new(&h.file, ...)` (Arc
+  derefs to `&File` at the call; `BackingReader` keeps borrowing `&File`).
 
-> Keep this trigger minimal: a single next-window prefetch per serving read is the
-> depth-1 pipeline. Task 14 makes the depth adaptive.
+Add a `Musefs` field `prefetch: Option<crate::readahead::PrefetchWorkers>`,
+initialized in `open` to `Some(PrefetchWorkers::new(2))` when
+`config.read_ahead_budget > 0`, else `None`.
 
-- [ ] **Step 5: Bump epoch on seek + release (Phase-2 cancellation)**
+- [ ] **Step 5: Move seek detection + epoch bump into `BackingReader` (NOT the facade)**
 
-In `read_into`, detect a seek at the facade level too (compare the incoming
-`offset`'s backing offset to the buffer's `next_expected`); on a seek and on
-`release_handle`, `h.epoch.fetch_add(1, ...)` so any in-flight prefetch is
-discarded. (The generation-bump epoch bump from Task 7 already covers refresh.)
+The `offset` the facade's `read_into` receives is the *virtual* file offset; the
+sequential predictor works in *backing* offsets, so seek detection MUST live where
+the backing offset is known — inside `BackingReader::read_exact_at`, not the
+facade. Add an epoch reference to `BackingReader`:
+```rust
+pub struct BackingReader<'a> {
+    file: &'a std::fs::File,
+    buf: &'a Arc<Mutex<ReadAhead>>,
+    pool: &'a ReadAheadPool,
+    epoch: &'a std::sync::atomic::AtomicU64,
+    key: usize,
+    backing_len: u64,
+    fills: Cell<u64>,
+}
+```
+`new` takes `epoch: &'a AtomicU64` as a new param. In `read_exact_at`, on a miss,
+detect a seek by comparing the backing `abs_offset` to the buffer's
+`next_expected` BEFORE filling, and bump the epoch so in-flight prefetch for the
+abandoned position is discarded:
+```rust
+if !ra.covers(abs_offset, dst.len()) {
+    crate::metrics::on_readahead_miss();
+    if abs_offset != ra.next_expected() {
+        // Seek: invalidate outstanding prefetch (Phase-2 cancellation).
+        self.epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+    }
+    let cap = self.pool.permitted_window(self.key, ra.len(), self.pool.per_stream_cap());
+    ra.set_cap(cap);
+} else {
+    crate::metrics::on_readahead_hit();
+}
+```
+**Update every `BackingReader::new` call site to pass an epoch** (this is the
+signature change the refactor requires):
+- `readahead.rs` unit tests (`backing_reader_tests`) and `reader.rs`
+  `readahead_differential_tests`: pass `&std::sync::atomic::AtomicU64::new(0)`.
+- `read_at_into` fallback (Task 5): pass `&std::sync::atomic::AtomicU64::new(0)`
+  (disabled pool never bumps it).
+- `facade.rs` `read_into` per-handle path: pass `&h.epoch`.
+
+Also bump the epoch in `release_handle` before deregistering:
+```rust
+pub fn release_handle(&self, fh: Fh) {
+    let key = fh.slab_key();
+    if let Some(h) = self.handles.get(key) {
+        h.epoch.fetch_add(1, Ordering::AcqRel); // cancel outstanding prefetch
+    }
+    self.readahead_pool.deregister(key);
+    self.handles.remove(key);
+}
+```
+(The refresh-generation bump from Task 7 already advances the epoch; seek is now
+covered here; release is covered above — the three invalidation signals are
+unified, per the spec.)
+
+- [ ] **Step 5b: Wire the prefetch trigger**
+
+When the pool is enabled, set the buffer's ring capacity once on first sequential
+use: `h.readahead.lock().unwrap().set_max_windows(2)` (depth-1 pipeline; Task 14
+makes it adaptive). After a successful per-handle `read_at_with_file_into`, if
+`self.prefetch` is `Some` and the just-served read was sequential (the buffer's
+`next_expected` advanced to the window tail), enqueue ONE next-window job:
+```rust
+if let Some(pf) = &self.prefetch {
+    let (start, len) = {
+        let ra = h.readahead.lock().unwrap();
+        (ra.next_expected(), self.readahead_pool.per_stream_cap())
+    };
+    if start < backing_len {
+        pf.request(crate::readahead::PrefetchJob {
+            file: Arc::clone(&h.file),
+            buf: Arc::clone(&h.readahead),
+            epoch: Arc::clone(&h.epoch),
+            dispatched_epoch: h.epoch.load(Ordering::Acquire),
+            start,
+            len,
+            backing_len,
+        });
+    }
+}
+```
+> `Handle.epoch` is already `Arc<AtomicU64>` (Task 7), so `Arc::clone(&h.epoch)`
+> shares it into the job while `&h.epoch` deref-coerces to the `&AtomicU64` that
+> `BackingReader::new` takes — no further type change needed.
 
 - [ ] **Step 6: Run the suite**
 
@@ -1714,11 +2018,20 @@ fake/instrumented prefetch sink:
 
 - [ ] **Step 2: Implement adaptive depth**
 
-Track a per-handle `depth` (in `ReadAhead` or a sibling atomic) that increments
-while sequential and resets on seek, capped so `depth * window <=
-per_stream_cap`. On each serving advance, enqueue up to `depth` next-window
-prefetch jobs (offsets `next_expected, next_expected+window, ...`), each with the
-current epoch.
+Track a per-handle `depth` that increments on each sequential serve and resets to
+1 on a seek (a seek is already detected in `BackingReader::read_exact_at` — have
+it also reset depth, or recompute depth in the facade from whether `next_expected`
+advanced contiguously). Cap depth so `depth * window <= per_stream_cap` (i.e.
+`depth = (per_stream_cap / window).max(1)`, clamped to a small absolute max like
+4 to bound thread fan-out). On each serving advance:
+1. Size the ring to hold the in-flight windows: `h.readahead.lock().unwrap().set_max_windows(depth + 1)`.
+2. Enqueue up to `depth` next-window jobs at offsets `next_expected,
+   next_expected + window, …`, each carrying the current `h.epoch` snapshot, each
+   skipped if `start >= backing_len`.
+
+Because the ring (Task 12) holds `depth + 1` windows, these prefetched windows
+accumulate ahead of the reader instead of clobbering the current one — this is the
+behavior the single-window design could not provide.
 
 - [ ] **Step 3: Run + commit**
 
@@ -1845,11 +2158,12 @@ git commit -m "docs: backing read-ahead architecture, Ogg, and CLI flag (#255)"
   No extra fstat needed.
 - **Budget accounting is the subtle part.** The invariant: `pool.charged` ==
   Σ(registered buffers' `bytes.len()`). Every path that changes a buffer's length
-  (`acquire` grow, `clear` on eviction/invalidation, `store_window` in Phase 2,
-  seek-shrink) must reconcile via `acquire`/`uncharge`. Task 10's forced-eviction
-  differential and a debug assertion (`charged <= budget`) are the safety net —
-  consider adding `debug_assert!(self.charged.load(Relaxed) <= self.budget)` after
-  each `acquire` return.
+  (window grow via `permitted_window` + `reconcile`, `clear` on
+  eviction/invalidation which uncharges inline, `store_window` in Phase 2,
+  seek-shrink) must keep `charged` in sync. Task 10's forced-eviction differential
+  is the safety net. Do NOT add a `charged <= budget` assertion — see `reconcile`:
+  a request larger than the per-stream cap legitimately overshoots by a bounded
+  amount, so that assertion would false-positive.
 - **`Handle.file` becomes `Arc<std::fs::File>` in Task 13** (prefetch jobs need an
   owned fd reference). Make that change in Task 13 and update `open_handle`,
   `validate_opened_backing` call sites (`&h.file` → `&*h.file`), and

--- a/docs/superpowers/plans/2026-06-14-read-ahead-overlap.md
+++ b/docs/superpowers/plans/2026-06-14-read-ahead-overlap.md
@@ -1,0 +1,1861 @@
+# Single-stream backing read-ahead Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Overlap/amortize backing-read latency on single sequential synthesis-mode streams so high-RTT NFS throughput stops collapsing to `chunk_count × RTT` (issue #255).
+
+**Architecture:** A per-handle backing read-ahead buffer caches *raw backing-file bytes keyed by absolute backing-file offset* and is consulted by every backing read (PCM `BackingAudio` and Ogg `serve_ogg_window` alike) through a single `BackingReader::read_exact_at`. An adaptive window grows geometrically on sequential access and resets on seek; all buffers draw from one global byte budget (`ReadAheadPool`) with `try_lock` LRU eviction. Phase 1 fills the window synchronously with one large `pread` (read amplification); Phase 2 adds background prefetch workers that fill ahead of the kernel position to fully hide RTT. Serving still flows through the existing per-read `validate_opened_backing`, so the cardinal audio-bytes invariant and retag/refresh semantics are untouched.
+
+**Tech Stack:** Rust, `musefs-core` crate (the integration layer). Synchronous `threadpool::ThreadPool` model (no async). `std::os::unix::fs::FileExt::read_exact_at` for positioned reads. `sharded_slab` (existing handle store), `Mutex`/`AtomicU64` for buffer + budget.
+
+**Source spec:** `docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md`
+
+**Phase boundary:** Tasks 1–11 are Phase 1 (synchronous amplification) and must land as a coherent, shippable unit. Tasks 12–15 are Phase 2 (parallel prefetch). Tasks 16–17 are rollout (bench + docs) and apply after Phase 1 (re-run after Phase 2). Each task ends in a green commit; the pre-commit hook runs the full workspace test suite.
+
+**Project gotchas every task must respect:**
+- Editing `reader.rs` / `facade.rs` / `ogg_index.rs` shifts the `.cargo/mutants.toml` line:col anchors → re-anchor in the SAME commit via each entry's `# guard:` tag (run `python3 scripts/check_mutant_anchors.py --fix` if present, else hand-fix; the pre-commit hook gate is `check_mutant_anchors.py`).
+- The CI `metrics` feature is NOT exercised by `cargo test --workspace`. After any read-path change run `cargo test -p musefs-core --features metrics`.
+- The workspace denies `unsafe_code` even in tests — use safe `std`/`rustix` wrappers only.
+- The out-of-workspace `fuzz/` crate isn't built by `cargo test`; if a `musefs-format` signature changes run `cargo +nightly fuzz build`. (This plan does not change format-layer signatures.)
+
+---
+
+## File Structure
+
+- **Create `musefs-core/src/readahead.rs`** — the entire read-ahead subsystem: `ReadAhead` (per-handle window state + decision table), `ReadAheadPool` (global budget + eviction registry), `BackingReader` (the `read_exact_at` shim wrapping fd + buffer + pool), and the Phase-2 prefetch ring/worker. One module, one responsibility (read-ahead), self-contained and heavily unit-tested.
+- **Modify `musefs-core/src/lib.rs`** — `mod readahead;` + re-exports.
+- **Modify `musefs-core/src/reader.rs`** — route the `BackingAudio` arm and the `file: Option<&File>` plumbing through `Option<&BackingReader>`.
+- **Modify `musefs-core/src/ogg_index.rs`** — `serve_ogg_window` / `read_counted` / `find_page_start` / `page_crc_ok` take `&BackingReader`.
+- **Modify `musefs-core/src/facade.rs`** — `Handle` gains the buffer + epoch; `Musefs` gains the `Arc<ReadAheadPool>`; `read_into` builds a `BackingReader`; `open_handle`/`release_handle` register/deregister; `MountConfig` gains the budget; epoch bumps on generation change / seek / release.
+- **Modify `musefs-core/src/metrics.rs`** — add read-ahead hit/miss counters.
+- **Modify `musefs-cli/src/lib.rs`** — `--read-ahead-budget-mib` flag → `MountConfig`.
+- **Modify `BENCHMARKS.md`, `ARCHITECTURE.md`, `docs/OGG.md`, `README.md`, `benches/storage_tunables_bench.sh`** — rollout.
+
+---
+
+## PHASE 1 — synchronous read amplification
+
+### Task 1: `ReadAhead` window core (decision table, no budget)
+
+**Files:**
+- Create: `musefs-core/src/readahead.rs`
+- Modify: `musefs-core/src/lib.rs`
+
+- [ ] **Step 1: Register the module**
+
+In `musefs-core/src/lib.rs`, add alongside the other `mod` lines:
+
+```rust
+mod readahead;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `musefs-core/src/readahead.rs` with ONLY the tests first (so it fails to compile → fails):
+
+```rust
+//! Per-handle backing read-ahead: an adaptive window over raw backing-file
+//! bytes, a global byte budget with eviction, and the `BackingReader` shim that
+//! every backing read flows through. See
+//! `docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md`.
+
+use std::io;
+
+/// Floor window size: a fresh or just-seeked stream still reads this much ahead.
+pub const WINDOW_FLOOR: u64 = 512 * 1024;
+/// Absolute per-stream window cap, independent of the global budget.
+pub const WINDOW_ABS_CAP: u64 = 8 * 1024 * 1024;
+
+#[cfg(test)]
+mod window_tests {
+    use super::*;
+
+    /// A fake backing file: `data` is the whole file; `fill` copies from it and
+    /// records each (offset, len) actually read so tests can assert pread counts.
+    struct Fake {
+        data: Vec<u8>,
+        reads: Vec<(u64, usize)>,
+    }
+    impl Fake {
+        fn new(len: usize) -> Self {
+            let data = (0..len).map(|i| (i % 251) as u8).collect();
+            Fake { data, reads: Vec::new() }
+        }
+        fn fill(&mut self, buf: &mut [u8], off: u64) -> io::Result<()> {
+            self.reads.push((off, buf.len()));
+            let o = off as usize;
+            buf.copy_from_slice(&self.data[o..o + buf.len()]);
+            Ok(())
+        }
+    }
+
+    fn serve(ra: &mut ReadAhead, fake: &mut Fake, off: u64, len: usize) -> Vec<u8> {
+        let mut dst = vec![0u8; len];
+        let backing_len = fake.data.len() as u64;
+        ra.read_into(&mut dst, off, backing_len, |b, o| fake.fill(b, o)).unwrap();
+        dst
+    }
+
+    #[test]
+    fn first_read_misses_then_sequential_reads_hit() {
+        let mut fake = Fake::new(4 * 1024 * 1024);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        // First 64 KiB read: a miss, fills a floor-sized window.
+        let a = serve(&mut ra, &mut fake, 0, 64 * 1024);
+        assert_eq!(a, fake.data[0..64 * 1024]);
+        assert_eq!(fake.reads.len(), 1, "first read must fill once");
+        // Next sequential 64 KiB: fully inside the window → no new pread.
+        let b = serve(&mut ra, &mut fake, 64 * 1024, 64 * 1024);
+        assert_eq!(b, fake.data[64 * 1024..128 * 1024]);
+        assert_eq!(fake.reads.len(), 1, "sequential hit must not pread");
+    }
+
+    #[test]
+    fn sequential_miss_grows_window_geometrically() {
+        let mut fake = Fake::new(16 * 1024 * 1024);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        // Read the full floor window, forcing a sequential miss at its end each time.
+        let floor = WINDOW_FLOOR as usize;
+        serve(&mut ra, &mut fake, 0, floor); // miss, window stays floor (first fill)
+        serve(&mut ra, &mut fake, WINDOW_FLOOR, floor); // seq miss → window doubles
+        // The second fill must have requested > floor bytes (geometric growth).
+        let second_fill_len = fake.reads[1].1 as u64;
+        assert!(second_fill_len > WINDOW_FLOOR, "window must grow on sequential miss");
+        assert!(second_fill_len <= WINDOW_ABS_CAP, "window capped");
+    }
+
+    #[test]
+    fn seek_resets_window_to_floor() {
+        let mut fake = Fake::new(16 * 1024 * 1024);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        serve(&mut ra, &mut fake, 0, WINDOW_FLOOR as usize);
+        serve(&mut ra, &mut fake, WINDOW_FLOOR, WINDOW_FLOOR as usize); // grow
+        // Seek far away → next fill is floor-sized again.
+        serve(&mut ra, &mut fake, 12 * 1024 * 1024, 4096);
+        let seek_fill_len = fake.reads.last().unwrap().1 as u64;
+        assert_eq!(seek_fill_len, WINDOW_FLOOR, "seek resets to floor");
+    }
+
+    #[test]
+    fn window_clamps_to_backing_len_at_eof() {
+        let mut fake = Fake::new(700 * 1024); // smaller than abs cap
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        // Read near EOF: requested range valid, but a full window would overrun.
+        let out = serve(&mut ra, &mut fake, 680 * 1024, 20 * 1024);
+        assert_eq!(out, fake.data[680 * 1024..700 * 1024]);
+        let (off, len) = fake.reads[0];
+        assert!(off + len as u64 <= 700 * 1024, "fill must not read past EOF");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-core readahead::window_tests 2>&1 | tail -20`
+Expected: FAIL — `cannot find type ReadAhead` / `ReadAhead::new` undefined.
+
+- [ ] **Step 4: Implement `ReadAhead`**
+
+Insert above the `#[cfg(test)]` block in `readahead.rs`:
+
+```rust
+/// A single contiguous read-ahead window over a backing file, keyed by absolute
+/// backing-file offset. NOT thread-safe; the caller wraps it in a `Mutex` (one
+/// per open handle). Caches raw backing bytes only — never synthesized output —
+/// so it is immune to retag and orthogonal to the DB snapshot path.
+pub struct ReadAhead {
+    /// Absolute backing offset of `bytes[0]`. Meaningless when `bytes` is empty.
+    win_start: u64,
+    /// Buffered raw backing bytes covering `[win_start, win_start + bytes.len())`.
+    bytes: Vec<u8>,
+    /// Backing offset just past the last served read — the sequential predictor.
+    /// `u64::MAX` until the first read, so the first read is always a (seek) miss.
+    next_expected: u64,
+    /// Current target window size; grows geometrically on a sequential miss,
+    /// resets to the floor on a seek. Bounded by `cap`.
+    window: u64,
+    /// Per-stream window cap (set from the budget: `min(WINDOW_ABS_CAP, budget/N)`).
+    cap: u64,
+}
+
+impl ReadAhead {
+    pub fn new(cap: u64) -> Self {
+        ReadAhead {
+            win_start: 0,
+            bytes: Vec::new(),
+            next_expected: u64::MAX,
+            window: WINDOW_FLOOR,
+            cap: cap.max(WINDOW_FLOOR),
+        }
+    }
+
+    /// Bytes currently held (charged against the global budget).
+    pub fn len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    /// Drop the buffered bytes (eviction / invalidation). Returns bytes freed.
+    pub fn clear(&mut self) -> u64 {
+        let freed = self.bytes.len() as u64;
+        self.bytes = Vec::new();
+        self.window = WINDOW_FLOOR.min(self.cap);
+        self.next_expected = u64::MAX;
+        freed
+    }
+
+    /// Update the per-stream cap (when the active-stream count changes the share).
+    pub fn set_cap(&mut self, cap: u64) {
+        self.cap = cap.max(WINDOW_FLOOR);
+        if self.window > self.cap {
+            self.window = self.cap;
+        }
+    }
+
+    fn covers(&self, off: u64, len: usize) -> bool {
+        let end = off.saturating_add(len as u64);
+        !self.bytes.is_empty()
+            && off >= self.win_start
+            && end <= self.win_start + self.bytes.len() as u64
+    }
+
+    /// Serve `[off, off+dst.len())` into `dst`. On a hit, memcpy from the window.
+    /// On a miss, `fill(window_buf, start)` does ONE positioned read of up to
+    /// `window` bytes (clamped to `backing_len`) starting at `off`. `backing_len`
+    /// is the backing file size; the caller guarantees `off+dst.len() <=
+    /// backing_len` (the splice loop already clamps the request).
+    ///
+    /// Returns `(old_len, new_len)` of `self.bytes` so the caller can reconcile
+    /// the global budget. A hit returns `(n, n)` (no change).
+    pub fn read_into(
+        &mut self,
+        dst: &mut [u8],
+        off: u64,
+        backing_len: u64,
+        mut fill: impl FnMut(&mut [u8], u64) -> io::Result<()>,
+    ) -> io::Result<(u64, u64)> {
+        let len = dst.len();
+        if len == 0 {
+            return Ok((self.bytes.len() as u64, self.bytes.len() as u64));
+        }
+        if self.covers(off, len) {
+            let lo = (off - self.win_start) as usize;
+            dst.copy_from_slice(&self.bytes[lo..lo + len]);
+            self.next_expected = off + len as u64;
+            let n = self.bytes.len() as u64;
+            return Ok((n, n));
+        }
+        let old_len = self.bytes.len() as u64;
+        // Sequential miss grows; a seek resets to floor.
+        if off == self.next_expected {
+            self.window = self.window.saturating_mul(2).min(self.cap);
+        } else {
+            self.window = WINDOW_FLOOR.min(self.cap);
+        }
+        // The window must at least cover the request, and never overrun EOF.
+        let want = self.window.max(len as u64).min(backing_len - off);
+        let mut buf = vec![0u8; want as usize];
+        fill(&mut buf, off)?;
+        dst.copy_from_slice(&buf[..len]);
+        self.win_start = off;
+        self.bytes = buf;
+        self.next_expected = off + len as u64;
+        Ok((old_len, self.bytes.len() as u64))
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-core readahead::window_tests 2>&1 | tail -20`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/readahead.rs musefs-core/src/lib.rs
+git commit -m "feat(core): adaptive read-ahead window core (#255)"
+```
+
+---
+
+### Task 2: `ReadAheadPool` budget + per-stream cap
+
+**Files:**
+- Modify: `musefs-core/src/readahead.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `readahead.rs`:
+
+```rust
+#[cfg(test)]
+mod pool_budget_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn disabled_pool_grants_nothing_and_reports_disabled() {
+        let pool = ReadAheadPool::new(0);
+        assert!(!pool.enabled());
+        assert_eq!(pool.per_stream_cap(), 0);
+    }
+
+    #[test]
+    fn per_stream_cap_is_budget_over_divisor_capped_by_abs() {
+        // 16 MiB budget / 4 = 4 MiB, below the 8 MiB abs cap.
+        let pool = ReadAheadPool::new(16 * 1024 * 1024);
+        assert_eq!(pool.per_stream_cap(), 4 * 1024 * 1024);
+        // Huge budget → abs cap wins.
+        let big = ReadAheadPool::new(1024 * 1024 * 1024);
+        assert_eq!(big.per_stream_cap(), WINDOW_ABS_CAP);
+    }
+
+    #[test]
+    fn permitted_window_grants_up_to_budget_then_clamps() {
+        let pool = ReadAheadPool::new(4 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        // Grow from 0 → 1 MiB: permitted fully, then charge the actual delta.
+        assert_eq!(pool.permitted_window(1, 0, 1024 * 1024), 1024 * 1024);
+        pool.reconcile(0, 1024 * 1024);
+        // charged is now 1 MiB; the per-stream cap is budget/4 = 1 MiB, so a
+        // request for 8 MiB is first capped to 1 MiB (== old_len) → no growth.
+        assert_eq!(pool.permitted_window(1, 1024 * 1024, 8 * 1024 * 1024), 1024 * 1024);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-core readahead::pool_budget_tests 2>&1 | tail -20`
+Expected: FAIL — `ReadAheadPool` undefined.
+
+- [ ] **Step 3: Implement the pool skeleton (budget + cap + register; eviction stubbed)**
+
+Add near the top of `readahead.rs` (after the constants):
+
+```rust
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Default global read-ahead budget when the operator passes no flag (64 MiB,
+/// mirroring `reader::DEFAULT_CACHE_BUDGET`). `0` disables read-ahead entirely.
+pub const DEFAULT_READAHEAD_BUDGET: u64 = 64 * 1024 * 1024;
+/// No single stream may hold more than `budget / PER_STREAM_DIVISOR`.
+const PER_STREAM_DIVISOR: u64 = 4;
+
+struct StreamEntry {
+    buf: Arc<Mutex<ReadAhead>>,
+    last_served: u64,
+}
+
+/// The process-wide read-ahead allocator: one byte budget shared by all active
+/// streams, with `try_lock` LRU eviction. Deadlock-free by construction — the
+/// budget is a lock-free atomic, the registry lock is a leaf (released before any
+/// buffer mutex), and eviction never blocks on a buffer mutex (`try_lock` + skip).
+pub struct ReadAheadPool {
+    /// Total RAM envelope; `0` means read-ahead is disabled.
+    budget: u64,
+    /// Currently charged bytes (sum of registered buffers' lengths).
+    charged: AtomicU64,
+    /// Active streaming handles keyed by slab key. Only sequential streams register.
+    streams: Mutex<HashMap<usize, StreamEntry>>,
+    /// Monotonic source for `last_served` stamps (LRU ordering).
+    clock: AtomicU64,
+}
+
+impl ReadAheadPool {
+    pub fn new(budget: u64) -> Self {
+        ReadAheadPool {
+            budget,
+            charged: AtomicU64::new(0),
+            streams: Mutex::new(HashMap::new()),
+            clock: AtomicU64::new(0),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.budget > 0
+    }
+
+    /// Per-stream window cap derived from the budget.
+    pub fn per_stream_cap(&self) -> u64 {
+        if self.budget == 0 {
+            return 0;
+        }
+        (self.budget / PER_STREAM_DIVISOR).min(WINDOW_ABS_CAP).max(WINDOW_FLOOR)
+    }
+
+    /// Lazily register a handle's buffer once sequential access is detected.
+    pub fn register(&self, key: usize, buf: Arc<Mutex<ReadAhead>>) {
+        let last_served = self.clock.fetch_add(1, Ordering::Relaxed);
+        self.streams
+            .lock()
+            .unwrap()
+            .insert(key, StreamEntry { buf, last_served });
+    }
+
+    /// Deregister on release; returns the bytes to uncharge.
+    pub fn deregister(&self, key: usize) {
+        let freed = {
+            let mut g = self.streams.lock().unwrap();
+            match g.remove(&key) {
+                Some(e) => e.buf.lock().unwrap().len(),
+                None => 0,
+            }
+        };
+        if freed > 0 {
+            self.charged.fetch_sub(freed, Ordering::Relaxed);
+        }
+    }
+
+    /// Mark `key` as most-recently-served (LRU bump). No-op if unregistered.
+    pub fn touch(&self, key: usize) {
+        let stamp = self.clock.fetch_add(1, Ordering::Relaxed);
+        if let Some(e) = self.streams.lock().unwrap().get_mut(&key) {
+            e.last_served = stamp;
+        }
+    }
+
+    /// Decide the largest window (≤ `desired`, ≤ per-stream cap) a stream may grow
+    /// to right now, given a current size of `old_len`. Evicts colder OTHER
+    /// streams as needed to make room for the `(window - old_len)` delta, but does
+    /// NOT charge — charging happens in `reconcile` against the ACTUAL bytes read.
+    /// Never blocks on a buffer mutex (`try_lock` + skip). Call only on a miss.
+    pub fn permitted_window(&self, key: usize, old_len: u64, desired: u64) -> u64 {
+        if self.budget == 0 {
+            return 0;
+        }
+        let desired = desired.min(self.per_stream_cap()).max(old_len);
+        let need = desired - old_len;
+        loop {
+            let cur = self.charged.load(Ordering::Relaxed);
+            let room = self.budget.saturating_sub(cur);
+            if room >= need {
+                return desired;
+            }
+            // Try to evict the coldest OTHER stream to free room.
+            match self.evict_one_coldest(key) {
+                Some(_) => continue, // evict_one_coldest already uncharged it
+                None => {
+                    // Nothing evictable: permit only what fits now.
+                    return old_len + room;
+                }
+            }
+        }
+    }
+
+    /// Charge the budget by the ACTUAL window-size change `(old_len → new_len)`.
+    /// Keeps the invariant `charged == Σ(registered buffers' bytes.len())`.
+    /// `new < old` (shrink/clear) uncharges. A no-op when `old == new` (hit).
+    pub fn reconcile(&self, old_len: u64, new_len: u64) {
+        if new_len > old_len {
+            self.charged.fetch_add(new_len - old_len, Ordering::Relaxed);
+        } else if new_len < old_len {
+            self.charged.fetch_sub(old_len - new_len, Ordering::Relaxed);
+        }
+        debug_assert!(self.charged.load(Ordering::Relaxed) <= self.budget.max(1) * 2);
+    }
+
+    /// Uncharge `bytes` directly (window cleared on invalidation/release).
+    pub fn uncharge(&self, bytes: u64) {
+        if bytes > 0 {
+            self.charged.fetch_sub(bytes, Ordering::Relaxed);
+        }
+    }
+
+    /// Find and clear the coldest registered buffer other than `except`, using
+    /// `try_lock` so eviction never blocks on an in-progress read. Returns the
+    /// freed byte count, or `None` if nothing was evictable this pass.
+    fn evict_one_coldest(&self, except: usize) -> Option<u64> {
+        // Snapshot candidates (key, last_served, buf Arc) under the registry lock,
+        // then release it before touching any buffer mutex (leaf-lock rule).
+        let candidates: Vec<(usize, u64, Arc<Mutex<ReadAhead>>)> = {
+            let g = self.streams.lock().unwrap();
+            let mut v: Vec<_> = g
+                .iter()
+                .filter(|(k, _)| **k != except)
+                .map(|(k, e)| (*k, e.last_served, Arc::clone(&e.buf)))
+                .collect();
+            v.sort_by_key(|(_, ls, _)| *ls); // coldest (smallest stamp) first
+            v
+        };
+        for (_, _, buf) in candidates {
+            if let Ok(mut ra) = buf.try_lock() {
+                let freed = ra.clear();
+                if freed > 0 {
+                    self.charged.fetch_sub(freed, Ordering::Relaxed);
+                    return Some(freed);
+                }
+            }
+        }
+        None
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p musefs-core readahead::pool_budget_tests 2>&1 | tail -20`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/readahead.rs
+git commit -m "feat(core): read-ahead global budget pool + per-stream cap (#255)"
+```
+
+---
+
+### Task 3: Eviction across streams
+
+**Files:**
+- Modify: `musefs-core/src/readahead.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `readahead.rs`:
+
+```rust
+#[cfg(test)]
+mod eviction_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Build a buffer holding exactly `bytes` real backing bytes and register it
+    /// with the pool, charging the pool for those bytes (mirrors what a real miss
+    /// does via permitted_window + reconcile). `bytes` must be >= WINDOW_FLOOR for
+    /// the stored window to equal `bytes`.
+    fn register_filled(pool: &ReadAheadPool, key: usize, bytes: usize) -> Arc<Mutex<ReadAhead>> {
+        let arc = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let data = vec![7u8; bytes * 2];
+        let mut dst = vec![0u8; bytes];
+        let (old, new) = arc
+            .lock()
+            .unwrap()
+            .read_into(&mut dst, 0, (bytes * 2) as u64, |b, _| {
+                b.copy_from_slice(&data[..b.len()]);
+                Ok(())
+            })
+            .unwrap();
+        pool.register(key, Arc::clone(&arc));
+        pool.reconcile(old, new);
+        arc
+    }
+
+    #[test]
+    fn permitted_window_evicts_coldest_other_stream_under_pressure() {
+        // Budget 4 MiB, per-stream cap 1 MiB. Fill the budget with four 1 MiB
+        // streams (registered keys 1..4, so key 1 is coldest), then a fifth stream
+        // wants to grow → must evict the coldest (key 1).
+        let pool = ReadAheadPool::new(4 * 1024 * 1024);
+        let mib = 1024 * 1024;
+        let cold = register_filled(&pool, 1, mib);
+        register_filled(&pool, 2, mib);
+        register_filled(&pool, 3, mib);
+        register_filled(&pool, 4, mib);
+        // Budget is now full (4 x 1 MiB). A fresh hot stream wants 1 MiB.
+        let hot = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(5, Arc::clone(&hot));
+        let granted = pool.permitted_window(5, 0, pool.per_stream_cap());
+        assert_eq!(granted, mib, "eviction frees room for the full cap");
+        assert_eq!(cold.lock().unwrap().len(), 0, "coldest stream was evicted");
+    }
+
+    #[test]
+    fn locked_victim_is_skipped_not_blocked() {
+        let pool = ReadAheadPool::new(4 * 1024 * 1024);
+        let mib = 1024 * 1024;
+        let victim = register_filled(&pool, 1, mib);
+        register_filled(&pool, 2, mib);
+        register_filled(&pool, 3, mib);
+        register_filled(&pool, 4, mib);
+        // Hold the coldest victim's lock: eviction must skip it (try_lock), not hang.
+        let _held = victim.lock().unwrap();
+        let hot = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(5, Arc::clone(&hot));
+        // Returns promptly: evicts the next-coldest unlocked victim instead.
+        let granted = pool.permitted_window(5, 0, pool.per_stream_cap());
+        assert!(granted > 0 && granted <= pool.per_stream_cap());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure or pass**
+
+Run: `cargo test -p musefs-core readahead::eviction_tests 2>&1 | tail -20`
+Expected: PASS — the eviction logic was implemented in Task 2. (If `permitted_window_evicts_coldest_other_stream_under_pressure` fails, the bug is in `evict_one_coldest` ordering or the `permitted_window` loop; fix the `sort_by_key`/`except` filter until green.) This task is the dedicated test gate for the Task-2 eviction code; keep it as a separate commit so a regression here bisects cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/src/readahead.rs
+git commit -m "test(core): read-ahead cross-stream eviction + try_lock skip (#255)"
+```
+
+---
+
+### Task 4: `BackingReader` shim (real fd + pool, synchronous fill)
+
+**Files:**
+- Modify: `musefs-core/src/readahead.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `readahead.rs`:
+
+```rust
+#[cfg(test)]
+mod backing_reader_tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::FileExt;
+    use std::sync::{Arc, Mutex};
+
+    fn temp_file(len: usize) -> (tempfile::TempDir, std::fs::File, Vec<u8>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("backing.bin");
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path).unwrap().write_all(&data).unwrap();
+        let f = std::fs::File::open(&path).unwrap();
+        (dir, f, data)
+    }
+
+    #[test]
+    fn sequential_reads_collapse_to_one_pread_per_window() {
+        let (_d, file, data) = temp_file(4 * 1024 * 1024);
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let backing_len = data.len() as u64;
+        let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+        // 16 sequential 64 KiB reads.
+        let mut out = vec![0u8; 64 * 1024];
+        for chunk in 0..16u64 {
+            br.read_exact_at(&mut out, chunk * 64 * 1024).unwrap();
+            assert_eq!(out, data[(chunk * 64 * 1024) as usize..][..64 * 1024]);
+        }
+        // Far fewer than 16 backing preads (window grows past 1 MiB quickly).
+        assert!(br.fills() < 16, "read-ahead must collapse preads, got {}", br.fills());
+    }
+
+    #[test]
+    fn bytes_match_direct_pread_for_random_access() {
+        let (_d, file, data) = temp_file(2 * 1024 * 1024);
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, data.len() as u64);
+        for &(off, len) in &[(0u64, 100usize), (1_000_000, 4096), (5000, 700), (2_097_000, 152)] {
+            let mut a = vec![0u8; len];
+            br.read_exact_at(&mut a, off).unwrap();
+            let mut b = vec![0u8; len];
+            file.read_exact_at(&mut b, off).unwrap();
+            assert_eq!(a, b, "read-ahead byte mismatch at {off}+{len}");
+        }
+    }
+}
+```
+
+Add `tempfile` to `musefs-core/Cargo.toml` dev-dependencies if not already present:
+
+```bash
+grep -q '^tempfile' musefs-core/Cargo.toml || echo "check [dev-dependencies] for tempfile"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-core readahead::backing_reader_tests 2>&1 | tail -20`
+Expected: FAIL — `BackingReader` undefined.
+
+- [ ] **Step 3: Implement `BackingReader`**
+
+Append to `readahead.rs` (before the test modules):
+
+```rust
+use std::cell::Cell;
+
+/// The shim every backing read flows through. Borrows an open backing fd, the
+/// handle's read-ahead buffer, and the global pool; serves from the window on a
+/// hit, else does one large positioned read that refills the window (Phase 1).
+/// Constructed per `read_into` call and dropped at its end.
+pub struct BackingReader<'a> {
+    file: &'a std::fs::File,
+    buf: &'a Arc<Mutex<ReadAhead>>,
+    pool: &'a ReadAheadPool,
+    key: usize,
+    backing_len: u64,
+    /// Backing preads actually issued (test/metrics visibility).
+    fills: Cell<u64>,
+}
+
+impl<'a> BackingReader<'a> {
+    pub fn new(
+        file: &'a std::fs::File,
+        buf: &'a Arc<Mutex<ReadAhead>>,
+        pool: &'a ReadAheadPool,
+        key: usize,
+        backing_len: u64,
+    ) -> Self {
+        BackingReader { file, buf, pool, key, backing_len, fills: Cell::new(0) }
+    }
+
+    pub fn fills(&self) -> u64 {
+        self.fills.get()
+    }
+
+    /// Read exactly `dst.len()` bytes at absolute backing offset `abs_offset`.
+    /// The caller (`read_segments_into`) guarantees the range is within the file.
+    pub fn read_exact_at(&self, dst: &mut [u8], abs_offset: u64) -> std::io::Result<()> {
+        // Read-ahead disabled → plain pread, no window.
+        if !self.pool.enabled() {
+            self.fills.set(self.fills.get() + 1);
+            crate::metrics::on_readahead_miss();
+            crate::metrics::on_pread(dst.len() as u64);
+            return crate::metrics::backing_read_exact_at(self.file, dst, abs_offset);
+        }
+        let mut ra = self.buf.lock().unwrap();
+        // On a miss (only), ask the pool how large this stream's window may grow —
+        // evicting colder streams to make room — BEFORE filling, so the global
+        // ceiling holds. A hit changes nothing and skips eviction entirely.
+        if !ra.covers(abs_offset, dst.len()) {
+            crate::metrics::on_readahead_miss();
+            let cap = self.pool.permitted_window(self.key, ra.len(), self.pool.per_stream_cap());
+            ra.set_cap(cap.max(WINDOW_FLOOR));
+        } else {
+            crate::metrics::on_readahead_hit();
+        }
+        let file = self.file;
+        let fills = &self.fills;
+        let (old_len, new_len) = ra.read_into(dst, abs_offset, self.backing_len, |b, o| {
+            fills.set(fills.get() + 1);
+            crate::metrics::on_pread(b.len() as u64);
+            crate::metrics::backing_read_exact_at(file, b, o)
+        })?;
+        // Charge the budget by the ACTUAL window-size change.
+        self.pool.reconcile(old_len, new_len);
+        drop(ra);
+        self.pool.touch(self.key);
+        Ok(())
+    }
+}
+```
+
+> Note: `on_readahead_hit` / `on_readahead_miss` are added in Task 8; until then add temporary no-op shims at the top of `readahead.rs`:
+> ```rust
+> // TEMP until Task 8 wires real metrics; remove these two lines in Task 8.
+> ```
+> Actually do not stub in two places — implement Task 8's metric functions FIRST if you reach a compile error, or guard the calls. Simplest: do Task 8's metric additions now (they are tiny) so these compile. The plan orders Task 8 later only for test-suite grouping; if you prefer, jump to Task 8 Step 3 (the metric fn definitions) before finishing this step.
+
+- [ ] **Step 4: Add the metric shims needed to compile**
+
+To keep this task self-contained, add the two counter functions now (full versions in Task 8). In `musefs-core/src/metrics.rs`, inside BOTH the `#[cfg(feature="metrics")]` module and the `#[cfg(not(feature="metrics"))]` module, add:
+
+Enabled module (near `on_art_chunk`):
+```rust
+    static READAHEAD_HITS: AtomicU64 = AtomicU64::new(0);
+    static READAHEAD_MISSES: AtomicU64 = AtomicU64::new(0);
+    pub fn on_readahead_hit() { READAHEAD_HITS.fetch_add(1, Ordering::Relaxed); }
+    pub fn on_readahead_miss() { READAHEAD_MISSES.fetch_add(1, Ordering::Relaxed); }
+```
+Disabled module:
+```rust
+    #[inline(always)]
+    pub fn on_readahead_hit() {}
+    #[inline(always)]
+    pub fn on_readahead_miss() {}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cargo test -p musefs-core readahead::backing_reader_tests 2>&1 | tail -20`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-core/src/readahead.rs musefs-core/src/metrics.rs musefs-core/Cargo.toml
+git commit -m "feat(core): BackingReader read-ahead shim over fd + budget (#255)"
+```
+
+---
+
+### Task 5: Route the PCM `BackingAudio` arm through `BackingReader`
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs`
+- Modify: `musefs-core/src/lib.rs` (re-export `BackingReader`, `ReadAheadPool`)
+
+- [ ] **Step 1: Re-export the types**
+
+In `musefs-core/src/lib.rs` add to the `pub use` of `readahead`:
+
+```rust
+pub use readahead::{BackingReader, ReadAheadPool, DEFAULT_READAHEAD_BUDGET};
+```
+
+- [ ] **Step 2: Write the failing differential test**
+
+In `reader.rs`, inside the existing test region (near `serve_cap_tests`), add a module:
+
+```rust
+#[cfg(test)]
+mod readahead_differential_tests {
+    use super::*;
+    use crate::readahead::{BackingReader, ReadAhead, ReadAheadPool};
+    use std::sync::{Arc, Mutex};
+
+    // Serve every byte of a PCM-backed resolved file two ways — directly and
+    // through a BackingReader — and assert identical output across odd splits.
+    #[test]
+    fn pcm_bytes_identical_through_backing_reader() {
+        let (db, resolved, file, backing_len) = pcm_fixture(); // see helper below
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+        let total = resolved.total_len;
+        for &size in &[1u64, 7, 4096, 65536, 262_144] {
+            let mut off = 0;
+            while off < total {
+                let n = size.min(total - off);
+                let mut via = Vec::new();
+                read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+                let mut direct = Vec::new();
+                read_segments_into_direct(&resolved, &db, &file, off, n, &mut direct).unwrap();
+                assert_eq!(via, direct, "mismatch at off={off} size={size}");
+                off += n;
+            }
+        }
+    }
+}
+```
+
+> The helpers `pcm_fixture()` and `read_segments_into_direct()` (a copy of the
+> pre-change splice using a raw `&File`, kept only in tests as the oracle) must be
+> written using the existing fixture builders in `reader.rs` tests. Reuse whatever
+> `ResolvedFile` PCM builder the existing `serve_cap_tests` use; if none exposes
+> the backing `File` + length, extend it minimally. Keep `read_segments_into_direct`
+> as a verbatim pre-change copy so it is an independent oracle.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cargo test -p musefs-core readahead_differential_tests 2>&1 | tail -20`
+Expected: FAIL — `read_segments_into` still takes `Option<&std::fs::File>`, not `Option<&BackingReader>`.
+
+- [ ] **Step 4: Change the signatures and the `BackingAudio` arm**
+
+In `reader.rs`:
+
+1. Change `read_segments_into` signature param `file: Option<&std::fs::File>` → `backing: Option<&crate::readahead::BackingReader>`.
+2. In the `Segment::BackingAudio { offset: bo, .. }` arm, replace:
+```rust
+let f = file.expect("backing segment requires an open backing file");
+let start = out.len();
+out.resize(start + n, 0);
+crate::metrics::backing_read_exact_at(f, &mut out[start..], bo + within)?;
+crate::metrics::on_pread(n as u64);
+```
+with (note: `on_pread` moves INTO `BackingReader`'s fill closure — Task 4 — so it
+counts *physical* preads; do NOT call it here or it double-counts):
+```rust
+let br = backing.expect("backing segment requires an open backing reader");
+let start = out.len();
+out.resize(start + n, 0);
+br.read_exact_at(&mut out[start..], bo + within)?;
+```
+3. In the `Segment::OggAudio { .. }` arm, temporarily keep it compiling by
+   obtaining the raw file from the reader for now — Task 6 routes it properly.
+   Add an accessor to `BackingReader`:
+```rust
+// in readahead.rs, impl BackingReader
+pub fn file(&self) -> &std::fs::File { self.file }
+```
+   and in the Ogg arm change `let f = file.expect(...)` → `let f = backing.expect("...").file();` (Task 6 replaces this).
+4. Update callers `read_at_with_file_into` and `read_at_into` to build a
+   `BackingReader`. For the non-handle `read_at_into` fallback (one-shot open, no
+   persistent buffer) construct a throwaway pool-less reader:
+```rust
+// read_at_into: needs_file branch
+let pool = crate::readahead::ReadAheadPool::new(0); // disabled → plain preads
+let buf = std::sync::Arc::new(std::sync::Mutex::new(
+    crate::readahead::ReadAhead::new(0)));
+let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+read_segments_into(resolved, db, Some(&br), offset, size, out)
+```
+   (`backing_len` for the fallback can be `resolved` audio bound; `total_len` is a
+   safe upper clamp because the splice never requests past it. If a stricter file
+   length is needed, `file.metadata()?.len()`.)
+5. Make `read_at_with_file_into` / `read_at_with_file` take `&BackingReader`
+   instead of `&std::fs::File` (callers in `facade.rs` updated in Task 7). Keep
+   their bodies delegating to `read_segments_into(..., Some(br), ...)`.
+
+Also expose `ReadAhead` from the crate for tests: in `lib.rs` re-export under a
+`#[cfg(test)]`-friendly path or make `pub use readahead::ReadAhead;`.
+
+- [ ] **Step 5: Run to verify pass + full crate build**
+
+Run: `cargo test -p musefs-core readahead_differential_tests 2>&1 | tail -20`
+Expected: PASS.
+Run: `cargo build -p musefs-core 2>&1 | tail -20`
+Expected: builds (Ogg arm compiles via the temporary `.file()` accessor).
+
+- [ ] **Step 6: Re-anchor mutants + commit**
+
+```bash
+python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
+git add musefs-core/src/reader.rs musefs-core/src/lib.rs musefs-core/src/readahead.rs .cargo/mutants.toml
+git commit -m "feat(core): route PCM backing reads through read-ahead (#255)"
+```
+
+---
+
+### Task 6: Route Ogg backing reads through `BackingReader`
+
+**Files:**
+- Modify: `musefs-core/src/ogg_index.rs`
+- Modify: `musefs-core/src/reader.rs` (the `OggAudio` arm call site)
+
+- [ ] **Step 1: Write the failing differential test**
+
+In `reader.rs` `readahead_differential_tests`, add an Ogg variant mirroring the
+PCM test but built from the existing Ogg serve fixture (reuse `ogg_serve_tests`'
+builders):
+
+```rust
+    #[test]
+    fn ogg_bytes_identical_through_backing_reader() {
+        let (db, resolved, file, backing_len) = ogg_fixture(); // reuse ogg_serve_tests builder
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+        let total = resolved.total_len;
+        for &size in &[1u64, 13, 4096, 65536] {
+            let mut off = 0;
+            while off < total {
+                let n = size.min(total - off);
+                let mut via = Vec::new();
+                read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+                let mut direct = Vec::new();
+                read_segments_into_direct(&resolved, &db, &file, off, n, &mut direct).unwrap();
+                assert_eq!(via, direct, "ogg mismatch at off={off} size={size}");
+                off += n;
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify it passes via the temporary `.file()` path, then make it route through the buffer**
+
+Run: `cargo test -p musefs-core readahead_differential_tests::ogg_bytes_identical_through_backing_reader 2>&1 | tail -20`
+Expected: PASS already (the temp `.file()` accessor serves correct bytes) — but it bypasses the read-ahead window. The point of this task is to route Ogg's preads through the buffer so they also benefit and are covered. Proceed to change the signatures.
+
+- [ ] **Step 3: Thread `&BackingReader` through `ogg_index.rs`**
+
+Change these signatures from `backing: &std::fs::File` / `f: &std::fs::File` to
+`backing: &crate::readahead::BackingReader`:
+- `serve_ogg_window`
+- `find_page_start`
+- `read_counted`
+- `page_crc_ok` (and any other `read_counted` caller)
+
+Change `read_counted` body to route through the shim and drop its own
+`on_pread` (the shim's fill closure counts physical preads — Task 4):
+```rust
+fn read_counted(
+    backing: &crate::readahead::BackingReader,
+    buf: &mut [u8],
+    offset: u64,
+) -> std::io::Result<()> {
+    // The BackingReader's fill closure increments `preads`; do not double-count.
+    backing.read_exact_at(buf, offset)
+}
+```
+**Counting model (already established in Task 4):** `preads` counts *physical*
+backing preads, incremented only inside `BackingReader`'s fill closure (and its
+disabled-pool path). Neither the PCM `BackingAudio` arm nor `read_counted` calls
+`on_pread`. Verify no stray `crate::metrics::on_pread(` remains in `reader.rs` or
+`ogg_index.rs`:
+```bash
+grep -rn "on_pread" musefs-core/src/reader.rs musefs-core/src/ogg_index.rs
+```
+Expected: no matches (all counting now lives in `readahead.rs`).
+
+- [ ] **Step 4: Update the `OggAudio` arm call site in `reader.rs`**
+
+```rust
+Segment::OggAudio { offset: ao, seq_delta, len } => {
+    let br = backing.expect("ogg-audio segment requires an open backing reader");
+    serve_ogg_window(br, *ao, *len, *seq_delta, within, within + n as u64, &mut *out, Some(&resolved.last_page))?;
+}
+```
+Remove the temporary `.file()` accessor usage. You may keep `BackingReader::file()`
+only if Phase 2 needs it; otherwise delete it to avoid a dead-code warning.
+
+- [ ] **Step 5: Run the full differential suite + crate tests**
+
+Run: `cargo test -p musefs-core readahead 2>&1 | tail -20`
+Expected: PASS.
+Run: `cargo test -p musefs-core 2>&1 | tail -20`
+Expected: PASS (whole crate).
+
+- [ ] **Step 6: Re-anchor mutants + commit**
+
+```bash
+python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
+git add musefs-core/src/ogg_index.rs musefs-core/src/reader.rs musefs-core/src/readahead.rs .cargo/mutants.toml
+git commit -m "feat(core): route Ogg backing reads through read-ahead (#255)"
+```
+
+---
+
+### Task 7: Wire the buffer onto `Handle` and into `read_into`
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `facade.rs` tests, add a sequential-read test that asserts read-ahead reduces
+physical preads through the real handle path (requires the `metrics` feature, so
+gate it):
+
+```rust
+#[cfg(all(test, feature = "metrics"))]
+mod readahead_handle_tests {
+    use super::*;
+
+    #[test]
+    fn sequential_handle_reads_amortize_preads() {
+        let fs = build_test_fs_with_one_large_pcm_track(); // reuse an existing builder
+        crate::metrics::reset();
+        let fh = fs.open_handle(file_inode).unwrap();
+        let mut buf = Vec::new();
+        // 32 sequential 256 KiB reads.
+        for i in 0..32u64 {
+            fs.read_into(file_inode, Some(fh), i * 262_144, 262_144, &mut buf).unwrap();
+        }
+        fs.release_handle(fh);
+        let s = crate::metrics::snapshot();
+        assert!(s.preads < 32, "read-ahead must amortize backing preads, got {}", s.preads);
+    }
+}
+```
+
+> If `metrics::reset()` does not exist, add it under the `metrics` feature (a
+> helper that zeroes the static counters) — it is needed for deterministic count
+> assertions and mirrors the existing test usage pattern.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-core --features metrics readahead_handle_tests 2>&1 | tail -20`
+Expected: FAIL — handle has no read-ahead yet (preads == 32), or build error (fields missing).
+
+- [ ] **Step 3: Extend `Handle` and `Musefs`**
+
+In `facade.rs`:
+
+1. `Handle` gains fields:
+```rust
+struct Handle {
+    track_id: i64,
+    resolved: arc_swap::ArcSwap<ResolvedFile>,
+    generation: AtomicU64,
+    file: std::fs::File,
+    /// Per-handle read-ahead window (raw backing bytes). Empty until sequential
+    /// access is detected; drawn from the shared `ReadAheadPool`.
+    readahead: Arc<Mutex<crate::readahead::ReadAhead>>,
+    /// Whether this handle is registered in the pool's active-stream registry.
+    registered: AtomicBool,
+    /// Bumped on a refresh-generation change, a seek, or release; an in-flight
+    /// Phase-2 prefetch checks it before storing (see spec §"Phase 2").
+    epoch: AtomicU64,
+}
+```
+
+2. `Musefs` gains a field:
+```rust
+readahead_pool: Arc<crate::readahead::ReadAheadPool>,
+```
+   Initialize it in `Musefs::open` from the config (Task 9 adds the config field;
+   for now seed with `crate::readahead::DEFAULT_READAHEAD_BUDGET`):
+```rust
+readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(
+    crate::readahead::DEFAULT_READAHEAD_BUDGET,
+)),
+```
+
+3. `open_handle` constructs the buffer:
+```rust
+fh_from_key(self.handles.insert(Arc::new(Handle {
+    track_id,
+    resolved: arc_swap::ArcSwap::from(resolved),
+    generation: AtomicU64::new(generation),
+    file,
+    readahead: Arc::new(Mutex::new(crate::readahead::ReadAhead::new(
+        self.readahead_pool.per_stream_cap(),
+    ))),
+    registered: AtomicBool::new(false),
+    epoch: AtomicU64::new(0),
+})))
+```
+
+4. In `read_into`, the per-handle served branch currently calls
+   `read_at_with_file_into(r, db, &h.file, offset, size, out)`. Replace the
+   `&h.file` argument with a freshly built `BackingReader`, and register the
+   stream lazily on first use:
+```rust
+// Build the per-call backing reader. Lazily register this handle as an active
+// stream the first time it is read so the pool can account/evict it.
+let key = fh.slab_key();
+if !h.registered.swap(true, Ordering::AcqRel) {
+    self.readahead_pool.register(key, Arc::clone(&h.readahead));
+}
+let backing_len = r.stamp.size; // backing file size from the validated stamp (u64 field)
+let br = crate::readahead::BackingReader::new(
+    &h.file, &h.readahead, &self.readahead_pool, key, backing_len,
+);
+read_at_with_file_into(r, db, &br, offset, size, out)?;
+```
+   (Adjust `read_at_with_file_into`'s signature use: it now takes `&BackingReader`
+   per Task 5/6.) Determine the correct `backing_len` accessor on `BackingStamp`;
+   if it stores size as a field use `r.stamp.size` / add a `size()` getter.
+
+5. On the generation-bump path in `read_into` (where `h.generation.store(cur, ...)`
+   happens after a re-resolve), drop the buffer and bump the epoch:
+```rust
+h.epoch.fetch_add(1, Ordering::AcqRel);
+let freed = h.readahead.lock().unwrap().clear();
+self.readahead_pool.uncharge(freed);
+```
+
+6. `release_handle` deregisters before removing:
+```rust
+pub fn release_handle(&self, fh: Fh) {
+    let key = fh.slab_key();
+    self.readahead_pool.deregister(key);
+    self.handles.remove(key);
+}
+```
+
+7. Seek detection lives inside `ReadAhead` already (offset != next_expected →
+   reset); no extra facade logic needed for Phase 1. The epoch's seek bump is only
+   needed for Phase 2 (Task 12).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p musefs-core --features metrics readahead_handle_tests 2>&1 | tail -20`
+Expected: PASS.
+Run: `cargo test -p musefs-core 2>&1 | tail -20`
+Expected: PASS (whole crate, default features).
+
+- [ ] **Step 5: Re-anchor mutants + commit**
+
+```bash
+python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
+git add musefs-core/src/facade.rs .cargo/mutants.toml
+git commit -m "feat(core): per-handle read-ahead buffer wired into read_into (#255)"
+```
+
+---
+
+### Task 8: Read-ahead metrics + update exact-count tests
+
+**Files:**
+- Modify: `musefs-core/src/metrics.rs`
+- Modify: existing `metrics`-feature count assertions wherever they live
+
+- [ ] **Step 1: Finalize the metric surface**
+
+Ensure `metrics.rs` has (enabled module):
+```rust
+static READAHEAD_HITS: AtomicU64 = AtomicU64::new(0);
+static READAHEAD_MISSES: AtomicU64 = AtomicU64::new(0);
+pub fn on_readahead_hit() { READAHEAD_HITS.fetch_add(1, Ordering::Relaxed); }
+pub fn on_readahead_miss() { READAHEAD_MISSES.fetch_add(1, Ordering::Relaxed); }
+```
+Add `readahead_hits` / `readahead_misses` to BOTH `Snapshot` structs and both
+`snapshot()` bodies, and to `reset()` if present.
+
+- [ ] **Step 2: Write the failing test for the new semantics**
+
+Add (enabled module tests):
+```rust
+#[test]
+fn readahead_counts_physical_preads_not_logical_reads() {
+    reset();
+    // Drive a known sequential pattern through a BackingReader (reuse the
+    // readahead::backing_reader_tests helper or replicate a tiny temp file).
+    // 16 sequential 64 KiB reads over a 4 MiB file.
+    // Assert: preads < 16 and readahead_hits + readahead_misses == 16.
+    // (Fill in with the same temp-file harness as readahead::backing_reader_tests.)
+}
+```
+
+- [ ] **Step 3: Fix the pre-existing exact-count assertions**
+
+Find every test that asserts `s.preads == N` on a read path:
+```bash
+grep -rn "preads, " musefs-core/src | grep assert
+```
+Re-derive the expected counts under read-ahead semantics (`preads` is now
+*physical* backing preads; a sequential second read is a hit, not a pread). For
+single-read tests the count is unchanged (first read always misses → 1 pread).
+For multi-sequential-read tests, lower the expected count and add a
+`readahead_hits`/`readahead_misses` assertion. Update each.
+
+- [ ] **Step 4: Run the metrics-feature suite**
+
+Run: `cargo test -p musefs-core --features metrics 2>&1 | tail -30`
+Expected: PASS (this is the CI `check`-job gate the local default run skips).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/metrics.rs musefs-core/src/reader.rs musefs-core/src/readahead.rs
+git commit -m "feat(core): read-ahead hit/miss metrics; preads now physical (#255)"
+```
+
+---
+
+### Task 9: CLI flag `--read-ahead-budget-mib`
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs` (`MountConfig` + `Musefs::open`)
+- Modify: `musefs-cli/src/lib.rs`
+
+- [ ] **Step 1: Write the failing CLI test**
+
+In `musefs-cli/src/lib.rs` tests, mirror the existing `--max-readahead-kib`
+assertion:
+```rust
+#[test]
+fn read_ahead_budget_flag_maps_to_mount_config() {
+    let args = parse_args(&["musefs", "/src", "/mnt", "--read-ahead-budget-mib", "128"]);
+    let cfg = mount_config(&args);
+    assert_eq!(cfg.read_ahead_budget, 128 * 1024 * 1024);
+}
+
+#[test]
+fn read_ahead_budget_zero_disables() {
+    let args = parse_args(&["musefs", "/src", "/mnt", "--read-ahead-budget-mib", "0"]);
+    let cfg = mount_config(&args);
+    assert_eq!(cfg.read_ahead_budget, 0);
+}
+```
+(Match the actual arg-parser/test helpers used near `max_readahead_kib`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-cli read_ahead_budget 2>&1 | tail -20`
+Expected: FAIL — no field / flag.
+
+- [ ] **Step 3: Add the config field and the flag**
+
+In `facade.rs` `MountConfig`:
+```rust
+/// Global read-ahead RAM envelope in bytes. `0` disables read-ahead. The
+/// operator sets the envelope; per-stream windows self-tune within it.
+pub read_ahead_budget: u64,
+```
+Set every existing `MountConfig { .. }` literal (search the crate + tests) to
+include `read_ahead_budget: crate::readahead::DEFAULT_READAHEAD_BUDGET,`.
+
+In `Musefs::open`, build the pool from it:
+```rust
+readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(config.read_ahead_budget)),
+```
+(Place this before `config` is moved into the struct, or read the field first.)
+
+In `musefs-cli/src/lib.rs`, add the clap arg next to `max_readahead_kib`:
+```rust
+/// Global read-ahead RAM budget (MiB) shared across all active streams. The
+/// operator sizes this to their concurrent-stream count; 0 disables read-ahead.
+#[arg(long, default_value_t = 64)]
+pub read_ahead_budget_mib: u32,
+```
+and in `mount_config`:
+```rust
+read_ahead_budget: u64::from(args.read_ahead_budget_mib).saturating_mul(1024 * 1024),
+```
+
+- [ ] **Step 4: Run to verify pass + workspace build**
+
+Run: `cargo test -p musefs-cli read_ahead_budget 2>&1 | tail -20`
+Expected: PASS.
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds (all `MountConfig` literals updated).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add musefs-core/src/facade.rs musefs-cli/src/lib.rs
+git commit -m "feat(cli): --read-ahead-budget-mib sets the read-ahead envelope (#255)"
+```
+
+---
+
+### Task 10: Forced-eviction + partial-seek differential coverage
+
+**Files:**
+- Modify: `musefs-core/src/reader.rs` (test module)
+
+- [ ] **Step 1: Write the tests**
+
+Add to `readahead_differential_tests`:
+```rust
+    // Tiny budget forces mid-stream eviction; bytes must still be correct.
+    #[test]
+    fn pcm_bytes_identical_under_forced_eviction() {
+        let (db, resolved, file, backing_len) = pcm_fixture();
+        let pool = ReadAheadPool::new(WINDOW_FLOOR * 2); // tiny: forces churn
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+        let total = resolved.total_len;
+        let mut off = 0;
+        while off < total {
+            let n = 65536u64.min(total - off);
+            let mut via = Vec::new();
+            read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+            let mut direct = Vec::new();
+            read_segments_into_direct(&resolved, &db, &file, off, n, &mut direct).unwrap();
+            assert_eq!(via, direct, "eviction mismatch at {off}");
+            off += n;
+        }
+    }
+
+    // A seek landing partially back inside a just-shrunk window: exercises the
+    // covers()/refill offset math.
+    #[test]
+    fn partial_overlap_seek_serves_correct_bytes() {
+        let (db, resolved, file, backing_len) = pcm_fixture();
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+        // A large read grows the window, then a seek lands partially back inside
+        // the just-shrunk region, then a near-adjacent read — exercising covers()
+        // and the refill offset math across the discontinuity.
+        let seq = [(0u64, 600_000u64), (590_000, 50_000), (10_000, 4096), (12_000, 4096)];
+        for &(off, n) in &seq {
+            let n = n.min(resolved.total_len.saturating_sub(off));
+            if n == 0 {
+                continue;
+            }
+            let mut via = Vec::new();
+            read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+            let mut direct = Vec::new();
+            read_segments_into_direct(&resolved, &db, &file, off, n, &mut direct).unwrap();
+            assert_eq!(via, direct, "partial-seek mismatch at {off}+{n}");
+        }
+    }
+```
+(Trim the obvious copy/paste; the essential assertions are the two `assert_eq!`s.)
+
+- [ ] **Step 2: Run to verify pass**
+
+Run: `cargo test -p musefs-core readahead_differential_tests 2>&1 | tail -20`
+Expected: PASS. If `pcm_bytes_identical_under_forced_eviction` fails, the bug is
+in budget reconciliation (`acquire`/`uncharge`) or `covers()` after a `clear()`;
+fix in `readahead.rs` until green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add musefs-core/src/reader.rs
+git commit -m "test(core): read-ahead forced-eviction + partial-seek differentials (#255)"
+```
+
+---
+
+### Task 11: Phase-1 verification gate (clippy, fmt, fuzz, full suite)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full workspace test**
+
+Run: `cargo test 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 2: Metrics feature**
+
+Run: `cargo test -p musefs-core --features metrics 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 3: Lint + format**
+
+Run: `cargo clippy --all-targets 2>&1 | tail -20`
+Expected: no warnings (workspace denies warnings in CI).
+Run: `cargo fmt --all --check`
+Expected: clean.
+
+- [ ] **Step 4: Fuzz smoke (signatures unchanged at format layer, but verify)**
+
+Run: `cargo +nightly fuzz build 2>&1 | tail -10`
+Expected: builds.
+
+- [ ] **Step 5: Local in-diff mutation gate (optional but recommended)**
+
+Run: `cargo mutants --in-place -j2 2>&1 | tail -20`
+Expected: no surviving mutants in the new `readahead.rs` logic; add tests for any survivor.
+
+- [ ] **Step 6: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "chore(core): Phase 1 read-ahead verification fixups (#255)"
+```
+
+---
+
+## PHASE 2 — parallel prefetch
+
+### Task 12: Generalize the window to a prefetch ring + epoch-checked store
+
+**Files:**
+- Modify: `musefs-core/src/readahead.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a `prefetch_tests` module:
+```rust
+#[cfg(test)]
+mod prefetch_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn store_with_stale_epoch_is_discarded() {
+        let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        // Dispatch a prefetch at epoch 0.
+        let dispatched = epoch.load(std::sync::atomic::Ordering::Acquire);
+        // A seek/refresh bumps the epoch.
+        epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        // Storing the prefetched window must be rejected.
+        let stored = try_store_prefetch(&ra, &epoch, dispatched, 0, vec![1, 2, 3]);
+        assert!(!stored, "stale-epoch prefetch must be discarded");
+        assert_eq!(ra.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn store_with_current_epoch_is_accepted() {
+        let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(5));
+        let stored = try_store_prefetch(&ra, &epoch, 5, 1000, vec![0u8; 4096]);
+        assert!(stored);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-core readahead::prefetch_tests 2>&1 | tail -20`
+Expected: FAIL — `try_store_prefetch` and the prefetch-store path undefined.
+
+- [ ] **Step 3: Implement the prefetch-store seam + a `store_window` on `ReadAhead`**
+
+Add to `ReadAhead`:
+```rust
+/// Adopt an externally prefetched window (Phase 2). Replaces the current window
+/// with `[start, start+bytes.len())`. Does not touch `next_expected` (the
+/// foreground reader owns the sequential predictor). Returns the byte delta
+/// `(old_len, new_len)` for budget reconciliation.
+pub fn store_window(&mut self, start: u64, bytes: Vec<u8>) -> (u64, u64) {
+    let old = self.bytes.len() as u64;
+    self.win_start = start;
+    self.bytes = bytes;
+    (old, self.bytes.len() as u64)
+}
+```
+Add a free function:
+```rust
+use std::sync::atomic::{AtomicU64 as Epoch, Ordering as O};
+
+/// Store a prefetched window only if `dispatched_epoch` still matches `epoch`
+/// (no seek/refresh/release happened since dispatch). Returns whether stored.
+pub fn try_store_prefetch(
+    buf: &Arc<Mutex<ReadAhead>>,
+    epoch: &Epoch,
+    dispatched_epoch: u64,
+    start: u64,
+    bytes: Vec<u8>,
+) -> bool {
+    let mut ra = buf.lock().unwrap();
+    if epoch.load(O::Acquire) != dispatched_epoch {
+        return false;
+    }
+    ra.store_window(start, bytes);
+    true
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p musefs-core readahead::prefetch_tests 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Re-anchor + commit**
+
+```bash
+python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
+git add musefs-core/src/readahead.rs .cargo/mutants.toml
+git commit -m "feat(core): epoch-checked prefetch window store seam (#255)"
+```
+
+---
+
+### Task 13: Prefetch worker pool (bounded, Db-free, best-effort)
+
+**Files:**
+- Modify: `musefs-core/src/readahead.rs`
+- Modify: `musefs-core/src/facade.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `readahead.rs`, add a test that a prefetch fills the next window ahead of a
+foreground read (using a real temp file + a small worker pool):
+```rust
+#[cfg(test)]
+mod prefetch_worker_tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn prefetch_fills_next_window_for_a_sequential_stream() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("b.bin");
+        let data: Vec<u8> = (0..8 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path).unwrap().write_all(&data).unwrap();
+        let file = Arc::new(std::fs::File::open(&path).unwrap());
+
+        let pool = Arc::new(ReadAheadPool::new(64 * 1024 * 1024));
+        let prefetch = PrefetchWorkers::new(2);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        pool.register(1, Arc::clone(&buf));
+
+        // Foreground reads window 0; request a prefetch of window 1.
+        prefetch.request(PrefetchJob {
+            file: Arc::clone(&file),
+            buf: Arc::clone(&buf),
+            epoch: Arc::clone(&epoch),
+            dispatched_epoch: 0,
+            start: 1024 * 1024,
+            len: 1024 * 1024,
+            backing_len: data.len() as u64,
+        });
+        prefetch.drain_for_test();
+        // The window now holds [1 MiB, 2 MiB).
+        let mut out = vec![0u8; 4096];
+        let mut ra = buf.lock().unwrap();
+        // covers() true → served without a fill closure call.
+        let mut fills = 0;
+        ra.read_into(&mut out, 1024 * 1024, data.len() as u64, |_, _| { fills += 1; Ok(()) }).unwrap();
+        assert_eq!(fills, 0, "prefetched window should serve without a pread");
+        assert_eq!(out, data[1024 * 1024..1024 * 1024 + 4096]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p musefs-core readahead::prefetch_worker_tests 2>&1 | tail -20`
+Expected: FAIL — `PrefetchWorkers` / `PrefetchJob` undefined.
+
+- [ ] **Step 3: Implement the worker pool**
+
+```rust
+use std::sync::mpsc;
+
+/// A prefetch job: read `[start, start+len)` (clamped to `backing_len`) from
+/// `file` and store it into `buf` iff `epoch` still equals `dispatched_epoch`.
+/// Carries ONLY the backing fd — never a `Db` handle (spec §4 invariant).
+pub struct PrefetchJob {
+    pub file: Arc<std::fs::File>,
+    pub buf: Arc<Mutex<ReadAhead>>,
+    pub epoch: Arc<std::sync::atomic::AtomicU64>,
+    pub dispatched_epoch: u64,
+    pub start: u64,
+    pub len: u64,
+    pub backing_len: u64,
+}
+
+/// A small, bounded pool of background prefetch threads, separate from the FUSE
+/// dispatch pool so prefetch can never consume `MAX_INFLIGHT_READS` slots or
+/// starve foreground reads. Best-effort: on a full queue or a read error the job
+/// is dropped, leaving the window empty so the foreground read re-misses.
+pub struct PrefetchWorkers {
+    tx: mpsc::SyncSender<PrefetchJob>,
+    #[cfg(test)]
+    handles: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl PrefetchWorkers {
+    pub fn new(threads: usize) -> Self {
+        // Bounded queue: a backlog means the consumer is slower than the stream,
+        // so dropping excess jobs is correct (the window just stays cold).
+        let (tx, rx) = mpsc::sync_channel::<PrefetchJob>(threads * 4);
+        let rx = Arc::new(Mutex::new(rx));
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let rx = Arc::clone(&rx);
+            let h = std::thread::spawn(move || {
+                while let Ok(job) = { let g = rx.lock().unwrap(); g.recv() } {
+                    Self::run_job(job);
+                }
+            });
+            handles.push(h);
+        }
+        PrefetchWorkers {
+            tx,
+            #[cfg(test)]
+            handles,
+        }
+    }
+
+    fn run_job(job: PrefetchJob) {
+        use std::os::unix::fs::FileExt;
+        // Early epoch check: skip work already invalidated.
+        if job.epoch.load(std::sync::atomic::Ordering::Acquire) != job.dispatched_epoch {
+            return;
+        }
+        let want = job.len.min(job.backing_len.saturating_sub(job.start));
+        if want == 0 {
+            return;
+        }
+        let mut bytes = vec![0u8; want as usize];
+        // Best-effort: swallow I/O errors (NFS ESTALE etc.) — leave window empty.
+        if job.file.read_exact_at(&mut bytes, job.start).is_err() {
+            return;
+        }
+        let _ = try_store_prefetch(&job.buf, &job.epoch, job.dispatched_epoch, job.start, bytes);
+    }
+
+    /// Enqueue a prefetch. Non-blocking: a full queue drops the job (best-effort).
+    pub fn request(&self, job: PrefetchJob) {
+        let _ = self.tx.try_send(job);
+    }
+
+    #[cfg(test)]
+    pub fn drain_for_test(&self) {
+        // Give workers a moment; jobs are tiny. For determinism, run synchronously
+        // instead in the test build:
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+```
+
+> If the 50 ms sleep is too flaky for CI, make `run_job` callable directly and
+> have the test call `PrefetchWorkers::run_job(job)` synchronously instead of
+> `request` + `drain_for_test`. Prefer the synchronous form for the unit test.
+
+- [ ] **Step 4: Trigger prefetch from `BackingReader` on a serving advance**
+
+In `facade.rs` `read_into`, after a successful `read_at_with_file_into`, if the
+pool is enabled and the read was sequential, enqueue a prefetch of the next
+window. Add a `Musefs` field `prefetch: crate::readahead::PrefetchWorkers`
+(initialize in `open` with e.g. `PrefetchWorkers::new(2)` only when budget > 0;
+when disabled, skip requests). Build the job from `h.file` (wrap the fd in an
+`Arc` once at `open` — change `Handle.file` to `Arc<std::fs::File>`), `h.readahead`,
+`h.epoch`, the current epoch value, the next window `start = next_expected`, and
+`len = per_stream_cap`. Gate the request on the buffer reporting a recent
+sequential serve (expose `ReadAhead::next_expected()` and only prefetch when the
+just-served read ended at the window tail).
+
+> Keep this trigger minimal: a single next-window prefetch per serving read is the
+> depth-1 pipeline. Task 14 makes the depth adaptive.
+
+- [ ] **Step 5: Bump epoch on seek + release (Phase-2 cancellation)**
+
+In `read_into`, detect a seek at the facade level too (compare the incoming
+`offset`'s backing offset to the buffer's `next_expected`); on a seek and on
+`release_handle`, `h.epoch.fetch_add(1, ...)` so any in-flight prefetch is
+discarded. (The generation-bump epoch bump from Task 7 already covers refresh.)
+
+- [ ] **Step 6: Run the suite**
+
+Run: `cargo test -p musefs-core 2>&1 | tail -20`
+Expected: PASS.
+Run: `cargo test -p musefs-core --features metrics 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 7: Re-anchor + commit**
+
+```bash
+python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
+git add musefs-core/src/readahead.rs musefs-core/src/facade.rs .cargo/mutants.toml
+git commit -m "feat(core): background prefetch workers (Db-free, best-effort) (#255)"
+```
+
+---
+
+### Task 14: Adaptive prefetch depth
+
+**Files:**
+- Modify: `musefs-core/src/facade.rs`
+- Modify: `musefs-core/src/readahead.rs`
+
+- [ ] **Step 1: Write the test**
+
+Assert that as a stream stays sequential, the number of windows prefetched ahead
+grows (depth ramps), bounded by the per-stream budget share. Use a counter on a
+fake/instrumented prefetch sink:
+```rust
+// In facade.rs tests (metrics feature), drive 64 sequential reads on a slow
+// fake backing and assert prefetch depth increased over the run (e.g. later
+// reads enqueue more next-windows than the first). Keep it tolerance-based.
+```
+
+- [ ] **Step 2: Implement adaptive depth**
+
+Track a per-handle `depth` (in `ReadAhead` or a sibling atomic) that increments
+while sequential and resets on seek, capped so `depth * window <=
+per_stream_cap`. On each serving advance, enqueue up to `depth` next-window
+prefetch jobs (offsets `next_expected, next_expected+window, ...`), each with the
+current epoch.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p musefs-core --features metrics 2>&1 | tail -20`
+Expected: PASS.
+```bash
+python3 scripts/check_mutant_anchors.py --fix 2>/dev/null || true
+git add musefs-core/src/facade.rs musefs-core/src/readahead.rs .cargo/mutants.toml
+git commit -m "feat(core): adaptive prefetch depth bounded by budget share (#255)"
+```
+
+---
+
+### Task 15: Phase-2 concurrency + TSan verification
+
+**Files:**
+- Modify: `musefs-core/src/readahead.rs` (test) or `musefs-core/tests/`
+
+- [ ] **Step 1: Write a concurrency stress test**
+
+Spawn N threads reading the SAME handle (random + sequential offsets) while
+prefetch runs, asserting every read matches a direct pread oracle. This is the
+TSan target.
+```rust
+#[test]
+fn concurrent_reads_same_handle_match_oracle() {
+    // Build a handle-equivalent (file + buf + pool + epoch); spawn 8 threads,
+    // each doing 200 reads at varied offsets through a BackingReader; compare to
+    // file.read_exact_at. Any data race surfaces under the TSan job.
+}
+```
+
+- [ ] **Step 2: Run normally**
+
+Run: `cargo test -p musefs-core concurrent_reads_same_handle 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 3: Run under TSan (matches CI)**
+
+Run: `RUSTFLAGS="-Zsanitizer=thread" cargo +nightly test -Zbuild-std -p musefs-core --target x86_64-unknown-linux-gnu concurrent_reads_same_handle 2>&1 | tail -30`
+Expected: PASS, no TSan reports. (See the `tsan-requires-build-std` project note.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "test(core): read-ahead concurrent-handle TSan stress (#255)"
+```
+
+---
+
+## ROLLOUT
+
+### Task 16: Benchmark + BENCHMARKS.md
+
+**Files:**
+- Modify: `benches/storage_tunables_bench.sh`
+- Modify: `BENCHMARKS.md`
+
+- [ ] **Step 1: Extend the bench harness**
+
+Add a read-ahead on/off single-stream throughput sweep to
+`benches/storage_tunables_bench.sh` (mount with `--read-ahead-budget-mib 0` vs the
+default; measure cold sequential MB/s). Keep it runnable in CI per the in-tree
+harness convention.
+
+- [ ] **Step 2: Run it (needs /dev/fuse + root; use the live-mount harness)**
+
+Run the bench per its header instructions; capture single-stream MB/s for HDD and
+(if available) the NFS-fault model.
+
+- [ ] **Step 3: Record results in BENCHMARKS.md**
+
+Replace the `#storage-tunables` "Latent finding (future work)" note with a new
+subsection documenting the measured read-ahead win (on/off table), and link it
+from the issue. Keep numbers backed by tmpfs-resident corpora per project policy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add benches/storage_tunables_bench.sh BENCHMARKS.md
+git commit -m "docs(bench): single-stream read-ahead throughput results (#255)"
+```
+
+---
+
+### Task 17: Docs
+
+**Files:**
+- Modify: `ARCHITECTURE.md`, `docs/OGG.md`, `README.md`
+
+- [ ] **Step 1: ARCHITECTURE.md**
+
+In the segment-model / reader section, add a short subsection: the per-handle
+backing read-ahead buffer (raw backing bytes keyed by absolute offset, adaptive
+window, global budget, `BackingReader` as the single backing-read path, Phase-2
+prefetch). Note it preserves the audio invariant and the per-read validation.
+
+- [ ] **Step 2: docs/OGG.md**
+
+Note that Ogg backing reads (`serve_ogg_window` page walk) now flow through the
+same read-ahead buffer; header patching is unchanged and orthogonal to the raw
+byte cache.
+
+- [ ] **Step 3: README.md**
+
+Document `--read-ahead-budget-mib` (default 64, 0 disables) in the flags section,
+framed as the RAM envelope for slow/high-RTT backing.
+
+- [ ] **Step 4: Commit (docs-only — cargo gate skipped)**
+
+```bash
+git add ARCHITECTURE.md docs/OGG.md README.md
+git commit -m "docs: backing read-ahead architecture, Ogg, and CLI flag (#255)"
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Backing length source:** several tasks need the backing file size. Use
+  `r.stamp.size` — `BackingStamp` (`musefs-core/src/freshness.rs`) exposes
+  `size: u64` as a public field, already captured and validated at resolve time.
+  No extra fstat needed.
+- **Budget accounting is the subtle part.** The invariant: `pool.charged` ==
+  Σ(registered buffers' `bytes.len()`). Every path that changes a buffer's length
+  (`acquire` grow, `clear` on eviction/invalidation, `store_window` in Phase 2,
+  seek-shrink) must reconcile via `acquire`/`uncharge`. Task 10's forced-eviction
+  differential and a debug assertion (`charged <= budget`) are the safety net —
+  consider adding `debug_assert!(self.charged.load(Relaxed) <= self.budget)` after
+  each `acquire` return.
+- **`Handle.file` becomes `Arc<std::fs::File>` in Task 13** (prefetch jobs need an
+  owned fd reference). Make that change in Task 13 and update `open_handle`,
+  `validate_opened_backing` call sites (`&h.file` → `&*h.file`), and
+  `passthrough_fd`'s `AsFd` impl accordingly.
+- **`on_pread` semantics changed in Task 6** (now physical preads). Re-audit any
+  `scan_*` metrics — they are a separate code path (scanning, not serving) and
+  must NOT route through `BackingReader`; leave them untouched.
+- **Fallback path (`read_at_into`) stays plain** (disabled pool). Confirm no
+  normal player read reaches it (FUSE always supplies the `open` fh).

--- a/docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md
+++ b/docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md
@@ -104,25 +104,47 @@ it:
   sequential access — so the thousands of handles a scanner opens-and-stats cost
   zero read-ahead RAM. Freed on `release`.
 - The no-handle fallback path (`read_at_into`, one-shot open) keeps doing plain
-  preads. It is the uncommon path with no persistent state to read ahead into.
+  preads. The FUSE `read` op always carries the fh issued by `open`, so a normal
+  sequential stream (player, `cat`, scanner) always resolves to a `Handle` and
+  gets read-ahead. The fallback in `read_into` is reached only when `fh` is
+  `None` or names a handle absent from the slab — a pathological case no normal
+  stream produces — so excluding it costs the headline numbers nothing.
+
+### `BackingReader` ownership
+
+`BackingReader` is constructed per `read_into` call and lives only for that call.
+It borrows the `Handle`'s backing fd and a reference to the global budget, and
+holds the per-handle `Mutex<Buffer>` guard. `read_exact_at` takes `&self` with
+the window/budget mutation behind that mutex (interior mutability) — no `&mut`
+threading through the splice loop. Phase 1's large refill `pread` runs on the
+foreground worker, which already holds an `MAX_INFLIGHT_READS` slot, so Phase 1
+adds no new slot pressure.
 
 ## Mechanism: sequential detection & adaptive window
 
-Per handle:
+Per handle, track `next_expected_offset` (the backing offset just past the last
+served read) and `window` (current size, between a floor and a cap — see Memory
+bounding). Each `read_exact_at(buf, abs_offset)` resolves via this decision
+table:
 
-- Track `next_expected_offset` (the backing offset just past the last served
-  read).
-- A `read_exact_at` whose start `== next_expected_offset` (or lands inside the
-  current window) is **sequential** → grow the window (e.g. double, capped by the
-  stream's budget share). Successive misses fetch ever-larger chunks; this is
-  what self-tunes HDD (stays small) vs 200 ms NFS (ramps to MBs).
-- A read landing outside the window is a **seek** → reset: shrink the window to
-  the floor and refill at the new offset, returning the reclaimed bytes to the
-  budget.
+| condition                                              | classification  | action                                                                       |
+| ------------------------------------------------------ | --------------- | ---------------------------------------------------------------------------- |
+| requested range ⊆ current window                       | **hit**         | memcpy from window, no syscall                                               |
+| range ⊄ window **and** `abs_offset == next_expected`   | **seq. miss**   | grow `window` (geometric, capped), refill at `abs_offset`, serve             |
+| range ⊄ window **and** `abs_offset != next_expected`   | **seek**        | shrink `window` to floor, free old bytes, refill at `abs_offset`, serve      |
+
+After serving, set `next_expected = abs_offset + len`. "Grow" is geometric
+(double, capped); successive sequential misses fetch ever-larger chunks, which is
+what self-tunes HDD (stays small) vs 200 ms NFS (ramps to MBs). On seek the old
+window's bytes are freed immediately (returned to the budget), not retained.
 
 For the Ogg page-walk, a page's header and payload preads are adjacent and the
 walk proceeds forward, so once the window covers a page both reads hit and the
-stream stays "sequential" under the same detector.
+stream stays sequential under the same detector. `serve_ogg_window` issues
+several `read_exact_at` calls per request (header + payload per page); each
+re-locks the per-handle buffer mutex, which is correct (intra-request re-locking
+is uncontended for a single stream) but changes the per-request pread count the
+`metrics`-feature tests assert — see Testing.
 
 ## Memory bounding
 
@@ -130,19 +152,40 @@ Hybrid: lazy per-handle buffers drawing from one global byte budget with
 eviction.
 
 - **Global budget:** a single process-wide cap on total buffered bytes, separate
-  from the `HeaderCache` budget. Each handle's window growth is charged against
-  it. N concurrent streams share the budget — 100 streams each get smaller
-  windows than 2 streams do, which is the correct graceful degradation (aggregate
-  RAM stays fixed).
-- **Eviction:** when the budget is exhausted and a stream needs to grow/refill,
-  reclaim from the coldest buffer(s) — least-recently-served handles give back
-  their window first. A reclaimed handle simply re-misses and re-fetches
-  (correctness unaffected). Because only *actively streaming* handles hold
-  buffers, the set to scan for an eviction victim is small (bounded by concurrent
-  streams, not total opens); a guarded last-served scan over that set suffices —
-  no `quick_cache` (its keys are content, not live handles).
+  from the `HeaderCache` budget, held as an `AtomicU64` charged/uncharged with
+  `fetch_add`/`fetch_sub`. No lock on the per-read hot path.
+- **Window floor / cap / growth.** Floor = one FUSE chunk-class size (e.g.
+  512 KiB) so a fresh or just-seeked stream still does useful read-ahead. Growth
+  = geometric doubling per sequential miss. Per-stream cap = `min(absolute_cap,
+  budget / DIVISOR)` (e.g. `DIVISOR = 4`), so no single stream can monopolize the
+  envelope. The division across N active streams is **emergent, not a static
+  partition**: each stream grows greedily toward its cap; the global atomic
+  budget is the hard ceiling, and LRU eviction (below) reclaims from colder
+  streams when a hotter one needs to grow. Under sustained N-stream load this
+  settles toward roughly equal shares without any explicit `budget / N`
+  computation. Final constants are benchmark-chosen in the plan; the policy
+  (floor, geometric growth, per-stream cap, global hard ceiling, LRU balancing)
+  is fixed here.
+- **Eviction + lock order (deadlock-free by construction).** When charging the
+  budget would exceed the cap, the growing stream runs eviction: it scans a small
+  guarded **active-stream registry** (live streaming-handle keys + last-served
+  counter — bounded by concurrent streams, not total opens), picks the coldest,
+  and reclaims it by `try_lock`-ing that victim's per-handle buffer mutex. The
+  strict rules that make this deadlock-free:
+  1. The budget is a lock-free atomic — never a held lock.
+  2. The registry lock is a leaf: victim keys are copied out and it is released
+     before touching any buffer mutex.
+  3. Eviction **never blocks** on a victim's buffer mutex — it `try_lock`s and
+     skips a victim that is mid-read, moving to the next-coldest. So no thread
+     ever holds buffer-mutex-A while waiting on buffer-mutex-B or the registry.
+  If nothing reclaimable is found (all candidates busy), the grower simply does
+  not grow this round and serves at the current window — graceful degradation,
+  never a stall. A reclaimed handle re-misses and re-fetches (correctness
+  unaffected). `quick_cache` is not used (its keys are content, not live
+  handles).
 - **Free on close / seek-shrink:** `release` returns the buffer to the budget; a
-  detected seek shrinks the window rather than holding the high-water mark.
+  detected seek shrinks the window and frees the old bytes rather than holding
+  the high-water mark.
 
 ### Configuration
 
@@ -168,7 +211,10 @@ validation.
 
 1. **Audio invariant.** The buffer stores backing bytes verbatim and serves them
    verbatim — never transformed. Ogg header *patching* happens on top of the raw
-   bytes after the read (unchanged), so caching raw bytes does not touch it.
+   bytes after the read (unchanged), so caching raw bytes does not touch it. The
+   existing one-entry `LastPageMemo` in `serve_ogg_window` (which caches a
+   *patched header*) is orthogonal to and independent of the new buffer (which
+   caches *raw backing bytes*); they cache different things and do not interact.
 2. **Retag/refresh survives the buffer for free.** A retag changes DB metadata —
    the synthesized segments (`Inline`/`ArtImage`/`BinaryTag`) and the virtual
    layout — but not the backing audio bytes nor their absolute offset in the
@@ -177,16 +223,42 @@ validation.
    nonetheless **dropped on any handle generation bump** (refills are cheap; this
    makes buffer validity trivially track the invariants the facade already
    enforces). A tight retag loop thrashes the buffer harmlessly; retags are rare
-   vs reads.
-3. **Per-read re-stat guard preserved.** Every FUSE read still runs
-   `validate_opened_backing` in `read_into` before any byte — buffered or freshly
-   pread — reaches the kernel. A buffered byte is handed out only if the fd still
-   validates at serve time, so staleness exposure is no wider than today's
-   documented size/mtime guarantee (Finding #15, ESTALE). On validation failure →
-   `BackingChanged`, buffer dropped.
+   vs reads. The generation bump, a seek, and `release` all advance **one
+   per-handle epoch**; any in-flight Phase-2 prefetch checks the epoch before
+   storing and discards a fill made against a stale one (§"Phase 2"). So seek,
+   release, and refresh are unified under a single invalidation signal rather
+   than two mechanisms.
+3. **Per-read re-stat guard preserved; the buffer is bound to `resolved.stamp`.**
+   `validate_opened_backing` compares the fd's live `BackingStamp` against
+   `resolved.stamp` (the stamp captured at resolve time) on every `read_into`
+   call, *before* the splice descends, and is terminal (`BackingChanged`) on
+   drift. The buffer is bound to that same `resolved`: it can only have been
+   filled through this fd, and it is **dropped on any generation bump** (§2),
+   which is the only event that swaps `resolved` (and thus `resolved.stamp`).
+   Therefore a buffered byte is served only when the current read's validate
+   passes — i.e. the fd's stamp still equals the stamp under which those bytes
+   were filled. No separate fill-time stamp is needed; `resolved.stamp` *is* the
+   fill-time stamp.
+   - **Detectable rewrite (size or mtime changes):** the next read's
+     `validate_opened_backing` mismatches `resolved.stamp` → `BackingChanged`
+     terminal; the buffer is never consulted. Identical behavior with or without
+     read-ahead.
+   - **Undetectable rewrite (same size *and* same mtime in place):** validate
+     passes either way. Without read-ahead a hit-region read preads post-rewrite
+     bytes; with read-ahead it may serve pre-rewrite buffered bytes. Both are real
+     backing bytes never modified by musefs; this same-size+same-mtime in-place
+     case is already outside the guarantee (Finding #15, ESTALE; the
+     external-writer contract requires content changes to bump `content_version`
+     rather than silently rewrite). Read-ahead's exposure is therefore the same
+     *kind* and bound by the same precondition as today's — not wider.
 4. **No interaction with the `begin_read` / `content_version` snapshot.** That
    machinery guards DB-sourced segments (`BinaryTag`); read-ahead caches only
-   backing bytes and sits outside that path.
+   backing bytes and sits outside that path. **Invariant (constrains the Phase-2
+   worker):** prefetch workers touch *only* the backing fd via positioned reads —
+   never the `Db`, the connection pool, or any WAL snapshot. A foreground read
+   may hold an open `db.begin_read()` snapshot while a background prefetch runs;
+   keeping prefetch `Db`-free means it cannot open a second snapshot, contend the
+   `PerThread` pool, or perturb `content_version` checks.
 5. **Concurrency.** The buffer is `Mutex`-guarded and per-handle. A single
    sequential stream never contends; concurrent/random reads on the same fh
    serialize on the buffer mutex only, with no cross-handle effect.
@@ -209,10 +281,13 @@ validation.
   queue, #308). Prefetch gets its own small concurrency bound so it can never
   starve foreground reads.
 - **Cancellation without killing preads:** a blocking `pread` cannot be
-  interrupted, so we do not try. Each handle carries an epoch; a seek or
-  `release` bumps it; a prefetch job checks the epoch before storing its result
-  and discards stale fills. The abandoned `pread` completes and its bytes are
-  dropped.
+  interrupted, so we do not try. Each handle carries the single epoch from
+  Correctness §2 — a seek, `release`, **or a refresh-generation bump** advances
+  it. A prefetch job reads the epoch when dispatched and re-checks it under the
+  buffer mutex before storing; if it changed, the fill is discarded. The
+  abandoned `pread` completes and its bytes are dropped. This is what makes an
+  in-flight prefetch against a layout that was just re-resolved (generation bump)
+  safe to throw away.
 - **Adaptive depth:** the window-growth signal also drives how many windows ahead
   to prefetch, bounded by the stream's budget share. High-RTT NFS ramps depth up;
   HDD stays shallow. No knob beyond the budget ceiling.
@@ -222,8 +297,12 @@ validation.
 - **Differential correctness (keystone).** For both PCM and Ogg fixtures, bytes
   served through the read-ahead path must be byte-for-byte identical to direct
   preads, across sequential and random access, arbitrary offset/size splits, and
-  buffer eviction. Reuses the existing `ogg_serve_tests` / serve fixtures in
-  `reader.rs`.
+  buffer eviction. The test injects a deliberately tiny budget via the
+  `with_budget` seam so eviction is *forced* mid-stream (a default-sized budget
+  would silently never exercise the eviction path). Includes a seek that lands
+  *partially* back inside a just-freed window region, to catch off-by-one in the
+  shrink/refill offset math. Reuses the existing `ogg_serve_tests` / serve
+  fixtures in `reader.rs`.
 - **Unit.** hit/miss; window grow-on-sequential; reset-on-seek; eviction reclaims
   coldest; drop-on-generation-bump; drop-on-validation-failure.
 - **Concurrency.** multi-thread reads of one handle (the existing TSan CI job

--- a/docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md
+++ b/docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md
@@ -1,0 +1,250 @@
+# Single-stream backing read-ahead (issue #255)
+
+## Problem
+
+In synthesis mode, a single sequential read through the mount is served one
+FUSE chunk (~256 KiB) at a time. Each chunk's backing bytes come from a
+positioned `pread` on the original file in `read_segments_into`
+(`musefs-core/src/reader.rs`) — for PCM via the `BackingAudio` arm, for Ogg via
+`serve_ogg_window` (`musefs-core/src/ogg_index.rs`). The kernel issues these
+reads strictly serially for one stream: it waits for each reply before issuing
+the next. Throughput is therefore `chunk_count × per-read latency` and is
+unaffected by `--max-readahead-kib`.
+
+Measured cold single-stream throughput (`BENCHMARKS.md#storage-tunables`):
+
+| backing            | MB/s |
+| ------------------ | ---- |
+| local HDD          | ~250 |
+| NFS 8 ms RTT       | ~31  |
+| NFS 50 ms RTT      | ~5   |
+| NFS 200 ms RTT     | ~1.3 |
+
+Concurrent streams over distinct files already hide the latency (16 NFS streams
+reach ~10× the single-stream aggregate), so the backing serves parallel reads
+fine — only the single-stream path lacks overlap.
+
+Pure-passthrough (structure-only) files dodge this entirely via kernel FUSE
+passthrough (Linux 6.9+): the kernel reads the backing fd directly. Synthesis
+files cannot — the metadata splice shifts byte offsets, so the daemon must serve
+them. This spec addresses synthesis mode only.
+
+## Non-goals
+
+- **No async runtime.** musefs deliberately rejected async-fuse as net-negative.
+  The prefetch pipeline uses the existing synchronous thread-pool model:
+  background OS threads issuing blocking `pread`s in parallel.
+- **Issue #173 (SQLite mmap for read-only serve connections) is out of scope.**
+  It targets a different layer (DB page access, not backing audio bytes), is an
+  investigation rather than a known win, and would not move the #255 numbers.
+  It gets its own spec.
+- **No per-medium / window-size knob.** The window sizing is fully adaptive
+  (see below). The only operator-facing control is the global memory ceiling.
+
+## Approach
+
+A **per-handle backing read-ahead buffer** that caches *raw backing-file bytes
+keyed by absolute backing-file offset* — not synthesized output. The backing
+`pread` is the only high-latency source; the synthesized header/art/tag segments
+are small, near offset 0, and already served cheaply (and `HeaderCache`-cached).
+Caching backing bytes (rather than synthesized output) also leaves the metadata
+freshness / retag semantics in `Musefs::read_into` (`facade.rs`) completely
+untouched.
+
+Delivered in two phases sharing one buffer abstraction:
+
+- **Phase 1 — read amplification (synchronous).** On a buffer miss, one large
+  `pread` refills the window; subsequent sequential chunks are served from it
+  with no syscall. Cuts round-trips by the amplification factor (e.g. ~16× for a
+  4 MiB window vs 256 KiB chunks). Latency is amortized, not hidden. This phase
+  builds and proves the buffer + invalidation substrate under the existing
+  retag/refresh races with no added concurrency.
+- **Phase 2 — parallel prefetch.** Background workers read ahead of the kernel's
+  position into a ring of windows, fully overlapping backing RTT
+  (bandwidth-bound, not RTT-bound). Reuses the Phase 1 buffer unchanged; only the
+  fill strategy changes.
+
+## Architecture
+
+### `BackingReader`
+
+A new type wrapping a handle's backing fd plus an adaptive read-ahead buffer,
+exposing the single method every backing read goes through:
+
+```
+read_exact_at(&self, buf: &mut [u8], abs_offset: u64) -> Result<()>
+```
+
+- **Hit** (requested range ⊆ current window): memcpy from the buffer, no syscall.
+- **Miss**: one large `pread` refilling the window starting at `abs_offset`,
+  sized to the current adaptive window; then serve from it.
+
+The unifying rule: **every read of the backing fd goes through
+`read_exact_at`.** This is what brings Ogg into scope rather than special-casing
+it:
+
+- `BackingAudio` arm of `read_segments_into`: today
+  `backing_read_exact_at(f, buf, bo + within)` → routes through the reader.
+- `OggAudio` arm: `serve_ogg_window`, `read_counted`, and `find_page_start`
+  (`ogg_index.rs`) take a `&BackingReader` instead of `&std::fs::File`; their
+  header and payload preads consult the same buffer. This is a wider signature
+  change through `ogg_index.rs`, accepted to keep Ogg first-class.
+
+`read_segments_into` / `read_at_with_file_into` thread an
+`Option<&BackingReader>` where they currently thread `Option<&std::fs::File>`.
+
+### Placement
+
+- The buffer is a field on `Handle` (`facade.rs`), behind a `Mutex`. `Handle`
+  already lives in `sharded_slab::Slab<Arc<Handle>>`, so no new slab is needed;
+  the per-handle slot lifecycle is already provided. A single sequential stream
+  never contends the mutex; it only serializes concurrent/random reads on the
+  same fh.
+- The buffer is **allocated lazily** — nothing until the detector sees
+  sequential access — so the thousands of handles a scanner opens-and-stats cost
+  zero read-ahead RAM. Freed on `release`.
+- The no-handle fallback path (`read_at_into`, one-shot open) keeps doing plain
+  preads. It is the uncommon path with no persistent state to read ahead into.
+
+## Mechanism: sequential detection & adaptive window
+
+Per handle:
+
+- Track `next_expected_offset` (the backing offset just past the last served
+  read).
+- A `read_exact_at` whose start `== next_expected_offset` (or lands inside the
+  current window) is **sequential** → grow the window (e.g. double, capped by the
+  stream's budget share). Successive misses fetch ever-larger chunks; this is
+  what self-tunes HDD (stays small) vs 200 ms NFS (ramps to MBs).
+- A read landing outside the window is a **seek** → reset: shrink the window to
+  the floor and refill at the new offset, returning the reclaimed bytes to the
+  budget.
+
+For the Ogg page-walk, a page's header and payload preads are adjacent and the
+walk proceeds forward, so once the window covers a page both reads hit and the
+stream stays "sequential" under the same detector.
+
+## Memory bounding
+
+Hybrid: lazy per-handle buffers drawing from one global byte budget with
+eviction.
+
+- **Global budget:** a single process-wide cap on total buffered bytes, separate
+  from the `HeaderCache` budget. Each handle's window growth is charged against
+  it. N concurrent streams share the budget — 100 streams each get smaller
+  windows than 2 streams do, which is the correct graceful degradation (aggregate
+  RAM stays fixed).
+- **Eviction:** when the budget is exhausted and a stream needs to grow/refill,
+  reclaim from the coldest buffer(s) — least-recently-served handles give back
+  their window first. A reclaimed handle simply re-misses and re-fetches
+  (correctness unaffected). Because only *actively streaming* handles hold
+  buffers, the set to scan for an eviction victim is small (bounded by concurrent
+  streams, not total opens); a guarded last-served scan over that set suffices —
+  no `quick_cache` (its keys are content, not live handles).
+- **Free on close / seek-shrink:** `release` returns the buffer to the budget; a
+  detected seek shrinks the window rather than holding the high-water mark.
+
+### Configuration
+
+- **One flag: `--read-ahead-budget-mib`** (default = a new internal constant,
+  e.g. 64). `0` disables read-ahead entirely — a clean escape hatch back to
+  per-chunk preads for debugging or pathological backing.
+- Rationale for exposing this one knob (against the project's anti-knob stance):
+  the read-ahead budget tracks *concurrent-consumer count*, which only the
+  operator knows and the daemon cannot infer — unlike the `HeaderCache` budget,
+  which tracks library size and stays an internal constant. A single-user and a
+  100-user deployment genuinely need different ceilings.
+- This stays a *single* knob: the operator sets the RAM envelope; the adaptive
+  window logic divides it across active streams. No window-size or prefetch-depth
+  knob is added.
+- Implementation seam: mirror `HeaderCache::with_budget` — the constructor takes
+  the budget (default backs the flag and tests).
+
+## Correctness & invalidation
+
+The design is safe because the buffer caches raw backing bytes keyed by absolute
+backing-file offset, and serving still flows through the existing per-read
+validation.
+
+1. **Audio invariant.** The buffer stores backing bytes verbatim and serves them
+   verbatim — never transformed. Ogg header *patching* happens on top of the raw
+   bytes after the read (unchanged), so caching raw bytes does not touch it.
+2. **Retag/refresh survives the buffer for free.** A retag changes DB metadata —
+   the synthesized segments (`Inline`/`ArtImage`/`BinaryTag`) and the virtual
+   layout — but not the backing audio bytes nor their absolute offset in the
+   original file. Keyed by backing-file offset (not virtual offset), cached bytes
+   cannot be made wrong by a retag. For maximal conservatism the buffer is
+   nonetheless **dropped on any handle generation bump** (refills are cheap; this
+   makes buffer validity trivially track the invariants the facade already
+   enforces). A tight retag loop thrashes the buffer harmlessly; retags are rare
+   vs reads.
+3. **Per-read re-stat guard preserved.** Every FUSE read still runs
+   `validate_opened_backing` in `read_into` before any byte — buffered or freshly
+   pread — reaches the kernel. A buffered byte is handed out only if the fd still
+   validates at serve time, so staleness exposure is no wider than today's
+   documented size/mtime guarantee (Finding #15, ESTALE). On validation failure →
+   `BackingChanged`, buffer dropped.
+4. **No interaction with the `begin_read` / `content_version` snapshot.** That
+   machinery guards DB-sourced segments (`BinaryTag`); read-ahead caches only
+   backing bytes and sits outside that path.
+5. **Concurrency.** The buffer is `Mutex`-guarded and per-handle. A single
+   sequential stream never contends; concurrent/random reads on the same fh
+   serialize on the buffer mutex only, with no cross-handle effect.
+6. **Phase 2 does not widen exposure.** Background prefetch only *fills* the
+   buffer; serving still gates on the per-read `validate_opened_backing`.
+   Prefetch I/O errors (e.g. NFS ESTALE) are swallowed, leaving the slot empty so
+   the serving read re-misses and surfaces the real error synchronously. Prefetch
+   is strictly best-effort.
+
+## Phase 2: parallel prefetch detail
+
+- The buffer generalizes from one window to a small **ring of windows**: while
+  the kernel consumes window *K*, a background worker fills *K+1* (up to a
+  prefetch depth of further windows).
+- **Trigger:** serving a read that advances into the buffer enqueues a fill for
+  the next not-yet-filled window, if one is not already outstanding. A per-handle
+  "fill in flight" state ensures one prefetch per window.
+- **Worker bound:** prefetch reads are daemon-internal and must **not** consume
+  the FUSE `MAX_INFLIGHT_READS` slots (that cap bounds the kernel-driven pool
+  queue, #308). Prefetch gets its own small concurrency bound so it can never
+  starve foreground reads.
+- **Cancellation without killing preads:** a blocking `pread` cannot be
+  interrupted, so we do not try. Each handle carries an epoch; a seek or
+  `release` bumps it; a prefetch job checks the epoch before storing its result
+  and discards stale fills. The abandoned `pread` completes and its bytes are
+  dropped.
+- **Adaptive depth:** the window-growth signal also drives how many windows ahead
+  to prefetch, bounded by the stream's budget share. High-RTT NFS ramps depth up;
+  HDD stays shallow. No knob beyond the budget ceiling.
+
+## Testing & rollout
+
+- **Differential correctness (keystone).** For both PCM and Ogg fixtures, bytes
+  served through the read-ahead path must be byte-for-byte identical to direct
+  preads, across sequential and random access, arbitrary offset/size splits, and
+  buffer eviction. Reuses the existing `ogg_serve_tests` / serve fixtures in
+  `reader.rs`.
+- **Unit.** hit/miss; window grow-on-sequential; reset-on-seek; eviction reclaims
+  coldest; drop-on-generation-bump; drop-on-validation-failure.
+- **Concurrency.** multi-thread reads of one handle (the existing TSan CI job
+  covers this; TSan needs `-Zbuild-std`).
+- **Memory.** global budget never exceeded under N concurrent streams; eviction
+  reclaims the coldest buffer.
+- **Metrics.** read-ahead changes `pread`/`open` counts, and the CI
+  `metrics`-feature tests assert exact counts — they need updating, plus a new
+  read-ahead hit/miss counter. Run `cargo test -p musefs-core --features metrics`
+  before push (local `--workspace` skips the `metrics` feature).
+- **Bench + docs.** Extend `benches/storage_tunables_bench.sh` to measure
+  single-stream throughput read-ahead on/off; record results in `BENCHMARKS.md`,
+  replacing the "latent finding / future work" note with the actual numbers. Doc
+  touch-ups: `ARCHITECTURE.md` (reader / segment-model note), `docs/OGG.md`,
+  README (`--read-ahead-budget-mib`).
+- **Phasing for the pre-commit gate.** Each phase lands as its own green commit
+  (Phase 1 buffer + amplification, then Phase 2 prefetch); the pre-commit hook
+  runs the full workspace test suite, so each commit must be green.
+  `.cargo/mutants.toml` line:col anchors shift when `reader.rs` / `facade.rs` /
+  `ogg_index.rs` change — re-anchor in the same commit via each entry's
+  `# guard:` tag.
+- **Fuzz check.** `serve_ogg_window` lives in `musefs-core` (not the format
+  layer), but verify the out-of-workspace `fuzz/` crate still builds if any
+  format-layer signature is touched: `cargo +nightly fuzz build`.

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -287,7 +287,8 @@ fuzz_target!(|data: &[u8]| {
     let file = std::fs::File::open(&resolved.backing_path).expect("backing file opens");
     let pool = ReadAheadPool::new(0);
     let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
-    let br = BackingReader::new(&file, &buf, &pool, 0, total, &std::sync::atomic::AtomicU64::new(0));
+    let epoch = std::sync::atomic::AtomicU64::new(0);
+    let br = BackingReader::new(&file, &buf, &pool, 0, total, &epoch);
 
     // Splice-consistency invariants. A successfully-resolved layout is internally
     // consistent regardless of how its rows were planted, so whenever the read

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -1,11 +1,14 @@
 #![no_main]
 use arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
-use musefs_core::{HeaderCache, Mode, read_at_with_file};
+use musefs_core::{
+    BackingReader, HeaderCache, Mode, ReadAhead, ReadAheadPool, read_at_with_file,
+};
 use musefs_db::{BinaryTag, Db, Format, NewArt, NewTrack, Tag, TrackArt};
 use musefs_fuzz::{MAX_INPUT, arb_arts, arb_tags};
 use std::io::Write;
 use std::os::unix::fs::MetadataExt;
+use std::sync::{Arc, Mutex};
 
 /// Build a one-track in-memory DB over `backing` written to a temp file, and
 /// return (tempdir, db, track_id). Returns None on any setup error.
@@ -282,6 +285,9 @@ fuzz_target!(|data: &[u8]| {
 
     let total = resolved.total_len;
     let file = std::fs::File::open(&resolved.backing_path).expect("backing file opens");
+    let pool = ReadAheadPool::new(0);
+    let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
+    let br = BackingReader::new(&file, &buf, &pool, 0, total);
 
     // Splice-consistency invariants. A successfully-resolved layout is internally
     // consistent regardless of how its rows were planted, so whenever the read
@@ -293,7 +299,7 @@ fuzz_target!(|data: &[u8]| {
     // as a clean Err(Format(Malformed)) at read time — that is the production code
     // correctly rejecting hostile state, not a clean-path failure. Only a
     // genuinely clean input (hostile == None) must read without error.
-    let whole = match read_at_with_file(&resolved, &db, &file, 0, total) {
+    let whole = match read_at_with_file(&resolved, &db, &br, 0, total) {
         Ok(w) => w,
         Err(_) if hostile.is_some() => return,
         Err(e) => panic!("clean-path whole read failed: {e:?}"),
@@ -315,7 +321,7 @@ fuzz_target!(|data: &[u8]| {
             Ok(v) => v,
             Err(_) => break,
         };
-        let got = match read_at_with_file(&resolved, &db, &file, offset, size) {
+        let got = match read_at_with_file(&resolved, &db, &br, offset, size) {
             Ok(g) => g,
             Err(_) if hostile.is_some() => break,
             Err(e) => panic!("clean-path window read failed: {e:?}"),

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -287,7 +287,7 @@ fuzz_target!(|data: &[u8]| {
     let file = std::fs::File::open(&resolved.backing_path).expect("backing file opens");
     let pool = ReadAheadPool::new(0);
     let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
-    let br = BackingReader::new(&file, &buf, &pool, 0, total);
+    let br = BackingReader::new(&file, &buf, &pool, 0, total, &std::sync::atomic::AtomicU64::new(0));
 
     // Splice-consistency invariants. A successfully-resolved layout is internally
     // consistent regardless of how its rows were planted, so whenever the read

--- a/fuzz/fuzz_targets/serve.rs
+++ b/fuzz/fuzz_targets/serve.rs
@@ -288,7 +288,8 @@ fuzz_target!(|data: &[u8]| {
     let pool = ReadAheadPool::new(0);
     let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
     let epoch = std::sync::atomic::AtomicU64::new(0);
-    let br = BackingReader::new(&file, &buf, &pool, 0, total, &epoch);
+    // backing_len is the raw backing-file length, not the synthesized total_len.
+    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.stamp.size, &epoch);
 
     // Splice-consistency invariants. A successfully-resolved layout is internally
     // consistent regardless of how its rows were planted, so whenever the read

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -43,6 +43,7 @@ pub struct Cli {
 /// Flags for `musefs mount`, grouped so the mount plumbing passes one value
 /// instead of ten ordering-fragile positional parameters.
 #[derive(clap::Args, Debug)]
+#[allow(clippy::struct_excessive_bools)] // independent CLI toggles, not a state machine
 pub struct MountArgs {
     /// Empty directory to mount at.
     #[arg(env = "MUSEFS_MOUNTPOINT")]
@@ -83,8 +84,13 @@ pub struct MountArgs {
     #[arg(long, env = "MUSEFS_MAX_READAHEAD_KIB", default_value_t = 512)]
     pub max_readahead_kib: u32,
     /// Global read-ahead RAM budget (MiB) shared across all active streams. 0 disables.
-    #[arg(long, default_value_t = 64)]
+    #[arg(long, env = "MUSEFS_READ_AHEAD_BUDGET_MIB", default_value_t = 64)]
     pub read_ahead_budget_mib: u32,
+    /// Enable Phase-2 background prefetch threads (advanced). Off by default:
+    /// read amplification alone carries the read-ahead win; the threads add
+    /// overhead without benefit on tested backends (NFS, SSD). See BENCHMARKS.md.
+    #[arg(long, env = "MUSEFS_READ_AHEAD_PREFETCH", default_value_t = false)]
+    pub read_ahead_prefetch: bool,
     /// Max outstanding background (readahead/async) requests the kernel queues.
     #[arg(long, env = "MUSEFS_MAX_BACKGROUND", default_value_t = 64)]
     pub max_background: u16,
@@ -278,6 +284,7 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
         case_insensitive: args.case_insensitive,
         read_ahead_budget: u64::from(args.read_ahead_budget_mib).saturating_mul(1024 * 1024),
+        read_ahead_prefetch: args.read_ahead_prefetch,
     };
     let defaults = musefs_fuse::FuseConfig::default();
     let fuse_config = musefs_fuse::FuseConfig {
@@ -375,6 +382,29 @@ mod tests {
         };
         let (config, _) = parse_mount_config(&args);
         assert_eq!(config.read_ahead_budget, 0);
+    }
+
+    #[test]
+    fn read_ahead_prefetch_defaults_off_and_opts_in() {
+        use clap::Parser;
+        let base = ["musefs", "mount", "/mnt", "--db", "/tmp/x.db"];
+        let off = Cli::try_parse_from(base).unwrap();
+        let Command::Mount(args) = off.command else {
+            panic!("expected Mount");
+        };
+        assert!(
+            !parse_mount_config(&args).0.read_ahead_prefetch,
+            "Phase-2 prefetch must default off"
+        );
+
+        let on = Cli::try_parse_from(base.iter().chain(["--read-ahead-prefetch"].iter())).unwrap();
+        let Command::Mount(args) = on.command else {
+            panic!("expected Mount");
+        };
+        assert!(
+            parse_mount_config(&args).0.read_ahead_prefetch,
+            "flag opts in"
+        );
     }
 
     #[test]

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -82,6 +82,9 @@ pub struct MountArgs {
     /// streaming; clamped to the kernel maximum at mount.
     #[arg(long, env = "MUSEFS_MAX_READAHEAD_KIB", default_value_t = 512)]
     pub max_readahead_kib: u32,
+    /// Global read-ahead RAM budget (MiB) shared across all active streams. 0 disables.
+    #[arg(long, default_value_t = 64)]
+    pub read_ahead_budget_mib: u32,
     /// Max outstanding background (readahead/async) requests the kernel queues.
     #[arg(long, env = "MUSEFS_MAX_BACKGROUND", default_value_t = 64)]
     pub max_background: u16,
@@ -274,6 +277,7 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         mode: args.mode.into(),
         poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
         case_insensitive: args.case_insensitive,
+        read_ahead_budget: u64::from(args.read_ahead_budget_mib).saturating_mul(1024 * 1024),
     };
     let defaults = musefs_fuse::FuseConfig::default();
     let fuse_config = musefs_fuse::FuseConfig {
@@ -332,6 +336,46 @@ pub fn run(cli: Cli) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_ahead_budget_flag_maps_to_mount_config() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "mount",
+            "/mnt",
+            "--db",
+            "/tmp/x.db",
+            "--read-ahead-budget-mib",
+            "128",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (config, _) = parse_mount_config(&args);
+        assert_eq!(config.read_ahead_budget, 128 * 1024 * 1024);
+    }
+
+    #[test]
+    fn read_ahead_budget_zero_disables() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "musefs",
+            "mount",
+            "/mnt",
+            "--db",
+            "/tmp/x.db",
+            "--read-ahead-budget-mib",
+            "0",
+        ])
+        .unwrap();
+        let Command::Mount(args) = cli.command else {
+            panic!("expected Mount");
+        };
+        let (config, _) = parse_mount_config(&args);
+        assert_eq!(config.read_ahead_budget, 0);
+    }
 
     #[test]
     fn scan_command_parses_jobs_flag() {

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -136,6 +136,7 @@ fn parse_mount_config_defaults_are_sensible() {
         file_mode: None,
         dir_mode: None,
         allow_other: false,
+        read_ahead_budget_mib: 64,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
@@ -169,6 +170,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         file_mode: None,
         dir_mode: None,
         allow_other: false,
+        read_ahead_budget_mib: 64,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
@@ -198,6 +200,7 @@ fn parse_mount_config_saturating_readahead() {
         file_mode: None,
         dir_mode: None,
         allow_other: false,
+        read_ahead_budget_mib: 64,
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
@@ -251,6 +254,7 @@ fn parse_mount_config_populates_per_field_fallbacks() {
         file_mode: None,
         dir_mode: None,
         allow_other: false,
+        read_ahead_budget_mib: 64,
     };
     let (config, _) = parse_mount_config(&args);
     assert_eq!(

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -137,6 +137,7 @@ fn parse_mount_config_defaults_are_sensible() {
         dir_mode: None,
         allow_other: false,
         read_ahead_budget_mib: 64,
+        read_ahead_prefetch: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
@@ -171,6 +172,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         dir_mode: None,
         allow_other: false,
         read_ahead_budget_mib: 64,
+        read_ahead_prefetch: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
@@ -201,6 +203,7 @@ fn parse_mount_config_saturating_readahead() {
         dir_mode: None,
         allow_other: false,
         read_ahead_budget_mib: 64,
+        read_ahead_prefetch: false,
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
@@ -255,6 +258,7 @@ fn parse_mount_config_populates_per_field_fallbacks() {
         dir_mode: None,
         allow_other: false,
         read_ahead_budget_mib: 64,
+        read_ahead_prefetch: false,
     };
     let (config, _) = parse_mount_config(&args);
     assert_eq!(

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -17,6 +17,7 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -18,6 +18,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1298,6 +1298,18 @@ impl Musefs {
         self.handles.remove(key);
     }
 
+    /// Test accessor: are the Phase-2 prefetch worker threads running?
+    #[cfg(test)]
+    pub(crate) fn prefetch_workers_active(&self) -> bool {
+        self.prefetch.is_some()
+    }
+
+    /// Test accessor: bytes currently charged against the read-ahead budget.
+    #[cfg(test)]
+    pub(crate) fn pool_charged(&self) -> u64 {
+        self.readahead_pool.charged_for_test()
+    }
+
     /// The backing fd behind `fh`, for kernel passthrough registration. `Some`
     /// only in StructureOnly mode, where the served bytes ARE the backing file;
     /// in Synthesis mode the bytes are spliced, so no single fd represents
@@ -1427,6 +1439,81 @@ mod tests {
             "handle did not re-resolve: {len_before} -> {len_after}"
         );
         fs.release_handle(fh);
+    }
+
+    #[test]
+    fn prefetch_workers_created_only_with_budget_and_flag() {
+        use std::collections::BTreeMap;
+        let mk = |budget: u64, prefetch: bool| {
+            let cfg = MountConfig {
+                template: "$artist/$title".to_string(),
+                fallbacks: BTreeMap::new(),
+                default_fallback: "Unknown".to_string(),
+                mode: Mode::Synthesis,
+                poll_interval: std::time::Duration::ZERO,
+                case_insensitive: false,
+                read_ahead_budget: budget,
+                read_ahead_prefetch: prefetch,
+            };
+            Musefs::open(musefs_db::Db::open_in_memory().unwrap(), cfg).unwrap()
+        };
+        assert!(
+            !mk(64 << 20, false).prefetch_workers_active(),
+            "default is Phase-1 amplification only"
+        );
+        assert!(mk(64 << 20, true).prefetch_workers_active(), "flag opts in");
+        assert!(
+            !mk(0, true).prefetch_workers_active(),
+            "budget 0 disables read-ahead entirely"
+        );
+        assert!(!mk(0, false).prefetch_workers_active());
+    }
+
+    #[test]
+    fn read_then_release_does_not_leak_budget() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+        let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+        let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+        let fh = fs.open_handle(file_inode).unwrap();
+        assert!(
+            !fs.read(file_inode, Some(fh), 0, 1 << 20)
+                .unwrap()
+                .is_empty()
+        );
+        // The read registers the stream and charges its window; release must
+        // deregister and uncharge it. A registration that does not fire on the
+        // first read leaks the charge (the buffer is never in the pool to free).
+        fs.release_handle(fh);
+        assert_eq!(fs.pool_charged(), 0, "release leaked the read-ahead charge");
     }
 
     /// The safety property the transactional `content_version` guard exists to

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1544,6 +1544,57 @@ mod tests {
         assert_eq!(fs.pool_charged(), 0, "release leaked the read-ahead charge");
     }
 
+    #[test]
+    fn two_handles_get_distinct_pool_keys() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut tag = id3::Tag::new();
+            tag.set_artist("Pix");
+            tag.set_title("Song");
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+        }
+        let db_path = dir.path().join("m.db");
+        {
+            let db = musefs_db::Db::open(&db_path).unwrap();
+            scan_directory(&db, dir.path()).unwrap();
+        }
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
+        };
+        let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+        let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
+        let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+        // Two handles on the same inode hold DISTINCT read-ahead buffers, so their
+        // pool keys (buffer addresses) must differ. A constant pool_key collides
+        // both onto one registry entry: the second registration overwrites the
+        // first, so only one of the two charges is freed on release — a leak.
+        let fh1 = fs.open_handle(inode).unwrap();
+        let fh2 = fs.open_handle(inode).unwrap();
+        assert!(!fs.read(inode, Some(fh1), 0, 1 << 20).unwrap().is_empty());
+        assert!(!fs.read(inode, Some(fh2), 0, 1 << 20).unwrap().is_empty());
+        fs.release_handle(fh1);
+        fs.release_handle(fh2);
+        assert_eq!(
+            fs.pool_charged(),
+            0,
+            "distinct keys must each free their charge"
+        );
+    }
+
     /// The safety property the transactional `content_version` guard exists to
     /// protect: a handle holding a `Segment::BinaryTag { payload_id }` must never
     /// serve the bytes of a *different* row that later reused that rowid under the

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -65,7 +65,6 @@ struct Handle {
     readahead: Arc<Mutex<crate::readahead::ReadAhead>>,
     registered: AtomicBool,
     epoch: Arc<AtomicU64>,
-    depth: std::sync::atomic::AtomicU32,
 }
 
 /// An owned view of an open handle's backing fd, for FUSE passthrough
@@ -1044,6 +1043,74 @@ impl Musefs {
 
     /// Serve a read into `out` (cleared first). The FUSE layer passes a reused
     /// per-worker buffer so the hot path allocates nothing per read (#70).
+    /// Serve `[offset, offset+size)` through the per-handle read-ahead buffer,
+    /// then (when Phase-2 prefetch is enabled and the stream is sequential)
+    /// enqueue depth-adaptive next-window jobs. Shared by the binary-tag
+    /// (snapshotted) and plain read branches of `read_into`.
+    #[expect(clippy::too_many_arguments)] // mirrors the read offset/size/out plumbing
+    fn serve_backing<M>(
+        &self,
+        h: &Handle,
+        key: usize,
+        db: &musefs_db::Db<M>,
+        r: &ResolvedFile,
+        offset: u64,
+        size: u64,
+        out: &mut Vec<u8>,
+    ) -> Result<()> {
+        if !h.registered.swap(true, Ordering::AcqRel) {
+            self.readahead_pool.register(key, Arc::clone(&h.readahead));
+        }
+        let backing_len = r.stamp.size;
+        let br = crate::readahead::BackingReader::new(
+            &h.file,
+            &h.readahead,
+            &self.readahead_pool,
+            key,
+            backing_len,
+            &h.epoch,
+        );
+        read_at_with_file_into(r, db, &br, offset, size, out)?;
+
+        let Some(pf) = &self.prefetch else {
+            return Ok(());
+        };
+        // Adaptive depth: keep roughly one per-stream budget share in flight.
+        // The window grows geometrically while sequential, so `cap / window`
+        // windows of the current size sum to about `cap`; clamp the thread
+        // fan-out to a small bound. A seek resets `window` to the floor, which
+        // raises depth again — no separate ramp counter is needed.
+        let (start, window) = {
+            let ra = h.readahead.lock().unwrap();
+            (ra.next_expected(), ra.window())
+        };
+        if window == 0 || start >= backing_len {
+            return Ok(());
+        }
+        let cap = self.readahead_pool.per_stream_cap();
+        let depth = crate::readahead::prefetch_depth(cap, window);
+        let ring = usize::try_from(depth).unwrap_or(4) + 1;
+        h.readahead.lock().unwrap().set_max_windows(ring);
+        let dispatched_epoch = h.epoch.load(Ordering::Acquire);
+        for i in 0..depth {
+            let s = start + i * window;
+            if s >= backing_len {
+                break;
+            }
+            pf.request(crate::readahead::PrefetchJob {
+                file: Arc::clone(&h.file),
+                buf: Arc::clone(&h.readahead),
+                pool: Arc::clone(&self.readahead_pool),
+                epoch: Arc::clone(&h.epoch),
+                dispatched_epoch,
+                start: s,
+                len: window,
+                backing_len,
+            });
+        }
+        Ok(())
+    }
+
     pub fn read_into(
         &self,
         inode: u64,
@@ -1076,7 +1143,6 @@ impl Musefs {
                         }
                         h.resolved.store(fresh);
                         h.generation.store(cur, Ordering::Release);
-                        h.depth.store(0, std::sync::atomic::Ordering::Relaxed);
                     }
                     let resolved = h.resolved.load();
                     let r: &ResolvedFile = &resolved;
@@ -1108,116 +1174,13 @@ impl Musefs {
                                 {
                                     return Ok(None); // stale layout — retry after re-resolve
                                 }
-                                let key = fh.slab_key();
-                                if !h.registered.swap(true, Ordering::AcqRel) {
-                                    self.readahead_pool.register(key, Arc::clone(&h.readahead));
-                                    if self.readahead_pool.enabled() {
-                                        h.readahead.lock().unwrap().set_max_windows(2);
-                                    }
-                                }
-                                let backing_len = r.stamp.size;
-                                let br = crate::readahead::BackingReader::new(
-                                    &h.file,
-                                    &h.readahead,
-                                    &self.readahead_pool,
-                                    key,
-                                    backing_len,
-                                    &h.epoch,
-                                );
-                                read_at_with_file_into(r, db, &br, offset, size, out)?;
-                                if let Some(pf) = &self.prefetch {
-                                    let (start, window_size) = {
-                                        let ra = h.readahead.lock().unwrap();
-                                        (ra.next_expected(), self.readahead_pool.per_stream_cap())
-                                    };
-                                    if start < backing_len {
-                                        let depth = h
-                                            .depth
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                                            + 1;
-                                        let max_depth =
-                                            ((window_size / window_size.max(1)).clamp(1, 4)) as u32;
-                                        let depth = depth.min(max_depth);
-                                        h.readahead
-                                            .lock()
-                                            .unwrap()
-                                            .set_max_windows((depth as usize) + 1);
-                                        let cur_epoch =
-                                            h.epoch.load(std::sync::atomic::Ordering::Acquire);
-                                        for i in 0..depth {
-                                            let start = start + u64::from(i) * window_size;
-                                            if start >= backing_len {
-                                                break;
-                                            }
-                                            pf.request(crate::readahead::PrefetchJob {
-                                                file: Arc::clone(&h.file),
-                                                buf: Arc::clone(&h.readahead),
-                                                epoch: Arc::clone(&h.epoch),
-                                                dispatched_epoch: cur_epoch,
-                                                start,
-                                                len: window_size,
-                                                backing_len,
-                                            });
-                                        }
-                                    }
-                                }
+                                self.serve_backing(&h, fh.slab_key(), db, r, offset, size, out)?;
                                 Ok(Some(()))
                             })();
                             let _ = db.end_read(); // always release the snapshot
                             res
                         } else {
-                            let key = fh.slab_key();
-                            if !h.registered.swap(true, Ordering::AcqRel) {
-                                self.readahead_pool.register(key, Arc::clone(&h.readahead));
-                                if self.readahead_pool.enabled() {
-                                    h.readahead.lock().unwrap().set_max_windows(2);
-                                }
-                            }
-                            let backing_len = r.stamp.size;
-                            let br = crate::readahead::BackingReader::new(
-                                &h.file,
-                                &h.readahead,
-                                &self.readahead_pool,
-                                key,
-                                backing_len,
-                                &h.epoch,
-                            );
-                            read_at_with_file_into(r, db, &br, offset, size, out)?;
-                            if let Some(pf) = &self.prefetch {
-                                let (start, window_size) = {
-                                    let ra = h.readahead.lock().unwrap();
-                                    (ra.next_expected(), self.readahead_pool.per_stream_cap())
-                                };
-                                if start < backing_len {
-                                    let depth =
-                                        h.depth.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                                            + 1;
-                                    let max_depth =
-                                        ((window_size / window_size.max(1)).clamp(1, 4)) as u32;
-                                    let depth = depth.min(max_depth);
-                                    h.readahead
-                                        .lock()
-                                        .unwrap()
-                                        .set_max_windows((depth as usize) + 1);
-                                    let cur_epoch =
-                                        h.epoch.load(std::sync::atomic::Ordering::Acquire);
-                                    for i in 0..depth {
-                                        let start = start + u64::from(i) * window_size;
-                                        if start >= backing_len {
-                                            break;
-                                        }
-                                        pf.request(crate::readahead::PrefetchJob {
-                                            file: Arc::clone(&h.file),
-                                            buf: Arc::clone(&h.readahead),
-                                            epoch: Arc::clone(&h.epoch),
-                                            dispatched_epoch: cur_epoch,
-                                            start,
-                                            len: window_size,
-                                            backing_len,
-                                        });
-                                    }
-                                }
-                            }
+                            self.serve_backing(&h, fh.slab_key(), db, r, offset, size, out)?;
                             Ok(Some(()))
                         }
                     })?;
@@ -1229,7 +1192,6 @@ impl Musefs {
                     h.resolved.store(fresh);
                     h.generation
                         .store(self.refresh_gen.load(Ordering::Acquire), Ordering::Release);
-                    h.depth.store(0, std::sync::atomic::Ordering::Relaxed);
                 }
                 // Pathological constant re-tagging raced every attempt; surface a
                 // retryable error rather than risk wrong bytes.
@@ -1300,7 +1262,6 @@ impl Musefs {
             ))),
             registered: AtomicBool::new(false),
             epoch: Arc::new(AtomicU64::new(0)),
-            depth: std::sync::atomic::AtomicU32::new(0),
         })))
     }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -44,6 +44,8 @@ pub struct MountConfig {
     /// Compare filenames case-insensitively (dirs merge, files disambiguate).
     /// Set by the CLI (`--case-insensitive`), default true on macOS.
     pub case_insensitive: bool,
+    /// Global read-ahead RAM envelope in bytes. `0` disables read-ahead.
+    pub read_ahead_budget: u64,
 }
 
 /// Attributes the FUSE layer maps onto `fuser::FileAttr`.
@@ -256,6 +258,7 @@ impl Musefs {
         let template = Template::parse(&config.template)?;
         let (tree, snapshot) = Self::build_full(&db, &template, &config, &mut alloc)?;
         let poll_interval = config.poll_interval;
+        let read_ahead_budget = config.read_ahead_budget;
         Ok(Musefs {
             cache: HeaderCache::new(config.mode),
             last_data_version: AtomicI64::new(last_data_version),
@@ -265,9 +268,7 @@ impl Musefs {
             config,
             template,
             handles: sharded_slab::Slab::new(),
-            readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(
-                crate::readahead::DEFAULT_READAHEAD_BUDGET,
-            )),
+            readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(read_ahead_budget)),
             size_cache: dashmap::DashMap::new(),
             last_poll: Mutex::new(std::time::Instant::now()),
             last_failed_refresh: Mutex::new(None),
@@ -1329,6 +1330,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1421,6 +1423,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1535,6 +1538,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1598,6 +1602,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
 
         let (entries, snapshot) = Musefs::render_entries(
@@ -1641,6 +1646,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1729,6 +1735,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: true,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1785,6 +1792,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: interval,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
         (dir, fs)
@@ -1852,6 +1860,7 @@ mod tests {
             mode,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
 
         // StructureOnly: exposed, and the fd refers to the backing inode.
@@ -1960,6 +1969,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let template = Template::parse(&config.template).expect("valid template");
 
@@ -2007,6 +2017,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -2049,6 +2060,7 @@ mod tests {
             mode: Mode::Synthesis,
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         assert!(matches!(
             Musefs::open(db, config),

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -65,6 +65,7 @@ struct Handle {
     readahead: Arc<Mutex<crate::readahead::ReadAhead>>,
     registered: AtomicBool,
     epoch: Arc<AtomicU64>,
+    depth: std::sync::atomic::AtomicU32,
 }
 
 /// An owned view of an open handle's backing fd, for FUSE passthrough
@@ -1075,6 +1076,7 @@ impl Musefs {
                         }
                         h.resolved.store(fresh);
                         h.generation.store(cur, Ordering::Release);
+                        h.depth.store(0, std::sync::atomic::Ordering::Relaxed);
                     }
                     let resolved = h.resolved.load();
                     let r: &ResolvedFile = &resolved;
@@ -1124,20 +1126,39 @@ impl Musefs {
                                 );
                                 read_at_with_file_into(r, db, &br, offset, size, out)?;
                                 if let Some(pf) = &self.prefetch {
-                                    let (start, len) = {
+                                    let (start, window_size) = {
                                         let ra = h.readahead.lock().unwrap();
                                         (ra.next_expected(), self.readahead_pool.per_stream_cap())
                                     };
                                     if start < backing_len {
-                                        pf.request(crate::readahead::PrefetchJob {
-                                            file: Arc::clone(&h.file),
-                                            buf: Arc::clone(&h.readahead),
-                                            epoch: Arc::clone(&h.epoch),
-                                            dispatched_epoch: h.epoch.load(Ordering::Acquire),
-                                            start,
-                                            len,
-                                            backing_len,
-                                        });
+                                        let depth = h
+                                            .depth
+                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                            + 1;
+                                        let max_depth =
+                                            ((window_size / window_size.max(1)).clamp(1, 4)) as u32;
+                                        let depth = depth.min(max_depth);
+                                        h.readahead
+                                            .lock()
+                                            .unwrap()
+                                            .set_max_windows((depth as usize) + 1);
+                                        let cur_epoch =
+                                            h.epoch.load(std::sync::atomic::Ordering::Acquire);
+                                        for i in 0..depth {
+                                            let start = start + u64::from(i) * window_size;
+                                            if start >= backing_len {
+                                                break;
+                                            }
+                                            pf.request(crate::readahead::PrefetchJob {
+                                                file: Arc::clone(&h.file),
+                                                buf: Arc::clone(&h.readahead),
+                                                epoch: Arc::clone(&h.epoch),
+                                                dispatched_epoch: cur_epoch,
+                                                start,
+                                                len: window_size,
+                                                backing_len,
+                                            });
+                                        }
                                     }
                                 }
                                 Ok(Some(()))
@@ -1163,20 +1184,38 @@ impl Musefs {
                             );
                             read_at_with_file_into(r, db, &br, offset, size, out)?;
                             if let Some(pf) = &self.prefetch {
-                                let (start, len) = {
+                                let (start, window_size) = {
                                     let ra = h.readahead.lock().unwrap();
                                     (ra.next_expected(), self.readahead_pool.per_stream_cap())
                                 };
                                 if start < backing_len {
-                                    pf.request(crate::readahead::PrefetchJob {
-                                        file: Arc::clone(&h.file),
-                                        buf: Arc::clone(&h.readahead),
-                                        epoch: Arc::clone(&h.epoch),
-                                        dispatched_epoch: h.epoch.load(Ordering::Acquire),
-                                        start,
-                                        len,
-                                        backing_len,
-                                    });
+                                    let depth =
+                                        h.depth.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                            + 1;
+                                    let max_depth =
+                                        ((window_size / window_size.max(1)).clamp(1, 4)) as u32;
+                                    let depth = depth.min(max_depth);
+                                    h.readahead
+                                        .lock()
+                                        .unwrap()
+                                        .set_max_windows((depth as usize) + 1);
+                                    let cur_epoch =
+                                        h.epoch.load(std::sync::atomic::Ordering::Acquire);
+                                    for i in 0..depth {
+                                        let start = start + u64::from(i) * window_size;
+                                        if start >= backing_len {
+                                            break;
+                                        }
+                                        pf.request(crate::readahead::PrefetchJob {
+                                            file: Arc::clone(&h.file),
+                                            buf: Arc::clone(&h.readahead),
+                                            epoch: Arc::clone(&h.epoch),
+                                            dispatched_epoch: cur_epoch,
+                                            start,
+                                            len: window_size,
+                                            backing_len,
+                                        });
+                                    }
                                 }
                             }
                             Ok(Some(()))
@@ -1190,6 +1229,7 @@ impl Musefs {
                     h.resolved.store(fresh);
                     h.generation
                         .store(self.refresh_gen.load(Ordering::Acquire), Ordering::Release);
+                    h.depth.store(0, std::sync::atomic::Ordering::Relaxed);
                 }
                 // Pathological constant re-tagging raced every attempt; surface a
                 // retryable error rather than risk wrong bytes.
@@ -1260,6 +1300,7 @@ impl Musefs {
             ))),
             registered: AtomicBool::new(false),
             epoch: Arc::new(AtomicU64::new(0)),
+            depth: std::sync::atomic::AtomicU32::new(0),
         })))
     }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -71,8 +71,10 @@ struct Handle {
     resolved: arc_swap::ArcSwap<ResolvedFile>,
     generation: AtomicU64,
     file: std::fs::File,
-    backing_pool: crate::readahead::ReadAheadPool,
-    backing_buf: Arc<Mutex<crate::readahead::ReadAhead>>,
+    readahead: Arc<Mutex<crate::readahead::ReadAhead>>,
+    registered: AtomicBool,
+    #[expect(dead_code)]
+    epoch: Arc<AtomicU64>,
 }
 
 /// An owned view of an open handle's backing fd, for FUSE passthrough
@@ -146,6 +148,7 @@ pub struct Musefs {
     /// a layout that was invalidated by a refresh the kernel did not yet see.
     refresh_gen: AtomicU64,
     handles: sharded_slab::Slab<Arc<Handle>>,
+    readahead_pool: Arc<crate::readahead::ReadAheadPool>,
     /// `SizeEntry` keyed by track id. Tiny entries, effectively unbounded; serves
     /// getattr/lookup without a backing stat or full synthesis. Self-invalidates on
     /// a content_version change.
@@ -262,6 +265,9 @@ impl Musefs {
             config,
             template,
             handles: sharded_slab::Slab::new(),
+            readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(
+                crate::readahead::DEFAULT_READAHEAD_BUDGET,
+            )),
             size_cache: dashmap::DashMap::new(),
             last_poll: Mutex::new(std::time::Instant::now()),
             last_failed_refresh: Mutex::new(None),
@@ -1105,12 +1111,17 @@ impl Musefs {
                                 {
                                     return Ok(None); // stale layout — retry after re-resolve
                                 }
+                                let key = fh.slab_key();
+                                if !h.registered.swap(true, Ordering::AcqRel) {
+                                    self.readahead_pool.register(key, Arc::clone(&h.readahead));
+                                }
+                                let backing_len = r.stamp.size;
                                 let br = crate::readahead::BackingReader::new(
                                     &h.file,
-                                    &h.backing_buf,
-                                    &h.backing_pool,
-                                    0,
-                                    r.stamp.size,
+                                    &h.readahead,
+                                    &self.readahead_pool,
+                                    key,
+                                    backing_len,
                                 );
                                 read_at_with_file_into(r, db, &br, offset, size, out)?;
                                 Ok(Some(()))
@@ -1118,12 +1129,17 @@ impl Musefs {
                             let _ = db.end_read(); // always release the snapshot
                             res
                         } else {
+                            let key = fh.slab_key();
+                            if !h.registered.swap(true, Ordering::AcqRel) {
+                                self.readahead_pool.register(key, Arc::clone(&h.readahead));
+                            }
+                            let backing_len = r.stamp.size;
                             let br = crate::readahead::BackingReader::new(
                                 &h.file,
-                                &h.backing_buf,
-                                &h.backing_pool,
-                                0,
-                                r.stamp.size,
+                                &h.readahead,
+                                &self.readahead_pool,
+                                key,
+                                backing_len,
                             );
                             read_at_with_file_into(r, db, &br, offset, size, out)?;
                             Ok(Some(()))
@@ -1197,24 +1213,24 @@ impl Musefs {
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
         validate_opened_backing(&file, &resolved)?;
-        let backing_pool =
-            crate::readahead::ReadAheadPool::new(crate::readahead::DEFAULT_READAHEAD_BUDGET);
-        let backing_buf = Arc::new(Mutex::new(crate::readahead::ReadAhead::new(
-            backing_pool.per_stream_cap(),
-        )));
         fh_from_key(self.handles.insert(Arc::new(Handle {
             track_id,
             resolved: arc_swap::ArcSwap::from(resolved),
             generation: AtomicU64::new(generation),
             file,
-            backing_pool,
-            backing_buf,
+            readahead: Arc::new(Mutex::new(crate::readahead::ReadAhead::new(
+                self.readahead_pool.per_stream_cap(),
+            ))),
+            registered: AtomicBool::new(false),
+            epoch: Arc::new(AtomicU64::new(0)),
         })))
     }
 
     /// Drop an open handle (closes its backing fd when the last reference goes).
     pub fn release_handle(&self, fh: Fh) {
-        self.handles.remove(fh.slab_key());
+        let key = fh.slab_key();
+        self.readahead_pool.deregister(key);
+        self.handles.remove(key);
     }
 
     /// The backing fd behind `fh`, for kernel passthrough registration. `Some`

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -57,25 +57,13 @@ pub struct Attr {
     pub mtime_secs: i64,
 }
 
-/// An open file handle: the resolved layout, the track it belongs to, the
-/// generation at which `resolved` was last validated, and a backing fd opened
-/// once at `open`.
-///
-/// A handle survives `poll_refresh`, but is **not** a frozen snapshot: when the
-/// global `refresh_gen` advances (a refresh applied changes), the next `read`
-/// re-resolves the track (a cheap `content_version`-keyed cache hit when the
-/// track is unchanged) and swaps in the fresh layout. This keeps a re-tagged
-/// file's handle consistent with the size the kernel sees via getattr, and
-/// prevents a stale `Segment::BinaryTag { payload_id }` from serving reused-rowid
-/// bytes after a re-tag.
 struct Handle {
     track_id: i64,
     resolved: arc_swap::ArcSwap<ResolvedFile>,
     generation: AtomicU64,
-    file: std::fs::File,
+    file: Arc<std::fs::File>,
     readahead: Arc<Mutex<crate::readahead::ReadAhead>>,
     registered: AtomicBool,
-    #[expect(dead_code)]
     epoch: Arc<AtomicU64>,
 }
 
@@ -151,6 +139,7 @@ pub struct Musefs {
     refresh_gen: AtomicU64,
     handles: sharded_slab::Slab<Arc<Handle>>,
     readahead_pool: Arc<crate::readahead::ReadAheadPool>,
+    prefetch: Option<crate::readahead::PrefetchWorkers>,
     /// `SizeEntry` keyed by track id. Tiny entries, effectively unbounded; serves
     /// getattr/lookup without a backing stat or full synthesis. Self-invalidates on
     /// a content_version change.
@@ -269,6 +258,11 @@ impl Musefs {
             template,
             handles: sharded_slab::Slab::new(),
             readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(read_ahead_budget)),
+            prefetch: if read_ahead_budget > 0 {
+                Some(crate::readahead::PrefetchWorkers::new(2))
+            } else {
+                None
+            },
             size_cache: dashmap::DashMap::new(),
             last_poll: Mutex::new(std::time::Instant::now()),
             last_failed_refresh: Mutex::new(None),
@@ -1115,6 +1109,9 @@ impl Musefs {
                                 let key = fh.slab_key();
                                 if !h.registered.swap(true, Ordering::AcqRel) {
                                     self.readahead_pool.register(key, Arc::clone(&h.readahead));
+                                    if self.readahead_pool.enabled() {
+                                        h.readahead.lock().unwrap().set_max_windows(2);
+                                    }
                                 }
                                 let backing_len = r.stamp.size;
                                 let br = crate::readahead::BackingReader::new(
@@ -1123,8 +1120,26 @@ impl Musefs {
                                     &self.readahead_pool,
                                     key,
                                     backing_len,
+                                    &h.epoch,
                                 );
                                 read_at_with_file_into(r, db, &br, offset, size, out)?;
+                                if let Some(pf) = &self.prefetch {
+                                    let (start, len) = {
+                                        let ra = h.readahead.lock().unwrap();
+                                        (ra.next_expected(), self.readahead_pool.per_stream_cap())
+                                    };
+                                    if start < backing_len {
+                                        pf.request(crate::readahead::PrefetchJob {
+                                            file: Arc::clone(&h.file),
+                                            buf: Arc::clone(&h.readahead),
+                                            epoch: Arc::clone(&h.epoch),
+                                            dispatched_epoch: h.epoch.load(Ordering::Acquire),
+                                            start,
+                                            len,
+                                            backing_len,
+                                        });
+                                    }
+                                }
                                 Ok(Some(()))
                             })();
                             let _ = db.end_read(); // always release the snapshot
@@ -1133,6 +1148,9 @@ impl Musefs {
                             let key = fh.slab_key();
                             if !h.registered.swap(true, Ordering::AcqRel) {
                                 self.readahead_pool.register(key, Arc::clone(&h.readahead));
+                                if self.readahead_pool.enabled() {
+                                    h.readahead.lock().unwrap().set_max_windows(2);
+                                }
                             }
                             let backing_len = r.stamp.size;
                             let br = crate::readahead::BackingReader::new(
@@ -1141,8 +1159,26 @@ impl Musefs {
                                 &self.readahead_pool,
                                 key,
                                 backing_len,
+                                &h.epoch,
                             );
                             read_at_with_file_into(r, db, &br, offset, size, out)?;
+                            if let Some(pf) = &self.prefetch {
+                                let (start, len) = {
+                                    let ra = h.readahead.lock().unwrap();
+                                    (ra.next_expected(), self.readahead_pool.per_stream_cap())
+                                };
+                                if start < backing_len {
+                                    pf.request(crate::readahead::PrefetchJob {
+                                        file: Arc::clone(&h.file),
+                                        buf: Arc::clone(&h.readahead),
+                                        epoch: Arc::clone(&h.epoch),
+                                        dispatched_epoch: h.epoch.load(Ordering::Acquire),
+                                        start,
+                                        len,
+                                        backing_len,
+                                    });
+                                }
+                            }
                             Ok(Some(()))
                         }
                     })?;
@@ -1212,7 +1248,7 @@ impl Musefs {
         let generation = self.refresh_gen.load(Ordering::Acquire);
         let resolved = self.pool.with(|db| self.cache.resolve(db, track_id))?;
         crate::metrics::on_open();
-        let file = std::fs::File::open(&resolved.backing_path)?;
+        let file = Arc::new(std::fs::File::open(&resolved.backing_path)?);
         validate_opened_backing(&file, &resolved)?;
         fh_from_key(self.handles.insert(Arc::new(Handle {
             track_id,
@@ -1230,6 +1266,9 @@ impl Musefs {
     /// Drop an open handle (closes its backing fd when the last reference goes).
     pub fn release_handle(&self, fh: Fh) {
         let key = fh.slab_key();
+        if let Some(h) = self.handles.get(key) {
+            h.epoch.fetch_add(1, Ordering::AcqRel);
+        }
         self.readahead_pool.deregister(key);
         self.handles.remove(key);
     }

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -46,6 +46,10 @@ pub struct MountConfig {
     pub case_insensitive: bool,
     /// Global read-ahead RAM envelope in bytes. `0` disables read-ahead.
     pub read_ahead_budget: u64,
+    /// Enable Phase-2 background prefetch threads. Off by default: Phase-1 read
+    /// amplification carries the entire measured read-ahead win (#255); the
+    /// prefetch threads add overhead without benefit on the backends tested.
+    pub read_ahead_prefetch: bool,
 }
 
 /// Attributes the FUSE layer maps onto `fuser::FileAttr`.
@@ -251,6 +255,7 @@ impl Musefs {
         let (tree, snapshot) = Self::build_full(&db, &template, &config, &mut alloc)?;
         let poll_interval = config.poll_interval;
         let read_ahead_budget = config.read_ahead_budget;
+        let read_ahead_prefetch = config.read_ahead_prefetch;
         Ok(Musefs {
             cache: HeaderCache::new(config.mode),
             last_data_version: AtomicI64::new(last_data_version),
@@ -261,7 +266,11 @@ impl Musefs {
             template,
             handles: sharded_slab::Slab::new(),
             readahead_pool: Arc::new(crate::readahead::ReadAheadPool::new(read_ahead_budget)),
-            prefetch: if read_ahead_budget > 0 {
+            // Phase 2 (background prefetch threads) runs only when read-ahead is
+            // on AND explicitly opted in. Off by default: Phase-1 amplification
+            // carries the whole win, and the threads add ~10% overhead without
+            // benefit on the backends benchmarked (#255).
+            prefetch: if read_ahead_budget > 0 && read_ahead_prefetch {
                 Some(crate::readahead::PrefetchWorkers::new(2))
             } else {
                 None
@@ -1386,6 +1395,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1479,6 +1489,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1594,6 +1605,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1658,6 +1670,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
 
         let (entries, snapshot) = Musefs::render_entries(
@@ -1702,6 +1715,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1791,6 +1805,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: true,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1848,6 +1863,7 @@ mod tests {
             poll_interval: interval,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
         (dir, fs)
@@ -1916,6 +1932,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
 
         // StructureOnly: exposed, and the fd refers to the backing inode.
@@ -2025,6 +2042,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let template = Template::parse(&config.template).expect("valid template");
 
@@ -2073,6 +2091,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -2116,6 +2135,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         assert!(matches!(
             Musefs::open(db, config),

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -71,6 +71,8 @@ struct Handle {
     resolved: arc_swap::ArcSwap<ResolvedFile>,
     generation: AtomicU64,
     file: std::fs::File,
+    backing_pool: crate::readahead::ReadAheadPool,
+    backing_buf: Arc<Mutex<crate::readahead::ReadAhead>>,
 }
 
 /// An owned view of an open handle's backing fd, for FUSE passthrough
@@ -1103,13 +1105,27 @@ impl Musefs {
                                 {
                                     return Ok(None); // stale layout — retry after re-resolve
                                 }
-                                read_at_with_file_into(r, db, &h.file, offset, size, out)?;
+                                let br = crate::readahead::BackingReader::new(
+                                    &h.file,
+                                    &h.backing_buf,
+                                    &h.backing_pool,
+                                    0,
+                                    r.stamp.size,
+                                );
+                                read_at_with_file_into(r, db, &br, offset, size, out)?;
                                 Ok(Some(()))
                             })();
                             let _ = db.end_read(); // always release the snapshot
                             res
                         } else {
-                            read_at_with_file_into(r, db, &h.file, offset, size, out)?;
+                            let br = crate::readahead::BackingReader::new(
+                                &h.file,
+                                &h.backing_buf,
+                                &h.backing_pool,
+                                0,
+                                r.stamp.size,
+                            );
+                            read_at_with_file_into(r, db, &br, offset, size, out)?;
                             Ok(Some(()))
                         }
                     })?;
@@ -1181,11 +1197,18 @@ impl Musefs {
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
         validate_opened_backing(&file, &resolved)?;
+        let backing_pool =
+            crate::readahead::ReadAheadPool::new(crate::readahead::DEFAULT_READAHEAD_BUDGET);
+        let backing_buf = Arc::new(Mutex::new(crate::readahead::ReadAhead::new(
+            backing_pool.per_stream_cap(),
+        )));
         fh_from_key(self.handles.insert(Arc::new(Handle {
             track_id,
             resolved: arc_swap::ArcSwap::from(resolved),
             generation: AtomicU64::new(generation),
             file,
+            backing_pool,
+            backing_buf,
         })))
     }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -65,6 +65,9 @@ struct Handle {
     readahead: Arc<Mutex<crate::readahead::ReadAhead>>,
     registered: AtomicBool,
     epoch: Arc<AtomicU64>,
+    /// Absolute backing offset through which prefetch jobs were already
+    /// dispatched, so a sequential stream does not re-request buffered windows.
+    prefetched_upto: AtomicU64,
 }
 
 /// An owned view of an open handle's backing fd, for FUSE passthrough
@@ -1079,24 +1082,34 @@ impl Musefs {
         // The window grows geometrically while sequential, so `cap / window`
         // windows of the current size sum to about `cap`; clamp the thread
         // fan-out to a small bound. A seek resets `window` to the floor, which
-        // raises depth again — no separate ramp counter is needed.
-        let (start, window) = {
-            let ra = h.readahead.lock().unwrap();
-            (ra.next_expected(), ra.window())
+        // raises depth again — no separate ramp counter is needed. `plan_prefetch`
+        // deduplicates against the per-handle watermark so a sequential stream
+        // enqueues only the freshly-exposed tail rather than re-requesting
+        // already-buffered windows. The watermark read/update sits under the
+        // buffer lock that also serialises concurrent reads of this handle.
+        let cap = self.readahead_pool.per_stream_cap();
+        let (starts, window) = {
+            let mut ra = h.readahead.lock().unwrap();
+            let start = ra.next_expected();
+            let window = ra.window();
+            let depth = crate::readahead::prefetch_depth(cap, window);
+            let ring = usize::try_from(depth).unwrap_or(4) + 1;
+            ra.set_max_windows(ring);
+            let (starts, upto) = crate::readahead::plan_prefetch(
+                h.prefetched_upto.load(Ordering::Relaxed),
+                start,
+                window,
+                depth,
+                backing_len,
+            );
+            h.prefetched_upto.store(upto, Ordering::Relaxed);
+            (starts, window)
         };
-        if window == 0 || start >= backing_len {
+        if starts.is_empty() {
             return Ok(());
         }
-        let cap = self.readahead_pool.per_stream_cap();
-        let depth = crate::readahead::prefetch_depth(cap, window);
-        let ring = usize::try_from(depth).unwrap_or(4) + 1;
-        h.readahead.lock().unwrap().set_max_windows(ring);
         let dispatched_epoch = h.epoch.load(Ordering::Acquire);
-        for i in 0..depth {
-            let s = start + i * window;
-            if s >= backing_len {
-                break;
-            }
+        for s in starts {
             pf.request(crate::readahead::PrefetchJob {
                 file: Arc::clone(&h.file),
                 buf: Arc::clone(&h.readahead),
@@ -1262,6 +1275,7 @@ impl Musefs {
             ))),
             registered: AtomicBool::new(false),
             epoch: Arc::new(AtomicU64::new(0)),
+            prefetched_upto: AtomicU64::new(0),
         })))
     }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -72,6 +72,29 @@ struct Handle {
     /// Absolute backing offset through which prefetch jobs were already
     /// dispatched, so a sequential stream does not re-request buffered windows.
     prefetched_upto: AtomicU64,
+    /// Shared so the read-ahead pool registration is cleaned up on the handle's
+    /// FINAL drop, not eagerly in `release_handle`. A read that races a release
+    /// holds an `Arc<Handle>` clone, so the buffer (and its budget charge) stays
+    /// alive until that read finishes; deregistering here, keyed by the buffer's
+    /// address, then frees exactly that stream's charge with no leak or reuse.
+    pool: Arc<crate::readahead::ReadAheadPool>,
+}
+
+impl Handle {
+    /// Stable pool key for this handle's read-ahead buffer: its heap address,
+    /// unique for the buffer's lifetime (the handle holds the `Arc`, so the
+    /// address can't be reused while still registered).
+    fn pool_key(&self) -> usize {
+        Arc::as_ptr(&self.readahead) as usize
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        // Runs when the last Arc<Handle> drops — after any in-flight read that
+        // re-registered the buffer post-release — so the budget never leaks.
+        self.pool.deregister(self.pool_key());
+    }
 }
 
 /// An owned view of an open handle's backing fd, for FUSE passthrough
@@ -1059,17 +1082,18 @@ impl Musefs {
     /// then (when Phase-2 prefetch is enabled and the stream is sequential)
     /// enqueue depth-adaptive next-window jobs. Shared by the binary-tag
     /// (snapshotted) and plain read branches of `read_into`.
-    #[expect(clippy::too_many_arguments)] // mirrors the read offset/size/out plumbing
     fn serve_backing<M>(
         &self,
         h: &Handle,
-        key: usize,
         db: &musefs_db::Db<M>,
         r: &ResolvedFile,
         offset: u64,
         size: u64,
         out: &mut Vec<u8>,
     ) -> Result<()> {
+        // Keyed by the buffer address (not the slab key) so the handle's Drop can
+        // deregister it after a racing release; see Handle::pool_key / Drop.
+        let key = h.pool_key();
         if !h.registered.swap(true, Ordering::AcqRel) {
             self.readahead_pool.register(key, Arc::clone(&h.readahead));
         }
@@ -1099,7 +1123,10 @@ impl Musefs {
         let cap = self.readahead_pool.per_stream_cap();
         let (starts, window) = {
             let mut ra = h.readahead.lock().unwrap();
-            let start = ra.next_expected();
+            // Start at the cached frontier, not the read cursor: a window-filling
+            // miss leaves next_expected mid-window, so dispatching from it would
+            // re-request the bytes just pulled synchronously.
+            let start = ra.frontier(ra.next_expected());
             let window = ra.window();
             let depth = crate::readahead::prefetch_depth(cap, window);
             let ring = usize::try_from(depth).unwrap_or(4) + 1;
@@ -1196,13 +1223,13 @@ impl Musefs {
                                 {
                                     return Ok(None); // stale layout — retry after re-resolve
                                 }
-                                self.serve_backing(&h, fh.slab_key(), db, r, offset, size, out)?;
+                                self.serve_backing(&h, db, r, offset, size, out)?;
                                 Ok(Some(()))
                             })();
                             let _ = db.end_read(); // always release the snapshot
                             res
                         } else {
-                            self.serve_backing(&h, fh.slab_key(), db, r, offset, size, out)?;
+                            self.serve_backing(&h, db, r, offset, size, out)?;
                             Ok(Some(()))
                         }
                     })?;
@@ -1285,6 +1312,7 @@ impl Musefs {
             registered: AtomicBool::new(false),
             epoch: Arc::new(AtomicU64::new(0)),
             prefetched_upto: AtomicU64::new(0),
+            pool: Arc::clone(&self.readahead_pool),
         })))
     }
 
@@ -1294,7 +1322,10 @@ impl Musefs {
         if let Some(h) = self.handles.get(key) {
             h.epoch.fetch_add(1, Ordering::AcqRel);
         }
-        self.readahead_pool.deregister(key);
+        // Pool deregistration is the handle's Drop responsibility, not done here:
+        // a read racing this release still holds an Arc<Handle>, so eagerly
+        // deregistering would drop the entry before that read's charge lands,
+        // leaking it. Drop runs once the last reference (the in-flight read) goes.
         self.handles.remove(key);
     }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -1123,10 +1123,7 @@ impl Musefs {
         let cap = self.readahead_pool.per_stream_cap();
         let (starts, window) = {
             let mut ra = h.readahead.lock().unwrap();
-            // Start at the cached frontier, not the read cursor: a window-filling
-            // miss leaves next_expected mid-window, so dispatching from it would
-            // re-request the bytes just pulled synchronously.
-            let start = ra.frontier(ra.next_expected());
+            let start = ra.next_expected();
             let window = ra.window();
             let depth = crate::readahead::prefetch_depth(cap, window);
             let ring = usize::try_from(depth).unwrap_or(4) + 1;

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -19,6 +19,7 @@ pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
 pub use facade::{Attr, Fh, Mode, MountConfig, Musefs, PassthroughFd};
 pub use musefs_db::convert;
+pub use readahead::{BackingReader, DEFAULT_READAHEAD_BUDGET, ReadAhead, ReadAheadPool};
 pub use reader::{HeaderCache, ResolvedFile, read_at, read_at_with_file};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -7,6 +7,8 @@ mod lock;
 mod mapping;
 pub mod metrics;
 mod ogg_index;
+#[allow(dead_code)]
+mod readahead;
 mod reader;
 mod refresh_diff;
 mod scan;

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -19,7 +19,7 @@ pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
 pub use facade::{Attr, Fh, Mode, MountConfig, Musefs, PassthroughFd};
 pub use musefs_db::convert;
-pub use readahead::{BackingReader, DEFAULT_READAHEAD_BUDGET, ReadAhead, ReadAheadPool};
+pub use readahead::{BackingReader, ReadAhead, ReadAheadPool};
 pub use reader::{HeaderCache, ResolvedFile, read_at, read_at_with_file};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -38,6 +38,8 @@ mod imp {
     static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
     static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
     static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
+    static READAHEAD_HITS: AtomicU64 = AtomicU64::new(0);
+    static READAHEAD_MISSES: AtomicU64 = AtomicU64::new(0);
     static PREAD_FAULT: OnceLock<Option<Duration>> = OnceLock::new();
 
     // Backing-read fault seam (test-only; process-global so it reaches the FUSE
@@ -183,6 +185,14 @@ mod imp {
         SCAN_BYTES_READ.fetch_add(bytes, Ordering::Relaxed);
     }
 
+    pub fn on_readahead_hit() {
+        READAHEAD_HITS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn on_readahead_miss() {
+        READAHEAD_MISSES.fetch_add(1, Ordering::Relaxed);
+    }
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub struct Snapshot {
         pub opens: u64,
@@ -194,6 +204,8 @@ mod imp {
         pub scan_opens: u64,
         pub scan_preads: u64,
         pub scan_bytes_read: u64,
+        pub readahead_hits: u64,
+        pub readahead_misses: u64,
     }
 
     pub fn snapshot() -> Snapshot {
@@ -207,6 +219,8 @@ mod imp {
             scan_opens: SCAN_OPENS.load(Ordering::Relaxed),
             scan_preads: SCAN_PREADS.load(Ordering::Relaxed),
             scan_bytes_read: SCAN_BYTES_READ.load(Ordering::Relaxed),
+            readahead_hits: READAHEAD_HITS.load(Ordering::Relaxed),
+            readahead_misses: READAHEAD_MISSES.load(Ordering::Relaxed),
         }
     }
 
@@ -220,6 +234,8 @@ mod imp {
         SCAN_OPENS.store(0, Ordering::Relaxed);
         SCAN_PREADS.store(0, Ordering::Relaxed);
         SCAN_BYTES_READ.store(0, Ordering::Relaxed);
+        READAHEAD_HITS.store(0, Ordering::Relaxed);
+        READAHEAD_MISSES.store(0, Ordering::Relaxed);
     }
 }
 
@@ -236,6 +252,8 @@ mod imp {
         pub scan_opens: u64,
         pub scan_preads: u64,
         pub scan_bytes_read: u64,
+        pub readahead_hits: u64,
+        pub readahead_misses: u64,
     }
 
     #[inline(always)]
@@ -263,6 +281,10 @@ mod imp {
     pub fn on_scan_open() {}
     #[inline(always)]
     pub fn on_scan_read(_bytes: u64) {}
+    #[inline(always)]
+    pub fn on_readahead_hit() {}
+    #[inline(always)]
+    pub fn on_readahead_miss() {}
     #[inline(always)]
     pub fn snapshot() -> Snapshot {
         Snapshot::default()

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -323,12 +323,15 @@ mod tests {
         on_pread(100);
         on_art_chunk();
         on_binary_tag_chunk();
+        on_readahead_miss();
         let s = snapshot();
         assert_eq!(s.opens, 2);
         assert_eq!(s.preads, 1);
         assert_eq!(s.pread_bytes, 100);
         assert_eq!(s.art_chunks, 1);
         assert_eq!(s.binary_tag_chunks, 1);
+        assert_eq!(s.readahead_misses, 1);
+        assert_eq!(s.readahead_hits, 0);
         reset();
         assert_eq!(snapshot(), Snapshot::default());
     }

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -145,7 +145,7 @@ fn page_crc_ok(backing: &std::fs::File, page_start: u64) -> Result<bool> {
 /// enforced, as a hard error in both debug and release builds.
 #[allow(clippy::too_many_arguments)] // serve geometry + memo; bundling adds no clarity
 pub fn serve_ogg_window(
-    backing: &std::fs::File,
+    backing: &crate::readahead::BackingReader,
     audio_offset: u64,
     audio_length: u64,
     seq_delta: i64,
@@ -159,7 +159,7 @@ pub fn serve_ogg_window(
     }
     let audio_end = audio_offset + audio_length;
     let abs_rstart = audio_offset + rstart;
-    let mut pos = find_page_start(backing, audio_offset, abs_rstart, memo)?;
+    let mut pos = find_page_start(backing.file(), audio_offset, abs_rstart, memo)?;
 
     while pos < audio_end {
         let page_rel = pos - audio_offset;
@@ -170,7 +170,7 @@ pub fn serve_ogg_window(
         // Clamped to the declared audio region end.
         let read_len = MAX_OGG_HEADER_BYTES.min(usize_from(audio_end - pos));
         let mut hdr_buf = vec![0u8; read_len];
-        read_counted(backing, &mut hdr_buf, pos)?;
+        backing.read_exact_at(&mut hdr_buf, pos)?;
         if hdr_buf.len() < 27 {
             return Err(musefs_format::FormatError::Malformed.into());
         }
@@ -227,7 +227,7 @@ pub fn serve_ogg_window(
             let n = usize_from(pe - ps);
             let start = out.len();
             out.resize(start + n, 0);
-            read_counted(backing, &mut out[start..], pos + header_len as u64 + within)?;
+            backing.read_exact_at(&mut out[start..], pos + header_len as u64 + within)?;
         }
 
         pos += (header_len + payload_len) as u64;
@@ -248,6 +248,27 @@ mod tests {
     use super::*;
     use musefs_format::ogg::page_test_support::lace_packet_pub;
     use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    struct TestBr {
+        pool: crate::readahead::ReadAheadPool,
+        buf: Arc<Mutex<crate::readahead::ReadAhead>>,
+    }
+    impl TestBr {
+        fn new() -> Self {
+            TestBr {
+                pool: crate::readahead::ReadAheadPool::new(0),
+                buf: Arc::new(Mutex::new(crate::readahead::ReadAhead::new(0))),
+            }
+        }
+        fn reader<'a>(
+            &'a self,
+            f: &'a std::fs::File,
+            len: u64,
+        ) -> crate::readahead::BackingReader<'a> {
+            crate::readahead::BackingReader::new(f, &self.buf, &self.pool, 0, len)
+        }
+    }
 
     /// CRC-32/Ogg: poly 0x04C11DB7, init 0, no reflection, no xorout. Independent
     /// of musefs-format::ogg::crc (different table, from the `crc` crate).
@@ -354,8 +375,10 @@ mod tests {
             .unwrap();
 
         let backing = std::fs::File::open(&path).unwrap();
+        let test_br = TestBr::new();
+        let br = test_br.reader(&backing, u64::MAX);
         let mut audio = Vec::new();
-        serve_ogg_window(&backing, ao, alen, delta, 0, alen, &mut audio, None).unwrap();
+        serve_ogg_window(&br, ao, alen, delta, 0, alen, &mut audio, None).unwrap();
 
         let mut full = hdr_bytes;
         full.extend_from_slice(&audio);
@@ -445,8 +468,10 @@ mod tests {
 
     fn new_serve_range(path: &std::path::Path, ao: u64, alen: u64, a: u64, b: u64) -> Vec<u8> {
         let backing = std::fs::File::open(path).unwrap();
+        let test_br = TestBr::new();
+        let br = test_br.reader(&backing, u64::MAX);
         let mut out = Vec::new();
-        serve_ogg_window(&backing, ao, alen, 2, a, b, &mut out, None).unwrap();
+        serve_ogg_window(&br, ao, alen, 2, a, b, &mut out, None).unwrap();
         out
     }
 
@@ -635,17 +660,10 @@ mod tests {
             .unwrap();
         let audio_length = bytes.len() as u64 - 5;
         let backing = std::fs::File::open(&path).unwrap();
+        let test_br = TestBr::new();
+        let br = test_br.reader(&backing, u64::MAX);
         let mut out = Vec::new();
-        let r = serve_ogg_window(
-            &backing,
-            0,
-            audio_length,
-            0,
-            0,
-            audio_length,
-            &mut out,
-            None,
-        );
+        let r = serve_ogg_window(&br, 0, audio_length, 0, 0, audio_length, &mut out, None);
         assert!(r.is_err(), "misaligned audio_length must error");
     }
 
@@ -658,13 +676,15 @@ mod tests {
         let (_d, path, ao, alen) = new_serve_fixture();
         let want = new_reference_region(&path, ao, alen);
         let backing = std::fs::File::open(&path).unwrap();
+        let test_br = TestBr::new();
+        let br = test_br.reader(&backing, u64::MAX);
         let memo: LastPageMemo = std::sync::Mutex::new(None);
         let mut out = Vec::new();
         let mut off = 0u64;
         let chunk = 20_000u64;
         while off < alen {
             let end = (off + chunk).min(alen);
-            serve_ogg_window(&backing, ao, alen, 2, off, end, &mut out, Some(&memo)).unwrap();
+            serve_ogg_window(&br, ao, alen, 2, off, end, &mut out, Some(&memo)).unwrap();
             off = end;
         }
         assert_eq!(out, want, "memo-served bytes must match the reference");
@@ -789,10 +809,12 @@ mod tests {
             .write_all(&data)
             .unwrap();
         let backing = std::fs::File::open(&path).unwrap();
+        let test_br = TestBr::new();
+        let br = test_br.reader(&backing, u64::MAX);
         let alen = data.len() as u64;
         let mut out = Vec::new();
         // seq_delta 0 → patched headers equal the originals, so output == input.
-        serve_ogg_window(&backing, 0, alen, 0, 0, alen, &mut out, None).unwrap();
+        serve_ogg_window(&br, 0, alen, 0, 0, alen, &mut out, None).unwrap();
         assert_eq!(out, data);
     }
 
@@ -859,8 +881,10 @@ mod tests {
         let ao = 16u64;
         let alen = page.len() as u64;
         let backing = std::fs::File::open(&path).unwrap();
+        let test_br = TestBr::new();
+        let br = test_br.reader(&backing, u64::MAX);
         let mut out = Vec::new();
-        serve_ogg_window(&backing, ao, alen, 1, 0, alen, &mut out, None).unwrap();
+        serve_ogg_window(&br, ao, alen, 1, 0, alen, &mut out, None).unwrap();
 
         // The served region must be the page with its sequence wrapped (u32::MAX + 1 == 0):
         // patched header followed by the original payload bytes.

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -253,12 +253,14 @@ mod tests {
     struct TestBr {
         pool: crate::readahead::ReadAheadPool,
         buf: Arc<Mutex<crate::readahead::ReadAhead>>,
+        epoch: std::sync::atomic::AtomicU64,
     }
     impl TestBr {
         fn new() -> Self {
             TestBr {
                 pool: crate::readahead::ReadAheadPool::new(0),
                 buf: Arc::new(Mutex::new(crate::readahead::ReadAhead::new(0))),
+                epoch: std::sync::atomic::AtomicU64::new(0),
             }
         }
         fn reader<'a>(
@@ -266,7 +268,7 @@ mod tests {
             f: &'a std::fs::File,
             len: u64,
         ) -> crate::readahead::BackingReader<'a> {
-            crate::readahead::BackingReader::new(f, &self.buf, &self.pool, 0, len)
+            crate::readahead::BackingReader::new(f, &self.buf, &self.pool, 0, len, &self.epoch)
         }
     }
 

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -13,9 +13,6 @@ pub const WINDOW_FLOOR: u64 = 512 * 1024;
 /// Absolute per-stream window cap, independent of the global budget.
 pub const WINDOW_ABS_CAP: u64 = 8 * 1024 * 1024;
 
-/// Default global read-ahead budget when the operator passes no flag (64 MiB,
-/// mirroring `reader::DEFAULT_CACHE_BUDGET`). `0` disables read-ahead entirely.
-pub const DEFAULT_READAHEAD_BUDGET: u64 = 64 * 1024 * 1024;
 /// No single stream may hold more than `budget / PER_STREAM_DIVISOR`.
 const PER_STREAM_DIVISOR: u64 = 4;
 
@@ -145,13 +142,6 @@ impl ReadAheadPool {
     #[cfg(test)]
     pub fn charged_for_test(&self) -> u64 {
         self.charged.load(O::Relaxed)
-    }
-
-    /// Uncharge `bytes` directly (window cleared on invalidation/release).
-    pub fn uncharge(&self, bytes: u64) {
-        if bytes > 0 {
-            self.charged.fetch_sub(bytes, O::Relaxed);
-        }
     }
 
     /// Find and clear the coldest registered buffer other than `except`, using
@@ -1267,5 +1257,183 @@ mod concurrency_tests {
                 });
             }
         });
+    }
+}
+
+/// Focused unit tests that pin the read-ahead pool/buffer arithmetic and
+/// accounting against the mutation gate (#255): each asserts an EXACT observable
+/// (charged bytes, grant size, window size, fill/epoch counts) rather than a
+/// loose range, so an operator/return mutation flips the assertion.
+#[cfg(test)]
+mod mutation_guard_tests {
+    use super::*;
+    use std::sync::atomic::Ordering as AO;
+    use std::sync::{Arc, Mutex};
+
+    #[expect(clippy::unnecessary_wraps)]
+    fn fillb(b: &mut [u8], _o: u64) -> io::Result<()> {
+        b.fill(7);
+        Ok(())
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    fn bk_temp(len: usize) -> (tempfile::TempDir, std::fs::File) {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bk.bin");
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        (dir, std::fs::File::open(&path).unwrap())
+    }
+
+    #[test]
+    fn next_expected_equals_consumed_tail() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        let mut dst = vec![0u8; 4096];
+        ra.read_into(&mut dst, 1000, 8 << 20, fillb).unwrap();
+        assert_eq!(ra.next_expected(), 1000 + 4096); // miss path: off + len
+        let mut d2 = vec![0u8; 100];
+        ra.read_into(&mut d2, 5096, 8 << 20, fillb).unwrap();
+        assert_eq!(ra.next_expected(), 5096 + 100); // hit path: off + len
+    }
+
+    #[test]
+    fn window_doubles_on_sequential_miss_and_floors_on_seek() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        let blen = 16 << 20;
+        #[expect(clippy::cast_possible_truncation)]
+        let mut dst = vec![0u8; WINDOW_FLOOR as usize];
+        ra.read_into(&mut dst, 0, blen, fillb).unwrap();
+        assert_eq!(ra.window(), WINDOW_FLOOR); // first miss
+        ra.read_into(&mut dst, WINDOW_FLOOR, blen, fillb).unwrap();
+        assert_eq!(ra.window(), WINDOW_FLOOR * 2); // sequential miss doubles
+        ra.read_into(&mut dst, 12 << 20, blen, fillb).unwrap();
+        assert_eq!(ra.window(), WINDOW_FLOOR); // seek resets to floor
+    }
+
+    #[test]
+    fn set_cap_clamps_window_down_only() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_cap(WINDOW_FLOOR / 2);
+        assert_eq!(ra.window(), WINDOW_FLOOR / 2); // window > cap → clamped
+        ra.set_cap(WINDOW_ABS_CAP);
+        assert_eq!(ra.window(), WINDOW_FLOOR / 2); // window < cap → untouched
+    }
+
+    #[test]
+    fn reconcile_charges_growth_and_uncharges_shrink() {
+        let pool = ReadAheadPool::new(64 << 20);
+        pool.reconcile(0, 1000);
+        assert_eq!(pool.charged_for_test(), 1000);
+        pool.reconcile(1000, 250); // shrink must uncharge by old-new
+        assert_eq!(pool.charged_for_test(), 250);
+        pool.reconcile(250, 250); // equal: no change
+        assert_eq!(pool.charged_for_test(), 250);
+    }
+
+    #[test]
+    fn has_room_for_zero_need_is_false_when_disabled() {
+        assert!(!ReadAheadPool::new(0).has_room_for(0)); // budget==0 guard
+        let p = ReadAheadPool::new(1 << 20);
+        p.reconcile(0, 1 << 20);
+        assert!(!p.has_room_for(1));
+    }
+
+    #[test]
+    fn permitted_window_need_is_relative_to_old_len() {
+        let pool = ReadAheadPool::new(2 << 20); // cap 512K
+        let cap = pool.per_stream_cap();
+        let b1 = Arc::new(Mutex::new(ReadAhead::new(cap)));
+        pool.register(1, Arc::clone(&b1));
+        pool.reconcile(0, cap); // stream 1 holds one cap; budget still has room
+        // need = cap - cap/2 fits in the free budget → full grant. If need used
+        // `cap + cap/2` it would exceed free room and clamp below cap.
+        assert_eq!(pool.permitted_window(2, cap / 2, cap), cap);
+    }
+
+    #[test]
+    fn permitted_window_clamps_to_room_when_nothing_evictable() {
+        let pool = ReadAheadPool::new(WINDOW_FLOOR); // budget==cap==floor
+        let cap = pool.per_stream_cap();
+        let locked = Arc::new(Mutex::new(ReadAhead::new(cap)));
+        pool.register(1, Arc::clone(&locked));
+        pool.reconcile(0, cap); // budget full
+        let _held = locked.lock().unwrap(); // un-evictable
+        // room == 0, nothing evictable → grant == old_len + room == old_len.
+        assert_eq!(pool.permitted_window(2, 1000, cap), 1000);
+    }
+
+    #[test]
+    #[expect(clippy::cast_possible_truncation)]
+    fn touch_keeps_a_stream_off_the_eviction_block() {
+        let pool = ReadAheadPool::new(2 << 20); // cap 512K, holds 4 streams
+        let cap = pool.per_stream_cap();
+        let mk = |key: usize| {
+            let arc = Arc::new(Mutex::new(ReadAhead::new(cap)));
+            let mut d = vec![0u8; cap as usize];
+            let (o, n) = arc
+                .lock()
+                .unwrap()
+                .read_into(&mut d, 0, cap * 4, fillb)
+                .unwrap();
+            pool.register(key, Arc::clone(&arc));
+            pool.reconcile(o, n);
+            arc
+        };
+        let s1 = mk(1);
+        let s2 = mk(2);
+        let _s3 = mk(3);
+        let _s4 = mk(4); // budget full (4×cap)
+        pool.touch(1); // stream 1 now most-recent → stream 2 is coldest
+        let hot = Arc::new(Mutex::new(ReadAhead::new(cap)));
+        pool.register(5, Arc::clone(&hot));
+        pool.permitted_window(5, 0, cap); // must evict the coldest OTHER (stream 2)
+        assert_eq!(s2.lock().unwrap().len(), 0, "coldest stream evicted");
+        assert!(s1.lock().unwrap().len() > 0, "touched stream survives");
+    }
+
+    #[test]
+    fn fills_count_is_exact() {
+        let (_d, file) = bk_temp(256 * 1024);
+        let mut d = vec![0u8; 4096];
+        // Disabled pool: every read is one physical fill.
+        let pool0 = ReadAheadPool::new(0);
+        let buf0 = Arc::new(Mutex::new(ReadAhead::new(0)));
+        let ep0 = std::sync::atomic::AtomicU64::new(0);
+        let br0 = BackingReader::new(&file, &buf0, &pool0, 0, 256 * 1024, &ep0);
+        br0.read_exact_at(&mut d, 0).unwrap();
+        br0.read_exact_at(&mut d, 100_000).unwrap();
+        assert_eq!(br0.fills(), 2);
+        // Enabled pool: a cold read is one amplified fill; the next sequential
+        // read hits the window and adds no fill.
+        let pool = ReadAheadPool::new(64 << 20);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let ep = std::sync::atomic::AtomicU64::new(0);
+        let br = BackingReader::new(&file, &buf, &pool, 1, 256 * 1024, &ep);
+        br.read_exact_at(&mut d, 0).unwrap();
+        assert_eq!(br.fills(), 1);
+        br.read_exact_at(&mut d, 4096).unwrap();
+        assert_eq!(br.fills(), 1);
+    }
+
+    #[test]
+    fn epoch_bumps_on_seek_not_on_sequential() {
+        let (_d, file) = bk_temp(1 << 20);
+        let pool = ReadAheadPool::new(64 << 20);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let ep = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let br = BackingReader::new(&file, &buf, &pool, 1, 1 << 20, &ep);
+        let mut d = vec![0u8; 4096];
+        br.read_exact_at(&mut d, 0).unwrap(); // first read: a "seek" off MAX
+        let base = ep.load(AO::Relaxed);
+        br.read_exact_at(&mut d, 4096).unwrap(); // sequential hit
+        assert_eq!(ep.load(AO::Relaxed), base, "sequential must not bump epoch");
+        br.read_exact_at(&mut d, 900_000).unwrap(); // genuine seek (miss, off != next)
+        assert_eq!(ep.load(AO::Relaxed), base + 1, "seek bumps epoch");
     }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -3,12 +3,166 @@
 //! every backing read flows through. See
 //! `docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md`.
 
+use std::collections::HashMap;
 use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 /// Floor window size: a fresh or just-seeked stream still reads this much ahead.
 pub const WINDOW_FLOOR: u64 = 512 * 1024;
 /// Absolute per-stream window cap, independent of the global budget.
 pub const WINDOW_ABS_CAP: u64 = 8 * 1024 * 1024;
+
+/// Default global read-ahead budget when the operator passes no flag (64 MiB,
+/// mirroring `reader::DEFAULT_CACHE_BUDGET`). `0` disables read-ahead entirely.
+pub const DEFAULT_READAHEAD_BUDGET: u64 = 64 * 1024 * 1024;
+/// No single stream may hold more than `budget / PER_STREAM_DIVISOR`.
+const PER_STREAM_DIVISOR: u64 = 4;
+
+struct StreamEntry {
+    buf: Arc<Mutex<ReadAhead>>,
+    last_served: u64,
+}
+
+/// The process-wide read-ahead allocator: one byte budget shared by all active
+/// streams, with `try_lock` LRU eviction. Deadlock-free by construction — the
+/// budget is a lock-free atomic, the registry lock is a leaf (released before any
+/// buffer mutex), and eviction never blocks on a buffer mutex (`try_lock` + skip).
+pub struct ReadAheadPool {
+    /// Total RAM envelope; `0` means read-ahead is disabled.
+    budget: u64,
+    /// Currently charged bytes (sum of registered buffers' lengths).
+    charged: AtomicU64,
+    /// Active streaming handles keyed by slab key. Only sequential streams register.
+    streams: Mutex<HashMap<usize, StreamEntry>>,
+    /// Monotonic source for `last_served` stamps (LRU ordering).
+    clock: AtomicU64,
+}
+
+impl ReadAheadPool {
+    pub fn new(budget: u64) -> Self {
+        ReadAheadPool {
+            budget,
+            charged: AtomicU64::new(0),
+            streams: Mutex::new(HashMap::new()),
+            clock: AtomicU64::new(0),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.budget > 0
+    }
+
+    /// Per-stream window cap derived from the budget.
+    pub fn per_stream_cap(&self) -> u64 {
+        if self.budget == 0 {
+            return 0;
+        }
+        (self.budget / PER_STREAM_DIVISOR).clamp(WINDOW_FLOOR, WINDOW_ABS_CAP)
+    }
+
+    /// Lazily register a handle's buffer once sequential access is detected.
+    pub fn register(&self, key: usize, buf: Arc<Mutex<ReadAhead>>) {
+        let last_served = self.clock.fetch_add(1, Ordering::Relaxed);
+        self.streams
+            .lock()
+            .unwrap()
+            .insert(key, StreamEntry { buf, last_served });
+    }
+
+    /// Deregister on release; returns the bytes to uncharge.
+    pub fn deregister(&self, key: usize) {
+        let freed = {
+            let mut g = self.streams.lock().unwrap();
+            match g.remove(&key) {
+                Some(e) => e.buf.lock().unwrap().len(),
+                None => 0,
+            }
+        };
+        if freed > 0 {
+            self.charged.fetch_sub(freed, Ordering::Relaxed);
+        }
+    }
+
+    /// Mark `key` as most-recently-served (LRU bump). No-op if unregistered.
+    pub fn touch(&self, key: usize) {
+        let stamp = self.clock.fetch_add(1, Ordering::Relaxed);
+        if let Some(e) = self.streams.lock().unwrap().get_mut(&key) {
+            e.last_served = stamp;
+        }
+    }
+
+    /// Decide the largest window (≤ `desired`, ≤ per-stream cap) a stream may grow
+    /// to right now, given a current size of `old_len`. Evicts colder OTHER
+    /// streams as needed to make room for the `(window - old_len)` delta, but does
+    /// NOT charge — charging happens in `reconcile` against the ACTUAL bytes read.
+    /// Never blocks on a buffer mutex (`try_lock` + skip). Call only on a miss.
+    pub fn permitted_window(&self, key: usize, old_len: u64, desired: u64) -> u64 {
+        if self.budget == 0 {
+            return 0;
+        }
+        let desired = desired.min(self.per_stream_cap()).max(old_len);
+        let need = desired - old_len;
+        loop {
+            let cur = self.charged.load(Ordering::Relaxed);
+            let room = self.budget.saturating_sub(cur);
+            if room >= need {
+                return desired;
+            }
+            // Try to evict the coldest OTHER stream to free room.
+            match self.evict_one_coldest(key) {
+                Some(_) => {}
+                None => {
+                    // Nothing evictable: permit only what fits now.
+                    return old_len + room;
+                }
+            }
+        }
+    }
+
+    /// Charge the budget by the ACTUAL window-size change `(old_len → new_len)`.
+    /// Keeps the invariant `charged == Σ(registered buffers' bytes.len())`.
+    pub fn reconcile(&self, old_len: u64, new_len: u64) {
+        if new_len > old_len {
+            self.charged.fetch_add(new_len - old_len, Ordering::Relaxed);
+        } else if new_len < old_len {
+            self.charged.fetch_sub(old_len - new_len, Ordering::Relaxed);
+        }
+    }
+
+    /// Uncharge `bytes` directly (window cleared on invalidation/release).
+    pub fn uncharge(&self, bytes: u64) {
+        if bytes > 0 {
+            self.charged.fetch_sub(bytes, Ordering::Relaxed);
+        }
+    }
+
+    /// Find and clear the coldest registered buffer other than `except`, using
+    /// `try_lock` so eviction never blocks on an in-progress read. Returns the
+    /// freed byte count, or `None` if nothing was evictable this pass.
+    fn evict_one_coldest(&self, except: usize) -> Option<u64> {
+        let candidates: Vec<(usize, u64, Arc<Mutex<ReadAhead>>)> = {
+            let g = self.streams.lock().unwrap();
+            let mut v: Vec<_> = g
+                .iter()
+                .filter(|(k, _)| **k != except)
+                .map(|(k, e)| (*k, e.last_served, Arc::clone(&e.buf)))
+                .collect();
+            v.sort_by_key(|(_, ls, _)| *ls); // coldest (smallest stamp) first
+            v
+        };
+        for (_, _, buf) in candidates {
+            if let Ok(mut ra) = buf.try_lock() {
+                let freed = ra.clear();
+                if freed > 0 {
+                    self.charged.fetch_sub(freed, Ordering::Relaxed);
+                    return Some(freed);
+                }
+            }
+        }
+        None
+    }
+}
 
 /// A single contiguous read-ahead window over a backing file, keyed by absolute
 /// backing-file offset. NOT thread-safe; the caller wraps it in a `Mutex` (one
@@ -214,6 +368,45 @@ mod window_tests {
         assert!(
             off + len as u64 <= 700 * 1024,
             "fill must not read past EOF"
+        );
+    }
+}
+
+#[cfg(test)]
+mod pool_budget_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn disabled_pool_grants_nothing_and_reports_disabled() {
+        let pool = ReadAheadPool::new(0);
+        assert!(!pool.enabled());
+        assert_eq!(pool.per_stream_cap(), 0);
+    }
+
+    #[test]
+    fn per_stream_cap_is_budget_over_divisor_capped_by_abs() {
+        // 16 MiB budget / 4 = 4 MiB, below the 8 MiB abs cap.
+        let pool = ReadAheadPool::new(16 * 1024 * 1024);
+        assert_eq!(pool.per_stream_cap(), 4 * 1024 * 1024);
+        // Huge budget → abs cap wins.
+        let big = ReadAheadPool::new(1024 * 1024 * 1024);
+        assert_eq!(big.per_stream_cap(), WINDOW_ABS_CAP);
+    }
+
+    #[test]
+    fn permitted_window_grants_up_to_budget_then_clamps() {
+        let pool = ReadAheadPool::new(4 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        // Grow from 0 → 1 MiB: permitted fully, then charge the actual delta.
+        assert_eq!(pool.permitted_window(1, 0, 1024 * 1024), 1024 * 1024);
+        pool.reconcile(0, 1024 * 1024);
+        // charged is now 1 MiB; the per-stream cap is budget/4 = 1 MiB, so a
+        // request for 8 MiB is first capped to 1 MiB (== old_len) → no growth.
+        assert_eq!(
+            pool.permitted_window(1, 1024 * 1024, 8 * 1024 * 1024),
+            1024 * 1024
         );
     }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -348,6 +348,42 @@ pub fn prefetch_depth(cap: u64, window: u64) -> u64 {
     (cap / window.max(1)).clamp(1, 4)
 }
 
+/// Plan which next-windows to enqueue, deduplicating against `prefetched_upto`
+/// (the offset through which jobs were already dispatched for this stream).
+///
+/// Anchoring dispatch to the moving `next_expected` made every read re-request
+/// the same forward windows at shifted offsets — a pile of overlapping preads.
+/// Instead we fetch contiguous `window`-sized blocks from the watermark up to
+/// the horizon (`start + depth*window`), so a sequential reader enqueues only
+/// the freshly-exposed tail (≈ one window per window consumed). A seek — the
+/// reader landing before the watermark, or the watermark sitting beyond the new
+/// horizon — restarts dispatch from `start`. Returns the window-aligned start
+/// offsets and the new watermark.
+pub fn plan_prefetch(
+    prefetched_upto: u64,
+    start: u64,
+    window: u64,
+    depth: u64,
+    backing_len: u64,
+) -> (Vec<u64>, u64) {
+    if window == 0 || start >= backing_len {
+        return (Vec::new(), prefetched_upto);
+    }
+    let horizon = start
+        .saturating_add(depth.saturating_mul(window))
+        .min(backing_len);
+    let mut s = prefetched_upto;
+    if s < start || s > horizon {
+        s = start; // seek / fell behind: dispatch from the current position
+    }
+    let mut starts = Vec::new();
+    while s < horizon {
+        starts.push(s);
+        s += window;
+    }
+    (starts, s.min(backing_len))
+}
+
 use std::cell::Cell;
 use std::sync::mpsc;
 
@@ -836,6 +872,48 @@ mod ring_tests {
         for w in [WINDOW_FLOOR, 1 << 20, 2 << 20, 4 << 20, cap] {
             assert!(prefetch_depth(cap, w) * w <= cap, "overshoot at window {w}");
         }
+    }
+
+    /// A sequential stream must not re-request windows it already dispatched:
+    /// after the initial fan-out, each subsequent read enqueues only the newly
+    /// exposed tail (no overlapping preads).
+    #[test]
+    fn plan_prefetch_dedups_sequential_dispatch() {
+        let win = WINDOW_FLOOR;
+        let cap = 8 * 1024 * 1024;
+        let depth = prefetch_depth(cap, win); // 4
+        let blen = 100 * 1024 * 1024;
+        // First read ends at `win`; fan out `depth` windows ahead.
+        let (s1, w1) = plan_prefetch(0, win, win, depth, blen);
+        assert_eq!(s1, vec![win, 2 * win, 3 * win, 4 * win]);
+        assert_eq!(w1, 5 * win);
+        // Reader advanced ~half a window. The already-requested windows are
+        // skipped — only the single newly-exposed window is enqueued.
+        let start2 = win + win / 2;
+        let (s2, w2) = plan_prefetch(w1, start2, win, depth, blen);
+        assert_eq!(s2, vec![5 * win], "must not re-dispatch buffered windows");
+        assert_eq!(w2, 6 * win);
+    }
+
+    #[test]
+    fn plan_prefetch_seek_resets_watermark() {
+        let win = WINDOW_FLOOR;
+        let depth = 4;
+        let blen = 100 * 1024 * 1024;
+        let (_s, w) = plan_prefetch(0, 10 * win, win, depth, blen);
+        // Seek backward, well before the watermark: dispatch restarts at `start`.
+        let (s2, w2) = plan_prefetch(w, 2 * win, win, depth, blen);
+        assert_eq!(s2.first(), Some(&(2 * win)));
+        assert_eq!(w2, 6 * win);
+    }
+
+    #[test]
+    fn plan_prefetch_clamps_to_backing_len() {
+        let win = WINDOW_FLOOR;
+        let blen = 3 * win + 100;
+        let (s, w) = plan_prefetch(0, win, win, 4, blen);
+        assert!(s.iter().all(|&x| x < blen), "no job starts past EOF");
+        assert!(w <= blen, "watermark clamped to EOF");
     }
 
     #[test]

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -195,6 +195,7 @@ impl ReadAhead {
     }
 
     /// Bytes currently held (charged against the global budget).
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
         self.bytes.len() as u64
     }
@@ -305,6 +306,10 @@ impl<'a> BackingReader<'a> {
 
     pub fn fills(&self) -> u64 {
         self.fills.get()
+    }
+
+    pub fn file(&self) -> &std::fs::File {
+        self.file
     }
 
     pub fn read_exact_at(&self, dst: &mut [u8], abs_offset: u64) -> std::io::Result<()> {

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -274,6 +274,70 @@ impl ReadAhead {
     }
 }
 
+use std::cell::Cell;
+
+pub struct BackingReader<'a> {
+    file: &'a std::fs::File,
+    buf: &'a Arc<Mutex<ReadAhead>>,
+    pool: &'a ReadAheadPool,
+    key: usize,
+    backing_len: u64,
+    fills: Cell<u64>,
+}
+
+impl<'a> BackingReader<'a> {
+    pub fn new(
+        file: &'a std::fs::File,
+        buf: &'a Arc<Mutex<ReadAhead>>,
+        pool: &'a ReadAheadPool,
+        key: usize,
+        backing_len: u64,
+    ) -> Self {
+        BackingReader {
+            file,
+            buf,
+            pool,
+            key,
+            backing_len,
+            fills: Cell::new(0),
+        }
+    }
+
+    pub fn fills(&self) -> u64 {
+        self.fills.get()
+    }
+
+    pub fn read_exact_at(&self, dst: &mut [u8], abs_offset: u64) -> std::io::Result<()> {
+        if !self.pool.enabled() {
+            self.fills.set(self.fills.get() + 1);
+            crate::metrics::on_readahead_miss();
+            crate::metrics::on_pread(dst.len() as u64);
+            return crate::metrics::backing_read_exact_at(self.file, dst, abs_offset);
+        }
+        let mut ra = self.buf.lock().unwrap();
+        if ra.covers(abs_offset, dst.len()) {
+            crate::metrics::on_readahead_hit();
+        } else {
+            crate::metrics::on_readahead_miss();
+            let cap = self
+                .pool
+                .permitted_window(self.key, ra.len(), self.pool.per_stream_cap());
+            ra.set_cap(cap);
+        }
+        let file = self.file;
+        let fills = &self.fills;
+        let (old_len, new_len) = ra.read_into(dst, abs_offset, self.backing_len, |b, o| {
+            fills.set(fills.get() + 1);
+            crate::metrics::on_pread(b.len() as u64);
+            crate::metrics::backing_read_exact_at(file, b, o)
+        })?;
+        self.pool.reconcile(old_len, new_len);
+        drop(ra);
+        self.pool.touch(self.key);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod window_tests {
     use super::*;
@@ -471,5 +535,68 @@ mod eviction_tests {
         // Returns promptly: evicts the next-coldest unlocked victim instead.
         let granted = pool.permitted_window(5, 0, pool.per_stream_cap());
         assert!(granted > 0 && granted <= pool.per_stream_cap());
+    }
+
+    #[cfg(test)]
+    mod backing_reader_tests {
+        use super::*;
+        use std::io::Write;
+        use std::os::unix::fs::FileExt;
+        use std::sync::{Arc, Mutex};
+
+        #[expect(clippy::cast_possible_truncation)]
+        fn temp_file(len: usize) -> (tempfile::TempDir, std::fs::File, Vec<u8>) {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("backing.bin");
+            let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            std::fs::File::create(&path)
+                .unwrap()
+                .write_all(&data)
+                .unwrap();
+            let f = std::fs::File::open(&path).unwrap();
+            (dir, f, data)
+        }
+
+        #[test]
+        fn sequential_reads_collapse_to_one_pread_per_window() {
+            let (_d, file, data) = temp_file(4 * 1024 * 1024);
+            let pool = ReadAheadPool::new(64 * 1024 * 1024);
+            let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+            pool.register(1, Arc::clone(&buf));
+            let backing_len = data.len() as u64;
+            let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+            let mut out = vec![0u8; 64 * 1024];
+            #[expect(clippy::cast_possible_truncation)]
+            for chunk in 0..16u64 {
+                br.read_exact_at(&mut out, chunk * 64 * 1024).unwrap();
+                assert_eq!(out, data[(chunk * 64 * 1024) as usize..][..64 * 1024]);
+            }
+            assert!(
+                br.fills() < 16,
+                "read-ahead must collapse preads, got {}",
+                br.fills()
+            );
+        }
+
+        #[test]
+        fn bytes_match_direct_pread_for_random_access() {
+            let (_d, file, data) = temp_file(2 * 1024 * 1024);
+            let pool = ReadAheadPool::new(64 * 1024 * 1024);
+            let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+            pool.register(1, Arc::clone(&buf));
+            let br = BackingReader::new(&file, &buf, &pool, 1, data.len() as u64);
+            for &(off, len) in &[
+                (0u64, 100usize),
+                (1_000_000, 4096),
+                (5000, 700),
+                (2_097_000, 152),
+            ] {
+                let mut a = vec![0u8; len];
+                br.read_exact_at(&mut a, off).unwrap();
+                let mut b = vec![0u8; len];
+                file.read_exact_at(&mut b, off).unwrap();
+                assert_eq!(a, b, "read-ahead byte mismatch at {off}+{len}");
+            }
+        }
     }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -366,8 +366,10 @@ pub fn plan_prefetch(
         .saturating_add(depth.saturating_mul(window))
         .min(backing_len);
     let mut s = prefetched_upto;
-    if s < start || s > horizon {
-        s = start; // seek / fell behind: dispatch from the current position
+    // Outside [start, horizon] means a seek (reader moved before the watermark)
+    // or the watermark ran past the horizon: dispatch from the current position.
+    if !(start..=horizon).contains(&s) {
+        s = start;
     }
     let mut starts = Vec::new();
     while s < horizon {
@@ -1344,26 +1346,29 @@ mod mutation_guard_tests {
 
     #[test]
     fn permitted_window_need_is_relative_to_old_len() {
-        let pool = ReadAheadPool::new(2 << 20); // cap 512K
+        // budget 2 MiB → cap 512K. Charge all but one cap (nothing registered, so
+        // nothing is evictable), leaving room == cap. A stream at old_len = cap/4
+        // asks for cap: need = cap − cap/4 = 384K ≤ room → full grant. If `need`
+        // were `cap + cap/4` (640K > room) it would fall through to the clamp and
+        // return old_len + room (640K) instead.
+        let pool = ReadAheadPool::new(2 << 20);
         let cap = pool.per_stream_cap();
-        let b1 = Arc::new(Mutex::new(ReadAhead::new(cap)));
-        pool.register(1, Arc::clone(&b1));
-        pool.reconcile(0, cap); // stream 1 holds one cap; budget still has room
-        // need = cap - cap/2 fits in the free budget → full grant. If need used
-        // `cap + cap/2` it would exceed free room and clamp below cap.
-        assert_eq!(pool.permitted_window(2, cap / 2, cap), cap);
+        pool.reconcile(0, (2 << 20) - cap); // room == cap
+        assert_eq!(pool.permitted_window(2, cap / 4, cap), cap);
     }
 
     #[test]
     fn permitted_window_clamps_to_room_when_nothing_evictable() {
-        let pool = ReadAheadPool::new(WINDOW_FLOOR); // budget==cap==floor
+        // budget 2 MiB → cap 512K. Charge to leave room == 256K. A stream at
+        // old_len = 128K asks for cap: need = 384K > room, nothing evictable, so
+        // the grant clamps to old_len + room = 384K. `old_len − room` underflows.
+        let pool = ReadAheadPool::new(2 << 20);
         let cap = pool.per_stream_cap();
-        let locked = Arc::new(Mutex::new(ReadAhead::new(cap)));
-        pool.register(1, Arc::clone(&locked));
-        pool.reconcile(0, cap); // budget full
-        let _held = locked.lock().unwrap(); // un-evictable
-        // room == 0, nothing evictable → grant == old_len + room == old_len.
-        assert_eq!(pool.permitted_window(2, 1000, cap), 1000);
+        pool.reconcile(0, (2 << 20) - 256 * 1024); // room == 256K
+        assert_eq!(
+            pool.permitted_window(2, 128 * 1024, cap),
+            128 * 1024 + 256 * 1024
+        );
     }
 
     #[test]
@@ -1435,5 +1440,46 @@ mod mutation_guard_tests {
         assert_eq!(ep.load(AO::Relaxed), base, "sequential must not bump epoch");
         br.read_exact_at(&mut d, 900_000).unwrap(); // genuine seek (miss, off != next)
         assert_eq!(ep.load(AO::Relaxed), base + 1, "seek bumps epoch");
+    }
+
+    #[test]
+    fn ring_trim_evicts_window_fully_behind_the_reader() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_max_windows(2);
+        ra.store_window(0, vec![0u8; 1000]); // [0, 1000)
+        ra.store_window(1000, vec![0u8; 1000]); // [1000, 2000)
+        // Advance the reader to 2000 so both windows are fully behind it.
+        let mut dst = vec![0u8; 10];
+        ra.read_into(&mut dst, 1990, 1 << 20, fillb).unwrap(); // hit → next_expected = 2000
+        // A third window forces a trim: the victim is the fully-behind window with
+        // the smallest start ([0,1000)) — NOT the just-stored ahead window. The
+        // `<=` filter (`start+len <= frontier`) selects which windows are behind.
+        ra.store_window(2000, vec![0u8; 1000]); // [2000, 3000)
+        assert!(!ra.covers(0, 10), "fully-behind window evicted");
+        assert!(ra.covers(1000, 10), "nearer behind window kept");
+        assert!(ra.covers(2000, 10), "just-stored ahead window kept");
+    }
+
+    #[test]
+    fn plan_prefetch_no_jobs_when_watermark_at_horizon() {
+        // Watermark already at the horizon (start + depth*window): nothing new to
+        // dispatch. The `s > horizon` reset guard must NOT fire at s == horizon
+        // (`>=` would reset to start and re-queue the whole horizon).
+        let win = WINDOW_FLOOR;
+        let depth = 4;
+        let start = 10 * win;
+        let horizon = start + depth * win;
+        let (starts, upto) = plan_prefetch(horizon, start, win, depth, 100 << 20);
+        assert!(starts.is_empty(), "caught up to horizon → no jobs");
+        assert_eq!(upto, horizon);
+    }
+
+    #[test]
+    fn plan_prefetch_window_zero_leaves_watermark_unchanged() {
+        // window == 0 short-circuits via the `||` early-out, returning the
+        // watermark UNCHANGED. With `&&` it would fall through and return `start`.
+        let (starts, upto) = plan_prefetch(500, 1000, 0, 4, 1 << 20);
+        assert!(starts.is_empty());
+        assert_eq!(upto, 500);
     }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -410,3 +410,66 @@ mod pool_budget_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod eviction_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Build a buffer holding exactly `bytes` real backing bytes and register it
+    /// with the pool, charging the pool for those bytes (mirrors what a real miss
+    /// does via permitted_window + reconcile). `bytes` must be >= WINDOW_FLOOR for
+    /// the stored window to equal `bytes`.
+    fn register_filled(pool: &ReadAheadPool, key: usize, bytes: usize) -> Arc<Mutex<ReadAhead>> {
+        let arc = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let data = vec![7u8; bytes * 2];
+        let mut dst = vec![0u8; bytes];
+        let (old, new) = arc
+            .lock()
+            .unwrap()
+            .read_into(&mut dst, 0, (bytes * 2) as u64, |b, _| {
+                b.copy_from_slice(&data[..b.len()]);
+                Ok(())
+            })
+            .unwrap();
+        pool.register(key, Arc::clone(&arc));
+        pool.reconcile(old, new);
+        arc
+    }
+
+    #[test]
+    fn permitted_window_evicts_coldest_other_stream_under_pressure() {
+        // Budget 4 MiB, per-stream cap 1 MiB. Fill the budget with four 1 MiB
+        // streams (registered keys 1..4, so key 1 is coldest), then a fifth stream
+        // wants to grow → must evict the coldest (key 1).
+        let pool = ReadAheadPool::new(4 * 1024 * 1024);
+        let mib = 1024 * 1024usize;
+        let cold = register_filled(&pool, 1, mib);
+        register_filled(&pool, 2, mib);
+        register_filled(&pool, 3, mib);
+        register_filled(&pool, 4, mib);
+        // Budget is now full (4 x 1 MiB). A fresh hot stream wants 1 MiB.
+        let hot = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(5, Arc::clone(&hot));
+        let granted = pool.permitted_window(5, 0, pool.per_stream_cap());
+        assert_eq!(granted, mib as u64, "eviction frees room for the full cap");
+        assert_eq!(cold.lock().unwrap().len(), 0, "coldest stream was evicted");
+    }
+
+    #[test]
+    fn locked_victim_is_skipped_not_blocked() {
+        let pool = ReadAheadPool::new(4 * 1024 * 1024);
+        let mib = 1024 * 1024;
+        let victim = register_filled(&pool, 1, mib);
+        register_filled(&pool, 2, mib);
+        register_filled(&pool, 3, mib);
+        register_filled(&pool, 4, mib);
+        // Hold the coldest victim's lock: eviction must skip it (try_lock), not hang.
+        let _held = victim.lock().unwrap();
+        let hot = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(5, Arc::clone(&hot));
+        // Returns promptly: evicts the next-coldest unlocked victim instead.
+        let granted = pool.permitted_window(5, 0, pool.per_stream_cap());
+        assert!(granted > 0 && granted <= pool.per_stream_cap());
+    }
+}

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -313,6 +313,70 @@ pub fn try_store_prefetch(
 }
 
 use std::cell::Cell;
+use std::sync::mpsc;
+
+pub struct PrefetchJob {
+    pub file: Arc<std::fs::File>,
+    pub buf: Arc<Mutex<ReadAhead>>,
+    pub epoch: Arc<std::sync::atomic::AtomicU64>,
+    pub dispatched_epoch: u64,
+    pub start: u64,
+    pub len: u64,
+    pub backing_len: u64,
+}
+
+pub struct PrefetchWorkers {
+    tx: mpsc::SyncSender<PrefetchJob>,
+    #[cfg(test)]
+    handles: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl PrefetchWorkers {
+    pub fn new(threads: usize) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<PrefetchJob>(threads * 4);
+        let rx = Arc::new(Mutex::new(rx));
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let rx = Arc::clone(&rx);
+            let h = std::thread::spawn(move || {
+                while let Ok(job) = {
+                    let g = rx.lock().unwrap();
+                    g.recv()
+                } {
+                    Self::run_job(job);
+                }
+            });
+            handles.push(h);
+        }
+        PrefetchWorkers {
+            tx,
+            #[cfg(test)]
+            handles,
+        }
+    }
+
+    #[expect(clippy::needless_pass_by_value)]
+    pub fn run_job(job: PrefetchJob) {
+        use std::os::unix::fs::FileExt;
+        if job.epoch.load(std::sync::atomic::Ordering::Acquire) != job.dispatched_epoch {
+            return;
+        }
+        let want = job.len.min(job.backing_len.saturating_sub(job.start));
+        if want == 0 {
+            return;
+        }
+        #[expect(clippy::cast_possible_truncation)]
+        let mut bytes = vec![0u8; want as usize];
+        if job.file.read_exact_at(&mut bytes, job.start).is_err() {
+            return;
+        }
+        let _ = try_store_prefetch(&job.buf, &job.epoch, job.dispatched_epoch, job.start, bytes);
+    }
+
+    pub fn request(&self, job: PrefetchJob) {
+        let _ = self.tx.try_send(job);
+    }
+}
 
 pub struct BackingReader<'a> {
     file: &'a std::fs::File,
@@ -321,6 +385,7 @@ pub struct BackingReader<'a> {
     key: usize,
     backing_len: u64,
     fills: Cell<u64>,
+    epoch: &'a std::sync::atomic::AtomicU64,
 }
 
 impl<'a> BackingReader<'a> {
@@ -330,6 +395,7 @@ impl<'a> BackingReader<'a> {
         pool: &'a ReadAheadPool,
         key: usize,
         backing_len: u64,
+        epoch: &'a std::sync::atomic::AtomicU64,
     ) -> Self {
         BackingReader {
             file,
@@ -338,6 +404,7 @@ impl<'a> BackingReader<'a> {
             key,
             backing_len,
             fills: Cell::new(0),
+            epoch,
         }
     }
 
@@ -361,6 +428,9 @@ impl<'a> BackingReader<'a> {
             crate::metrics::on_readahead_hit();
         } else {
             crate::metrics::on_readahead_miss();
+            if abs_offset != ra.next_expected() {
+                self.epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            }
             let cap = self
                 .pool
                 .permitted_window(self.key, ra.len(), self.pool.per_stream_cap());
@@ -606,7 +676,8 @@ mod eviction_tests {
             let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
             pool.register(1, Arc::clone(&buf));
             let backing_len = data.len() as u64;
-            let br = BackingReader::new(&file, &buf, &pool, 1, backing_len);
+            let epoch = std::sync::atomic::AtomicU64::new(0);
+            let br = BackingReader::new(&file, &buf, &pool, 1, backing_len, &epoch);
             let mut out = vec![0u8; 64 * 1024];
             #[expect(clippy::cast_possible_truncation)]
             for chunk in 0..16u64 {
@@ -626,7 +697,8 @@ mod eviction_tests {
             let pool = ReadAheadPool::new(64 * 1024 * 1024);
             let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
             pool.register(1, Arc::clone(&buf));
-            let br = BackingReader::new(&file, &buf, &pool, 1, data.len() as u64);
+            let epoch = std::sync::atomic::AtomicU64::new(0);
+            let br = BackingReader::new(&file, &buf, &pool, 1, data.len() as u64, &epoch);
             for &(off, len) in &[
                 (0u64, 100usize),
                 (1_000_000, 4096),
@@ -727,5 +799,49 @@ mod prefetch_store_tests {
         let epoch = AtomicU64::new(5);
         assert!(try_store_prefetch(&ra, &epoch, 5, 1000, vec![0u8; 4096]));
         assert!(ra.lock().unwrap().covers(1000, 4096));
+    }
+}
+
+#[cfg(test)]
+mod prefetch_worker_tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn prefetch_fills_next_window_for_a_sequential_stream() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("b.bin");
+        let data: Vec<u8> = (0u64..8 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        let file = Arc::new(std::fs::File::open(&path).unwrap());
+
+        let pool = Arc::new(ReadAheadPool::new(64 * 1024 * 1024));
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        pool.register(1, Arc::clone(&buf));
+
+        PrefetchWorkers::run_job(PrefetchJob {
+            file: Arc::clone(&file),
+            buf: Arc::clone(&buf),
+            epoch: Arc::clone(&epoch),
+            dispatched_epoch: 0,
+            start: 1024 * 1024,
+            len: 1024 * 1024,
+            backing_len: data.len() as u64,
+        });
+        let mut out = vec![0u8; 4096];
+        let mut ra = buf.lock().unwrap();
+        let mut fills = 0;
+        ra.read_into(&mut out, 1024 * 1024, data.len() as u64, |_, _| {
+            fills += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(fills, 0, "prefetched window should serve without a pread");
+        assert_eq!(out, data[1024 * 1024..1024 * 1024 + 4096]);
     }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -206,6 +206,22 @@ impl ReadAhead {
         self.window
     }
 
+    /// First backing offset at or after `from` that is NOT resident — i.e. the
+    /// end of the contiguous run of cached windows covering `from`. Prefetch
+    /// starts here (not at the read cursor) so it never re-requests bytes a
+    /// window-filling miss already pulled in synchronously.
+    pub fn frontier(&self, from: u64) -> u64 {
+        let mut f = from;
+        while let Some(w) = self
+            .windows
+            .iter()
+            .find(|w| w.start <= f && f < w.start + w.bytes.len() as u64)
+        {
+            f = w.start + w.bytes.len() as u64;
+        }
+        f
+    }
+
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
         self.windows.iter().map(|w| w.bytes.len() as u64).sum()

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -1,0 +1,219 @@
+//! Per-handle backing read-ahead: an adaptive window over raw backing-file
+//! bytes, a global byte budget with eviction, and the `BackingReader` shim that
+//! every backing read flows through. See
+//! `docs/superpowers/specs/2026-06-14-read-ahead-overlap-design.md`.
+
+use std::io;
+
+/// Floor window size: a fresh or just-seeked stream still reads this much ahead.
+pub const WINDOW_FLOOR: u64 = 512 * 1024;
+/// Absolute per-stream window cap, independent of the global budget.
+pub const WINDOW_ABS_CAP: u64 = 8 * 1024 * 1024;
+
+/// A single contiguous read-ahead window over a backing file, keyed by absolute
+/// backing-file offset. NOT thread-safe; the caller wraps it in a `Mutex` (one
+/// per open handle). Caches raw backing bytes only — never synthesized output —
+/// so it is immune to retag and orthogonal to the DB snapshot path.
+pub struct ReadAhead {
+    /// Absolute backing offset of `bytes[0]`. Meaningless when `bytes` is empty.
+    win_start: u64,
+    /// Buffered raw backing bytes covering `[win_start, win_start + bytes.len())`.
+    bytes: Vec<u8>,
+    /// Backing offset just past the last served read — the sequential predictor.
+    /// `u64::MAX` until the first read, so the first read is always a (seek) miss.
+    next_expected: u64,
+    /// Current target window size; grows geometrically on a sequential miss,
+    /// resets to the floor on a seek. Bounded by `cap`.
+    window: u64,
+    /// Per-stream window cap (set from the budget: `min(WINDOW_ABS_CAP, budget/N)`).
+    cap: u64,
+}
+
+impl ReadAhead {
+    pub fn new(cap: u64) -> Self {
+        ReadAhead {
+            win_start: 0,
+            bytes: Vec::new(),
+            next_expected: u64::MAX,
+            window: WINDOW_FLOOR,
+            cap,
+        }
+    }
+
+    /// Bytes currently held (charged against the global budget).
+    pub fn len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    /// Drop the buffered bytes (eviction / invalidation). Returns bytes freed.
+    pub fn clear(&mut self) -> u64 {
+        let freed = self.bytes.len() as u64;
+        self.bytes = Vec::new();
+        self.window = WINDOW_FLOOR.min(self.cap);
+        self.next_expected = u64::MAX;
+        freed
+    }
+
+    /// Update the per-stream cap (when the budget share changes). No floor — see
+    /// `new`: a sub-floor cap must shrink the window, not be silently raised.
+    pub fn set_cap(&mut self, cap: u64) {
+        self.cap = cap;
+        if self.window > self.cap {
+            self.window = self.cap;
+        }
+    }
+
+    fn covers(&self, off: u64, len: usize) -> bool {
+        let end = off.saturating_add(len as u64);
+        !self.bytes.is_empty()
+            && off >= self.win_start
+            && end <= self.win_start + self.bytes.len() as u64
+    }
+
+    /// Serve `[off, off+dst.len())` into `dst`. On a hit, memcpy from the window.
+    /// On a miss, `fill(window_buf, start)` does ONE positioned read of up to
+    /// `window` bytes (clamped to `backing_len`) starting at `off`. `backing_len`
+    /// is the backing file size; the caller guarantees `off+dst.len() <=
+    /// backing_len` (the splice loop already clamps the request).
+    ///
+    /// Returns `(old_len, new_len)` of `self.bytes` so the caller can reconcile
+    /// the global budget. A hit returns `(n, n)` (no change).
+    pub fn read_into(
+        &mut self,
+        dst: &mut [u8],
+        off: u64,
+        backing_len: u64,
+        mut fill: impl FnMut(&mut [u8], u64) -> io::Result<()>,
+    ) -> io::Result<(u64, u64)> {
+        let len = dst.len();
+        if len == 0 {
+            return Ok((self.bytes.len() as u64, self.bytes.len() as u64));
+        }
+        if self.covers(off, len) {
+            #[expect(clippy::cast_possible_truncation)]
+            let lo = (off - self.win_start) as usize;
+            dst.copy_from_slice(&self.bytes[lo..lo + len]);
+            self.next_expected = off + len as u64;
+            let n = self.bytes.len() as u64;
+            return Ok((n, n));
+        }
+        let old_len = self.bytes.len() as u64;
+        if off == self.next_expected {
+            self.window = self.window.saturating_mul(2).min(self.cap);
+        } else {
+            self.window = WINDOW_FLOOR.min(self.cap);
+        }
+        debug_assert!(off < backing_len && off + len as u64 <= backing_len);
+        let want = self
+            .window
+            .max(len as u64)
+            .min(self.cap.max(len as u64))
+            .min(backing_len.saturating_sub(off));
+        #[expect(clippy::cast_possible_truncation)]
+        let mut buf = vec![0u8; want as usize];
+        fill(&mut buf, off)?;
+        dst.copy_from_slice(&buf[..len]);
+        self.win_start = off;
+        self.bytes = buf;
+        self.next_expected = off + len as u64;
+        Ok((old_len, self.bytes.len() as u64))
+    }
+}
+
+#[cfg(test)]
+mod window_tests {
+    use super::*;
+
+    /// A fake backing file: `data` is the whole file; `fill` copies from it and
+    /// records each (offset, len) actually read so tests can assert pread counts.
+    struct Fake {
+        data: Vec<u8>,
+        reads: Vec<(u64, usize)>,
+    }
+    impl Fake {
+        fn new(len: usize) -> Self {
+            #[expect(clippy::cast_possible_truncation)]
+            let data = (0..len).map(|i| (i % 251) as u8).collect();
+            Fake {
+                data,
+                reads: Vec::new(),
+            }
+        }
+        #[expect(clippy::unnecessary_wraps)]
+        fn fill(&mut self, buf: &mut [u8], off: u64) -> io::Result<()> {
+            self.reads.push((off, buf.len()));
+            #[expect(clippy::cast_possible_truncation)]
+            let o = off as usize;
+            buf.copy_from_slice(&self.data[o..o + buf.len()]);
+            Ok(())
+        }
+    }
+
+    fn serve(ra: &mut ReadAhead, fake: &mut Fake, off: u64, len: usize) -> Vec<u8> {
+        let mut dst = vec![0u8; len];
+        let backing_len = fake.data.len() as u64;
+        ra.read_into(&mut dst, off, backing_len, |b, o| fake.fill(b, o))
+            .unwrap();
+        dst
+    }
+
+    #[test]
+    fn first_read_misses_then_sequential_reads_hit() {
+        let mut fake = Fake::new(4 * 1024 * 1024);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        // First 64 KiB read: a miss, fills a floor-sized window.
+        let a = serve(&mut ra, &mut fake, 0, 64 * 1024);
+        assert_eq!(a, fake.data[0..64 * 1024]);
+        assert_eq!(fake.reads.len(), 1, "first read must fill once");
+        // Next sequential 64 KiB: fully inside the window → no new pread.
+        let b = serve(&mut ra, &mut fake, 64 * 1024, 64 * 1024);
+        assert_eq!(b, fake.data[64 * 1024..128 * 1024]);
+        assert_eq!(fake.reads.len(), 1, "sequential hit must not pread");
+    }
+
+    #[test]
+    fn sequential_miss_grows_window_geometrically() {
+        let mut fake = Fake::new(16 * 1024 * 1024);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        // Read the full floor window, forcing a sequential miss at its end each time.
+        #[expect(clippy::cast_possible_truncation)]
+        let floor = WINDOW_FLOOR as usize;
+        serve(&mut ra, &mut fake, 0, floor); // miss, window stays floor (first fill)
+        serve(&mut ra, &mut fake, WINDOW_FLOOR, floor); // seq miss → window doubles
+        // The second fill must have requested > floor bytes (geometric growth).
+        let second_fill_len = fake.reads[1].1 as u64;
+        assert!(
+            second_fill_len > WINDOW_FLOOR,
+            "window must grow on sequential miss"
+        );
+        assert!(second_fill_len <= WINDOW_ABS_CAP, "window capped");
+    }
+
+    #[test]
+    fn seek_resets_window_to_floor() {
+        let mut fake = Fake::new(16 * 1024 * 1024);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        #[expect(clippy::cast_possible_truncation)]
+        serve(&mut ra, &mut fake, 0, WINDOW_FLOOR as usize);
+        #[expect(clippy::cast_possible_truncation)]
+        serve(&mut ra, &mut fake, WINDOW_FLOOR, WINDOW_FLOOR as usize); // grow
+        // Seek far away → next fill is floor-sized again.
+        serve(&mut ra, &mut fake, 12 * 1024 * 1024, 4096);
+        let seek_fill_len = fake.reads.last().unwrap().1 as u64;
+        assert_eq!(seek_fill_len, WINDOW_FLOOR, "seek resets to floor");
+    }
+
+    #[test]
+    fn window_clamps_to_backing_len_at_eof() {
+        let mut fake = Fake::new(700 * 1024); // smaller than abs cap
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        // Read near EOF: requested range valid, but a full window would overrun.
+        let out = serve(&mut ra, &mut fake, 680 * 1024, 20 * 1024);
+        assert_eq!(out, fake.data[680 * 1024..700 * 1024]);
+        let (off, len) = fake.reads[0];
+        assert!(
+            off + len as u64 <= 700 * 1024,
+            "fill must not read past EOF"
+        );
+    }
+}

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::io;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64 as Epoch, Ordering as O};
 use std::sync::{Arc, Mutex};
 
 /// Floor window size: a fresh or just-seeked stream still reads this much ahead.
@@ -32,20 +32,20 @@ pub struct ReadAheadPool {
     /// Total RAM envelope; `0` means read-ahead is disabled.
     budget: u64,
     /// Currently charged bytes (sum of registered buffers' lengths).
-    charged: AtomicU64,
+    charged: Epoch,
     /// Active streaming handles keyed by slab key. Only sequential streams register.
     streams: Mutex<HashMap<usize, StreamEntry>>,
     /// Monotonic source for `last_served` stamps (LRU ordering).
-    clock: AtomicU64,
+    clock: Epoch,
 }
 
 impl ReadAheadPool {
     pub fn new(budget: u64) -> Self {
         ReadAheadPool {
             budget,
-            charged: AtomicU64::new(0),
+            charged: Epoch::new(0),
             streams: Mutex::new(HashMap::new()),
-            clock: AtomicU64::new(0),
+            clock: Epoch::new(0),
         }
     }
 
@@ -63,7 +63,7 @@ impl ReadAheadPool {
 
     /// Lazily register a handle's buffer once sequential access is detected.
     pub fn register(&self, key: usize, buf: Arc<Mutex<ReadAhead>>) {
-        let last_served = self.clock.fetch_add(1, Ordering::Relaxed);
+        let last_served = self.clock.fetch_add(1, O::Relaxed);
         self.streams
             .lock()
             .unwrap()
@@ -80,13 +80,13 @@ impl ReadAheadPool {
             }
         };
         if freed > 0 {
-            self.charged.fetch_sub(freed, Ordering::Relaxed);
+            self.charged.fetch_sub(freed, O::Relaxed);
         }
     }
 
     /// Mark `key` as most-recently-served (LRU bump). No-op if unregistered.
     pub fn touch(&self, key: usize) {
-        let stamp = self.clock.fetch_add(1, Ordering::Relaxed);
+        let stamp = self.clock.fetch_add(1, O::Relaxed);
         if let Some(e) = self.streams.lock().unwrap().get_mut(&key) {
             e.last_served = stamp;
         }
@@ -104,7 +104,7 @@ impl ReadAheadPool {
         let desired = desired.min(self.per_stream_cap()).max(old_len);
         let need = desired - old_len;
         loop {
-            let cur = self.charged.load(Ordering::Relaxed);
+            let cur = self.charged.load(O::Relaxed);
             let room = self.budget.saturating_sub(cur);
             if room >= need {
                 return desired;
@@ -124,16 +124,16 @@ impl ReadAheadPool {
     /// Keeps the invariant `charged == Σ(registered buffers' bytes.len())`.
     pub fn reconcile(&self, old_len: u64, new_len: u64) {
         if new_len > old_len {
-            self.charged.fetch_add(new_len - old_len, Ordering::Relaxed);
+            self.charged.fetch_add(new_len - old_len, O::Relaxed);
         } else if new_len < old_len {
-            self.charged.fetch_sub(old_len - new_len, Ordering::Relaxed);
+            self.charged.fetch_sub(old_len - new_len, O::Relaxed);
         }
     }
 
     /// Uncharge `bytes` directly (window cleared on invalidation/release).
     pub fn uncharge(&self, bytes: u64) {
         if bytes > 0 {
-            self.charged.fetch_sub(bytes, Ordering::Relaxed);
+            self.charged.fetch_sub(bytes, O::Relaxed);
         }
     }
 
@@ -155,7 +155,7 @@ impl ReadAheadPool {
             if let Ok(mut ra) = buf.try_lock() {
                 let freed = ra.clear();
                 if freed > 0 {
-                    self.charged.fetch_sub(freed, Ordering::Relaxed);
+                    self.charged.fetch_sub(freed, O::Relaxed);
                     return Some(freed);
                 }
             }
@@ -164,53 +164,47 @@ impl ReadAheadPool {
     }
 }
 
-/// A single contiguous read-ahead window over a backing file, keyed by absolute
-/// backing-file offset. NOT thread-safe; the caller wraps it in a `Mutex` (one
-/// per open handle). Caches raw backing bytes only — never synthesized output —
-/// so it is immune to retag and orthogonal to the DB snapshot path.
-pub struct ReadAhead {
-    /// Absolute backing offset of `bytes[0]`. Meaningless when `bytes` is empty.
-    win_start: u64,
-    /// Buffered raw backing bytes covering `[win_start, win_start + bytes.len())`.
+struct Window {
+    start: u64,
     bytes: Vec<u8>,
-    /// Backing offset just past the last served read — the sequential predictor.
-    /// `u64::MAX` until the first read, so the first read is always a (seek) miss.
+}
+
+pub struct ReadAhead {
+    windows: Vec<Window>,
     next_expected: u64,
-    /// Current target window size; grows geometrically on a sequential miss,
-    /// resets to the floor on a seek. Bounded by `cap`.
     window: u64,
-    /// Per-stream window cap (set from the budget: `min(WINDOW_ABS_CAP, budget/N)`).
     cap: u64,
+    max_windows: usize,
 }
 
 impl ReadAhead {
     pub fn new(cap: u64) -> Self {
         ReadAhead {
-            win_start: 0,
-            bytes: Vec::new(),
+            windows: Vec::new(),
             next_expected: u64::MAX,
             window: WINDOW_FLOOR,
             cap,
+            max_windows: 1,
         }
     }
-
-    /// Bytes currently held (charged against the global budget).
-    #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> u64 {
-        self.bytes.len() as u64
+    pub fn set_max_windows(&mut self, n: usize) {
+        self.max_windows = n.max(1);
+    }
+    pub fn next_expected(&self) -> u64 {
+        self.next_expected
     }
 
-    /// Drop the buffered bytes (eviction / invalidation). Returns bytes freed.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> u64 {
+        self.windows.iter().map(|w| w.bytes.len() as u64).sum()
+    }
     pub fn clear(&mut self) -> u64 {
-        let freed = self.bytes.len() as u64;
-        self.bytes = Vec::new();
+        let freed = self.len();
+        self.windows.clear();
         self.window = WINDOW_FLOOR.min(self.cap);
         self.next_expected = u64::MAX;
         freed
     }
-
-    /// Update the per-stream cap (when the budget share changes). No floor — see
-    /// `new`: a sub-floor cap must shrink the window, not be silently raised.
     pub fn set_cap(&mut self, cap: u64) {
         self.cap = cap;
         if self.window > self.cap {
@@ -218,21 +212,46 @@ impl ReadAhead {
         }
     }
 
-    fn covers(&self, off: u64, len: usize) -> bool {
+    pub fn covers(&self, off: u64, len: usize) -> bool {
         let end = off.saturating_add(len as u64);
-        !self.bytes.is_empty()
-            && off >= self.win_start
-            && end <= self.win_start + self.bytes.len() as u64
+        self.windows
+            .iter()
+            .any(|w| off >= w.start && end <= w.start + w.bytes.len() as u64)
     }
 
-    /// Serve `[off, off+dst.len())` into `dst`. On a hit, memcpy from the window.
-    /// On a miss, `fill(window_buf, start)` does ONE positioned read of up to
-    /// `window` bytes (clamped to `backing_len`) starting at `off`. `backing_len`
-    /// is the backing file size; the caller guarantees `off+dst.len() <=
-    /// backing_len` (the splice loop already clamps the request).
-    ///
-    /// Returns `(old_len, new_len)` of `self.bytes` so the caller can reconcile
-    /// the global budget. A hit returns `(n, n)` (no change).
+    fn window_containing(&self, off: u64, len: usize) -> Option<&Window> {
+        let end = off.saturating_add(len as u64);
+        self.windows
+            .iter()
+            .find(|w| off >= w.start && end <= w.start + w.bytes.len() as u64)
+    }
+
+    fn insert_window(&mut self, w: Window) {
+        if let Some(slot) = self.windows.iter_mut().find(|x| x.start == w.start) {
+            *slot = w;
+        } else {
+            self.windows.push(w);
+        }
+        self.windows.sort_by_key(|x| x.start);
+        while self.windows.len() > self.max_windows {
+            let frontier = self.next_expected;
+            let idx = self
+                .windows
+                .iter()
+                .enumerate()
+                .filter(|(_, w)| w.start + w.bytes.len() as u64 <= frontier)
+                .min_by_key(|(_, w)| w.start)
+                .map_or(0, |(i, _)| i);
+            self.windows.remove(idx);
+        }
+    }
+
+    pub fn store_window(&mut self, start: u64, bytes: Vec<u8>) -> (u64, u64) {
+        let old = self.len();
+        self.insert_window(Window { start, bytes });
+        (old, self.len())
+    }
+
     pub fn read_into(
         &mut self,
         dst: &mut [u8],
@@ -242,17 +261,18 @@ impl ReadAhead {
     ) -> io::Result<(u64, u64)> {
         let len = dst.len();
         if len == 0 {
-            return Ok((self.bytes.len() as u64, self.bytes.len() as u64));
-        }
-        if self.covers(off, len) {
-            #[expect(clippy::cast_possible_truncation)]
-            let lo = (off - self.win_start) as usize;
-            dst.copy_from_slice(&self.bytes[lo..lo + len]);
-            self.next_expected = off + len as u64;
-            let n = self.bytes.len() as u64;
+            let n = self.len();
             return Ok((n, n));
         }
-        let old_len = self.bytes.len() as u64;
+        if let Some(w) = self.window_containing(off, len) {
+            #[expect(clippy::cast_possible_truncation)]
+            let lo = (off - w.start) as usize;
+            dst.copy_from_slice(&w.bytes[lo..lo + len]);
+            self.next_expected = off + len as u64;
+            let n = self.len();
+            return Ok((n, n));
+        }
+        let old = self.len();
         if off == self.next_expected {
             self.window = self.window.saturating_mul(2).min(self.cap);
         } else {
@@ -268,11 +288,28 @@ impl ReadAhead {
         let mut buf = vec![0u8; want as usize];
         fill(&mut buf, off)?;
         dst.copy_from_slice(&buf[..len]);
-        self.win_start = off;
-        self.bytes = buf;
+        self.insert_window(Window {
+            start: off,
+            bytes: buf,
+        });
         self.next_expected = off + len as u64;
-        Ok((old_len, self.bytes.len() as u64))
+        Ok((old, self.len()))
     }
+}
+
+pub fn try_store_prefetch(
+    buf: &Arc<Mutex<ReadAhead>>,
+    epoch: &Epoch,
+    dispatched_epoch: u64,
+    start: u64,
+    bytes: Vec<u8>,
+) -> bool {
+    let mut ra = buf.lock().unwrap();
+    if epoch.load(O::Acquire) != dispatched_epoch {
+        return false;
+    }
+    ra.store_window(start, bytes);
+    true
 }
 
 use std::cell::Cell;
@@ -603,5 +640,92 @@ mod eviction_tests {
                 assert_eq!(a, b, "read-ahead byte mismatch at {off}+{len}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod ring_tests {
+    use super::*;
+
+    #[test]
+    fn default_ring_holds_one_window_like_phase1() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        let data = (0..2 * 1024 * 1024u64)
+            .map(|i| (i % 251) as u8)
+            .collect::<Vec<u8>>();
+        let blen = data.len() as u64;
+        let mut dst = vec![0u8; 4096];
+        ra.read_into(&mut dst, 0, blen, |b, o| {
+            #[expect(clippy::cast_possible_truncation)]
+            let o = o as usize;
+            b.copy_from_slice(&data[o..][..b.len()]);
+            Ok(())
+        })
+        .unwrap();
+        ra.read_into(&mut dst, 1_000_000, blen, |b, o| {
+            #[expect(clippy::cast_possible_truncation)]
+            let o = o as usize;
+            b.copy_from_slice(&data[o..][..b.len()]);
+            Ok(())
+        })
+        .unwrap();
+        assert!(
+            !ra.covers(0, 4096),
+            "single-window ring evicts the old window"
+        );
+        assert!(ra.covers(1_000_000, 4096));
+    }
+
+    #[test]
+    fn ring_of_two_keeps_current_and_prefetched_window() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_max_windows(2);
+        ra.store_window(1024 * 1024, vec![9u8; 512 * 1024]);
+        let mut dst = vec![0u8; 4096];
+        ra.read_into(&mut dst, 0, 4 * 1024 * 1024, |b, _| {
+            b.fill(1u8);
+            Ok(())
+        })
+        .unwrap();
+        assert!(ra.covers(0, 4096), "current window present");
+        assert!(
+            ra.covers(1024 * 1024, 4096),
+            "prefetched window NOT clobbered"
+        );
+    }
+
+    #[test]
+    fn len_sums_all_windows_and_clear_drops_all() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_max_windows(3);
+        ra.store_window(0, vec![0u8; 100]);
+        ra.store_window(1000, vec![0u8; 200]);
+        assert_eq!(ra.len(), 300);
+        assert_eq!(ra.clear(), 300);
+        assert_eq!(ra.len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod prefetch_store_tests {
+    use super::*;
+    use std::sync::atomic::AtomicU64;
+
+    #[test]
+    fn store_with_stale_epoch_is_discarded() {
+        let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
+        let epoch = AtomicU64::new(0);
+        epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        assert!(!try_store_prefetch(&ra, &epoch, 0, 0, vec![1, 2, 3]));
+        assert_eq!(ra.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn store_with_current_epoch_is_accepted() {
+        let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
+        ra.lock().unwrap().set_max_windows(2);
+        let epoch = AtomicU64::new(5);
+        assert!(try_store_prefetch(&ra, &epoch, 5, 1000, vec![0u8; 4096]));
+        assert!(ra.lock().unwrap().covers(1000, 4096));
     }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -206,22 +206,6 @@ impl ReadAhead {
         self.window
     }
 
-    /// First backing offset at or after `from` that is NOT resident — i.e. the
-    /// end of the contiguous run of cached windows covering `from`. Prefetch
-    /// starts here (not at the read cursor) so it never re-requests bytes a
-    /// window-filling miss already pulled in synchronously.
-    pub fn frontier(&self, from: u64) -> u64 {
-        let mut f = from;
-        while let Some(w) = self
-            .windows
-            .iter()
-            .find(|w| w.start <= f && f < w.start + w.bytes.len() as u64)
-        {
-            f = w.start + w.bytes.len() as u64;
-        }
-        f
-    }
-
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
         self.windows.iter().map(|w| w.bytes.len() as u64).sum()

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -845,3 +845,62 @@ mod prefetch_worker_tests {
         assert_eq!(out, data[1024 * 1024..1024 * 1024 + 4096]);
     }
 }
+
+#[cfg(test)]
+mod concurrency_tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::FileExt;
+    use std::sync::Arc;
+
+    #[test]
+    fn concurrent_reads_same_handle_match_oracle() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("concurrent.bin");
+        #[expect(clippy::cast_sign_loss)]
+        let data: Vec<u8> = (0..4 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        let file = Arc::new(std::fs::File::open(&path).unwrap());
+
+        let pool = Arc::new(ReadAheadPool::new(64 * 1024 * 1024));
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        pool.register(1, Arc::clone(&buf));
+
+        let backing_len = data.len() as u64;
+        let num_threads: u64 = 8;
+        let reads_per_thread = 200;
+
+        std::thread::scope(|s| {
+            for tid in 0..num_threads {
+                let file = Arc::clone(&file);
+                let buf = Arc::clone(&buf);
+                let pool = Arc::clone(&pool);
+                let epoch = Arc::clone(&epoch);
+                s.spawn(move || {
+                    let br = BackingReader::new(&file, &buf, &pool, 1, backing_len, &epoch);
+                    let mut rng_state: u64 = tid * 7919;
+                    for _ in 0..reads_per_thread {
+                        rng_state = rng_state
+                            .wrapping_mul(6_364_136_223_846_793_005)
+                            .wrapping_add(1);
+                        let off = rng_state % (backing_len.saturating_sub(4096).max(1));
+                        #[expect(clippy::cast_possible_truncation)]
+                        let len = 4096usize.min((backing_len - off) as usize);
+                        let mut got = vec![0u8; len];
+                        br.read_exact_at(&mut got, off).unwrap();
+                        let mut expected = vec![0u8; len];
+                        file.read_exact_at(&mut expected, off).unwrap();
+                        assert_eq!(
+                            got, expected,
+                            "mismatch at off={off} len={len} from thread {tid}"
+                        );
+                    }
+                });
+            }
+        });
+    }
+}

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -1116,4 +1116,94 @@ mod concurrency_tests {
             }
         });
     }
+
+    /// Stress the Phase-2 surface single-stream tests miss: worker-side
+    /// `run_job` (store + budget `reconcile`) racing reads, while a second
+    /// contended stream forces cross-buffer `try_lock` eviction — all hammering
+    /// the shared `charged` budget. Asserts byte-correctness; run under TSan for
+    /// race detection.
+    #[test]
+    #[expect(clippy::cast_possible_truncation)]
+    fn workers_and_eviction_race_reads_without_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("race.bin");
+        let data: Vec<u8> = (0u64..4 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        let file = Arc::new(std::fs::File::open(&path).unwrap());
+        let backing_len = data.len() as u64;
+
+        // Small budget: the worker's has_room_for gate bites and stream 2's
+        // misses must evict stream 1 to make room.
+        let pool = Arc::new(ReadAheadPool::new(2 * 1024 * 1024));
+        let window = pool.per_stream_cap();
+        let buf1 = Arc::new(Mutex::new(ReadAhead::new(window)));
+        buf1.lock().unwrap().set_max_windows(4);
+        let buf2 = Arc::new(Mutex::new(ReadAhead::new(window)));
+        let epoch1 = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let epoch2 = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        pool.register(1, Arc::clone(&buf1));
+        pool.register(2, Arc::clone(&buf2));
+
+        std::thread::scope(|s| {
+            // Stream 1: one sequential reader (epoch stays stable, so the
+            // prefetched windows actually store + reconcile).
+            {
+                let (file, buf1, pool, epoch1, data) = (&file, &buf1, &pool, &epoch1, &data);
+                s.spawn(move || {
+                    let br = BackingReader::new(file, buf1, pool, 1, backing_len, epoch1);
+                    let mut off = 0u64;
+                    while off < backing_len {
+                        let len = (64 * 1024).min((backing_len - off) as usize);
+                        let mut got = vec![0u8; len];
+                        br.read_exact_at(&mut got, off).unwrap();
+                        assert_eq!(got, data[off as usize..off as usize + len]);
+                        off += len as u64;
+                    }
+                });
+            }
+            // Two prefetchers driving real `run_job` (store + reconcile) for
+            // stream 1, concurrent with its reader.
+            for _ in 0..2 {
+                let (file, buf1, pool, epoch1) = (&file, &buf1, &pool, &epoch1);
+                s.spawn(move || {
+                    for _ in 0..4 {
+                        let mut start = 0u64;
+                        while start < backing_len {
+                            PrefetchWorkers::run_job(PrefetchJob {
+                                file: Arc::clone(file),
+                                buf: Arc::clone(buf1),
+                                pool: Arc::clone(pool),
+                                epoch: Arc::clone(epoch1),
+                                dispatched_epoch: epoch1.load(std::sync::atomic::Ordering::Acquire),
+                                start,
+                                len: window,
+                                backing_len,
+                            });
+                            start += window;
+                        }
+                    }
+                });
+            }
+            // Stream 2: random-offset readers → misses → permitted_window →
+            // cross-buffer eviction of stream 1 (try_lock), churning `charged`.
+            for tid in 0..4u64 {
+                let (file, buf2, pool, epoch2, data) = (&file, &buf2, &pool, &epoch2, &data);
+                s.spawn(move || {
+                    let br = BackingReader::new(file, buf2, pool, 2, backing_len, epoch2);
+                    let mut rng: u64 = tid * 7919 + 1;
+                    for _ in 0..300 {
+                        rng = rng.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+                        let off = rng % backing_len.saturating_sub(4096).max(1);
+                        let len = 4096usize.min((backing_len - off) as usize);
+                        let mut got = vec![0u8; len];
+                        br.read_exact_at(&mut got, off).unwrap();
+                        assert_eq!(got, data[off as usize..off as usize + len]);
+                    }
+                });
+            }
+        });
+    }
 }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -130,6 +130,20 @@ impl ReadAheadPool {
         }
     }
 
+    /// Best-effort check that `need` bytes of *free* (uncharged) budget exist.
+    /// Speculative prefetch uses this rather than evicting live streams: under
+    /// memory pressure it simply declines to prefetch. Racy by design — the
+    /// caller still `reconcile`s the actual stored delta, so the
+    /// `charged == Σ bytes` invariant holds regardless; this only bounds overshoot.
+    pub fn has_room_for(&self, need: u64) -> bool {
+        self.budget > 0 && self.budget.saturating_sub(self.charged.load(O::Relaxed)) >= need
+    }
+
+    #[cfg(test)]
+    pub fn charged_for_test(&self) -> u64 {
+        self.charged.load(O::Relaxed)
+    }
+
     /// Uncharge `bytes` directly (window cleared on invalidation/release).
     pub fn uncharge(&self, bytes: u64) {
         if bytes > 0 {
@@ -192,6 +206,11 @@ impl ReadAhead {
     }
     pub fn next_expected(&self) -> u64 {
         self.next_expected
+    }
+    /// The current adaptive window size (grows geometrically on sequential
+    /// access, resets to the floor on seek). Drives prefetch depth.
+    pub fn window(&self) -> u64 {
+        self.window
     }
 
     #[allow(clippy::len_without_is_empty)]
@@ -297,7 +316,12 @@ impl ReadAhead {
     }
 }
 
+/// Store a prefetched window into `buf` iff the handle's epoch is unchanged, and
+/// charge the global budget by the resulting size delta so the
+/// `charged == Σ(registered buffers' bytes.len())` invariant is preserved. A
+/// stale epoch (seek/release/refresh since dispatch) drops the window untouched.
 pub fn try_store_prefetch(
+    pool: &ReadAheadPool,
     buf: &Arc<Mutex<ReadAhead>>,
     epoch: &Epoch,
     dispatched_epoch: u64,
@@ -308,8 +332,20 @@ pub fn try_store_prefetch(
     if epoch.load(O::Acquire) != dispatched_epoch {
         return false;
     }
-    ra.store_window(start, bytes);
+    let (old, new) = ra.store_window(start, bytes);
+    drop(ra);
+    pool.reconcile(old, new);
     true
+}
+
+/// How many `window`-sized next-windows to keep in flight for a sequential
+/// stream: enough that their combined size is about one per-stream budget share
+/// (`cap`), clamped to a small thread fan-out. Decreases as the adaptive window
+/// grows toward `cap` (fewer, larger chunks) and rises again after a seek resets
+/// the window to the floor. Always ≥ 1 and never `cap / cap == 1` regardless of
+/// `window`.
+pub fn prefetch_depth(cap: u64, window: u64) -> u64 {
+    (cap / window.max(1)).clamp(1, 4)
 }
 
 use std::cell::Cell;
@@ -318,6 +354,7 @@ use std::sync::mpsc;
 pub struct PrefetchJob {
     pub file: Arc<std::fs::File>,
     pub buf: Arc<Mutex<ReadAhead>>,
+    pub pool: Arc<ReadAheadPool>,
     pub epoch: Arc<std::sync::atomic::AtomicU64>,
     pub dispatched_epoch: u64,
     pub start: u64,
@@ -365,12 +402,24 @@ impl PrefetchWorkers {
         if want == 0 {
             return;
         }
+        // Speculative: only prefetch into free budget, never evicting a live
+        // stream. Under pressure we skip rather than thrash real reads.
+        if !job.pool.has_room_for(want) {
+            return;
+        }
         #[expect(clippy::cast_possible_truncation)]
         let mut bytes = vec![0u8; want as usize];
         if job.file.read_exact_at(&mut bytes, job.start).is_err() {
             return;
         }
-        let _ = try_store_prefetch(&job.buf, &job.epoch, job.dispatched_epoch, job.start, bytes);
+        let _ = try_store_prefetch(
+            &job.pool,
+            &job.buf,
+            &job.epoch,
+            job.dispatched_epoch,
+            job.start,
+            bytes,
+        );
     }
 
     pub fn request(&self, job: PrefetchJob) {
@@ -766,6 +815,29 @@ mod ring_tests {
         );
     }
 
+    /// Regression for the `cap / cap == 1` tautology: depth must track the live
+    /// adaptive window, fanning out when the window is small and collapsing to 1
+    /// as it grows to `cap` — and the in-flight prefetch (`depth * window`) must
+    /// stay within one per-stream budget share.
+    #[test]
+    fn prefetch_depth_tracks_window_and_bounds_inflight() {
+        let cap = 8 * 1024 * 1024;
+        // Fresh / just-seeked: floor-sized window → fan out (16 → clamp 4),
+        // NOT 1 (which the old cap/cap formula always produced).
+        assert_eq!(prefetch_depth(cap, WINDOW_FLOOR), 4);
+        assert_eq!(prefetch_depth(cap, 2 * 1024 * 1024), 4);
+        assert_eq!(prefetch_depth(cap, 4 * 1024 * 1024), 2);
+        // Window grown to the cap → a single next-window suffices.
+        assert_eq!(prefetch_depth(cap, cap), 1);
+        // Degenerate inputs never panic or return 0.
+        assert_eq!(prefetch_depth(cap, 0), 4);
+        assert_eq!(prefetch_depth(cap, cap * 2), 1);
+        // In-flight bytes stay within one budget share across the growth curve.
+        for w in [WINDOW_FLOOR, 1 << 20, 2 << 20, 4 << 20, cap] {
+            assert!(prefetch_depth(cap, w) * w <= cap, "overshoot at window {w}");
+        }
+    }
+
     #[test]
     fn len_sums_all_windows_and_clear_drops_all() {
         let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
@@ -785,20 +857,82 @@ mod prefetch_store_tests {
 
     #[test]
     fn store_with_stale_epoch_is_discarded() {
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
         let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
         let epoch = AtomicU64::new(0);
         epoch.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-        assert!(!try_store_prefetch(&ra, &epoch, 0, 0, vec![1, 2, 3]));
+        assert!(!try_store_prefetch(&pool, &ra, &epoch, 0, 0, vec![1, 2, 3]));
         assert_eq!(ra.lock().unwrap().len(), 0);
     }
 
     #[test]
-    fn store_with_current_epoch_is_accepted() {
+    fn store_with_current_epoch_is_accepted_and_charges_budget() {
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
         let ra = Arc::new(Mutex::new(ReadAhead::new(WINDOW_ABS_CAP)));
         ra.lock().unwrap().set_max_windows(2);
         let epoch = AtomicU64::new(5);
-        assert!(try_store_prefetch(&ra, &epoch, 5, 1000, vec![0u8; 4096]));
+        assert!(try_store_prefetch(
+            &pool,
+            &ra,
+            &epoch,
+            5,
+            1000,
+            vec![0u8; 4096]
+        ));
         assert!(ra.lock().unwrap().covers(1000, 4096));
+        // The stored window is charged against the global budget.
+        assert_eq!(pool.charged_for_test(), 4096);
+    }
+
+    /// Regression: a prefetched window must charge the budget so that the
+    /// subsequent uncharge on eviction/release cannot drive `charged` negative
+    /// (an underflow that silently disabled read-ahead process-wide).
+    #[test]
+    #[expect(clippy::cast_possible_truncation)]
+    fn prefetch_charge_survives_release_without_underflow() {
+        let pool = ReadAheadPool::new(2 * 1024 * 1024); // per-stream cap 512K
+        let cap = pool.per_stream_cap();
+        let buf = Arc::new(Mutex::new(ReadAhead::new(cap)));
+        buf.lock().unwrap().set_max_windows(2);
+        pool.register(1, Arc::clone(&buf));
+        // Sync read fills + charges one cap-sized window at offset 0.
+        let mut dst = vec![0u8; cap as usize];
+        let (o, n) = buf
+            .lock()
+            .unwrap()
+            .read_into(&mut dst, 0, 8 * 1024 * 1024, |b, _| {
+                b.fill(1);
+                Ok(())
+            })
+            .unwrap();
+        pool.reconcile(o, n);
+        // Prefetch a second cap-sized window — now charged via try_store_prefetch.
+        let epoch = Epoch::new(0);
+        assert!(try_store_prefetch(
+            &pool,
+            &buf,
+            &epoch,
+            0,
+            cap,
+            vec![2u8; cap as usize]
+        ));
+        assert_eq!(pool.charged_for_test(), 2 * cap);
+        pool.deregister(1);
+        assert_eq!(pool.charged_for_test(), 0, "release must not underflow");
+        // A fresh stream still gets its full grant — read-ahead is not disabled.
+        let hot = Arc::new(Mutex::new(ReadAhead::new(cap)));
+        pool.register(2, Arc::clone(&hot));
+        assert_eq!(pool.permitted_window(2, 0, cap), cap);
+    }
+
+    /// Under budget pressure, prefetch declines (no free room) rather than
+    /// evicting a live stream or overshooting the budget.
+    #[test]
+    fn prefetch_declines_when_budget_full() {
+        let pool = ReadAheadPool::new(1024 * 1024);
+        assert!(pool.has_room_for(512 * 1024));
+        pool.reconcile(0, 1024 * 1024); // fill the budget
+        assert!(!pool.has_room_for(1));
     }
 }
 
@@ -827,6 +961,7 @@ mod prefetch_worker_tests {
         PrefetchWorkers::run_job(PrefetchJob {
             file: Arc::clone(&file),
             buf: Arc::clone(&buf),
+            pool: Arc::clone(&pool),
             epoch: Arc::clone(&epoch),
             dispatched_epoch: 0,
             start: 1024 * 1024,

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -70,14 +70,17 @@ impl ReadAheadPool {
             .insert(key, StreamEntry { buf, last_served });
     }
 
-    /// Deregister on release; returns the bytes to uncharge.
+    /// Deregister on release; returns the bytes to uncharge. Drops the `streams`
+    /// lock BEFORE locking the buffer: a concurrent read holds its buffer mutex
+    /// and then blocking-acquires `streams` (via `permitted_window`), so holding
+    /// `streams` while locking the buffer here would invert that order and
+    /// deadlock. Keeping `streams` a leaf (released before any buffer mutex)
+    /// preserves the pool's deadlock-free invariant.
     pub fn deregister(&self, key: usize) {
-        let freed = {
-            let mut g = self.streams.lock().unwrap();
-            match g.remove(&key) {
-                Some(e) => e.buf.lock().unwrap().len(),
-                None => 0,
-            }
+        let entry = self.streams.lock().unwrap().remove(&key);
+        let freed = match entry {
+            Some(e) => e.buf.lock().unwrap().len(),
+            None => 0,
         };
         if freed > 0 {
             self.charged.fetch_sub(freed, O::Relaxed);
@@ -1201,6 +1204,65 @@ mod concurrency_tests {
                         let mut got = vec![0u8; len];
                         br.read_exact_at(&mut got, off).unwrap();
                         assert_eq!(got, data[off as usize..off as usize + len]);
+                    }
+                });
+            }
+        });
+    }
+
+    /// Regression for the deregister deadlock: `deregister` takes `streams` then
+    /// the buffer mutex, while a read holds the buffer mutex then blocking-locks
+    /// `streams` via `permitted_window` → eviction. Racing them on the same key
+    /// would deadlock if `deregister` held `streams` across the buffer lock.
+    /// Asserts bytes stay correct and the run completes; the tsan job's
+    /// deadlock detector flags a regression even without an actual hang.
+    #[test]
+    #[expect(clippy::cast_possible_truncation)]
+    fn deregister_races_reads_without_deadlock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dereg.bin");
+        let data: Vec<u8> = (0u64..2 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        let file = Arc::new(std::fs::File::open(&path).unwrap());
+        let backing_len = data.len() as u64;
+
+        // Small budget so reads miss and run permitted_window → eviction, which
+        // blocking-locks `streams` while the read holds the buffer mutex.
+        let pool = Arc::new(ReadAheadPool::new(1024 * 1024));
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        pool.register(1, Arc::clone(&buf));
+        // A second registered stream gives eviction a candidate to walk.
+        let buf2 = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(2, Arc::clone(&buf2));
+
+        std::thread::scope(|s| {
+            for tid in 0..4u64 {
+                let (file, buf, pool, epoch, data) = (&file, &buf, &pool, &epoch, &data);
+                s.spawn(move || {
+                    let br = BackingReader::new(file, buf, pool, 1, backing_len, epoch);
+                    let mut rng = tid * 7919 + 1;
+                    for _ in 0..300 {
+                        rng = rng.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+                        let off = rng % backing_len.saturating_sub(4096).max(1);
+                        let len = 4096usize.min((backing_len - off) as usize);
+                        let mut got = vec![0u8; len];
+                        br.read_exact_at(&mut got, off).unwrap();
+                        assert_eq!(got, data[off as usize..off as usize + len]);
+                    }
+                });
+            }
+            // Churn registration of the SAME key the readers use — the path that
+            // takes `streams` and then the buffer mutex.
+            {
+                let (pool, buf) = (&pool, &buf);
+                s.spawn(move || {
+                    for _ in 0..2000 {
+                        pool.deregister(1);
+                        pool.register(1, Arc::clone(buf));
                     }
                 });
             }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -367,7 +367,11 @@ pub fn read_at_into<M>(
     if needs_file {
         crate::metrics::on_open();
         let file = std::fs::File::open(&resolved.backing_path)?;
-        read_segments_into(resolved, db, Some(&file), offset, size, out)
+        let pool = crate::readahead::ReadAheadPool::new(0);
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(crate::readahead::ReadAhead::new(0)));
+        let backing_len = resolved.stamp.size;
+        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, backing_len);
+        read_segments_into(resolved, db, Some(&br), offset, size, out)
     } else {
         read_segments_into(resolved, db, None, offset, size, out)
     }
@@ -394,13 +398,13 @@ pub fn read_at<M>(resolved: &ResolvedFile, db: &Db<M>, offset: u64, size: u64) -
     Ok(out)
 }
 
-/// The single segment-splicing loop. `file` is `Some` whenever the layout has a
+/// The single segment-splicing loop. `backing` is `Some` whenever the layout has a
 /// `BackingAudio`/`OggAudio` segment (guaranteed by `read_at`/`read_at_with_file`);
 /// the backing arms treat `None` as a contract violation.
 fn read_segments_into<M>(
     resolved: &ResolvedFile,
     db: &Db<M>,
-    file: Option<&std::fs::File>,
+    backing: Option<&crate::readahead::BackingReader>,
     offset: u64,
     size: u64,
     out: &mut Vec<u8>,
@@ -426,16 +430,10 @@ fn read_segments_into<M>(
                     out.extend_from_slice(&bytes[w..w + n]);
                 }
                 Segment::BackingAudio { offset: bo, .. } => {
-                    let f = file.expect("backing segment requires an open backing file");
-                    // Finding #15 (ESTALE, untested by design): on an NFS-backed mount a stale file
-                    // handle surfaces here as a raw io::Error from the positioned read (or as
-                    // BackingChanged from the size/mtime re-validation) and is propagated verbatim
-                    // through the FUSE layer. There is no test-framework support to inject NFS ESTALE,
-                    // so this path is documented rather than covered.
+                    let br = backing.expect("backing segment requires an open backing reader");
                     let start = out.len();
                     out.resize(start + n, 0);
-                    crate::metrics::backing_read_exact_at(f, &mut out[start..], bo + within)?;
-                    crate::metrics::on_pread(n as u64);
+                    br.read_exact_at(&mut out[start..], bo + within)?;
                 }
                 Segment::ArtImage { art_id, .. } => {
                     let start = out.len();
@@ -454,7 +452,9 @@ fn read_segments_into<M>(
                     seq_delta,
                     len,
                 } => {
-                    let f = file.expect("ogg-audio segment requires an open backing file");
+                    let f = backing
+                        .expect("ogg-audio segment requires an open backing reader")
+                        .file();
                     serve_ogg_window(
                         f,
                         *ao,
@@ -474,7 +474,6 @@ fn read_segments_into<M>(
                     ..
                 } => {
                     if *base64 {
-                        // Output base64 chars [offset+within, +n) of base64(image).
                         let w =
                             musefs_format::ogg::b64_window(*offset + within, n as u64, *art_total);
                         let raw = db.read_art_chunk(*art_id, w.in_start, usize_from(w.in_len))?;
@@ -483,7 +482,6 @@ fn read_segments_into<M>(
                             &raw, w.skip, n,
                         ));
                     } else {
-                        // Raw image bytes (OggFLAC PICTURE block).
                         let start = out.len();
                         out.resize(start + n, 0);
                         db.read_art_chunk_into(*art_id, *offset + within, &mut out[start..])?;
@@ -500,28 +498,28 @@ fn read_segments_into<M>(
     Ok(())
 }
 
-/// Serve into `out` from an already-open backing `file` (per-handle path).
+/// Serve into `out` from an already-open backing reader (per-handle path).
 pub fn read_at_with_file_into<M>(
     resolved: &ResolvedFile,
     db: &Db<M>,
-    file: &std::fs::File,
+    backing: &crate::readahead::BackingReader,
     offset: u64,
     size: u64,
     out: &mut Vec<u8>,
 ) -> Result<()> {
-    read_segments_into(resolved, db, Some(file), offset, size, out)
+    read_segments_into(resolved, db, Some(backing), offset, size, out)
 }
 
 /// Allocating form of `read_at_with_file_into`.
 pub fn read_at_with_file<M>(
     resolved: &ResolvedFile,
     db: &Db<M>,
-    file: &std::fs::File,
+    backing: &crate::readahead::BackingReader,
     offset: u64,
     size: u64,
 ) -> Result<Vec<u8>> {
     let mut out = Vec::new();
-    read_at_with_file_into(resolved, db, file, offset, size, &mut out)?;
+    read_at_with_file_into(resolved, db, backing, offset, size, &mut out)?;
     Ok(out)
 }
 
@@ -751,7 +749,10 @@ mod resolve_ogg_tests {
 
         let via_open = read_at(&resolved, &db, 0, resolved.total_len).unwrap();
         let file = std::fs::File::open(&resolved.backing_path).unwrap();
-        let via_file = read_at_with_file(&resolved, &db, &file, 0, resolved.total_len).unwrap();
+        let pool = crate::readahead::ReadAheadPool::new(0);
+        let buf = Arc::new(Mutex::new(crate::readahead::ReadAhead::new(0)));
+        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, meta.len());
+        let via_file = read_at_with_file(&resolved, &db, &br, 0, resolved.total_len).unwrap();
         assert_eq!(via_open, via_file);
     }
 
@@ -1546,5 +1547,119 @@ mod serve_cap_tests {
             matches!(err, CoreError::Io(_)),
             "expected Io error at the cap boundary, got {err:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod readahead_differential_tests {
+    use super::*;
+    use crate::readahead::{BackingReader, ReadAhead, ReadAheadPool};
+    use std::sync::{Arc, Mutex};
+
+    fn pcm_fixture() -> (musefs_db::Db, Arc<ResolvedFile>, std::fs::File) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.wav");
+        let mut body = Vec::new();
+        body.extend_from_slice(b"fmt ");
+        body.extend_from_slice(&16u32.to_le_bytes());
+        body.extend_from_slice(&1u16.to_le_bytes());
+        body.extend_from_slice(&1u16.to_le_bytes());
+        body.extend_from_slice(&44100u32.to_le_bytes());
+        body.extend_from_slice(&88200u32.to_le_bytes());
+        body.extend_from_slice(&2u16.to_le_bytes());
+        body.extend_from_slice(&16u16.to_le_bytes());
+        let audio_data: Vec<u8> = (0..1024u32).map(|i| (i % 251) as u8).collect();
+        body.extend_from_slice(b"data");
+        body.extend_from_slice(&u32::try_from(audio_data.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(&audio_data);
+        let mut riff = b"RIFF".to_vec();
+        riff.extend_from_slice(&u32::try_from(body.len()).unwrap().to_le_bytes());
+        riff.extend_from_slice(b"WAVE");
+        riff.extend_from_slice(&body);
+        let audio_offset = (riff.len() - audio_data.len()) as u64;
+        std::fs::write(&path, &riff).unwrap();
+
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        use std::os::unix::fs::MetadataExt;
+        let track_id = db
+            .upsert_track(&musefs_db::NewTrack {
+                backing_path: path.to_string_lossy().into_owned(),
+                format: musefs_db::Format::Wav,
+                audio_offset,
+                audio_length: audio_data.len() as u64,
+                backing_size: meta.len(),
+                backing_mtime_ns: meta.mtime() * 1_000_000_000 + meta.mtime_nsec(),
+                backing_ctime_ns: meta.ctime() * 1_000_000_000 + meta.ctime_nsec(),
+            })
+            .unwrap();
+        let cache = HeaderCache::new(Mode::Synthesis);
+        let resolved = cache.resolve(&db, track_id).unwrap();
+        let file = std::fs::File::open(&resolved.backing_path).unwrap();
+        (db, resolved, file)
+    }
+
+    fn oracle_read(
+        resolved: &ResolvedFile,
+        file: &std::fs::File,
+        offset: u64,
+        size: u64,
+        out: &mut Vec<u8>,
+    ) -> Result<()> {
+        if offset >= resolved.total_len || size == 0 {
+            return Ok(());
+        }
+        let end = offset.saturating_add(size).min(resolved.total_len);
+        out.reserve(usize_from(end - offset));
+        let mut seg_start = 0u64;
+        for seg in resolved.layout.segments() {
+            let seg_len = seg.len();
+            let seg_end = seg_start + seg_len;
+            let ov_start = offset.max(seg_start);
+            let ov_end = end.min(seg_end);
+            if ov_start < ov_end {
+                let within = ov_start - seg_start;
+                let n = usize_from(ov_end - ov_start);
+                match seg {
+                    Segment::Inline(bytes) => {
+                        let w = usize_from(within);
+                        out.extend_from_slice(&bytes[w..w + n]);
+                    }
+                    Segment::BackingAudio { offset: bo, .. } => {
+                        let start = out.len();
+                        out.resize(start + n, 0);
+                        use std::os::unix::fs::FileExt;
+                        file.read_exact_at(&mut out[start..], bo + within)?;
+                    }
+                    _ => panic!("unexpected segment in PCM fixture"),
+                }
+            }
+            seg_start = seg_end;
+            if seg_start >= end {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn pcm_bytes_identical_through_backing_reader() {
+        let (db, resolved, file) = pcm_fixture();
+        let pool = ReadAheadPool::new(0);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
+        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.stamp.size);
+        let total = resolved.total_len;
+        for &size in &[1u64, 7, 4096, 65536, 262_144] {
+            let mut off = 0;
+            while off < total {
+                let n = size.min(total - off);
+                let mut via = Vec::new();
+                read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+                let mut direct = Vec::new();
+                oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
+                assert_eq!(via, direct, "mismatch at off={off} size={size}");
+                off += n;
+            }
+        }
     }
 }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -452,11 +452,9 @@ fn read_segments_into<M>(
                     seq_delta,
                     len,
                 } => {
-                    let f = backing
-                        .expect("ogg-audio segment requires an open backing reader")
-                        .file();
+                    let br = backing.expect("ogg-audio segment requires an open backing reader");
                     serve_ogg_window(
-                        f,
+                        br,
                         *ao,
                         *len,
                         *seq_delta,

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -370,7 +370,8 @@ pub fn read_at_into<M>(
         let pool = crate::readahead::ReadAheadPool::new(0);
         let buf = std::sync::Arc::new(std::sync::Mutex::new(crate::readahead::ReadAhead::new(0)));
         let backing_len = resolved.stamp.size;
-        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, backing_len);
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, backing_len, &epoch);
         read_segments_into(resolved, db, Some(&br), offset, size, out)
     } else {
         read_segments_into(resolved, db, None, offset, size, out)
@@ -749,7 +750,8 @@ mod resolve_ogg_tests {
         let file = std::fs::File::open(&resolved.backing_path).unwrap();
         let pool = crate::readahead::ReadAheadPool::new(0);
         let buf = Arc::new(Mutex::new(crate::readahead::ReadAhead::new(0)));
-        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, meta.len());
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, meta.len(), &epoch);
         let via_file = read_at_with_file(&resolved, &db, &br, 0, resolved.total_len).unwrap();
         assert_eq!(via_open, via_file);
     }
@@ -1645,7 +1647,8 @@ mod readahead_differential_tests {
         let (db, resolved, file) = pcm_fixture();
         let pool = ReadAheadPool::new(0);
         let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
-        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.stamp.size);
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.stamp.size, &epoch);
         let total = resolved.total_len;
         for &size in &[1u64, 7, 4096, 65536, 262_144] {
             let mut off = 0;
@@ -1667,7 +1670,8 @@ mod readahead_differential_tests {
         let pool = ReadAheadPool::new(1024 * 1024);
         let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
         pool.register(1, Arc::clone(&buf));
-        let br = BackingReader::new(&file, &buf, &pool, 1, resolved.stamp.size);
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let br = BackingReader::new(&file, &buf, &pool, 1, resolved.stamp.size, &epoch);
         let total = resolved.total_len;
         let mut off = 0;
         while off < total {
@@ -1687,7 +1691,8 @@ mod readahead_differential_tests {
         let pool = ReadAheadPool::new(64 * 1024 * 1024);
         let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
         pool.register(1, Arc::clone(&buf));
-        let br = BackingReader::new(&file, &buf, &pool, 1, resolved.stamp.size);
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let br = BackingReader::new(&file, &buf, &pool, 1, resolved.stamp.size, &epoch);
         let seq = [(0u64, 600u64), (590, 50), (10, 4096), (12, 4096)];
         for &(off, n) in &seq {
             let n = n.min(resolved.total_len.saturating_sub(off));

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -1660,4 +1660,45 @@ mod readahead_differential_tests {
             }
         }
     }
+
+    #[test]
+    fn pcm_bytes_identical_under_forced_eviction() {
+        let (db, resolved, file) = pcm_fixture();
+        let pool = ReadAheadPool::new(1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, resolved.stamp.size);
+        let total = resolved.total_len;
+        let mut off = 0;
+        while off < total {
+            let n = 65536u64.min(total - off);
+            let mut via = Vec::new();
+            read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+            let mut direct = Vec::new();
+            oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
+            assert_eq!(via, direct, "eviction mismatch at {off}");
+            off += n;
+        }
+    }
+
+    #[test]
+    fn partial_overlap_seek_serves_correct_bytes() {
+        let (db, resolved, file) = pcm_fixture();
+        let pool = ReadAheadPool::new(64 * 1024 * 1024);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let br = BackingReader::new(&file, &buf, &pool, 1, resolved.stamp.size);
+        let seq = [(0u64, 600u64), (590, 50), (10, 4096), (12, 4096)];
+        for &(off, n) in &seq {
+            let n = n.min(resolved.total_len.saturating_sub(off));
+            if n == 0 {
+                continue;
+            }
+            let mut via = Vec::new();
+            read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+            let mut direct = Vec::new();
+            oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
+            assert_eq!(via, direct, "partial-seek mismatch at {off}+{n}");
+        }
+    }
 }

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -191,6 +191,7 @@ fn bench_read_under_latency() {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     };
     fn first_inode(fs: &Musefs, dir: u64) -> Option<u64> {
         for (_, ino, is_dir) in fs.readdir(dir).unwrap() {

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -183,6 +183,15 @@ fn bench_read_under_latency() {
         return;
     };
     let tier = std::env::var("MUSEFS_BENCH_TIER").unwrap_or_else(|_| "ci".into());
+    // Sweep the read-ahead budget off (0) vs on (default 64 MiB) to isolate the
+    // backing read-ahead win at each latency profile.
+    let ra_mib: u64 = std::env::var("MUSEFS_BENCH_READAHEAD_MIB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(64);
+    // Opt into Phase-2 prefetch threads (off by default) for the bench sweep.
+    let ra_prefetch = std::env::var("MUSEFS_READ_AHEAD_PREFETCH")
+        .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"));
 
     let cfg = || MountConfig {
         template: "$artist/$album/$title".to_string(),
@@ -191,7 +200,8 @@ fn bench_read_under_latency() {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_budget: ra_mib * 1024 * 1024,
+        read_ahead_prefetch: ra_prefetch,
     };
     fn first_inode(fs: &Musefs, dir: u64) -> Option<u64> {
         for (_, ino, is_dir) in fs.readdir(dir).unwrap() {
@@ -222,13 +232,17 @@ fn bench_read_under_latency() {
         let fs = Musefs::open(db, cfg()).unwrap();
         let inode = first_inode(&fs, VirtualTree::ROOT).expect("an ogg inode");
         let size = fs.getattr(inode).unwrap().size;
+        // Read through a real handle: `None` would take the fallback path (a
+        // fresh disabled-pool reader), bypassing the per-handle read-ahead this
+        // bench measures. Open outside the timed region so only reads are timed.
+        let fh = fs.open_handle(inode).unwrap();
 
         metrics::reset();
         let t0 = Instant::now();
         if whole {
             let mut off = 0u64;
             while off < size {
-                let got = fs.read(inode, None, off, 128 * 1024).unwrap();
+                let got = fs.read(inode, Some(fh), off, 128 * 1024).unwrap();
                 if got.is_empty() {
                     break;
                 }
@@ -236,17 +250,18 @@ fn bench_read_under_latency() {
             }
         } else {
             let off = (size * 7 / 8).min(size.saturating_sub(128 * 1024));
-            let _ = fs.read(inode, None, off, 128 * 1024).unwrap();
+            let _ = fs.read(inode, Some(fh), off, 128 * 1024).unwrap();
         }
         let ms = t0.elapsed().as_millis();
         let s = metrics::snapshot();
+        fs.release_handle(fh);
         println!(
             "{}",
             RunReport {
                 label: label.into(),
                 format: "ogg".into(),
                 tier: tier.clone(),
-                storage: profile.clone(),
+                storage: format!("{profile}/ra{ra_mib}"),
                 wall_ms: ms,
                 opens: s.opens,
                 preads: s.preads,

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -200,7 +200,7 @@ fn bench_read_under_latency() {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
-        read_ahead_budget: ra_mib * 1024 * 1024,
+        read_ahead_budget: ra_mib.saturating_mul(1024 * 1024),
         read_ahead_prefetch: ra_prefetch,
     };
     fn first_inode(fs: &Musefs, dir: u64) -> Option<u64> {
@@ -261,7 +261,10 @@ fn bench_read_under_latency() {
                 label: label.into(),
                 format: "ogg".into(),
                 tier: tier.clone(),
-                storage: format!("{profile}/ra{ra_mib}"),
+                storage: format!(
+                    "{profile}/ra{ra_mib}/pf{}",
+                    if ra_prefetch { "on" } else { "off" }
+                ),
                 wall_ms: ms,
                 opens: s.opens,
                 preads: s.preads,

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -16,6 +16,7 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: Duration::ZERO, // no debounce: each poll actually polls
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -17,6 +17,7 @@ fn config() -> MountConfig {
         poll_interval: Duration::ZERO, // no debounce: each poll actually polls
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/tests/binary_tag_tree.rs
+++ b/musefs-core/tests/binary_tag_tree.rs
@@ -11,6 +11,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-core/tests/binary_tag_tree.rs
+++ b/musefs-core/tests/binary_tag_tree.rs
@@ -12,6 +12,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/tests/concurrent_reads.rs
+++ b/musefs-core/tests/concurrent_reads.rs
@@ -5,9 +5,9 @@
 //! asserts on bytes) so it can gate CI and run under AddressSanitizer.
 mod common;
 
-use std::sync::{Arc, Barrier};
+use std::sync::{Arc, Barrier, Mutex};
 
-use musefs_core::{HeaderCache, Mode, read_at_with_file};
+use musefs_core::{BackingReader, HeaderCache, Mode, ReadAhead, ReadAheadPool, read_at_with_file};
 use musefs_db::Db;
 
 /// Build a file-backed store with `n` FLAC tracks (each a real backing file),
@@ -54,7 +54,10 @@ fn read_full(db_path: &std::path::Path, cache: &HeaderCache, id: i64) -> Vec<u8>
     let db = Db::open_readonly(db_path).unwrap();
     let resolved = cache.resolve(&db, id).unwrap();
     let file = std::fs::File::open(&resolved.backing_path).unwrap();
-    read_at_with_file(&resolved, &db, &file, 0, resolved.total_len).unwrap()
+    let pool = ReadAheadPool::new(0);
+    let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
+    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+    read_at_with_file(&resolved, &db, &br, 0, resolved.total_len).unwrap()
 }
 
 #[test]

--- a/musefs-core/tests/concurrent_reads.rs
+++ b/musefs-core/tests/concurrent_reads.rs
@@ -56,7 +56,8 @@ fn read_full(db_path: &std::path::Path, cache: &HeaderCache, id: i64) -> Vec<u8>
     let file = std::fs::File::open(&resolved.backing_path).unwrap();
     let pool = ReadAheadPool::new(0);
     let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
-    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+    let epoch = std::sync::atomic::AtomicU64::new(0);
+    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len, &epoch);
     read_at_with_file(&resolved, &db, &br, 0, resolved.total_len).unwrap()
 }
 

--- a/musefs-core/tests/concurrent_reads.rs
+++ b/musefs-core/tests/concurrent_reads.rs
@@ -57,7 +57,7 @@ fn read_full(db_path: &std::path::Path, cache: &HeaderCache, id: i64) -> Vec<u8>
     let pool = ReadAheadPool::new(0);
     let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
     let epoch = std::sync::atomic::AtomicU64::new(0);
-    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len, &epoch);
+    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.stamp.size, &epoch);
     read_at_with_file(&resolved, &db, &br, 0, resolved.total_len).unwrap()
 }
 

--- a/musefs-core/tests/contract_emit.rs
+++ b/musefs-core/tests/contract_emit.rs
@@ -26,7 +26,8 @@ fn emit_contract_fixtures() {
         let file = std::fs::File::open(&resolved.backing_path).expect("open backing file");
         let pool = ReadAheadPool::new(0);
         let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
-        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+        let epoch = std::sync::atomic::AtomicU64::new(0);
+        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len, &epoch);
         let bytes = read_at_with_file(&resolved, &db, &br, 0, resolved.total_len)
             .expect("synthesize served bytes");
         // Name the output by track id + the backing file's extension, so the

--- a/musefs-core/tests/contract_emit.rs
+++ b/musefs-core/tests/contract_emit.rs
@@ -3,8 +3,9 @@
 //! for an independent reader (mutagen) to verify. Mirrors `interop_emit.rs` but
 //! sources rows from an EXISTING DB (scan + python-musefs writes) rather than
 //! building one in-process.
-use musefs_core::{HeaderCache, Mode, read_at_with_file};
+use musefs_core::{BackingReader, HeaderCache, Mode, ReadAhead, ReadAheadPool, read_at_with_file};
 use musefs_db::Db;
+use std::sync::{Arc, Mutex};
 
 #[test]
 #[ignore = "contract emitter; run with MUSEFS_DB + MUSEFS_INTEROP_DIR set (see scripts/contract-roundtrip.sh)"]
@@ -23,7 +24,10 @@ fn emit_contract_fixtures() {
     for track in tracks {
         let resolved = cache.resolve(&db, track.id).expect("resolve track");
         let file = std::fs::File::open(&resolved.backing_path).expect("open backing file");
-        let bytes = read_at_with_file(&resolved, &db, &file, 0, resolved.total_len)
+        let pool = ReadAheadPool::new(0);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
+        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+        let bytes = read_at_with_file(&resolved, &db, &br, 0, resolved.total_len)
             .expect("synthesize served bytes");
         // Name the output by track id + the backing file's extension, so the
         // independent reader can pick the right parser.

--- a/musefs-core/tests/contract_emit.rs
+++ b/musefs-core/tests/contract_emit.rs
@@ -27,7 +27,7 @@ fn emit_contract_fixtures() {
         let pool = ReadAheadPool::new(0);
         let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
         let epoch = std::sync::atomic::AtomicU64::new(0);
-        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len, &epoch);
+        let br = BackingReader::new(&file, &buf, &pool, 0, resolved.stamp.size, &epoch);
         let bytes = read_at_with_file(&resolved, &db, &br, 0, resolved.total_len)
             .expect("synthesize served bytes");
         // Name the output by track id + the backing file's extension, so the

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -13,6 +13,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -12,6 +12,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -50,6 +50,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -51,6 +51,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/tests/incremental_refresh.rs
+++ b/musefs-core/tests/incremental_refresh.rs
@@ -23,12 +23,14 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 
 fn config_ci() -> MountConfig {
     MountConfig {
         case_insensitive: true,
+        read_ahead_budget: 64 * 1024 * 1024,
         ..config()
     }
 }

--- a/musefs-core/tests/incremental_refresh.rs
+++ b/musefs-core/tests/incremental_refresh.rs
@@ -24,6 +24,7 @@ fn config() -> MountConfig {
         poll_interval: Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 
@@ -31,6 +32,7 @@ fn config_ci() -> MountConfig {
     MountConfig {
         case_insensitive: true,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
         ..config()
     }
 }

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -22,6 +22,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -23,6 +23,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -22,6 +22,10 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        // Read-ahead off: these goldens are exact per-format pread counts that
+        // detect synthesis-path regressions; read amplification would collapse
+        // and mask them. Read-ahead's own effects are covered in readahead.rs.
+        read_ahead_budget: 0,
     }
 }
 

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -26,6 +26,7 @@ fn config() -> MountConfig {
         // detect synthesis-path regressions; read amplification would collapse
         // and mask them. Read-ahead's own effects are covered in readahead.rs.
         read_ahead_budget: 0,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -167,7 +167,8 @@ fn read_at_with_file_out_of_range_and_zero_size_return_empty() {
     let file = std::fs::File::open(&resolved.backing_path).unwrap();
     let pool = ReadAheadPool::new(0);
     let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
-    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
+    let epoch = std::sync::atomic::AtomicU64::new(0);
+    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len, &epoch);
 
     // The per-handle path has no outer guard: read_segments_into itself must
     // bail on offset > total_len (its window arithmetic would underflow).

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -1,8 +1,11 @@
 mod common;
 use common::write_flac;
 use musefs_core::freshness::BackingStamp;
-use musefs_core::{HeaderCache, Mode, read_at, read_at_with_file};
+use musefs_core::{
+    BackingReader, HeaderCache, Mode, ReadAhead, ReadAheadPool, read_at, read_at_with_file,
+};
 use musefs_db::{Db, Format, NewTrack, Tag};
+use std::sync::{Arc, Mutex};
 
 fn setup() -> (tempfile::TempDir, Db, i64) {
     let dir = tempfile::tempdir().unwrap();
@@ -162,6 +165,9 @@ fn read_at_with_file_out_of_range_and_zero_size_return_empty() {
     let cache = HeaderCache::new(Mode::Synthesis);
     let resolved = cache.resolve(&db, id).unwrap();
     let file = std::fs::File::open(&resolved.backing_path).unwrap();
+    let pool = ReadAheadPool::new(0);
+    let buf = Arc::new(Mutex::new(ReadAhead::new(0)));
+    let br = BackingReader::new(&file, &buf, &pool, 0, resolved.total_len);
 
     // The per-handle path has no outer guard: read_segments_into itself must
     // bail on offset > total_len (its window arithmetic would underflow).
@@ -171,7 +177,7 @@ fn read_at_with_file_out_of_range_and_zero_size_return_empty() {
         (10, 0),
     ] {
         assert!(
-            read_at_with_file(&resolved, &db, &file, off, size)
+            read_at_with_file(&resolved, &db, &br, off, size)
                 .unwrap()
                 .is_empty()
         );

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -920,6 +920,7 @@ mod tests {
             // Zero interval => poll_due() is always true, isolating the gate.
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
         };
         let core =
             Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -921,6 +921,7 @@ mod tests {
             poll_interval: std::time::Duration::ZERO,
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
         };
         let core =
             Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -77,6 +77,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -76,6 +76,7 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/concurrent_reads.rs
+++ b/musefs-fuse/tests/concurrent_reads.rs
@@ -59,6 +59,7 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/concurrent_reads.rs
+++ b/musefs-fuse/tests/concurrent_reads.rs
@@ -60,6 +60,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/fault_injection.rs
+++ b/musefs-fuse/tests/fault_injection.rs
@@ -57,6 +57,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/fault_injection.rs
+++ b/musefs-fuse/tests/fault_injection.rs
@@ -56,6 +56,7 @@ fn config() -> MountConfig {
         mode: Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -56,6 +56,7 @@ fn mount_config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -57,6 +57,7 @@ fn mount_config() -> MountConfig {
         poll_interval: Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -53,6 +53,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -54,6 +54,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -77,6 +77,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -76,6 +76,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -77,6 +77,7 @@ fn config(mode: Mode) -> MountConfig {
         mode,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -78,6 +78,7 @@ fn config(mode: Mode) -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -23,6 +23,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -24,6 +24,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -67,6 +67,7 @@ fn config() -> MountConfig {
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
     }
 }
 

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -66,6 +66,7 @@ fn config() -> MountConfig {
         mode: musefs_core::Mode::Synthesis,
         poll_interval: std::time::Duration::ZERO,
         case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
     }
 }
 

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -60,7 +60,8 @@ fn nap(d: Duration) {
     }
 }
 
-/// Per-operation injected latency. `ssd` is all-zero (≈ no injection).
+/// Per-operation injected latency. Unknown profiles are all-zero (≈ no
+/// injection); `ssd` models local NVMe-class latency, not zero.
 #[derive(Clone, Copy, Default)]
 pub struct Latency {
     pub open: Duration,
@@ -72,9 +73,19 @@ pub struct Latency {
 }
 
 impl Latency {
-    /// Named profiles. Unknown / "ssd" => zero.
+    /// Named profiles. Unknown => zero (pure passthrough, no injection).
     pub fn profile(name: &str) -> Latency {
         match name {
+            // Local NVMe-class: ~80µs queue-depth-1 random read. A zero "ssd"
+            // would measure only the bench's own FUSE overhead, not SSD latency.
+            "ssd" => Latency {
+                open: us(80),
+                stat: us(40),
+                read: us(80),
+                write: us(80),
+                fsync: us(300),
+                other: us(40),
+            },
             "hdd" => Latency {
                 open: ms(8),
                 stat: ms(8),
@@ -768,8 +779,8 @@ mod tests {
     }
 
     #[test]
-    fn profile_ssd_and_unknown_are_zero() {
-        for name in ["ssd", "", "garbage"] {
+    fn profile_unknown_is_zero() {
+        for name in ["", "garbage"] {
             let l = Latency::profile(name);
             assert_eq!(l.open, Duration::ZERO);
             assert_eq!(l.stat, Duration::ZERO);
@@ -778,6 +789,17 @@ mod tests {
             assert_eq!(l.fsync, Duration::ZERO);
             assert_eq!(l.other, Duration::ZERO);
         }
+    }
+
+    #[test]
+    fn profile_ssd_values() {
+        let l = Latency::profile("ssd");
+        assert_eq!(l.open, micros(80));
+        assert_eq!(l.stat, micros(40));
+        assert_eq!(l.read, micros(80));
+        assert_eq!(l.write, micros(80));
+        assert_eq!(l.fsync, micros(300));
+        assert_eq!(l.other, micros(40));
     }
 
     // Assert against literal `Duration`s rather than ms()/us(), so a mutation

--- a/musefs-latencyfs/tests/latency_effect.rs
+++ b/musefs-latencyfs/tests/latency_effect.rs
@@ -17,7 +17,7 @@ fn nonzero_profile_is_slower_than_ssd() {
     let backing = tempfile::tempdir().unwrap();
     std::fs::write(backing.path().join("f.bin"), vec![0u8; 64 * 1024]).unwrap();
 
-    // ssd (~0) baseline.
+    // ssd (local NVMe-class, ~80µs/op) baseline.
     let fast = LatencyMount::new(backing.path(), "ssd").unwrap();
     let t0 = Instant::now();
     for _ in 0..20 {


### PR DESCRIPTION
Closes #255.

## Problem

In synthesis mode a single sequential read was served one ≤256 KiB FUSE chunk at a time, each paying the full backing-read RTT with no overlap. On a high-RTT NFS mount that collapses throughput to chunk_count × per-read latency — ~1.3 MB/s at 200 ms RTT.

## Approach

A per-handle **backing read-ahead** buffer caches *raw backing-file bytes keyed by absolute backing offset* and is consulted by every backing read (PCM `BackingAudio` and the Ogg `serve_ogg_window` page walk alike) through a single `BackingReader::read_exact_at`. On a sequential miss it does **one large `pread`** (geometric window growth up to a per-stream cap) instead of the small FUSE chunk, so the backing client can pipeline/parallelize the RPCs behind one syscall. A seek resets the window to the floor. All handles draw from one process-wide RAM budget (`--read-ahead-budget-mib`, default 64) with deadlock-free `try_lock` LRU eviction.

Keying on the absolute backing offset (not synthesized output) makes the cache **retag-immune**, and serving still flows through the per-read `validate_opened_backing` re-stat, so the cardinal audio-bytes invariant and freshness semantics are untouched.

A Phase-2 background-prefetch-threads layer also exists but is **off by default** (`--read-ahead-prefetch` to opt in) — benchmarks found amplification alone carries the whole win.

## Results (BENCHMARKS.md#backing-read-ahead-255)

Cold single-stream throughput:

| backing | off | Phase-1 (default) | passthrough |
|---|---|---|---|
| local HDD (real FLAC) | ~60 | ~62 (neutral) | ~58 |
| NFS, 200 ms RTT | 1.2 | **7.4** (~6×) | 9.8 |

Concurrent ×8 over NFS: 1.6 → **13.6** MB/s. At SSD latency (in-process latencyfs): 774 → 32 backing preads, 45 → 26 ms.

Phase 2 never beat Phase-1-only (consistently ~10% behind, single and concurrent), so it ships opt-in.

## Correctness

- Audio-bytes invariant preserved (absolute-offset keying + per-read re-stat).
- Budget accounting invariant `charged == Σ buffer bytes`, with a regression test for the prefetch-path underflow.
- Byte-exact differential tests (PCM + Ogg + forced-eviction + partial-seek).
- TSan-clean: `concurrent_reads` plus a worker-`reconcile` / cross-stream-eviction stress under `-Zsanitizer=thread -Zbuild-std`.

## Notes

- The design spec and implementation plan are included under `docs/superpowers/`.
- New flags documented in README, `contrib/systemd/musefs.conf.example`, ARCHITECTURE.md, and docs/OGG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved single-stream sequential performance with backing read-ahead using an adaptive per-handle window and a configurable global RAM budget (`--read-ahead-budget-mib`, default 64 MiB; set to 0 to disable).
  * Optional Phase 2 background prefetch (`--read-ahead-prefetch`) remains off by default.
  * Added readahead hit/miss counters when metrics are enabled.
* **Documentation**
  * Updated README tuning, systemd config example, BENCHMARKS, and OGG read-ahead behavior notes.
* **Tests**
  * Expanded/updated read-ahead benchmarks, differential correctness, concurrency coverage, and fuzz routing through the new backing reader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->