### PR TITLE
refactor(thin-crates): collapse musefs-fuse/cli/latencyfs duplication (closes #449)

### DIFF
--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -247,27 +247,27 @@ fn parse_fallback(s: &str) -> Result<(String, String), String> {
     Ok((field.to_string(), value.to_string()))
 }
 
+/// Resolve a `--owner`/`--group` value: an all-numeric string is taken as a raw
+/// id (never a name, matching `chown`); otherwise `lookup` resolves it by name,
+/// with `noun` naming the entity in the not-found error.
+fn parse_id(s: &str, lookup: impl FnOnce(&str) -> Option<u32>, noun: &str) -> Result<u32, String> {
+    if let Ok(id) = s.parse::<u32>() {
+        return Ok(id);
+    }
+    lookup(s).ok_or_else(|| format!("no such {noun}: {s}"))
+}
+
 /// Resolve `--owner`: a numeric uid is used directly; anything else is looked
 /// up as a username. An all-numeric string is always treated as an id (never a
 /// name), matching `chown`.
 fn parse_owner(s: &str) -> Result<u32, String> {
-    if let Ok(uid) = s.parse::<u32>() {
-        return Ok(uid);
-    }
-    uzers::get_user_by_name(s)
-        .map(|u| u.uid())
-        .ok_or_else(|| format!("no such user: {s}"))
+    parse_id(s, |n| uzers::get_user_by_name(n).map(|u| u.uid()), "user")
 }
 
 /// Resolve `--group`: a numeric gid is used directly; anything else is looked
 /// up as a group name.
 fn parse_group(s: &str) -> Result<u32, String> {
-    if let Ok(gid) = s.parse::<u32>() {
-        return Ok(gid);
-    }
-    uzers::get_group_by_name(s)
-        .map(|g| g.gid())
-        .ok_or_else(|| format!("no such group: {s}"))
+    parse_id(s, |n| uzers::get_group_by_name(n).map(|g| g.gid()), "group")
 }
 
 /// Parse a bare octal permission word (e.g. `644`, `0755`) — NOT decimal, and

--- a/musefs-fuse/src/convert.rs
+++ b/musefs-fuse/src/convert.rs
@@ -13,6 +13,37 @@ use std::time::{Duration, SystemTime};
 use fuser::{FileAttr, FileType, INodeNo};
 use musefs_core::Attr;
 
+/// Build a `FileAttr` from the fields that actually vary between musefs's nodes,
+/// applying the conventions shared by all of them: every timestamp set to
+/// `mtime`, `blocks` derived from `size`, and the fixed `rdev = 0` /
+/// `blksize = 512` / `flags = 0`.
+pub(crate) fn make_attr(
+    ino: u64,
+    size: u64,
+    (kind, perm, nlink): (FileType, u16, u32),
+    uid: u32,
+    gid: u32,
+    mtime: SystemTime,
+) -> FileAttr {
+    FileAttr {
+        ino: INodeNo(ino),
+        size,
+        blocks: size.div_ceil(512),
+        atime: mtime,
+        mtime,
+        ctime: mtime,
+        crtime: mtime,
+        kind,
+        perm,
+        nlink,
+        uid,
+        gid,
+        rdev: 0,
+        blksize: 512,
+        flags: 0,
+    }
+}
+
 /// Translate a core `Attr` into a `fuser::FileAttr`. Permission bits come from
 /// `dir_mode`/`file_mode` (the mount is read-only, so these are advertised but
 /// inert for writes). A zero `mtime_secs` (e.g. synthetic directories) falls
@@ -33,28 +64,12 @@ pub(crate) fn to_file_attr(
     } else {
         fallback_mtime
     };
-    let (kind, perm, nlink) = if attr.is_dir {
+    let node = if attr.is_dir {
         (FileType::Directory, dir_mode, 2)
     } else {
         (FileType::RegularFile, file_mode, 1)
     };
-    FileAttr {
-        ino: INodeNo(attr.inode),
-        size: attr.size,
-        blocks: attr.size.div_ceil(512),
-        atime: mtime,
-        mtime,
-        ctime: mtime,
-        crtime: mtime,
-        kind,
-        perm,
-        nlink,
-        uid,
-        gid,
-        rdev: 0,
-        blksize: 512,
-        flags: 0,
-    }
+    make_attr(attr.inode, attr.size, node, uid, gid, mtime)
 }
 
 /// Assemble a directory's readdir listing: `.`, `..`, the children, then the

--- a/musefs-fuse/src/metrics_dir.rs
+++ b/musefs-fuse/src/metrics_dir.rs
@@ -10,7 +10,7 @@
 
 use std::time::SystemTime;
 
-use fuser::{FileAttr, FileType, INodeNo};
+use fuser::{FileAttr, FileType};
 
 /// Mount root inode (fuser's FUSE root id).
 const ROOT_INO: u64 = 1;
@@ -44,46 +44,28 @@ pub fn metrics_lookup(parent: u64, name: &str) -> Option<u64> {
 
 /// Attributes for the synthetic directory (read-only, size 0, nlink 2).
 pub fn dir_attr(uid: u32, gid: u32, dir_mode: u16, mtime: SystemTime) -> FileAttr {
-    FileAttr {
-        ino: INodeNo(METRICS_DIR_INO),
-        size: 0,
-        blocks: 0,
-        atime: mtime,
-        mtime,
-        ctime: mtime,
-        crtime: mtime,
-        kind: FileType::Directory,
-        perm: dir_mode,
-        nlink: 2,
+    crate::convert::make_attr(
+        METRICS_DIR_INO,
+        0,
+        (FileType::Directory, dir_mode, 2),
         uid,
         gid,
-        rdev: 0,
-        blksize: 512,
-        flags: 0,
-    }
+        mtime,
+    )
 }
 
 /// Attributes for the synthetic `metrics` file. Size 0 (`/proc`-style): the
 /// content is served at read time via `FOPEN_DIRECT_IO`, so the kernel reads to
 /// EOF rather than trusting `st_size`.
 pub fn file_attr(uid: u32, gid: u32, file_mode: u16, mtime: SystemTime) -> FileAttr {
-    FileAttr {
-        ino: INodeNo(METRICS_FILE_INO),
-        size: 0,
-        blocks: 0,
-        atime: mtime,
-        mtime,
-        ctime: mtime,
-        crtime: mtime,
-        kind: FileType::RegularFile,
-        perm: file_mode,
-        nlink: 1,
+    crate::convert::make_attr(
+        METRICS_FILE_INO,
+        0,
+        (FileType::RegularFile, file_mode, 1),
         uid,
         gid,
-        rdev: 0,
-        blksize: 512,
-        flags: 0,
-    }
+        mtime,
+    )
 }
 
 /// The readdir entry to append when listing the root (only the root).

--- a/musefs-fuse/src/platform/spotlight.rs
+++ b/musefs-fuse/src/platform/spotlight.rs
@@ -4,7 +4,7 @@
 
 use std::time::SystemTime;
 
-use fuser::{FileAttr, FileType, INodeNo};
+use fuser::{FileAttr, FileType};
 
 /// Mount root inode (fuser's FUSE root id). The marker is a child of the root.
 #[cfg(target_os = "macos")]
@@ -23,23 +23,14 @@ pub const MARKER_INO: u64 = u64::MAX;
 /// The marker's attributes: a zero-byte, read-only regular file owned by the
 /// mount, all timestamps set to `mtime` (matching synthetic-node stamping).
 pub fn marker_attr(uid: u32, gid: u32, file_mode: u16, mtime: SystemTime) -> FileAttr {
-    FileAttr {
-        ino: INodeNo(MARKER_INO),
-        size: 0,
-        blocks: 0,
-        atime: mtime,
-        mtime,
-        ctime: mtime,
-        crtime: mtime,
-        kind: FileType::RegularFile,
-        perm: file_mode,
-        nlink: 1,
+    crate::convert::make_attr(
+        MARKER_INO,
+        0,
+        (FileType::RegularFile, file_mode, 1),
         uid,
         gid,
-        rdev: 0,
-        blksize: 512,
-        flags: 0,
-    }
+        mtime,
+    )
 }
 
 /// Marker inode if `(parent, name)` addresses it; `None` otherwise (always `None`
@@ -80,6 +71,8 @@ pub fn marker_dir_entry(_dir_ino: u64) -> Option<(u64, FileType, String)> {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
+
+    use fuser::INodeNo;
 
     use super::*;
 

--- a/musefs-latencyfs/src/lib.rs
+++ b/musefs-latencyfs/src/lib.rs
@@ -221,6 +221,13 @@ fn attr_from_meta(ino: u64, m: &std::fs::Metadata) -> FileAttr {
     }
 }
 
+/// Map a `std::io::Error` onto the errno for a FUSE reply, defaulting to `EIO`
+/// when the error carries no raw OS errno. Local to this bench harness, mirroring
+/// `musefs-fuse`'s `errno` without taking a dependency on the production crate.
+fn io_errno(e: &std::io::Error) -> fuser::Errno {
+    fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO))
+}
+
 /// The passthrough filesystem. Root inode (1) maps to the backing root.
 ///
 /// Invariant: mounted with single-threaded FUSE dispatch (`Config::default()`,
