### PR TITLE
refactor(db): collapse musefs-db duplication

### DIFF
--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -11,43 +11,41 @@ pub(crate) fn sha256_hex(data: &[u8]) -> String {
 
 impl<M> Db<M> {
     pub fn get_art(&self, id: i64) -> Result<Option<Art>> {
-        let mut stmt = self.conn.prepare(
+        crate::query_optional(
+            &self.conn,
             "SELECT id, sha256, mime, width, height, byte_len, data FROM art WHERE id = ?1",
-        )?;
-        let mut rows = stmt.query(params![id])?;
-        match rows.next()? {
-            Some(r) => Ok(Some(Art {
-                id: r.get(0)?,
-                sha256: r.get(1)?,
-                mime: r.get(2)?,
-                width: r.get(3)?,
-                height: r.get(4)?,
-                byte_len: r.get(5)?,
-                data: r.get(6)?,
-            })),
-            None => Ok(None),
-        }
+            params![id],
+            |r| {
+                Ok(Art {
+                    id: r.get(0)?,
+                    sha256: r.get(1)?,
+                    mime: r.get(2)?,
+                    width: r.get(3)?,
+                    height: r.get(4)?,
+                    byte_len: r.get(5)?,
+                    data: r.get(6)?,
+                })
+            },
+        )
     }
 
     /// Art row metadata without loading the image blob — used to build synthesis
     /// inputs at resolve time without materializing art in memory.
     pub fn get_art_meta(&self, id: i64) -> Result<Option<ArtMeta>> {
-        let mut stmt = self.conn.prepare_cached(
+        crate::query_optional(
+            &self.conn,
             "SELECT length(mime), mime, width, height, byte_len FROM art WHERE id = ?1",
-        )?;
-        let mut rows = stmt.query(params![id])?;
-        match rows.next()? {
-            Some(r) => {
+            params![id],
+            |r| {
                 check_field_len("art", "mime", r.get(0)?, MAX_ART_MIME_LEN)?;
-                Ok(Some(ArtMeta {
+                Ok(ArtMeta {
                     mime: r.get(1)?,
                     width: r.get(2)?,
                     height: r.get(3)?,
                     byte_len: r.get(4)?,
-                }))
-            }
-            None => Ok(None),
-        }
+                })
+            },
+        )
     }
 
     /// Stream art-blob bytes at `offset` directly into `buf` via SQLite incremental
@@ -147,44 +145,57 @@ impl<M> Db<M> {
     }
 }
 
+/// Insert `a` (deduplicated by content sha256) and return its `art` id. Runs on
+/// `conn` so `Db<ReadWrite>` and `BulkWriter` share one body.
+pub(crate) fn upsert_art_in(conn: &rusqlite::Connection, a: &NewArt) -> Result<i64> {
+    let sha = sha256_hex(&a.data);
+    conn.execute(
+        "INSERT INTO art (sha256, mime, width, height, byte_len, data)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) ON CONFLICT(sha256) DO NOTHING",
+        params![sha, a.mime, a.width, a.height, a.data.len() as u64, a.data],
+    )?;
+    Ok(
+        conn.query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| {
+            r.get(0)
+        })?,
+    )
+}
+
+/// Replace a track's `track_art` links. Runs on `conn` so `Db<ReadWrite>` (own
+/// transaction) and `BulkWriter` (caller-held transaction) share one body.
+pub(crate) fn set_track_art_in(
+    conn: &rusqlite::Connection,
+    track_id: i64,
+    items: &[TrackArt],
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM track_art WHERE track_id = ?1",
+        params![track_id],
+    )?;
+    let mut stmt = conn.prepare_cached(
+        "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )?;
+    for it in items {
+        stmt.execute(params![
+            track_id,
+            it.art_id,
+            it.picture_type,
+            it.description,
+            it.ordinal
+        ])?;
+    }
+    Ok(())
+}
+
 impl Db<ReadWrite> {
     pub fn upsert_art(&self, a: &NewArt) -> Result<i64> {
-        let sha = sha256_hex(&a.data);
-        self.conn.execute(
-            "INSERT INTO art (sha256, mime, width, height, byte_len, data)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(sha256) DO NOTHING",
-            params![sha, a.mime, a.width, a.height, a.data.len() as u64, a.data],
-        )?;
-        let id =
-            self.conn
-                .query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| {
-                    r.get(0)
-                })?;
-        Ok(id)
+        upsert_art_in(&self.conn, a)
     }
 
     pub fn set_track_art(&self, track_id: i64, items: &[TrackArt]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM track_art WHERE track_id = ?1",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-            )?;
-            for it in items {
-                stmt.execute(params![
-                    track_id,
-                    it.art_id,
-                    it.picture_type,
-                    it.description,
-                    it.ordinal
-                ])?;
-            }
-        }
+        set_track_art_in(&tx, track_id, items)?;
         tx.commit()?;
         Ok(())
     }
