### PR TITLE
perf(musefs-core): cut scan probe I/O — smaller window, lock-free queue, canonicalize once

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1122:46:',
+    'musefs-core/src/scan\.rs:1128:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1232:29:',
+    'musefs-core/src/scan\.rs:1245:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1234:32:',
+    'musefs-core/src/scan\.rs:1247:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1234:47:',
+    'musefs-core/src/scan\.rs:1247:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1234:62:',
+    'musefs-core/src/scan\.rs:1247:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1242:37:',
+    'musefs-core/src/scan\.rs:1255:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1244:40:',
+    'musefs-core/src/scan\.rs:1257:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1244:55:',
+    'musefs-core/src/scan\.rs:1257:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1244:70:',
+    'musefs-core/src/scan\.rs:1257:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1365:29:',
+    'musefs-core/src/scan\.rs:1382:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1373:29:',
+    'musefs-core/src/scan\.rs:1391:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1416:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1436:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1120:46:',
+    'musefs-core/src/scan\.rs:1122:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1229:29:',
+    'musefs-core/src/scan\.rs:1232:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1231:32:',
+    'musefs-core/src/scan\.rs:1234:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1231:47:',
+    'musefs-core/src/scan\.rs:1234:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1231:62:',
+    'musefs-core/src/scan\.rs:1234:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1239:37:',
+    'musefs-core/src/scan\.rs:1242:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1241:40:',
+    'musefs-core/src/scan\.rs:1244:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1241:55:',
+    'musefs-core/src/scan\.rs:1244:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1241:70:',
+    'musefs-core/src/scan\.rs:1244:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1362:29:',
+    'musefs-core/src/scan\.rs:1365:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1370:29:',
+    'musefs-core/src/scan\.rs:1373:29:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1413:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1416:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1104,7 +1104,7 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
 /// single writer (this thread) in batched transactions. Per-file errors are
 /// counted, not fatal.
 fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<ScanStats> {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
     let jobs = effective_jobs(opts.jobs);
     let total = files.len() as u64;
@@ -1115,24 +1115,27 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
     let failed = Arc::new(AtomicU64::new(0));
     let raced = Arc::new(AtomicU64::new(0));
 
-    // Work queue: a shared iterator behind a mutex (cheap; probing dominates).
-    let work = Arc::new(std::sync::Mutex::new(files.into_iter()));
+    // Work queue: a shared slice with an atomic cursor — each worker claims the
+    // next index with a single relaxed `fetch_add`, no per-file lock contention.
+    let files = Arc::new(files);
+    let cursor = Arc::new(AtomicUsize::new(0));
     let (tx, rx) = sync_channel::<Unit>(jobs * 2);
 
     let mut workers = Vec::with_capacity(jobs);
     for _ in 0..jobs {
-        let work = Arc::clone(&work);
+        let files = Arc::clone(&files);
+        let cursor = Arc::clone(&cursor);
         let tx = tx.clone();
         let budget = Arc::clone(&budget);
         let failed = Arc::clone(&failed);
         let raced = Arc::clone(&raced);
         workers.push(std::thread::spawn(move || {
             loop {
-                let next = { work.lock().unwrap().next() };
-                let Some(path) = next else { break };
-                match probe_file_caught(&path, window) {
+                let i = cursor.fetch_add(1, Ordering::Relaxed);
+                let Some(path) = files.get(i) else { break };
+                match probe_file_caught(path, window) {
                     Ok(ProbeOutcome::Probed(probed, stamp)) => {
-                        let abs = match std::fs::canonicalize(&path) {
+                        let abs = match std::fs::canonicalize(path) {
                             Ok(abs) => abs,
                             Err(e) => {
                                 log::warn!("skipping {}: {e}", path.display());

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -15,9 +15,9 @@ use std::sync::mpsc::sync_channel;
 const BATCH_FILES: usize = 256;
 const BATCH_BYTES: u64 = 64 << 20; // 64 MiB
 
-/// Initial bounded-read window. Covers typical metadata + cover art; a larger
-/// metadata region triggers a `NeedMore` widen.
-const WINDOW: usize = 1 << 20; // 1 MiB
+/// Initial bounded-read window. Sized to cover most files' metadata in one read;
+/// larger metadata (e.g. embedded cover art) triggers a precise `NeedMore` widen.
+const WINDOW: usize = 1 << 16; // 64 KiB
 /// Cap on widen iterations before falling back to a full-buffer read.
 const MAX_WIDEN_RETRIES: usize = 8;
 /// Hard ceiling on bytes read to probe one file. Real audio metadata fits far

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1062,6 +1062,11 @@ fn ingest_bulk(
 /// per-file I/O or parse error increment `ScanStats::failed` and do not abort
 /// the scan.
 pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
+    // Canonicalize the root once. With symlinks unfollowed (the default) every
+    // path the walk yields is then already absolute and symlink-free — i.e.
+    // canonical — so the workers need not canonicalize each probed file (#440).
+    let canon = std::fs::canonicalize(root)?;
+    let root = canon.as_path();
     let mut files = Vec::new();
     let mut tally = SkipTally::default();
     if root.is_file() {
@@ -1110,6 +1115,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
     let total = files.len() as u64;
     let progress = opts.progress.as_ref();
     let window = opts.window;
+    let follow_symlinks = opts.follow_symlinks;
     let cap = opts.batch_bytes;
     let budget = Arc::new(ByteBudget::new(cap));
     let failed = Arc::new(AtomicU64::new(0));
@@ -1135,18 +1141,25 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                 let Some(path) = files.get(i) else { break };
                 match probe_file_caught(path, window) {
                     Ok(ProbeOutcome::Probed(probed, stamp)) => {
-                        let abs = match std::fs::canonicalize(path) {
-                            Ok(abs) => abs,
-                            Err(e) => {
-                                log::warn!("skipping {}: {e}", path.display());
-                                failed.fetch_add(1, Ordering::Relaxed);
-                                continue;
+                        // No-follow paths are canonical by construction (the root
+                        // was canonicalized up front); only the opt-in symlink walk
+                        // can yield a path with a symlink component to resolve (#440).
+                        let abs_path = if follow_symlinks {
+                            match std::fs::canonicalize(path) {
+                                Ok(abs) => abs.to_string_lossy().into_owned(),
+                                Err(e) => {
+                                    log::warn!("skipping {}: {e}", path.display());
+                                    failed.fetch_add(1, Ordering::Relaxed);
+                                    continue;
+                                }
                             }
+                        } else {
+                            path.to_string_lossy().into_owned()
                         };
                         let weight = payload_weight(&probed);
                         budget.acquire(weight); // backpressure on in-flight art bytes
                         let unit = Unit {
-                            abs_path: abs.to_string_lossy().into_owned(),
+                            abs_path,
                             stamp,
                             probed,
                             weight,
@@ -1318,6 +1331,10 @@ pub fn scan_directory_full_oracle(db: &Db, root: &Path) -> Result<ScanStats> {
 /// candidate during the skip pass is counted in `failed` (and the file is left
 /// for the next revalidation) rather than re-probed or pruned.
 pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<RevalidateStats> {
+    // Canonicalize once; see scan_directory_with (#440). The prune pass below reuses
+    // this canonical root for its `starts_with` scope check.
+    let canon = std::fs::canonicalize(root)?;
+    let root = canon.as_path();
     let mut files = Vec::new();
     if root.is_file() {
         if is_supported_audio(root) {
@@ -1366,15 +1383,18 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
                 continue;
             }
         };
-        let abs = match std::fs::canonicalize(&path) {
-            Ok(abs) => abs,
-            Err(e) => {
-                log::warn!("skipping {}: {e}", path.display());
-                skip_failed += 1;
-                continue;
+        let key = if opts.follow_symlinks {
+            match std::fs::canonicalize(&path) {
+                Ok(abs) => abs.to_string_lossy().into_owned(),
+                Err(e) => {
+                    log::warn!("skipping {}: {e}", path.display());
+                    skip_failed += 1;
+                    continue;
+                }
             }
+        } else {
+            path.to_string_lossy().into_owned()
         };
-        let key = abs.to_string_lossy().into_owned();
         if let Some((stamp, id, format)) = existing.get(&key).copied() {
             let needs_backfill = format == Format::Flac && !have_structural.contains(&id);
             if crate::freshness::BackingStamp::from_metadata(&meta) == stamp && !needs_backfill {
@@ -1394,10 +1414,10 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
     let scan = run_pipeline(db, changed, opts)?;
 
     // Prune + GC on the writer connection (single-threaded), unchanged from before.
-    let canon_root = std::fs::canonicalize(root)?;
+    let canon_root = root;
     let mut pruned = 0u64;
     for track in db.list_tracks()? {
-        if !Path::new(&track.backing_path).starts_with(&canon_root) {
+        if !Path::new(&track.backing_path).starts_with(canon_root) {
             continue;
         }
         if let Err(e) = std::fs::metadata(&track.backing_path)

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -134,6 +134,31 @@ fn collect_audio_skips_broken_symlink_when_following() {
 }
 
 #[test]
+fn scan_stores_canonical_path_through_symlinked_root() {
+    // Scanning through a directory symlink must still store the canonical,
+    // symlink-resolved backing path, so a later revalidate — which keys on the
+    // canonical path — matches it rather than re-probing or pruning (#440).
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    write_flac(&real.join("t.flac"), &["ARTIST=A", "TITLE=T"], None);
+    let link = tmp.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    crate::scan_directory(&db, &link).unwrap();
+
+    let track = db.list_tracks().unwrap().into_iter().next().unwrap();
+    let expected = std::fs::canonicalize(real.join("t.flac")).unwrap();
+    assert_eq!(std::path::Path::new(&track.backing_path), expected);
+
+    let stats = crate::revalidate(&db, &link).unwrap();
+    assert_eq!(stats.unchanged, 1, "canonical key must match on revalidate");
+    assert_eq!(stats.updated, 0);
+    assert_eq!(stats.pruned, 0);
+}
+
+#[test]
 fn collect_audio_does_not_follow_symlinks_by_default() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("real.flac"), b"x").unwrap();

--- a/musefs-core/src/scan/scan_unit_tests.rs
+++ b/musefs-core/src/scan/scan_unit_tests.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 fn scan_options_defaults() {
     let d = ScanOptions::default();
     assert_eq!(d.jobs, 0, "jobs default = use available parallelism");
-    assert_eq!(d.window, 1_048_576, "window default = 1 MiB");
+    assert_eq!(d.window, 65_536, "window default = 64 KiB");
     assert_eq!(d.batch_bytes, 67_108_864, "batch_bytes default = 64 MiB");
 }
 

--- a/musefs-core/tests/metrics.rs
+++ b/musefs-core/tests/metrics.rs
@@ -420,7 +420,7 @@ fn oggflac_raw_art_serve_increments_art_chunks() {
 }
 
 /// #67: only .mp3 consumes the ID3v1 tail; non-MP3 formats must not pay the
-/// 128-byte tail read. A 300-byte FLAC (< the 1 MiB window) probes in exactly
+/// 128-byte tail read. A 300-byte FLAC (< the 64 KiB window) probes in exactly
 /// one positioned read of exactly the file's length.
 #[test]
 fn scan_reads_no_id3v1_tail_for_flac() {
@@ -480,7 +480,7 @@ fn scan_still_reads_id3v1_tail_for_mp3() {
     metrics::reset();
     scan_directory(&db, &target.corpus_dir).unwrap();
     let s = metrics::snapshot();
-    // Corpus tracks are far below the default 1 MiB scan window (this test must
+    // Corpus tracks are far below the default 64 KiB scan window (this test must
     // keep the default ScanOptions::window): one prefix read + the tail. read_tail_128
     // always reads 128 bytes when file_len >= 128, trailer present or not, so
     // the +128 assertion is robust.

--- a/musefs-core/tests/perf_counters.rs
+++ b/musefs-core/tests/perf_counters.rs
@@ -179,7 +179,7 @@ fn read_preads_and_seek_match_goldens() {
     }
 }
 
-/// Ingest of files LARGER than the ~1 MiB bounded metadata window: the scanner
+/// Ingest of files LARGER than the ~64 KiB bounded metadata window: the scanner
 /// reads only a bounded prefix, never the whole file. A reintroduced slurp shows
 /// up as `scan_bytes_read` jumping toward `tracks * 2 MiB`. Counts frozen below.
 #[test]
@@ -188,8 +188,8 @@ fn ingest_reads_bounded_prefix_not_whole_file() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     const TRACKS: usize = 3;
-    const BYTES_PER_TRACK: usize = 2 * 1024 * 1024; // > 1 MiB scan window
-    let (exp_opens, exp_preads, exp_bytes): (u64, u64, u64) = (3, 3, 3_145_728);
+    const BYTES_PER_TRACK: usize = 2 * 1024 * 1024; // > 64 KiB scan window
+    let (exp_opens, exp_preads, exp_bytes): (u64, u64, u64) = (3, 3, 196_608); // 3 × 64 KiB
 
     let base = tempfile::tempdir().unwrap();
     let params = CorpusParams {
@@ -210,7 +210,7 @@ fn ingest_reads_bounded_prefix_not_whole_file() {
     assert_eq!(s.scan_preads, exp_preads, "scan_preads");
     assert_eq!(s.scan_bytes_read, exp_bytes, "scan_bytes_read");
     // Hard upper bound independent of the frozen number: a slurp reads the whole
-    // 2 MiB/track (6 MiB total); the bounded prefix is ~1 MiB/track (3 MiB). Sit
+    // 2 MiB/track (6 MiB total); the bounded prefix is 64 KiB/track (192 KiB). Sit
     // the bound between them so any drift toward a slurp trips even if the golden
     // is updated.
     assert!(


### PR DESCRIPTION
Three independent scan-pipeline performance fixes (`musefs-core/src/scan.rs`), each behavior-preserving and measured against a real 4389-track FLAC library.

## #441 — initial probe window 1 MiB → 64 KiB
`WINDOW` sized the up-front `min(WINDOW, file_len)` read at 1 MiB, so a typical track read 1 MiB before parsing (~4.4 GiB for a 4000-track library) even though most headers parse in well under 64 KiB. The `NeedMore` loop already widens precisely (formats report an exact `up_to`), so larger embedded art just costs one extra contiguous read from the already-open fd.

Sizing came from the real library: metadata extent is a **median of 8.7 KiB** and within 64 KiB for **83%** of files. At 64 KiB ~17% widen once; total read volume drops from ~4.4 GiB to ~420 MiB (~10x). Covered for every format by the existing 64-byte-window `probe_equivalence` test; only the default-value assertion changed.

## #439 — work queue: per-file Mutex → atomic cursor
Probe workers pulled paths from a shared `Mutex<vec::IntoIter>` with one global lock acquisition per file — a serialization point on the otherwise parallel probe path. Replaced with an `Arc<Vec<PathBuf>>` and an `AtomicUsize` cursor: each worker claims its next index with a single relaxed `fetch_add`. Drain semantics unchanged (an index past the end yields `None` and the worker exits).

## #440 — canonicalize the scan root once, not every probed file
Every probed file went through `std::fs::canonicalize`, resolving every symlink component and stat-ing each ancestor — real per-file path-walk I/O on a deep HDD tree, in both the scan pipeline and the revalidate skip pass.

The canonical stored path is a load-bearing contract: `revalidate_with` matches DB keys by re-canonicalizing candidates and prune is scoped by `canon_root.starts_with`. So instead of dropping it: canonicalize the root **once** up front and walk from it — with symlinks unfollowed (the default) every walked path is then already canonical, so workers and the revalidate skip pass use it directly. The opt-in `--follow-symlinks` walk keeps per-file canonicalize (its paths can carry a symlink component), preserving the exact keys revalidate/prune depend on. Added `scan_stores_canonical_path_through_symlinked_root` to pin that scanning through a directory symlink still stores the resolved canonical path.

## Notes
- Re-anchored the shifted `.cargo/mutants.toml` `file:line:col` coordinates (via `--fix` plus manual re-anchoring of the repeated-`+=` sites).
- Full workspace test suite + clippy `-D warnings` + the mutant-anchor drift guard pass on each commit.

Closes #439
Closes #440
Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)