### PR TITLE
perf(musefs-core): fan out prefetch workers, share dispatch context (#430, #431)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -467,7 +467,7 @@ exclude_re = [
     # the ring under the read lock); the fn's other two `+` are the observable fills
     # counters and stay killable, so this one is pinned by coordinate, not by fn.
     # guard: op="+" fn="BackingReader<'a>::read_exact_at" rows=2
-    'musefs-core/src/readahead\.rs:584:68:',
+    'musefs-core/src/readahead\.rs:591:68:',
     #
     # More hang-class (TIMEOUT-only, CANCEL the in-diff job): `len() -> 1` /
     # `clear() -> 1` force a constant resident size, so `evict_one_coldest` keeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +959,7 @@ dependencies = [
  "base64",
  "crc",
  "criterion",
+ "crossbeam-channel",
  "dashmap",
  "id3",
  "im",

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -11,6 +11,7 @@ metrics = []
 
 [dependencies]
 arc-swap = "1"
+crossbeam-channel = "0.5"
 dashmap = "6"
 im = "15"
 log = "0.4"

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -450,16 +450,21 @@ impl Musefs {
             return Ok(());
         }
         let dispatched_epoch = h.epoch.load(Ordering::Acquire);
+        // All windows in this dispatch share one context, so each job bumps a
+        // single refcount instead of re-cloning four Arcs per window (#431).
+        let ctx = Arc::new(crate::readahead::PrefetchContext {
+            file: Arc::clone(&h.file),
+            buf: Arc::clone(&h.readahead),
+            pool: Arc::clone(&self.readahead_pool),
+            epoch: Arc::clone(&h.epoch),
+            dispatched_epoch,
+            len: window,
+            backing_len,
+        });
         for s in starts {
             pf.request(crate::readahead::PrefetchJob {
-                file: Arc::clone(&h.file),
-                buf: Arc::clone(&h.readahead),
-                pool: Arc::clone(&self.readahead_pool),
-                epoch: Arc::clone(&h.epoch),
-                dispatched_epoch,
+                ctx: Arc::clone(&ctx),
                 start: s,
-                len: window,
-                backing_len,
             });
         }
         Ok(())

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -406,37 +406,43 @@ pub fn plan_prefetch(
 }
 
 use std::cell::Cell;
-use std::sync::mpsc;
 
-pub struct PrefetchJob {
+/// The per-dispatch inputs shared by every window planned from one read: the
+/// same file/buffer/pool/epoch at the same dispatched epoch. Held once behind an
+/// `Arc` so each `PrefetchJob` bumps a single refcount instead of re-cloning the
+/// four Arcs per window (#431).
+pub struct PrefetchContext {
     pub file: Arc<std::fs::File>,
     pub buf: Arc<Mutex<ReadAhead>>,
     pub pool: Arc<ReadAheadPool>,
-    pub epoch: Arc<std::sync::atomic::AtomicU64>,
+    pub epoch: Arc<Epoch>,
     pub dispatched_epoch: u64,
-    pub start: u64,
     pub len: u64,
     pub backing_len: u64,
 }
 
+pub struct PrefetchJob {
+    pub ctx: Arc<PrefetchContext>,
+    pub start: u64,
+}
+
 pub struct PrefetchWorkers {
-    tx: mpsc::SyncSender<PrefetchJob>,
+    tx: crossbeam_channel::Sender<PrefetchJob>,
     #[cfg(test)]
     handles: Vec<std::thread::JoinHandle<()>>,
 }
 
 impl PrefetchWorkers {
     pub fn new(threads: usize) -> Self {
-        let (tx, rx) = mpsc::sync_channel::<PrefetchJob>(threads * 4);
-        let rx = Arc::new(Mutex::new(rx));
+        // A multi-consumer channel: every worker owns its own `Receiver` clone and
+        // blocks in `recv` independently, so job hand-off and wake-ups fan out
+        // across all threads instead of serializing behind one shared lock (#430).
+        let (tx, rx) = crossbeam_channel::bounded::<PrefetchJob>(threads * 4);
         let mut handles = Vec::new();
         for _ in 0..threads {
-            let rx = Arc::clone(&rx);
+            let rx = rx.clone();
             let h = std::thread::spawn(move || {
-                while let Ok(job) = {
-                    let g = rx.lock().unwrap();
-                    g.recv()
-                } {
+                while let Ok(job) = rx.recv() {
                     Self::run_job(job);
                 }
             });
@@ -452,28 +458,29 @@ impl PrefetchWorkers {
     #[expect(clippy::needless_pass_by_value)]
     pub fn run_job(job: PrefetchJob) {
         use std::os::unix::fs::FileExt;
-        if job.epoch.load(std::sync::atomic::Ordering::Acquire) != job.dispatched_epoch {
+        let ctx = &job.ctx;
+        if ctx.epoch.load(std::sync::atomic::Ordering::Acquire) != ctx.dispatched_epoch {
             return;
         }
-        let want = job.len.min(job.backing_len.saturating_sub(job.start));
+        let want = ctx.len.min(ctx.backing_len.saturating_sub(job.start));
         if want == 0 {
             return;
         }
         // Speculative: only prefetch into free budget, never evicting a live
         // stream. Under pressure we skip rather than thrash real reads.
-        if !job.pool.has_room_for(want) {
+        if !ctx.pool.has_room_for(want) {
             return;
         }
         #[expect(clippy::cast_possible_truncation)]
         let mut bytes = vec![0u8; want as usize];
-        if job.file.read_exact_at(&mut bytes, job.start).is_err() {
+        if ctx.file.read_exact_at(&mut bytes, job.start).is_err() {
             return;
         }
         let _ = try_store_prefetch(
-            &job.pool,
-            &job.buf,
-            &job.epoch,
-            job.dispatched_epoch,
+            &ctx.pool,
+            &ctx.buf,
+            &ctx.epoch,
+            ctx.dispatched_epoch,
             job.start,
             bytes,
         );
@@ -1101,14 +1108,16 @@ mod prefetch_worker_tests {
         pool.register(1, Arc::clone(&buf));
 
         PrefetchWorkers::run_job(PrefetchJob {
-            file: Arc::clone(&file),
-            buf: Arc::clone(&buf),
-            pool: Arc::clone(&pool),
-            epoch: Arc::clone(&epoch),
-            dispatched_epoch: 0,
+            ctx: Arc::new(PrefetchContext {
+                file: Arc::clone(&file),
+                buf: Arc::clone(&buf),
+                pool: Arc::clone(&pool),
+                epoch: Arc::clone(&epoch),
+                dispatched_epoch: 0,
+                len: 1024 * 1024,
+                backing_len: data.len() as u64,
+            }),
             start: 1024 * 1024,
-            len: 1024 * 1024,
-            backing_len: data.len() as u64,
         });
         let mut out = vec![0u8; 4096];
         let mut ra = buf.lock().unwrap();
@@ -1119,6 +1128,64 @@ mod prefetch_worker_tests {
         })
         .unwrap();
         assert_eq!(fills, 0, "prefetched window should serve without a pread");
+        assert_eq!(out, data[1024 * 1024..1024 * 1024 + 4096]);
+    }
+
+    /// The worker-pool path the single-stream test skips: a job pushed through
+    /// `request` must reach one of the recv-ing worker threads and run, storing
+    /// the window. Guards the crossbeam hand-off (#430).
+    #[test]
+    fn dispatched_job_reaches_a_worker_and_fills_the_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("w.bin");
+        let data: Vec<u8> = (0u64..8 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&data)
+            .unwrap();
+        let file = Arc::new(std::fs::File::open(&path).unwrap());
+
+        let pool = Arc::new(ReadAheadPool::new(64 * 1024 * 1024));
+        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+        let epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        pool.register(1, Arc::clone(&buf));
+
+        let workers = PrefetchWorkers::new(2);
+        workers.request(PrefetchJob {
+            ctx: Arc::new(PrefetchContext {
+                file: Arc::clone(&file),
+                buf: Arc::clone(&buf),
+                pool: Arc::clone(&pool),
+                epoch: Arc::clone(&epoch),
+                dispatched_epoch: 0,
+                len: 1024 * 1024,
+                backing_len: data.len() as u64,
+            }),
+            start: 1024 * 1024,
+        });
+
+        // Hand-off is asynchronous; poll until the worker has charged the stored
+        // window. Bounded so a broken hand-off fails fast rather than hanging.
+        let step = std::time::Duration::from_millis(5);
+        let mut waited = std::time::Duration::ZERO;
+        while pool.charged() == 0 && waited < std::time::Duration::from_secs(5) {
+            std::thread::sleep(step);
+            waited += step;
+        }
+        assert!(pool.charged() > 0, "dispatched job never reached a worker");
+
+        let mut out = vec![0u8; 4096];
+        let mut ra = buf.lock().unwrap();
+        let mut fills = 0;
+        ra.read_into(&mut out, 1024 * 1024, data.len() as u64, |_, _| {
+            fills += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            fills, 0,
+            "worker-prefetched window should serve without a pread"
+        );
         assert_eq!(out, data[1024 * 1024..1024 * 1024 + 4096]);
     }
 }
@@ -1236,16 +1303,16 @@ mod concurrency_tests {
                     for _ in 0..4 {
                         let mut start = 0u64;
                         while start < backing_len {
-                            PrefetchWorkers::run_job(PrefetchJob {
+                            let ctx = Arc::new(PrefetchContext {
                                 file: Arc::clone(file),
                                 buf: Arc::clone(buf1),
                                 pool: Arc::clone(pool),
                                 epoch: Arc::clone(epoch1),
                                 dispatched_epoch: epoch1.load(std::sync::atomic::Ordering::Acquire),
-                                start,
                                 len: window,
                                 backing_len,
                             });
+                            PrefetchWorkers::run_job(PrefetchJob { ctx, start });
                             start += window;
                         }
                     }


### PR DESCRIPTION
Two avoidable costs on the Phase-2 prefetch hot path under bursty, sequential streaming.

## #430 — workers funnel through one shared `Mutex<Receiver>`
The N worker threads shared a single `Arc<Mutex<mpsc::Receiver>>` and each held the lock across a blocking `recv()`, so only one worker could wait at a time and job hand-off / wake-ups serialized — defeating multi-threaded fan-out under bursty dispatch.

Swapped the std mpsc channel for a `crossbeam-channel` bounded MPMC channel: every worker owns its own cheap `Receiver` clone and blocks in `recv()` independently, so dispatch fans out across all threads. Drop-on-full backpressure (`try_send`) and drop-based shutdown are unchanged.

## #431 — four Arc clones per window per read
Each dispatched window cloned the `file` / `buf` / `pool` / `epoch` Arcs — up to 16 refcount ops per read at depth 4. Moved the shared per-dispatch inputs into a single `Arc<PrefetchContext>`; each `PrefetchJob` now clones one Arc instead of four (4 + N bumps per read instead of 4 × N).

## Tests
- Added `dispatched_job_reaches_a_worker_and_fills_the_buffer`, covering the previously-untested `new` + `request` + concurrent-recv path (signals on `pool.charged()`).
- `cargo test --workspace`: 1113 passed; `-p musefs-core --features metrics`: 476 passed.
- `cargo clippy --all-targets` and `cargo fmt --all --check`: clean.
- Re-anchored the fmt-fragile `mutants.toml` coordinate shifted by the edit; `check_mutant_anchors.py`: OK.
- In-diff mutation gate (CI's exact invocation) over the 4 in-scope mutants: 4/4 caught.

Fixes #430
Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)