@@ -349,5 +360,14 @@ mod guard_tests {
         drop(stmt);
         tx.commit().unwrap();
         assert_eq!(db.get_track_art(track).unwrap().len(), 4096);
+    }
+
+    #[test]
+    fn sha256_hex_matches_known_digest() {
+        // NIST sample vector: sha256("abc").
+        assert_eq!(
+            super::sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
     }
 }

--- a/musefs-db/src/bulk.rs
+++ b/musefs-db/src/bulk.rs
@@ -1,7 +1,10 @@
-use crate::art::sha256_hex;
+use crate::art::{set_track_art_in, upsert_art_in};
 use crate::models::{BinaryTag, NewArt, NewTrack, StructuralBlock, Tag, TrackArt};
+use crate::structural::set_structural_blocks_in;
+use crate::tags::{replace_tags_in, set_binary_tags_in};
+use crate::tracks::upsert_track_in;
 use crate::{Db, ReadWrite, Result};
-use rusqlite::{Transaction, params};
+use rusqlite::Transaction;
 
 impl Db<ReadWrite> {
     /// Apply the bulk-write pragmas to an open connection. WAL is left untouched
@@ -28,58 +31,26 @@ impl Db<ReadWrite> {
     }
 }
 
-/// A batch of track writes held in one transaction. Mirrors `Db::upsert_track` /
-/// `replace_tags` / `upsert_art` / `set_track_art`, but executes on a single
-/// caller-held transaction so a whole batch commits with one fsync.
+/// A batch of track writes held in one transaction. Each method delegates to the
+/// shared per-row writer helper (`upsert_track_in` / `replace_tags_in` /
+/// `set_binary_tags_in` / `set_structural_blocks_in` / `upsert_art_in` /
+/// `set_track_art_in`) that also backs the `Db<ReadWrite>` writers, but runs it
+/// on a single caller-held transaction so a whole batch commits with one fsync.
 pub struct BulkWriter<'c> {
     tx: Transaction<'c>,
 }
 
 impl BulkWriter<'_> {
     pub fn upsert_track(&mut self, t: &NewTrack) -> Result<i64> {
-        Ok(self.tx.query_row(
-            "INSERT INTO tracks
-                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime_ns, backing_ctime_ns, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
-             ON CONFLICT(backing_path) DO UPDATE SET
-                format=excluded.format, audio_offset=excluded.audio_offset,
-                audio_length=excluded.audio_length, backing_size=excluded.backing_size,
-                backing_mtime_ns=excluded.backing_mtime_ns,
-                backing_ctime_ns=excluded.backing_ctime_ns,
-                updated_at=CAST(strftime('%s','now') AS INTEGER)
-             RETURNING id",
-            params![t.backing_path, t.format.as_str(), t.audio_offset, t.audio_length, t.backing_size, t.backing_mtime_ns, t.backing_ctime_ns],
-            |r| r.get(0),
-        )?)
+        upsert_track_in(&self.tx, t)
     }
 
     pub fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> Result<()> {
-        self.tx.execute(
-            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
-            params![track_id],
-        )?;
-        let mut stmt = self.tx.prepare_cached(
-            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
-        )?;
-        for t in tags {
-            stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
-        }
-        Ok(())
+        replace_tags_in(&self.tx, track_id, tags)
     }
 
     pub fn set_binary_tags(&mut self, track_id: i64, tags: &[BinaryTag]) -> Result<()> {
-        self.tx.execute(
-            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
-            params![track_id],
-        )?;
-        let mut stmt = self.tx.prepare_cached(
-            "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
-             VALUES (?1, ?2, '', ?3, ?4)",
-        )?;
-        for t in tags {
-            stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
-        }
-        Ok(())
+        set_binary_tags_in(&self.tx, track_id, tags)
     }
 
     pub fn set_structural_blocks(
@@ -87,53 +58,15 @@ impl BulkWriter<'_> {
         track_id: i64,
         blocks: &[StructuralBlock],
     ) -> Result<()> {
-        self.tx.execute(
-            "DELETE FROM structural_blocks WHERE track_id = ?1",
-            params![track_id],
-        )?;
-        let mut stmt = self.tx.prepare_cached(
-            "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
-             VALUES (?1, ?2, ?3, ?4)",
-        )?;
-        for b in blocks {
-            stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
-        }
-        Ok(())
+        set_structural_blocks_in(&self.tx, track_id, blocks)
     }
 
     pub fn upsert_art(&mut self, a: &NewArt) -> Result<i64> {
-        let sha = sha256_hex(&a.data);
-        self.tx.execute(
-            "INSERT INTO art (sha256, mime, width, height, byte_len, data)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6) ON CONFLICT(sha256) DO NOTHING",
-            params![sha, a.mime, a.width, a.height, a.data.len() as u64, a.data],
-        )?;
-        Ok(self
-            .tx
-            .query_row("SELECT id FROM art WHERE sha256 = ?1", params![sha], |r| {
-                r.get(0)
-            })?)
+        upsert_art_in(&self.tx, a)
     }
 
     pub fn set_track_art(&mut self, track_id: i64, items: &[TrackArt]) -> Result<()> {
-        self.tx.execute(
-            "DELETE FROM track_art WHERE track_id = ?1",
-            params![track_id],
-        )?;
-        let mut stmt = self.tx.prepare_cached(
-            "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-        )?;
-        for it in items {
-            stmt.execute(params![
-                track_id,
-                it.art_id,
-                it.picture_type,
-                it.description,
-                it.ordinal
-            ])?;
-        }
-        Ok(())
+        set_track_art_in(&self.tx, track_id, items)
     }
 
     pub fn commit(self) -> Result<()> {
@@ -215,15 +148,6 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM track_art", [], |r| r.get(0))
             .unwrap();
         assert_eq!(track_art_count, 3);
-    }
-
-    #[test]
-    fn sha256_hex_matches_known_digest() {
-        // NIST sample vector: sha256("abc").
-        assert_eq!(
-            super::sha256_hex(b"abc"),
-            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-        );
     }
 
     #[test]

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -22,6 +22,45 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+/// Run a single-row query, mapping the row with `map` if present. The shared
+/// shape behind every `Result<Option<T>>` point read (`get_art`,
+/// `track_version_and_path`, the `Track` readers, …): prepare-cached, step once,
+/// map-or-`None`.
+pub(crate) fn query_optional<T>(
+    conn: &Connection,
+    sql: &str,
+    params: impl rusqlite::Params,
+    map: impl FnOnce(&rusqlite::Row) -> Result<T>,
+) -> Result<Option<T>> {
+    let mut stmt = conn.prepare_cached(sql)?;
+    let mut rows = stmt.query(params)?;
+    match rows.next()? {
+        Some(r) => Ok(Some(map(r)?)),
+        None => Ok(None),
+    }
+}
+
+/// Run an `IN (?,?,…)` query over `items` split into chunks within SQLite's bound
+/// variable limit. `make_sql` receives the comma-joined placeholder list for the
+/// chunk; `consume` drains the resulting rows (a chunk's items bind positionally
+/// in order).
+pub(crate) fn query_in_chunks<T: rusqlite::ToSql>(
+    conn: &Connection,
+    items: &[T],
+    make_sql: impl Fn(&str) -> String,
+    mut consume: impl FnMut(&mut rusqlite::Rows) -> Result<()>,
+) -> Result<()> {
+    const CHUNK: usize = 900;
+    for chunk in items.chunks(CHUNK) {
+        let placeholders = vec!["?"; chunk.len()].join(",");
+        let sql = make_sql(&placeholders);
+        let mut stmt = conn.prepare(&sql)?;
+        let mut rows = stmt.query(rusqlite::params_from_iter(chunk.iter()))?;
+        consume(&mut rows)?;
+    }
+    Ok(())
+}
+
 /// Type-state markers for [`Db`]: the connection's write capability, at the
 /// type level. Write APIs exist only on `Db<ReadWrite>`.
 #[derive(Debug)]

--- a/musefs-db/src/structural.rs
+++ b/musefs-db/src/structural.rs
@@ -56,23 +56,32 @@ impl<M> Db<M> {
     }
 }
 
