### PR TITLE
fix(musefs-core): isolate scan-path parser panics per-file

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:603:31:',
+    'musefs-core/src/scan\.rs:629:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:610:30:',
+    'musefs-core/src/scan\.rs:636:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,14 +127,14 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:621:21:',
+    'musefs-core/src/scan\.rs:647:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:626:17:',
+    'musefs-core/src/scan\.rs:652:17:',
     # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
     # per oversized mp4 `covr` / `----` payload the format layer skipped before
     # materialization (#343) and returns nothing. With no log-capture harness in the
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1094:46:',
+    'musefs-core/src/scan\.rs:1120:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1203:29:',
+    'musefs-core/src/scan\.rs:1229:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1205:32:',
+    'musefs-core/src/scan\.rs:1231:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1205:47:',
+    'musefs-core/src/scan\.rs:1231:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1205:62:',
+    'musefs-core/src/scan\.rs:1231:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1213:37:',
+    'musefs-core/src/scan\.rs:1239:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1215:40:',
+    'musefs-core/src/scan\.rs:1241:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1215:55:',
+    'musefs-core/src/scan\.rs:1241:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1215:70:',
+    'musefs-core/src/scan\.rs:1241:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1336:29:',
+    'musefs-core/src/scan\.rs:1362:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1344:29:',
+    'musefs-core/src/scan\.rs:1370:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1387:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1413:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -536,6 +536,32 @@ fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     })
 }
 
+/// Run [`probe_file`] under a panic boundary so a residual parser panic — one
+/// the format-layer alloc guards (`id3v2_alloc_safe` and friends) don't catch —
+/// drops just that file instead of unwinding the scan worker thread. An unwound
+/// worker would skip its `failed.fetch_add`, and a crafted directory could kill
+/// every worker, closing the channel so the writer reports success while
+/// silently truncating the rest of the library (#425). A caught panic is logged
+/// and folded into `ProbeOutcome::Unparseable`, which the worker already counts
+/// as `failed`. Mirrors the read path's `read_outcome` boundary (#359).
+fn probe_file_caught(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| probe_file(path, window))) {
+        Ok(res) => res,
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("<non-string panic>");
+            log::error!(
+                "scan worker panicked probing {}: {msg}; counting as failed",
+                path.display()
+            );
+            Ok(ProbeOutcome::Unparseable)
+        }
+    }
+}
+
 /// The per-format metadata dispatch for one already-opened backing file, over
 /// its first `file_len` bytes. Split out of `probe_file` so the fstat-sandwich
 /// wrapper stays legible. Never reads the audio payload (M4A uses the seek
@@ -1104,7 +1130,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
             loop {
                 let next = { work.lock().unwrap().next() };
                 let Some(path) = next else { break };
-                match probe_file(&path, window) {
+                match probe_file_caught(&path, window) {
                     Ok(ProbeOutcome::Probed(probed, stamp)) => {
                         let abs = match std::fs::canonicalize(&path) {
                             Ok(abs) => abs,

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -318,6 +318,22 @@ fn scan_directory_counts_scanned_failed_and_skipped() {
 }
 
 #[test]
+fn probe_file_caught_isolates_parser_panic_as_failed() {
+    // A residual parser panic — one the format-layer alloc guards don't catch —
+    // must drop just that file (counted as failed), not unwind the scan worker
+    // thread and silently truncate the rest of the library (#425). Mirrors the
+    // read path's `read_outcome` panic boundary (#359). The after-S1 hook stands
+    // in for a parser that panics partway through the probe.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("boom.flac");
+    write_flac(&path, &["ARTIST=A", "TITLE=T"], None);
+    set_after_s1_hook(|| panic!("parser exploded"));
+    let out = probe_file_caught(&path, WINDOW);
+    clear_after_s1_hook();
+    assert!(matches!(out, Ok(ProbeOutcome::Unparseable)), "got {out:?}");
+}
+
+#[test]
 fn skip_tally_summary_orders_by_descending_count() {
     let mut tally = super::SkipTally::default();
     for _ in 0..20 {


### PR DESCRIPTION
## Summary

Closes #425.

The read path wraps synthesis in `catch_unwind` so a residual parser panic becomes an `EIO` reply rather than unwinding a pool worker (`read_outcome`, #359). The scan worker loop had no equivalent backstop: `run_pipeline` called `probe_file()` directly in each worker thread, so a residual parser panic — one the format-layer alloc guards don't catch — unwound the worker instead of being counted.

Effects of the gap:
- The file was silently dropped without incrementing `failed` (the panic skipped `failed.fetch_add`).
- The worker thread died. A directory of crafted files could kill every worker; once all `tx` clones dropped, the writer saw a closed channel and the scan reported **success while silently truncating the rest of the library**.

## Fix

- Add `probe_file_caught()` — wraps `probe_file()` in a `catch_unwind` boundary, logs a caught panic, and folds it into `ProbeOutcome::Unparseable`, which the worker already counts as `failed`. Mirrors the read path's `read_outcome` boundary.
- Wire the worker loop to call it instead of `probe_file()`.

A caught panic now behaves like any other per-file probe failure: counted in `failed`, worker stays alive, scan continues.

## Test

`probe_file_caught_isolates_parser_panic_as_failed` (TDD red→green) uses the existing after-S1 hook to inject a panic mid-probe and asserts it is folded to `Unparseable` rather than unwinding. (The hook is thread-local so it can't reach spawned workers; the helper is unit-tested directly, exactly as `read_outcome` is.)

## Verification

- `cargo test --workspace` (full pre-commit suite) green; `--features metrics` green
- `cargo clippy --all-targets -D warnings` clean, `cargo fmt --check` clean
- Mutant-anchor guard re-anchored (scan.rs +26 lines) and re-validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)