@@ -318,9 +325,7 @@ impl fuser::Filesystem for PassthroughFs {
         let rd = match std::fs::read_dir(&dir) {
             Ok(rd) => rd,
             Err(e) => {
-                return reply.error(fuser::Errno::from_i32(
-                    e.raw_os_error().unwrap_or(libc::EIO),
-                ));
+                return reply.error(io_errno(&e));
             }
         };
         for ent in rd.flatten() {
@@ -363,9 +368,7 @@ impl fuser::Filesystem for PassthroughFs {
             Err(_) => match File::open(&p) {
                 Ok(f) => f,
                 Err(e) => {
-                    return reply.error(fuser::Errno::from_i32(
-                        e.raw_os_error().unwrap_or(libc::EIO),
-                    ));
+                    return reply.error(io_errno(&e));
                 }
             },
         };
@@ -399,9 +402,7 @@ impl fuser::Filesystem for PassthroughFs {
         match file.read_at(&mut buf, offset) {
             Ok(n) => reply.data(&buf[..n]),
             Err(e) => {
-                reply.error(fuser::Errno::from_i32(
-                    e.raw_os_error().unwrap_or(libc::EIO),
-                ));
+                reply.error(io_errno(&e));
             }
         }
     }
@@ -484,17 +485,13 @@ impl fuser::Filesystem for PassthroughFs {
         {
             Ok(f) => f,
             Err(e) => {
-                return reply.error(fuser::Errno::from_i32(
-                    e.raw_os_error().unwrap_or(libc::EIO),
-                ));
+                return reply.error(io_errno(&e));
             }
         };
         let m = match file.metadata() {
             Ok(m) => m,
             Err(e) => {
-                return reply.error(fuser::Errno::from_i32(
-                    e.raw_os_error().unwrap_or(libc::EIO),
-                ));
+                return reply.error(io_errno(&e));
             }
         };
         let ino = self.inodes.lock().unwrap().intern(child);
@@ -531,9 +528,7 @@ impl fuser::Filesystem for PassthroughFs {
         match file.write_at(data, offset) {
             Ok(n) => reply.written(u32::try_from(n).unwrap_or(u32::MAX)),
             Err(e) => {
-                reply.error(fuser::Errno::from_i32(
-                    e.raw_os_error().unwrap_or(libc::EIO),
-                ));
+                reply.error(io_errno(&e));
             }
         }
     }
@@ -559,9 +554,7 @@ impl fuser::Filesystem for PassthroughFs {
         };
         match r {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            )),
+            Err(e) => reply.error(io_errno(&e)),
         }
     }
 
