### PR TITLE
perf(musefs-core): cut serve-path lock contention (#427, #428, #429)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -463,8 +463,11 @@ exclude_re = [
     #
     # Phase-2 prefetch ring size (`depth + 1`), off by default and best-effort: a
     # wrong ring size only changes how many speculative windows are retained, never
-    # the served bytes. Sole `+` in serve_backing.
-    'replace \+ with (-|\*) in Musefs::serve_backing',
+    # the served bytes. #429 moved it from serve_backing into read_exact_at (sizing
+    # the ring under the read lock); the fn's other two `+` are the observable fills
+    # counters and stay killable, so this one is pinned by coordinate, not by fn.
+    # guard: op="+" fn="BackingReader<'a>::read_exact_at" rows=2
+    'musefs-core/src/readahead\.rs:584:68:',
     #
     # More hang-class (TIMEOUT-only, CANCEL the in-diff job): `len() -> 1` /
     # `clear() -> 1` force a constant resident size, so `evict_one_coldest` keeps

--- a/musefs-core/src/db_pool.rs
+++ b/musefs-core/src/db_pool.rs
@@ -12,12 +12,12 @@
 //! lifetime, not the thread's. Each pool has its own map, so multiple mounts
 //! (or test DBs) on the same thread don't collide.
 
-use std::collections::{HashMap, hash_map::Entry};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::ThreadId;
 
-use parking_lot::{Mutex, ReentrantMutex};
+use dashmap::DashMap;
+use parking_lot::ReentrantMutex;
 
 use musefs_db::{Db, ReadOnly};
 
@@ -29,18 +29,20 @@ use crate::error::{CoreError, Result};
 ///
 /// The `poll`/`conns` asymmetry is deliberate. `poll` is uniquely owned (the
 /// `Box` only keeps the variant small) because `with_poll` locks it in place
-/// and takes no other lock. `conns` values are `Arc`-wrapped so `with` can
-/// clone a handle and release the map guard *before* running the caller's
-/// closure — holding the (non-reentrant) map guard across it would deadlock
-/// nested `with`. The inner `ReentrantMutex` is never contended (only its
-/// owning thread locks it) but is load-bearing for the type system: `Db` is
-/// `Send + !Sync`, so the mutex wrapper is what keeps the map field, and
-/// therefore `DbPool`, `Send + Sync`.
+/// and takes no other lock. `conns` is a `DashMap`, so `with` never
+/// serializes concurrent reads on a single map lock — a steady-state hit
+/// takes only a shard read lock. Values are `Arc`-wrapped so `with` can clone
+/// a handle and release the shard guard *before* running the caller's closure
+/// — holding a (non-reentrant) shard guard across it would deadlock a nested
+/// `with` whose thread hashes to the same shard. The inner `ReentrantMutex` is
+/// never contended (only its owning thread locks it) but is load-bearing for
+/// the type system: `Db` is `Send + !Sync`, so the mutex wrapper is what keeps
+/// the map values, and therefore `DbPool`, `Send + Sync`.
 pub enum DbPool {
     PerThread {
         path: PathBuf,
         poll: Box<ReentrantMutex<Db<ReadOnly>>>,
-        conns: Mutex<HashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>>,
+        conns: DashMap<ThreadId, Arc<ReentrantMutex<Db<ReadOnly>>>>,
     },
     Shared(Arc<ReentrantMutex<Db<ReadOnly>>>),
 }
@@ -56,7 +58,7 @@ impl DbPool {
             Some(p) => Ok(DbPool::PerThread {
                 path: p.to_path_buf(),
                 poll: Box::new(ReentrantMutex::new(db)),
-                conns: Mutex::new(HashMap::new()),
+                conns: DashMap::new(),
             }),
             None => Ok(DbPool::Shared(Arc::new(ReentrantMutex::new(db)))),
         }
@@ -81,17 +83,23 @@ impl DbPool {
         match self {
             DbPool::PerThread { path, conns, .. } => {
                 let tid = std::thread::current().id();
-                let db = {
-                    let mut map = conns.lock();
-                    match map.entry(tid) {
-                        Entry::Occupied(entry) => Arc::clone(entry.get()),
-                        Entry::Vacant(entry) => {
+                // Clone the handle and release every DashMap shard guard before
+                // running `f`: holding a shard guard across the closure would
+                // deadlock a nested `with` whose thread hashes to the same shard.
+                // The steady-state hit takes only a shard *read* lock (`get`), so
+                // concurrent reads never serialize on a single global lock.
+                let db = if let Some(existing) = conns.get(&tid) {
+                    Arc::clone(existing.value())
+                } else {
+                    match conns.entry(tid) {
+                        dashmap::Entry::Occupied(entry) => Arc::clone(entry.get()),
+                        dashmap::Entry::Vacant(entry) => {
                             let db =
                                 Db::open_readonly(path).map_err(|source| CoreError::DbOpen {
                                     path: path.clone(),
                                     source,
                                 })?;
-                            Arc::clone(entry.insert(Arc::new(ReentrantMutex::new(db))))
+                            Arc::clone(&entry.insert(Arc::new(ReentrantMutex::new(db))))
                         }
                     }
                 };
@@ -263,7 +271,7 @@ mod tests {
             poll: Box::new(ReentrantMutex::new(
                 Db::open_in_memory().unwrap().into_read_only(),
             )),
-            conns: Mutex::new(HashMap::new()),
+            conns: DashMap::new(),
         };
         let msg = pool.with(|_db| Ok(())).unwrap_err().to_string();
         assert!(

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -405,7 +405,7 @@ impl Musefs {
             self.readahead_pool.register(key, Arc::clone(&h.readahead));
         }
         let backing_len = r.stamp.size;
-        let br = crate::readahead::BackingReader::new(
+        let mut br = crate::readahead::BackingReader::new(
             &h.file,
             &h.readahead,
             &self.readahead_pool,
@@ -413,6 +413,12 @@ impl Musefs {
             backing_len,
             &h.epoch,
         );
+        // Only capture prefetch-planning inputs (and size the eviction ring)
+        // when Phase-2 prefetch is on; otherwise the ring must stay at the
+        // single Phase-1 window.
+        if self.prefetch.is_some() {
+            br = br.with_prefetch_planning();
+        }
         read_at_with_file_into(r, db, &br, offset, size, out)?;
 
         let Some(pf) = &self.prefetch else {
@@ -425,26 +431,21 @@ impl Musefs {
         // raises depth again — no separate ramp counter is needed. `plan_prefetch`
         // deduplicates against the per-handle watermark so a sequential stream
         // enqueues only the freshly-exposed tail rather than re-requesting
-        // already-buffered windows. The watermark read/update sits under the
-        // buffer lock that also serialises concurrent reads of this handle.
+        // already-buffered windows. The backing read above already sized the
+        // eviction ring and captured the post-read frontier/window under the
+        // per-handle lock (see `BackingReader::with_prefetch_planning`), so this
+        // planning runs without re-locking that mutex (#429).
         let cap = self.readahead_pool.per_stream_cap();
-        let (starts, window) = {
-            let mut ra = h.readahead.lock().unwrap();
-            let start = ra.next_expected();
-            let window = ra.window();
-            let depth = crate::readahead::prefetch_depth(cap, window);
-            let ring = usize::try_from(depth).unwrap_or(4) + 1;
-            ra.set_max_windows(ring);
-            let (starts, upto) = crate::readahead::plan_prefetch(
-                h.prefetched_upto.load(Ordering::Relaxed),
-                start,
-                window,
-                depth,
-                backing_len,
-            );
-            h.prefetched_upto.store(upto, Ordering::Relaxed);
-            (starts, window)
-        };
+        let (start, window) = br.prefetch_plan();
+        let depth = crate::readahead::prefetch_depth(cap, window);
+        let (starts, upto) = crate::readahead::plan_prefetch(
+            h.prefetched_upto.load(Ordering::Relaxed),
+            start,
+            window,
+            depth,
+            backing_len,
+        );
+        h.prefetched_upto.store(upto, Ordering::Relaxed);
         if starts.is_empty() {
             return Ok(());
         }

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -155,16 +155,17 @@ impl ReadAheadPool {
     /// `try_lock` so eviction never blocks on an in-progress read. Returns the
     /// freed byte count, or `None` if nothing was evictable this pass.
     fn evict_one_coldest(&self, except: usize) -> Option<u64> {
-        let candidates: Vec<(usize, u64, Arc<Mutex<ReadAhead>>)> = {
+        // Snapshot the candidates under the `streams` lock, then sort by warmth
+        // *after* releasing it — the ordering work no longer blocks registration
+        // or deregistration of other streams.
+        let mut candidates: Vec<(usize, u64, Arc<Mutex<ReadAhead>>)> = {
             let g = self.streams.lock().unwrap();
-            let mut v: Vec<_> = g
-                .iter()
+            g.iter()
                 .filter(|(k, _)| **k != except)
                 .map(|(k, e)| (*k, e.last_served, Arc::clone(&e.buf)))
-                .collect();
-            v.sort_by_key(|(_, ls, _)| *ls); // coldest (smallest stamp) first
-            v
+                .collect()
         };
+        candidates.sort_by_key(|(_, ls, _)| *ls); // coldest (smallest stamp) first
         for (_, _, buf) in candidates {
             if let Ok(mut ra) = buf.try_lock() {
                 let freed = ra.clear();
@@ -185,6 +186,10 @@ struct Window {
 
 pub struct ReadAhead {
     windows: Vec<Window>,
+    /// Running sum of `windows[*].bytes.len()`, maintained on every insert,
+    /// eviction and clear so `len()` is O(1) on the read hot path instead of
+    /// re-summing every window under the per-handle lock.
+    cached_bytes: u64,
     next_expected: u64,
     window: u64,
     cap: u64,
@@ -195,6 +200,7 @@ impl ReadAhead {
     pub fn new(cap: u64) -> Self {
         ReadAhead {
             windows: Vec::new(),
+            cached_bytes: 0,
             next_expected: u64::MAX,
             window: WINDOW_FLOOR,
             cap,
@@ -215,11 +221,12 @@ impl ReadAhead {
 
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
-        self.windows.iter().map(|w| w.bytes.len() as u64).sum()
+        self.cached_bytes
     }
     pub fn clear(&mut self) -> u64 {
-        let freed = self.len();
+        let freed = self.cached_bytes;
         self.windows.clear();
+        self.cached_bytes = 0;
         self.window = WINDOW_FLOOR.min(self.cap);
         self.next_expected = u64::MAX;
         freed
@@ -246,21 +253,33 @@ impl ReadAhead {
     }
 
     fn insert_window(&mut self, w: Window) {
-        if let Some(slot) = self.windows.iter_mut().find(|x| x.start == w.start) {
-            *slot = w;
-        } else {
-            self.windows.push(w);
+        let w_bytes = w.bytes.len() as u64;
+        // `windows` is kept sorted by `start`, so storing a window is a binary
+        // search + positional insert rather than a full re-sort on every miss
+        // and every completed prefetch.
+        match self.windows.binary_search_by_key(&w.start, |x| x.start) {
+            Ok(i) => {
+                self.cached_bytes -= self.windows[i].bytes.len() as u64;
+                self.cached_bytes += w_bytes;
+                self.windows[i] = w;
+            }
+            Err(i) => {
+                self.cached_bytes += w_bytes;
+                self.windows.insert(i, w);
+            }
         }
-        self.windows.sort_by_key(|x| x.start);
         while self.windows.len() > self.max_windows {
             let frontier = self.next_expected;
+            // Sorted by `start`, so the first window lying fully behind the read
+            // frontier is also the lowest-start such window — the victim the
+            // previous min-by-start scan picked. Fall back to the oldest (index
+            // 0) when nothing is fully consumed yet.
             let idx = self
                 .windows
                 .iter()
-                .enumerate()
-                .filter(|(_, w)| w.start + w.bytes.len() as u64 <= frontier)
-                .min_by_key(|(_, w)| w.start)
-                .map_or(0, |(i, _)| i);
+                .position(|w| w.start + w.bytes.len() as u64 <= frontier)
+                .unwrap_or(0);
+            self.cached_bytes -= self.windows[idx].bytes.len() as u64;
             self.windows.remove(idx);
         }
     }
@@ -473,6 +492,12 @@ pub struct BackingReader<'a> {
     backing_len: u64,
     fills: Cell<u64>,
     epoch: &'a std::sync::atomic::AtomicU64,
+    /// When set, each backing read sizes the eviction ring and stashes the
+    /// post-read frontier/window below, so the caller can plan prefetch without
+    /// re-acquiring the per-handle lock (#429). Off by default.
+    prefetch: bool,
+    planned_next_expected: Cell<u64>,
+    planned_window: Cell<u64>,
 }
 
 impl<'a> BackingReader<'a> {
@@ -492,7 +517,27 @@ impl<'a> BackingReader<'a> {
             backing_len,
             fills: Cell::new(0),
             epoch,
+            prefetch: false,
+            planned_next_expected: Cell::new(u64::MAX),
+            planned_window: Cell::new(0),
         }
+    }
+
+    /// Opt into prefetch-plan capture: every backing read sizes the eviction
+    /// ring and records the post-read `next_expected`/`window` under the read
+    /// lock, so the caller reads them via [`Self::prefetch_plan`] without a
+    /// second lock acquisition (#429).
+    #[must_use]
+    pub fn with_prefetch_planning(mut self) -> Self {
+        self.prefetch = true;
+        self
+    }
+
+    /// The `(next_expected, window)` captured by the most recent backing read,
+    /// or `(u64::MAX, 0)` if no backing read occurred. Only meaningful when
+    /// constructed via [`Self::with_prefetch_planning`].
+    pub fn prefetch_plan(&self) -> (u64, u64) {
+        (self.planned_next_expected.get(), self.planned_window.get())
     }
 
     pub fn fills(&self) -> u64 {
@@ -530,6 +575,16 @@ impl<'a> BackingReader<'a> {
             crate::metrics::on_pread(b.len() as u64);
             crate::metrics::backing_read_exact_at(file, b, o)
         })?;
+        if self.prefetch {
+            // Size the eviction ring and capture the post-read frontier/window
+            // under the lock we already hold, so the caller plans prefetch
+            // without re-locking this per-handle mutex (#429).
+            let window = ra.window();
+            let depth = prefetch_depth(self.pool.per_stream_cap(), window);
+            ra.set_max_windows(usize::try_from(depth).unwrap_or(4) + 1);
+            self.planned_next_expected.set(ra.next_expected());
+            self.planned_window.set(window);
+        }
         self.pool.reconcile(old_len, new_len);
         drop(ra);
         self.pool.touch(self.key);

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -1551,4 +1551,48 @@ mod mutation_guard_tests {
         assert!(starts.is_empty());
         assert_eq!(upto, 500);
     }
+
+    #[test]
+    fn cached_len_replaces_same_start_window() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.store_window(100, vec![0u8; 1000]);
+        assert_eq!(ra.len(), 1000);
+        // Re-storing at the same start must subtract the old window's bytes and
+        // add the new ones — not sum them, scale either, or leave the count
+        // stale. A single window of 2500 bytes remains.
+        ra.store_window(100, vec![0u8; 2500]);
+        assert_eq!(ra.len(), 2500);
+    }
+
+    #[test]
+    fn cached_len_drops_evicted_window_bytes() {
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        ra.set_max_windows(2);
+        ra.store_window(0, vec![0u8; 1000]);
+        ra.store_window(1000, vec![0u8; 1000]);
+        assert_eq!(ra.len(), 2000);
+        let mut dst = vec![0u8; 10];
+        ra.read_into(&mut dst, 1990, 1 << 20, fillb).unwrap(); // hit → next_expected = 2000
+        // The third window trims one fully-behind window; len() must drop exactly
+        // the evicted window's bytes (3000 stored − 1000 evicted == 2000).
+        ra.store_window(2000, vec![0u8; 1000]);
+        assert_eq!(ra.len(), 2000);
+    }
+
+    #[test]
+    fn prefetch_plan_reports_captured_frontier_and_window() {
+        let (_d, file) = bk_temp(256 * 1024);
+        let pool = ReadAheadPool::new(64 << 20);
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        pool.register(1, Arc::clone(&buf));
+        let ep = std::sync::atomic::AtomicU64::new(0);
+        let br =
+            BackingReader::new(&file, &buf, &pool, 1, 256 * 1024, &ep).with_prefetch_planning();
+        let mut d = vec![0u8; 4096];
+        br.read_exact_at(&mut d, 0).unwrap();
+        // The read above captured the post-read frontier (off + len) and the
+        // first-miss window (the floor); `prefetch_plan` must return those exact
+        // values, not a constant placeholder.
+        assert_eq!(br.prefetch_plan(), (4096, WINDOW_FLOOR));
+    }
 }


### PR DESCRIPTION
Fixes #427
Fixes #428
Fixes #429

Three independent hot-path contention fixes on the read/getattr serve path. All behavior-preserving — these only remove redundant work and lock round-trips.

## Fixes

### #427 — `DbPool::with` global mutex
The per-thread serve connection was fetched through one global `Mutex<HashMap<ThreadId, …>>`, serializing the entry of every concurrent read/getattr. `conns` is now a `DashMap` (already a workspace dep): the steady-state hit takes only a shard **read** lock via `get`, and the slow path falls back to `entry` for first-time open. The load-bearing invariant is preserved — the shard guard is released before the caller's closure runs, so a nested `with` whose thread hashes to the same shard can't deadlock.

### #428 — `ReadAhead` redundant work under the per-handle lock
- `len()` is now O(1) via a maintained `cached_bytes` counter instead of re-summing every window (it's called several times per read).
- `insert_window` keeps `windows` sorted and uses a binary-search positional insert instead of a full re-sort on every store (every miss, every completed prefetch). Eviction picks the victim via `position`, provably the same lowest-start window the old `min_by_key` scan chose.
- `evict_one_coldest` snapshots candidates under the `streams` lock and sorts **after** releasing it.

### #429 — `serve_backing` double lock
`read_at_with_file_into` locked `h.readahead` for the backing read, then the prefetch-planning block re-locked it. `BackingReader::with_prefetch_planning` now captures the post-read `next_expected`/`window` and sizes the eviction ring under the read lock it already holds, so planning needs no second acquisition. Gated on `self.prefetch.is_some()` so the default (prefetch-off) config keeps its single Phase-1 window; opt-in builder avoids rippling a new ctor arg through the other `BackingReader::new` call sites.

## Notes
- The prefetch-ring `+ 1` mutant moved from `serve_backing` into `read_exact_at`, so its `.cargo/mutants.toml` exclude is re-anchored by coordinate (the fn's other two `+` are observable `fills` counters and stay killable). `scripts/check_mutant_anchors.py` passes.

## Verification
- `cargo test --workspace` — 1108 passed
- `cargo test -p musefs-core --features metrics` — 471 passed (CI-only getattr/read stat-count assertions)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `python3 scripts/check_mutant_anchors.py` — OK (66 entries / 3526 mutants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
