### PR TITLE
refactor(core): collapse musefs-core duplication (closes #447)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1063:46:',
+    'musefs-core/src/scan\.rs:1094:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1172:29:',
+    'musefs-core/src/scan\.rs:1203:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1174:32:',
+    'musefs-core/src/scan\.rs:1205:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1174:47:',
+    'musefs-core/src/scan\.rs:1205:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1174:62:',
+    'musefs-core/src/scan\.rs:1205:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1182:37:',
+    'musefs-core/src/scan\.rs:1213:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1184:40:',
+    'musefs-core/src/scan\.rs:1215:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1184:55:',
+    'musefs-core/src/scan\.rs:1215:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1184:70:',
+    'musefs-core/src/scan\.rs:1215:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1305:29:',
+    'musefs-core/src/scan\.rs:1336:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1313:29:',
+    'musefs-core/src/scan\.rs:1344:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1356:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1387:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are
@@ -318,22 +318,19 @@ exclude_re = [
     # guard: op="<" fn="serve_ogg_window" rows=1
     'musefs-core/src/ogg_index\.rs:225:15: replace < with <= in serve_ogg_window',
 
-    # Phase 4 poll_due (#89) — equivalent `<`->`<=` on the two wall-clock gates
-    # (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <
-    # refresh_retry_backoff`). The operators differ only when `Instant::elapsed()`
-    # equals the bound at the exact nanosecond it is sampled — a measure-zero
-    # boundary no deterministic test can construct: the `*_for_test` hooks backdate
-    # the stamp by exactly the bound, but time advances before the comparison runs,
-    # so elapsed() is already strictly greater under both operators. The same
-    # measure-zero class applies to the mirrored gates in `poll_refresh_notify`
-    # (both `<` gates there) — covered by the sibling entry below; it surfaced
-    # once the edition-2024 let-chain reformat pulled the refresh_retry_backoff
-    # gate into a diff. The `<`->`>`/`==` variants ARE caught and stay in scope;
-    # anchored on operator+function since both `<` in each fn are this class.
+    # Phase 4 poll debounce (#89) — equivalent `<`->`<=` on the two wall-clock
+    # gates (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <
+    # refresh_retry_backoff`), now shared by `poll_due` (advisory pre-check) and
+    # `poll_refresh_notify` (authoritative) via the `poll_debounced` helper. The
+    # operators differ only when `Instant::elapsed()` equals the bound at the exact
+    # nanosecond it is sampled — a measure-zero boundary no deterministic test can
+    # construct: the `*_for_test` hooks backdate the stamp by exactly the bound, but
+    # time advances before the comparison runs, so elapsed() is already strictly
+    # greater under both operators. The `<`->`>`/`==` variants ARE caught and stay
+    # in scope; anchored on operator+function since both `<` in the fn are this
+    # class.
     # guard: count=2
-    'musefs-core/src/facade\.rs:\d+:\d+: replace < with <= in Musefs::poll_due',
-    # guard: count=2
-    'replace < with <= in Musefs::poll_refresh_notify',
+    'replace < with <= in Musefs::poll_debounced',
 
     # CACHE_ESTIMATED_ITEMS const arithmetic — equivalent mutant. This is the
     # `estimated_items_capacity` hint passed to Cache::with_weighter; it sizes

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -690,30 +690,41 @@ impl Musefs {
     // the read guard before the `insert`; `retain` is never called while a `Ref`
     // is held), so it imposes no problematic lock ordering / no cross-lock cycle.
 
-    /// Cheap, synchronous "is a `data_version` poll worth dispatching?" predicate
-    /// for the FUSE dispatch thread to gate `fire_poll_refresh` on, so a
-    /// metadata-op storm doesn't flood the worker pool with no-op poll tasks (#89).
-    /// Mirrors the early-return gates in `poll_refresh_notify` — keep the two in
-    /// sync. Advisory only: no DB access, no `data_version` read, no rebuild. A
-    /// stale `true` costs at most one task the inner gate short-circuits, and
-    /// `needs_rebuild` is checked first so a self-heal is never debounced away.
-    pub fn poll_due(&self) -> bool {
-        if self.needs_rebuild.load(Ordering::Acquire) {
-            return true;
-        }
+    /// The shared debounce/backoff gate: `true` when a `data_version` poll
+    /// should be skipped because the poll interval hasn't elapsed since the last
+    /// poll, or the retry backoff hasn't elapsed since the last failed refresh.
+    /// The single source for both `poll_due` (the advisory dispatch-thread
+    /// pre-check) and `poll_refresh_notify` (the authoritative gate), so the two
+    /// can't drift out of sync (#89). Advisory-cheap: lock + `Instant::elapsed`,
+    /// no DB access.
+    fn poll_debounced(&self) -> bool {
         if !self.poll_interval.is_zero()
             && crate::lock::lock_recover(&self.last_poll, "last_poll").elapsed()
                 < self.poll_interval
         {
-            return false;
+            return true;
         }
         if let Some(last_failed) =
             *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
             && last_failed.elapsed() < self.refresh_retry_backoff
         {
-            return false;
+            return true;
         }
-        true
+        false
+    }
+
+    /// Cheap, synchronous "is a `data_version` poll worth dispatching?" predicate
+    /// for the FUSE dispatch thread to gate `fire_poll_refresh` on, so a
+    /// metadata-op storm doesn't flood the worker pool with no-op poll tasks (#89).
+    /// Shares the `poll_debounced` gate with `poll_refresh_notify`. Advisory only:
+    /// no DB access, no `data_version` read, no rebuild. A stale `true` costs at
+    /// most one task the inner gate short-circuits, and `needs_rebuild` is checked
+    /// first so a self-heal is never debounced away.
+    pub fn poll_due(&self) -> bool {
+        if self.needs_rebuild.load(Ordering::Acquire) {
+            return true;
+        }
+        !self.poll_debounced()
     }
 
     /// See `poll_refresh_notify`; this is the no-callback form.
@@ -730,8 +741,8 @@ impl Musefs {
     /// Single-flighted: if a rebuild is already in progress, concurrent callers
     /// return `Ok(false)` immediately.
     pub fn poll_refresh_notify(&self, mut on_changed: impl FnMut(u64)) -> Result<bool> {
-        // These early-return gates are mirrored by the cheap `poll_due` pre-check
-        // the FUSE layer runs on the dispatch thread (#89); keep the two in sync.
+        // The debounce / backoff gate is shared with the cheap `poll_due`
+        // pre-check the FUSE layer runs on the dispatch thread (#89).
         // A poisoned VFS-state lock scheduled a full rebuild: do it now,
         // bypassing the debounce / backoff / data_version gates (#96).
         if self.needs_rebuild.load(Ordering::Acquire) {
@@ -747,16 +758,7 @@ impl Musefs {
             return self.force_full_rebuild(&mut on_changed);
         }
 
-        if !self.poll_interval.is_zero()
-            && crate::lock::lock_recover(&self.last_poll, "last_poll").elapsed()
-                < self.poll_interval
-        {
-            return Ok(false);
-        }
-        if let Some(last_failed) =
-            *crate::lock::lock_recover(&self.last_failed_refresh, "last_failed_refresh")
-            && last_failed.elapsed() < self.refresh_retry_backoff
-        {
+        if self.poll_debounced() {
             return Ok(false);
         }
         // Stamp the failure on a broken data_version read too: it propagates before
@@ -1291,16 +1293,7 @@ impl Musefs {
             }
         }
         // Fallback (no prior open, or unknown handle): resolve by inode and open.
-        let track_id = {
-            let tree = self.tree.load();
-            match tree.node(inode) {
-                None => return Err(CoreError::NoEntry(inode)),
-                Some(node) => match &node.kind {
-                    NodeKind::Dir => return Err(CoreError::IsDir(inode)),
-                    NodeKind::File { track_id } => *track_id,
-                },
-            }
-        };
+        let track_id = self.track_id_for(inode)?;
         self.pool.with(|db| {
             let resolved = self.cache.resolve(db, track_id)?;
             read_at_into(&resolved, db, offset, size, out)
@@ -1314,20 +1307,26 @@ impl Musefs {
         Ok(out)
     }
 
+    /// Resolve a file `inode` to its `track_id` for the read/open fast paths,
+    /// erroring on an unknown inode (`NoEntry`) or a directory (`IsDir`). The
+    /// `read_into` fallback and `open_handle` share this; `getattr` deliberately
+    /// diverges (it returns an attr for directories rather than erroring).
+    fn track_id_for(&self, inode: u64) -> Result<i64> {
+        let tree = self.tree.load();
+        match tree.node(inode) {
+            None => Err(CoreError::NoEntry(inode)),
+            Some(node) => match &node.kind {
+                NodeKind::Dir => Err(CoreError::IsDir(inode)),
+                NodeKind::File { track_id } => Ok(*track_id),
+            },
+        }
+    }
+
     /// Open a file handle: resolve + validate the layout and open the backing fd
     /// once, store it, and return a handle. Subsequent `read`s with this handle
     /// reuse the fd (no per-read open/stat).
     pub fn open_handle(&self, inode: u64) -> Result<Fh> {
-        let track_id = {
-            let tree = self.tree.load();
-            match tree.node(inode) {
-                None => return Err(CoreError::NoEntry(inode)),
-                Some(node) => match &node.kind {
-                    NodeKind::Dir => return Err(CoreError::IsDir(inode)),
-                    NodeKind::File { track_id } => *track_id,
-                },
-            }
-        };
+        let track_id = self.track_id_for(inode)?;
         // Snapshot the generation BEFORE resolving: if a refresh lands during the
         // resolve, stamping the post-refresh gen onto this (pre-refresh) layout
         // would make the first read skip re-resolution and serve stale bytes. With

--- a/musefs-core/src/metrics.rs
+++ b/musefs-core/src/metrics.rs
@@ -21,6 +21,43 @@
 //! served via kernel passthrough never reach userspace and are invisible to
 //! `on_pread` — by design (the passthrough e2e test asserts exactly this).
 
+/// Single source of the counter list: `public Snapshot field => backing static`.
+/// The `Snapshot` struct below and the metrics-on statics / `snapshot()` /
+/// `reset()` are all generated from this one list (the x-macro / callback
+/// pattern), so adding a counter is a one-line edit here instead of four edits
+/// scattered across both `imp` modules.
+macro_rules! for_each_counter {
+    ($cb:ident) => {
+        $cb! {
+            opens => OPENS,
+            stats => STATS,
+            preads => PREADS,
+            pread_bytes => PREAD_BYTES,
+            art_chunks => ART_CHUNKS,
+            binary_tag_chunks => BINARY_TAG_CHUNKS,
+            scan_opens => SCAN_OPENS,
+            scan_preads => SCAN_PREADS,
+            scan_bytes_read => SCAN_BYTES_READ,
+            readahead_hits => READAHEAD_HITS,
+            readahead_misses => READAHEAD_MISSES,
+        }
+    };
+}
+
+macro_rules! decl_snapshot {
+    ($($field:ident => $stat:ident),* $(,)?) => {
+        /// Counter totals sampled by `snapshot`; zeroable by `reset`. Generated
+        /// from `for_each_counter!` so the fields stay in lockstep with the
+        /// backing statics. Present (and `Default`) even without the `metrics`
+        /// feature so consumers compile unconditionally.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+        pub struct Snapshot {
+            $(pub $field: u64,)*
+        }
+    };
+}
+for_each_counter!(decl_snapshot);
+
 pub use imp::*;
 
 #[cfg(feature = "metrics")]
@@ -29,17 +66,25 @@ mod imp {
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use std::time::Duration;
 
-    static OPENS: AtomicU64 = AtomicU64::new(0);
-    static STATS: AtomicU64 = AtomicU64::new(0);
-    static PREADS: AtomicU64 = AtomicU64::new(0);
-    static PREAD_BYTES: AtomicU64 = AtomicU64::new(0);
-    static ART_CHUNKS: AtomicU64 = AtomicU64::new(0);
-    static BINARY_TAG_CHUNKS: AtomicU64 = AtomicU64::new(0);
-    static SCAN_OPENS: AtomicU64 = AtomicU64::new(0);
-    static SCAN_PREADS: AtomicU64 = AtomicU64::new(0);
-    static SCAN_BYTES_READ: AtomicU64 = AtomicU64::new(0);
-    static READAHEAD_HITS: AtomicU64 = AtomicU64::new(0);
-    static READAHEAD_MISSES: AtomicU64 = AtomicU64::new(0);
+    // The counter statics, `snapshot()`, and `reset()` are all generated from the
+    // one `for_each_counter!` list (see the top of the file) so they can't drift.
+    macro_rules! decl_counters {
+        ($($field:ident => $stat:ident),* $(,)?) => {
+            $(static $stat: AtomicU64 = AtomicU64::new(0);)*
+
+            pub fn snapshot() -> super::Snapshot {
+                super::Snapshot {
+                    $($field: $stat.load(Ordering::Relaxed),)*
+                }
+            }
+
+            pub fn reset() {
+                $($stat.store(0, Ordering::Relaxed);)*
+            }
+        };
+    }
+    for_each_counter!(decl_counters);
+
     static PREAD_FAULT: OnceLock<Option<Duration>> = OnceLock::new();
 
     // Backing-read fault seam (test-only; process-global so it reaches the FUSE
@@ -192,70 +237,10 @@ mod imp {
     pub fn on_readahead_miss() {
         READAHEAD_MISSES.fetch_add(1, Ordering::Relaxed);
     }
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-    pub struct Snapshot {
-        pub opens: u64,
-        pub stats: u64,
-        pub preads: u64,
-        pub pread_bytes: u64,
-        pub art_chunks: u64,
-        pub binary_tag_chunks: u64,
-        pub scan_opens: u64,
-        pub scan_preads: u64,
-        pub scan_bytes_read: u64,
-        pub readahead_hits: u64,
-        pub readahead_misses: u64,
-    }
-
-    pub fn snapshot() -> Snapshot {
-        Snapshot {
-            opens: OPENS.load(Ordering::Relaxed),
-            stats: STATS.load(Ordering::Relaxed),
-            preads: PREADS.load(Ordering::Relaxed),
-            pread_bytes: PREAD_BYTES.load(Ordering::Relaxed),
-            art_chunks: ART_CHUNKS.load(Ordering::Relaxed),
-            binary_tag_chunks: BINARY_TAG_CHUNKS.load(Ordering::Relaxed),
-            scan_opens: SCAN_OPENS.load(Ordering::Relaxed),
-            scan_preads: SCAN_PREADS.load(Ordering::Relaxed),
-            scan_bytes_read: SCAN_BYTES_READ.load(Ordering::Relaxed),
-            readahead_hits: READAHEAD_HITS.load(Ordering::Relaxed),
-            readahead_misses: READAHEAD_MISSES.load(Ordering::Relaxed),
-        }
-    }
-
-    pub fn reset() {
-        OPENS.store(0, Ordering::Relaxed);
-        STATS.store(0, Ordering::Relaxed);
-        PREADS.store(0, Ordering::Relaxed);
-        PREAD_BYTES.store(0, Ordering::Relaxed);
-        ART_CHUNKS.store(0, Ordering::Relaxed);
-        BINARY_TAG_CHUNKS.store(0, Ordering::Relaxed);
-        SCAN_OPENS.store(0, Ordering::Relaxed);
-        SCAN_PREADS.store(0, Ordering::Relaxed);
-        SCAN_BYTES_READ.store(0, Ordering::Relaxed);
-        READAHEAD_HITS.store(0, Ordering::Relaxed);
-        READAHEAD_MISSES.store(0, Ordering::Relaxed);
-    }
 }
 
 #[cfg(not(feature = "metrics"))]
 mod imp {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-    pub struct Snapshot {
-        pub opens: u64,
-        pub stats: u64,
-        pub preads: u64,
-        pub pread_bytes: u64,
-        pub art_chunks: u64,
-        pub binary_tag_chunks: u64,
-        pub scan_opens: u64,
-        pub scan_preads: u64,
-        pub scan_bytes_read: u64,
-        pub readahead_hits: u64,
-        pub readahead_misses: u64,
-    }
-
     #[inline(always)]
     pub fn on_open() {}
     #[inline(always)]
@@ -286,8 +271,8 @@ mod imp {
     #[inline(always)]
     pub fn on_readahead_miss() {}
     #[inline(always)]
-    pub fn snapshot() -> Snapshot {
-        Snapshot::default()
+    pub fn snapshot() -> super::Snapshot {
+        super::Snapshot::default()
     }
     #[inline(always)]
     pub fn reset() {}

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -851,16 +851,103 @@ fn log_mp4_oversize_drops(path: &Path, art: &[mp4::OversizeDrop], binary: &[mp4:
     }
 }
 
-/// Upsert a track from a probed backing file: write the track row, replace its
-/// seeded tags, and ingest its embedded art (capped, deduped, clamped).
-fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
-    let stamp = BackingStamp::from_metadata(meta);
-    let track_id = db.upsert_track(&NewTrack {
+/// The write surface `ingest_into` drives: satisfied by both a direct `&Db`
+/// (its methods take `&self`) and a batched `&mut BulkWriter` (`&mut self`), so
+/// the upsert body lives in exactly one place. Each method delegates through the
+/// concrete type path (`Db::`/`BulkWriter::`), which names the inherent method
+/// unambiguously so the same-named trait method can't recurse into itself.
+trait TrackSink {
+    fn upsert_track(&mut self, t: &NewTrack) -> musefs_db::Result<i64>;
+    fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> musefs_db::Result<()>;
+    fn set_binary_tags(
+        &mut self,
+        track_id: i64,
+        tags: &[musefs_db::BinaryTag],
+    ) -> musefs_db::Result<()>;
+    fn set_structural_blocks(
+        &mut self,
+        track_id: i64,
+        blocks: &[musefs_db::StructuralBlock],
+    ) -> musefs_db::Result<()>;
+    fn upsert_art(&mut self, a: &NewArt) -> musefs_db::Result<i64>;
+    fn set_track_art(&mut self, track_id: i64, items: &[TrackArt]) -> musefs_db::Result<()>;
+}
+
+impl TrackSink for &Db {
+    fn upsert_track(&mut self, t: &NewTrack) -> musefs_db::Result<i64> {
+        Db::upsert_track(self, t)
+    }
+    fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> musefs_db::Result<()> {
+        Db::replace_tags(self, track_id, tags)
+    }
+    fn set_binary_tags(
+        &mut self,
+        track_id: i64,
+        tags: &[musefs_db::BinaryTag],
+    ) -> musefs_db::Result<()> {
+        Db::set_binary_tags(self, track_id, tags)
+    }
+    fn set_structural_blocks(
+        &mut self,
+        track_id: i64,
+        blocks: &[musefs_db::StructuralBlock],
+    ) -> musefs_db::Result<()> {
+        Db::set_structural_blocks(self, track_id, blocks)
+    }
+    fn upsert_art(&mut self, a: &NewArt) -> musefs_db::Result<i64> {
+        Db::upsert_art(self, a)
+    }
+    fn set_track_art(&mut self, track_id: i64, items: &[TrackArt]) -> musefs_db::Result<()> {
+        Db::set_track_art(self, track_id, items)
+    }
+}
+
+impl TrackSink for &mut musefs_db::BulkWriter<'_> {
+    fn upsert_track(&mut self, t: &NewTrack) -> musefs_db::Result<i64> {
+        musefs_db::BulkWriter::upsert_track(self, t)
+    }
+    fn replace_tags(&mut self, track_id: i64, tags: &[Tag]) -> musefs_db::Result<()> {
+        musefs_db::BulkWriter::replace_tags(self, track_id, tags)
+    }
+    fn set_binary_tags(
+        &mut self,
+        track_id: i64,
+        tags: &[musefs_db::BinaryTag],
+    ) -> musefs_db::Result<()> {
+        musefs_db::BulkWriter::set_binary_tags(self, track_id, tags)
+    }
+    fn set_structural_blocks(
+        &mut self,
+        track_id: i64,
+        blocks: &[musefs_db::StructuralBlock],
+    ) -> musefs_db::Result<()> {
+        musefs_db::BulkWriter::set_structural_blocks(self, track_id, blocks)
+    }
+    fn upsert_art(&mut self, a: &NewArt) -> musefs_db::Result<i64> {
+        musefs_db::BulkWriter::upsert_art(self, a)
+    }
+    fn set_track_art(&mut self, track_id: i64, items: &[TrackArt]) -> musefs_db::Result<()> {
+        musefs_db::BulkWriter::set_track_art(self, track_id, items)
+    }
+}
+
+/// Upsert a track from a probed backing file into `w`: write the track row,
+/// replace its seeded tags, and ingest its embedded art (capped, deduped,
+/// clamped). The single source of the ingest body shared by `ingest` (direct
+/// `&Db`) and `ingest_bulk` (batched `BulkWriter`). Takes `probed` by value so
+/// picture/binary-tag/structural-block bytes are moved, not cloned (#68).
+fn ingest_into(
+    mut w: impl TrackSink,
+    abs_path: &str,
+    stamp: BackingStamp,
+    probed: Probed,
+) -> Result<()> {
+    let track_id = w.upsert_track(&NewTrack {
         backing_path: abs_path.to_string(),
         format: probed.format,
         audio_offset: probed.audio_offset,
         audio_length: probed.audio_length,
-        backing_size: meta.len(),
+        backing_size: stamp.size,
         backing_mtime_ns: stamp.mtime_ns,
         backing_ctime_ns: stamp.ctime_ns,
     })?;
@@ -875,10 +962,10 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
         tags.push(Tag::new(&key, &value, *ord));
         *ord += 1;
     }
-    db.replace_tags(track_id, &tags)?;
+    w.replace_tags(track_id, &tags)?;
 
     let binary_tags = accept_binary_tags(abs_path, probed.binary_tags);
-    db.set_binary_tags(track_id, &binary_tags)?;
+    w.set_binary_tags(track_id, &binary_tags)?;
 
     let mut sb_ordinals: HashMap<String, u64> = HashMap::new();
     let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
@@ -895,14 +982,14 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
             sb
         })
         .collect();
-    db.set_structural_blocks(track_id, &structural_blocks)?;
+    w.set_structural_blocks(track_id, &structural_blocks)?;
 
     let mut track_arts = Vec::new();
     for (ordinal, pic) in accept_pictures(abs_path, probed.pictures)
         .into_iter()
         .enumerate()
     {
-        let art_id = db.upsert_art(&NewArt {
+        let art_id = w.upsert_art(&NewArt {
             mime: pic.mime,
             width: (pic.width != 0).then_some(pic.width),
             height: (pic.height != 0).then_some(pic.height),
@@ -916,81 +1003,25 @@ fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> 
             ordinal: ordinal as u64,
         });
     }
-    db.set_track_art(track_id, &track_arts)?;
+    w.set_track_art(track_id, &track_arts)?;
     Ok(())
 }
 
-/// Like `ingest`, but writes through a batch `BulkWriter`. Takes `probed` by
-/// value so picture/binary-tag/structural-block bytes are moved, not cloned (#68).
+/// Upsert a track from a probed backing file through a direct `&Db`. Thin
+/// wrapper over [`ingest_into`]; the `oracle`/non-bulk scan path.
+fn ingest(db: &Db, abs_path: &str, meta: &std::fs::Metadata, probed: Probed) -> Result<()> {
+    ingest_into(db, abs_path, BackingStamp::from_metadata(meta), probed)
+}
+
+/// Like [`ingest`], but writes through a batch `BulkWriter`. Thin wrapper over
+/// [`ingest_into`]; the `stamp` is captured once by the caller's `fstat`.
 fn ingest_bulk(
     bw: &mut musefs_db::BulkWriter<'_>,
     abs_path: &str,
     stamp: BackingStamp,
     probed: Probed,
 ) -> Result<()> {
-    let track_id = bw.upsert_track(&NewTrack {
-        backing_path: abs_path.to_string(),
-        format: probed.format,
-        audio_offset: probed.audio_offset,
-        audio_length: probed.audio_length,
-        backing_size: stamp.size,
-        backing_mtime_ns: stamp.mtime_ns,
-        backing_ctime_ns: stamp.ctime_ns,
-    })?;
-
-    let mut tags = Vec::new();
-    let mut ordinals: HashMap<String, u64> = HashMap::new();
-    for (key, value) in &probed.tags {
-        if !key_passes_floor(key) {
-            continue;
-        }
-        let ord = ordinals.entry(key.clone()).or_insert(0);
-        tags.push(Tag::new(key, value, *ord));
-        *ord += 1;
-    }
-    bw.replace_tags(track_id, &tags)?;
-
-    let binary_tags = accept_binary_tags(abs_path, probed.binary_tags);
-    bw.set_binary_tags(track_id, &binary_tags)?;
-
-    let mut sb_ordinals: HashMap<String, u64> = HashMap::new();
-    let structural_blocks: Vec<musefs_db::StructuralBlock> = probed
-        .structural_blocks
-        .into_iter()
-        .map(|(kind, body)| {
-            let ord = sb_ordinals.entry(kind.clone()).or_insert(0);
-            let sb = musefs_db::StructuralBlock {
-                kind,
-                ordinal: *ord,
-                body,
-            };
-            *ord += 1;
-            sb
-        })
-        .collect();
-    bw.set_structural_blocks(track_id, &structural_blocks)?;
-
-    let mut track_arts = Vec::new();
-    for (ordinal, pic) in accept_pictures(abs_path, probed.pictures)
-        .into_iter()
-        .enumerate()
-    {
-        let art_id = bw.upsert_art(&NewArt {
-            mime: pic.mime,
-            width: (pic.width != 0).then_some(pic.width),
-            height: (pic.height != 0).then_some(pic.height),
-            data: pic.data,
-        })?;
-        let picture_type = pic.picture_type.get();
-        track_arts.push(TrackArt {
-            art_id,
-            picture_type,
-            description: pic.description,
-            ordinal: ordinal as u64,
-        });
-    }
-    bw.set_track_art(track_id, &track_arts)?;
-    Ok(())
+    ingest_into(bw, abs_path, stamp, probed)
 }
 
 /// Public entry: parallel-probe / single-writer scan of `root`.


### PR DESCRIPTION
DRY-audit follow-up to #446 (the musefs-db counterpart, #455). Resolves the four duplications flagged in #447 in `musefs-core`, all **behavior-preserving** — no public API or on-disk behavior changes.

## Changes

1. **`ingest` / `ingest_bulk` twins** (`scan.rs`) — the two ~70-line near-verbatim functions now share one `ingest_into` body behind a private `TrackSink` trait (implemented for `&Db` and `&mut BulkWriter`). `ingest` and `ingest_bulk` stay as thin wrappers so their direct-call unit tests keep working.
2. **Debounce/backoff gate** (`facade.rs`) — the identical poll-interval + retry-backoff gate in `poll_due` and `poll_refresh_notify` is extracted into `poll_debounced()`, so the two can no longer drift (the old in-sync comments are gone).
3. **Inode→track_id resolution** (`facade.rs`) — the byte-identical `match tree.node(inode)` block in the `read_into` fallback and `open_handle` is extracted into `track_id_for()`. The `getattr` variant is a deliberate divergence (returns an attr for dirs) and is left as-is.
4. **Metrics `Snapshot`** (`metrics.rs`) — the 11-field struct, the counter statics, `snapshot()`, and `reset()` are now generated from one `for_each_counter!` list instead of four hand-kept copies. Adding a counter is a one-line edit.

## Mutation config

`.cargo/mutants.toml` re-anchored to match:
- The scan refactor shifts the `run_pipeline` / `revalidate_with` `line:col` anchors by +31.
- The `poll_debounced` extraction moves the equivalent `< -> <=` mutants out of `poll_due`/`poll_refresh_notify`; the two entries collapse to one for `poll_debounced`.

`scripts/check_mutant_anchors.py` validates all 65 exclude entries against the live mutant set (3611 mutants).

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`
- `cargo test` (full workspace, 1109 passed) and `cargo test -p musefs-core --features metrics` (471 passed)
- Mutant-anchor drift guard green
- Full pre-commit hook green on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)