@@ -611,15 +604,11 @@ impl fuser::Filesystem for PassthroughFs {
                 .open(&p)
                 .and_then(|f| f.set_len(sz))
         {
-            return reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            ));
+            return reply.error(io_errno(&e));
         }
         match std::fs::symlink_metadata(&p) {
             Ok(m) => reply.attr(&TTL, &attr_from_meta(ino.0, &m)),
-            Err(e) => reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            )),
+            Err(e) => reply.error(io_errno(&e)),
         }
     }
 
@@ -634,9 +623,7 @@ impl fuser::Filesystem for PassthroughFs {
                 self.inodes.lock().unwrap().forget_path(&child);
                 reply.ok();
             }
-            Err(e) => reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            )),
+            Err(e) => reply.error(io_errno(&e)),
         }
     }
 
@@ -661,9 +648,7 @@ impl fuser::Filesystem for PassthroughFs {
                 self.inodes.lock().unwrap().rename(&from, to);
                 reply.ok();
             }
-            Err(e) => reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            )),
+            Err(e) => reply.error(io_errno(&e)),
         }
     }
 
@@ -686,9 +671,7 @@ impl fuser::Filesystem for PassthroughFs {
                 let ino = self.inodes.lock().unwrap().intern(child);
                 reply.entry(&TTL, &attr_from_meta(ino, &m), Generation(0));
             }
