### PR TITLE
test(musefs-fuse): extract shared FLAC/config fixtures into tests/common (closes #450)

### DIFF
--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3"
 rustix = { version = "1", features = ["fs"] }
 metaflac = "0.2"
 musefs-db = { path = "../musefs-db" }
-musefs-format = { path = "../musefs-format" }
+musefs-format = { path = "../musefs-format", features = ["fuzzing"] }
 ogg = "0.9"
 sha2 = "0.11"
 memmap2 = "0.9"

--- a/musefs-fuse/tests/common/mod.rs
+++ b/musefs-fuse/tests/common/mod.rs
@@ -1,0 +1,91 @@
+//! Shared fixtures for the `musefs-fuse` integration tests: the minimal proven
+//! FLAC builder, the default [`MountConfig`], a tiny PNG + FLAC PICTURE block,
+//! and a recursive tree walk. The FLAC byte-layout primitives are reused from
+//! `musefs_format::fuzz_check::fixtures` so there is a single source of truth.
+//!
+//! `#![allow(dead_code)]` because each integration-test binary compiles this
+//! module in full but only uses a subset of the helpers.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use musefs_core::{Mode, MountConfig};
+use musefs_format::fuzz_check::fixtures::{flac_block, streaminfo_body, vorbis_comment_body};
+
+/// Minimal proven FLAC stream: `fLaC` + STREAMINFO + a VORBIS_COMMENT carrying
+/// the already-formatted `KEY=value` `comments`, followed by raw `audio`.
+pub fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"fLaC");
+    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
+    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
+    out.extend_from_slice(audio);
+    out
+}
+
+/// Default mount config: `$artist/$title`, Synthesis mode, no polling.
+pub fn config() -> MountConfig {
+    config_with_mode(Mode::Synthesis)
+}
+
+/// Mount config with an explicit [`Mode`] (passthrough exercises StructureOnly).
+pub fn config_with_mode(mode: Mode) -> MountConfig {
+    MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode,
+        poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
+        skip_on_missing: false,
+    }
+}
+
+/// A tiny valid 4×4 front-cover PNG used to embed art into test fixtures.
+pub const COVER_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x08, 0x02, 0x00, 0x00, 0x00, 0x26, 0x93, 0x09,
+    0x29, 0x00, 0x00, 0x00, 0x09, 0x70, 0x48, 0x59, 0x73, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x4F, 0x25, 0xC4, 0xD6, 0x00, 0x00, 0x00, 0x14, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C,
+    0x63, 0x64, 0x60, 0xF8, 0xC7, 0x00, 0x03, 0x2C, 0x0C, 0x48, 0x00, 0x37, 0x07, 0x00, 0x32, 0x3E,
+    0x01, 0x0C, 0x1C, 0xDB, 0xAF, 0x41, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42,
+    0x60, 0x82,
+];
+
+/// Build a FLAC METADATA PICTURE block body (the same structure used verbatim in a
+/// FLAC `PICTURE` block and, base64-encoded, in a Vorbis `METADATA_BLOCK_PICTURE`
+/// tag): picture type, MIME, description, dimensions, then the image. Big-endian.
+pub fn flac_picture_block(png: &[u8]) -> Vec<u8> {
+    let mime: &[u8] = b"image/png";
+    let mut out = Vec::new();
+    out.extend_from_slice(&3u32.to_be_bytes()); // type: front cover
+    out.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
+    out.extend_from_slice(mime);
+    out.extend_from_slice(&0u32.to_be_bytes()); // description length (empty)
+    out.extend_from_slice(&4u32.to_be_bytes()); // width
+    out.extend_from_slice(&4u32.to_be_bytes()); // height
+    out.extend_from_slice(&24u32.to_be_bytes()); // color depth
+    out.extend_from_slice(&0u32.to_be_bytes()); // colors used (0 = non-indexed)
+    out.extend_from_slice(&u32::try_from(png.len()).unwrap().to_be_bytes());
+    out.extend_from_slice(png);
+    out
+}
+
+/// All regular files under `dir`, recursively.
+pub fn walk_tree(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                out.extend(walk_tree(&p));
+            } else {
+                out.push(p);
+            }
+        }
+    }
+    out
+}

