### PR TITLE
feat(template): skip tracks missing a top-level template field

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -339,7 +339,11 @@ mapping from rendered paths. Paths come from beets-style templates
 (`template.rs`): `$field` / `${field}` substitutions (with `${a|b}` fallback
 chains) over the track's tag fields, each resolving through per-field fallbacks
 and then a global `default_fallback`; `[...]` conditional sections suppress
-their literals when every field they reference is empty. Plain values are
+their literals when every field they reference is empty. With `skip_on_missing`
+set (CLI `--skip-on-missing`), an unresolved *top-level* field instead drops the
+track from the mount: `render_one` returns `None`, so the track enters neither
+the snapshot nor the tree, and the incremental refresh path reclassifies a track
+that loses (or regains) such a field as a removal (or addition). Plain values are
 sanitized to a single path component ('/' and control characters become '_',
 components equal to `.` or `..` are dropped, and any component is truncated to
 255 bytes on a UTF-8 boundary so it stays within NAME_MAX),

--- a/README.md
+++ b/README.md
@@ -379,6 +379,13 @@ any tag key in the store works):
   fallback** from `--fallback FIELD=VALUE` (repeatable, e.g. `--fallback
   albumartist='Unknown Artist'`), then `--default-fallback`. Per-field
   fallbacks let one field default differently from the rest.
+- `--skip-on-missing` — drop a track from the mount entirely when a **top-level**
+  template field stays unresolved, instead of substituting `--default-fallback`.
+  Per-field `--fallback` chains and `[ … ]` sections are unaffected (a field
+  resolved via its fallback counts as present, and section fields stay optional).
+  Handy when an external tool tags only some tracks, e.g.
+  `--template '$!{beets_path}' --skip-on-missing` hides tracks beets left without
+  a `beets_path` (such as deduplicated albums).
 - `[ … ]` — **conditional section**: the bracketed text is emitted only when at
   least one field inside it is present. So `$album[ - CD $disc]` yields
   `Album - CD 2`, or just `Album` on a single-disc release. Write `$[` / `$]`

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -26,6 +26,10 @@ MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
 #MUSEFS_TEMPLATE=$albumartist/$album/$title
 # Value substituted for any missing template field.
 #MUSEFS_DEFAULT_FALLBACK=Unknown