-            Err(e) => reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            )),
+            Err(e) => reply.error(io_errno(&e)),
         }
     }
 
@@ -703,9 +686,7 @@ impl fuser::Filesystem for PassthroughFs {
                 self.inodes.lock().unwrap().forget_path(&child);
                 reply.ok();
             }
-            Err(e) => reply.error(fuser::Errno::from_i32(
-                e.raw_os_error().unwrap_or(libc::EIO),
-            )),
+            Err(e) => reply.error(io_errno(&e)),
         }
     }
 }


### PR DESCRIPTION
Collapses the three sets of near-identical code surfaced by the DRY audit in #449. Behavior-preserving throughout.

Closes #449.

## Changes

**1. Shared synthetic `FileAttr` constructor** (`musefs-fuse`)
Adds `make_attr(ino, size, (kind, perm, nlink), uid, gid, mtime)` in `convert.rs`, applying the conventions common to every served node: all four timestamps set to `mtime`, `blocks` derived from `size`, and the fixed `rdev = 0` / `blksize = 512` / `flags = 0`. `marker_attr`, `dir_attr`, `file_attr`, and the tail of `to_file_attr` now delegate to it. Kept to 6 params (the `(kind, perm, nlink)` tuple) to avoid `too_many_arguments`, which the project deliberately does not `#[allow]`.

**2. Centralized io-error → errno reply** (`musefs-latencyfs`)
Adds a local `io_errno(&e)` helper and routes the 13 inline `reply.error(fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)))` sites through it. Kept local to the bench harness — mirrors `musefs-fuse`'s `errno` without taking a dependency on the production crate (consistent with the issue's note on the deliberately-standalone `usize_from`).

**3. Shared numeric-or-name id resolver** (`musefs-cli`)
Collapses `parse_owner`/`parse_group` onto a shared `parse_id(s, lookup, noun)`; each caller now supplies only its `uzers` accessor/projection closure and the error noun.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test --workspace` (1109 passed), and the `musefs-core` `metrics`-feature leg (471 passed) all green.
- Mutation-safe: `fuser::FileAttr` is not `Default`, so the delegating one-liners yield only unviable mutants; `convert.rs`'s existing tests cover `make_attr` via `to_file_attr`; `musefs-cli` is mutation-excluded; and no `exclude_re` anchors live in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)