--- a/musefs-fuse/tests/concurrency.rs
+++ b/musefs-fuse/tests/concurrency.rs
@@ -4,83 +4,14 @@
 //! Run with:
 //!   cargo test -p musefs-fuse --features metrics -- --ignored --nocapture --test-threads=1
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use fuser::BackgroundSession;
-use musefs_core::{Mode, MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 
-// ---------------------------------------------------------------------------
-// Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)
-// ---------------------------------------------------------------------------
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).expect("FLAC block length high byte fits in u8"));
-    out.push(u8::try_from((len >> 8) & 0xFF).expect("FLAC block length middle byte fits in u8"));
-    out.push(u8::try_from(len & 0xFF).expect("FLAC block length low byte fits in u8"));
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(
-        &u32::try_from(vendor.len())
-            .expect("vendor length fits in u32")
-            .to_le_bytes(),
-    );
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(
-        &u32::try_from(comments.len())
-            .expect("comment count fits in u32")
-            .to_le_bytes(),
-    );
-    for c in comments {
-        out.extend_from_slice(
-            &u32::try_from(c.len())
-                .expect("comment length fits in u32")
-                .to_le_bytes(),
-        );
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config, make_flac};
 
 // ---------------------------------------------------------------------------
 // Setup: two-track mount with an on-disk DB (required for PerThread pool)

--- a/musefs-fuse/tests/concurrent_reads.rs
+++ b/musefs-fuse/tests/concurrent_reads.rs
@@ -2,68 +2,13 @@
 //! and many files in parallel, driving the DbPool::PerThread worker pool.
 //! `--ignored` (needs /dev/fuse); runs in the e2e job and the TSan job.
 
-use std::collections::BTreeMap;
 use std::sync::{Arc, Barrier};
 
 use fuser::BackgroundSession;
-use musefs_core::{Mode, MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 
-// --- Copy these helpers verbatim from mount.rs / concurrency.rs ---
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
-    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
-    out.push(u8::try_from(len & 0xFF).unwrap());
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config, make_flac};
 
 // ---------------------------------------------------------------------------
 

--- a/musefs-fuse/tests/fault_injection.rs
+++ b/musefs-fuse/tests/fault_injection.rs
@@ -2,65 +2,11 @@
 //! mount, proving the process-global fault seam reaches the worker thread.
 #![cfg(feature = "metrics")]
 
-use std::collections::BTreeMap;
-
 use musefs_core::metrics::{BackingFault, set_backing_fault};
-use musefs_core::{Mode, MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
-    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
-    out.push(u8::try_from(len & 0xFF).unwrap());
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config, make_flac};
 
 #[test]
 #[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse --features metrics -- --ignored"]

--- a/musefs-fuse/tests/keep_cache.rs
+++ b/musefs-fuse/tests/keep_cache.rs
@@ -1,66 +1,9 @@
-use std::collections::BTreeMap;
 use std::time::Duration;
 
-use musefs_core::{MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 
-// --- minimal proven FLAC fixture (mirrors musefs-fuse/tests/mount.rs) ---
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
-    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
-    out.push(u8::try_from(len & 0xFF).unwrap());
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-/// Scan a backing dir into a Db with poll_interval=ZERO so metadata ops
-/// trigger refresh immediately.
-fn mount_config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
-        poll_interval: Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config, make_flac};
 
 #[test]
 #[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse -- --ignored"]
