### PR TITLE
feat(lidarr): cover-art sync and transient-failure retry

### DIFF
--- a/contrib/lidarr/README.md
+++ b/contrib/lidarr/README.md
@@ -21,9 +21,11 @@ The package installs two console scripts that plug into Lidarr's hooks:
 - **`musefs-lidarr-sync`** (Custom Script notification) — fires after an
   import or rename: it queries Lidarr's API for the affected tracks' metadata
   (title, artist/albumartist, album, track/disc numbers, release date,
-  MusicBrainz ids, genres), runs `musefs scan` on the files to create/refresh
-  their track rows (the structural columns only musefs can compute), and
-  writes the tags into the store.
+  MusicBrainz ids, genres) plus each album's cover art, runs `musefs scan` on
+  the files to create/refresh their track rows (the structural columns only
+  musefs can compute), and writes the tags and art into the store. Transient
+  API failures (network errors, timeouts, 5xx) are retried with backoff so a
+  blip or a Lidarr restart mid-import doesn't silently drop the sync.
 
 musefs's auto-refresh surfaces each sync at the mount with no remount. Both
 scripts build on the shared [`python-musefs`](../python-musefs/README.md)
@@ -188,8 +190,9 @@ binary are importable/on `PATH`.
 - **Tags are fully replaced** with Lidarr's view on every sync (scanner-written
   binary tags always survive — see the
   [external-writer contract](../../ARCHITECTURE.md#the-external-writer-contract)).
-- **No art sync:** the integration writes text tags only; any art `musefs scan`
-  ingested from embedded pictures is preserved.
+- **Cover art:** each album's Lidarr cover is fetched and written as the front
+  cover, replacing the track's art rows on every sync (an over-cap or
+  unreachable cover is skipped, leaving any scanner-ingested art in place).
 - **Schema version:** the sync refuses to run if the DB's `user_version`
   differs from the version it targets — rebuild the store after upgrading
   musefs.

--- a/contrib/lidarr/src/musefs_lidarr/api.py
+++ b/contrib/lidarr/src/musefs_lidarr/api.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from dataclasses import dataclass
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from .errors import ConfigError, LidarrApiError
+
+# Lidarr custom scripts are fire-and-forget: a transient API error or a restart
+# mid-import otherwise silently loses the sync, so retry these with backoff.
+_RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+_RETRY_BACKOFF_BASE = 0.5
 
 
 def redacted(value: str | None) -> str:
@@ -52,37 +58,77 @@ class PreflightResult:
 class LidarrClient:
     """Minimal read-only client for the Lidarr v1 REST API."""
 
-    def __init__(self, config: LidarrConfig, *, opener=urlopen, timeout: int = 15):
+    def __init__(
+        self,
+        config: LidarrConfig,
+        *,
+        opener=urlopen,
+        timeout: int = 15,
+        retries: int = 3,
+        sleep=time.sleep,
+    ):
         if not config.url or not config.api_key:
             raise ConfigError("Lidarr API configuration is required")
         self._base = config.url.rstrip("/")
         self._api_key = config.api_key
         self._opener = opener
         self._timeout = timeout
+        self._retries = max(1, retries)
+        self._sleep = sleep
 
     def get_json(self, path: str, params: dict[str, object] | None = None):
         """GET ``path`` with optional query params; return parsed JSON.
 
         Raises ``LidarrApiError`` on HTTP, network, or JSON-decode failure.
         """