+/// Replace a track's structural blocks. Runs on `conn` so `Db<ReadWrite>` (own
+/// transaction) and `BulkWriter` (caller-held transaction) share one body.
+pub(crate) fn set_structural_blocks_in(
+    conn: &rusqlite::Connection,
+    track_id: i64,
+    blocks: &[StructuralBlock],
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM structural_blocks WHERE track_id = ?1",
+        params![track_id],
+    )?;
+    let mut stmt = conn.prepare_cached(
+        "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
+         VALUES (?1, ?2, ?3, ?4)",
+    )?;
+    for b in blocks {
+        stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
+    }
+    Ok(())
+}
+
 impl Db<ReadWrite> {
     /// Replace the track's structural blocks (FLAC STREAMINFO/SEEKTABLE).
     pub fn set_structural_blocks(&self, track_id: i64, blocks: &[StructuralBlock]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM structural_blocks WHERE track_id = ?1",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO structural_blocks (track_id, kind, ordinal, body) \
-                 VALUES (?1, ?2, ?3, ?4)",
-            )?;
-            for b in blocks {
-                stmt.execute(params![track_id, b.kind, b.ordinal, b.body])?;
-            }
-        }
+        set_structural_blocks_in(&tx, track_id, blocks)?;
         tx.commit()?;
         Ok(())
     }

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -14,6 +14,38 @@ fn check_tag_lengths(key_len: i64, value_len: i64) -> Result<()> {
     Ok(())
 }
 