@@ -76,7 +19,7 @@ fn keep_cache_mount_reflects_retag_after_refresh() {
     let db = musefs_db::Db::open(&db_path).unwrap();
     scan_directory(&db, backing.path()).unwrap();
 
-    let fs = Musefs::open(db, mount_config()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
 
     // 2. Mount with keep-cache=true and debounce=ZERO (already set via MountConfig).
     let cfg = musefs_fuse::FuseConfig {

--- a/musefs-fuse/tests/metrics_e2e.rs
+++ b/musefs-fuse/tests/metrics_e2e.rs
@@ -4,70 +4,13 @@
 //! Run with:
 //!   cargo test -p musefs-fuse --features metrics --test metrics_e2e -- --ignored --nocapture
 
-use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom};
 
-use musefs_core::{MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 use musefs_fuse::FuseConfig;
 
-// ---------------------------------------------------------------------------
-// Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)
-// ---------------------------------------------------------------------------
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
-    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
-    out.push(u8::try_from(len & 0xFF).unwrap());
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn core_config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config, make_flac};
 
 fn fuse_config() -> FuseConfig {
     FuseConfig {
@@ -103,7 +46,7 @@ fn metrics_surface_e2e() {
     std::fs::write(backing.path().join("a.flac"), &flac).unwrap();
     let db = musefs_db::Db::open_in_memory().unwrap();
     scan_directory(&db, backing.path()).unwrap();
-    let fs = Musefs::open(db, core_config()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
 
     // Mount with expose_metrics on.
     let mountpoint = tempfile::tempdir().unwrap();

--- a/musefs-fuse/tests/mount.rs
+++ b/musefs-fuse/tests/mount.rs
@@ -1,63 +1,7 @@
-use std::collections::BTreeMap;
+use musefs_core::{Musefs, scan_directory};
 
-use musefs_core::{MountConfig, Musefs, scan_directory};
-
-// --- minimal proven FLAC fixture (mirrors musefs-core/tests/common) ---
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
-    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
-    out.push(u8::try_from(len & 0xFF).unwrap());
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config, make_flac};
 
 #[test]
 #[ignore = "requires /dev/fuse; run with: cargo test -p musefs-fuse -- --ignored"]

--- a/musefs-fuse/tests/ogg_read_through.rs
+++ b/musefs-fuse/tests/ogg_read_through.rs
@@ -1,7 +1,8 @@
-use std::collections::BTreeMap;
-
 use base64::Engine as _;
-use musefs_core::{MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
+
+mod common;
+use common::{COVER_PNG, config, flac_picture_block};
 
 /// Encode a tiny tagged fixture with ffmpeg. `args` are the codec-specific ffmpeg
 /// args (codec + container). Returns false (skip) if ffmpeg/codec is unavailable.
@@ -68,20 +69,6 @@ fn find_one_file(root: &std::path::Path) -> std::path::PathBuf {
     }
 }
 
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
-
 /// Mount a single-track backing dir containing `src`, read the one synthesized
 /// file back, and validate: all page CRCs valid (read_packets), the comment packet
 /// carries the rewritten title, and the AUDIO packets are byte-identical to the
@@ -130,37 +117,6 @@ fn mount_and_validate(src: &std::path::Path) {
     );
 
     drop(session);
-}
-
-/// A valid 4x4 PNG cover image. ffmpeg 8's PNG decoder rejects malformed chunks,
-/// so this must be a real, decodable image.
-const COVER_PNG: &[u8] = &[
-    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-    0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x08, 0x02, 0x00, 0x00, 0x00, 0x26, 0x93, 0x09,
-    0x29, 0x00, 0x00, 0x00, 0x09, 0x70, 0x48, 0x59, 0x73, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-    0x01, 0x00, 0x4F, 0x25, 0xC4, 0xD6, 0x00, 0x00, 0x00, 0x14, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C,
-    0x63, 0x64, 0x60, 0xF8, 0xC7, 0x00, 0x03, 0x2C, 0x0C, 0x48, 0x00, 0x37, 0x07, 0x00, 0x32, 0x3E,
-    0x01, 0x0C, 0x1C, 0xDB, 0xAF, 0x41, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42,
-    0x60, 0x82,
-];
-
-/// Build a FLAC METADATA PICTURE block body: picture type, MIME, description,
-/// dimensions, then the image. Base64-encoded, this is a Vorbis
-/// `METADATA_BLOCK_PICTURE` comment value. Big-endian.
-fn flac_picture_block(png: &[u8]) -> Vec<u8> {
-    let mime: &[u8] = b"image/png";
-    let mut out = Vec::new();
-    out.extend_from_slice(&3u32.to_be_bytes()); // type: front cover
-    out.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
-    out.extend_from_slice(mime);
-    out.extend_from_slice(&0u32.to_be_bytes()); // description length (empty)
-    out.extend_from_slice(&4u32.to_be_bytes()); // width
-    out.extend_from_slice(&4u32.to_be_bytes()); // height
-    out.extend_from_slice(&24u32.to_be_bytes()); // color depth
-    out.extend_from_slice(&0u32.to_be_bytes()); // colors used (0 = non-indexed)
-    out.extend_from_slice(&u32::try_from(png.len()).unwrap().to_be_bytes());
-    out.extend_from_slice(png);
-    out
 }
 
 /// Generate an Ogg fixture carrying a cover image via a base64

--- a/musefs-fuse/tests/passthrough.rs
+++ b/musefs-fuse/tests/passthrough.rs
@@ -7,81 +7,12 @@
 //! Run with:
 //!   cargo test -p musefs-fuse --features metrics --test passthrough -- --ignored --nocapture --test-threads=1
 
-use std::collections::BTreeMap;
 use std::io::Read;
 
-use musefs_core::{Mode, MountConfig, Musefs, metrics, scan_directory};
+use musefs_core::{Mode, Musefs, metrics, scan_directory};
 
-// ---------------------------------------------------------------------------
-// Minimal proven FLAC fixture (mirrors tests/mount.rs exactly)
-// ---------------------------------------------------------------------------
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).expect("FLAC block length high byte fits in u8"));
-    out.push(u8::try_from((len >> 8) & 0xFF).expect("FLAC block length middle byte fits in u8"));
-    out.push(u8::try_from(len & 0xFF).expect("FLAC block length low byte fits in u8"));
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(
-        &u32::try_from(vendor.len())
-            .expect("vendor length fits in u32")
-            .to_le_bytes(),
-    );
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(
-        &u32::try_from(comments.len())
-            .expect("comment count fits in u32")
-            .to_le_bytes(),
-    );
-    for c in comments {
-        out.extend_from_slice(
-            &u32::try_from(c.len())
-                .expect("comment length fits in u32")
-                .to_le_bytes(),
-        );
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn config(mode: Mode) -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{config_with_mode, make_flac};
 
 /// FUSE passthrough landed in mainline 6.9.
 fn kernel_supports_passthrough() -> bool {
@@ -114,7 +45,7 @@ fn mount_one_track(
     let db = musefs_db::Db::open(&db_path).unwrap();
     scan_directory(&db, backing.path()).unwrap();
 
-    let fs = Musefs::open(db, config(mode)).unwrap();
+    let fs = Musefs::open(db, config_with_mode(mode)).unwrap();
     let mountpoint = tempfile::tempdir().unwrap();
     let session = musefs_fuse::spawn(fs, mountpoint.path(), "musefs-passthrough-test").unwrap();
     let mnt = mountpoint.keep(); // keep mount alive for the test's duration

--- a/musefs-fuse/tests/playback_pcm.rs
+++ b/musefs-fuse/tests/playback_pcm.rs
@@ -1,9 +1,11 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use musefs_core::{MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 use sha2::{Digest, Sha256};
+
+mod common;
+use common::{config, walk_tree};
 
 #[derive(Clone, Copy)]
 struct PlaybackCase {
@@ -13,20 +15,6 @@ struct PlaybackCase {
     artist: &'static str,
     freq: u32,
     codec_args: &'static [&'static str],
-}
-
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
 }
 
 fn playback_cases() -> Vec<PlaybackCase> {
@@ -157,21 +145,6 @@ fn mounted_path(mountpoint: &Path, case: PlaybackCase) -> PathBuf {
     mountpoint
         .join(case.artist)
         .join(format!("{}.{}", case.title, case.served_ext))
-}
-
-fn walk_tree(dir: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let p = entry.path();
-            if p.is_dir() {
-                out.extend(walk_tree(&p));
-            } else {
-                out.push(p);
-            }
-        }
-    }
-    out
 }
 
 #[test]

--- a/musefs-fuse/tests/read_consistency.rs
+++ b/musefs-fuse/tests/read_consistency.rs
@@ -5,72 +5,17 @@
 //! fidelity, and that every mutating op is refused on the read-only mount.
 //! See docs/superpowers/specs/2026-06-10-mount-read-consistency-design.md.
 
-use std::collections::BTreeMap;
 use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::FileExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 use base64::Engine as _;
-use musefs_core::{MountConfig, Musefs, scan_directory};
+use musefs_core::{Musefs, scan_directory};
 
-// --- minimal proven FLAC fixture (mirrors musefs-fuse/tests/mount.rs) ---
-
-fn flac_block(block_type: u8, body: &[u8], is_last: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.push((if is_last { 0x80 } else { 0 }) | (block_type & 0x7F));
-    let len = body.len();
-    out.push(u8::try_from((len >> 16) & 0xFF).unwrap());
-    out.push(u8::try_from((len >> 8) & 0xFF).unwrap());
-    out.push(u8::try_from(len & 0xFF).unwrap());
-    out.extend_from_slice(body);
-    out
-}
-
-fn streaminfo_body() -> Vec<u8> {
-    let mut b = vec![
-        0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0xC4, 0x42, 0xF0, 0x00,
-        0x00, 0x00, 0x00,
-    ];
-    b.extend_from_slice(&[0u8; 16]);
-    b
-}
-
-fn vorbis_comment_body(vendor: &str, comments: &[&str]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(&u32::try_from(vendor.len()).unwrap().to_le_bytes());
-    out.extend_from_slice(vendor.as_bytes());
-    out.extend_from_slice(&u32::try_from(comments.len()).unwrap().to_le_bytes());
-    for c in comments {
-        out.extend_from_slice(&u32::try_from(c.len()).unwrap().to_le_bytes());
-        out.extend_from_slice(c.as_bytes());
-    }
-    out
-}
-
-fn make_flac(comments: &[&str], audio: &[u8]) -> Vec<u8> {
-    let mut out = Vec::new();
-    out.extend_from_slice(b"fLaC");
-    out.extend_from_slice(&flac_block(0, &streaminfo_body(), false));
-    out.extend_from_slice(&flac_block(4, &vorbis_comment_body("orig", comments), true));
-    out.extend_from_slice(audio);
-    out
-}
-
-fn config() -> MountConfig {
-    MountConfig {
-        template: "$artist/$title".to_string(),
-        fallbacks: BTreeMap::new(),
-        default_fallback: "Unknown".to_string(),
-        mode: musefs_core::Mode::Synthesis,
-        poll_interval: std::time::Duration::ZERO,
-        case_insensitive: false,
-        read_ahead_budget: 64 * 1024 * 1024,
-        read_ahead_prefetch: false,
-        skip_on_missing: false,
-    }
-}
+mod common;
+use common::{COVER_PNG, config, flac_picture_block, make_flac, walk_tree};
 
 /// A deterministic backing-audio payload of `n` bytes. Distinct per-offset
 /// values make any splice/offset mismatch visible in the oracle compare.
@@ -551,37 +496,6 @@ fn sweep_cases() -> &'static [SweepCase] {
     ]
 }
 
-/// A valid 4x4 PNG cover image. ffmpeg 8's PNG decoder rejects malformed chunks,
-/// so this must be a real, decodable image.
-const COVER_PNG: &[u8] = &[
-    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-    0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x08, 0x02, 0x00, 0x00, 0x00, 0x26, 0x93, 0x09,
-    0x29, 0x00, 0x00, 0x00, 0x09, 0x70, 0x48, 0x59, 0x73, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-    0x01, 0x00, 0x4F, 0x25, 0xC4, 0xD6, 0x00, 0x00, 0x00, 0x14, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C,
-    0x63, 0x64, 0x60, 0xF8, 0xC7, 0x00, 0x03, 0x2C, 0x0C, 0x48, 0x00, 0x37, 0x07, 0x00, 0x32, 0x3E,
-    0x01, 0x0C, 0x1C, 0xDB, 0xAF, 0x41, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42,
-    0x60, 0x82,
-];
-
-/// Build a FLAC METADATA PICTURE block body (the same structure used verbatim in a
-/// FLAC `PICTURE` block and, base64-encoded, in a Vorbis `METADATA_BLOCK_PICTURE`
-/// tag): picture type, MIME, description, dimensions, then the image. Big-endian.
-fn flac_picture_block(png: &[u8]) -> Vec<u8> {
-    let mime: &[u8] = b"image/png";
-    let mut out = Vec::new();
-    out.extend_from_slice(&3u32.to_be_bytes()); // type: front cover
-    out.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
-    out.extend_from_slice(mime);
-    out.extend_from_slice(&0u32.to_be_bytes()); // description length (empty)
-    out.extend_from_slice(&4u32.to_be_bytes()); // width
-    out.extend_from_slice(&4u32.to_be_bytes()); // height
-    out.extend_from_slice(&24u32.to_be_bytes()); // color depth
-    out.extend_from_slice(&0u32.to_be_bytes()); // colors used (0 = non-indexed)
-    out.extend_from_slice(&u32::try_from(png.len()).unwrap().to_be_bytes());
-    out.extend_from_slice(png);
-    out
-}
-
 /// Number of embedded pictures in `path`, via musefs's own readers, for the
 /// formats whose art the sweep verifies (FLAC and the Ogg family). `None` for
 /// formats without a reader used here (mp3/m4a/wav).
@@ -641,22 +555,6 @@ fn make_sweep_fixture(dir: &Path, case: &SweepCase) -> bool {
 
     cmd.arg(&out).stdout(Stdio::null()).stderr(Stdio::null());
     cmd.status().is_ok_and(|s| s.success()) && out.exists()
-}
-
-/// All regular files under `dir`, recursively.
-fn walk_tree(dir: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let p = entry.path();
-            if p.is_dir() {
-                out.extend(walk_tree(&p));
-            } else {
-                out.push(p);
-            }
-        }
-    }
-    out
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Eight `musefs-fuse` integration tests each carried a byte-identical copy of the FLAC fixture builders (`flac_block`/`streaminfo_body`/`vorbis_comment_body`/`make_flac`) and the `config()`/`MountConfig` builder (~55 lines × 8), with `COVER_PNG` + `flac_picture_block` and `walk_tree` further duplicated across the ogg/playback tests. Unlike `musefs-core/tests/`, this crate had no `tests/common/` module.

This adds `musefs-fuse/tests/common/mod.rs` (mirroring the `musefs-core` precedent) and routes every test through it.

## Details

- The FLAC byte-layout primitives are reused from `musefs_format::fuzz_check::fixtures` — the same single source of truth `musefs-core/tests/common` uses — so the dev-dependency on `musefs-format` now enables the `fuzzing` feature (matching `musefs-core`).
- The two stylistic variants (`.unwrap()` vs `.expect(...)`) produced identical bytes; the centralized fixtures are byte-for-byte equivalent to the old copies, so the **audio invariant is unaffected**.
- `config()` / `config_with_mode(mode)` replace the per-file `config()` / `mount_config()` / `core_config()` / `config(mode)` spellings.

Net: **627 deletions / 128 insertions**, with the shared helpers in one place.

## Test plan

- `cargo test --workspace` (full suite, via pre-commit hook) — all green
- `cargo clippy -p musefs-fuse --all-targets` with and without `--features metrics` — clean under `-D warnings`
- `cargo fmt --check` — clean
- The `/dev/fuse` e2e tests that decode the synthesized FLAC remain `#[ignore]` (unchanged, run in the e2e CI job)

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)