### PR TITLE
feat(picard): map Picard's full tag set; align beets store keys (#424)

### DIFF
--- a/contrib/beets/beetsplug/_core.py
+++ b/contrib/beets/beetsplug/_core.py
@@ -50,6 +50,9 @@ RENAME = {
     "mb_releasegroupid": "musicbrainz_releasegroupid",
     "mb_releasetrackid": "musicbrainz_releasetrackid",
     "mb_workid": "musicbrainz_workid",
+    "artist_sort": "artistsort",
+    "albumartist_sort": "albumartistsort",
+    "comp": "compilation",
 }
 
 # plural beets list field -> the singular beets field it collapses onto. The
@@ -82,7 +85,7 @@ _DROP_IF_ZERO = {
     "discnumber",
     "tracktotal",
     "disctotal",
-    "comp",
+    "compilation",
     "bpm",
     "original_year",
     "original_month",

--- a/contrib/beets/tests/test_map_fields.py
+++ b/contrib/beets/tests/test_map_fields.py
@@ -37,6 +37,7 @@ _TAG_FIELDS = (
     "mb_trackid",
     "artist_sort",
     "artists_sort",
+    "albumartist_sort",
     "bitrate",
     "length",
     "format",  # file facts: present on item, NOT tag fields
@@ -107,12 +108,26 @@ def test_genre_plural_collapses_to_genre_key():
     assert [v for k, v in pairs if k == "genre"] == ["Rock", "Pop"]
 
 
-def test_comp_one_kept_zero_dropped():
-    # beets `comp` is a 0/1 int; bool here too. 1 -> kept "1", 0/False -> dropped.
-    assert dict(map_fields(item(comp=True)))["comp"] == "1"
-    assert dict(map_fields(item(comp=1)))["comp"] == "1"
-    assert "comp" not in dict(map_fields(item(comp=False)))
-    assert "comp" not in dict(map_fields(item(comp=0)))
+def test_comp_renamed_to_compilation_and_zero_dropped():
+    # beets `comp` is a 0/1 int; it maps to the on-disk `compilation` key.
+    # 1 -> kept "1", 0/False -> dropped.
+    assert dict(map_fields(item(comp=True)))["compilation"] == "1"
+    assert dict(map_fields(item(comp=1)))["compilation"] == "1"
+    assert "comp" not in dict(map_fields(item(comp=True)))
+    assert "compilation" not in dict(map_fields(item(comp=False)))
+    assert "compilation" not in dict(map_fields(item(comp=0)))
+
+
+def test_sort_fields_renamed_to_on_disk_keys():
+    # artist_sort/albumartist_sort are beets' internal attribute names; the
+    # on-disk standard (matching Picard) is artistsort/albumartistsort.
+    d = dict(map_fields(item(artist_sort="Beatles, The", albumartist_sort="V, The")))
+    assert d["artistsort"] == "Beatles, The"
+    assert d["albumartistsort"] == "V, The"
+    assert "artist_sort" not in d and "albumartist_sort" not in d
+    # plural twin collapses to the singular attr, then renames to on-disk key
+    pairs = map_fields(item(artists_sort=["A", "B"]))
+    assert [v for k, v in pairs if k == "artistsort"] == ["A", "B"]
 
 
 def test_file_facts_excluded():

--- a/contrib/picard/README.md
+++ b/contrib/picard/README.md
@@ -46,8 +46,9 @@ Options → musefs sync:
   auto-create rows. Default `musefs`.
 - **Run `musefs scan` before syncing** — autoscan toggle (default on). With it
   off, run `musefs scan` yourself first or the sync errors on a missing DB.
-- **Extra field map** — optional `key=value` list mapping extra Picard tag names
-  to musefs keys, e.g. `comment=comment`.
+- **Extra field map** — optional `key=value` list mapping additional or custom
+  Picard tag names to musefs store keys (applied verbatim, last-wins, on top of
+  the automatic full-tag-set sync), e.g. `mymood=mood`.
 
 `MUSEFS_DB` and `MUSEFS_BIN` environment variables override the DB/binary
 settings (handy for testing).
@@ -67,6 +68,11 @@ settings (handy for testing).
   art lets the embedded picture re-seed when autoscan is on (musefs scan
   re-reads the file); with autoscan off, existing art is left untouched.
 - **Tags are fully replaced** with Picard's view on every sync.
+- **Field coverage:** every populated Picard tag is synced under its canonical
+  musefs (on-disk) key — all MusicBrainz IDs, sort and performer/credit fields,
+  movement, totals, and any custom field; multi-values expand and per-role
+  performers fold to `Name (Role)`. Picard's hidden `~` internals (length,
+  rating, …) are never written.
 - **Orphaned art:** replacing art can orphan old blobs; `musefs scan --revalidate`
   garbage-collects them.
 - **Schema version:** the plugin refuses to run if the DB's `user_version`

--- a/contrib/picard/musefs/_core.py
+++ b/contrib/picard/musefs/_core.py
@@ -12,97 +12,99 @@ from dataclasses import dataclass, field
 
 from ._common.sync import ArtImage
 
-# Picard internal tag name -> musefs (Vorbis-lowercase) key. Picard's internal
-# names already match musefs keys, so this is mostly identity.
-DIRECT_FIELDS = {
-    "title": "title",
-    "artist": "artist",
-    "albumartist": "albumartist",
-    "album": "album",
-    "genre": "genre",
-    "composer": "composer",
-    "tracknumber": "tracknumber",
-    "discnumber": "discnumber",
-    "date": "date",
-    "comment": "comment",
-    "lyrics": "lyrics",
-    "grouping": "grouping",
-    "isrc": "isrc",
-    "replaygain_track_gain": "replaygain_track_gain",
-    "replaygain_album_gain": "replaygain_album_gain",
-    "replaygain_track_peak": "replaygain_track_peak",
-    "replaygain_album_peak": "replaygain_album_peak",
-    "musicbrainz_albumid": "musicbrainz_albumid",
-    "musicbrainz_artistid": "musicbrainz_artistid",
+# Picard internal tag name -> canonical musefs store key, for the few names whose
+# on-disk form differs from Picard's variable name. Mirrors the format-agnostic
+# subset of Picard's own var->tag translation (its vorbis.py ``__rtranslate``):
+# the MusicBrainz recording/track id swap, the movement name/number swap, and the
+# track/disc totals. Every other Picard name already equals its on-disk key and
+# passes through verbatim.
+RENAME = {
+    "musicbrainz_recordingid": "musicbrainz_trackid",
+    "musicbrainz_trackid": "musicbrainz_releasetrackid",
+    "movementnumber": "movement",
+    "movement": "movementname",
+    "totaltracks": "tracktotal",
+    "totaldiscs": "disctotal",
 }
 
-# Keys whose value is dropped when it normalizes to zero (a 0 track/disc is noise).
-_NUMERIC_KEYS = {"tracknumber", "discnumber"}
+# Output keys whose value is dropped when it normalizes to zero (a 0
+# number/total/compilation flag is noise, not data).
+_DROP_IF_ZERO = {
+    "tracknumber",
+    "discnumber",
+    "tracktotal",
+    "disctotal",
+    "compilation",
+    "bpm",
+}
 
 
 class MusefsError(Exception):  # noqa: N818
     """A user-facing failure (binary missing, scan failed, DB absent)."""
 
 
-def _to_int(value):
-    """Coerce to int, tolerating None and non-numeric strings so a bad tag
-    can't abort sync."""
+def _is_zero(text):
+    """True when ``text`` represents a numeric zero, so a 0 placeholder is
+    dropped. Float-aware (matches the beets sibling's check): non-numeric and
+    fractional non-zero values are not zero and pass through unharmed."""
     try:
-        return int(value or 0)
-    except (ValueError, TypeError):
-        return 0
+        return float(text) == 0.0
+    except ValueError:
+        return False
 
 
-def _values(metadata, field_name):
-    """All non-empty, stripped string values of a Picard metadata field. Reads
-    ``metadata.getall(field)`` when available (Picard's multi-valued accessor),
-    else falls back to a plain ``.get``."""
-    getall = getattr(metadata, "getall", None)
-    if getall is not None:
-        values = getall(field_name)
-    else:
-        v = metadata.get(field_name) if hasattr(metadata, "get") else None
-        values = v if isinstance(v, (list, tuple)) else ([] if v is None else [v])
-    return [text for v in values if (text := str(v).strip())]
+def _output_key(name):
+    """Map a Picard tag name to a ``(store_key, performer_role)`` pair.
 
-
-def _first_value(metadata, field_name):
-    """First non-empty, stripped string value of a Picard metadata field, or
-    ``""`` if none."""
-    values = _values(metadata, field_name)
-    return values[0] if values else ""
-
-
-# Keys whose Picard values may legitimately be multi-valued (one store row each).
-# Everything else (title, tracknumber, discnumber, date) stays a single scalar.
-_MULTI_VALUE_KEYS = {"artist", "albumartist", "genre", "composer"}
+    ``performer_role`` is ``None`` for ordinary keys; for ``performer`` /
+    ``performer:<role>`` it is the role string ("" when bare) so the caller folds
+    it into the value in Picard's own ``Name (Role)`` form. ``comment`` /
+    ``lyrics`` (bare or with a description) collapse to their base key, dropping
+    the description. Everything else is renamed via ``RENAME`` or passes through
+    verbatim. Picard's ``normalize_tag`` strips trailing colons, so a key only
+    carries a ``:`` when it has a non-empty description/role.
+    """
+    base, _, desc = name.partition(":")
+    if base == "performer":
+        return "performer", desc
+    if base in ("comment", "lyrics"):
+        return base, None
+    return RENAME.get(name, name), None
 
 
 def map_fields(metadata, extra_fields=None):
-    """Map a Picard Metadata (dict-like) to a list of (musefs_key, value) pairs.
+    """Map a Picard ``Metadata`` to a list of ``(store_key, value)`` pairs.
 
-    Keys in ``_MULTI_VALUE_KEYS`` emit one row per non-empty value (preserving
-    Picard's order); every other key emits a single row (the first non-empty).
-    Empty strings are omitted, as is a zero tracknumber/discnumber.
-    ``extra_fields`` merges into (and can override) the direct-copy table.
+    Enumerates every populated tag via ``rawitems``, skipping Picard's hidden
+    ``~``-prefixed internals. Each non-empty value becomes its own row (the store
+    has set semantics); values sharing an output key accumulate, so multi-role
+    performers and multi-description comments all survive. Keys are canonicalized
+    by :func:`_output_key`; ``_DROP_IF_ZERO`` keys drop a zero value.
+    ``extra_fields`` (the options-page ``picard_field -> store_key`` map) is a
+    final override layer applied verbatim — no role-fold, no zero-drop.
     """
-    fields = dict(DIRECT_FIELDS)
-    if extra_fields:
-        fields.update(extra_fields)
+    emitted = {}  # store_key -> list[str], insertion-ordered, accumulating
+    for name, values in metadata.rawitems():
+        if name.startswith("~"):
+            continue
+        key, role = _output_key(name)
+        for raw in values:
+            text = str(raw).strip()
+            if not text:
+                continue
+            if role:
+                text = f"{text} ({role})"
+            if key in _DROP_IF_ZERO and _is_zero(text):
+                continue
+            emitted.setdefault(key, []).append(text)
 
-    pairs = []
-    for pic_field, key in fields.items():
-        if key in _MULTI_VALUE_KEYS:
-            for text in _values(metadata, pic_field):
-                pairs.append((key, text))
-            continue
-        text = _first_value(metadata, pic_field)
-        if not text:
-            continue
-        if key in _NUMERIC_KEYS and _to_int(text) == 0:
-            continue
-        pairs.append((key, text))
-    return pairs
+    if extra_fields:
+        for pic_field, store_key in extra_fields.items():
+            values = [t for v in metadata.getall(pic_field) if (t := str(v).strip())]
+            if values:
+                emitted[store_key] = values
+
+    return [(key, value) for key, values in emitted.items() for value in values]
 
 
 # Picard maintype → ID3 picture type (mirrors Picard's own ID3 image-type

--- a/contrib/picard/tests/conftest.py
+++ b/contrib/picard/tests/conftest.py
@@ -83,6 +83,9 @@ class FakeMetadata:
     def getall(self, key):
         return self._tags.get(key, [])
 
+    def rawitems(self):
+        return self._tags.items()
+
 
 @pytest.fixture
 def fake_metadata():

--- a/contrib/picard/tests/test_map_fields.py
+++ b/contrib/picard/tests/test_map_fields.py
@@ -8,72 +8,172 @@ def test_direct_fields_copied(fake_metadata):
     assert d["album"] == "Disc"
 
 
-def test_multivalued_field_expands(fake_metadata):
-    # Picard multi-valued: getall returns a list; multi-value-eligible keys
-    # (artist/albumartist/genre/composer) emit one row per value.
+def test_all_fields_multi_value_expand(fake_metadata):
+    # The old _MULTI_VALUE_KEYS allowlist is gone: every field emits one row per
+    # value, order preserved.
     pairs = map_fields(fake_metadata(artist=["First", "Second"]))
-    artists = [v for k, v in pairs if k == "artist"]
-    assert artists == ["First", "Second"]
-
-
-def test_genre_multivalue_expands(fake_metadata):
+    assert [v for k, v in pairs if k == "artist"] == ["First", "Second"]
     pairs = map_fields(fake_metadata(genre=["Rock", "Pop"]))
     assert [v for k, v in pairs if k == "genre"] == ["Rock", "Pop"]
-
-
-def test_date_not_multivalue_expanded(fake_metadata):
-    # date is NOT in the multi-value allowlist: stays a single scalar row even
-    # if Picard happens to expose multiple values.
-    pairs = map_fields(fake_metadata(date=["2020", "2021"]))
-    assert [v for k, v in pairs if k == "date"] == ["2020"]
+    pairs = map_fields(fake_metadata(mood=["Happy", "Sad"]))
+    assert [v for k, v in pairs if k == "mood"] == ["Happy", "Sad"]
 
 
 def test_empty_and_whitespace_omitted(fake_metadata):
-    d = dict(map_fields(fake_metadata(title="", artist="   ")))
-    assert d == {}
+    assert dict(map_fields(fake_metadata(title="", artist="   "))) == {}
 
 
-def test_tracknumber_and_discnumber_passthrough(fake_metadata):
+def test_tracknumber_discnumber_passthrough_and_zero_dropped(fake_metadata):
     d = dict(map_fields(fake_metadata(tracknumber="7", discnumber="2")))
-    assert d["tracknumber"] == "7"
-    assert d["discnumber"] == "2"
-
-
-def test_zero_tracknumber_omitted(fake_metadata):
-    d = dict(map_fields(fake_metadata(tracknumber="0", discnumber="0")))
-    assert "tracknumber" not in d
-    assert "discnumber" not in d
+    assert d["tracknumber"] == "7" and d["discnumber"] == "2"
+    z = dict(map_fields(fake_metadata(tracknumber="0", discnumber="0")))
+    assert "tracknumber" not in z and "discnumber" not in z
 
 
 def test_date_passthrough(fake_metadata):
     assert dict(map_fields(fake_metadata(date="1999-03-05")))["date"] == "1999-03-05"
-    assert dict(map_fields(fake_metadata(date="1999")))["date"] == "1999"
 
 
-def test_extra_field_override_adds_mapping(fake_metadata):
-    md = fake_metadata(title="Song", comment="hi")
-    d = dict(map_fields(md, extra_fields={"comment": "comment"}))
-    assert d["comment"] == "hi"
+def test_replaygain_and_misc_passthrough(fake_metadata):
+    d = dict(
+        map_fields(
+            fake_metadata(
+                replaygain_track_gain="-7.50 dB",
+                musicbrainz_albumid="abc",
+                grouping="set",
+                isrc="US-X",
+                label="Label",
+            )
+        )
+    )
+    assert d["replaygain_track_gain"] == "-7.50 dB"
+    assert d["musicbrainz_albumid"] == "abc"
+    assert d["grouping"] == "set" and d["isrc"] == "US-X" and d["label"] == "Label"
+
+
+def test_musicbrainz_id_swap(fake_metadata):
+    # Picard's recording id is the on-disk musicbrainz_trackid; Picard's track id
+    # is the on-disk musicbrainz_releasetrackid. Both source vars present together.
+    d = dict(map_fields(fake_metadata(musicbrainz_recordingid="rec", musicbrainz_trackid="trk")))
+    assert d["musicbrainz_trackid"] == "rec"
+    assert d["musicbrainz_releasetrackid"] == "trk"
+    assert "musicbrainz_recordingid" not in d
+
+
+def test_musicbrainz_ids_passthrough(fake_metadata):
+    d = dict(
+        map_fields(
+            fake_metadata(
+                musicbrainz_albumid="al",
+                musicbrainz_artistid="ar",
+                musicbrainz_albumartistid="aa",
+                musicbrainz_releasegroupid="rg",
+                musicbrainz_workid="wk",
+            )
+        )
+    )
+    assert d["musicbrainz_albumid"] == "al"
+    assert d["musicbrainz_artistid"] == "ar"
+    assert d["musicbrainz_albumartistid"] == "aa"
+    assert d["musicbrainz_releasegroupid"] == "rg"
+    assert d["musicbrainz_workid"] == "wk"
+
+
+def test_sort_fields_passthrough(fake_metadata):
+    d = dict(map_fields(fake_metadata(artistsort="B, The", albumartistsort="A, An")))
+    assert d["artistsort"] == "B, The"
+    assert d["albumartistsort"] == "A, An"
+
+
+def test_artist_and_artists_both_emitted(fake_metadata):
+    # Picard exposes the credited join string (artist) and the individual list
+    # (artists) as distinct on-disk tags; emit both, no twin-collapse.
+    pairs = map_fields(
+        fake_metadata(
+            artist="Alice & Bob",
+            artists=["Alice", "Bob"],
+            albumartist="Alice & Bob",
+            albumartists=["Alice", "Bob"],
+        )
+    )
+    assert [v for k, v in pairs if k == "artist"] == ["Alice & Bob"]
+    assert [v for k, v in pairs if k == "artists"] == ["Alice", "Bob"]
+    assert [v for k, v in pairs if k == "albumartist"] == ["Alice & Bob"]
+    assert [v for k, v in pairs if k == "albumartists"] == ["Alice", "Bob"]
+
+
+def test_movement_swap(fake_metadata):
+    d = dict(map_fields(fake_metadata(movement="Allegro", movementnumber="1")))
+    assert d["movementname"] == "Allegro"
+    assert d["movement"] == "1"
+
+
+def test_totals_renamed_and_zero_dropped(fake_metadata):
+    d = dict(map_fields(fake_metadata(totaltracks="12", totaldiscs="2")))
+    assert d["tracktotal"] == "12" and d["disctotal"] == "2"
+    z = dict(map_fields(fake_metadata(totaltracks="0", totaldiscs="0")))
+    assert "tracktotal" not in z and "disctotal" not in z
+
+
+def test_compilation_and_bpm_zero_dropped(fake_metadata):
+    assert dict(map_fields(fake_metadata(compilation="1")))["compilation"] == "1"
+    assert "compilation" not in dict(map_fields(fake_metadata(compilation="0")))
+    assert dict(map_fields(fake_metadata(bpm="120")))["bpm"] == "120"
+    assert "bpm" not in dict(map_fields(fake_metadata(bpm="0")))
+    assert "bpm" not in dict(map_fields(fake_metadata(bpm="0.0")))
+    # a fractional, non-zero value must survive (float-aware zero check)
+    assert dict(map_fields(fake_metadata(bpm="128.5")))["bpm"] == "128.5"
+
+
+def test_performer_role_folded_into_value(fake_metadata):
+    pairs = map_fields(fake_metadata(**{"performer:Piano": "Joe Barr"}))
+    assert pairs == [("performer", "Joe Barr (Piano)")]
+
+
+def test_performer_bare_value_only(fake_metadata):
+    pairs = map_fields(fake_metadata(performer="Joe Barr"))
+    assert pairs == [("performer", "Joe Barr")]
+
+
+def test_performer_multiple_roles_accumulate(fake_metadata):
+    pairs = map_fields(
+        fake_metadata(**{
+            "performer:Piano": ["Joe Barr"],
+            "performer:Guitar": ["Ann Lee", "Max Roe"],
+        })
+    )
+    performers = sorted(v for k, v in pairs if k == "performer")
+    assert performers == ["Ann Lee (Guitar)", "Joe Barr (Piano)", "Max Roe (Guitar)"]
+
+
+def test_comment_and_lyrics_collapse(fake_metadata):
+    # Bare and described forms collapse to the base key; description dropped.
+    d = dict(map_fields(fake_metadata(**{"comment:eng": "hello", "lyrics": "la"})))
+    assert d["comment"] == "hello"
+    assert d["lyrics"] == "la"
+
+
+def test_comment_descriptions_accumulate(fake_metadata):
+    pairs = map_fields(fake_metadata(**{"comment": "main", "comment:eng": "english"}))
+    assert sorted(v for k, v in pairs if k == "comment") == ["english", "main"]
+
+
+def test_hidden_vars_skipped(fake_metadata):
+    pairs = map_fields(fake_metadata(**{"~length": "210000", "~rating": "5", "title": "Keep"}))
+    keys = {k for k, _ in pairs}
+    assert keys == {"title"}
+
+
+def test_extra_fields_override_verbatim(fake_metadata):
+    # The options-page map adds/overrides a store key, last-wins, value verbatim
+    # (no role-fold, no zero-drop). Other fields' natural mapping is unaffected.
+    md = fake_metadata(title="Song", **{"performer:Piano": "Joe Barr"})
+    d = dict(map_fields(md, extra_fields={"performer:Piano": "soloist"}))
+    assert d["soloist"] == "Joe Barr"  # verbatim: NOT "Joe Barr (Piano)"
     assert d["title"] == "Song"
 
 
-def test_extra_field_remaps_existing_key(fake_metadata):
-    d = dict(map_fields(fake_metadata(title="Song"), extra_fields={"title": "subtitle"}))
-    assert d["subtitle"] == "Song"
-    assert "title" not in d
-
-
-def test_replaygain_and_musicbrainz_and_comment_mapped(fake_metadata):
-    md = fake_metadata(
-        replaygain_track_gain="-7.50 dB",
-        musicbrainz_albumid="abc",
-        comment="hello",
-        lyrics="la",
-        grouping="set",
-        isrc="US-X",
-    )
-    d = dict(map_fields(md))
-    assert d["replaygain_track_gain"] == "-7.50 dB"
-    assert d["musicbrainz_albumid"] == "abc"
-    assert d["comment"] == "hello"
-    assert d["lyrics"] == "la" and d["grouping"] == "set" and d["isrc"] == "US-X"
+def test_extra_fields_override_replaces_target_key(fake_metadata):
+    md = fake_metadata(title="Song", subtitle="Sub")
+    d = dict(map_fields(md, extra_fields={"title": "subtitle"}))
+    assert d["subtitle"] == "Song"  # override wins over the natural subtitle row

--- a/docs/superpowers/plans/2026-06-15-picard-full-tagset-mapping.md
+++ b/docs/superpowers/plans/2026-06-15-picard-full-tagset-mapping.md
@@ -1,0 +1,587 @@
+# Picard Full Tag-Set Mapping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Picard plugin's static ~20-field whitelist with dynamic enumeration of Picard's full metadata, emitting standard on-disk store keys, and realign the beets sibling's three outlier keys so both plugins converge.
+
+**Architecture:** `map_fields` enumerates `metadata.rawitems()`, skips `~`-hidden vars, canonicalizes each key via a `RENAME` swap table + colon-suffix handling (performer role-fold; comment/lyrics collapse), accumulates multi-values, and drops zero numerics. The beets plugin adds three `RENAME` entries (`artist_sort→artistsort`, `albumartist_sort→albumartistsort`, `comp→compilation`) so its on-disk-standard keys match Picard's. No Rust, schema, or shared-lib changes — store keys for non-VOCAB fields round-trip verbatim as the synthesized file's field name.
+
+**Tech Stack:** Python 3 (Picard plugin: vendored `musefs._common`, no Picard import in `_core.py`; beets plugin: `beetsplug` + `python-musefs`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-picard-full-tagset-mapping-design.md`
+
+---
+
+## File Structure
+
+- `contrib/picard/musefs/_core.py` — **modify**: replace the mapping block (lines 15–105 inclusive: the `# Picard internal tag name` comment, `DIRECT_FIELDS`, `_NUMERIC_KEYS`, `MusefsError`, `_to_int`, `_values`, `_first_value`, `_MULTI_VALUE_KEYS`, `map_fields`) with `RENAME`, `_DROP_IF_ZERO`, `MusefsError` (re-included verbatim), a float-aware `_is_zero` (replacing `_to_int`), `_output_key`, and the rewritten `map_fields`. Do not touch line 14 (`from ._common.sync import ArtImage`) or above; everything from `_picture_type` onward stays untouched.
+- `contrib/picard/tests/conftest.py` — **modify**: add `rawitems()` to `FakeMetadata`.
+- `contrib/picard/tests/test_map_fields.py` — **rewrite**: new dynamic-shape test suite.
+- `contrib/beets/beetsplug/_core.py` — **modify**: 3 new `RENAME` entries; `comp`→`compilation` in `_DROP_IF_ZERO`.
+- `contrib/beets/tests/test_map_fields.py` — **modify**: rename `comp` test to `compilation`; add a sort-rename test (+ `albumartist_sort` to the stub `_TAG_FIELDS`).
+- `contrib/picard/README.md`, `contrib/beets/README.md` — **modify if** they enumerate field keys.
+
+Note: `contrib/picard/musefs/__init__.py` imports only `map_fields` (public API, signature unchanged: `map_fields(metadata, extra_fields=None)`), so no caller changes are needed. `test_batch_scan.py` monkeypatches `map_fields` with a compatible `(md, fields)` lambda — leave it.
+
+---
+
+## Task 1: Picard — dynamic full-tag-set mapping
+
+**Files:**
+- Modify: `contrib/picard/tests/conftest.py` (FakeMetadata)
+- Test: `contrib/picard/tests/test_map_fields.py` (full rewrite)
+- Modify: `contrib/picard/musefs/_core.py:15-105`
+
+All commands run from `contrib/picard`. No venv or Picard import needed for these stub-based tests.
+
+- [ ] **Step 1: Add `rawitems()` to the FakeMetadata stub**
+
+In `contrib/picard/tests/conftest.py`, the `FakeMetadata` class currently ends with `getall`. Add a `rawitems` method right after it:
+
+```python
+    def getall(self, key):
+        return self._tags.get(key, [])
+
+    def rawitems(self):
+        return self._tags.items()
+```
+
+Leave a comment-free addition; the surrounding class already documents itself. (The stub stores keys verbatim and does NOT replicate Picard's `normalize_tag` trailing-colon stripping — so tests use post-normalize key forms: `comment`, `performer`, never `comment:`.)
+
+- [ ] **Step 2: Rewrite `test_map_fields.py` with the new suite**
+
+Replace the **entire** contents of `contrib/picard/tests/test_map_fields.py` with:
+
+```python
+from musefs._core import map_fields
+
+
+def test_direct_fields_copied(fake_metadata):
+    d = dict(map_fields(fake_metadata(title="Song", artist="Band", album="Disc")))
+    assert d["title"] == "Song"
+    assert d["artist"] == "Band"
+    assert d["album"] == "Disc"
+
+
+def test_all_fields_multi_value_expand(fake_metadata):
+    # The old _MULTI_VALUE_KEYS allowlist is gone: every field emits one row per
+    # value, order preserved.
+    pairs = map_fields(fake_metadata(artist=["First", "Second"]))
+    assert [v for k, v in pairs if k == "artist"] == ["First", "Second"]
+    pairs = map_fields(fake_metadata(genre=["Rock", "Pop"]))
+    assert [v for k, v in pairs if k == "genre"] == ["Rock", "Pop"]
+    pairs = map_fields(fake_metadata(mood=["Happy", "Sad"]))
+    assert [v for k, v in pairs if k == "mood"] == ["Happy", "Sad"]
+
+
+def test_empty_and_whitespace_omitted(fake_metadata):
+    assert dict(map_fields(fake_metadata(title="", artist="   "))) == {}
+
+
+def test_tracknumber_discnumber_passthrough_and_zero_dropped(fake_metadata):
+    d = dict(map_fields(fake_metadata(tracknumber="7", discnumber="2")))
+    assert d["tracknumber"] == "7" and d["discnumber"] == "2"
+    z = dict(map_fields(fake_metadata(tracknumber="0", discnumber="0")))
+    assert "tracknumber" not in z and "discnumber" not in z
+
+
+def test_date_passthrough(fake_metadata):
+    assert dict(map_fields(fake_metadata(date="1999-03-05")))["date"] == "1999-03-05"
+
+
+def test_replaygain_and_misc_passthrough(fake_metadata):
+    d = dict(
+        map_fields(
+            fake_metadata(
+                replaygain_track_gain="-7.50 dB",
+                musicbrainz_albumid="abc",
+                grouping="set",
+                isrc="US-X",
+                label="Label",
+            )
+        )
+    )
+    assert d["replaygain_track_gain"] == "-7.50 dB"
+    assert d["musicbrainz_albumid"] == "abc"
+    assert d["grouping"] == "set" and d["isrc"] == "US-X" and d["label"] == "Label"
+
+
+def test_musicbrainz_id_swap(fake_metadata):
+    # Picard's recording id is the on-disk musicbrainz_trackid; Picard's track id
+    # is the on-disk musicbrainz_releasetrackid. Both source vars present together.
+    d = dict(
+        map_fields(
+            fake_metadata(musicbrainz_recordingid="rec", musicbrainz_trackid="trk")
+        )
+    )
+    assert d["musicbrainz_trackid"] == "rec"
+    assert d["musicbrainz_releasetrackid"] == "trk"
+    assert "musicbrainz_recordingid" not in d
+
+
+def test_musicbrainz_ids_passthrough(fake_metadata):
+    d = dict(
+        map_fields(
+            fake_metadata(
+                musicbrainz_albumid="al",
+                musicbrainz_artistid="ar",
+                musicbrainz_albumartistid="aa",
+                musicbrainz_releasegroupid="rg",
+                musicbrainz_workid="wk",
+            )
+        )
+    )
+    assert d["musicbrainz_albumid"] == "al"
+    assert d["musicbrainz_artistid"] == "ar"
+    assert d["musicbrainz_albumartistid"] == "aa"
+    assert d["musicbrainz_releasegroupid"] == "rg"
+    assert d["musicbrainz_workid"] == "wk"
+
+
+def test_sort_fields_passthrough(fake_metadata):
+    d = dict(map_fields(fake_metadata(artistsort="B, The", albumartistsort="A, An")))
+    assert d["artistsort"] == "B, The"
+    assert d["albumartistsort"] == "A, An"
+
+
+def test_artist_and_artists_both_emitted(fake_metadata):
+    # Picard exposes the credited join string (artist) and the individual list
+    # (artists) as distinct on-disk tags; emit both, no twin-collapse.
+    pairs = map_fields(
+        fake_metadata(
+            artist="Alice & Bob",
+            artists=["Alice", "Bob"],
+            albumartist="Alice & Bob",
+            albumartists=["Alice", "Bob"],
+        )
+    )
+    assert [v for k, v in pairs if k == "artist"] == ["Alice & Bob"]
+    assert [v for k, v in pairs if k == "artists"] == ["Alice", "Bob"]
+    assert [v for k, v in pairs if k == "albumartist"] == ["Alice & Bob"]
+    assert [v for k, v in pairs if k == "albumartists"] == ["Alice", "Bob"]
+
+
+def test_movement_swap(fake_metadata):
+    d = dict(map_fields(fake_metadata(movement="Allegro", movementnumber="1")))
+    assert d["movementname"] == "Allegro"
+    assert d["movement"] == "1"
+
+
+def test_totals_renamed_and_zero_dropped(fake_metadata):
+    d = dict(map_fields(fake_metadata(totaltracks="12", totaldiscs="2")))
+    assert d["tracktotal"] == "12" and d["disctotal"] == "2"
+    z = dict(map_fields(fake_metadata(totaltracks="0", totaldiscs="0")))
+    assert "tracktotal" not in z and "disctotal" not in z
+
+
+def test_compilation_and_bpm_zero_dropped(fake_metadata):
+    assert dict(map_fields(fake_metadata(compilation="1")))["compilation"] == "1"
+    assert "compilation" not in dict(map_fields(fake_metadata(compilation="0")))
+    assert dict(map_fields(fake_metadata(bpm="120")))["bpm"] == "120"
+    assert "bpm" not in dict(map_fields(fake_metadata(bpm="0")))
+    assert "bpm" not in dict(map_fields(fake_metadata(bpm="0.0")))
+    # a fractional, non-zero value must survive (float-aware zero check)
+    assert dict(map_fields(fake_metadata(bpm="128.5")))["bpm"] == "128.5"
+
+
+def test_performer_role_folded_into_value(fake_metadata):
+    pairs = map_fields(fake_metadata(**{"performer:Piano": "Joe Barr"}))
+    assert pairs == [("performer", "Joe Barr (Piano)")]
+
+
+def test_performer_bare_value_only(fake_metadata):
+    pairs = map_fields(fake_metadata(performer="Joe Barr"))
+    assert pairs == [("performer", "Joe Barr")]
+
+
+def test_performer_multiple_roles_accumulate(fake_metadata):
+    pairs = map_fields(
+        fake_metadata(
+            **{
+                "performer:Piano": ["Joe Barr"],
+                "performer:Guitar": ["Ann Lee", "Max Roe"],
+            }
+        )
+    )
+    performers = sorted(v for k, v in pairs if k == "performer")
+    assert performers == ["Ann Lee (Guitar)", "Joe Barr (Piano)", "Max Roe (Guitar)"]
+
+
+def test_comment_and_lyrics_collapse(fake_metadata):
+    # Bare and described forms collapse to the base key; description dropped.
+    d = dict(map_fields(fake_metadata(**{"comment:eng": "hello", "lyrics": "la"})))
+    assert d["comment"] == "hello"
+    assert d["lyrics"] == "la"
+
+
+def test_comment_descriptions_accumulate(fake_metadata):
+    pairs = map_fields(fake_metadata(**{"comment": "main", "comment:eng": "english"}))
+    assert sorted(v for k, v in pairs if k == "comment") == ["english", "main"]
+
+
+def test_hidden_vars_skipped(fake_metadata):
+    pairs = map_fields(
+        fake_metadata(**{"~length": "210000", "~rating": "5", "title": "Keep"})
+    )
+    keys = {k for k, _ in pairs}
+    assert keys == {"title"}
+
+
+def test_extra_fields_override_verbatim(fake_metadata):
+    # The options-page map adds/overrides a store key, last-wins, value verbatim
+    # (no role-fold, no zero-drop). Other fields' natural mapping is unaffected.
+    md = fake_metadata(title="Song", **{"performer:Piano": "Joe Barr"})
+    d = dict(map_fields(md, extra_fields={"performer:Piano": "soloist"}))
+    assert d["soloist"] == "Joe Barr"  # verbatim: NOT "Joe Barr (Piano)"
+    assert d["title"] == "Song"
+
+
+def test_extra_fields_override_replaces_target_key(fake_metadata):
+    md = fake_metadata(title="Song", subtitle="Sub")
+    d = dict(map_fields(md, extra_fields={"title": "subtitle"}))
+    assert d["subtitle"] == "Song"  # override wins over the natural subtitle row
+```
+
+- [ ] **Step 3: Run the rewritten tests to verify they FAIL**
+
+Run: `cd contrib/picard && PYTHONPATH=. python3 -m pytest tests/test_map_fields.py -q`
+Expected: FAIL — the old `map_fields` doesn't do the swaps/folds (e.g. `test_musicbrainz_id_swap`, `test_performer_role_folded_into_value` error/assert).
+
+- [ ] **Step 4: Rewrite the mapping block in `_core.py`**
+
+In `contrib/picard/musefs/_core.py`, replace **lines 15–105 inclusive** — from the `# Picard internal tag name -> musefs ...` comment (line 15) through the final `return pairs` of `map_fields` (line 105) — with the block below. This span contains, in order: the comment, `DIRECT_FIELDS`, `_NUMERIC_KEYS`, `MusefsError`, `_to_int`, `_values`, `_first_value`, `_MULTI_VALUE_KEYS`, `map_fields`. **Do not touch line 14 (`from ._common.sync import ArtImage`) or anything above it**, and leave `# Picard maintype → ID3 picture type ...` and all code below it unchanged. The replacement re-includes `MusefsError` verbatim and swaps `_to_int` for the float-aware `_is_zero`:
+
+```python
+# Picard internal tag name -> canonical musefs store key, for the few names whose
+# on-disk form differs from Picard's variable name. Mirrors the format-agnostic
+# subset of Picard's own var->tag translation (its vorbis.py ``__rtranslate``):
+# the MusicBrainz recording/track id swap, the movement name/number swap, and the
+# track/disc totals. Every other Picard name already equals its on-disk key and
+# passes through verbatim.
+RENAME = {
+    "musicbrainz_recordingid": "musicbrainz_trackid",
+    "musicbrainz_trackid": "musicbrainz_releasetrackid",
+    "movementnumber": "movement",
+    "movement": "movementname",
+    "totaltracks": "tracktotal",
+    "totaldiscs": "disctotal",
+}
+
+# Output keys whose value is dropped when it normalizes to zero (a 0
+# number/total/compilation flag is noise, not data).
+_DROP_IF_ZERO = {
+    "tracknumber",
+    "discnumber",
+    "tracktotal",
+    "disctotal",
+    "compilation",
+    "bpm",
+}
+
+
+class MusefsError(Exception):  # noqa: N818
+    """A user-facing failure (binary missing, scan failed, DB absent)."""
+
+
+def _is_zero(text):
+    """True when ``text`` represents a numeric zero, so a 0 placeholder is
+    dropped. Float-aware (matches the beets sibling's check): non-numeric and
+    fractional non-zero values are not zero and pass through unharmed."""
+    try:
+        return float(text) == 0.0
+    except ValueError:
+        return False
+
+
+def _output_key(name):
+    """Map a Picard tag name to a ``(store_key, performer_role)`` pair.
+
+    ``performer_role`` is ``None`` for ordinary keys; for ``performer`` /
+    ``performer:<role>`` it is the role string ("" when bare) so the caller folds
+    it into the value in Picard's own ``Name (Role)`` form. ``comment`` /
+    ``lyrics`` (bare or with a description) collapse to their base key, dropping
+    the description. Everything else is renamed via ``RENAME`` or passes through
+    verbatim. Picard's ``normalize_tag`` strips trailing colons, so a key only
+    carries a ``:`` when it has a non-empty description/role.
+    """
+    base, _, desc = name.partition(":")
+    if base == "performer":
+        return "performer", desc
+    if base in ("comment", "lyrics"):
+        return base, None
+    return RENAME.get(name, name), None
+
+
+def map_fields(metadata, extra_fields=None):
+    """Map a Picard ``Metadata`` to a list of ``(store_key, value)`` pairs.
+
+    Enumerates every populated tag via ``rawitems``, skipping Picard's hidden
+    ``~``-prefixed internals. Each non-empty value becomes its own row (the store
+    has set semantics); values sharing an output key accumulate, so multi-role
+    performers and multi-description comments all survive. Keys are canonicalized
+    by :func:`_output_key`; ``_DROP_IF_ZERO`` keys drop a zero value.
+    ``extra_fields`` (the options-page ``picard_field -> store_key`` map) is a
+    final override layer applied verbatim — no role-fold, no zero-drop.
+    """
+    emitted = {}  # store_key -> list[str], insertion-ordered, accumulating
+    for name, values in metadata.rawitems():
+        if name.startswith("~"):
+            continue
+        key, role = _output_key(name)
+        for raw in values:
+            text = str(raw).strip()
+            if not text:
+                continue
+            if role:
+                text = f"{text} ({role})"
+            if key in _DROP_IF_ZERO and _is_zero(text):
+                continue
+            emitted.setdefault(key, []).append(text)
+
+    if extra_fields:
+        for pic_field, store_key in extra_fields.items():
+            values = [t for v in metadata.getall(pic_field) if (t := str(v).strip())]
+            if values:
+                emitted[store_key] = values
+
+    return [(key, value) for key, values in emitted.items() for value in values]
+```
+
+- [ ] **Step 5: Run the map_fields + contract tests to verify they PASS**
+
+Run: `cd contrib/picard && PYTHONPATH=. python3 -m pytest tests/test_map_fields.py tests/test_contract.py -q`
+Expected: PASS (all map_fields tests + the unchanged shared contract).
+
+- [ ] **Step 6: Run the full Picard stub suite to confirm no regression**
+
+Run: `cd contrib/picard && PYTHONPATH=. python3 -m pytest tests -q`
+Expected: PASS or skips only. Real-Picard/Qt tests (e.g. `test_plugin_loads`, `test_options_page`) silently skip without an importable Picard — that's expected here (verified for real in Task 4). No failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/picard-tags
+git add contrib/picard/musefs/_core.py contrib/picard/tests/conftest.py contrib/picard/tests/test_map_fields.py
+git commit -m "$(cat <<'EOF'
+feat(picard): map Picard's full tag set, not a static whitelist
+
+Enumerate every populated Picard tag via rawitems() instead of the fixed
+~20-field DIRECT_FIELDS, emitting standard on-disk store keys: the
+MusicBrainz recording/track id swap, movement swap, track/disc totals,
+sort/credit fields, per-role performers (folded to "Name (Role)"), and
+comment/lyrics collapse. Hidden ~-prefixed vars are skipped; all fields
+multi-value-expand; numeric zero placeholders are dropped. Fixes #424.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(The pre-commit hook runs fmt + clippy + the full workspace test suite + ruff; a Python-only change keeps the Rust suite green. Do NOT use `--no-verify`.)
+
+---
+
+## Task 2: beets — realign outlier keys to the on-disk standard
+
+**Files:**
+- Modify: `contrib/beets/beetsplug/_core.py` (`RENAME`, `_DROP_IF_ZERO`)
+- Modify: `contrib/beets/tests/test_map_fields.py`
+
+beets needs a venv (PEP 668; none currently exists). Note: a grep of `contrib/beets/tests/` for `comp`/`artist_sort`/`albumartist_sort` confirmed `test_map_fields.py` is the **only** test asserting these output keys — no other beets test needs updating.
+
+- [ ] **Step 1: Ensure the beets venv exists with the local deps**
+
+Run:
+```bash
+cd /home/cfutro/git/musefs/.worktrees/picard-tags/contrib/beets
+[ -x .venv/bin/python ] || python3 -m venv .venv
+.venv/bin/pip install -q -e ../python-musefs && .venv/bin/pip install -q -e ".[test]"
+.venv/bin/python -m pytest tests/test_map_fields.py -q
+```
+Expected: the existing suite PASSES (baseline before changes).
+
+- [ ] **Step 2: Update the beets tests to the realigned keys**
+
+In `contrib/beets/tests/test_map_fields.py`:
+
+(a) Add `albumartist_sort` to the stub `_TAG_FIELDS` tuple (so the sort test can set it). Insert it right after the existing `"artists_sort",` line:
+
+```python
+    "artist_sort",
+    "artists_sort",
+    "albumartist_sort",
+```
+
+(b) Replace the `test_comp_one_kept_zero_dropped` function with:
+
+```python
+def test_comp_renamed_to_compilation_and_zero_dropped():
+    # beets `comp` is a 0/1 int; it maps to the on-disk `compilation` key.
+    # 1 -> kept "1", 0/False -> dropped.
+    assert dict(map_fields(item(comp=True)))["compilation"] == "1"
+    assert dict(map_fields(item(comp=1)))["compilation"] == "1"
+    assert "comp" not in dict(map_fields(item(comp=True)))
+    assert "compilation" not in dict(map_fields(item(comp=False)))
+    assert "compilation" not in dict(map_fields(item(comp=0)))
+```
+
+(c) Add a new sort-rename test (place it after the function above):
+
+```python
+def test_sort_fields_renamed_to_on_disk_keys():
+    # artist_sort/albumartist_sort are beets' internal attribute names; the
+    # on-disk standard (matching Picard) is artistsort/albumartistsort.
+    d = dict(map_fields(item(artist_sort="Beatles, The", albumartist_sort="V, The")))
+    assert d["artistsort"] == "Beatles, The"
+    assert d["albumartistsort"] == "V, The"
+    assert "artist_sort" not in d and "albumartist_sort" not in d
+    # plural twin collapses to the singular attr, then renames to on-disk key
+    pairs = map_fields(item(artists_sort=["A", "B"]))
+    assert [v for k, v in pairs if k == "artistsort"] == ["A", "B"]
+```
+
+- [ ] **Step 3: Run the beets map_fields tests to verify the new ones FAIL**
+
+Run: `cd contrib/beets && .venv/bin/python -m pytest tests/test_map_fields.py -q`
+Expected: FAIL — `test_comp_renamed_to_compilation_and_zero_dropped` and `test_sort_fields_renamed_to_on_disk_keys` fail (current code still emits `comp`/`artist_sort`).
+
+- [ ] **Step 4: Add the three `RENAME` entries in `beetsplug/_core.py`**
+
+In `contrib/beets/beetsplug/_core.py`, the `RENAME` dict ends with `"mb_workid": "musicbrainz_workid",`. Add three entries before the closing `}`:
+
+```python
+    "mb_workid": "musicbrainz_workid",
+    "artist_sort": "artistsort",
+    "albumartist_sort": "albumartistsort",
+    "comp": "compilation",
+}
+```
+
+- [ ] **Step 5: Update `_DROP_IF_ZERO` in `beetsplug/_core.py`**
+
+In the same file, change the `_DROP_IF_ZERO` set: replace the `"comp",` line with `"compilation",` (it is keyed on the output key, which is now `compilation`):
+
+```python
+    "disctotal",
+    "compilation",
+    "bpm",
+```
+
+- [ ] **Step 6: Run the beets map_fields tests to verify they PASS**
+
+Run: `cd contrib/beets && .venv/bin/python -m pytest tests/test_map_fields.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full beets suite to confirm no regression**
+
+Run: `cd contrib/beets && .venv/bin/python -m pytest tests -q`
+Expected: PASS (opt-in `musefs_bin`/`e2e` tiers are skipped by default). The shared contract test (`test_contract.py`) is unaffected — it covers only title/artist/album/genre/composer.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/picard-tags
+git add contrib/beets/beetsplug/_core.py contrib/beets/tests/test_map_fields.py
+git commit -m "$(cat <<'EOF'
+fix(beets): emit on-disk-standard store keys for sort and compilation
+
+Map beets' internal attribute names artist_sort/albumartist_sort/comp to
+the on-disk tag names artistsort/albumartistsort/compilation, so a
+beets-produced musefs view matches what beets (via MediaFile) and Picard
+both write to real files, and the two plugins converge on one canonical
+key set. Old keys clear via the accumulating musefs_managed delete_keys
+diff on the next sync. Part of #424.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Documentation
+
+**Files:** `contrib/picard/README.md` (two edits). `contrib/beets/README.md` needs **no change** — verified: its "Field coverage" note (line 120) already says "every tag beets writes to a file … is synced … under canonical musefs keys" and it documents no outlier key spellings (`comp`/`artist_sort` appear nowhere in it).
+
+- [ ] **Step 1: Fix the stale "Extra field map" example in the Picard README**
+
+The plugin now syncs the full tag set automatically, so the old `comment=comment` example (comment maps by default) is misleading. In `contrib/picard/README.md`, replace these two lines (49–50):
+
+```markdown
+- **Extra field map** — optional `key=value` list mapping extra Picard tag names
+  to musefs keys, e.g. `comment=comment`.
+```
+
+with:
+
+```markdown
+- **Extra field map** — optional `key=value` list mapping additional or custom
+  Picard tag names to musefs store keys (applied verbatim, last-wins, on top of
+  the automatic full-tag-set sync), e.g. `mymood=mood`.
+```
+
+- [ ] **Step 2: Add a "Field coverage" note to the Picard README Notes section**
+
+In the `## Notes` section, immediately after the bullet `- **Tags are fully replaced** with Picard's view on every sync.`, insert:
+
+```markdown
+- **Field coverage:** every populated Picard tag is synced under its canonical
+  musefs (on-disk) key — all MusicBrainz IDs, sort and performer/credit fields,
+  movement, totals, and any custom field; multi-values expand and per-role
+  performers fold to `Name (Role)`. Picard's hidden `~` internals (length,
+  rating, …) are never written.
+```
+
+- [ ] **Step 3: Verify the rendered Markdown reads cleanly**
+
+Run: `sed -n '44,72p' contrib/picard/README.md`
+Expected: the updated "Extra field map" bullet and the new "Field coverage" bullet appear, correctly placed and formatted.
+
+- [ ] **Step 4: Commit (docs-only)**
+
+```bash
+cd /home/cfutro/git/musefs/.worktrees/picard-tags
+git add contrib/picard/README.md
+git commit -m "$(cat <<'EOF'
+docs(picard): document full tag-set mapping coverage
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(Docs-only commits skip the cargo gate; ruff/shellcheck/yamllint legs still run.)
+
+---
+
+## Task 4: Final verification (real Picard + both suites)
+
+No code changes — confirm the change works against real Picard and re-run both suites.
+
+- [ ] **Step 1: Run the Picard suite against real Picard (the silently-skipped tests)**
+
+Run:
+```bash
+cd /home/cfutro/git/musefs/.worktrees/picard-tags/contrib/picard
+PYTHONPATH=".:/usr/lib/picard:/usr/lib/python3/dist-packages" /usr/bin/python3 -m pytest tests -q
+```
+Expected: the real-Picard tests now execute (not skip) and PASS. `pytest-qt`-dependent tests (qtbot/qapp) may still skip if pytest-qt is absent — that's acceptable. No failures. (If `test_map_fields`/`test_contract` were already green under the stub run, they stay green here.)
+
+- [ ] **Step 2: Re-run the beets suite**
+
+Run: `cd contrib/beets && .venv/bin/python -m pytest tests -q`
+Expected: PASS.
+
+- [ ] **Step 3: Confirm the git log**
+
+Run: `git log --oneline -4`
+Expected: the picard feat, beets fix, and docs commits on `picard-tags` atop `bfef2f7`.
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Spec coverage:** enumeration + `~`-skip + multi-value (Task 1 §1), `_output_key`/RENAME/colon-fold (Task 1 §2), drop-if-zero (Task 1 §3), `extra_fields` verbatim (Task 1 §4), removed symbols (Task 1 Step 4 replaces the block), beets §6 alignment (Task 2), tests both plugins (Tasks 1–2), docs (Task 3), real-Picard verification (Task 4). The migration note and convergence audit in the spec are informational (no code).
+- **No `--no-verify`, no `--amend`** (project rule). Each non-docs commit runs the full workspace suite via the pre-commit hook; a Python-only change keeps Rust green.
+- **Signature stability:** `map_fields(metadata, extra_fields=None)` is unchanged; `__init__.py` calls `map_fields(f.metadata, opts.fields)` positionally — still valid.
+- **`normalize_tag` reality:** real Picard yields bare `comment`/`performer` (trailing colon stripped) and `comment:eng`/`performer:Piano` for real descriptions; the stub stores keys verbatim, so tests use those post-normalize forms.

--- a/docs/superpowers/specs/2026-06-15-picard-full-tagset-mapping-design.md
+++ b/docs/superpowers/specs/2026-06-15-picard-full-tagset-mapping-design.md
@@ -1,0 +1,300 @@
+# Picard plugin: full tag-set mapping (issue #424)
+
+## Problem
+
+The Picard plugin (`contrib/picard/musefs/_core.py`) maps a fixed ~20-field
+whitelist (`DIRECT_FIELDS`). Among MusicBrainz identifiers it forwards only
+`musicbrainz_albumid` and `musicbrainz_artistid`, dropping recording / track /
+release-group / work / album-artist IDs. It also omits sort fields
+(`artistsort`, `albumartistsort`, …), performer/credit fields, movement, totals,
+and anything else Picard sets. A musefs view produced by Picard therefore loses
+much of the metadata Picard itself generates.
+
+The beets sibling (`contrib/beets/beetsplug/_core.py`) already maps the host's
+full tag set dynamically. This change brings the Picard plugin to the same level
+of coverage.
+
+## Goal
+
+Replace the static `DIRECT_FIELDS` whitelist with dynamic enumeration of
+Picard's entire metadata, so every tag Picard sets reaches the store under the
+correct **canonical store key** — the on-disk tag name a real tagged file
+carries.
+
+## Key principle: store keys are on-disk tag names
+
+musefs's Rust format layer canonicalizes only the ~22 keys in
+`musefs-format/src/tagmap.rs::VOCAB`; every other key round-trips **verbatim**
+through each format's extension slot, i.e. the store key becomes the synthesized
+file's field name directly. So for non-VOCAB fields the store key must be the
+**standard on-disk tag name**.
+
+That standard is what *both* taggers write to real files:
+
+- Picard writes sort tags as `ARTISTSORT` / `ALBUMARTISTSORT` and compilation as
+  `COMPILATION` (Picard's `vorbis.py` passes them through verbatim; not in its
+  `__translate` table).
+- beets writes the *same* on-disk tags: MediaFile maps its internal attributes
+  `artist_sort → ARTISTSORT`, `albumartist_sort → ALBUMARTISTSORT`,
+  `comp → COMPILATION` (`mediafile/__init__.py`).
+
+The beets *plugin* currently emits its host's **internal attribute** spellings
+(`artist_sort`, `albumartist_sort`, `comp`) as store keys, which diverge from the
+on-disk standard. **This work fixes both siblings**: the Picard plugin emits the
+standard on-disk names from the start (§1–§5), and the beets plugin is realigned
+to the same standard (§6), so the two converge on one canonical key set.
+
+The MusicBrainz ID swap is the same in both Picard's and beets' on-disk output,
+so the two siblings agree there once this change lands.
+
+## Design
+
+### 1. Enumeration
+
+`map_fields(metadata, extra_fields=None)` iterates `metadata.rawitems()` (real
+Picard returns `(name, [values])` pairs). For each `(name, values)`:
+
+- **Skip** if `name.startswith("~")` — Picard's hidden/internal vars (`~length`,
+  `~rating`, file facts). Picard has no `_media_tag_fields`-style boundary like
+  beets; the `~` prefix is the *only* gate, and it is sufficient: every Picard
+  file-fact / derived var is `~`-prefixed, and all enumerable non-`~` keys are
+  genuine tags (`picard/util/tags.py::TAG_NAMES`) or user-defined tags that
+  should round-trip. A test enumerates known `~` vars to lock this in (§Tests).
+- Derive the output key from `name` (§2).
+- **Expand every value** to its own `(key, value)` row — the store has set
+  semantics, matching beets. This **retires `_MULTI_VALUE_KEYS`**: *all* fields
+  multi-value-expand, not just a hardcoded allowlist of four.
+- Drop empty / whitespace-only values.
+- Apply numeric drop-if-zero (§3).
+
+**Collision model: accumulate, do not first-writer-win.** The `emitted` dict
+maps output key → list of values, and each source **extends** (appends to) its
+output key's list. This differs deliberately from the beets sibling's
+first-writer-wins rule, which exists there only to let a *plural twin* claim its
+singular key. Picard needs accumulation instead because multiple distinct source
+keys legitimately collapse to one output key — chiefly per-role performers
+(`performer:Piano`, `performer:Guitar` → several `performer` rows) and
+multi-description comments (`comment:eng`, `comment:deu`). First-writer-wins
+would silently drop the later roles/comments. After the §2 RENAME swaps, no two
+*non-colon* source vars map to the same output key (the MB-ID and movement
+renames are clean bijective swaps), so accumulation never produces spurious
+duplicates for ordinary fields.
+
+**No twin-collapse (unlike beets).** Picard exposes `artist` (the credited
+join-phrase string, e.g. `"Alice & Bob"`) and `artists` (the individual-name
+list) as **distinct on-disk tags** (`ARTIST` vs `ARTISTS`; same for
+`albumartist`/`albumartists`). Picard writes both to a file, so — under the
+on-disk-fidelity principle — the plugin emits both as separate keys (`artist`,
+`artists`, `albumartist`, `albumartists`) rather than collapsing the plural into
+the singular. `artists`/`albumartists` are not in VOCAB and round-trip verbatim
+(`ARTISTS` in Vorbis, `TXXX:ARTISTS` in ID3 — matching Picard). This is an
+*intentional, acceptable* representation divergence from the beets sibling (which
+collapses `artists → artist`); both produce valid standard tags, just structured
+per host. It is **not** in scope to change beets' twin handling.
+
+### 2. Output key derivation (`_output_key`)
+
+Applies Picard's own universal var→tag conventions (the format-agnostic subset
+of Picard's `vorbis.py` `__rtranslate` plus the colon-suffix handling):
+
+**RENAME map** (Picard var → canonical store key):
+
+```
+musicbrainz_recordingid -> musicbrainz_trackid
+musicbrainz_trackid     -> musicbrainz_releasetrackid
+movementnumber          -> movement
+movement                -> movementname
+totaltracks             -> tracktotal
+totaldiscs              -> disctotal
+```
+
+**Colon-suffixed keys.** Picard's `Metadata.normalize_tag()` is
+`name.rstrip(':')` (`/usr/lib/picard/picard/metadata.py:459`), so the keys that
+actually arrive via `rawitems()` are **either bare** (`comment`, `lyrics`,
+`performer` — the empty-description case) **or carry a non-empty description**
+(`comment:eng`, `performer:Piano`). A trailing-colon-only key (`comment:`) is
+*never* yielded; the spec and tests must use the post-normalize forms. Detect a
+description by splitting on the first `:` and checking the suffix is non-empty:
+
+- `performer:<role>` → key `performer`, value folded to Picard's own form:
+  `"<value> (<role>)"`. Bare `performer` → key `performer`, value verbatim. (Per
+  the settled decision: preserve the role by folding it into the value, exactly
+  how Picard renders performers to a file.) Each value in the list folds
+  independently; multiple roles **accumulate** under `performer` (per §1).
+- `comment:<desc>` → key `comment`, value **verbatim** (description dropped).
+  Bare `comment` → key `comment`, value verbatim.
+- `lyrics:<desc>` → key `lyrics`, value **verbatim**. Bare `lyrics` → `lyrics`.
+
+  Rationale for *collapse, don't fold* on comment/lyrics: folding a description
+  into the value (`"text (eng)"`) is a Vorbis-specific rendering that would
+  corrupt the structured ID3 `COMM` / MP4 `©cmt` frames the format layer
+  produces. The description is empty in the overwhelmingly common case (the key
+  arrives bare), so collapsing to the VOCAB-canonical base key loses nothing in
+  practice while keeping comments correct across all formats. Multiple
+  descriptions accumulate as separate `comment`/`lyrics` rows (per §1).
+
+**Everything else**: the name lowercased verbatim (Picard names are already
+lowercase) — so `artistsort`, `albumartistsort`, `albumsort`, `composersort`,
+`titlesort`, `compilation`, `isrc`, `label`, `barcode`, `acoustid_id`, all other
+`musicbrainz_*` IDs, etc. pass straight through with their standard on-disk
+names.
+
+### 3. Numeric drop-if-zero
+
+For these **output** keys, drop a value that parses to integer 0 (reusing
+`_to_int`), so Picard's "0" placeholders don't leak as tags:
+
+```
+{tracknumber, discnumber, tracktotal, disctotal, compilation, bpm}
+```
+
+Picard stores track/disc numbers and totals as **scalar** strings (it splits the
+combined `"1/12"` form into separate `tracknumber`/`totaltracks` vars), so
+`_to_int` never sees a slash form here and is safe on these keys.
+
+### 4. `extra_fields` override
+
+Unchanged in spirit: the options-page field map remains a final
+`picard_field → store_key` override layer, last-wins. Implemented by reading
+`metadata.getall(picard_field)` for each mapping and **replacing**
+`emitted[store_key]` with those (non-empty) values, overriding any natural
+mapping. (`getall` is retained on `metadata` for this path; it applies
+`normalize_tag`, so a source field written with a trailing colon resolves to its
+normalized key.)
+
+Override values are taken **verbatim**: the override path does *not* apply the
+performer/comment colon-fold, the §3 numeric drop-if-zero, or the §2 RENAME — the
+user has explicitly named both the source field and the target store key, so the
+plugin honors that mapping literally. (Consequence: mapping a source like
+`performer:Piano` yields the unfolded player name under the chosen key; documented
+so it is not mistaken for a bug.)
+
+### 5. Functions removed / changed
+
+- `DIRECT_FIELDS`, `_MULTI_VALUE_KEYS` — removed (superseded by enumeration).
+- `_first_value` — removed (no longer single-value-per-field).
+- `_values` — removed; value iteration/stripping is inlined into the enumeration
+  loop (every key multi-value-expands now, so the per-field helper is redundant).
+- `_NUMERIC_KEYS` → replaced by the §3 drop-if-zero set keyed on output keys.
+- New: `RENAME` map, `_output_key` (RENAME + colon split), and a small
+  performer value-fold helper.
+
+### 6. beets sibling alignment (in scope)
+
+`contrib/beets/beetsplug/_core.py` — realign the three outlier output keys to the
+on-disk standard so both plugins emit identical store keys:
+
+- Add to `RENAME` (applied by `_output_key` after TWINS collapse):
+  ```
+  artist_sort      -> artistsort
+  albumartist_sort -> albumartistsort
+  comp             -> compilation
+  ```
+  This also covers the plural twins automatically: `artists_sort →
+  artist_sort → artistsort`, `albumartists_sort → albumartist_sort →
+  albumartistsort` (TWINS collapse runs first in `_output_key`).
+- Update `_DROP_IF_ZERO`: replace `comp` with `compilation` (the set is keyed on
+  the **output** key, which is now `compilation`). `tracktotal` / `disctotal`
+  already match the standard and stay.
+- The `artist_credit` / `albumartist_credit` keys are left unchanged: Picard has
+  no credit field, so there is no cross-sibling conflict and no established
+  on-disk standard to realign to.
+
+**Convergence audit (verified):** beyond the three keys above, the siblings
+already agree on every shared field — track/disc numbers and totals, ReplayGain,
+the MB-ID swap, `comments → comment`, and the artist/albumartist/genre/composer
+families. beets has no per-role performer concept and no `lyrics:<desc>` form, so
+the §2 colon-collapse introduces no new divergence. The one accepted,
+intentional difference is artist/artists representation (§1, "No twin-collapse"):
+Picard emits both `artist` and `artists`; beets collapses to `artist`. Both are
+valid standard tags; reconciling that is explicitly out of scope.
+
+**Migration note:** existing stores written by the old beets plugin hold the old
+keys (`comp`, `artist_sort`, `albumartist_sort`), recorded in each item's
+accumulating `musefs_managed` flexattr. After this change the plugin emits the new
+keys, and `build_records` computes `delete_keys = prev - keys_now`
+(`contrib/beets/beetsplug/_core.py`), so on the next sync the old keys are placed
+in `delete_keys` and cleared by `merge_tags`. The convergence is therefore clean
+by design — no stale duplicates — with the old keys lingering only as harmless
+re-deleted tombstones in the managed set (until `restore_backing` forgets them).
+No data loss; the realigned values reappear under the new keys in the same sync.
+
+## Tests
+
+`contrib/picard/tests/`:
+
+- **`conftest.py`**: extend `FakeMetadata` to be enumerable — add
+  `rawitems()` returning `self._tags.items()` (it already stores
+  `{key: [values]}`); keep `getall` for the `extra_fields` path. **Note:** the
+  stub stores keys verbatim and does *not* replicate Picard's
+  `normalize_tag` trailing-colon stripping — so test authors must write the
+  post-normalize key form (`comment`, `performer`), never `comment:`, to match
+  what real Picard yields.
+- **`test_map_fields.py`**: rework existing assertions to the new dynamic shape
+  and add coverage for:
+  - MB ID swap: `musicbrainz_recordingid → musicbrainz_trackid`,
+    `musicbrainz_trackid → musicbrainz_releasetrackid`, and the unchanged
+    `musicbrainz_albumid/artistid/albumartistid/releasegroupid/workid`.
+  - **MB IDs both present together:** with `musicbrainz_recordingid` *and*
+    `musicbrainz_trackid` both set on one metadata, assert the output has both
+    `musicbrainz_trackid` (from recording) and `musicbrainz_releasetrackid`
+    (from track), distinct and not clobbered — guards the swap ordering.
+  - Sort fields pass through (`artistsort`, `albumartistsort`).
+  - **artist/artists both emitted:** `artist="Alice & Bob"`, `artists=["Alice","Bob"]`
+    → key `artist` = `"Alice & Bob"` and key `artists` = `["Alice","Bob"]`, kept
+    separate (no twin-collapse). Same for `albumartist`/`albumartists`.
+  - Performer role-fold: `performer:Piano = "Joe Barr"` →
+    `("performer", "Joe Barr (Piano)")`; bare `performer` → value only.
+  - **Performer multi-role accumulation:** `performer:Piano=["Joe Barr"]` and
+    `performer:Guitar=["Ann Lee"]` both present → two `performer` rows
+    (`"Joe Barr (Piano)"`, `"Ann Lee (Guitar)"`), neither dropped; and a single
+    role with two players folds each independently.
+  - Comment/lyrics collapse: bare `comment` and `comment:eng` both → key
+    `comment`, value verbatim (description dropped); multiple descriptions
+    accumulate as separate rows; same for `lyrics`.
+  - Totals rename + zero-drop: `totaltracks → tracktotal`, etc.
+  - Arbitrary field multi-value expansion (e.g. two `mood` values).
+  - `~`-prefixed keys skipped (e.g. `~length`, `~rating`) — and a positive case
+    asserting non-`~` tags alongside them still emit, confirming `~`-prefix is
+    the correct, sufficient gate.
+  - `compilation` / `bpm` zero-drop.
+  - **`extra_fields` semantics:** override replaces the natural mapping
+    (last-wins) and takes the value **verbatim** — no colon-fold, no zero-drop
+    (e.g. mapping a `performer:*` source yields the unfolded player name).
+- **`test_contract.py`**: the shared `musefs_common/contract.py` contract
+  (title/artist/albumartist/album/genre/composer only) must keep passing
+  unchanged — a guard that the rework preserves the shared behavior.
+
+`contrib/beets/tests/`:
+
+- **`test_map_fields.py`**: update assertions that reference the realigned keys —
+  `test_comp_one_kept_zero_dropped` now asserts the `compilation` output key
+  (`comp=True → ("compilation", "1")`, zero dropped); add a sort-rename test
+  asserting `artist_sort → artistsort` and `albumartist_sort → albumartistsort`.
+- Grep the rest of `contrib/beets/tests/` (e.g. `test_build_records.py`,
+  `test_reconcile.py`, `test_managed_state.py`, `test_contract.py`) for the
+  literals `"comp"`, `"artist_sort"`, `"albumartist_sort"` and update any that
+  assert the old output keys. The shared contract test is unaffected (it doesn't
+  cover these fields).
+
+Run the real-Picard contrib tests before pushing (they silently skip without an
+importable Picard): `/usr/bin/python3` with `PYTHONPATH` to `/usr/lib/picard`
+and dist-packages PyQt5 (see CONTRIBUTING.md / project memory).
+
+## Documentation
+
+- Check `contrib/picard/README.md` first: if it documents the fixed field list,
+  replace that with the dynamic full-tag-set mapping (the `~`-skip, performer
+  role-fold, comment/lyrics collapse, artist/artists both emitted, and the
+  options-page `fields:` override). If it doesn't enumerate fields, the doc edit
+  is smaller — just note the broadened coverage.
+- Check `contrib/beets/README.md` for any documented store-key spellings
+  (`comp`, `artist_sort`) and update them to the realigned standard names.
+
+## Out of scope / follow-up
+
+- Picard format-peculiar value rewrites that are *not* universal (e.g.
+  `musicip_fingerprint → fingerprint` with a value prefix, Vorbis
+  `sanitize_date`) are intentionally **not** replicated: the store is
+  format-agnostic and the Rust layer handles per-format rendering. Such fields
+  pass through verbatim.


### PR DESCRIPTION
## What & why

Fixes #424. The Picard plugin mapped a fixed ~20-field whitelist (`DIRECT_FIELDS`), forwarding only `musicbrainz_albumid`/`musicbrainz_artistid` among MusicBrainz IDs and dropping recording/track/release-group/work IDs, sort fields, performers, movement, totals, and anything else Picard sets. A musefs view produced by Picard lost much of the metadata Picard generates.

This replaces the whitelist with **dynamic enumeration of Picard's full metadata** and emits **standard on-disk store keys** (the keys musefs writes verbatim into synthesized files for non-VOCAB tags). It also **realigns the beets sibling's three outlier keys** so both plugins converge on the same on-disk standard.

## Picard plugin

`map_fields` now enumerates `metadata.rawitems()` and:
- skips Picard's hidden `~`-prefixed internals (length, rating, file facts);
- expands **every** field's values to one row each (the old `_MULTI_VALUE_KEYS` allowlist is gone);
- applies Picard's own var→tag conventions (the format-agnostic subset of its `vorbis.py __rtranslate`): the MusicBrainz **recording/track id swap** (`musicbrainz_recordingid → musicbrainz_trackid`, `musicbrainz_trackid → musicbrainz_releasetrackid`), the **movement** name/number swap, and `totaltracks/totaldiscs → tracktotal/disctotal`;
- folds per-role **performers** into Picard's own `Name (Role)` form and accumulates multiple roles;
- collapses `comment:<desc>`/`lyrics:<desc>` to their canonical base key (description dropped);
- emits `artist` **and** `artists` (and the albumartist pair) as the distinct on-disk tags Picard writes — no twin-collapse;
- drops numeric zero placeholders via a float-aware check (so a fractional `bpm` survives);
- keeps the options-page `fields:` map as a final verbatim `picard_field → store_key` override.

## beets plugin

beets wrote `artist_sort`/`albumartist_sort`/`comp` as store keys — its internal **attribute** names. But beets-via-MediaFile (and Picard) both write the on-disk tags `ARTISTSORT`/`ALBUMARTISTSORT`/`COMPILATION`. Three `RENAME` entries (+ a `_DROP_IF_ZERO` rekey) realign beets to those standard names, so a beets- or Picard-produced view matches a real tagged file and the two siblings agree. Existing stores converge cleanly on the next sync via the accumulating `musefs_managed` `delete_keys` diff (no stale duplicates, no data loss).

## Key principle

musefs's Rust format layer canonicalizes only ~22 keys (`musefs-format/src/tagmap.rs::VOCAB`); every other store key round-trips verbatim as the synthesized file's field name. So non-VOCAB store keys must be the standard **on-disk** tag name — which is what both taggers write to real files. The choice is "match the on-disk standard," not "prefer one tagger."

## Tests

- Picard (real Picard 2.13.3 + PyQt5, headless): **56 passed, 0 skipped** — including the pytest-qt options-page and sync-callback tests.
- beets: **64 passed**.
- Rust workspace: green via the pre-commit gate (fmt + clippy + full workspace test suite + ruff) on each implementation commit.

New coverage: MB-ID swap (incl. both source vars present), sort passthrough, artist/artists both emitted, movement swap, totals rename + zero-drop, performer fold + multi-role accumulation, comment/lyrics collapse + accumulation, `~`-skip, float-aware bpm zero-drop, and both `extra_fields` override semantics; beets gains a comp→compilation and a sort-rename test.

Design + plan: `docs/superpowers/specs/2026-06-15-picard-full-tagset-mapping-design.md`, `docs/superpowers/plans/2026-06-15-picard-full-tagset-mapping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)