+/// Columns the grouped tag readers project: `track_id` followed by the five
+/// columns `read_tag_row` consumes. Kept in lockstep with `read_tag_row`'s
+/// offset arithmetic.
+const GROUPED_TAG_COLS: &str = "track_id, length(key), length(value), key, value, ordinal";
+
+/// Read one text-tag row laid out as `length(key), length(value), key, value,
+/// ordinal` starting at column `base`; length-guards the row before its strings
+/// are materialized (spec N13).
+fn read_tag_row(r: &rusqlite::Row, base: usize) -> Result<Tag> {
+    check_tag_lengths(r.get(base)?, r.get(base + 1)?)?;
+    Ok(Tag {
+        key: r.get(base + 2)?,
+        value: r.get(base + 3)?,
+        ordinal: r.get(base + 4)?,
+    })
+}
+
+/// Drain grouped tag rows (`GROUPED_TAG_COLS`: `track_id` then `read_tag_row`'s
+/// five columns at base 1) into `out`, enforcing the per-track count cap.
+fn collect_grouped_tags(
+    rows: &mut rusqlite::Rows,
+    out: &mut std::collections::HashMap<i64, Vec<Tag>>,
+) -> Result<()> {
+    while let Some(r) = rows.next()? {
+        let track_id: i64 = r.get(0)?;
+        let entry = out.entry(track_id).or_default();
+        entry.push(read_tag_row(r, 1)?);
+        check_tag_count(track_id, entry.len())?;
+    }
+    Ok(())
+}
+
 impl<M> Db<M> {
     pub fn get_tags(&self, track_id: i64) -> Result<Vec<Tag>> {
         let mut stmt = self.conn.prepare_cached(
@@ -23,12 +55,7 @@ impl<M> Db<M> {
         let mut rows = stmt.query(params![track_id])?;
         let mut out = Vec::new();
         while let Some(r) = rows.next()? {
-            check_tag_lengths(r.get(0)?, r.get(1)?)?;
-            out.push(Tag {
-                key: r.get(2)?,
-                value: r.get(3)?,
-                ordinal: r.get(4)?,
-            });
+            out.push(read_tag_row(r, 0)?);
             check_tag_count(track_id, out.len())?;
         }
         Ok(out)
@@ -38,51 +65,31 @@ impl<M> Db<M> {
         &self,
         track_ids: &[i64],
     ) -> Result<std::collections::HashMap<i64, Vec<Tag>>> {
-        const CHUNK: usize = 900;
-        let mut out: std::collections::HashMap<i64, Vec<Tag>> = std::collections::HashMap::new();
-        for chunk in track_ids.chunks(CHUNK) {
-            let placeholders = vec!["?"; chunk.len()].join(",");
-            let sql = format!(
-                "SELECT track_id, length(key), length(value), key, value, ordinal FROM tags \
-                 WHERE track_id IN ({placeholders}) AND value_blob IS NULL \
-                 ORDER BY track_id, key, ordinal"
-            );
-            let mut stmt = self.conn.prepare(&sql)?;
-            let params = rusqlite::params_from_iter(chunk.iter());
-            let mut rows = stmt.query(params)?;
-            while let Some(r) = rows.next()? {
-                let track_id: i64 = r.get(0)?;
-                check_tag_lengths(r.get(1)?, r.get(2)?)?;
-                let entry = out.entry(track_id).or_default();
-                entry.push(Tag {
-                    key: r.get(3)?,
-                    value: r.get(4)?,
-                    ordinal: r.get(5)?,
-                });
-                check_tag_count(track_id, entry.len())?;
-            }
-        }
+        let mut out = std::collections::HashMap::new();
+        crate::query_in_chunks(
+            &self.conn,
+            track_ids,
+            |ph| {
+                format!(
+                    "SELECT {GROUPED_TAG_COLS} FROM tags \
+                     WHERE track_id IN ({ph}) AND value_blob IS NULL \
+                     ORDER BY track_id, key, ordinal"
+                )
+            },
+            |rows| collect_grouped_tags(rows, &mut out),
+        )?;
         Ok(out)
     }
 
     pub fn tags_grouped(&self) -> Result<std::collections::HashMap<i64, Vec<Tag>>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT track_id, length(key), length(value), key, value, ordinal FROM tags \
-             WHERE value_blob IS NULL ORDER BY track_id, key, ordinal",
-        )?;
+        let sql = format!(
+            "SELECT {GROUPED_TAG_COLS} FROM tags \
+             WHERE value_blob IS NULL ORDER BY track_id, key, ordinal"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt.query([])?;
-        let mut out: std::collections::HashMap<i64, Vec<Tag>> = std::collections::HashMap::new();
-        while let Some(r) = rows.next()? {
-            let track_id: i64 = r.get(0)?;
-            check_tag_lengths(r.get(1)?, r.get(2)?)?;
-            let entry = out.entry(track_id).or_default();
-            entry.push(Tag {
-                key: r.get(3)?,
-                value: r.get(4)?,
-                ordinal: r.get(5)?,
-            });
-            check_tag_count(track_id, entry.len())?;
-        }
+        let mut out = std::collections::HashMap::new();
+        collect_grouped_tags(&mut rows, &mut out)?;
         Ok(out)
     }
 
@@ -90,31 +97,20 @@ impl<M> Db<M> {
         &self,
         keys: &[&str],
     ) -> Result<std::collections::HashMap<i64, Vec<Tag>>> {
-        const CHUNK: usize = 900;
-        let mut out: std::collections::HashMap<i64, Vec<Tag>> = std::collections::HashMap::new();
-        for chunk in keys.chunks(CHUNK) {
-            let lowered: Vec<String> = chunk.iter().map(|k| k.to_ascii_lowercase()).collect();
-            let placeholders = vec!["?"; lowered.len()].join(",");
-            let sql = format!(
-                "SELECT track_id, length(key), length(value), key, value, ordinal FROM tags \
-                 WHERE value_blob IS NULL AND lower(key) IN ({placeholders}) \
-                 ORDER BY track_id, key, ordinal"
-            );
-            let mut stmt = self.conn.prepare(&sql)?;
-            let params = rusqlite::params_from_iter(lowered.iter());
-            let mut rows = stmt.query(params)?;
-            while let Some(r) = rows.next()? {
-                let track_id: i64 = r.get(0)?;
-                check_tag_lengths(r.get(1)?, r.get(2)?)?;
-                let entry = out.entry(track_id).or_default();
-                entry.push(Tag {
-                    key: r.get(3)?,
-                    value: r.get(4)?,
-                    ordinal: r.get(5)?,
-                });
-                check_tag_count(track_id, entry.len())?;
-            }
-        }
+        let lowered: Vec<String> = keys.iter().map(|k| k.to_ascii_lowercase()).collect();
+        let mut out = std::collections::HashMap::new();
+        crate::query_in_chunks(
+            &self.conn,
+            &lowered,
+            |ph| {
+                format!(
+                    "SELECT {GROUPED_TAG_COLS} FROM tags \
+                     WHERE value_blob IS NULL AND lower(key) IN ({ph}) \
+                     ORDER BY track_id, key, ordinal"
+                )
+            },
+            |rows| collect_grouped_tags(rows, &mut out),
+        )?;
         Ok(out)
     }
 
@@ -173,21 +169,53 @@ impl<M> Db<M> {
     }
 }
 
+/// Replace a track's text-tag rows (`value_blob IS NULL`); binary rows are
+/// untouched. Runs on `conn` so both `Db<ReadWrite>` (own transaction) and
+/// `BulkWriter` (caller-held transaction) share one implementation.
+pub(crate) fn replace_tags_in(
+    conn: &rusqlite::Connection,
+    track_id: i64,
+    tags: &[Tag],
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
+        params![track_id],
+    )?;
+    let mut stmt = conn.prepare_cached(
+        "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
+    )?;
+    for t in tags {
+        stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
+    }
+    Ok(())
+}
+
+/// Replace a track's binary-tag rows (`value_blob IS NOT NULL`); text rows are
+/// untouched. Binary rows store `''` in `value`. See `replace_tags_in` for the
+/// shared-`conn` rationale.
+pub(crate) fn set_binary_tags_in(
+    conn: &rusqlite::Connection,
+    track_id: i64,
+    tags: &[BinaryTag],
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
+        params![track_id],
+    )?;
+    let mut stmt = conn.prepare_cached(
+        "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
+         VALUES (?1, ?2, '', ?3, ?4)",
+    )?;
+    for t in tags {
+        stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
+    }
+    Ok(())
+}
+
 impl Db<ReadWrite> {
     pub fn replace_tags(&self, track_id: i64, tags: &[Tag]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NULL",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, ?2, ?3, ?4)",
-            )?;
-            for t in tags {
-                stmt.execute(params![track_id, t.key, t.value, t.ordinal])?;
-            }
-        }
+        replace_tags_in(&tx, track_id, tags)?;
         tx.commit()?;
         Ok(())
     }