+        try:
+            return json.loads(self._request(self._url(path, params)).decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise LidarrApiError("Lidarr API returned invalid JSON") from exc
+
+    def media_cover(self, url: str) -> bytes:
+        """Fetch raw cover-art bytes for a Lidarr image ``url``.
+
+        ``url`` is the server-relative path from an album's ``images`` entry
+        (e.g. ``/MediaCover/Albums/20/cover.jpg``); an absolute ``remoteUrl`` is
+        used as-is. Retries transient failures like :meth:`get_json`.
+        """
+        full = url if url.startswith(("http://", "https://")) else f"{self._base}{url}"
+        return self._request(full)
+
+    def _url(self, path: str, params: dict[str, object] | None = None) -> str:
         query = ""
         if params:
             clean = {k: v for k, v in params.items() if v is not None}
             if clean:
                 query = "?" + urlencode(clean, doseq=True)
-        url = f"{self._base}{path}{query}"
+        return f"{self._base}{path}{query}"
+
+    def _request(self, url: str) -> bytes:
+        """GET ``url`` with the API key, returning the raw response body.
+
+        Retries up to ``self._retries`` attempts with exponential backoff on
+        transient failures (network errors, timeouts, and the 5xx/429/408 HTTP
+        statuses); non-transient HTTP errors fail fast.
+        """
         request = Request(url, headers={"X-Api-Key": self._api_key})
-        try:
-            with self._opener(request, timeout=self._timeout) as response:
-                return json.loads(response.read().decode("utf-8"))
-        except HTTPError as exc:
-            raise LidarrApiError(
-                f"Lidarr API request failed with HTTP {exc.code}; api_key={redacted(self._api_key)}"
-            ) from exc
-        except URLError as exc:
-            raise LidarrApiError(f"Lidarr API request failed: {exc.reason}") from exc
-        except json.JSONDecodeError as exc:
-            raise LidarrApiError("Lidarr API returned invalid JSON") from exc
+        for attempt in range(self._retries):
+            last = attempt + 1 == self._retries
+            try:
+                with self._opener(request, timeout=self._timeout) as response:
+                    return response.read()
+            except HTTPError as exc:
+                if last or exc.code not in _RETRYABLE_STATUS:
+                    raise LidarrApiError(
+                        f"Lidarr API request failed with HTTP {exc.code}; "
+                        f"api_key={redacted(self._api_key)}"
+                    ) from exc
+            except (URLError, TimeoutError) as exc:
+                if last:
+                    reason = getattr(exc, "reason", exc)
+                    raise LidarrApiError(f"Lidarr API request failed: {reason}") from exc
+            self._sleep(_RETRY_BACKOFF_BASE * (2**attempt))
+        raise AssertionError("unreachable")  # pragma: no cover
 
     def media_management_config(self):
         """Return Lidarr's media-management config."""

--- a/contrib/lidarr/src/musefs_lidarr/cli_sync.py
+++ b/contrib/lidarr/src/musefs_lidarr/cli_sync.py
@@ -82,6 +82,7 @@ def run(
                 tracks=payloads.tracks,
                 albums_by_id=payloads.albums_by_id,
                 artists_by_id=payloads.artists_by_id,
+                art_by_album_id=payloads.art_by_album_id,
             )
             print(f"musefs-lidarr-sync: {stats.summary()}")
             return 0
@@ -120,6 +121,7 @@ def run(
             tracks=payloads.tracks,
             albums_by_id=payloads.albums_by_id,
             artists_by_id=payloads.artists_by_id,
+            art_by_album_id=payloads.art_by_album_id,
         )
         print(f"musefs-lidarr-sync: {stats.summary()}")
         return 0

--- a/contrib/lidarr/src/musefs_lidarr/mapping.py
+++ b/contrib/lidarr/src/musefs_lidarr/mapping.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 
-from musefs_common import Record, realpath_key
+from musefs_common import ArtImage, Record, realpath_key
 
 from .errors import MappingError
 
@@ -82,6 +82,26 @@ def _tracks_by_file(tracks: list[dict]) -> dict[int, list[dict]]:
     return grouped
 
 
+def _album_cover_url(album: dict) -> str | None:
+    """Return the album's cover-art image URL, or None.
+
+    Prefers the image whose ``coverType`` is ``cover``; otherwise falls back to
+    the first image that carries a usable ``url``/``remoteUrl``.
+    """
+    fallback = None
+    for image in album.get("images") or []:
+        if not isinstance(image, dict):
+            continue
+        url = image.get("url") or image.get("remoteUrl")
+        if not url:
+            continue
+        if str(image.get("coverType") or "").lower() == "cover":
+            return url
+        if fallback is None:
+            fallback = url
+    return fallback
+
+
 def records_for_paths(
     *,
     paths: list[str],
@@ -89,12 +109,15 @@ def records_for_paths(
     tracks: list[dict],
     albums_by_id: dict[int, dict],
     artists_by_id: dict[int, dict],
+    art_by_album_id: dict[int, ArtImage] | None = None,
 ) -> tuple[list[Record], list[SkippedPath]]:
     """Build a store ``Record`` per path; return (records, skipped).
 
     A path is skipped when no track file matches it or its track/album/artist
-    metadata is unavailable.
+    metadata is unavailable. When ``art_by_album_id`` maps the file's album id to
+    an ``ArtImage``, that cover is attached to the record.
     """
+    art_by_album_id = art_by_album_id or {}
     tracks_by_file = _tracks_by_file(tracks)
     records = []
     skipped = []
@@ -116,5 +139,6 @@ def records_for_paths(
         pairs = []
         for track in linked:
             pairs.extend(build_pairs(track=track, album=album, artist=artist))
-        records.append(Record(key=key, pairs=pairs, art=None))
+        art = art_by_album_id.get(int(track_file["albumId"]))
+        records.append(Record(key=key, pairs=pairs, art=[art] if art else None))
     return records, skipped

--- a/contrib/lidarr/src/musefs_lidarr/sync.py
+++ b/contrib/lidarr/src/musefs_lidarr/sync.py
@@ -6,21 +6,23 @@ from dataclasses import dataclass
 
 from musefs_common import (
     SCAN_TIMEOUT_SECONDS,
+    ArtImage,
     SyncStats,
     check_schema_version,
     connect,
     prune_missing,
     realpath_key,
     run_scan,
+    sniff_mime,
     sync_files,
     track_id_for_path,
     track_ids_for_paths,
 )
 
-from .errors import ConfigError
+from .errors import ConfigError, LidarrApiError
 from .events import LidarrEvent
 from .import_link import LinkMode, parse_link_mode
-from .mapping import records_for_paths
+from .mapping import _album_cover_url, records_for_paths
 
 
 @dataclass(frozen=True)
@@ -42,6 +44,7 @@ class EventPayloads:
     tracks: list[dict]
     albums_by_id: dict[int, dict]
     artists_by_id: dict[int, dict]
+    art_by_album_id: dict[int, ArtImage]
 
 
 def _env_bool(value: str | None, *, default: bool) -> bool:
@@ -90,6 +93,30 @@ def _log_invalid(invalid, *, warning_printer) -> None:
         )
 
 
+def _collect_album_art(client, albums_by_id, *, warning_printer=print) -> dict[int, ArtImage]:
+    """Fetch each album's cover art via ``client``; return ``{album_id: ArtImage}``.
+
+    Albums with no cover image are skipped silently. A failed fetch is logged and
+    skipped rather than aborting the sync (Lidarr custom scripts are
+    fire-and-forget, so a partial sync beats none).
+    """
+    art_by_album_id: dict[int, ArtImage] = {}
+    for album_id, album in albums_by_id.items():
+        url = _album_cover_url(album)
+        if not url:
+            continue
+        try:
+            data = client.media_cover(url)
+        except LidarrApiError as exc:
+            warning_printer(
+                f"musefs-lidarr-sync: art fetch failed for album {album_id}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        art_by_album_id[album_id] = ArtImage(data=data, mime=sniff_mime(data, url))
+    return art_by_album_id
+
+
 def sync_records(
     *,
     config: SyncConfig,
@@ -98,6 +125,7 @@ def sync_records(
     tracks: list[dict],
     albums_by_id: dict[int, dict],
     artists_by_id: dict[int, dict],
+    art_by_album_id: dict[int, ArtImage] | None = None,
     warning_printer=print,
 ) -> SyncStats:
     """Map the event's paths to records and write their tags into the store.
@@ -111,6 +139,7 @@ def sync_records(
         tracks=tracks,
         albums_by_id=albums_by_id,
         artists_by_id=artists_by_id,
+        art_by_album_id=art_by_album_id,
     )
     _log_skipped(skipped_paths, warning_printer=warning_printer)
 
@@ -222,12 +251,14 @@ def collect_event_payloads(*, client, event: LidarrEvent) -> EventPayloads:
             artist_id: client.artist(artist_id)
             for artist_id in _artist_ids(track_files, event.artist_id, album_artist_id)
         }
+        albums_by_id = {album_id: album}
         return EventPayloads(
             paths=[track_file["path"] for track_file in track_files],
             track_files=track_files,
             tracks=tracks,
-            albums_by_id={album_id: album},
+            albums_by_id=albums_by_id,
             artists_by_id=artists_by_id,
+            art_by_album_id=_collect_album_art(client, albums_by_id),
         )
     if event.artist_id is not None:
         track_files = client.track_files(artist_id=event.artist_id)
@@ -243,6 +274,7 @@ def collect_event_payloads(*, client, event: LidarrEvent) -> EventPayloads:
             tracks=tracks,
             albums_by_id=albums_by_id,
             artists_by_id=artists_by_id,
+            art_by_album_id=_collect_album_art(client, albums_by_id),
         )
     raise ConfigError("Lidarr event must include Lidarr_Artist_Id or Lidarr_Album_Id")
 
@@ -273,6 +305,7 @@ def collect_all_payloads(*, client) -> EventPayloads:
         tracks=tracks,
         albums_by_id=albums_by_id,
         artists_by_id=artists_by_id,
+        art_by_album_id=_collect_album_art(client, albums_by_id),
     )
 
 
@@ -284,6 +317,7 @@ def sync_event_with_payloads(
     tracks: list[dict],
     albums_by_id: dict[int, dict],
     artists_by_id: dict[int, dict],
+    art_by_album_id: dict[int, ArtImage] | None = None,
     scanner=run_scan,
 ) -> SyncStats:
     """Scan, write tags, then prune renames for one event; return its stats."""
@@ -295,6 +329,7 @@ def sync_event_with_payloads(
         tracks=tracks,
         albums_by_id=albums_by_id,
         artists_by_id=artists_by_id,
+        art_by_album_id=art_by_album_id,
     )
     sync_rename_prune(config=config, previous_paths=event.previous_paths)
     return stats

--- a/contrib/lidarr/tests/test_api.py
+++ b/contrib/lidarr/tests/test_api.py
@@ -1,5 +1,5 @@
 import json
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -97,3 +97,109 @@ def test_check_safe_settings_reports_all_unsafe_values():
 def test_config_requires_url_and_key_together():
     with pytest.raises(ConfigError, match="MUSEFS_LIDARR_URL"):
         LidarrConfig.from_env({"MUSEFS_LIDARR_API_KEY": "secret"})
+
+
+class RawResponse:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+def _flaky_opener(failures):
+    """Opener that raises each exception in ``failures`` (oldest first) before
+    finally returning ``FakeResponse({"ok": True})``."""
+    pending = list(failures)
+    calls = []
+
+    def opener(request, timeout):
+        calls.append(request.full_url)
+        if pending:
+            raise pending.pop(0)
+        return FakeResponse({"ok": True})
+
+    return opener, calls
+
+
+def test_get_json_retries_transient_url_error_then_succeeds():
+    opener, calls = _flaky_opener([URLError("connection refused"), URLError("still down")])
+    sleeps = []
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local", api_key="secret"),
+        opener=opener,
+        retries=3,
+        sleep=sleeps.append,
+    )
+
+    assert client.get_json("/api/v1/album/1") == {"ok": True}
+    assert len(calls) == 3
+    assert len(sleeps) == 2
+
+
+def test_get_json_retries_on_5xx_then_succeeds():
+    err = HTTPError("http://lidarr.local/api/v1/album/1", 503, "Service Unavailable", None, None)
+    opener, calls = _flaky_opener([err])
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local", api_key="secret"),
+        opener=opener,
+        retries=3,
+        sleep=lambda _: None,
+    )
+
+    assert client.get_json("/api/v1/album/1") == {"ok": True}
+    assert len(calls) == 2
+
+
+def test_get_json_does_not_retry_on_4xx():
+    err = HTTPError("http://lidarr.local/api/v1/album/1", 401, "Unauthorized", None, None)
+    opener, calls = _flaky_opener([err])
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local", api_key="secret"),
+        opener=opener,
+        retries=3,
+        sleep=lambda _: None,
+    )
+
+    with pytest.raises(LidarrApiError):
+        client.get_json("/api/v1/album/1")
+    assert len(calls) == 1
+
+
+def test_get_json_gives_up_after_exhausting_retries():
+    opener, calls = _flaky_opener([URLError("down")] * 5)
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local", api_key="secret"),
+        opener=opener,
+        retries=3,
+        sleep=lambda _: None,
+    )
+
+    with pytest.raises(LidarrApiError):
+        client.get_json("/api/v1/album/1")
+    assert len(calls) == 3
+
+
+def test_media_cover_fetches_raw_bytes_with_api_key():
+    captured = {}
+
+    def opener(request, timeout):
+        captured["url"] = request.full_url
+        captured["headers"] = dict(request.header_items())
+        return RawResponse(b"\xff\xd8\xff\xe0jpegdata")
+
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local/", api_key="secret"), opener=opener
+    )
+
+    data = client.media_cover("/MediaCover/Albums/20/cover.jpg?lastModified=1")
+
+    assert data == b"\xff\xd8\xff\xe0jpegdata"
+    assert captured["url"] == "http://lidarr.local/MediaCover/Albums/20/cover.jpg?lastModified=1"
+    assert captured["headers"]["X-api-key"] == "secret"

--- a/contrib/lidarr/tests/test_mapping.py
+++ b/contrib/lidarr/tests/test_mapping.py
@@ -1,8 +1,14 @@
 import pytest
-from musefs_common import realpath_key
+from musefs_common import ArtImage, realpath_key
 
 from musefs_lidarr.errors import MappingError
-from musefs_lidarr.mapping import SkippedPath, build_pairs, match_track_file, records_for_paths
+from musefs_lidarr.mapping import (
+    SkippedPath,
+    _album_cover_url,
+    build_pairs,
+    match_track_file,
+    records_for_paths,
+)
 
 
 def test_build_pairs_maps_core_tags(sample_artist, sample_album, sample_track):
@@ -135,3 +141,57 @@ def test_records_for_paths_returns_reason_for_missing_linked_tracks(
             reason="multi-track metadata unavailable",
         )
     ]
+
+
+def test_album_cover_url_prefers_cover_type():
+    album = {
+        "images": [
+            {"coverType": "fanart", "url": "/MediaCover/Albums/20/fanart.jpg"},
+            {"coverType": "cover", "url": "/MediaCover/Albums/20/cover.jpg"},
+        ]
+    }
+
+    assert _album_cover_url(album) == "/MediaCover/Albums/20/cover.jpg"
+
+
+def test_album_cover_url_falls_back_to_first_image():
+    album = {"images": [{"coverType": "poster", "remoteUrl": "http://img/poster.jpg"}]}
+
+    assert _album_cover_url(album) == "http://img/poster.jpg"
+
+
+def test_album_cover_url_none_when_no_images():
+    assert _album_cover_url({"images": []}) is None
+    assert _album_cover_url({}) is None
+
+
+def test_records_for_paths_attaches_album_art(
+    sample_artist, sample_album, sample_track, sample_track_file
+):
+    art = ArtImage(data=b"\xff\xd8\xffjpeg", mime="image/jpeg")
+
+    records, skipped = records_for_paths(
+        paths=[sample_track_file["path"]],
+        track_files=[sample_track_file],
+        tracks=[sample_track],
+        albums_by_id={20: sample_album},
+        artists_by_id={10: sample_artist},
+        art_by_album_id={20: art},
+    )
+
+    assert records[0].art == [art]
+
+
+def test_records_for_paths_no_art_when_album_missing_from_map(
+    sample_artist, sample_album, sample_track, sample_track_file
+):
+    records, _ = records_for_paths(
+        paths=[sample_track_file["path"]],
+        track_files=[sample_track_file],
+        tracks=[sample_track],
+        albums_by_id={20: sample_album},
+        artists_by_id={10: sample_artist},
+        art_by_album_id={},
+    )
+
+    assert records[0].art is None

--- a/contrib/lidarr/tests/test_sync.py
+++ b/contrib/lidarr/tests/test_sync.py
@@ -1,9 +1,11 @@
-from musefs_common import SCAN_TIMEOUT_SECONDS, connect, realpath_key
+from musefs_common import SCAN_TIMEOUT_SECONDS, ArtImage, connect, realpath_key
 
+from musefs_lidarr.errors import LidarrApiError
 from musefs_lidarr.events import EventType, LidarrEvent
 from musefs_lidarr.import_link import LinkMode
 from musefs_lidarr.sync import (
     SyncConfig,
+    _collect_album_art,
     collect_all_payloads,
     collect_event_payloads,
     config_from_env,
@@ -15,15 +17,21 @@ from musefs_lidarr.sync import (
 
 
 class FakeClient:
-    def __init__(self, *, track_files, tracks, albums, artists):
+    def __init__(self, *, track_files, tracks, albums, artists, art=None):
         self.track_file_calls = []
         self.track_calls = []
         self.artist_calls = []
         self.album_calls = []
+        self.media_cover_calls = []
         self._track_files = track_files
         self._tracks = tracks
         self._albums = {album["id"]: album for album in albums}
         self._artists = {artist["id"]: artist for artist in artists}
+        self._art = art or {}
+
+    def media_cover(self, url):
+        self.media_cover_calls.append(url)
+        return self._art[url]
 
     def track_files(self, **kwargs):
         self.track_file_calls.append(kwargs)
@@ -386,3 +394,109 @@ def test_collect_all_payloads_queries_each_artist(
     assert payloads.track_files == [sample_track_file]
     assert payloads.tracks == [sample_track]
     assert payloads.paths == [sample_track_file["path"]]
+
+
+def test_sync_records_writes_album_art(
+    db_path, make_track, sample_track_file, sample_track, sample_album, sample_artist
+):
+    key = realpath_key(sample_track_file["path"])
+    make_track(key)
+    event = LidarrEvent(
+        event_type=EventType.ALBUM_DOWNLOAD,
+        raw_type="AlbumDownload",
+        paths=[sample_track_file["path"]],
+        artist_id=10,
+        album_id=20,
+    )
+    config = SyncConfig(db_path=db_path, link_mode=LinkMode.SYMLINK, autoscan=False)
+    art = ArtImage(data=b"\xff\xd8\xff\xe0cover", mime="image/jpeg")
+
+    stats = sync_records(
+        config=config,
+        event=event,
+        track_files=[sample_track_file],
+        tracks=[sample_track],
+        albums_by_id={20: sample_album},
+        artists_by_id={10: sample_artist},
+        art_by_album_id={20: art},
+    )
+
+    assert stats.art_linked == 1
+    conn = connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT a.data, a.mime, ta.picture_type FROM track_art ta "
+            "JOIN art a ON a.id = ta.art_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [(b"\xff\xd8\xff\xe0cover", "image/jpeg", 3)]
+
+
+def test_collect_event_payloads_fetches_album_art(
+    sample_track_file, sample_track, sample_album, sample_artist
+):
+    album = dict(
+        sample_album,
+        images=[{"coverType": "cover", "url": "/MediaCover/Albums/20/cover.jpg"}],
+    )
+    client = FakeClient(
+        track_files=[sample_track_file],
+        tracks=[sample_track],
+        albums=[album],
+        artists=[sample_artist],
+        art={"/MediaCover/Albums/20/cover.jpg": b"\xff\xd8\xff\xe0cover"},
+    )
+    event = LidarrEvent(
+        event_type=EventType.ALBUM_DOWNLOAD,
+        raw_type="AlbumDownload",
+        paths=[sample_track_file["path"]],
+        artist_id=10,
+        album_id=20,
+    )
+
+    payloads = collect_event_payloads(client=client, event=event)
+
+    assert client.media_cover_calls == ["/MediaCover/Albums/20/cover.jpg"]
+    art = payloads.art_by_album_id[20]
+    assert art.data == b"\xff\xd8\xff\xe0cover"
+    assert art.mime == "image/jpeg"
+
+
+def test_collect_event_payloads_skips_album_without_art(
+    sample_track_file, sample_track, sample_album, sample_artist
+):
+    client = FakeClient(
+        track_files=[sample_track_file],
+        tracks=[sample_track],
+        albums=[sample_album],
+        artists=[sample_artist],
+    )
+    event = LidarrEvent(
+        event_type=EventType.ALBUM_DOWNLOAD,
+        raw_type="AlbumDownload",
+        paths=[sample_track_file["path"]],
+        artist_id=10,
+        album_id=20,
+    )
+
+    payloads = collect_event_payloads(client=client, event=event)
+
+    assert client.media_cover_calls == []
+    assert payloads.art_by_album_id == {}
+
+
+def test_collect_album_art_logs_and_skips_fetch_failure(sample_album, sample_artist, capsys):
+    album = dict(
+        sample_album,
+        images=[{"coverType": "cover", "url": "/MediaCover/Albums/20/cover.jpg"}],
+    )
+
+    class FailingClient:
+        def media_cover(self, url):
+            raise LidarrApiError("boom")
+
+    result = _collect_album_art(FailingClient(), {20: album})
+
+    assert result == {}
+    assert "album 20" in capsys.readouterr().err

--- a/scripts/lidarr-e2e/fixtures/metadata/album.json
+++ b/scripts/lidarr-e2e/fixtures/metadata/album.json
@@ -17,8 +17,8 @@
  "images": [
   {
    "CoverType": "Cover",
-   "Url": "https://images.lidarr.audio/cache/https://coverartarchive.org/release/59d2fc91-8a6a-45da-9e12-51b01d2a50d7/37224917897-1200.jpg",
-   "remoteUrl": "https://coverartarchive.org/release/59d2fc91-8a6a-45da-9e12-51b01d2a50d7/37224917897-1200.jpg"
+   "Url": "http://host.containers.internal:9701/cover.jpg",
+   "remoteUrl": "http://host.containers.internal:9701/cover.jpg"
   }
  ],
  "Releases": [

--- a/scripts/lidarr-e2e/mock_metadata.py
+++ b/scripts/lidarr-e2e/mock_metadata.py
@@ -9,12 +9,20 @@ monitor the artist with no network dependency. Lidarr is pointed here via its
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "metadata")
+
+# A minimal valid 1x1 PNG. album.json's cover image Url points back here so the
+# real Lidarr downloads it locally (network-free), then musefs-lidarr-sync writes
+# it into the store as the served file's cover art.
+COVER_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
 
 
 def _load(name):
@@ -35,11 +43,20 @@ def make_handler():
             self.end_headers()
             self.wfile.write(body)
 
+        def _send_bytes(self, data, ctype):
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
         def do_GET(self):  # noqa: N802
             path = urlparse(self.path).path
             # strip the /api/v0.4 prefix Lidarr's base URL carries
             route = path.split("/api/v0.4/", 1)[-1] if "/api/v0.4/" in path else path.lstrip("/")
-            if route.startswith("artist/"):
+            if route == "cover.jpg":
+                self._send_bytes(COVER_PNG, "image/jpeg")
+            elif route.startswith("artist/"):
                 self._send(artist)
             elif route.startswith("album/"):
                 self._send(album)

--- a/scripts/lidarr-e2e/run-e2e.sh
+++ b/scripts/lidarr-e2e/run-e2e.sh
@@ -128,6 +128,14 @@ vals=[r[0] for r in c.execute("SELECT value FROM tags WHERE key='artist'")]
 print("  [ok] store artist tags:", vals)
 assert "Komiku" in vals, vals
 PY
+# store got the album cover (the sync fetched Lidarr's MediaCover art)
+python3 - "$W/store/store.db" <<'PY' || fail "store carries no album art"
+import sqlite3,sys
+c=sqlite3.connect(sys.argv[1])
+n=c.execute("SELECT COUNT(*) FROM track_art").fetchone()[0]
+print("  [ok] store track_art rows:", n)
+assert n>=1, n
+PY
 SHA_AFTER="$(sha256sum "$BACKING" | awk '{print $1}')"
 [ "$SHA_BEFORE" = "$SHA_AFTER" ] || fail "backing audio bytes changed"
 echo "  [ok] backing bytes unchanged"
@@ -154,5 +162,14 @@ assert aa=="Komiku", f"served albumartist={aa!r} (expected Komiku, supplied by L
 assert (t.get("date") or "").startswith("2020-05-03"), f"served date={t.get('date')!r} (expected Lidarr's 2020-05-03)"
 print("  [ok] served file carries Lidarr-supplied metadata absent from the backing file:")
 print("       artist=%r albumartist=%r date=%r title=%r" % (t.get("artist"), aa, t.get("date"), t.get("title")))
+PY
+# served file carries the embedded cover (Lidarr's art spliced into the view);
+# the backing file has none, so an attached_pic stream must be musefs-generated.
+ffprobe -hide_banner -loglevel error -show_streams -of json "$SERVED" > "$W/served-streams.json"
+python3 - "$W/served-streams.json" <<'PY' || fail "served file has no embedded cover art"
+import json,sys
+streams=json.load(open(sys.argv[1])).get("streams",[])
+assert any(s.get("disposition",{}).get("attached_pic") for s in streams), "no attached_pic stream"
+print("  [ok] served file carries embedded cover art")
 PY
 echo "lidarr-e2e: PASS"

--- a/scripts/lidarr-smoke.sh
+++ b/scripts/lidarr-smoke.sh
@@ -116,8 +116,9 @@ assert_bytes_unchanged(before, {p: sha256_file(p) for p in files})
 print("bytes unchanged: OK")
 PY
 
-# Store received tags (>= 2 tracks; loud-fails a vacuous 0-record pass).
-python3 "$HERE/store_assert.py" --db "$MUSEFS_DB" --min-records 2
+# Store received tags AND the album cover for both tracks (loud-fails a vacuous
+# 0-record pass).
+python3 "$HERE/store_assert.py" --db "$MUSEFS_DB" --min-records 2 --min-art 2
 
 # Served mount carries the tags.
 "$MUSEFS" mount "$WORK/mnt" --db "$MUSEFS_DB" &
@@ -133,6 +134,16 @@ from lidarr_smoke_lib import parse_ffprobe_tags
 tags = parse_ffprobe_tags(open(sys.argv[1]).read())
 assert tags.get("artist") == "Alice", f"served file artist tag wrong: {tags}"
 print("served tags: OK")
+PY
+
+# Served mount carries the embedded cover (Lidarr's art spliced into the view).
+ffprobe -hide_banner -loglevel error -show_streams -of json "$SERVED" > "$WORK/streams.json"
+python3 - "$WORK/streams.json" <<'PY'
+import sys
+sys.path.insert(0, "scripts")
+from lidarr_smoke_lib import has_attached_picture
+assert has_attached_picture(open(sys.argv[1]).read()), "served file has no embedded cover art"
+print("served art: OK")
 PY
 
 echo "lidarr-smoke: PASS"

--- a/scripts/lidarr_smoke_lib.py
+++ b/scripts/lidarr_smoke_lib.py
@@ -50,6 +50,19 @@ def parse_ffprobe_tags(ffprobe_json: str) -> dict[str, str]:
     return {str(k).lower(): str(v) for k, v in tags.items()}
 
 
+def has_attached_picture(ffprobe_streams_json: str) -> bool:
+    """True if ``ffprobe -show_streams -of json`` reports embedded cover art.
+
+    Cover art rides as a video stream flagged ``disposition.attached_pic`` (FLAC
+    METADATA_BLOCK_PICTURE, ID3 APIC, etc.).
+    """
+    data = json.loads(ffprobe_streams_json)
+    for stream in data.get("streams", []):
+        if stream.get("disposition", {}).get("attached_pic"):
+            return True
+    return False
+
+
 def sha256_file(path: str) -> str:
     h = hashlib.sha256()
     with open(path, "rb") as fh:

--- a/scripts/mock_lidarr.py
+++ b/scripts/mock_lidarr.py
@@ -9,13 +9,23 @@ the fixture describes a single album.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse
 
+# A minimal valid 1x1 PNG, served as the album cover so the sync exercises the
+# art-write path deterministically (sniff_mime keys off these magic bytes).
+COVER_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
 
 def build_fixture(*, album_id, artist_id, artist_name, album_title, tracks):
-    """Return a {path: response} map. ``tracks`` = [(tf_id, path, title, no), ...]."""
+    """Return a {path: response} map. ``tracks`` = [(tf_id, path, title, no), ...].
+
+    JSON routes map to dict/list values; the cover-art route maps to raw bytes.
+    """
     trackfiles = [
         {"id": tf_id, "path": path, "albumId": album_id, "artistId": artist_id}
         for (tf_id, path, _title, _no) in tracks
@@ -24,6 +34,7 @@ def build_fixture(*, album_id, artist_id, artist_name, album_title, tracks):
         {"trackFileId": tf_id, "title": title, "trackNumber": no}
         for (tf_id, _path, title, no) in tracks
     ]
+    cover_url = f"/MediaCover/Albums/{album_id}/cover.jpg"
     return {
         "/api/v1/config/mediamanagement": {"fileDate": "none", "setPermissionsLinux": False},
         "/api/v1/config/metadataprovider": {"writeAudioTags": "no"},
@@ -36,12 +47,14 @@ def build_fixture(*, album_id, artist_id, artist_name, album_title, tracks):
             "releaseDate": "2020-01-01T00:00:00Z",
             "genres": ["Test"],
             "foreignAlbumId": "00000000-0000-0000-0000-0000000000a1",
+            "images": [{"coverType": "cover", "url": cover_url}],
         },
         f"/api/v1/artist/{artist_id}": {
             "id": artist_id,
             "artistName": artist_name,
             "foreignArtistId": "00000000-0000-0000-0000-0000000000b2",
         },
+        cover_url: COVER_PNG,
     }
 
 
@@ -50,9 +63,13 @@ def make_handler(fixture):
         def do_GET(self):  # noqa: N802
             path = urlparse(self.path).path
             if path in fixture:
-                body = json.dumps(fixture[path]).encode()
+                value = fixture[path]
+                if isinstance(value, (bytes, bytearray)):
+                    body, ctype = bytes(value), "image/jpeg"
+                else:
+                    body, ctype = json.dumps(value).encode(), "application/json"
                 self.send_response(200)
-                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Type", ctype)
                 self.end_headers()
                 self.wfile.write(body)
             else:

--- a/scripts/store_assert.py
+++ b/scripts/store_assert.py
@@ -1,8 +1,9 @@
-"""Assert the musefs store received Lidarr's tags (no vacuous pass).
+"""Assert the musefs store received Lidarr's tags and art (no vacuous pass).
 
-Counts distinct tracks carrying a non-empty `artist` tag. A host/path mismatch
-that skips every track leaves 0 — requiring --min-records == the track count
-makes that fail loud instead of passing green.
+Counts distinct tracks carrying a non-empty `artist` tag (and, with --min-art,
+distinct tracks linked to cover art). A host/path mismatch that skips every
+track leaves 0 — requiring the counts to meet the track count makes that fail
+loud instead of passing green.
 """
 
 from __future__ import annotations
@@ -21,16 +22,31 @@ def count_artist_tagged_tracks(db_path: str) -> int:
         con.close()
 
 
+def count_arted_tracks(db_path: str) -> int:
+    con = sqlite3.connect(db_path)
+    try:
+        return con.execute("SELECT COUNT(DISTINCT track_id) FROM track_art").fetchone()[0]
+    finally:
+        con.close()
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--db", required=True)
     p.add_argument("--min-records", type=int, default=1)
+    p.add_argument("--min-art", type=int, default=0)
     a = p.parse_args(argv)
     n = count_artist_tagged_tracks(a.db)
     if n < a.min_records:
         print(f"::error::store has {n} artist-tagged tracks, expected >= {a.min_records}")
         return 1
     print(f"store records OK: {n} artist-tagged tracks")
+    if a.min_art:
+        arted = count_arted_tracks(a.db)
+        if arted < a.min_art:
+            print(f"::error::store has {arted} arted tracks, expected >= {a.min_art}")
+            return 1
+        print(f"store art OK: {arted} arted tracks")
     return 0
 
 

--- a/scripts/test_lidarr_smoke_lib.py
+++ b/scripts/test_lidarr_smoke_lib.py
@@ -3,6 +3,7 @@ from lidarr_smoke_lib import (
     assert_bytes_unchanged,
     build_album_download_env,
     build_import_env,
+    has_attached_picture,
     parse_ffprobe_tags,
     sha256_file,
 )
@@ -59,3 +60,16 @@ def test_assert_bytes_unchanged_passes_when_equal():
 def test_assert_bytes_unchanged_raises_on_change():
     with pytest.raises(AssertionError, match="a.flac"):
         assert_bytes_unchanged({"a.flac": "x"}, {"a.flac": "y"})
+
+
+def test_has_attached_picture_true_for_attached_pic_stream():
+    payload = (
+        '{"streams": [{"codec_type": "audio"}, '
+        '{"codec_type": "video", "disposition": {"attached_pic": 1}}]}'
+    )
+    assert has_attached_picture(payload) is True
+
+
+def test_has_attached_picture_false_without_attached_pic():
+    payload = '{"streams": [{"codec_type": "audio"}]}'
+    assert has_attached_picture(payload) is False

--- a/scripts/test_mock_lidarr.py
+++ b/scripts/test_mock_lidarr.py
@@ -53,3 +53,18 @@ def test_fixture_album_and_artist_have_required_fields():
     assert fx["/api/v1/album/34"]["title"] == "Demo"
     assert fx["/api/v1/artist/7"]["artistName"] == "Alice"
     assert fx["/api/v1/artist/7"]["id"] == 7
+
+
+def test_fixture_album_carries_cover_image_pointing_at_served_bytes():
+    fx = build_fixture(
+        album_id=34,
+        artist_id=7,
+        artist_name="Alice",
+        album_title="Demo",
+        tracks=[(100, "/m/01.flac", "One", 1)],
+    )
+    images = fx["/api/v1/album/34"]["images"]
+    cover = next(i for i in images if i["coverType"] == "cover")
+    body = fx[cover["url"]]
+    assert isinstance(body, (bytes, bytearray))
+    assert bytes(body[:8]) == b"\x89PNG\r\n\x1a\n"

--- a/scripts/test_store_assert.py
+++ b/scripts/test_store_assert.py
@@ -1,6 +1,6 @@
 import sqlite3
 
-from store_assert import count_artist_tagged_tracks
+from store_assert import count_arted_tracks, count_artist_tagged_tracks
 
 
 def _store(tmp_path, rows):
@@ -28,3 +28,27 @@ def test_ignores_empty_artist_values(tmp_path):
 def test_zero_when_no_artist_tags(tmp_path):
     db = _store(tmp_path, [(1, "title", "One")])
     assert count_artist_tagged_tracks(db) == 0
+
+
+def _store_with_art(tmp_path, track_ids):
+    db = tmp_path / "art.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        "CREATE TABLE track_art (track_id INTEGER, art_id INTEGER, ordinal INTEGER DEFAULT 0);"
+    )
+    con.executemany(
+        "INSERT INTO track_art (track_id, art_id) VALUES (?, 1)", [(t,) for t in track_ids]
+    )
+    con.commit()
+    con.close()
+    return str(db)
+
+
+def test_counts_distinct_arted_tracks(tmp_path):
+    db = _store_with_art(tmp_path, [1, 1, 2])
+    assert count_arted_tracks(db) == 2
+
+
+def test_zero_when_no_art(tmp_path):
+    db = _store_with_art(tmp_path, [])
+    assert count_arted_tracks(db) == 0


### PR DESCRIPTION
Fixes #423.

Closes two robustness gaps in the Lidarr integration.

## Cover art
`build_pairs` only ever emitted text tags, so a Lidarr-produced view had no embedded art even though the shared library supports art writes (beets/Picard already use them).

- `LidarrClient.media_cover(url)` fetches raw cover bytes.
- `_album_cover_url(album)` picks the `coverType=="cover"` image (falling back to the first usable image).
- `records_for_paths` gained an `art_by_album_id` map and attaches an `ArtImage` (front cover, mime via `sniff_mime`) per record.
- `sync.py` fetches art during payload collection (`_collect_album_art`, into `EventPayloads.art_by_album_id`) and threads it through `sync_records` / `sync_event_with_payloads`; `cli_sync` passes it on. A missing or unreachable cover is logged and skipped, never aborting the sync. Over-cap covers fall through to the shared `sync_one` size-cap handling.

## Retry on transient failures
`get_json` raised on the first `HTTPError`/`URLError`/timeout. Since Lidarr custom scripts are fire-and-forget, a blip or a Lidarr restart mid-import silently lost the sync.

- `get_json` now routes through a shared `_request` with bounded exponential backoff (default 3 attempts, injectable `sleep`).
- Retries network errors, timeouts, and `5xx`/`429`/`408`; `4xx` and JSON-decode errors still fail fast.
- Covers both the metadata and the new art fetches.

## Tests
- New unit tests (TDD): retry paths + `media_cover` (`test_api`), `_album_cover_url` + art attachment (`test_mapping`), art fetch in collect / DB art write / fetch-failure logging (`test_sync`).
- Release harnesses now gate the art path:
  - **smoke** (mocked, deterministic): `mock_lidarr` serves an album cover; `store_assert --min-art` checks both tracks get art; the served FLAC is asserted to carry an embedded cover via `ffprobe -show_streams`.
  - **e2e** (real Lidarr): `mock_metadata` serves a local `/cover.jpg` (run stays network-free); adds store `track_art` and served `attached_pic` assertions.
- Verified end-to-end locally: `musefs scan` → `musefs-lidarr-sync` (`art_linked=1`) → `musefs mount` → served file reports embedded art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)