### PR TITLE
perf(musefs-db): cache remaining fixed-SQL and chunked IN-list statements

### DIFF
--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -51,10 +51,17 @@ pub(crate) fn query_in_chunks<T: rusqlite::ToSql>(
     mut consume: impl FnMut(&mut rusqlite::Rows) -> Result<()>,
 ) -> Result<()> {
     const CHUNK: usize = 900;
+    // Full chunks share one placeholder list (and thus one cached statement);
+    // only the trailing partial chunk allocates its own.
+    let mut full_placeholders: Option<String> = None;
     for chunk in items.chunks(CHUNK) {
-        let placeholders = vec!["?"; chunk.len()].join(",");
-        let sql = make_sql(&placeholders);
-        let mut stmt = conn.prepare(&sql)?;
+        let sql = if chunk.len() == CHUNK {
+            let ph = full_placeholders.get_or_insert_with(|| vec!["?"; CHUNK].join(","));
+            make_sql(ph)
+        } else {
+            make_sql(&vec!["?"; chunk.len()].join(","))
+        };
+        let mut stmt = conn.prepare_cached(&sql)?;
         let mut rows = stmt.query(rusqlite::params_from_iter(chunk.iter()))?;
         consume(&mut rows)?;
     }

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -119,7 +119,7 @@ impl<M> Db<M> {
     /// order. The blob bytes stream at read time; only `key` (materialized here)
     /// is length-guarded, plus the per-track row count.
     pub fn get_binary_tags(&self, track_id: i64) -> Result<Vec<BinaryTagRow>> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT length(key), rowid, key, length(value_blob) FROM tags \
              WHERE track_id = ?1 AND value_blob IS NOT NULL ORDER BY key, ordinal",
         )?;


### PR DESCRIPTION
Picks up the two prepared-statement-caching gaps in `musefs-db` left over from #378.

## #434 — `get_binary_tags` re-prepared its fixed SQL
`get_binary_tags` (`musefs-db/src/tags.rs`) used `prepare` rather than `prepare_cached`, re-parsing its fixed SQL on every cold resolve of a FLAC/binary-tag track via `mapping::binary_tags_to_inputs`. Switched to `prepare_cached` to match the other hot fixed-SQL readers.

Closes #434

## #435 — chunked IN-list queries re-prepared and re-allocated per batch
`query_in_chunks` (`musefs-db/src/lib.rs`, used by `tags_for_tracks` and `render_keys_for`) rebuilt the `IN (?,?,…)` placeholder list with `vec!["?"; n].join(",")` and called `prepare` per chunk.

- Full chunks (every chunk but the trailing partial one) share an identical placeholder list — it's now allocated once and reused.
- Switched to `prepare_cached`, so the fixed-size full-chunk statement is reused across chunks and across calls on the refresh path.
- The trailing partial chunk still builds its own list, but lazily, so small id sets (the common refresh case) never allocate the full-size string.

Closes #435

## Testing
Behaviour-preserving (identical SQL and results), so covered by the existing `musefs-db` suite. Full workspace test suite passes via the pre-commit gate on each commit; `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)