@@ -196,19 +224,7 @@ impl Db<ReadWrite> {
     /// (managed by `replace_tags`) are untouched. Binary rows store '' in `value`.
     pub fn set_binary_tags(&self, track_id: i64, tags: &[BinaryTag]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM tags WHERE track_id = ?1 AND value_blob IS NOT NULL",
-            params![track_id],
-        )?;
-        {
-            let mut stmt = tx.prepare(
-                "INSERT INTO tags (track_id, key, value, value_blob, ordinal) \
-                 VALUES (?1, ?2, '', ?3, ?4)",
-            )?;
-            for t in tags {
-                stmt.execute(params![track_id, t.key, t.payload, t.ordinal])?;
-            }
-        }
+        set_binary_tags_in(&tx, track_id, tags)?;
         tx.commit()?;
         Ok(())
     }

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -55,6 +55,34 @@ fn row_to_track(r: &Row) -> rusqlite::Result<Track> {
     })
 }
 
+/// Upsert a track by `backing_path`, returning its id (via `RETURNING`, so the
+/// insert and id-read are one statement). Runs on `conn` so `Db<ReadWrite>` and
+/// `BulkWriter` share one body.
+pub(crate) fn upsert_track_in(conn: &rusqlite::Connection, t: &NewTrack) -> Result<i64> {
+    Ok(conn.query_row(
+        "INSERT INTO tracks
+            (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime_ns, backing_ctime_ns, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
+         ON CONFLICT(backing_path) DO UPDATE SET
+            format=excluded.format, audio_offset=excluded.audio_offset,
+            audio_length=excluded.audio_length, backing_size=excluded.backing_size,
+            backing_mtime_ns=excluded.backing_mtime_ns,
+            backing_ctime_ns=excluded.backing_ctime_ns,
+            updated_at=CAST(strftime('%s','now') AS INTEGER)
+         RETURNING id",
+        params![
+            t.backing_path,
+            t.format.as_str(),
+            t.audio_offset,
+            t.audio_length,
+            t.backing_size,
+            t.backing_mtime_ns,
+            t.backing_ctime_ns,
+        ],
+        |r| r.get(0),
+    )?)
+}
+
 /// One read of the changelog ring past `last_seq`: the distinct changed track
 /// ids (ascending) plus the table's retained seq bounds (0/0 when empty). The
 /// caller derives gap detection from `min_seq` (see musefs-core's refresh).
@@ -93,14 +121,12 @@ impl<M> Db<M> {
     /// without materializing a full `Track` (no `format` parse, no
     /// `TrackBounds`) on the hottest metadata op. `None` if the id is unknown.
     pub fn track_version_and_path(&self, id: i64) -> Result<Option<(i64, String)>> {
-        let mut stmt = self
-            .conn
-            .prepare_cached("SELECT content_version, backing_path FROM tracks WHERE id = ?1")?;
-        let mut rows = stmt.query(params![id])?;
-        match rows.next()? {
-            Some(r) => Ok(Some((r.get(0)?, r.get(1)?))),
-            None => Ok(None),
-        }
+        crate::query_optional(
+            &self.conn,
+            "SELECT content_version, backing_path FROM tracks WHERE id = ?1",
+            params![id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
     }
 
     /// Begin a deferred (read) transaction: subsequent reads on this connection see
@@ -118,12 +144,7 @@ impl<M> Db<M> {
     }
 
     fn query_optional_track(&self, sql: &str, p: impl rusqlite::Params) -> Result<Option<Track>> {
-        let mut stmt = self.conn.prepare_cached(sql)?;
-        let mut rows = stmt.query(p)?;
-        match rows.next()? {
-            Some(r) => Ok(Some(row_to_track(r)?)),
-            None => Ok(None),
-        }
+        crate::query_optional(&self.conn, sql, p, |r| Ok(row_to_track(r)?))
     }
 
     /// Cheap render-key identity scan for incremental refresh: `(id, content_version,
@@ -176,60 +197,35 @@ impl<M> Db<M> {
     /// Render keys for a specific id set (the changelog ids); ids no longer in
     /// `tracks` are simply absent from the result. Chunked like `tags_for_tracks`.
     pub fn render_keys_for(&self, ids: &[i64]) -> Result<Vec<(i64, i64, Format)>> {
-        const CHUNK: usize = 900;
         let mut out = Vec::with_capacity(ids.len());
-        for chunk in ids.chunks(CHUNK) {
-            let placeholders = vec!["?"; chunk.len()].join(",");
-            let sql = format!(
-                "SELECT id, content_version, format FROM tracks \
-                 WHERE id IN ({placeholders}) ORDER BY id"
-            );
-            let mut stmt = self.conn.prepare(&sql)?;
-            let params = rusqlite::params_from_iter(chunk.iter());
-            let rows = stmt.query_map(params, |r| {
-                let fmt: String = r.get(2)?;
-                Ok((
-                    r.get::<_, i64>(0)?,
-                    r.get::<_, i64>(1)?,
-                    parse_format_col(&fmt)?,
-                ))
-            })?;
-            out.extend(rows.collect::<rusqlite::Result<Vec<_>>>()?);
-        }
+        crate::query_in_chunks(
+            &self.conn,
+            ids,
+            |ph| {
+                format!(
+                    "SELECT id, content_version, format FROM tracks \
+                     WHERE id IN ({ph}) ORDER BY id"
+                )
+            },
+            |rows| {
+                while let Some(r) = rows.next()? {
+                    let fmt: String = r.get(2)?;
+                    out.push((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, i64>(1)?,
+                        parse_format_col(&fmt)?,
+                    ));
+                }
+                Ok(())
+            },
+        )?;
         Ok(out)
     }
 }
 
 impl Db<ReadWrite> {
     pub fn upsert_track(&self, t: &NewTrack) -> Result<i64> {
-        self.conn.execute(
-            "INSERT INTO tracks
-                (backing_path, format, audio_offset, audio_length, backing_size, backing_mtime_ns, backing_ctime_ns, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, CAST(strftime('%s','now') AS INTEGER))
-             ON CONFLICT(backing_path) DO UPDATE SET
-                format        = excluded.format,
-                audio_offset  = excluded.audio_offset,
-                audio_length  = excluded.audio_length,
-                backing_size  = excluded.backing_size,
-                backing_mtime_ns = excluded.backing_mtime_ns,
-                backing_ctime_ns = excluded.backing_ctime_ns,
-                updated_at    = CAST(strftime('%s','now') AS INTEGER)",
-            params![
-                t.backing_path,
-                t.format.as_str(),
-                t.audio_offset,
-                t.audio_length,
-                t.backing_size,
-                t.backing_mtime_ns,
-                t.backing_ctime_ns,
-            ],
-        )?;
-        let id = self.conn.query_row(
-            "SELECT id FROM tracks WHERE backing_path = ?1",
-            params![t.backing_path],
-            |r| r.get(0),
-        )?;
-        Ok(id)
+        upsert_track_in(&self.conn, t)
     }
 
     /// Delete a track row. Foreign keys cascade to its `tags` and `track_art`


### PR DESCRIPTION
Closes #446.

A DRY audit of `musefs-db` surfaced four families of duplication. This factors each into a single source while preserving behavior — all 150 `musefs-db` tests and the full 1109-test workspace suite stay green, clippy (`-D warnings`) and `fmt` are clean.

## Changes

**New crate-private query helpers (`lib.rs`)**
- `query_optional` — the `prepare → step once → map-or-None` shape behind every `Result<Option<T>>` point read.
- `query_in_chunks` — the `CHUNK=900 / placeholders / params_from_iter` IN-scaffold.

**1. `BulkWriter` ↔ `Db<ReadWrite>` writers**
Extracted one `*_in(conn, …)` free function per writer (`upsert_track_in`, `replace_tags_in`, `set_binary_tags_in`, `set_structural_blocks_in`, `upsert_art_in`, `set_track_art_in`), each next to its module's table. The `Db<ReadWrite>` method (own transaction) and the `BulkWriter` method (caller-held transaction) both delegate via `Transaction → Connection` deref coercion. This also resolves the drift the issue flagged — `upsert_track` is unified on the single-statement `RETURNING id` form.

**2. Tag-reader row loop ×4**
`read_tag_row(r, base)` centralizes the length-guard + `Tag` construction (the column-index-offset risk); `collect_grouped_tags` shares the grouped trio's inner loop; the projection lives once in `GROUPED_TAG_COLS`.

**3. Chunked `IN (?,?,…)` scaffold ×3**
`tags_for_tracks`, `tags_grouped_for_keys`, and `render_keys_for` now drive `query_in_chunks` with a per-query `make_sql` closure.

**4. Single-row `Option<T>` fetch**
`query_optional` folds in `get_art`, `get_art_meta`, `track_version_and_path`, and `query_optional_track`.

Also moved the `sha256_hex_matches_known_digest` test from `bulk.rs` to `art.rs` (where `sha256_hex` lives), since `bulk.rs` no longer imports it.

No changelog entry: the Unreleased section tracks only user-facing Added/Fixed, and this is a behavior-preserving internal refactor with no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)