### PR TITLE
fix(beets): surface read-only/permission DB errors; doc no-write config

### DIFF
--- a/contrib/beets/README.md
+++ b/contrib/beets/README.md
@@ -86,6 +86,35 @@ left behind at the old one. A metadata-only `beet modify` (no `-w`) doesn't fire
 a hook — re-run `beet musefs`. With `autoscan: no`, run `musefs scan` yourself
 first; the hooks then skip gracefully if the DB is missing.
 
+## Never writing to your backing audio files
+
+If your backing files must stay byte-for-byte untouched — you're seeding them as
+a torrent, the library is immutable, or you simply want beets to drive the musefs
+view without ever rewriting a tag — configure beets to never write to disk:
+
+```yaml
+import:
+    copy: no
+    move: no
+    write: no
+```
+
+`write: no` is enough on its own: every stock beets plugin gates its file writes
+on `import.write`. The musefs plugin reads canonical metadata from the **beets
+database**, not from the files, and `musefs scan` ingests/synthesizes embedded
+art itself — so `write: no` loses nothing in the musefs view.
+
+A few plugins ignore that gate or are redundant in this mode:
+
+- **scrub** — deletes all tags from files directly via mutagen, *ignoring*
+  `import.write`; its auto-import hook would wipe tags from your backing files.
+  Don't enable it.
+- **embedart** — embeds cover art into the audio files. Redundant: musefs already
+  presents embedded art in the virtual files (scan ingestion plus the plugin's
+  overlay of the album's `artpath`).
+- **zero** — only acts during a file write, so it is inert with `write: no`
+  (nothing to do, but nothing to worry about either).
+
 ## Notes
 
 - **Field coverage:** every tag beets writes to a file (its `_media_tag_fields`)

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -137,7 +137,28 @@ class MusefsPlugin(BeetsPlugin):
             # environmental failure (locked DB, vanished file, wedged scan); those
             # degrade to a warning. An unexpected exception still propagates so a
             # real bug surfaces instead of hiding behind a one-line warning.
-            self._log.warning("musefs: {}", exc)
+            if self._is_permission_error(exc):
+                # A persistent setup failure (read-only DB / permission denied)
+                # would otherwise be a silent no-op: beets hides plugin WARNINGs
+                # at default verbosity, so the user gets no sign the sync did
+                # nothing. Surface it via ui.print_ — but still don't abort.
+                ui.print_(
+                    f"musefs: cannot write {db_path} (read-only/permission denied) "
+                    f"— metadata not synced"
+                )
+            else:
+                self._log.warning("musefs: {}", exc)
+
+    @staticmethod
+    def _is_permission_error(exc):
+        """True if ``exc`` is a persistent permission/read-only DB failure (worth
+        surfacing loudly), as opposed to a transient lock or a vanished file."""
+        if isinstance(exc, PermissionError):
+            return True
+        if isinstance(exc, sqlite3.OperationalError):
+            msg = str(exc).lower()
+            return "readonly database" in msg or "unable to open database file" in msg
+        return False
 
     # --- helpers ---------------------------------------------------------
 

--- a/contrib/beets/tests/test_reconcile.py
+++ b/contrib/beets/tests/test_reconcile.py
@@ -35,10 +35,18 @@ def _plugin(monkeypatch, *, sync_raises=None):
     return plugin
 
 
+def _capture_prints(monkeypatch):
+    prints = []
+    monkeypatch.setattr(musefs_mod.ui, "print_", lambda *a: prints.append(a))
+    return prints
+
+
 def test_reconcile_swallows_db_error_as_warning(monkeypatch):
     plugin = _plugin(monkeypatch, sync_raises=sqlite3.OperationalError("database is locked"))
+    prints = _capture_prints(monkeypatch)
     plugin._reconcile_pending()  # must NOT raise
     assert len(plugin._log.warnings) == 1
+    assert prints == []  # transient failures stay quiet
 
 
 def test_reconcile_swallows_os_error_as_warning(monkeypatch):
@@ -51,6 +59,41 @@ def test_reconcile_propagates_unexpected_error(monkeypatch):
     plugin = _plugin(monkeypatch, sync_raises=ValueError("a real bug"))
     with pytest.raises(ValueError):
         plugin._reconcile_pending()
+
+
+def test_reconcile_surfaces_readonly_db_loudly(monkeypatch):
+    plugin = _plugin(
+        monkeypatch,
+        sync_raises=sqlite3.OperationalError("attempt to write a readonly database"),
+    )
+    prints = _capture_prints(monkeypatch)
+    plugin._reconcile_pending()  # still must NOT raise
+    assert plugin._log.warnings == []  # not buried in a default-hidden warning
+    assert len(prints) == 1
+    msg = prints[0][0]
+    assert "/db.sqlite" in msg and "not synced" in msg
+
+
+def test_reconcile_surfaces_unwritable_dir_loudly(monkeypatch):
+    # A non-writable DB directory surfaces as SQLite "unable to open database
+    # file" when it tries to create the -wal/-shm files — also persistent.
+    plugin = _plugin(
+        monkeypatch,
+        sync_raises=sqlite3.OperationalError("unable to open database file"),
+    )
+    prints = _capture_prints(monkeypatch)
+    plugin._reconcile_pending()
+    assert plugin._log.warnings == []
+    assert len(prints) == 1
+
+
+def test_reconcile_surfaces_permission_error_loudly(monkeypatch):
+    plugin = _plugin(monkeypatch, sync_raises=PermissionError(13, "Permission denied"))
+    prints = _capture_prints(monkeypatch)
+    plugin._reconcile_pending()
+    assert plugin._log.warnings == []
+    assert len(prints) == 1
+    assert "/db.sqlite" in prints[0][0]
 
 
 def test_run_scan_passes_shared_timeout(monkeypatch):


### PR DESCRIPTION
Handles #403 and #405.

## #405 — surface persistent DB write failures
`MusefsPlugin._reconcile_pending` (the `cli_exit` hook) is best-effort and degraded *every* caught failure to a `self._log.warning`, which beets hides at default verbosity. A **persistent setup** failure — read-only DB, `EACCES`/`PermissionError`, directory not writable — then became a silent no-op: `beet import` reports success, nothing syncs into the store, and the user gets no indication anything went wrong.

This classifies persistent permission/read-only failures (`PermissionError`, or `sqlite3.OperationalError` matching `readonly database` / `unable to open database file`) and surfaces them via `ui.print_` even at default verbosity:

> `musefs: cannot write <db> (read-only/permission denied) — metadata not synced`

Transient/environmental failures (locked DB, vanished file, wedged scan) stay quiet best-effort warnings as before, and the hook still never aborts the beets operation. Unexpected exceptions still propagate.

## #403 — document the never-write-to-backing-files config
New README section covering `import.copy/move/write: no`, why `write: no` loses nothing in the musefs view (plugins gate writes on `import.write`; canonical metadata comes from the beets DB; `musefs scan` handles embedded art), and the `scrub`/`embedart`/`zero` caveats.

## Tests
3 new cases in `tests/test_reconcile.py` (read-only DB, unwritable dir, `PermissionError` → loud `print_`; transient → quiet warning). Full beets suite green (62 passed, 15 e2e/bin deselected); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)