+# Drop tracks missing a top-level template field instead of substituting
+# MUSEFS_DEFAULT_FALLBACK (per-field fallbacks and [ ... ] sections still apply).
+# Useful with e.g. MUSEFS_TEMPLATE=$!{beets_path} to hide untagged tracks.
+#MUSEFS_SKIP_ON_MISSING=false
 # How file contents are served: synthesis or structure-only.
 #MUSEFS_MODE=synthesis
 # Compare filenames case-insensitively. Default: false on Linux/FreeBSD,

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -74,6 +74,12 @@ pub struct MountArgs {
     /// albumartist="Unknown Artist" --fallback genre=Misc`.
     #[arg(long = "fallback", value_name = "FIELD=VALUE", value_parser = parse_fallback)]
     pub fallbacks: Vec<(String, String)>,
+    /// Drop tracks whose path is missing a top-level template field instead of
+    /// substituting `--default-fallback` (per-field `--fallback` chains and
+    /// `[...]` sections still apply). Useful when an external writer only tags a
+    /// subset of tracks, e.g. skipping tracks beets left without a `beets_path`.
+    #[arg(long, env = "MUSEFS_SKIP_ON_MISSING", default_value_t = false)]
+    pub skip_on_missing: bool,
     /// How file contents are served.
     #[arg(long, value_enum, env = "MUSEFS_MODE", default_value_t = CliMode::Synthesis)]
     pub mode: CliMode,
@@ -303,6 +309,7 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
         case_insensitive: args.case_insensitive,
         read_ahead_budget: u64::from(args.read_ahead_budget_mib).saturating_mul(1024 * 1024),
         read_ahead_prefetch: args.read_ahead_prefetch,
+        skip_on_missing: args.skip_on_missing,
     };
     let defaults = musefs_fuse::FuseConfig::default();
     let fuse_config = musefs_fuse::FuseConfig {
@@ -424,6 +431,26 @@ mod tests {
             parse_mount_config(&args).0.read_ahead_prefetch,
             "flag opts in"
         );
+    }
+
+    #[test]
+    fn skip_on_missing_defaults_off_and_opts_in() {
+        use clap::Parser;
+        let base = ["musefs", "mount", "/mnt", "--db", "/tmp/x.db"];
+        let off = Cli::try_parse_from(base).unwrap();
+        let Command::Mount(args) = off.command else {
+            panic!("expected Mount");
+        };
+        assert!(
+            !parse_mount_config(&args).0.skip_on_missing,
+            "skip-on-missing must default off"
+        );
+
+        let on = Cli::try_parse_from(base.iter().chain(["--skip-on-missing"].iter())).unwrap();
+        let Command::Mount(args) = on.command else {
+            panic!("expected Mount");
+        };
+        assert!(parse_mount_config(&args).0.skip_on_missing, "flag opts in");
     }
 
     #[test]

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -138,6 +138,7 @@ fn parse_mount_config_defaults_are_sensible() {
         allow_other: false,
         read_ahead_budget_mib: 64,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
         expose_metrics: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
@@ -174,6 +175,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         allow_other: false,
         read_ahead_budget_mib: 64,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
         expose_metrics: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
@@ -206,6 +208,7 @@ fn parse_mount_config_saturating_readahead() {
         allow_other: false,
         read_ahead_budget_mib: 64,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
         expose_metrics: false,
     };
     let (_, fuse_config) = parse_mount_config(&args);
@@ -262,6 +265,7 @@ fn parse_mount_config_populates_per_field_fallbacks() {
         allow_other: false,
         read_ahead_budget_mib: 64,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
         expose_metrics: false,
     };
     let (config, _) = parse_mount_config(&args);

--- a/musefs-core/benches/read_throughput.rs
+++ b/musefs-core/benches/read_throughput.rs
@@ -19,6 +19,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -50,6 +50,10 @@ pub struct MountConfig {
     /// amplification carries the entire measured read-ahead win (#255); the
     /// prefetch threads add overhead without benefit on the backends tested.
     pub read_ahead_prefetch: bool,
+    /// Drop a track from the mount when a top-level template field is unresolved,
+    /// instead of substituting `default_fallback`. Per-field fallback chains and
+    /// `[...]` sections are unaffected. Set by the CLI (`--skip-on-missing`).
+    pub skip_on_missing: bool,
 }
 
 /// Attributes the FUSE layer maps onto `fuser::FileAttr`.
@@ -325,19 +329,25 @@ impl Musefs {
 
     /// Render a single track's path from its tags + format. The one place
     /// `Template::render` is called, shared by full and incremental rebuilds.
+    /// Returns `None` when `skip_on_missing` is set and a top-level template
+    /// field is unresolved — the caller drops the track from the mount.
     fn render_one(
         template: &Template,
         config: &MountConfig,
         format: musefs_db::Format,
         tags: &[musefs_db::Tag],
-    ) -> String {
+    ) -> Option<String> {
         let fields = tags_to_fields(tags);
-        template.render(
-            &fields,
-            &config.fallbacks,
-            &config.default_fallback,
-            format.as_str(),
-        )
+        if config.skip_on_missing {
+            template.render_checked(&fields, &config.fallbacks, format.as_str())
+        } else {
+            Some(template.render(
+                &fields,
+                &config.fallbacks,
+                &config.default_fallback,
+                format.as_str(),
+            ))
+        }
     }
 
     /// DB read + path render with no allocator: the lock-free phase shared by
@@ -350,6 +360,9 @@ impl Musefs {
     /// (#188): the build path's insertion order decides which member of a colliding
     /// path keeps the bare name, and that must match the incremental path's min-id
     /// rule regardless of the source query's ordering.
+    ///
+    /// Tracks that `render_one` drops (`skip_on_missing` + an unresolved top-level
+    /// field) enter neither `entries` nor the snapshot, so they never materialize.
     #[allow(clippy::type_complexity)]
     fn render_entries<M>(
         db: &Db<M>,
@@ -364,7 +377,9 @@ impl Musefs {
         let mut snapshot = HashMap::with_capacity(tracks.len());
         for t in &tracks {
             let tags = tags_by_track.remove(&t.id).unwrap_or_default();
-            let path = Self::render_one(template, config, t.format, &tags);
+            let Some(path) = Self::render_one(template, config, t.format, &tags) else {
+                continue;
+            };
             snapshot.insert(
                 t.id,
                 TrackRenderState {
@@ -544,7 +559,7 @@ impl Musefs {
                 .filter_map(|id| snap.get(id).map(|s| (*id, s.clone())))
                 .collect()
         };
-        let change = partition_changelog(&prev_states, &log.changed_ids, &keys);
+        let mut change = partition_changelog(&prev_states, &log.changed_ids, &keys);
 
         // Phase 3 (DB, no VFS locks): render changed ∪ added.
         let mut to_render: Vec<i64> = change.changed.clone();
@@ -557,20 +572,39 @@ impl Musefs {
             let mut tags_by_track = self.pool.with(|db| Ok(db.tags_for_tracks(&to_render)?))?;
             to_render
                 .iter()
-                .map(|&id| {
+                .filter_map(|&id| {
                     let (cv, fmt) = key_of[&id];
                     let tags = tags_by_track.remove(&id).unwrap_or_default();
-                    (
-                        id,
-                        TrackRenderState {
-                            content_version: cv,
-                            format: fmt,
-                            path: Self::render_one(&self.template, &self.config, fmt, &tags),
-                        },
-                    )
+                    Self::render_one(&self.template, &self.config, fmt, &tags).map(|path| {
+                        (
+                            id,
+                            TrackRenderState {
+                                content_version: cv,
+                                format: fmt,
+                                path,
+                            },
+                        )
+                    })
                 })
                 .collect()
         };
+
+        // Reconcile `skip_on_missing` drops: a `changed`/`added` id that rendered
+        // nothing (`render_one` -> None) produced no `new_states` entry. A changed
+        // id was materialized before, so it becomes a removal; an added id never
+        // was, so it just disappears from the change set. Keeps the change set and
+        // `new_states` agreeing for `apply_changes` and the snapshot mutation below.
+        let mut vanished = Vec::new();
+        change.changed.retain(|id| {
+            if new_states.contains_key(id) {
+                true
+            } else {
+                vanished.push(*id);
+                false
+            }
+        });
+        change.added.retain(|id| new_states.contains_key(id));
+        change.removed.extend(vanished);
 
         // Phase 4 (snapshot + inodes locks, pure CPU): mutate in place, apply delta.
         let mut snap = crate::lock::lock_or_flag(&self.snapshot, &self.needs_rebuild, "snapshot");
@@ -1474,6 +1508,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1520,6 +1555,7 @@ mod tests {
                 case_insensitive: false,
                 read_ahead_budget: budget,
                 read_ahead_prefetch: prefetch,
+                skip_on_missing: false,
             };
             Musefs::open(musefs_db::Db::open_in_memory().unwrap(), cfg).unwrap()
         };
@@ -1565,6 +1601,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
         let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
@@ -1612,6 +1649,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
         let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");
@@ -1694,6 +1732,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1810,6 +1849,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -1875,6 +1915,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
 
         let (entries, snapshot) = Musefs::render_entries(
@@ -1888,6 +1929,54 @@ mod tests {
         let id = entries[0].0;
         assert_eq!(snapshot[&id].path, "Pix/Song.mp3");
         assert!(snapshot[&id].content_version >= 1);
+    }
+
+    #[test]
+    fn render_entries_skips_tracks_missing_top_level_field_when_enabled() {
+        use crate::scan::scan_directory;
+        use id3::TagLike;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mk = |name: &str, artist: Option<&str>, title: &str| {
+            let mut tag = id3::Tag::new();
+            if let Some(a) = artist {
+                tag.set_artist(a);
+            }
+            tag.set_title(title);
+            let mut bytes = Vec::new();
+            tag.write_to(&mut bytes, id3::Version::Id3v24).unwrap();
+            bytes.extend_from_slice(&[0xFF, 0xFB, 1, 2, 3, 4]);
+            std::fs::write(dir.path().join(name), &bytes).unwrap();
+        };
+        mk("full.mp3", Some("Pix"), "Song");
+        mk("partial.mp3", None, "Lonely");
+
+        let db = musefs_db::Db::open(dir.path().join("m.db")).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+
+        let cfg = MountConfig {
+            template: "$artist/$title".to_string(),
+            fallbacks: BTreeMap::new(),
+            default_fallback: "Unknown".to_string(),
+            mode: Mode::Synthesis,
+            poll_interval: std::time::Duration::ZERO,
+            case_insensitive: false,
+            read_ahead_budget: 64 * 1024 * 1024,
+            read_ahead_prefetch: false,
+            skip_on_missing: true,
+        };
+
+        let (entries, snapshot) = Musefs::render_entries(
+            &db,
+            &Template::parse(&cfg.template).expect("valid template"),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 1, "the artist-less track must be skipped");
+        assert_eq!(entries[0].1, "Pix/Song.mp3");
+        let id = entries[0].0;
+        assert_eq!(snapshot.len(), 1);
+        assert!(snapshot.contains_key(&id));
     }
 
     #[test]
@@ -1920,6 +2009,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -2010,6 +2100,7 @@ mod tests {
             case_insensitive: true,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -2068,6 +2159,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
         (dir, fs)
@@ -2137,6 +2229,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
 
         // StructureOnly: exposed, and the fd refers to the backing inode.
@@ -2247,6 +2340,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let template = Template::parse(&config.template).expect("valid template");
 
@@ -2296,6 +2390,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
 
@@ -2340,6 +2435,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         assert!(matches!(
             Musefs::open(db, config),
@@ -2377,6 +2473,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
         let artist = fs.lookup(VirtualTree::ROOT, "Pix").expect("artist dir");

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -93,10 +93,30 @@ impl Template {
         default_fallback: &str,
         ext: &str,
     ) -> String {
-        let (mut out, _) = render_parts(&self.parts, fields, fallbacks, default_fallback, false);
+        let (mut out, _, _) = render_parts(&self.parts, fields, fallbacks, default_fallback, false);
         out.push('.');
         out.push_str(ext);
         out
+    }
+
+    /// Like [`render`](Self::render), but returns `None` when any *top-level*
+    /// (non-section) field is unresolved — the caller's signal to skip the track
+    /// rather than substitute `default_fallback`. Per-field fallback chains and
+    /// `[...]` sections behave exactly as in `render`; only the top-level default
+    /// substitution is replaced by the skip. Backs `--skip-on-missing`.
+    pub fn render_checked(
+        &self,
+        fields: &BTreeMap<String, &str>,
+        fallbacks: &BTreeMap<String, String>,
+        ext: &str,
+    ) -> Option<String> {
+        let (mut out, _, top_complete) = render_parts(&self.parts, fields, fallbacks, "", false);
+        if !top_complete {
+            return None;
+        }
+        out.push('.');
+        out.push_str(ext);
+        Some(out)
     }
 }
 
@@ -221,18 +241,21 @@ fn collect_field_names(parts: &[Part], out: &mut BTreeSet<String>) {
     }
 }
 
-/// Render `parts`, returning the text and whether at least one referenced field
-/// was present. `in_section` gates `default_fallback`: it is substituted only at
-/// the top level (outside any `[...]`).
+/// Render `parts`, returning the text, whether at least one referenced field
+/// was present, and whether every *top-level* field resolved (no
+/// `default_fallback` substitution was needed). `in_section` gates
+/// `default_fallback`: it is substituted only at the top level (outside any
+/// `[...]`), and only a top-level miss clears `top_complete`.
 fn render_parts(
     parts: &[Part],
     fields: &BTreeMap<String, &str>,
     fallbacks: &BTreeMap<String, String>,
     default_fallback: &str,
     in_section: bool,
-) -> (String, bool) {
+) -> (String, bool, bool) {
     let mut out = String::new();
     let mut any_present = false;
+    let mut top_complete = true;
     for part in parts {
         match part {
             Part::Literal(lit) => out.push_str(lit),
@@ -242,6 +265,7 @@ fn render_parts(
                     any_present = true;
                 } else if !in_section {
                     sanitize_into(&mut out, default_fallback);
+                    top_complete = false;
                 }
             }
             Part::Field { names, raw: true } => {
@@ -250,10 +274,11 @@ fn render_parts(
                     any_present = true;
                 } else if !in_section {
                     sanitize_into(&mut out, default_fallback);
+                    top_complete = false;
                 }
             }
             Part::Section(inner) => {
-                let (text, present) =
+                let (text, present, _) =
                     render_parts(inner, fields, fallbacks, default_fallback, true);
                 if present {
                     out.push_str(&text);
@@ -262,7 +287,7 @@ fn render_parts(
             }
         }
     }
-    (out, any_present)
+    (out, any_present, top_complete)
 }
 
 /// First candidate with a non-empty value, checked against `fields` then

--- a/musefs-core/tests/bench_ingest.rs
+++ b/musefs-core/tests/bench_ingest.rs
@@ -202,6 +202,7 @@ fn bench_read_under_latency() {
         case_insensitive: false,
         read_ahead_budget: ra_mib.saturating_mul(1024 * 1024),
         read_ahead_prefetch: ra_prefetch,
+        skip_on_missing: false,
     };
     fn first_inode(fs: &Musefs, dir: u64) -> Option<u64> {
         for (_, ino, is_dir) in fs.readdir(dir).unwrap() {

--- a/musefs-core/tests/bench_refresh.rs
+++ b/musefs-core/tests/bench_refresh.rs
@@ -18,6 +18,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/tests/binary_tag_tree.rs
+++ b/musefs-core/tests/binary_tag_tree.rs
@@ -13,6 +13,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/tests/facade.rs
+++ b/musefs-core/tests/facade.rs
@@ -14,6 +14,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/tests/flac_binary_tags.rs
+++ b/musefs-core/tests/flac_binary_tags.rs
@@ -52,6 +52,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/tests/incremental_refresh.rs
+++ b/musefs-core/tests/incremental_refresh.rs
@@ -25,6 +25,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 
@@ -33,6 +34,14 @@ fn config_ci() -> MountConfig {
         case_insensitive: true,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
+        ..config()
+    }
+}
+
+fn config_skip() -> MountConfig {
+    MountConfig {
+        skip_on_missing: true,
         ..config()
     }
 }
@@ -95,6 +104,58 @@ fn incremental_refresh_matches_full_rebuild_over_edits() {
         tree_fingerprint(&reference).keys().collect::<Vec<_>>(),
         "incremental and full-rebuild paths must match"
     );
+}
+
+#[test]
+fn incremental_skip_on_missing_matches_full_rebuild_over_key_loss_and_gain() {
+    let target = small_corpus(4);
+    let db_path = target.db_path.clone();
+    let corpus = target.corpus_dir.clone();
+
+    let db = Db::open(&db_path).unwrap();
+    scan_directory(&db, &corpus).unwrap();
+    let fs = Musefs::open(Db::open(&db_path).unwrap(), config_skip()).unwrap();
+
+    let writer = Db::open(&db_path).unwrap();
+    let ids: Vec<i64> = writer.list_tracks().unwrap().iter().map(|t| t.id).collect();
+
+    let full = |label: &str, fs: &Musefs| {
+        let reference = Musefs::open(Db::open(&db_path).unwrap(), config_skip()).unwrap();
+        let inc = tree_fingerprint(fs);
+        assert_eq!(
+            inc.keys().collect::<Vec<_>>(),
+            tree_fingerprint(&reference).keys().collect::<Vec<_>>(),
+            "{label}: incremental must match full rebuild"
+        );
+        inc.len()
+    };
+
+    assert_eq!(full("baseline", &fs), 4);
+
+    // Key loss: drop TITLE (a top-level template field) from ids[0]. Full rebuild
+    // skips it, so the incremental path must drop it too.
+    writer
+        .replace_tags(
+            ids[0],
+            &[Tag::new("ARTIST", "Zed", 0), Tag::new("ALBUM", "Al", 0)],
+        )
+        .unwrap();
+    fs.poll_refresh().unwrap();
+    assert_eq!(full("key loss", &fs), 3);
+
+    // Key gain: restore TITLE; the track must reappear.
+    writer
+        .replace_tags(
+            ids[0],
+            &[
+                Tag::new("ARTIST", "Zed", 0),
+                Tag::new("ALBUM", "Al", 0),
+                Tag::new("TITLE", "Back", 0),
+            ],
+        )
+        .unwrap();
+    fs.poll_refresh().unwrap();
+    assert_eq!(full("key gain", &fs), 4);
 }
 
 #[test]

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -24,6 +24,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -27,6 +27,7 @@ fn config() -> MountConfig {
         // and mask them. Read-ahead's own effects are covered in readahead.rs.
         read_ahead_budget: 0,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-core/tests/template.rs
+++ b/musefs-core/tests/template.rs
@@ -318,3 +318,58 @@ fn bracket_escapes_and_slashes_still_parse() {
     );
     assert_eq!(path, "[X]/a/b.flac");
 }
+
+#[test]
+fn checked_render_returns_path_when_all_top_level_fields_present() {
+    let f = fields(&[("albumartist", "AC"), ("album", "LP"), ("title", "Song")]);
+    assert_eq!(
+        parse("$albumartist/$album/$title").render_checked(&f, &BTreeMap::new(), "flac"),
+        Some("AC/LP/Song.flac".to_string())
+    );
+}
+
+#[test]
+fn checked_render_returns_none_when_top_level_field_missing() {
+    let f = fields(&[("album", "LP"), ("title", "Song")]);
+    assert_eq!(
+        parse("$albumartist/$album/$title").render_checked(&f, &BTreeMap::new(), "flac"),
+        None
+    );
+}
+
+#[test]
+fn checked_render_ignores_missing_fields_inside_sections() {
+    let f = fields(&[("album", "LP")]);
+    assert_eq!(
+        parse("$album[ - CD $disc]").render_checked(&f, &BTreeMap::new(), "flac"),
+        Some("LP.flac".to_string())
+    );
+}
+
+#[test]
+fn checked_render_counts_fallback_chain_as_present() {
+    let f = fields(&[("artist", "Beck"), ("title", "Loser")]);
+    assert_eq!(
+        parse("${albumartist|artist}/$title").render_checked(&f, &BTreeMap::new(), "flac"),
+        Some("Beck/Loser.flac".to_string())
+    );
+}
+
+#[test]
+fn checked_render_counts_per_field_fallback_as_present() {
+    let f = fields(&[("title", "Loser")]);
+    let fb = owned(&[("albumartist", "VA")]);
+    assert_eq!(
+        parse("$albumartist/$title").render_checked(&f, &fb, "flac"),
+        Some("VA/Loser.flac".to_string())
+    );
+}
+
+#[test]
+fn checked_render_path_field_all_segments_dropped_is_none() {
+    let f = fields(&[("p", "..")]);
+    assert_eq!(
+        parse("$!{p}").render_checked(&f, &BTreeMap::new(), "flac"),
+        None
+    );
+}

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -1089,6 +1089,7 @@ mod tests {
             case_insensitive: false,
             read_ahead_budget: 64 * 1024 * 1024,
             read_ahead_prefetch: false,
+            skip_on_missing: false,
         };
         let core =
             Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -78,6 +78,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/concurrent_reads.rs
+++ b/musefs-fuse/tests/concurrent_reads.rs
@@ -61,6 +61,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/fault_injection.rs
+++ b/musefs-fuse/tests/fault_injection.rs
@@ -58,6 +58,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -58,6 +58,7 @@ fn mount_config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/metrics_e2e.rs
+++ b/musefs-fuse/tests/metrics_e2e.rs
@@ -65,6 +65,7 @@ fn core_config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -55,6 +55,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -78,6 +78,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -79,6 +79,7 @@ fn config(mode: Mode) -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -25,6 +25,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -68,6 +68,7 @@ fn config() -> MountConfig {
         case_insensitive: false,
         read_ahead_budget: 64 * 1024 * 1024,
         read_ahead_prefetch: false,
+        skip_on_missing: false,
     }
 }
 


### PR DESCRIPTION
Closes #408.

## What

Adds an opt-in `--skip-on-missing` flag (env `MUSEFS_SKIP_ON_MISSING`, default off) that **drops a track from the mount** when a *top-level* template field stays unresolved, instead of substituting `--default-fallback`.

Per-field `--fallback` chains and `[...]` sections are unaffected: a field resolved via its fallback counts as present, and section fields remain optional. So with the flag on, a track is dropped exactly where `--default-fallback` would otherwise have been substituted at the top level.

The motivating case (#408) is:

```
musefs mount … --template '$!{beets_path}' --skip-on-missing
```

which hides tracks beets left without a `beets_path` (e.g. deduplicated albums) rather than collapsing them into an `Unknown` bucket.

## How

- **`Template::render_checked`** (`template.rs`) returns `None` when any top-level field is unresolved; `render` is unchanged (a `top_complete` signal threaded through `render_parts`).
- **`render_one`** now returns `Option<String>`. The full build (`render_entries`) drops `None` renders so they never enter the snapshot or tree.
- **`rebuild_incremental`** reconciles drops against the changelog partition: a previously-materialized track that loses a key becomes a *removal*, a new track that renders nothing is dropped, and a track that regains its key is re-*added* — keeping the incremental path equivalent to a full rebuild (covered by the existing `incremental == full` property test plus a new deterministic loss/gain test).

## Tests (TDD)

- `template.rs`: 6 unit tests for `render_checked` (present, missing top-level, section-optional, fallback-chain/per-field-fallback counted present, path-field all-segments-dropped).
- `facade.rs`: full build skips an artist-less track.
- `incremental_refresh.rs`: incremental matches full rebuild across key **loss and re-gain**.
- `musefs-cli`: `--skip-on-missing` maps into `MountConfig`.

## Docs

CLI `--help` text, README template section, `ARCHITECTURE.md` virtual-tree section, and `contrib/systemd/musefs.conf.example` (`MUSEFS_SKIP_ON_MISSING`).

Note: most of the 28-file diff is the one-line `skip_on_missing: false,` added to each exhaustive `MountConfig`/`MountArgs` test literal — the repo convention when adding a config field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)