### PR TITLE
feat: progress indicator for scan / revalidate (#406)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:498:31:',
+    'musefs-core/src/scan\.rs:603:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:505:30:',
+    'musefs-core/src/scan\.rs:610:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,14 +127,14 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:516:21:',
+    'musefs-core/src/scan\.rs:621:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:521:17:',
+    'musefs-core/src/scan\.rs:626:17:',
     # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
     # per oversized mp4 `covr` / `----` payload the format layer skipped before
     # materialization (#343) and returns nothing. With no log-capture harness in the
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:944:46:',
+    'musefs-core/src/scan\.rs:1063:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1039:29:',
+    'musefs-core/src/scan\.rs:1165:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1041:32:',
+    'musefs-core/src/scan\.rs:1167:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1041:47:',
+    'musefs-core/src/scan\.rs:1167:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1041:62:',
+    'musefs-core/src/scan\.rs:1167:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1049:37:',
+    'musefs-core/src/scan\.rs:1175:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1051:40:',
+    'musefs-core/src/scan\.rs:1177:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1051:55:',
+    'musefs-core/src/scan\.rs:1177:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1051:70:',
+    'musefs-core/src/scan\.rs:1177:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1167:29:',
+    'musefs-core/src/scan\.rs:1298:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1175:29:',
+    'musefs-core/src/scan\.rs:1306:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1212:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1349:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1165:29:',
+    'musefs-core/src/scan\.rs:1172:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1167:32:',
+    'musefs-core/src/scan\.rs:1174:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1167:47:',
+    'musefs-core/src/scan\.rs:1174:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1167:62:',
+    'musefs-core/src/scan\.rs:1174:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1175:37:',
+    'musefs-core/src/scan\.rs:1182:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1177:40:',
+    'musefs-core/src/scan\.rs:1184:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1177:55:',
+    'musefs-core/src/scan\.rs:1184:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1177:70:',
+    'musefs-core/src/scan\.rs:1184:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1298:29:',
+    'musefs-core/src/scan\.rs:1305:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1306:29:',
+    'musefs-core/src/scan\.rs:1313:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1349:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1356:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -287,6 +287,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -721,6 +739,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +935,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "indicatif",
  "musefs-core",
  "musefs-db",
  "musefs-fuse",
@@ -1084,6 +1115,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "ogg"
@@ -1467,7 +1504,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1686,7 +1723,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1988,6 +2025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,7 +2056,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2026,12 +2073,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ symlinks are logged and skipped). `--quiet`
 (`-q`) suppresses the per-target summary for scripting; scan failures still
 surface on stderr (raise detail with `RUST_LOG=info`).
 
+`scan` and `scan --revalidate` show a live progress indicator: on an interactive
+terminal, a discovery spinner followed by a determinate bar (position, percent,
+ETA, current file); on a non-interactive stderr (piped or logged), throttled
+`ingested N/M (P%)` lines. `--quiet` (`-q`) suppresses the progress indicator
+and the per-target summary. Each summary line ends with the elapsed time.
+
 The per-target summary reads `scanned N: … skipped X, failed Y`. `skipped`
 counts every file that isn't a supported audio format — cover art, `.cue` /
 `.log` / `.nfo` sidecars, and anything else non-audio — so a large `skipped`

