### PR TITLE
fix(contrib): case-fold merge key match to avoid duplicate rendered tags

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,7 +251,11 @@ out of band (the beets plugin uses a beets flexattr; the store is not the
 place for plugin state). musefs renders tags outside its native VOCAB
 (`musefs-format/src/tagmap.rs`) by passthrough (Vorbis uppercased, mp3
 `TXXX`, mp4 freeform), so such tags appear but are not guaranteed
-byte-identical to a given tagger's own per-format encoding.
+byte-identical to a given tagger's own per-format encoding. A merge matches
+the keys it manages **case-insensitively**, so a writer's canonical
+(lowercase) key replaces a scan-seeded row stored under the backing file's
+native case (e.g. Vorbis `LABEL`) instead of coexisting with it — Vorbis keys
+render case-insensitively, so two such rows would otherwise duplicate.
 
 **Path layout offload.** External tools can also offload path layout
 entirely: a plugin evaluates its own (arbitrarily complex) path logic, writes

--- a/contrib/picard/musefs/_common/store.py
+++ b/contrib/picard/musefs/_common/store.py
@@ -153,9 +153,14 @@ def merge_tags(conn, track_id, managed_pairs, delete_keys):
         for key, value in managed_pairs:
             by_key.setdefault(key, []).append(value)
 
+        # Case-fold the key match: a scan seeds an unmapped tag in the file's
+        # native case (e.g. Vorbis ``LABEL``) while the plugin canonicalises to
+        # lowercase (``label``). Vorbis keys render case-insensitively, so an
+        # exact-case delete would leave the scan row and render a duplicate (#407).
         for key in set(by_key) | set(delete_keys or ()):
             conn.execute(
-                "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+                "DELETE FROM tags WHERE track_id = ? AND lower(key) = lower(?) "
+                "AND value_blob IS NULL",
                 (track_id, key),
             )
 

--- a/contrib/python-musefs/src/musefs_common/store.py
+++ b/contrib/python-musefs/src/musefs_common/store.py
@@ -150,9 +150,14 @@ def merge_tags(conn, track_id, managed_pairs, delete_keys):
         for key, value in managed_pairs:
             by_key.setdefault(key, []).append(value)
 
+        # Case-fold the key match: a scan seeds an unmapped tag in the file's
+        # native case (e.g. Vorbis ``LABEL``) while the plugin canonicalises to
+        # lowercase (``label``). Vorbis keys render case-insensitively, so an
+        # exact-case delete would leave the scan row and render a duplicate (#407).
         for key in set(by_key) | set(delete_keys or ()):
             conn.execute(
-                "DELETE FROM tags WHERE track_id = ? AND key = ? AND value_blob IS NULL",
+                "DELETE FROM tags WHERE track_id = ? AND lower(key) = lower(?) "
+                "AND value_blob IS NULL",
                 (track_id, key),
             )
 

--- a/contrib/python-musefs/tests/test_merge_tags.py
+++ b/contrib/python-musefs/tests/test_merge_tags.py
@@ -76,3 +76,39 @@ def test_merge_preserves_binary_tags(db_path):
         assert text_tags(conn, tid)["comment"] == ["text"]
     finally:
         conn.close()
+
+
+def test_merge_replaces_case_variant_scan_key(db_path):
+    """A scan seeds an unmapped Vorbis key in the file's native (upper) case;
+    the plugin's lowercase canonical key must replace it, not coexist (#407)."""
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/e.flac")
+        # Scanner-seeded row, native FLAC Vorbis case (uppercase).
+        replace_tags(conn, tid, [("LABEL", "New Friends")])
+        # Plugin sync writes the canonical lowercase key for the same field.
+        merge_tags(conn, tid, [("label", "New Friends")], delete_keys=[])
+        conn.commit()
+        rows = conn.execute(
+            "SELECT key, value FROM tags WHERE track_id=? AND value_blob IS NULL", (tid,)
+        ).fetchall()
+        # Exactly one row survives (no LABEL/label duplicate that renders twice).
+        assert rows == [("label", "New Friends")]
+    finally:
+        conn.close()
+
+
+def test_merge_delete_keys_clears_case_variant(db_path):
+    """delete_keys must also clear a scan-seeded case variant of the named key."""
+    conn = connect(db_path)
+    try:
+        tid = insert_track(conn, "/m/f.flac")
+        replace_tags(conn, tid, [("LABEL", "Old")])
+        merge_tags(conn, tid, [], delete_keys=["label"])
+        conn.commit()
+        rows = conn.execute(
+            "SELECT key FROM tags WHERE track_id=? AND value_blob IS NULL", (tid,)
+        ).fetchall()
+        assert rows == []
+    finally:
+        conn.close()


### PR DESCRIPTION
Fixes #407.

## Problem

A `musefs scan` followed by a `beet musefs` / Picard sync rendered a duplicated tag value:

```
TAG:LABEL=New Friends;New Friends
```

`musefs scan` seeds an unmapped tag under the backing file's native key case (Vorbis comments are conventionally uppercase, e.g. `LABEL`), while the plugins canonicalise keys to lowercase (`label`). The `tags` PK is case-sensitive, and `merge_tags` deleted by **exact** key, so the plugin's `label` insert never displaced the scanner's `LABEL` — both rows survived. Because Vorbis keys render case-insensitively, both surfaced as `LABEL`, yielding the duplicate.

This only affected **unmapped/user-defined** keys (vocab keys like `artist` already converge on lowercase via the tagmap) and was general across formats (Vorbis, MP3 `TXXX`, MP4 freeform).

## Fix

Match the merge/delete keys **case-insensitively** (`lower(key) = lower(?)`) in `merge_tags`, so a writer's canonical lowercase key replaces a scan-seeded native-case row instead of coexisting with it.

This is the right layer: the duplicate only arises at the scan↔sync boundary that `merge_tags` owns; it fixes all formats in one place and self-heals existing duplicate rows on the next sync of the affected key. Scan-time normalisation (the other suggested fix) was rejected because lowercasing all scanned keys would change *visible* MP3/MP4 output for unmapped keys (TXXX descriptions render verbatim), breaking the documented "user-defined keys round-trip verbatim" contract.

## Changes

- `contrib/python-musefs/src/musefs_common/store.py` — case-fold the merge delete (canonical source).
- `contrib/picard/musefs/_common/store.py` — regenerated via `vendor_to_picard.py` (vendor-sync test passes); beets picks it up through its `musefs_common` import.
- `contrib/python-musefs/tests/test_merge_tags.py` — two tests (managed-key replace + `delete_keys`), red before / green after.
- `ARCHITECTURE.md` — documented the case-insensitive match in the external-writer contract.

All 65 python-musefs tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)