### PR TITLE
perf(musefs-fuse): slice readdir from offset instead of linear skip

### DIFF
--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -852,7 +852,8 @@ impl Filesystem for MusefsFs {
         self.fire_poll_refresh();
         if self.config.expose_metrics && ino.0 == metrics_dir::METRICS_DIR_INO {
             let listing = metrics_dir::dir_listing();
-            for (i, (child, kind, name)) in listing.iter().enumerate().skip(usize_from(offset)) {
+            let start = usize_from(offset).min(listing.len());
+            for (i, (child, kind, name)) in (start..).zip(&listing[start..]) {
                 if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
                     break;
                 }
@@ -874,7 +875,10 @@ impl Filesystem for MusefsFs {
                 Err(e) => return reply.error(reply_errno("readdir", ino.0, &e)),
             },
         };
-        for (i, (child, kind, name)) in listing.iter().enumerate().skip(usize_from(offset)) {
+        // Slice from `offset` directly so paginated calls don't re-walk the
+        // skipped prefix; full enumeration stays O(n), not O(n^2) (#442).
+        let start = usize_from(offset).min(listing.len());
+        for (i, (child, kind, name)) in (start..).zip(&listing[start..]) {
             // The stored offset is the index of the *next* entry to return.
             if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
                 break;


### PR DESCRIPTION
## Summary

Fixes #442. The `readdir` handler served entries with `iter().enumerate().skip(offset)`. The kernel issues `readdir` in buffer-sized chunks, so each call re-walked the skipped prefix, making full enumeration of one directory O(n²) in its entry count — pathological for very large flat directories.

This slices from `offset` directly (`(start..).zip(&listing[start..])`, with `start = usize_from(offset).min(len)`), mirroring the `read` handler's existing `start.min(len)` idiom. Reaching the first returned entry is now O(1), so full enumeration is O(n). Applied to both the metrics-dir loop and the main listing loop. Observable behavior (entries, ordering, `offset+1` cookie) is unchanged.

## Testing

- `cargo clippy -p musefs-fuse --all-targets` — clean
- Full workspace test suite (pre-commit gate) — green
- `cargo test -p musefs-fuse -- --ignored` — 18 e2e tests pass, including `large_directory_lists_fully_across_paginated_readdir` (5000-entry directory, every entry listed exactly once) and the metrics-dir readdir path

🤖 Generated with [Claude Code](https://claude.com/claude-code)