### PR TITLE
refactor(format): dedup PICTURE builder, block walk, endian readers (#448)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -86,7 +86,7 @@ exclude_re = [
     # header. The `size + (size & 1)` operator at :35 and the `& 1` at :43 cannot
     # zero the advance (min 8) and stay IN scope (caught by that same test).
     # guard: op="+" fn="walk_chunks" rows=2
-    'musefs-format/src/wav\.rs:58:28:',
+    'musefs-format/src/wav\.rs:57:28:',
     # dirty_min_flip_ancestors (add-side walk) `id < introducing_id(child)`: the
     # `<`->`<=` boundary is unreachable-different. Equality needs the walked id to
     # BE the subtree's introducing id, which only a moved-in id can satisfy (pure

--- a/musefs-format/src/bytes.rs
+++ b/musefs-format/src/bytes.rs
@@ -1,0 +1,20 @@
+//! Bounds-checked fixed-width integer readers shared across the format parsers.
+//! Each reads a big- or little-endian integer at `pos`, returning
+//! [`FormatError::Malformed`] if the field runs past the end of `data`.
+
+use crate::error::{FormatError, Result};
+
+pub(crate) fn read_u32_be(data: &[u8], pos: usize) -> Result<u32> {
+    let s = data.get(pos..pos + 4).ok_or(FormatError::Malformed)?;
+    Ok(u32::from_be_bytes(s.try_into().unwrap()))
+}
+
+pub(crate) fn read_u64_be(data: &[u8], pos: usize) -> Result<u64> {
+    let s = data.get(pos..pos + 8).ok_or(FormatError::Malformed)?;
+    Ok(u64::from_be_bytes(s.try_into().unwrap()))
+}
+
+pub(crate) fn read_u32_le(data: &[u8], pos: usize) -> Result<u32> {
+    let s = data.get(pos..pos + 4).ok_or(FormatError::Malformed)?;
+    Ok(u32::from_le_bytes(s.try_into().unwrap()))
+}

--- a/musefs-format/src/flac.rs
+++ b/musefs-format/src/flac.rs
@@ -1,3 +1,4 @@
+use crate::bytes::read_u32_be;
 use crate::error::{FormatError, Result};
 use crate::probe::Extent;
 use crate::size;
@@ -35,44 +36,124 @@ pub struct FlacMeta {
     pub preserved: Vec<MetadataBlock>,
 }
 
-fn parse_blocks(data: &[u8]) -> Result<FlacMeta> {
-    if data.len() < 4 || &data[0..4] != FLAC_MARKER {
-        return Err(FormatError::NotFlac);
-    }
-    let mut pos = 4usize;
-    let mut index = 0usize;
-    let mut preserved = Vec::new();
-    loop {
-        if pos + 4 > data.len() {
-            return Err(FormatError::Malformed);
+/// Decoded header fields of one FLAC metadata block.
+struct BlockHead {
+    /// 0-based position of this block in the metadata sequence.
+    index: usize,
+    /// The 7-bit block type (`BLOCK_*`).
+    block_type: u8,
+    /// Declared body length in bytes.
+    len: usize,
+}
+
+/// One step of a metadata-block walk produced by [`BlockWalker::next_block`].
+enum BlockStep<'a> {
+    /// A complete block: its decoded header plus an in-bounds view of its body.
+    Ready(BlockHead, &'a [u8]),
+    /// The header decoded but its declared body runs past the data. `up_to` is the
+    /// byte index just past the body — what a bounded reader must widen the window
+    /// to before retrying.
+    Truncated(BlockHead, u64),
+    /// Fewer than the 4 header bytes remain. `up_to` is `pos + 4`.
+    NeedHeader(u64),
+}
+
+/// Walks the metadata blocks of a FLAC stream after the `fLaC` marker, decoding
+/// one block header per [`BlockWalker::next_block`] call. This centralizes the
+/// marker check, header decode, 24-bit length, and body-bounds arithmetic shared
+/// by the four metadata readers; each caller supplies its own short-body policy
+/// (`Malformed` vs `NeedMore`), STREAMINFO validation, and per-block action.
+struct BlockWalker<'a> {
+    data: &'a [u8],
+    pos: usize,
+    index: usize,
+    done: bool,
+}
+
+impl<'a> BlockWalker<'a> {
+    /// Validate the `fLaC` marker and position at the first metadata block.
+    fn new(data: &'a [u8]) -> Result<Self> {
+        if data.len() < 4 || &data[0..4] != FLAC_MARKER {
+            return Err(FormatError::NotFlac);
         }
-        let header = data[pos];
+        Ok(Self {
+            data,
+            pos: 4,
+            index: 0,
+            done: false,
+        })
+    }
+
+    /// Byte offset just past the last fully-walked block. Once the walk has
+    /// completed (the `is_last` block was returned as `Ready`), this is the
+    /// audio offset.
+    fn audio_offset(&self) -> u64 {
+        self.pos as u64
+    }
+
+    /// Decode the next block header, or `None` once the last block has been
+    /// returned or a short/truncated read has been reported.
+    fn next_block(&mut self) -> Option<BlockStep<'a>> {
+        if self.done {
+            return None;
+        }
+        if self.pos + 4 > self.data.len() {
+            // Need at least the 4-byte block header.
+            self.done = true;
+            return Some(BlockStep::NeedHeader((self.pos + 4) as u64));
+        }
+        let header = self.data[self.pos];
         let is_last = (header & 0x80) != 0;
         let block_type = header & 0x7F;
-        let len = u24_be(data[pos + 1], data[pos + 2], data[pos + 3]);
-        let body_start = pos + 4;
+        let len = u24_be(
+            self.data[self.pos + 1],
+            self.data[self.pos + 2],
+            self.data[self.pos + 3],
+        );
+        let head = BlockHead {
+            index: self.index,
+            block_type,
+            len,
+        };
+        let body_start = self.pos + 4;
         let body_end = body_start + len;
-        if body_end > data.len() {
-            return Err(FormatError::Malformed);
+        if body_end > self.data.len() {
+            self.done = true;
+            return Some(BlockStep::Truncated(head, body_end as u64));
         }
-        check_streaminfo_position(index, block_type, len)?;
-        match block_type {
-            BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
-                preserved.push(MetadataBlock {
-                    block_type,
-                    body: data[body_start..body_end].to_vec(),
-                });
-            }
-            _ => {}
-        }
-        pos = body_end;
-        index += 1;
+        self.pos = body_end;
+        self.index += 1;
         if is_last {
-            break;
+            self.done = true;
+        }
+        Some(BlockStep::Ready(head, &self.data[body_start..body_end]))
+    }
+}
+
+fn parse_blocks(data: &[u8]) -> Result<FlacMeta> {
+    let mut walker = BlockWalker::new(data)?;
+    let mut preserved = Vec::new();
+    while let Some(step) = walker.next_block() {
+        match step {
+            BlockStep::Ready(head, body) => {
+                check_streaminfo_position(head.index, head.block_type, head.len)?;
+                if matches!(
+                    head.block_type,
+                    BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET
+                ) {
+                    preserved.push(MetadataBlock {
+                        block_type: head.block_type,
+                        body: body.to_vec(),
+                    });
+                }
+            }
+            BlockStep::Truncated(..) | BlockStep::NeedHeader(_) => {
+                return Err(FormatError::Malformed);
+            }
         }
     }
     Ok(FlacMeta {
-        audio_offset: pos as u64,
+        audio_offset: walker.audio_offset(),
         preserved,
     })
 }
@@ -89,51 +170,36 @@ pub fn read_metadata(data: &[u8]) -> Result<FlacMeta> {
 /// body runs past the prefix, return `NeedMore { up_to }` with the exact end of
 /// that block — the caller widens the window and retries. Otherwise `Complete`.
 pub fn read_metadata_bounded(prefix: &[u8]) -> Result<Extent<FlacMeta>> {
-    if prefix.len() < 4 || &prefix[0..4] != FLAC_MARKER {
-        return Err(FormatError::NotFlac);
-    }
-    let mut pos = 4usize;
-    let mut index = 0usize;
+    let mut walker = BlockWalker::new(prefix)?;
     let mut preserved = Vec::new();
-    loop {
-        if pos + 4 > prefix.len() {
-            // Need at least the 4-byte block header.
-            return Ok(Extent::NeedMore {
-                up_to: (pos + 4) as u64,
-            });
-        }
-        let header = prefix[pos];
-        let is_last = (header & 0x80) != 0;
-        let block_type = header & 0x7F;
-        let len = u24_be(prefix[pos + 1], prefix[pos + 2], prefix[pos + 3]);
-        // Header-only validation: fail closed on a bad STREAMINFO header (wrong
-        // position/length, or a duplicate) before widening the probe to read a
-        // body that can never make the file valid.
-        check_streaminfo_position(index, block_type, len)?;
-        let body_start = pos + 4;
-        let body_end = body_start + len;
-        if body_end > prefix.len() {
-            return Ok(Extent::NeedMore {
-                up_to: body_end as u64,
-            });
-        }
-        match block_type {
-            BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET => {
-                preserved.push(MetadataBlock {
-                    block_type,
-                    body: prefix[body_start..body_end].to_vec(),
-                });
+    while let Some(step) = walker.next_block() {
+        match step {
+            BlockStep::Ready(head, body) => {
+                check_streaminfo_position(head.index, head.block_type, head.len)?;
+                if matches!(
+                    head.block_type,
+                    BLOCK_STREAMINFO | BLOCK_APPLICATION | BLOCK_SEEKTABLE | BLOCK_CUESHEET
+                ) {
+                    preserved.push(MetadataBlock {
+                        block_type: head.block_type,
+                        body: body.to_vec(),
+                    });
+                }
             }
-            _ => {}
-        }
-        pos = body_end;
-        index += 1;
-        if is_last {
-            break;
+            BlockStep::Truncated(head, up_to) => {
+                // Header-only validation: fail closed on a bad STREAMINFO header
+                // (wrong position/length, or a duplicate) before widening the probe
+                // to read a body that can never make the file valid.
+                check_streaminfo_position(head.index, head.block_type, head.len)?;
+                return Ok(Extent::NeedMore { up_to });
+            }
+            BlockStep::NeedHeader(up_to) => {
+                return Ok(Extent::NeedMore { up_to });
+            }
         }
     }
     Ok(Extent::Complete(FlacMeta {
-        audio_offset: pos as u64,
+        audio_offset: walker.audio_offset(),
         preserved,
     }))
 }
@@ -235,7 +301,12 @@ pub fn split_preserved(
     (structural, binary)
 }
 
-fn picture_body_framing(art: &ArtInput) -> Result<Vec<u8>> {
+/// Serialize a FLAC PICTURE block *body* for `art`: type, mime, description,
+/// dimensions, depth+colors placeholders, and the declared image-data length.
+/// The image bytes themselves are not appended. `description` is taken as a
+/// parameter (rather than `art.description`) so the OGG path can pass a
+/// space-padded variant for incremental base64 — see [`crate::ogg`].
+pub(crate) fn picture_body_framing(art: &ArtInput, description: &str) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(&art.picture_type.get().to_be_bytes());
     out.extend_from_slice(
@@ -245,11 +316,11 @@ fn picture_body_framing(art: &ArtInput) -> Result<Vec<u8>> {
     );
     out.extend_from_slice(art.mime.as_bytes());
     out.extend_from_slice(
-        &u32::try_from(art.description.len())
+        &u32::try_from(description.len())
             .map_err(|_| FormatError::TooLarge)?
             .to_be_bytes(),
     );
-    out.extend_from_slice(art.description.as_bytes());
+    out.extend_from_slice(description.as_bytes());
     out.extend_from_slice(&art.width.to_be_bytes());
     out.extend_from_slice(&art.height.to_be_bytes());
     out.extend_from_slice(&0u32.to_be_bytes()); // color depth (unknown)
@@ -338,7 +409,7 @@ pub fn synthesize_layout(
     }
 
     for art in arts {
-        let framing = picture_body_framing(art)?;
+        let framing = picture_body_framing(art, &art.description)?;
         let body_len = size::checked_add(framing.len() as u64, art.data_len.get())?;
         if body_len > MAX_BLOCK_BODY {
             return Err(FormatError::TooLarge);
@@ -373,29 +444,17 @@ pub fn synthesize_layout(
 /// `(FIELD, value)` pairs in order. Comments without a `=` are skipped. Returns
 /// an empty vec if there is no comment block. Used by the scanner to seed tags.
 pub fn read_vorbis_comments(data: &[u8]) -> Result<Vec<(String, String)>> {
-    if data.len() < 4 || &data[0..4] != FLAC_MARKER {
-        return Err(FormatError::NotFlac);
-    }
-    let mut pos = 4usize;
-    loop {
-        if pos + 4 > data.len() {
-            return Err(FormatError::Malformed);
-        }
-        let header = data[pos];
-        let is_last = (header & 0x80) != 0;
-        let block_type = header & 0x7F;
-        let len = u24_be(data[pos + 1], data[pos + 2], data[pos + 3]);
-        let body_start = pos + 4;
-        let body_end = body_start + len;
-        if body_end > data.len() {
-            return Err(FormatError::Malformed);
-        }
-        if block_type == BLOCK_VORBIS_COMMENT {
-            return crate::vorbiscomment::parse(&data[body_start..body_end]);
-        }
-        pos = body_end;
-        if is_last {
-            break;
+    let mut walker = BlockWalker::new(data)?;
+    while let Some(step) = walker.next_block() {
+        match step {
+            BlockStep::Ready(head, body) => {
+                if head.block_type == BLOCK_VORBIS_COMMENT {
+                    return crate::vorbiscomment::parse(body);
+                }
+            }
+            BlockStep::Truncated(..) | BlockStep::NeedHeader(_) => {
+                return Err(FormatError::Malformed);
+            }
         }
     }
     Ok(Vec::new())
@@ -404,18 +463,6 @@ pub fn read_vorbis_comments(data: &[u8]) -> Result<Vec<(String, String)>> {
 /// Assemble a 24-bit big-endian block length from its three raw bytes.
 fn u24_be(b0: u8, b1: u8, b2: u8) -> usize {
     u32::from_be_bytes([0, b0, b1, b2]) as usize
-}
-
-pub(crate) fn read_u32_be(data: &[u8], pos: usize) -> Result<u32> {
-    if pos + 4 > data.len() {
-        return Err(FormatError::Malformed);
-    }
-    Ok(u32::from_be_bytes([
-        data[pos],
-        data[pos + 1],
-        data[pos + 2],
-        data[pos + 3],
-    ]))
 }
 
 pub(crate) fn parse_picture_block(body: &[u8]) -> Result<EmbeddedPicture> {
@@ -465,30 +512,18 @@ pub(crate) fn parse_picture_block(body: &[u8]) -> Result<EmbeddedPicture> {
 /// Extract all PICTURE blocks from a complete FLAC file as embedded pictures, for
 /// scan-time art ingestion. Returns an empty vec if there are none.
 pub fn read_pictures(data: &[u8]) -> Result<Vec<EmbeddedPicture>> {
-    if data.len() < 4 || &data[0..4] != FLAC_MARKER {
-        return Err(FormatError::NotFlac);
-    }
-    let mut pos = 4usize;
+    let mut walker = BlockWalker::new(data)?;
     let mut out = Vec::new();
-    loop {
-        if pos + 4 > data.len() {
-            return Err(FormatError::Malformed);
-        }
-        let header = data[pos];
-        let is_last = (header & 0x80) != 0;
-        let block_type = header & 0x7F;
-        let len = u24_be(data[pos + 1], data[pos + 2], data[pos + 3]);
-        let body_start = pos + 4;
-        let body_end = body_start + len;
-        if body_end > data.len() {
-            return Err(FormatError::Malformed);
-        }
-        if block_type == BLOCK_PICTURE {
-            out.push(parse_picture_block(&data[body_start..body_end])?);
-        }
-        pos = body_end;
-        if is_last {
-            break;
+    while let Some(step) = walker.next_block() {
+        match step {
+            BlockStep::Ready(head, body) => {
+                if head.block_type == BLOCK_PICTURE {
+                    out.push(parse_picture_block(body)?);
+                }
+            }
+            BlockStep::Truncated(..) | BlockStep::NeedHeader(_) => {
+                return Err(FormatError::Malformed);
+            }
         }
     }
     Ok(out)
@@ -1075,7 +1110,8 @@ mod tests {
         // Derive the exact framing length from production rather than hardcoding it
         // (it is independent of the data_len *value* — that field is always 4 bytes).
         // This keeps the boundary correct regardless of the framing's field count.
-        let framing_len = picture_body_framing(&mk(1)).unwrap().len() as u64;
+        let art = mk(1);
+        let framing_len = picture_body_framing(&art, &art.description).unwrap().len() as u64;
         let at_limit = 0x00FF_FFFF - framing_len; // body_len == 0x00FF_FFFF exactly
         // original `>` accepts the inclusive boundary; the `>=` mutant rejects it.
         // (data_len is only a count; no large allocation occurs.)

--- a/musefs-format/src/lib.rs
+++ b/musefs-format/src/lib.rs
@@ -1,3 +1,4 @@
+mod bytes;
 mod convert;
 mod error;
 pub mod flac;

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -24,6 +24,20 @@ fn synchsafe_decode(b: &[u8]) -> u32 {
         | u32::from(b[3] & 0x7F)
 }
 
+/// Decode an ID3v2 frame's 4-byte size field. ID3v2.4 sizes are syncsafe (a 28-bit
+/// value with the high bit of each byte cleared); v2.3 and earlier use a plain
+/// big-endian `u32`. `major_version` is the tag header's version byte (ID3v2
+/// offset 3). The write path emits v2.4 syncsafe sizes via [`syncsafe`]; keeping
+/// the version-dependent rule named here keeps read decode and write encode from
+/// silently drifting apart.
+fn decode_frame_size(major_version: u8, raw: &[u8]) -> u32 {
+    if major_version == 3 {
+        u32::from_be_bytes([raw[0], raw[1], raw[2], raw[3]])
+    } else {
+        synchsafe_decode(raw)
+    }
+}
+
 fn id3v2_header_len(data: &[u8]) -> Result<Option<usize>> {
     if data.len() < 10 || &data[0..3] != b"ID3" {
         return Ok(None);
@@ -611,12 +625,7 @@ pub fn read_binary_tags(data: &[u8]) -> (Vec<EmbeddedBinaryTag>, Vec<(String, St
             break;
         }
         let id = &data[pos..pos + 4];
-        let size = if data[3] == 3 {
-            u32::from_be_bytes([data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7]])
-                as usize
-        } else {
-            synchsafe_decode(&data[pos + 4..pos + 8]) as usize
-        };
+        let size = decode_frame_size(data[3], &data[pos + 4..pos + 8]) as usize;
         let body_start = pos + 10;
         if body_start + size > tag_end {
             break;

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -3,6 +3,7 @@
 //! whose `mdat` audio payload is served verbatim. Strict: anything outside the
 //! supported shape (single audio track, one `mdat`, non-fragmented) is rejected.
 
+use crate::bytes::{read_u32_be, read_u64_be};
 use crate::convert::usize_from;
 use crate::error::{FormatError, Result};
 use crate::input::{
@@ -13,16 +14,6 @@ use crate::size;
 use std::io::{self, Read, Seek, SeekFrom};
 
 const MAX_MP4_METADATA_BYTES: u64 = 256 * 1024 * 1024;
-
-fn be_u32(b: &[u8], pos: usize) -> Result<u32> {
-    let s = b.get(pos..pos + 4).ok_or(FormatError::Malformed)?;
-    Ok(u32::from_be_bytes(s.try_into().unwrap()))
-}
-
-fn be_u64(b: &[u8], pos: usize) -> Result<u64> {
-    let s = b.get(pos..pos + 8).ok_or(FormatError::Malformed)?;
-    Ok(u64::from_be_bytes(s.try_into().unwrap()))
-}
 
 /// A located box header within some buffer. `start` is relative to that buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,14 +58,14 @@ pub struct BoxHeader {
 /// largesize). `remaining` is the byte count from this box's start to EOF, used
 /// to resolve a `size == 0` ("extends to end") box.
 pub fn box_header(hdr: &[u8], remaining: u64) -> Result<BoxHeader> {
-    let size32 = u64::from(be_u32(hdr, 0)?);
+    let size32 = u64::from(read_u32_be(hdr, 0)?);
     let kind: [u8; 4] = hdr
         .get(4..8)
         .ok_or(FormatError::Malformed)?
         .try_into()
         .unwrap();
     let (header_len, total_len) = match size32 {
-        1 => (16u64, be_u64(hdr, 8)?),
+        1 => (16u64, read_u64_be(hdr, 8)?),
         0 => (8u64, remaining),
         n => (8u64, n),
     };
@@ -106,14 +97,14 @@ pub enum Mp4ScanError {
 }
 
 fn read_box(buf: &[u8], pos: usize) -> Result<BoxRef> {
-    let size32 = u64::from(be_u32(buf, pos)?);
+    let size32 = u64::from(read_u32_be(buf, pos)?);
     let kind: [u8; 4] = buf
         .get(pos + 4..pos + 8)
         .ok_or(FormatError::Malformed)?
         .try_into()
         .unwrap();
     let (header_len, total) = match size32 {
-        1 => (16usize, be_u64(buf, pos + 8)?),
+        1 => (16usize, read_u64_be(buf, pos + 8)?),
         0 => (8usize, (buf.len() - pos) as u64),
         n => (8usize, n),
     };
@@ -600,13 +591,20 @@ fn boxed(kind: &[u8; 4], payload: &[u8]) -> Result<Vec<u8>> {
     Ok(v)
 }
 
+/// Build a UTF-8 `data` sub-box: a `1u32` type tag (UTF-8), a `0u32` locale, then
+/// the value bytes, wrapped as a `data` box. Shared by `text_atom` and
+/// `freeform_atom`, whose value lists emit one of these per value.
+fn utf8_data_box(value: &str) -> Result<Vec<u8>> {
+    let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
+    data.extend_from_slice(&0u32.to_be_bytes()); // locale
+    data.extend_from_slice(value.as_bytes());
+    boxed(b"data", &data)
+}
+
 fn text_atom(kind: &[u8; 4], values: &[&str]) -> Result<Vec<u8>> {
     let mut inner = Vec::new();
     for v in values {
-        let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
-        data.extend_from_slice(&0u32.to_be_bytes()); // locale
-        data.extend_from_slice(v.as_bytes());
-        inner.extend(boxed(b"data", &data)?);
+        inner.extend(utf8_data_box(v)?);
     }
     boxed(kind, &inner)
 }
@@ -638,10 +636,7 @@ fn freeform_atom(mean: &str, name: &str, values: &[&str]) -> Result<Vec<u8>> {
     name_body.extend_from_slice(name.as_bytes());
     inner.extend(boxed(b"name", &name_body)?);
     for v in values {
-        let mut data = 1u32.to_be_bytes().to_vec(); // type 1 = UTF-8
-        data.extend_from_slice(&0u32.to_be_bytes()); // locale
-        data.extend_from_slice(v.as_bytes());
-        inner.extend(boxed(b"data", &data)?);
+        inner.extend(utf8_data_box(v)?);
     }
     boxed(b"----", &inner)
 }
@@ -854,18 +849,18 @@ fn patch_chunk_offsets(kept: &mut [u8], delta: i64) -> Result<()> {
         },
     };
     let (start, len) = range;
-    let count = be_u32(kept, start + 4)? as usize;
+    let count = read_u32_be(kept, start + 4)? as usize;
     for i in 0..count {
         let pos = start + 8 + i * entry;
         if pos + entry > start + len {
             return Err(FormatError::Malformed);
         }
         if entry == 4 {
-            let v = i64::from(be_u32(kept, pos)?) + delta;
+            let v = i64::from(read_u32_be(kept, pos)?) + delta;
             let new_val = u32::try_from(v).map_err(|_| FormatError::TooLarge)?;
             kept[pos..pos + 4].copy_from_slice(&new_val.to_be_bytes());
         } else {
-            let v = be_u64(kept, pos)?.cast_signed() + delta;
+            let v = read_u64_be(kept, pos)?.cast_signed() + delta;
             if v < 0 {
                 return Err(FormatError::Malformed);
             }

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -282,37 +282,16 @@ pub fn synthesize_layout(
 /// This makes `base64(prefix ++ image) == base64(prefix) ++ base64(image)`, so the
 /// image's base64 is an independent substring that can be served incrementally.
 /// The declared data-length field is the true image length (`art.data_len`).
+///
+/// The actual byte layout is shared with the plain FLAC write path via
+/// [`crate::flac::picture_body_framing`]; only the description padding is unique here.
 fn picture_prefix(art: &crate::input::ArtInput) -> Result<Vec<u8>> {
     // Unpadded prefix length = 4(type)+4(mimelen)+mime +4(desclen)+desc
     //   +4(w)+4(h)+4(depth)+4(colors)+4(datalen) = 32 + mime + desc.
     let base = 32 + art.mime.len() + art.description.len();
     let pad = (3 - base % 3) % 3;
     let description = format!("{}{}", art.description, " ".repeat(pad));
-
-    let mut out = Vec::new();
-    out.extend_from_slice(&art.picture_type.get().to_be_bytes());
-    out.extend_from_slice(
-        &u32::try_from(art.mime.len())
-            .map_err(|_| FormatError::TooLarge)?
-            .to_be_bytes(),
-    );
-    out.extend_from_slice(art.mime.as_bytes());
-    out.extend_from_slice(
-        &u32::try_from(description.len())
-            .map_err(|_| FormatError::TooLarge)?
-            .to_be_bytes(),
-    );
-    out.extend_from_slice(description.as_bytes());
-    out.extend_from_slice(&art.width.to_be_bytes());
-    out.extend_from_slice(&art.height.to_be_bytes());
-    out.extend_from_slice(&0u32.to_be_bytes()); // depth
-    out.extend_from_slice(&0u32.to_be_bytes()); // colors
-    out.extend_from_slice(
-        &u32::try_from(art.data_len.get())
-            .map_err(|_| FormatError::TooLarge)?
-            .to_be_bytes(),
-    ); // image data length
-    Ok(out)
+    crate::flac::picture_body_framing(art, &description)
 }
 
 use crate::ogg::page::PayloadChunk;

--- a/musefs-format/src/vorbiscomment.rs
+++ b/musefs-format/src/vorbiscomment.rs
@@ -2,6 +2,7 @@
 //! Ogg codecs' comment packets. This is the body only: it never includes the
 //! Vorbis framing bit or any codec-specific magic.
 
+use crate::bytes::read_u32_le;
 use crate::error::{FormatError, Result};
 use crate::input::TagInput;
 
@@ -44,18 +45,6 @@ pub(crate) fn build(tags: &[TagInput]) -> Result<Vec<u8>> {
         out.extend_from_slice(comment.as_bytes());
     }
     Ok(out)
-}
-
-fn read_u32_le(data: &[u8], pos: usize) -> Result<u32> {
-    if pos + 4 > data.len() {
-        return Err(FormatError::Malformed);
-    }
-    Ok(u32::from_le_bytes([
-        data[pos],
-        data[pos + 1],
-        data[pos + 2],
-        data[pos + 3],
-    ]))
 }
 
 /// Parse a VorbisComment body into `(key, value)` pairs in order. Comments

--- a/musefs-format/src/wav.rs
+++ b/musefs-format/src/wav.rs
@@ -1,3 +1,4 @@
+use crate::bytes::read_u32_le;
 use crate::error::{FormatError, Result};
 use crate::input::{BinaryTagInput, EmbeddedBinaryTag, EmbeddedPicture};
 use crate::probe::Extent;
@@ -26,7 +27,8 @@ fn riff_wave_start(buf: &[u8]) -> Result<(usize, u64)> {
     if buf.len() < 12 || &buf[0..4] != b"RIFF" || &buf[8..12] != b"WAVE" {
         return Err(FormatError::NotWav);
     }
-    let riff_size = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+    let riff_size =
+        read_u32_le(buf, 4).expect("RIFF size field within the validated 12-byte header");
     Ok((12, 8 + u64::from(riff_size)))
 }
 
@@ -47,12 +49,9 @@ fn walk_chunks(buf: &[u8]) -> Vec<([u8; 4], usize, u64)> {
     while pos + 8 <= ceiling {
         let mut id = [0u8; 4];
         id.copy_from_slice(&buf[pos..pos + 4]);
-        let size = u64::from(u32::from_le_bytes([
-            buf[pos + 4],
-            buf[pos + 5],
-            buf[pos + 6],
-            buf[pos + 7],
-        ]));
+        let size = u64::from(
+            read_u32_le(buf, pos + 4).expect("chunk size field within the loop-guarded bounds"),
+        );
         let payload_offset = pos + 8;
         out.push((id, payload_offset, size));
         let advance = 8u64 + size + (size & 1); // word-align: pad odd payloads
@@ -338,7 +337,8 @@ fn read_info_tags(body: &[u8]) -> Vec<(String, String)> {
     while pos + 8 <= body.len() {
         let mut id = [0u8; 4];
         id.copy_from_slice(&body[pos..pos + 4]);
-        let size = u32::from_le_bytes([body[pos + 4], body[pos + 5], body[pos + 6], body[pos + 7]])
+        let size = read_u32_le(body, pos + 4)
+            .expect("subchunk size field within the loop-guarded bounds")
             as usize;
         let val_start = pos + 8;
         let val_end = val_start.saturating_add(size).min(body.len());


### PR DESCRIPTION
Closes #448.

A DRY pass over `musefs-format` collapsing the five forked code paths surfaced by the issue audit. Every change is behavior-preserving and covered by the existing suite.

## Changes
1. **Endian readers** — new `musefs-format/src/bytes.rs` with `read_u32_be`/`read_u64_be`/`read_u32_le` (single bounds-check style). Replaces mp4's `be_u32`/`be_u64`, flac's `read_u32_be`, vorbiscomment's `read_u32_le`, and WAV's three inline little-endian reads. The two WAV reads inside already-bounds-guarded loops use `.expect` (sanctioned by the project's cast convention for structurally-bounded reads), preserving the original index-panic contract without adding error branches.
2. **FLAC PICTURE body** — `picture_body_framing` now takes a `description` argument and is the single body builder; OGG's `picture_prefix` computes its base64 space-padding and delegates, ending the write-side fork (the read side was already shared).
3. **FLAC block walk** — a shared `BlockWalker` (marker check, header decode, 24-bit length, body bounds) drives `parse_blocks`, `read_metadata_bounded`, `read_vorbis_comments`, and `read_pictures`. Each caller keeps its own short-body policy (`Malformed` vs `NeedMore`), STREAMINFO validation, and per-block action via the `Ready`/`Truncated`/`NeedHeader` step enum — including the header-only STREAMINFO validation on a truncated body in the bounded reader.
4. **MP4 `data` sub-box** — extracted `utf8_data_box` shared by `text_atom` and `freeform_atom`.
5. **ID3v2 frame size** — extracted `decode_frame_size` naming the v2.3-plain vs v2.4-syncsafe rule next to `syncsafe`/`synchsafe_decode`.

Also re-anchored the line-pinned `wav.rs` `walk_chunks` advance mutant (`58:28` → `57:28`) in `.cargo/mutants.toml` after the WAV edits shifted the line.

## Verification
- `cargo test -p musefs-format`: 391 passed; full `cargo test --workspace`: 1109 passed; `cargo test -p musefs-core --features metrics`: 471 passed
- `cargo clippy --all-targets`: clean; `cargo fmt --all --check`: clean
- `cargo +nightly fuzz build` (out-of-workspace crate): clean
- `scripts/check_mutant_anchors.py`: 66 entries validated against 3476 mutants
- Pre-commit hook (fmt, clippy `-D warnings`, full workspace tests, anchor guard, ruff) passed on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)