### PR TITLE
docs(changelog): catch up Unreleased entries since v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Runtime telemetry (`.musefs-metrics`):** an opt-in `--expose-metrics` flag
+  (env `MUSEFS_EXPOSE_METRICS`) surfaces a synthetic `.musefs-metrics` file at
+  the mount root rendering Prometheus-format counters — getattr/read/open
+  activity, backing read-ahead behavior, and (when built with jemalloc)
+  allocator stats. Off by default; the file is absent unless enabled. See the
+  README [Metrics](README.md#metrics) section (#394).
+- **Scan progress indicator:** `scan` and `scan --revalidate` render a live
+  progress bar (indicatif) with an elapsed-time summary on an interactive
+  terminal, falling back to periodic `ingested N/M (P%)` log lines when output
+  is non-interactive. A new `--quiet`/`-q` flag suppresses it (#406).
+- **`--skip-on-missing` template flag:** an opt-in `--skip-on-missing` (env
+  `MUSEFS_SKIP_ON_MISSING`) drops a track from the mount when a top-level
+  template field stays unresolved, instead of substituting `--default-fallback`.
+  Per-field `--fallback` chains and `[...]` optional sections are unaffected (a
+  field resolved via its fallback counts as present). The motivating case is
+  `--template '$!{beets_path}' --skip-on-missing`, which hides tracks beets left
+  without a `beets_path` rather than collapsing them into an `Unknown` bucket
+  (#408).
+- **`--read-ahead-prefetch` flag:** opt-in background prefetch threads layered on
+  top of read amplification, default off — benchmarks found amplification alone
+  delivers the entire read-ahead win, while the threads add ~10% overhead with no
+  measured benefit. Enable only when profiling a backend where a single large
+  read does not self-pipeline (#255).
 - **riscv64 release platform:** prebuilt `riscv64gc-unknown-linux-{gnu,musl}`
   binaries and `linux/riscv64` Docker images now ship with each tagged release.
   Container bases bumped to current stable: glibc Debian bookworm → trixie

--- a/contrib/CHANGELOG.md
+++ b/contrib/CHANGELOG.md
@@ -10,6 +10,23 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Duplicate rendered tags from case-only key differences:** a `musefs scan`
+  seeds an unmapped tag under the backing file's native key case (e.g. Vorbis
+  `LABEL`), while the beets/Picard plugins canonicalize keys to lowercase
+  (`label`). `merge_tags` deleted by exact key, so the plugin's `label` insert
+  never displaced the scanner's `LABEL` and both rows survived — rendering a
+  duplicated value. The merge/delete key match is now case-insensitive, so a
+  writer's canonical lowercase key replaces the scan-seeded native-case row;
+  existing duplicates self-heal on the next sync of the affected key (#407).
+- **beets reconcile failures no longer silent:** the beets `cli_exit` reconcile
+  hook degraded every failure to a `_log.warning`, which beets hides at default
+  verbosity — so a persistent setup failure (read-only DB, `EACCES`) became a
+  silent no-op. Persistent permission/read-only failures are now surfaced loudly
+  via `ui.print_` while transient failures (locked DB, vanished file) stay quiet;
+  the beets operation is still never aborted (#405).
+
 ## [1.0.0] - 2026-06-12
 
 First stable release.


### PR DESCRIPTION
Audited the commits since `v1.0.0` (and contrib commits since `py-v1.0.0`) against the `[Unreleased]` sections of both changelogs and added the user-facing changes that weren't yet recorded.

## Root `CHANGELOG.md` — added
- **`.musefs-metrics` / `--expose-metrics`** runtime telemetry surface (#394)
- **Scan progress indicator** + `--quiet`/`-q` (#406)
- **`--skip-on-missing`** template flag (#408)
- **`--read-ahead-prefetch`** opt-in flag (#255)

## `contrib/CHANGELOG.md` — added (Unreleased was empty)
- Case-insensitive merge-key dedup, fixing duplicate rendered tags (#407)
- beets reconcile failures surfaced loudly instead of silently warned (#405)

Remaining post-tag commits were dependabot bumps, CI/release plumbing, docs, tests, and the read-ahead mutation/bench follow-ups under #255 — none warrant their own changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Opt-in runtime telemetry with Prometheus-format metrics exposure
  * Live scan progress indicator with quiet suppression option
  * Skip-on-missing template flag for unresolved fields
  * Background prefetch threads for enhanced read-ahead performance

* **Bug Fixes**
  * Fixed duplicate rendered tags from case-insensitive key handling
  * Improved error visibility for beets reconcile failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->