--- a/docs/superpowers/plans/2026-06-14-scan-progress-indicator.md
+++ b/docs/superpowers/plans/2026-06-14-scan-progress-indicator.md
@@ -1,0 +1,774 @@
+# Scan Progress Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `musefs scan` and `musefs scan --revalidate` live progress (discovery spinner → determinate bar on a TTY, throttled `N/M` lines otherwise) plus an elapsed-time summary, honouring `--quiet`.
+
+**Architecture:** `musefs-core` stays UI-agnostic — it emits `ScanProgress` events through an optional `ProgressSink` callback held in `ScanOptions` (default `None`, so all existing callers are untouched). `musefs-cli` owns rendering via `indicatif`, building the sink from `--quiet` and `stderr().is_terminal()`. The walk emits `Discovered`, the callers emit `Walked` once totals are known, and the single writer thread in `run_pipeline` emits `Ingested` per committed file.
+
+**Tech Stack:** Rust workspace (db→format→core→cli→binary), `indicatif` (new `musefs-cli` dep), `std::io::IsTerminal`, existing `cargo-mutants` anchor tooling.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-14-scan-progress-indicator-design.md`
+
+---
+
+## File Structure
+
+- `musefs-core/src/scan.rs` — **modify.** Add `ScanProgress<'a>` enum + `ProgressSink` type, `ScanOptions.progress` field, walk/pipeline wiring, and core tests.
+- `musefs-core/src/lib.rs` — **modify.** Re-export `ScanProgress`, `ProgressSink`.
+- `.cargo/mutants.toml` — **modify.** Re-anchor `scan.rs` `file:line:col` entries shifted by the edits.
+- `musefs-cli/Cargo.toml` — **modify.** Add `indicatif`.
+- `musefs-cli/src/progress.rs` — **create.** `next_milestone` pure fn (+ unit tests) and the `ScanReporter`/`Renderer` indicatif renderer.
+- `musefs-cli/src/lib.rs` — **modify.** `mod progress;`, wire `run_scan` (build reporter, pass sink, elapsed summaries, finish).
+- `musefs-cli/tests/scan.rs` — **modify.** Smoke integration tests for the progress-enabled paths.
+- `README.md` — **modify.** Note progress behaviour + `--quiet`.
+
+> **Note on commit granularity:** The spec floated splitting the core work into 1a/1b. This plan keeps all `scan.rs` changes in **one** commit (Task 1) so the `.cargo/mutants.toml` re-anchor — which requires a `cargo mutants --list` run (minutes) — happens **once** instead of twice. The reviewer flagged the split as optional; consolidating is the lower-churn choice given the anchor gate.
+
+---
+
+## Task 1: Core progress events + wiring (`musefs-core`)
+
+**Files:**
+- Modify: `musefs-core/src/scan.rs`
+- Modify: `musefs-core/src/lib.rs`
+- Modify: `.cargo/mutants.toml`
+
+This task compiles only once all of steps 2–7 land, so the new tests are written first (they fail to compile = "fail"), then the implementation, then one green commit.
+
+- [ ] **Step 1: Write the failing core tests**
+
+Add to the `scan_unit_tests` module in `musefs-core/src/scan.rs` (the module that already defines `flac_block` / `streaminfo` / `write_flac` helpers). These use the same minimal-FLAC bytes pattern as the existing `jobs1_and_jobs_n_produce_equivalent_state` test.
+
+```rust
+    #[test]
+    fn scan_options_debug_includes_progress_sink() {
+        let opts = ScanOptions {
+            progress: Some(ProgressSink::new(|_| {})),
+            ..Default::default()
+        };
+        assert!(format!("{opts:?}").contains("ProgressSink"));
+    }
+
+    #[test]
+    fn scan_emits_discovered_walked_ingested_events() {
+        use std::sync::Mutex;
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            let mut bytes = b"fLaC".to_vec();
+            bytes.push(0x80);
+            bytes.extend_from_slice(&[0, 0, 34]);
+            bytes.extend(std::iter::repeat_n(0u8, 34));
+            bytes.extend_from_slice(format!("AUDIO-{i}").as_bytes());
+            std::fs::write(dir.path().join(format!("t{i}.flac")), &bytes).unwrap();
+        }
+
+        let events = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorder = Arc::clone(&events);
+        let sink = ProgressSink::new(move |ev| {
+            let line = match ev {
+                ScanProgress::Discovered { found } => format!("disc:{found}"),
+                ScanProgress::Walked { total } => format!("walk:{total}"),
+                ScanProgress::Ingested { done, total, .. } => format!("ing:{done}/{total}"),
+            };
+            recorder.lock().unwrap().push(line);
+        });
+
+        let db = Db::open_in_memory().unwrap();
+        let opts = ScanOptions {
+            jobs: 1,
+            progress: Some(sink),
+            ..Default::default()
+        };
+        let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+        assert_eq!(stats.scanned, 5);
+
+        let ev = events.lock().unwrap();
+        // Discovery climbs to the full count.
+        assert!(ev.iter().any(|e| e == "disc:5"), "events: {ev:?}");
+        // Walk reports the total to ingest.
+        assert!(ev.contains(&"walk:5".to_string()), "events: {ev:?}");
+        // Ingest reports each committed file, done strictly 1..=total.
+        let ing: Vec<&String> = ev.iter().filter(|e| e.starts_with("ing:")).collect();
+        assert_eq!(
+            ing,
+            vec!["ing:1/5", "ing:2/5", "ing:3/5", "ing:4/5", "ing:5/5"],
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail (don't compile)**
+
+Run: `cargo test -p musefs-core --lib scan_emits_discovered_walked_ingested_events 2>&1 | tail -20`
+Expected: compile error — `cannot find type ScanProgress` / no field `progress` on `ScanOptions`.
+
+- [ ] **Step 3: Add the `ScanProgress` enum and `ProgressSink` type**
+
+In `musefs-core/src/scan.rs`, add two module-level imports next to the existing `use` block at the top (`use std::sync::mpsc::sync_channel;` is already there):
+
+```rust
+use std::fmt;
+use std::sync::Arc;
+```
+
+Then **remove** the now-redundant function-local `use std::sync::Arc;` line inside `run_pipeline` (leaving its `use std::sync::atomic::{AtomicU64, Ordering};`). A nested redundant import trips `unused_imports` under `-D warnings`.
+
+Add the types just above the `ScanStats` struct:
+
+```rust
+/// A progress event emitted during a scan or revalidate. Borrows the current
+/// path to avoid a per-file allocation in the writer; the saved allocation is
+/// negligible next to the existing per-file `to_string_lossy` + DB write, so do
+/// not contort the API to preserve the borrow.
+#[derive(Debug, Clone, Copy)]
+pub enum ScanProgress<'a> {
+    /// A supported-audio file was found during the walk; `found` is the running
+    /// count of collected files.
+    Discovered { found: u64 },
+    /// The walk (and, for revalidate, the skip-unchanged pass) finished;
+    /// `total` files will be ingested and tracked by the determinate bar.
+    Walked { total: u64 },
+    /// A file was committed. `done` runs 1..=total; `path` is its absolute path.
+    Ingested { done: u64, total: u64, path: &'a str },
+}
+
+/// UI-agnostic progress callback for [`ScanOptions`]. Invoked only from the
+/// caller's thread (the walk and the single writer), never from probe workers.
+/// The `Send + Sync` bound is not required by today's code; it is deliberate
+/// future-proofing and free here (`indicatif::ProgressBar` is `Send + Sync`).
+#[derive(Clone)]
+pub struct ProgressSink(Arc<dyn for<'a> Fn(ScanProgress<'a>) + Send + Sync>);
+
+impl ProgressSink {
+    pub fn new(f: impl for<'a> Fn(ScanProgress<'a>) + Send + Sync + 'static) -> Self {
+        ProgressSink(Arc::new(f))
+    }
+
+    fn emit(&self, ev: ScanProgress<'_>) {
+        (self.0)(ev);
+    }
+}
+
+impl fmt::Debug for ProgressSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ProgressSink")
+    }
+}
+```
+
+- [ ] **Step 4: Add the `progress` field to `ScanOptions`**
+
+In the `ScanOptions` struct, add the field after `follow_symlinks`:
+
+```rust
+    /// Optional progress callback. `None` (the default) disables reporting.
+    pub progress: Option<ProgressSink>,
+```
+
+In `impl Default for ScanOptions`, add `progress: None,` after `follow_symlinks: false,`.
+
+- [ ] **Step 5: Thread discovery progress through the walk**
+
+Replace `collect_audio` with a thin wrapper that delegates to a new `collect_audio_with` carrying the sink (keeps the existing 3-arg signature so the ~9 other call sites and tests stay unchanged):
+
+```rust
+fn collect_audio(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+) -> std::io::Result<SkipTally> {
+    collect_audio_with(root, out, follow_symlinks, None)
+}
+
+fn collect_audio_with(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    progress: Option<&ProgressSink>,
+) -> std::io::Result<SkipTally> {
+    let mut visited = HashSet::new();
+    let mut files_visited = HashSet::new();
+    let mut tally = SkipTally::default();
+    if follow_symlinks {
+        if let Ok(meta) = std::fs::metadata(root) {
+            visited.insert(dir_key(&meta));
+        }
+    }
+    collect_audio_inner(
+        root,
+        out,
+        follow_symlinks,
+        &mut visited,
+        &mut files_visited,
+        &mut tally,
+        progress,
+    )?;
+    Ok(tally)
+}
+```
+
+Add a trailing `progress: Option<&ProgressSink>` parameter to `collect_audio_inner` and `descend`, and forward it at every recursive call and `push_file` call inside them (each existing call gets `, progress` appended). `descend`'s two `collect_audio_inner(...)` calls and `collect_audio_inner`'s `descend(...)` / `push_file(...)` calls all gain the argument.
+
+Update `push_file` to accept the sink and emit `Discovered` after each successful push:
+
+```rust
+fn push_file(
+    path: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    files_visited: &mut HashSet<(u64, u64)>,
+    known_meta: Option<&std::fs::Metadata>,
+    progress: Option<&ProgressSink>,
+) {
+    if !follow_symlinks {
+        out.push(path.to_path_buf());
+        if let Some(p) = progress {
+            p.emit(ScanProgress::Discovered { found: out.len() as u64 });
+        }
+        return;
+    }
+    let key = match known_meta {
+        Some(m) => Some(dir_key(m)),
+        None => std::fs::metadata(path).ok().map(|m| dir_key(&m)),
+    };
+    match key {
+        Some(k) if !files_visited.insert(k) => {
+            log::debug!("skipping duplicate backing target {}", path.display());
+        }
+        _ => {
+            out.push(path.to_path_buf());
+            if let Some(p) = progress {
+                p.emit(ScanProgress::Discovered { found: out.len() as u64 });
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Emit `Walked` in the callers and `Ingested` in the pipeline**
+
+In `scan_directory_with`: pass the sink into the walk and emit `Walked` before `run_pipeline`. Change the directory branch from `collect_audio(root, &mut files, opts.follow_symlinks)?` to `collect_audio_with(root, &mut files, opts.follow_symlinks, opts.progress.as_ref())?`, then after the `if root.is_file() { … } else { … }` block and before `db.apply_bulk_pragmas_self()?`:
+
+```rust
+    if let Some(p) = &opts.progress {
+        p.emit(ScanProgress::Walked { total: files.len() as u64 });
+    }
+```
+
+In `revalidate_with`: change `collect_audio(root, &mut files, opts.follow_symlinks)?` to `collect_audio_with(root, &mut files, opts.follow_symlinks, opts.progress.as_ref())?`, and immediately before `let scan = run_pipeline(db, changed, opts)?;` add:
+
+```rust
+    if let Some(p) = &opts.progress {
+        p.emit(ScanProgress::Walked { total: changed.len() as u64 });
+    }
+```
+
+In `run_pipeline`: capture the total and the sink before `files` is moved into the work queue. Right after `let jobs = effective_jobs(opts.jobs);`:
+
+```rust
+    let total = files.len() as u64;
+    let progress = opts.progress.as_ref();
+```
+
+Then inside the `flush` closure's per-unit `for` loop, immediately after `*scanned += 1;`, add the emit (`abs_path` is still in scope — `ingest_bulk` borrows it, does not move it):
+
+```rust
+            if let Some(p) = progress {
+                p.emit(ScanProgress::Ingested {
+                    done: *scanned,
+                    total,
+                    path: &abs_path,
+                });
+            }
+```
+
+The closure already captures by reference; `progress` (`Option<&ProgressSink>`, `Copy`) and `total` (`u64`, `Copy`) are captured automatically.
+
+- [ ] **Step 7: Re-export the new types**
+
+In `musefs-core/src/lib.rs`, extend the `pub use scan::{ … }` block to include `ProgressSink` and `ScanProgress`:
+
+```rust
+pub use scan::{
+    ProgressSink, RevalidateStats, ScanOptions, ScanProgress, ScanStats, revalidate,
+    revalidate_with, scan_directory, scan_directory_with,
+};
+```
+
+- [ ] **Step 8: Run the core tests to confirm they pass**
+
+Run: `cargo test -p musefs-core --lib scan 2>&1 | tail -20`
+Expected: the two new tests pass and no existing `scan` test regresses. (rtk may summarise the output as `cargo test: N passed`; trust the exit code.)
+
+- [ ] **Step 9: Re-anchor `.cargo/mutants.toml`**
+
+The edits shift the `scan.rs` `file:line:col` anchors (run_pipeline `+=`/`>=`/`||`/`*`, revalidate `+=`). Re-anchor in this commit:
+
+```bash
+cargo mutants --no-config --list --json > /tmp/scan-mutants.json
+python3 scripts/check_mutant_anchors.py --fix --mutants-json /tmp/scan-mutants.json
+python3 scripts/check_mutant_anchors.py --mutants-json /tmp/scan-mutants.json
+```
+
+The final command must print `OK: … entries validated`. `--fix` only re-anchors covering-set clusters; for any remaining failure it reports, open `.cargo/mutants.toml`, find the entry by its `# guard:` tag (e.g. `op="+=" fn="run_pipeline" rows=2`), and replace the `file:line:col` with the new coordinates from `/tmp/scan-mutants.json` (match the same op/function). Re-run until `OK`.
+
+> Do not add new exclusions here. The new `*scanned`/`done`/`found`/`total` counters are killed by the Step 1 event test; only the pre-existing anchored entries move.
+
+- [ ] **Step 10: Format and lint**
+
+Run: `cargo fmt -p musefs-core && cargo clippy -p musefs-core --all-targets 2>&1 | tail -20`
+Expected: no diff from fmt, no clippy warnings.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add musefs-core/src/scan.rs musefs-core/src/lib.rs .cargo/mutants.toml
+git commit -m "feat(core): emit scan/revalidate progress events via ScanOptions sink (#406)"
+```
+(The pre-commit hook runs the full workspace suite + the mutant-anchor guard; both must pass.)
+
+---
+
+## Task 2: CLI rendering (`musefs-cli`)
+
+**Files:**
+- Modify: `musefs-cli/Cargo.toml`
+- Create: `musefs-cli/src/progress.rs`
+- Modify: `musefs-cli/src/lib.rs`
+- Test: `musefs-cli/src/progress.rs` (unit), `musefs-cli/tests/scan.rs` (integration)
+
+- [ ] **Step 1: Add the `indicatif` dependency**
+
+In `musefs-cli/Cargo.toml`, under `[dependencies]`, add:
+
+```toml
+indicatif = { version = "0.17", default-features = false }
+```
+
+Run `cargo build -p musefs-cli` to confirm it resolves. If the workspace MSRV rejects this `indicatif`, pin the latest version that builds and note it.
+
+- [ ] **Step 2: Write `next_milestone` and its failing unit tests**
+
+Create `musefs-cli/src/progress.rs` with the pure decision function and tests (implementation filled in the same step so the file compiles; the tests are the verification gate):
+
+```rust
+//! Progress rendering for `musefs scan` / `--revalidate`. The decision logic
+//! (`next_milestone`) is split out as a pure function so the mutation gate can
+//! reach it; the indicatif rendering itself is unobservable side-effect I/O.
+
+const STEP: u64 = 5; // milestone granularity, percent
+
+/// The milestone percent (a multiple of `STEP`, or 100) that `done` newly
+/// reaches relative to `prev_done`, else `None`. `total == 0` yields `None`
+/// (no divide-by-zero); reaching `total` always yields `Some(100)` so the
+/// final line prints even when the last step is smaller than `STEP`.
+pub(crate) fn next_milestone(prev_done: u64, done: u64, total: u64) -> Option<u64> {
+    if total == 0 || done <= prev_done {
+        return None;
+    }
+    if done >= total {
+        return Some(100);
+    }
+    let bucket = done * 100 / total / STEP;
+    let prev_bucket = prev_done * 100 / total / STEP;
+    if bucket > prev_bucket {
+        Some(bucket * STEP)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod milestone_tests {
+    use super::next_milestone;
+
+    #[test]
+    fn zero_total_is_none() {
+        assert_eq!(next_milestone(0, 0, 0), None);
+    }
+
+    #[test]
+    fn no_advance_is_none() {
+        assert_eq!(next_milestone(3, 3, 100), None);
+    }
+
+    #[test]
+    fn single_file_is_hundred() {
+        assert_eq!(next_milestone(0, 1, 1), Some(100));
+    }
+
+    #[test]
+    fn final_step_below_granularity_still_fires() {
+        // 30 files: 29 -> 30 is < 5% but completion must always report.
+        assert_eq!(next_milestone(29, 30, 30), Some(100));
+    }
+
+    #[test]
+    fn crossing_first_five_percent() {
+        assert_eq!(next_milestone(0, 1, 20), Some(5));
+    }
+
+    #[test]
+    fn within_a_bucket_is_none() {
+        assert_eq!(next_milestone(5, 6, 100), None);
+    }
+
+    #[test]
+    fn crossing_into_ten_percent() {
+        assert_eq!(next_milestone(9, 10, 100), Some(10));
+    }
+}
+```
+
+Add `mod progress;` to `musefs-cli/src/lib.rs` (near the top, with the other module declarations).
+
+- [ ] **Step 3: Run the unit tests to confirm they pass**
+
+Run: `cargo test -p musefs-cli --lib milestone 2>&1 | tail -20`
+Expected: all 7 `milestone_tests` pass.
+
+- [ ] **Step 4: Implement the `ScanReporter` renderer**
+
+Append to `musefs-cli/src/progress.rs`:
+
+```rust
+use std::io::IsTerminal;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+use musefs_core::{ProgressSink, ScanProgress};
+
+enum Mode {
+    /// `--quiet`: no progress at all.
+    Quiet,
+    /// stderr is a TTY: animated spinner that becomes a determinate bar.
+    Tty(ProgressBar),
+    /// stderr is not a TTY: throttled `N/M` lines.
+    Plain,
+}
+
+struct Renderer {
+    mode: Mode,
+    /// Last `done` for which a `Plain` line was printed; reset per target.
+    prev_done: AtomicU64,
+}
+
+impl Renderer {
+    fn handle(&self, ev: ScanProgress<'_>) {
+        match (&self.mode, ev) {
+            (Mode::Tty(bar), ScanProgress::Discovered { found }) => {
+                bar.set_message(format!("discovering files… {found} found"));
+            }
+            (Mode::Tty(bar), ScanProgress::Walked { total }) => {
+                bar.set_style(
+                    ProgressStyle::with_template(
+                        "{spinner} [{elapsed_precise}] [{bar:30}] {pos}/{len} ({percent}%) {wide_msg}",
+                    )
+                    .expect("static template")
+                    .progress_chars("##-"),
+                );
+                bar.set_length(total);
+                bar.set_position(0);
+            }
+            (Mode::Tty(bar), ScanProgress::Ingested { done, path, .. }) => {
+                bar.set_position(done);
+                bar.set_message(basename(path));
+            }
+            (Mode::Plain, ScanProgress::Ingested { done, total, .. }) => {
+                let prev = self.prev_done.load(Ordering::Relaxed);
+                if let Some(pct) = next_milestone(prev, done, total) {
+                    eprintln!("ingested {done}/{total} ({pct}%)");
+                    self.prev_done.store(done, Ordering::Relaxed);
+                }
+            }
+            // Quiet ignores everything; Plain ignores Discovered/Walked
+            // (per-target reset happens in `start_target`).
+            _ => {}
+        }
+    }
+}
+
+fn basename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map_or_else(|| path.to_string(), |n| n.to_string_lossy().into_owned())
+}
+
+/// Owns the progress renderer for a scan run. Build once, hand `sink()` to
+/// `ScanOptions`, then call `finish()` after the last target.
+pub(crate) struct ScanReporter {
+    inner: Arc<Renderer>,
+}
+
+impl ScanReporter {
+    pub(crate) fn new(quiet: bool) -> Self {
+        let mode = if quiet {
+            Mode::Quiet
+        } else if std::io::stderr().is_terminal() {
+            let bar = ProgressBar::new_spinner();
+            bar.enable_steady_tick(Duration::from_millis(120));
+            bar.set_message("discovering files…");
+            Mode::Tty(bar)
+        } else {
+            Mode::Plain
+        };
+        ScanReporter {
+            inner: Arc::new(Renderer { mode, prev_done: AtomicU64::new(0) }),
+        }
+    }
+
+    /// `None` under `--quiet`, so `ScanOptions.progress` stays unset.
+    pub(crate) fn sink(&self) -> Option<ProgressSink> {
+        if matches!(self.inner.mode, Mode::Quiet) {
+            return None;
+        }
+        let inner = Arc::clone(&self.inner);
+        Some(ProgressSink::new(move |ev| inner.handle(ev)))
+    }
+
+    /// Reset for the next target in a multi-target run: rewind the TTY bar back
+    /// to the discovery spinner (target N-1 left it as a finished determinate
+    /// bar) and clear the Plain milestone watermark. Call at the top of each
+    /// target iteration, including the first (a no-op there).
+    pub(crate) fn start_target(&self) {
+        self.inner.prev_done.store(0, Ordering::Relaxed);
+        if let Mode::Tty(bar) = &self.inner.mode {
+            bar.set_style(ProgressStyle::default_spinner());
+            bar.set_position(0);
+            bar.set_message("discovering files…");
+        }
+    }
+
+    pub(crate) fn finish(&self) {
+        if let Mode::Tty(bar) = &self.inner.mode {
+            bar.finish_and_clear();
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Wire `run_scan`**
+
+In `musefs-cli/src/lib.rs`, add imports near the existing `use` lines:
+
+```rust
+use std::time::Instant;
+
+use indicatif::HumanDuration;
+
+use crate::progress::ScanReporter;
+```
+
+Rewrite `run_scan` to build the reporter, thread the sink, time each target, append elapsed to both summaries, and finish:
+
+```rust
+pub fn run_scan(
+    db_path: &Path,
+    targets: &[PathBuf],
+    revalidate: bool,
+    jobs: usize,
+    follow_symlinks: bool,
+    quiet: bool,
+) -> Result<()> {
+    let db =
+        Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
+    let reporter = ScanReporter::new(quiet);
+    let opts = musefs_core::ScanOptions {
+        jobs,
+        follow_symlinks,
+        progress: reporter.sink(),
+        ..Default::default()
+    };
+    for target in targets {
+        reporter.start_target();
+        let start = Instant::now();
+        if revalidate {
+            let stats = musefs_core::revalidate_with(&db, target, &opts)
+                .with_context(|| format!("revalidating {}", target.display()))?;
+            if !quiet {
+                println!(
+                    "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed in {}",
+                    target.display(),
+                    stats.updated,
+                    stats.unchanged,
+                    stats.pruned,
+                    stats.failed,
+                    HumanDuration(start.elapsed()),
+                );
+            }
+        } else {
+            let stats = musefs_core::scan_directory_with(&db, target, &opts)
+                .with_context(|| format!("scanning {}", target.display()))?;
+            if !quiet {
+                println!(
+                    "scanned {}: {} file(s), skipped {}, failed {} in {}",
+                    target.display(),
+                    stats.scanned,
+                    stats.skipped,
+                    stats.failed,
+                    HumanDuration(start.elapsed()),
+                );
+            }
+        }
+    }
+    reporter.finish();
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Add integration smoke tests**
+
+`musefs-cli/tests/scan.rs` runs `run_scan` in-process under `cargo test`, where stderr is captured (non-TTY → the `Plain` printer path). In-process stderr text cannot be captured without extra deps, so these assert that progress wiring does not break ingest across a ≥20-file library (the printed-line *decision* is already covered by `next_milestone` units; TTY rendering is manual — see Task 4). Append:
+
+```rust
+fn write_n_flacs(dir: &std::path::Path, n: usize) {
+    for i in 0..n {
+        // make_flac takes `&[&str]`; bind the owned String first so the slice
+        // element is `&str` (a `&String` element does not coerce).
+        let title = format!("TITLE=T{i}");
+        std::fs::write(
+            dir.join(format!("t{i:02}.flac")),
+            make_flac(&[title.as_str()], &[0xAB; 32]),
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn scan_with_progress_ingests_all_files() {
+    let backing = tempfile::tempdir().unwrap();
+    write_n_flacs(backing.path(), 20);
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    // quiet = false exercises the Plain milestone printer.
+    run_scan(&db_path, &[backing.path().to_path_buf()], false, 0, false, false).unwrap();
+
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 20);
+}
+
+#[test]
+fn quiet_scan_still_ingests_all_files() {
+    let backing = tempfile::tempdir().unwrap();
+    write_n_flacs(backing.path(), 20);
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    // quiet = true: sink is None; ingest must be identical.
+    run_scan(&db_path, &[backing.path().to_path_buf()], true, 0, false, false).unwrap();
+
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 20);
+}
+
+#[test]
+fn revalidate_with_progress_reports_unchanged() {
+    let backing = tempfile::tempdir().unwrap();
+    write_n_flacs(backing.path(), 20);
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    run_scan(&db_path, &[backing.path().to_path_buf()], false, 0, false, false).unwrap();
+    // Second pass as revalidate: all unchanged, no panic, rows preserved.
+    run_scan(&db_path, &[backing.path().to_path_buf()], true, 0, false, false).unwrap();
+
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 20);
+}
+```
+
+- [ ] **Step 7: Run CLI tests, lint, format**
+
+Run: `cargo test -p musefs-cli 2>&1 | tail -20`
+Expected: all pass (existing + 7 milestone + 3 integration).
+
+Run: `cargo clippy -p musefs-cli --all-targets 2>&1 | tail -20 && cargo fmt -p musefs-cli`
+Expected: no clippy warnings, no fmt diff.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add musefs-cli/Cargo.toml Cargo.lock musefs-cli/src/progress.rs musefs-cli/src/lib.rs musefs-cli/tests/scan.rs
+git commit -m "feat(cli): render scan/revalidate progress with indicatif + elapsed summary (#406)"
+```
+
+---
+
+## Task 3: Documentation (`README.md`)
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Document the progress behaviour**
+
+In the `scan` usage section of `README.md`, add a short paragraph near the `--quiet` flag:
+
+> `scan` and `scan --revalidate` show a live progress indicator: on an interactive
+> terminal, a discovery spinner followed by a determinate bar (position, percent,
+> ETA, current file); on a non-interactive stderr (piped or logged), throttled
+> `ingested N/M (P%)` lines. `--quiet` (`-q`) suppresses the progress indicator
+> and the per-target summary. Each summary line ends with the elapsed time.
+
+(Match the exact heading/anchor style already used in `README.md` for the scan flags.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: describe scan progress indicator and --quiet (#406)"
+```
+
+(Docs-only commit: the pre-commit cargo gate is skipped.)
+
+---
+
+## Task 4: Whole-feature verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full workspace suite + metrics feature**
+
+Run: `cargo test --workspace 2>&1 | tail -15`
+Expected: all green.
+
+Run: `cargo test -p musefs-core --features metrics 2>&1 | tail -15`
+Expected: green. (Scan changes do not touch the getattr/read counters, but this is the CI `check` job's feature set — confirm no surprise.)
+
+- [ ] **Step 2: Mutation gate on the diff**
+
+Per the local in-diff gate procedure (mutants run `--in-place`, serial, default `/tmp` TMPDIR), run the in-diff mutation gate against this branch's diff. Sanity-check that the diff actually contains the new `scan.rs`/`progress.rs` lines (a silent empty diff is a false pass).
+
+- `next_milestone` mutants must be **killed** by `milestone_tests`; the core counter mutants by `scan_emits_discovered_walked_ingested_events`.
+- The indicatif `Renderer::handle` rendering arms are unobservable side-effect I/O (same class as the existing `log_mp4_oversize_drops` exclusion). For any survivors there, add a documented `exclude_re` entry to `.cargo/mutants.toml` with a `# guard:` tag explaining the unobservability — do **not** add tests that assert on terminal output. Re-run the anchor guard (`python3 scripts/check_mutant_anchors.py`) after editing the toml, and fold the change into the relevant commit (amend Task 1's commit if pre-PR, else a follow-up `test:` commit).
+
+- [ ] **Step 3: Manual TTY verification (no automated coverage)**
+
+The indicatif TTY branch is unreachable under `cargo test`. Verify by hand on a real terminal against a real library subdirectory (e.g. one album under `/data/media/music`; mount is not needed for scan):
+
+```bash
+cargo run -p musefs -- scan --db /tmp/progress-check.db /data/media/music/<one-album>
+```
+
+Confirm:
+- the discovery spinner animates; on `Walked` it switches to a determinate bar; the bar shows percent / ETA / current file basename; `log::warn` lines (if any) do not permanently corrupt the bar; the bar clears cleanly at the end; the summary prints with `in …` elapsed.
+- **Multi-target** (`scan … <album-a> <album-b>`): the bar rewinds to a discovery spinner at the start of the *second* target (not stuck at target 1's finished determinate bar), then re-lengths for target 2's ingest.
+- **Empty library** (`scan …` on a directory with no supported audio): the spinner clears with no hung bar, and the summary still prints `0 file(s)`.
+- Repeat once with `--revalidate` (re-run against the same DB) and once with `--quiet` (no spinner, no summary).
+- `… | cat` (non-TTY): prints `ingested N/M (P%)` lines instead of a bar.
+
+- [ ] **Step 4: Finish the development branch**
+
+Once all tasks are green and the manual check passes, use the `superpowers:finishing-a-development-branch` skill to choose how to integrate (PR to `main`, etc.). Reference issue #406 in the PR.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** discovery spinner (Task 1 push_file `Discovered` + Task 2 Tty arm), determinate bar (Task 2 Walked/Ingested arms), non-TTY lines (Task 2 Plain + `next_milestone`), `--quiet` (Task 2 `Mode::Quiet` + `sink()` → None), elapsed summary (Task 2 run_scan), revalidate coverage (Task 1 Walked in `revalidate_with`, shared `run_pipeline` Ingested), `total == 0` guard (`next_milestone` + Tty `set_length(0)` finishes), single-file target (`Walked { total: 1 }` via the `is_file` branch path). All present.
+- **Type consistency:** `ProgressSink::new` / `emit`, `ScanProgress::{Discovered,Walked,Ingested}` field names, and `next_milestone(prev_done, done, total) -> Option<u64>` are used identically across core wiring, the renderer, and tests.
+- **Casts:** `len() as u64` (usize→u64 widening, clippy-clean, matches existing `data.len() as u64` in scan.rs); `next_milestone` stays in `u64` end-to-end to avoid a narrowing cast.
+- **No placeholders:** every code step contains complete code; the only "fill-in" is matching README's existing anchor style (Task 3) and adding mutation exclusions *iff* survivors appear (Task 4), which cannot be enumerated before running the gate.

--- a/docs/superpowers/plans/2026-06-14-scan-progress-indicator.md
+++ b/docs/superpowers/plans/2026-06-14-scan-progress-indicator.md
@@ -659,7 +659,7 @@ fn quiet_scan_still_ingests_all_files() {
     let db_path = db_dir.path().join("musefs.db");
 
     // quiet = true: sink is None; ingest must be identical.
-    run_scan(&db_path, &[backing.path().to_path_buf()], true, 0, false, false).unwrap();
+    run_scan(&db_path, &[backing.path().to_path_buf()], false, 0, false, true).unwrap();
 
     let db = musefs_db::Db::open(&db_path).unwrap();
     assert_eq!(db.list_tracks().unwrap().len(), 20);

--- a/docs/superpowers/specs/2026-06-14-scan-progress-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-14-scan-progress-indicator-design.md
@@ -167,7 +167,10 @@ mutation gate can reach the densest new arithmetic (the integration test cannot)
 ```rust
 /// Returns the milestone percent (a multiple of `STEP`, or 100) that `done`
 /// newly reaches versus `prev_done`, else `None`. `total == 0` → `None`.
-fn next_milestone(prev_done: u64, done: u64, total: u64) -> Option<u8>;
+/// Implementation note: the return is `Option<u64>` (not `u8`) so the percent
+/// stays in `u64` end-to-end, avoiding a narrowing cast under the workspace's
+/// `cast_possible_truncation` lint.
+fn next_milestone(prev_done: u64, done: u64, total: u64) -> Option<u64>;
 ```
 
 Progress always renders on **stderr**, leaving stdout clean for the summary
@@ -186,6 +189,11 @@ wraps each target in an `Instant`, builds the sink once, passes it via
   `Walked { total: 1 }`, no discovery ticks.
 - Failures / races: tracked in the summary as today; they do not advance the
   bar, which `finish_and_clear`s regardless of final position.
+- Multiple targets: one renderer is shared across the target loop, with a
+  per-target reset that rewinds the TTY bar to the discovery spinner (and clears
+  the non-TTY milestone watermark) at the start of each target, so target N does
+  not inherit target N-1's finished determinate bar. The bar is finished once,
+  after the last target.
 
 ## Tests
 
@@ -219,17 +227,27 @@ mutants):
   when the last step is smaller than 5%.
 - `total == 1` (`done` 0→1) returns `Some(100)`.
 
-### CLI integration (`musefs-cli/tests/scan.rs`, `assert_cmd` — runs non-TTY)
+### CLI integration (`musefs-cli/tests/scan.rs` — in-process, runs non-TTY)
 
-`assert_cmd` pipes streams, so `is_terminal()` is false: these exercise only the
-non-TTY line printer. The fixture must hold **≥ 20 supported files** so at least
-one intermediate milestone is guaranteed in addition to the final line.
+The existing harness calls `run_scan` **in-process** (no `assert_cmd` subprocess)
+and asserts on the resulting DB. Under `cargo test`, stderr is captured, so
+`is_terminal()` is false — the non-TTY `Plain` printer path runs. In-process
+stderr text cannot be captured without a new dev-dep, so these are **smoke
+tests** that progress wiring does not break ingest; the milestone-line *decision*
+is covered by the `next_milestone` unit tests above, and the actual rendered
+output is covered by the manual TTY check. The fixture holds **≥ 20 supported
+files** so the `Plain` path crosses at least one intermediate milestone at run
+time.
 
-- A non-quiet scan emits the final `ingested {total}/{total} (100%)` line (and at
-  least one intermediate milestone) on stderr, and the summary with ` in …`
-  elapsed on stdout.
-- `--quiet` emits neither progress nor summary.
-- A revalidate run emits the same milestone lines and an elapsed summary.
+- A non-quiet scan over ≥20 files ingests all rows (exercises the `Plain` printer
+  without asserting its text).
+- `--quiet` ingests identically with the sink disabled.
+- A revalidate pass ingests/preserves all rows.
+
+> The spec originally proposed `assert_cmd` + asserting the printed stderr line;
+> that is intentionally dropped because the real harness is in-process. Asserting
+> printed output would require adding `assert_cmd` (subprocess) — out of scope for
+> v1.
 
 ### Manual TTY verification (no automated coverage)
 

--- a/docs/superpowers/specs/2026-06-14-scan-progress-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-14-scan-progress-indicator-design.md
@@ -1,0 +1,273 @@
+# Progress indicator for `musefs scan` / `musefs scan --revalidate`
+
+Issue: [#406](https://github.com/Sohex/musefs/issues/406)
+Date: 2026-06-14
+Status: design approved, pending spec review
+
+## Problem
+
+`musefs scan` walks the backing tree and ingests supported audio into the
+SQLite store. On a multi-hundred-album library this runs for a long time with
+no feedback — the operator cannot tell whether it is progressing, stalled, or
+how far along it is. The same applies to `musefs scan --revalidate`.
+
+## Goals
+
+- A live progress indicator on an interactive terminal: a discovery spinner
+  during the walk, then a determinate bar (position / total, percent, ETA,
+  current file) during ingest.
+- Plain line-based progress on a non-TTY (logged / piped runs).
+- A final summary line that includes elapsed time.
+- Honour the existing `--quiet` flag: suppress progress *and* the summary.
+- Cover both the `scan` and `revalidate` code paths.
+
+## Non-goals
+
+- An `added / updated / unchanged` breakdown for the full-scan path. That would
+  require plumbing per-file upsert disposition through `ingest_bulk` and the DB
+  layer; out of scope. The scan summary keeps `scanned / skipped / failed`;
+  revalidate already reports `updated / unchanged / pruned / failed`.
+- A `log`↔progress-bar bridge (e.g. `indicatif-log-bridge`). Core `log::warn`
+  lines share stderr with the bar and may briefly smear it; indicatif redraws
+  on the next tick. Acceptable for v1.
+
+## Layering
+
+`musefs-core` stays UI-agnostic. It emits progress *events* through an optional
+callback held in `ScanOptions`. All rendering — indicatif on a TTY, plain lines
+otherwise — lives in `musefs-cli`. Core never prints progress.
+
+## Core API (`musefs-core/src/scan.rs`)
+
+```rust
+/// A progress event emitted during a scan or revalidate. Borrows the current
+/// path to avoid a per-file allocation in the writer hot path.
+#[derive(Debug, Clone, Copy)]
+pub enum ScanProgress<'a> {
+    /// A supported-audio file was found during the directory walk;
+    /// `found` is the running count.
+    Discovered { found: u64 },
+    /// The walk (and, for revalidate, the skip-unchanged pass) finished;
+    /// `total` files will be ingested and tracked by the determinate bar.
+    Walked { total: u64 },
+    /// A file was committed. `done` runs 1..=total; `path` is its absolute path.
+    Ingested { done: u64, total: u64, path: &'a str },
+}
+
+/// UI-agnostic progress callback. Invoked only from the caller's thread (the
+/// walk and the single writer thread), never from probe workers — `ScanOptions`
+/// is passed into `run_pipeline` by `&` and never moves into a worker. The
+/// `Send + Sync` bound is therefore not required by today's code; it is kept
+/// deliberately as future-proofing (so emit could move into workers without an
+/// API break) and is free here because `indicatif::ProgressBar` is already
+/// `Send + Sync`. The `for<'a> Fn` HRTB is needed only because `Ingested`
+/// borrows the path; the allocation it saves is negligible next to the existing
+/// per-file `to_string_lossy().into_owned()` + DB write, so a maintainer should
+/// not contort the API to preserve the borrow.
+#[derive(Clone)]
+pub struct ProgressSink(Arc<dyn for<'a> Fn(ScanProgress<'a>) + Send + Sync>);
+
+impl ProgressSink {
+    pub fn new(f: impl for<'a> Fn(ScanProgress<'a>) + Send + Sync + 'static) -> Self;
+    fn emit(&self, ev: ScanProgress<'_>); // pub(crate)
+}
+
+impl fmt::Debug for ProgressSink { /* writes "ProgressSink" so ScanOptions: Debug holds */ }
+```
+
+`ScanOptions` gains:
+
+```rust
+pub progress: Option<ProgressSink>, // Default: None
+```
+
+`Default::default()` sets it to `None`, so every existing caller (and the many
+tests using `..Default::default()`) is unaffected.
+
+`ScanProgress` and `ProgressSink` are re-exported from `musefs-core/src/lib.rs`.
+
+## Core wiring
+
+### Discovery (shared by scan and revalidate)
+
+The private walk helpers `collect_audio_inner`, `descend`, and `push_file` gain
+a `progress: Option<&ProgressSink>` parameter. `push_file` emits
+`Discovered { found: out.len() }` immediately after it pushes a file (the only
+choke point where the collected count grows).
+
+To avoid touching the ~9 existing `collect_audio(root, out, follow_symlinks)`
+call sites (tests, the full-oracle path, the revalidate skip pass), the current
+signature is preserved as a thin wrapper that delegates with `None`:
+
+```rust
+fn collect_audio(root, out, follow_symlinks) -> io::Result<SkipTally> {
+    collect_audio_with(root, out, follow_symlinks, None)
+}
+fn collect_audio_with(root, out, follow_symlinks, progress: Option<&ProgressSink>)
+    -> io::Result<SkipTally> { /* existing body, threads progress inward */ }
+```
+
+`scan_directory_with` and `revalidate_with` call `collect_audio_with(.., opts.progress.as_ref())`.
+
+### `Walked`
+
+- `scan_directory_with`: emit `Walked { total: files.len() }` after the walk,
+  before `run_pipeline`. (For a single-file target, `total == 1`; for an empty
+  library, `total == 0`.)
+- `revalidate_with`: emit `Walked { total: changed.len() }` after the
+  skip-unchanged pass, before `run_pipeline`. The bar therefore tracks only the
+  files actually re-ingested. The (potentially slow) skip pass emits nothing;
+  the CLI spinner keeps animating via steady-tick.
+
+### `Ingested` (shared)
+
+`run_pipeline` reads `opts.progress`. It captures `total = files.len()` before
+moving `files` into the work queue. Inside `flush`'s per-unit drain, right after
+the existing `*scanned += 1`, it emits
+`Ingested { done: *scanned, total, path: &abs_path }` — `abs_path` is in scope
+there (it is borrowed, not moved, by `ingest_bulk(&mut bw, &abs_path, ..)`). The
+emit stays at the per-unit point (not after `commit()`), so events arrive
+per-file (`done` strictly increasing `1..=total`) even though commits are
+batched. Per-file failures and races do not advance `done`.
+
+## CLI rendering (`musefs-cli`)
+
+Add the `indicatif` dependency (with `default-features = false` plus only the
+features needed for `ProgressBar` + `HumanDuration`, to avoid pulling unused
+transitive crates). The TTY predicate is **`std::io::stderr().is_terminal()`**
+specifically (not stdout): progress renders on stderr, so a `musefs scan | tee`
+that leaves a TTY on stderr still animates while stdout stays a clean,
+pipe-friendly summary. A helper constructs the `ProgressSink` from `quiet` and
+that predicate:
+
+- **`quiet`** → no sink (`None`). Progress and summary both suppressed, as today.
+- **TTY** → indicatif on stderr:
+  - A spinner with `enable_steady_tick`, message `discovering files… {N} found`,
+    updated on `Discovered`.
+  - On the first `Walked { total }`: finish the spinner and start a determinate
+    bar, **also with `enable_steady_tick`** (so it redraws over interleaved
+    `env_logger` warn lines without waiting for the next position update);
+    `set_length(total)`; template shows position/length, percent, ETA, and the
+    current file's basename as the message. `total == 0` finishes immediately.
+  - `Ingested { done, path }` → `set_position(done)` and `set_message(basename)`.
+  - At the end: `finish_and_clear()`.
+- **non-TTY** → a throttled plain-line printer to stderr driven by a pure
+  decision function (see below): on each `Ingested` it prints
+  `ingested {done}/{total} ({pct}%)` when a new 5%-of-total milestone is crossed,
+  and **always** prints the final `done == total` line. Counts only, no
+  animation. This is the "logged runs" path. Discovery on a non-TTY stays quiet
+  (no per-file count line) to avoid log spam; milestone lines begin once
+  `Walked` is known. On `Walked { total: 0 }` the printer emits nothing (the
+  arithmetic is guarded against `total == 0`); the summary still prints
+  `0 file(s)`.
+
+The milestone decision is isolated in a pure, unit-testable function so the
+mutation gate can reach the densest new arithmetic (the integration test cannot):
+
+```rust
+/// Returns the milestone percent (a multiple of `STEP`, or 100) that `done`
+/// newly reaches versus `prev_done`, else `None`. `total == 0` → `None`.
+fn next_milestone(prev_done: u64, done: u64, total: u64) -> Option<u8>;
+```
+
+Progress always renders on **stderr**, leaving stdout clean for the summary
+line — `env_logger` (the binary's default `warn`→stderr sink) and the bar
+intentionally share stderr; coexistence is cosmetic-only (steady-tick redraw)
+and called out as a manual-verification item, not asserted in tests. `run_scan`
+wraps each target in an `Instant`, builds the sink once, passes it via
+`ScanOptions { progress, .. }`, and appends ` in {HumanDuration}`
+(`indicatif::HumanDuration`) to both the scan and revalidate summary lines.
+
+## Edge cases
+
+- Empty library / no supported audio: `Walked { total: 0 }`; spinner finishes,
+  no bar; summary still prints `0 file(s)`.
+- Single-file target: `scan_directory_with` pushes one file without walking;
+  `Walked { total: 1 }`, no discovery ticks.
+- Failures / races: tracked in the summary as today; they do not advance the
+  bar, which `finish_and_clear`s regardless of final position.
+
+## Tests
+
+### Core (`musefs-core/src/scan.rs` tests, or `tests/`)
+
+Inject a recording sink backed by `Arc<Mutex<Vec<…>>>` and assert against a
+fixture library:
+
+- `Walked.total` equals the number of supported files (scan) / changed files
+  (revalidate).
+- `Ingested.done` is strictly increasing `1..=total`; the final event has
+  `done == total`.
+- `Discovered.found` increases over the walk and ends at the discovered count.
+- A `quiet`-equivalent run (sink `None`) is exercised implicitly by the existing
+  suite (no panics, unchanged stats).
+- `format!("{opts:?}")` succeeds and contains `ProgressSink`, locking the manual
+  `Debug` impl (existing consumers rely on `ScanOptions: Debug`).
+
+These assertions kill the value mutants on the new counters.
+
+### CLI — `next_milestone` unit tests (`musefs-cli`)
+
+Direct boundary tests on the pure function (this is where the densest new
+arithmetic lives; the integration test alone leaks `>=`→`>` and `*100/total`
+mutants):
+
+- `total == 0` → `None` (no divide-by-zero).
+- crossing exactly one 5% boundary returns `Some(pct)`; staying within a bucket
+  returns `None`.
+- `done == total` always returns `Some(100)` (the guaranteed final line), even
+  when the last step is smaller than 5%.
+- `total == 1` (`done` 0→1) returns `Some(100)`.
+
+### CLI integration (`musefs-cli/tests/scan.rs`, `assert_cmd` — runs non-TTY)
+
+`assert_cmd` pipes streams, so `is_terminal()` is false: these exercise only the
+non-TTY line printer. The fixture must hold **≥ 20 supported files** so at least
+one intermediate milestone is guaranteed in addition to the final line.
+
+- A non-quiet scan emits the final `ingested {total}/{total} (100%)` line (and at
+  least one intermediate milestone) on stderr, and the summary with ` in …`
+  elapsed on stdout.
+- `--quiet` emits neither progress nor summary.
+- A revalidate run emits the same milestone lines and an elapsed summary.
+
+### Manual TTY verification (no automated coverage)
+
+The entire indicatif TTY branch (spinner → determinate bar → `finish_and_clear`)
+is unreachable under `assert_cmd`. Verify by hand on a real terminal against a
+library subdirectory (e.g. one album from `/data/media/music`, or the live
+~4427-track DB per the live-mount harness): confirm the discovery spinner
+animates, the spinner→bar transition fires on `Walked`, the bar shows
+percent/ETA/current basename, warn lines do not permanently corrupt the bar, and
+the bar clears cleanly at the end. Repeat once for `--revalidate`. This step is
+intentionally manual-only.
+
+## Housekeeping
+
+- Editing `scan.rs` shifts the `line:col` anchors in `.cargo/mutants.toml`.
+  Re-anchor in the **same commit**: run `check_mutant_anchors.py --fix`, then
+  fix any remaining entries by hand, so the pre-commit anchor guard passes.
+- README: note that scan/revalidate show a progress bar on a TTY, degrade to
+  line-based progress on a non-TTY, and that `--quiet` suppresses both progress
+  and the summary.
+- `indicatif` is a new `musefs-cli` runtime dependency (well-established;
+  stderr-targeted), pinned with `default-features = false` + only the needed
+  features. No new dependency in `musefs-core`. Confirm the workspace MSRV
+  covers `std::io::IsTerminal` (stable 1.70) and the chosen `indicatif` version.
+
+## Commit plan (each commit green — pre-commit runs the full suite)
+
+Commit 1 is split to shrink the blast radius for the anchor + mutation gates:
+
+1a. Core types: `ScanProgress` / `ProgressSink` (manual `Debug`) /
+    `ScanOptions.progress` + re-exports + the `Debug`/`Clone` test. Re-anchor
+    `.cargo/mutants.toml` here (this commit is where most `scan.rs` line shifts
+    land); **gate: run the pre-commit anchor guard locally before committing** —
+    `--fix` only re-anchors covering-set clusters, so op/fn-position anchors are
+    fixed by hand and verified, or the commit is rejected.
+1b. Core wiring: walk emit (`collect_audio_with` + `push_file`), `Walked` in
+    `scan_directory_with` / `revalidate_with`, `Ingested` in `run_pipeline`, and
+    the recording-sink tests.
+2. CLI: `indicatif` dep, `next_milestone` + its unit tests, the renderer,
+   `run_scan` wiring (sink + elapsed), CLI integration tests.
+3. Docs: README progress/`--quiet` note.

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -16,6 +16,7 @@ musefs-core = { path = "../musefs-core", version = "1.0.0" }
 musefs-fuse = { path = "../musefs-fuse", version = "1.0.0" }
 signal-hook = "0.4"
 uzers = "0.12"
+indicatif = { version = "0.17", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -2,12 +2,17 @@
 //! SQLite store) and `mount` (serve a read-only FUSE view of that store).
 
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use indicatif::HumanDuration;
 use musefs_core::{MountConfig, Musefs};
 use musefs_db::Db;
 
+use crate::progress::ScanReporter;
+
+mod progress;
 mod signal;
 
 /// Mount content mode (CLI surface for `musefs_core::Mode`).
@@ -181,23 +186,28 @@ pub fn run_scan(
 ) -> Result<()> {
     let db =
         Db::open(db_path).with_context(|| format!("opening database at {}", db_path.display()))?;
+    let reporter = ScanReporter::new(quiet);
     let opts = musefs_core::ScanOptions {
         jobs,
         follow_symlinks,
+        progress: reporter.sink(),
         ..Default::default()
     };
     for target in targets {
+        reporter.start_target();
+        let start = Instant::now();
         if revalidate {
             let stats = musefs_core::revalidate_with(&db, target, &opts)
                 .with_context(|| format!("revalidating {}", target.display()))?;
             if !quiet {
                 println!(
-                    "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed",
+                    "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed in {}",
                     target.display(),
                     stats.updated,
                     stats.unchanged,
                     stats.pruned,
-                    stats.failed
+                    stats.failed,
+                    HumanDuration(start.elapsed()),
                 );
             }
         } else {
@@ -205,15 +215,17 @@ pub fn run_scan(
                 .with_context(|| format!("scanning {}", target.display()))?;
             if !quiet {
                 println!(
-                    "scanned {}: {} file(s), skipped {}, failed {}",
+                    "scanned {}: {} file(s), skipped {}, failed {} in {}",
                     target.display(),
                     stats.scanned,
                     stats.skipped,
-                    stats.failed
+                    stats.failed,
+                    HumanDuration(start.elapsed()),
                 );
             }
         }
     }
+    reporter.finish();
     Ok(())
 }
 

--- a/musefs-cli/src/progress.rs
+++ b/musefs-cli/src/progress.rs
@@ -1,0 +1,164 @@
+use std::io::IsTerminal;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+use musefs_core::{ProgressSink, ScanProgress};
+
+const STEP: u64 = 5;
+
+pub(crate) fn next_milestone(prev_done: u64, done: u64, total: u64) -> Option<u64> {
+    if total == 0 || done <= prev_done {
+        return None;
+    }
+    if done >= total {
+        return Some(100);
+    }
+    let bucket = done * 100 / total / STEP;
+    let prev_bucket = prev_done * 100 / total / STEP;
+    if bucket > prev_bucket {
+        Some(bucket * STEP)
+    } else {
+        None
+    }
+}
+
+enum Mode {
+    Quiet,
+    Tty(ProgressBar),
+    Plain,
+}
+
+struct Renderer {
+    mode: Mode,
+    prev_done: AtomicU64,
+}
+
+impl Renderer {
+    fn handle(&self, ev: ScanProgress<'_>) {
+        match (&self.mode, ev) {
+            (Mode::Tty(bar), ScanProgress::Discovered { found }) => {
+                bar.set_message(format!("discovering files… {found} found"));
+            }
+            (Mode::Tty(bar), ScanProgress::Walked { total }) => {
+                bar.set_style(
+                    ProgressStyle::with_template(
+                        "{spinner} [{elapsed_precise}] [{bar:30}] {pos}/{len} ({percent}%) {wide_msg}",
+                    )
+                    .expect("static template")
+                    .progress_chars("##-"),
+                );
+                bar.set_length(total);
+                bar.set_position(0);
+            }
+            (Mode::Tty(bar), ScanProgress::Ingested { done, path, .. }) => {
+                bar.set_position(done);
+                bar.set_message(basename(path));
+            }
+            (Mode::Plain, ScanProgress::Ingested { done, total, .. }) => {
+                let prev = self.prev_done.load(Ordering::Relaxed);
+                if let Some(pct) = next_milestone(prev, done, total) {
+                    eprintln!("ingested {done}/{total} ({pct}%)");
+                    self.prev_done.store(done, Ordering::Relaxed);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn basename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map_or_else(|| path.to_string(), |n| n.to_string_lossy().into_owned())
+}
+
+pub(crate) struct ScanReporter {
+    inner: Arc<Renderer>,
+}
+
+impl ScanReporter {
+    pub(crate) fn new(quiet: bool) -> Self {
+        let mode = if quiet {
+            Mode::Quiet
+        } else if std::io::stderr().is_terminal() {
+            let bar = ProgressBar::new_spinner();
+            bar.enable_steady_tick(Duration::from_millis(120));
+            bar.set_message("discovering files…");
+            Mode::Tty(bar)
+        } else {
+            Mode::Plain
+        };
+        ScanReporter {
+            inner: Arc::new(Renderer {
+                mode,
+                prev_done: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub(crate) fn sink(&self) -> Option<ProgressSink> {
+        if matches!(self.inner.mode, Mode::Quiet) {
+            return None;
+        }
+        let inner = Arc::clone(&self.inner);
+        Some(ProgressSink::new(move |ev| inner.handle(ev)))
+    }
+
+    pub(crate) fn start_target(&self) {
+        self.inner.prev_done.store(0, Ordering::Relaxed);
+        if let Mode::Tty(bar) = &self.inner.mode {
+            bar.set_style(ProgressStyle::default_spinner());
+            bar.set_position(0);
+            bar.set_message("discovering files…");
+        }
+    }
+
+    pub(crate) fn finish(&self) {
+        if let Mode::Tty(bar) = &self.inner.mode {
+            bar.finish_and_clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod milestone_tests {
+    use super::next_milestone;
+
+    #[test]
+    fn zero_total_is_none() {
+        assert_eq!(next_milestone(0, 0, 0), None);
+    }
+
+    #[test]
+    fn no_advance_is_none() {
+        assert_eq!(next_milestone(3, 3, 100), None);
+    }
+
+    #[test]
+    fn single_file_is_hundred() {
+        assert_eq!(next_milestone(0, 1, 1), Some(100));
+    }
+
+    #[test]
+    fn final_step_below_granularity_still_fires() {
+        assert_eq!(next_milestone(29, 30, 30), Some(100));
+    }
+
+    #[test]
+    fn crossing_first_five_percent() {
+        assert_eq!(next_milestone(0, 1, 20), Some(5));
+    }
+
+    #[test]
+    fn within_a_bucket_is_none() {
+        assert_eq!(next_milestone(5, 6, 100), None);
+    }
+
+    #[test]
+    fn crossing_into_ten_percent() {
+        assert_eq!(next_milestone(9, 10, 100), Some(10));
+    }
+}

--- a/musefs-cli/tests/scan.rs
+++ b/musefs-cli/tests/scan.rs
@@ -130,3 +130,86 @@ fn scan_fails_fast_on_a_bad_target() {
     );
     assert!(result.is_err());
 }
+
+fn write_n_flacs(dir: &std::path::Path, n: usize) {
+    for i in 0..n {
+        let title = format!("TITLE=T{i}");
+        std::fs::write(
+            dir.join(format!("t{i:02}.flac")),
+            make_flac(&[title.as_str()], &[0xAB; 32]),
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn scan_with_progress_ingests_all_files() {
+    let backing = tempfile::tempdir().unwrap();
+    write_n_flacs(backing.path(), 20);
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    run_scan(
+        &db_path,
+        &[backing.path().to_path_buf()],
+        false,
+        0,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 20);
+}
+
+#[test]
+fn quiet_scan_still_ingests_all_files() {
+    let backing = tempfile::tempdir().unwrap();
+    write_n_flacs(backing.path(), 20);
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    run_scan(
+        &db_path,
+        &[backing.path().to_path_buf()],
+        false,
+        0,
+        false,
+        true,
+    )
+    .unwrap();
+
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 20);
+}
+
+#[test]
+fn revalidate_with_progress_reports_unchanged() {
+    let backing = tempfile::tempdir().unwrap();
+    write_n_flacs(backing.path(), 20);
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    run_scan(
+        &db_path,
+        &[backing.path().to_path_buf()],
+        false,
+        0,
+        false,
+        false,
+    )
+    .unwrap();
+    run_scan(
+        &db_path,
+        &[backing.path().to_path_buf()],
+        true,
+        0,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 20);
+}

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -24,8 +24,8 @@ pub use readahead::{BackingReader, ReadAhead, ReadAheadPool};
 pub use reader::{HeaderCache, ResolvedFile, read_at, read_at_with_file};
 pub use scan::scan_directory_full_oracle;
 pub use scan::{
-    RevalidateStats, ScanOptions, ScanStats, revalidate, revalidate_with, scan_directory,
-    scan_directory_with,
+    ProgressSink, RevalidateStats, ScanOptions, ScanProgress, ScanStats, revalidate,
+    revalidate_with, scan_directory, scan_directory_with,
 };
 pub use telemetry::{
     AllocatorStats, CoreTelemetry, FuseTelemetry, PassthroughTelemetry, render_prometheus,

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -8,6 +8,8 @@ use musefs_format::{EmbeddedBinaryTag, EmbeddedPicture, Extent, flac, mp3, mp4, 
 use crate::byte_budget::ByteBudget;
 use crate::error::Result;
 use crate::freshness::BackingStamp;
+use std::fmt;
+use std::sync::Arc;
 use std::sync::mpsc::sync_channel;
 
 const BATCH_FILES: usize = 256;
@@ -66,6 +68,49 @@ fn set_after_s1_hook(f: impl FnMut() + 'static) {
 #[cfg(test)]
 fn clear_after_s1_hook() {
     AFTER_S1_HOOK.with(|h| *h.borrow_mut() = None);
+}
+
+/// A progress event emitted during a scan or revalidate. Borrows the current
+/// path to avoid a per-file allocation in the writer; the saved allocation is
+/// negligible next to the existing per-file `to_string_lossy` + DB write, so do
+/// not contort the API to preserve the borrow.
+#[derive(Debug, Clone, Copy)]
+pub enum ScanProgress<'a> {
+    /// A supported-audio file was found during the walk; `found` is the running
+    /// count of collected files.
+    Discovered { found: u64 },
+    /// The walk (and, for revalidate, the skip-unchanged pass) finished;
+    /// `total` files will be ingested and tracked by the determinate bar.
+    Walked { total: u64 },
+    /// A file was committed. `done` runs 1..=total; `path` is its absolute path.
+    Ingested {
+        done: u64,
+        total: u64,
+        path: &'a str,
+    },
+}
+
+/// UI-agnostic progress callback for [`ScanOptions`]. Invoked only from the
+/// caller's thread (the walk and the single writer), never from probe workers.
+/// The `Send + Sync` bound is not required by today's code; it is deliberate
+/// future-proofing and free here (`indicatif::ProgressBar` is `Send + Sync`).
+#[derive(Clone)]
+pub struct ProgressSink(Arc<dyn for<'a> Fn(ScanProgress<'a>) + Send + Sync>);
+
+impl ProgressSink {
+    pub fn new(f: impl for<'a> Fn(ScanProgress<'a>) + Send + Sync + 'static) -> Self {
+        ProgressSink(Arc::new(f))
+    }
+
+    fn emit(&self, ev: ScanProgress<'_>) {
+        (self.0)(ev);
+    }
+}
+
+impl fmt::Debug for ProgressSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ProgressSink")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -150,15 +195,20 @@ fn collect_audio(
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
 ) -> std::io::Result<SkipTally> {
+    collect_audio_with(root, out, follow_symlinks, None)
+}
+
+fn collect_audio_with(
+    root: &Path,
+    out: &mut Vec<PathBuf>,
+    follow_symlinks: bool,
+    progress: Option<&ProgressSink>,
+) -> std::io::Result<SkipTally> {
     let mut visited = HashSet::new();
     let mut files_visited = HashSet::new();
     let mut tally = SkipTally::default();
-    if follow_symlinks {
-        // Seed with the root's identity so a symlink pointing back to it is
-        // caught as a cycle on the first descent.
-        if let Ok(meta) = std::fs::metadata(root) {
-            visited.insert(dir_key(&meta));
-        }
+    if follow_symlinks && let Ok(meta) = std::fs::metadata(root) {
+        visited.insert(dir_key(&meta));
     }
     collect_audio_inner(
         root,
@@ -167,6 +217,7 @@ fn collect_audio(
         &mut visited,
         &mut files_visited,
         &mut tally,
+        progress,
     )?;
     Ok(tally)
 }
@@ -178,16 +229,25 @@ fn collect_audio_inner(
     visited: &mut HashSet<(u64, u64)>,
     files_visited: &mut HashSet<(u64, u64)>,
     tally: &mut SkipTally,
+    progress: Option<&ProgressSink>,
 ) -> std::io::Result<()> {
     for entry in std::fs::read_dir(root)? {
         let entry = entry?;
         let path = entry.path();
         let ftype = entry.file_type()?;
         if ftype.is_dir() {
-            descend(&path, out, follow_symlinks, visited, files_visited, tally)?;
+            descend(
+                &path,
+                out,
+                follow_symlinks,
+                visited,
+                files_visited,
+                tally,
+                progress,
+            )?;
         } else if ftype.is_file() {
             if is_supported_audio(&path) {
-                push_file(&path, out, follow_symlinks, files_visited, None);
+                push_file(&path, out, follow_symlinks, files_visited, None, progress);
             } else {
                 tally.record(&path);
             }
@@ -201,11 +261,26 @@ fn collect_audio_inner(
             }
             match std::fs::metadata(&path) {
                 Ok(meta) if meta.is_dir() => {
-                    descend(&path, out, follow_symlinks, visited, files_visited, tally)?;
+                    descend(
+                        &path,
+                        out,
+                        follow_symlinks,
+                        visited,
+                        files_visited,
+                        tally,
+                        progress,
+                    )?;
                 }
                 Ok(meta) if meta.is_file() => {
                     if is_supported_audio(&path) {
-                        push_file(&path, out, follow_symlinks, files_visited, Some(&meta));
+                        push_file(
+                            &path,
+                            out,
+                            follow_symlinks,
+                            files_visited,
+                            Some(&meta),
+                            progress,
+                        );
                     } else {
                         tally.record(&path);
                     }
@@ -227,9 +302,18 @@ fn descend(
     visited: &mut HashSet<(u64, u64)>,
     files_visited: &mut HashSet<(u64, u64)>,
     tally: &mut SkipTally,
+    progress: Option<&ProgressSink>,
 ) -> std::io::Result<()> {
     if !follow_symlinks {
-        return collect_audio_inner(path, out, follow_symlinks, visited, files_visited, tally);
+        return collect_audio_inner(
+            path,
+            out,
+            follow_symlinks,
+            visited,
+            files_visited,
+            tally,
+            progress,
+        );
     }
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
@@ -242,7 +326,15 @@ fn descend(
         log::warn!("skipping symlink cycle at {}", path.display());
         return Ok(());
     }
-    collect_audio_inner(path, out, follow_symlinks, visited, files_visited, tally)
+    collect_audio_inner(
+        path,
+        out,
+        follow_symlinks,
+        visited,
+        files_visited,
+        tally,
+        progress,
+    )
 }
 
 fn dir_key(meta: &std::fs::Metadata) -> (u64, u64) {
@@ -263,9 +355,15 @@ fn push_file(
     follow_symlinks: bool,
     files_visited: &mut HashSet<(u64, u64)>,
     known_meta: Option<&std::fs::Metadata>,
+    progress: Option<&ProgressSink>,
 ) {
     if !follow_symlinks {
         out.push(path.to_path_buf());
+        if let Some(p) = progress {
+            p.emit(ScanProgress::Discovered {
+                found: out.len() as u64,
+            });
+        }
         return;
     }
     let key = match known_meta {
@@ -276,7 +374,14 @@ fn push_file(
         Some(k) if !files_visited.insert(k) => {
             log::debug!("skipping duplicate backing target {}", path.display());
         }
-        _ => out.push(path.to_path_buf()),
+        _ => {
+            out.push(path.to_path_buf());
+            if let Some(p) = progress {
+                p.emit(ScanProgress::Discovered {
+                    found: out.len() as u64,
+                });
+            }
+        }
     }
 }
 
@@ -617,6 +722,8 @@ pub struct ScanOptions {
     /// Follow symlinks during collection. Off by default: symlinks are logged
     /// and skipped, which keeps the walk immune to directory-symlink cycles.
     pub follow_symlinks: bool,
+    /// Optional progress callback. `None` (the default) disables reporting.
+    pub progress: Option<ProgressSink>,
 }
 
 impl Default for ScanOptions {
@@ -626,6 +733,7 @@ impl Default for ScanOptions {
             window: WINDOW,
             batch_bytes: BATCH_BYTES,
             follow_symlinks: false,
+            progress: None,
         }
     }
 }
@@ -906,7 +1014,17 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
             tally.record(root);
         }
     } else {
-        tally = collect_audio(root, &mut files, opts.follow_symlinks)?;
+        tally = collect_audio_with(
+            root,
+            &mut files,
+            opts.follow_symlinks,
+            opts.progress.as_ref(),
+        )?;
+    }
+    if let Some(p) = &opts.progress {
+        p.emit(ScanProgress::Walked {
+            total: files.len() as u64,
+        });
     }
     db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
     let mut stats = run_pipeline(db, files, opts)?;
@@ -929,10 +1047,11 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
 /// single writer (this thread) in batched transactions. Per-file errors are
 /// counted, not fatal.
 fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<ScanStats> {
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     let jobs = effective_jobs(opts.jobs);
+    let total = files.len() as u64;
+    let progress = opts.progress.as_ref();
     let window = opts.window;
     let cap = opts.batch_bytes;
     let budget = Arc::new(ByteBudget::new(cap));
@@ -1015,6 +1134,13 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
             weights.push(weight);
             ingest_bulk(&mut bw, &abs_path, stamp, probed)?;
             *scanned += 1;
+            if let Some(p) = progress {
+                p.emit(ScanProgress::Ingested {
+                    done: *scanned,
+                    total,
+                    path: &abs_path,
+                });
+            }
         }
         bw.commit()?;
         for w in weights {
@@ -1131,7 +1257,12 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
             files.push(root.to_path_buf());
         }
     } else {
-        collect_audio(root, &mut files, opts.follow_symlinks)?;
+        collect_audio_with(
+            root,
+            &mut files,
+            opts.follow_symlinks,
+            opts.progress.as_ref(),
+        )?;
     }
     db.apply_bulk_pragmas_self()?;
 
@@ -1185,6 +1316,12 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
             }
         }
         changed.push(path);
+    }
+
+    if let Some(p) = &opts.progress {
+        p.emit(ScanProgress::Walked {
+            total: changed.len() as u64,
+        });
     }
 
     let scan = run_pipeline(db, changed, opts)?;
@@ -1456,6 +1593,61 @@ mod scan_unit_tests {
         assert!(
             probed.binary_tags.is_empty(),
             "oversized binary freeform must be skipped at extraction, not materialized"
+        );
+    }
+
+    #[test]
+    fn scan_options_debug_includes_progress_sink() {
+        let opts = ScanOptions {
+            progress: Some(ProgressSink::new(|_| {})),
+            ..Default::default()
+        };
+        assert!(format!("{opts:?}").contains("ProgressSink"));
+    }
+
+    #[test]
+    fn scan_emits_discovered_walked_ingested_events() {
+        use std::sync::Mutex;
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            let mut bytes = b"fLaC".to_vec();
+            bytes.push(0x80);
+            bytes.extend_from_slice(&[0, 0, 34]);
+            bytes.extend(std::iter::repeat_n(0u8, 34));
+            bytes.extend_from_slice(format!("AUDIO-{i}").as_bytes());
+            std::fs::write(dir.path().join(format!("t{i}.flac")), &bytes).unwrap();
+        }
+
+        let events = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recorder = Arc::clone(&events);
+        let sink = ProgressSink::new(move |ev| {
+            let line = match ev {
+                ScanProgress::Discovered { found } => format!("disc:{found}"),
+                ScanProgress::Walked { total } => format!("walk:{total}"),
+                ScanProgress::Ingested { done, total, .. } => format!("ing:{done}/{total}"),
+            };
+            recorder.lock().unwrap().push(line);
+        });
+
+        let db = Db::open_in_memory().unwrap();
+        let opts = ScanOptions {
+            jobs: 1,
+            progress: Some(sink),
+            ..Default::default()
+        };
+        let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+        assert_eq!(stats.scanned, 5);
+
+        let ev = events.lock().unwrap();
+        // Discovery climbs to the full count.
+        assert!(ev.iter().any(|e| e == "disc:5"), "events: {ev:?}");
+        // Walk reports the total to ingest.
+        assert!(ev.contains(&"walk:5".to_string()), "events: {ev:?}");
+        // Ingest reports each committed file, done strictly 1..=total.
+        let ing: Vec<&String> = ev.iter().filter(|e| e.starts_with("ing:")).collect();
+        assert_eq!(
+            ing,
+            vec!["ing:1/5", "ing:2/5", "ing:3/5", "ing:4/5", "ing:5/5"],
         );
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1124,6 +1124,10 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         // Budget weights are released only after commit, and ingest_bulk consumes
         // the Probed — capture each unit's weight before the move (#68).
         let mut weights = Vec::with_capacity(batch.len());
+        // `Ingested` reports committed files, so buffer the paths and emit only
+        // after `bw.commit()` succeeds — a failed commit aborts the scan without
+        // having advanced the progress bar past unpersisted files.
+        let mut committed: Vec<String> = Vec::new();
         for Unit {
             abs_path,
             stamp,
@@ -1133,6 +1137,10 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         {
             weights.push(weight);
             ingest_bulk(&mut bw, &abs_path, stamp, probed)?;
+            committed.push(abs_path);
+        }
+        bw.commit()?;
+        for abs_path in committed {
             *scanned += 1;
             if let Some(p) = progress {
                 p.emit(ScanProgress::Ingested {
@@ -1142,7 +1150,6 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                 });
             }
         }
-        bw.commit()?;
         for w in weights {
             budget.release(w);
         }


### PR DESCRIPTION
## Summary

Adds a live progress indicator to `musefs scan` and `musefs scan --revalidate`, plus an elapsed-time summary. Closes #406.

- **Core stays UI-agnostic.** `musefs-core` emits `ScanProgress` events (`Discovered` / `Walked` / `Ingested`) through an optional `ProgressSink` callback held in `ScanOptions` (default `None`, so every existing caller is untouched). The walk emits discovery ticks, the callers emit the total once known, and the single writer thread in `run_pipeline` emits per committed file — shared by both scan and revalidate.
- **CLI owns rendering** (`indicatif`). On a TTY: a discovery spinner that becomes a determinate bar (position, percent, ETA, current file). On a non-TTY stderr: throttled `ingested N/M (P%)` lines at 5% milestones plus a guaranteed final line. `--quiet` (`-q`) suppresses both the indicator and the summary. Each summary line now ends with the elapsed time.
- Progress renders on **stderr**, leaving stdout clean for the summary. Multi-target runs reset to the discovery spinner per target.

## Implementation notes

- Discovery threading reuses the existing `collect_audio` recursion via a new `collect_audio_with(.., progress)`; the 3-arg `collect_audio` stays as a thin wrapper so other callers/tests are unchanged.
- The milestone-throttle decision is a pure `next_milestone(prev, done, total) -> Option<u64>` so it is directly unit-testable.
- `.cargo/mutants.toml` re-anchored for the shifted `scan.rs` `line:col` entries (in the same commit as the core change).
- Built spec-first: design + implementation plan under `docs/superpowers/{specs,plans}/`, each reviewed by the spec-plan-reviewer.

## Test Plan

- [x] `cargo test --workspace` — 1100 passed, 34 ignored
- [x] `cargo test -p musefs-core --features metrics` — 463 passed
- [x] `cargo clippy --all-targets` + `cargo fmt --all --check` — clean
- [x] Mutant-anchor guard — 66 entries validate against 3593 mutants
- [x] In-diff mutation gate on the diff — 14 mutants: 10 caught, 4 unviable, 0 survivors
- [x] Live binary (synthetic FLACs): non-TTY 5% lines + final, TTY spinner via PTY, multi-target, `--quiet` silent, revalidate elapsed summary
- [ ] Manual eyeball of determinate-bar smoothness over a genuinely large library (synthetic corpus ingests too fast to watch the bar fill; `/data/media/music` is currently empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live scan progress indicator with spinner and determinate progress bar for interactive terminals
  * Non-interactive runs now display throttled progress milestones
  * New `--quiet` flag suppresses progress indicators and per-target summaries
  * Scan result summaries now include elapsed time

* **Documentation**
  * Updated README with scan progress indicator behavior documentation

* **Tests**
  * Added integration tests for scan progress functionality across different modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->