### PR TITLE
docs: sync stale claims with code (images, FreeBSD CI, merge keys)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,8 +128,8 @@ truth — CI and local runs invoke the same scripts, so they can't drift:
 **CI.** The `freebsd` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
 runs these in a `vmactions/freebsd-vm` VM. It is expensive (a full in-VM build),
 so it does **not** run on every PR — only when the FUSE/mount surface or its
-harness changed (`musefs-fuse/`, `scripts/freebsd-vm/`, `ci.yml`) or on a release
-tag (`v*`).
+harness changed (`musefs/`, `musefs-fuse/`, `scripts/freebsd-vm/`, `Cargo.lock`,
+`ci.yml`) or on a release tag (`v*`).
 
 **Local run (one command):**
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Registry:
 
 | Image | libc | Platforms |
 | --- | --- | --- |
-| `ghcr.io/sohex/musefs:<version>`, `ghcr.io/sohex/musefs:latest` | glibc | amd64, arm64 |
-| `ghcr.io/sohex/musefs:<version>-musl`, `ghcr.io/sohex/musefs:musl` | musl | amd64, arm64 |
+| `ghcr.io/sohex/musefs:<version>`, `ghcr.io/sohex/musefs:latest` | glibc | amd64, arm64, riscv64 |
+| `ghcr.io/sohex/musefs:<version>-musl`, `ghcr.io/sohex/musefs:musl` | musl | amd64, arm64, riscv64 |
 
 `docker pull` selects the CPU architecture automatically. Use the `-musl` /
 `:musl` tags when slotting musefs into an Alpine-based stack; the default

--- a/contrib/python-musefs/README.md
+++ b/contrib/python-musefs/README.md
@@ -109,6 +109,11 @@ rest. The store does not remember which keys you manage — **you** track your
 managed-key set out of band (the contract is explicit that the store is not the
 place for plugin state).
 
+Merge-mode key matching is **case-insensitive** (`lower(key) = lower(?)`): Vorbis
+keys render case-insensitively, so a scan that seeds a tag in the file's native
+case (e.g. `LABEL`) is correctly replaced when your plugin canonicalizes to
+lowercase (`label`), rather than leaving the original row behind as a duplicate.
+
 When the user removes a tag in the host, merge mode needs to delete the
 now-orphaned store row. The beets plugin solves this with an **accumulating
 managed-key set** (the `musefs_managed` pattern), worth copying:


### PR DESCRIPTION
Documentation audit pass — fixes three places where docs drifted from the code/CI. Docs-only; no behavior change.

## Changes
- **README** (container image table): both the glibc and `-musl` image rows now advertise `riscv64` alongside `amd64`/`arm64`. The release workflow already publishes the multi-arch manifest as `linux/amd64,linux/arm64,linux/riscv64` for both variants, and the prebuilt-binary section already lists riscv64 — the image table was the lone holdout.
- **CONTRIBUTING** (FreeBSD CI section): the trigger list now includes `musefs/` and `Cargo.lock`, matching the actual path filter in `.github/workflows/ci.yml` (allocator/dependency changes trigger the FreeBSD job too).
- **contrib/python-musefs** (merge-vs-replace section): documents that merge-mode key matching is case-insensitive (`lower(key) = lower(?)`), so a scan-seeded tag in the file's native case (e.g. `LABEL`) is correctly replaced by a plugin's lowercase canonical key instead of leaving a duplicate (#407).

## Not changed
Format docs (`docs/{FLAC,M4A,MP3,OGG,WAV}.md`), `BENCHMARKS.md`, `SECURITY.md`, and the lidarr/picard/systemd contrib READMEs were audited and verified accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added riscv64 platform support to container images alongside amd64 and arm64.
  * Clarified that merge-mode key matching performs case-insensitive comparisons.
  * Updated FreeBSD CI job trigger conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->