### PR TITLE
Storage tunables: default keep-cache on (#432); window-cap HDD bench (#433)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -750,7 +750,9 @@ Cold read then immediate reopen (no cache drop between); `reopen_s` is the signa
 With `--keep-cache` the kernel retains the page cache across opens, so a re-opened file
 is served from RAM instead of re-fetched over slow storage — **~3× faster reopen**,
 consistent across HDD and NFS. This is the only tunable worth changing for slow backing
-(relevant for players/scanners that re-open files), and it needs no preset.
+(relevant for players/scanners that re-open files), and it needs no preset. **It is on by
+default as of #432** (inode invalidation on retag keeps it consistent); disable with
+`--keep-cache false` on memory-constrained hosts.
 
 ### Conclusions
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -829,6 +829,47 @@ hypothetical backends where one large read does not self-pipeline.
 **Defaults:** read-ahead on at `--read-ahead-budget-mib 64`, Phase-1 amplification only. Set
 `0` to disable on local-disk-only setups (no benefit there, though no harm either).
 
+### Internal window cap on HDD (#433)
+
+The amplification window doubles per sequential read up to `WINDOW_ABS_CAP` (8 MiB,
+`musefs-core/src/readahead.rs`). The #256 sweep above measured the *kernel* `max_readahead`
+knob — where ≥2048 KiB hurts on HDD — but never this daemon-internal cap, so #433 asked whether
+8 MiB is too large for spinning media.
+
+**Methodology.** `WINDOW_ABS_CAP` is a compile-time const, so the sweep builds one release binary
+per value (`benches/storage_tunables_bench.sh window-cap`, which patches the const in place and
+restores it after each build). Cold (`drop_caches`) single-stream reads of the same ~270 MiB real
+FLAC, synthesis mount, default flags (amplification on, prefetch off), real backing on a btrfs
+HDD (`/data`, 4389-track corpus). Reproduce:
+
+```sh
+WINDOW_CAP_MIB="1 2 4 8 16" MUSEFS_BENCH_CORPUS_SRC=<music-tree> MUSEFS_BENCH_CORPUS_MAX_MIB=300 \
+  benches/storage_tunables_bench.sh window-cap <hdd-backing-dir>
+```
+
+**Result: no measurable cap effect — the medium's noise dominates.** Median MB/s (and the
+within-cap min–max over 7 cold samples) overlap across every cap, and the apparent ordering is an
+artifact of *measurement order*, not the cap: throughput drifts down through each run, so whatever
+runs first looks fastest. Sweeping the caps in the reverse order reverses the "trend".
+
+| cap (MiB) | ascending sweep, median (min–max) | descending sweep, median |
+|----------:|----------------------------------:|-------------------------:|
+| 1  | 104 (65–132) | 46 |
+| 2  | 85 (54–142)  | 58 |
+| 4  | 83 (51–104)  | 61 |
+| 8  | 61 (54–72)   | 61 |
+| 16 | 68 (54–94)   | 86 |
+
+The current default (8 MiB) lands at ~61 MB/s in both orderings; the first-measured cap is fastest
+in both (104 for cap 1 ascending, 86 for cap 16 descending). The within-cap spread (≈50–140 MB/s)
+dwarfs every between-cap median gap. This corroborates the #256 finding that backing read-ahead is
+neutral on local HDD.
+
+**Decision: keep 8 MiB, no runtime knob.** There is no HDD gain to capture, and the cap exists for
+the proven case — the ~6× single-stream amplification win on high-RTT NFS/remote, where coalescing
+into one large `pread` lets the client pipeline RPCs. Lowering the cap to chase an unmeasurable HDD
+effect would regress that win.
+
 ---
 
 ## Global allocator — steady-state RSS (#360)

--- a/README.md
+++ b/README.md
@@ -403,18 +403,19 @@ default template is `$albumartist/$album/$title`.
 
 ### Tuning
 
-The defaults are sensible for most setups. On slow or high-latency backing (NFS, remote,
-HDD), the two flags worth knowing are `--read-ahead-budget-mib` — the daemon-level backing
-read-ahead that hides per-read latency, the single biggest win for NFS/remote — and
-`--keep-cache`. The *kernel*-level read-ahead / background knobs have little measurable
-effect (see [BENCHMARKS.md](BENCHMARKS.md#storage-tunables) for the methodology and numbers).
+The defaults are sensible for most setups, including the two measured storage wins —
+daemon-level backing read-ahead (`--read-ahead-budget-mib`, the single biggest win for
+NFS/remote) and keeping the kernel page cache across opens (`--keep-cache`, on by default,
+~3× faster reopen on HDD/NFS). The *kernel*-level read-ahead / background knobs have little
+measurable effect (see [BENCHMARKS.md](BENCHMARKS.md#storage-tunables) for the methodology
+and numbers).
 
 | Flag | Default | What it does |
 | ---- | ------- | ------------ |
 | `--poll-interval-ms` | `1000` | Debounce window for detecting external DB edits. |
 | `--read-ahead-budget-mib` | `64` | Per-mount RAM budget (MiB) for **backing read-ahead**: the daemon coalesces a stream's small FUSE reads into one large positioned read, so the backing client can pipeline/parallelize them. **The biggest lever for slow/high-latency backing** — ~5–6× single-stream throughput over a 200 ms-RTT NFS mount; neutral on local disk. Shared across all active streams with LRU eviction; `0` disables it. |
 | `--read-ahead-prefetch` | disabled | Advanced: add background prefetch threads on top of read amplification. Off by default — benchmarks found amplification alone delivers the entire read-ahead win, while the threads add ~10% overhead with no measured benefit. Enable only when profiling a backend where a single large read does not self-pipeline. |
-| `--keep-cache` | disabled | Keep the kernel page cache across opens. **Worth enabling on HDD/NFS:** repeat opens of a file are then served from cache instead of re-read over slow storage (~3× faster reopen in our benches). External re-tags auto-invalidate the affected files, so cached bytes never go stale. |
+| `--keep-cache <true\|false>` | `true` | Keep the kernel page cache across opens. **On by default** — it is the one measured storage win: repeat opens of a file are served from cache instead of re-read over slow storage (~3× faster reopen on HDD/NFS in our benches). External re-tags auto-invalidate the affected files, so cached bytes never go stale. Disable with `--keep-cache false` (e.g. on a memory-constrained host where the page cache is contended). |
 | `--attr-ttl-ms` | `1000` | How long the kernel may trust cached entry/attr lookups. Higher cuts `lookup`/`getattr` traffic — useful for metadata-heavy clients (library scanners) over high-latency backing — but bounds how fast external edits become visible. |
 | `--max-readahead-kib` | `512` | *Kernel* read-ahead window (clamped to the kernel maximum). Distinct from `--read-ahead-budget-mib` (the daemon-level read-ahead, which is the effective one): this kernel knob does **not** speed up musefs streaming, since reads reach the daemon in fixed FUSE-sized chunks regardless. On HDD, values well above the default can even hurt. Leave at the default unless your own profiling shows otherwise. |
 | `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. Does **not** bound foreground reads (those scale with client concurrency), so it has little effect on read throughput; left for completeness. |

--- a/benches/storage_tunables_bench.sh
+++ b/benches/storage_tunables_bench.sh
@@ -8,24 +8,37 @@
 # synthesis: structure-only triggers kernel passthrough when privileged and bypasses
 # the daemon read path entirely.
 #
-# Usage (run as root; reads drop the page cache between samples):
-#   storage_tunables_bench.sh local <backing-dir> [size_mib] [streams]
-#   storage_tunables_bench.sh nfs   <export-dir>  <netem_ms_per_way> [size_mib] [streams]
+# Usage (reads drop the page cache between samples — needs root or passwordless sudo):
+#   storage_tunables_bench.sh local      <backing-dir> [size_mib] [streams]
+#   storage_tunables_bench.sh nfs        <export-dir>  <netem_ms_per_way> [size_mib] [streams]
+#   storage_tunables_bench.sh window-cap <backing-dir> [size_mib] [streams]
 #
-#   local: <backing-dir> is a real disk (e.g. an HDD) holding the corpus.
-#   nfs:   <export-dir> is exported via loopback NFSv4 and `tc netem` adds
-#          <netem_ms_per_way> per packet (~2x that as RPC RTT). Backing it on tmpfs
-#          isolates the RPC tax; on HDD adds real seeks. Needs nfs-kernel-server + tc.
+#   local:      <backing-dir> is a real disk (e.g. an HDD) holding the corpus.
+#   nfs:        <export-dir> is exported via loopback NFSv4 and `tc netem` adds
+#               <netem_ms_per_way> per packet (~2x that as RPC RTT). Backing it on tmpfs
+#               isolates the RPC tax; on HDD adds real seeks. Needs nfs-kernel-server + tc.
+#   window-cap: sweeps the daemon-internal read-amplification window cap
+#               (WINDOW_ABS_CAP) on real backing (issue #433). Builds one release
+#               binary per value in $WINDOW_CAP_MIB (default "1 2 4 8 16"), patching
+#               the const in place and restoring it after each build. Run this mode
+#               as the *normal user* (it rebuilds via cargo); it uses `sudo` only to
+#               drop the page cache. Point MUSEFS_BENCH_CORPUS_SRC at a real audio tree.
 set -euo pipefail
 
-MODE="${1:?usage: $0 local|nfs <dir> ...}"
-BIN="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)/target/release/musefs"
-[ -x "$BIN" ] || { echo "build first: cargo build --release -p musefs" >&2; exit 1; }
+MODE="${1:?usage: $0 local|nfs|window-cap <dir> ...}"
+ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+BIN="$ROOT/target/release/musefs"
+RA="$ROOT/musefs-core/src/readahead.rs"
+# window-cap (issue #433) builds its own per-cap-value binaries; the other modes
+# need a prebuilt release binary.
+[ "$MODE" = window-cap ] || [ -x "$BIN" ] || { echo "build first: cargo build --release -p musefs" >&2; exit 1; }
 
 NFSMNT=/tmp/sp-nfsmnt
 MMNT=/tmp/sp-musefs-mnt
 DB=/tmp/sp-tunables.db
 MP=""; NETEM=0; NFS_EXP=""
+# Internal read-amplification window caps to sweep (WINDOW_ABS_CAP, MiB).
+CAP_MIB="${WINDOW_CAP_MIB:-1 2 4 8 16}"
 
 cleanup() {
   [ -n "$MP" ] && kill "$MP" 2>/dev/null || true
@@ -36,6 +49,9 @@ cleanup() {
     mountpoint -q "$NFSMNT" && umount -l "$NFSMNT" 2>/dev/null || true
     exportfs -u localhost:"$NFS_EXP" 2>/dev/null || true
   fi
+  # window-cap patches WINDOW_ABS_CAP in-place to build each variant; always
+  # restore the source so an interrupt can't leave the tree modified.
+  [ -n "${RA:-}" ] && git -C "$ROOT" checkout -- "$RA" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -82,7 +98,10 @@ gen_corpus() { # $1=backing-dir $2=size_mib $3=streams
       -printf '%s\t%p\n' 2>/dev/null | awk -v m="$maxb" -F'\t' 'm==0 || $1<=m' |
       sort -rn | head -n "$n" | cut -f2-) || true
     while IFS= read -r f; do
-      [ -n "$f" ] && { cp -n "$f" "$1/" 2>/dev/null || true; }
+      # --reflink=auto: on a CoW fs (btrfs/xfs) this shares extents with the
+      # source instead of copying bytes, but the data still lives on the same
+      # platter, so cold reads hit real backing. Falls back to a full copy off-CoW.
+      [ -n "$f" ] && { cp --reflink=auto -n "$f" "$1/" 2>/dev/null || true; }
     done <<< "$list"
     return 0
   fi
@@ -105,11 +124,20 @@ case "$MODE" in
     mount -t nfs -o vers=4.2 localhost:"$NFS_EXP" "$NFSMNT"
     SCANDIR="$NFSMNT/backing"
     echo "nfs export=$NFS_EXP ($(stat -f -c %T "$NFS_EXP"))  netem=${NETEM_MS}ms/way  size=${SIZE}MiB  streams=$STREAMS" ;;
+  window-cap)
+    BACKING="${2:?need backing dir}"; SIZE="${3:-512}"; STREAMS="${4:-8}"
+    gen_corpus "$BACKING/backing" "$SIZE" "$STREAMS"
+    SCANDIR="$BACKING/backing"
+    echo "window-cap backing=$BACKING ($(stat -f -c %T "$BACKING"))  size=${SIZE}MiB  streams=$STREAMS  caps=[$CAP_MIB]MiB" ;;
   *) echo "unknown mode: $MODE" >&2; exit 2 ;;
 esac
 
 mkdir -p "$MMNT"
-rm -f "$DB"; "$BIN" scan "$SCANDIR" --db "$DB" >/dev/null   # scan before adding netem
+# window-cap scans inside its own section (after building a binary); the scan is
+# independent of the read-ahead window so any variant binary produces the same DB.
+if [ "$MODE" != window-cap ]; then
+  rm -f "$DB"; "$BIN" scan "$SCANDIR" --db "$DB" >/dev/null   # scan before adding netem
+fi
 if [ "$MODE" = nfs ]; then tc qdisc add dev lo root netem delay "${NETEM_MS}ms"; NETEM=1; fi
 
 # shellcheck disable=SC2016  # '$title' is a musefs output-template literal, not a shell var
@@ -117,7 +145,16 @@ mount_mode() { local m="$1"; shift; "$BIN" mount "$MMNT" --db "$DB" --mode "$m" 
   local f=""; for _ in $(seq 1 60); do f=$(find "$MMNT" -type f 2>/dev/null|head -1); [ -n "$f" ] && break; sleep 0.25; done; }
 mount_m() { mount_mode synthesis "$@"; }
 umount_m() { kill "$MP" 2>/dev/null||true; for _ in $(seq 1 20); do kill -0 "$MP" 2>/dev/null||break; sleep 0.25; done; MP=""; }
-drop() { sync; echo 3 > /proc/sys/vm/drop_caches; }
+drop() { sync; if [ "$(id -u)" -eq 0 ]; then echo 3 > /proc/sys/vm/drop_caches
+  else sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'; fi; }
+# Build a musefs release binary with WINDOW_ABS_CAP patched to $1 MiB, restore the
+# source, and stash the binary at a per-cap path (echoed). #433.
+build_cap() { local c="$1" out="/tmp/sp-musefs-cap${1}mib"
+  git -C "$ROOT" checkout -- "$RA"
+  sed -i -E "s|(pub const WINDOW_ABS_CAP: u64 =).*;|\1 ${c} * 1024 * 1024;|" "$RA"
+  ( cd "$ROOT" && cargo build --release -p musefs -q )
+  git -C "$ROOT" checkout -- "$RA"
+  cp "$BIN" "$out"; echo "$out"; }
 biggest() { find "$MMNT" -type f -printf '%s\t%p\n'|sort -rn|head -1|cut -f2-; }
 secs() { dd if="$1" of=/dev/null bs=1M 2>&1|tail -1|awk '{for(i=1;i<=NF;i++) if($i=="copied,") print $(i+1)}'; }
 cold_mbps() { local v; v="$(biggest)"; local o
@@ -125,6 +162,9 @@ cold_mbps() { local v; v="$(biggest)"; local o
     dd if="$v" of=/dev/null bs=1M 2>&1|tail -1|awk '{b=$1}{for(i=1;i<=NF;i++) if($i=="copied,")s=$(i+1)}END{if(s>0)printf "%.1f\n",b/1e6/s}'
   done|sort -n|sed -n 2p); echo "${o:-0}"; }
 
+# The kernel/mount-knob sweeps below are the #256 investigation; window-cap (#433)
+# runs its own section instead — the cap is a daemon-internal const, not a knob.
+if [ "$MODE" != window-cap ]; then
 echo "## read_ahead_budget (cold single-stream MB/s; issue #255)"
 printf '%-24s %10s\n' config MBps
 # off (ra=0) vs the default Phase-1 read amplification (ra=64, prefetch off).
@@ -159,3 +199,38 @@ for kc in false true; do
   c=$(secs "$v"); r=$(secs "$v"); umount_m
   printf '%-16s %10s %10s\n' "$kc" "$c" "$r"
 done
+fi  # end non-window-cap sweeps
+
+if [ "$MODE" = window-cap ]; then
+  # Sweep the daemon-internal read-amplification window cap (WINDOW_ABS_CAP) on
+  # real spinning media (#433). Each cap value is its own release build; the
+  # source is patched in place and restored after every build (and on exit).
+  echo "## window_cap build (one release binary per cap value)"
+  declare -A CAPBIN; SCANBIN=""
+  for c in $CAP_MIB; do
+    printf '  building cap=%s MiB ... ' "$c" >&2
+    CAPBIN[$c]="$(build_cap "$c")"; [ -z "$SCANBIN" ] && SCANBIN="${CAPBIN[$c]}"
+    echo "ok" >&2
+  done
+  rm -f "$DB"; "$SCANBIN" scan "$SCANDIR" --db "$DB" >/dev/null
+
+  echo "## window_cap (cold single-stream MB/s; default mount = amplification on, prefetch off)"
+  printf '%-12s %10s\n' cap_MiB MBps
+  for c in $CAP_MIB; do
+    BIN="${CAPBIN[$c]}"; mount_m
+    printf '%-12s %10s\n' "$c" "$(cold_mbps)"; umount_m
+  done
+
+  if [ "$STREAMS" -gt 0 ]; then
+    echo "## window_cap ($STREAMS concurrent cold streams, aggregate wall s)"
+    printf '%-12s %10s\n' cap_MiB wall_s
+    for c in $CAP_MIB; do
+      BIN="${CAPBIN[$c]}"; mount_m
+      mapfile -t files < <(find "$MMNT" -type f ! -path "$(biggest)")
+      drop; t0=$(date +%s.%N); pids=()
+      for f in "${files[@]:0:$STREAMS}"; do dd if="$f" of=/dev/null bs=1M 2>/dev/null & pids+=("$!"); done
+      wait "${pids[@]}"; t1=$(date +%s.%N); umount_m
+      printf '%-12s %10s\n' "$c" "$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.2f",b-a}')"
+    done
+  fi
+fi

--- a/docs/superpowers/specs/2026-06-15-storage-tunables-432-433-design.md
+++ b/docs/superpowers/specs/2026-06-15-storage-tunables-432-433-design.md
@@ -1,0 +1,139 @@
+# Storage tunables follow-ups: #432 (keep-cache default) + #433 (window-cap HDD bench)
+
+**Date:** 2026-06-15
+**Branch:** `tunables`
+**Issues:** [#432](https://github.com/Sohex/musefs/issues/432), [#433](https://github.com/Sohex/musefs/issues/433)
+**Lands as:** two commits, one PR.
+
+These are sibling follow-ups to the storage-tunables investigation (#256): #432
+acts on its one measured win, #433 closes a gap in what it measured.
+
+---
+
+## #432 — Default `keep_cache` to `true`
+
+### Problem
+
+`FuseConfig::keep_cache` defaults to `false` (`musefs-fuse/src/lib.rs:84`), so
+`FOPEN_KEEP_CACHE` is omitted and the kernel drops the page cache on every close,
+re-reading from the daemon on the next open. BENCHMARKS.md (#256) measured
+`--keep-cache` as the one real storage win (~3× faster repeat-open on HDD/NFS),
+and the inode-invalidation machinery that keeps it consistent under external
+retags already exists (`poll_refresh_notify` → `inval_inode`). The conservative
+default is no longer justified.
+
+### Change
+
+1. `musefs-fuse/src/lib.rs:84` — `keep_cache: false` → `true` in
+   `Default for FuseConfig`.
+2. `musefs-cli/src/lib.rs:111` — make the flag value-taking with a `true`
+   default while keeping the bare flag working:
+   ```rust
+   #[arg(long, env = "MUSEFS_KEEP_CACHE", default_value_t = true,
+         num_args = 0..=1, default_missing_value = "true",
+         value_parser = clap::builder::BoolishValueParser::new())]
+   pub keep_cache: bool,
+   ```
+   This gives three working forms — default `true`, bare `--keep-cache`
+   (still `true`, backward-compatible), and `--keep-cache false` to opt out.
+   It also fixes the latently-broken `--keep-cache false` call in
+   `storage_tunables_bench.sh:157` (which errors against today's presence-only
+   flag).
+
+### Why `num_args = 0..=1` over `action = Set`
+
+`action = Set` (the `case_insensitive` convention) would require a value and turn
+a bare `--keep-cache` into a parse error — a needless break for existing scripts.
+`num_args = 0..=1` + `default_missing_value` is strictly more compatible and
+costs nothing.
+
+### Tests (TDD: adjust assertions to the new default first, watch them fail, then flip)
+
+- `musefs-fuse/src/lib.rs:1052` — `assert!(!c.keep_cache)` → assert default `true`.
+- `musefs-cli/src/lib.rs:568` — flip the default assertion; add a case proving
+  `--keep-cache false` parses to `keep_cache == false`, and that bare
+  `--keep-cache` still yields `true`.
+- `musefs-fuse/tests/keep_cache.rs` — audit for any default-off assumption.
+
+### Docs
+
+- `README.md:417` — flip the table row from "disabled" to "enabled by default";
+  reword the prose at `README.md:409` if it implies the knobs are off.
+- `keep_cache` doc comments in both crates — note it is now on by default and how
+  to disable.
+- BENCHMARKS.md — one-line note that the measured win is now the default.
+
+### Validation
+
+Run the diff through the local in-diff mutation gate (SP convention: `-j2`,
+`--output` on `/tmp`, `TMPDIR=$HOME/.cache/musefs-mutants-tmp`, sanity-check the
+diff is non-empty). `0 missed` is the gate. Also run the `metrics`-feature core
+tests if the open/read path is touched (it is not, but the assertion counts are
+fragile) — N/A here since only defaults/flags change.
+
+---
+
+## #433 — Benchmark the 8 MiB internal window cap on HDD
+
+### Problem
+
+The per-stream read-amplification window doubles per sequential read up to
+`WINDOW_ABS_CAP = 8 MiB` (`musefs-core/src/readahead.rs:12`), a **compile-time
+const**. The #256 investigation found large read-ahead hurts on HDD, but that
+measured the FUSE kernel `max_readahead` knob, not this internal amplification
+window. BENCHMARKS.md shows phase-1 amplification (at the 8 MiB cap) is *neutral*
+on local HDD (~62 vs ~60 MB/s), but the cap itself was never swept on spinning
+media, so its effect is unmeasured.
+
+### Approach — measure, change only if warranted
+
+Production `readahead.rs` stays untouched unless the data shows 8 MiB hurts.
+
+**Mechanism.** Extend `benches/storage_tunables_bench.sh` with a `window-cap`
+sweep: for each cap value it patches `WINDOW_ABS_CAP` in `readahead.rs`, rebuilds
+`--release`, measures cold single-stream MB/s (and one concurrent-streams row) on
+the real-FLAC HDD corpus, then restores the source. The patch/restore is
+`git`-based and `trap`-protected so an interrupted run cannot leave the tree
+modified or half-built.
+
+**Corpus.** Real FLAC at `/data/torrents/completed/music` (btrfs HDD, 4389
+files). The single-stream row uses the 1112 MiB FLAC for a long, stable cold
+read; concurrent rows use the next-largest distinct tracks. Provision via
+`cp --reflink=auto` into a writable backing dir (no byte copy — extents are
+shared, cold reads still hit the platter) **or** point the scan at the tree
+directly. The corpus must be incompressible real audio, not `/dev/zero` (a
+compressing fs collapses zero-fill to a cached extent and silently inverts HDD
+numbers — see BENCHMARKS.md methodology).
+
+**Run conditions.** Mountpoint + DB on `/tmp` (AppArmor allows FUSE mounts
+there; `/data` is denied). Cold samples via `echo 3 > /proc/sys/vm/drop_caches`
+(needs `sudo`). Mode **synthesis** (structure-only triggers kernel passthrough
+when privileged and bypasses the daemon read path). Cap sweep: 1 / 2 / 4 / 8 /
+16 MiB, median of 3.
+
+### Outcome
+
+A new subsection under "Backing read-ahead (#255)" in BENCHMARKS.md with the
+sweep table, methodology, and reproduce command.
+
+- **If 8 MiB is within run-to-run noise / optimal:** no code change. Document and
+  close #433 with the evidence.
+- **If a smaller cap clearly wins on HDD:** stop and bring the data back before
+  touching the const or adding a runtime knob (a permanent tunable is out of
+  scope for this pass per the agreed "change only if warranted" decision).
+
+### Validation
+
+Bench + docs only in the no-change case (no Rust source change → no mutation
+gate). The new bench sweep is committed in-tree as a runnable script section
+(per the harness-in-tree convention).
+
+---
+
+## Out of scope
+
+- A permanent `--read-ahead-window-cap-*` runtime tunable (only if #433 data
+  warrants it; would be a separate decision).
+- Re-touching `max_readahead` / `max_background` — empirically disproven in #256,
+  do not re-propose without new evidence.
+- Per-medium `--storage-profile` presets — proposed and dropped in #256.

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -105,10 +105,11 @@ pub struct MountArgs {
     /// Max outstanding background (readahead/async) requests the kernel queues.
     #[arg(long, env = "MUSEFS_MAX_BACKGROUND", default_value_t = 64)]
     pub max_background: u16,
-    /// Keep the kernel page cache across opens. External re-tags auto-invalidate
-    /// the affected inodes on refresh, so cached bytes are dropped when content
-    /// changes.
-    #[arg(long, env = "MUSEFS_KEEP_CACHE", value_parser = clap::builder::BoolishValueParser::new())]
+    /// Keep the kernel page cache across opens. On by default: it is the one
+    /// measured storage win (~3× faster repeat-open on HDD/NFS, #432). External
+    /// re-tags auto-invalidate the affected inodes on refresh, so cached bytes
+    /// are dropped when content changes. Disable with `--keep-cache false`.
+    #[arg(long, env = "MUSEFS_KEEP_CACHE", default_value_t = true, num_args = 0..=1, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub keep_cache: bool,
     /// Compare filenames case-insensitively: case-variant directories merge and
     /// case-variant files are disambiguated. Defaults to true on macOS (whose
@@ -565,7 +566,8 @@ mod tests {
         assert_eq!(config.template, "$albumartist/$album/$title");
         assert_eq!(config.default_fallback, "Unknown");
         assert_eq!(config.mode, musefs_core::Mode::Synthesis);
-        assert!(!fuse_config.keep_cache);
+        // #432: keep-cache defaults on when the flag is absent.
+        assert!(fuse_config.keep_cache);
         assert_eq!(config.case_insensitive, cfg!(target_os = "macos"));
         // ms → Duration.
         assert_eq!(config.poll_interval, std::time::Duration::from_millis(250));
@@ -574,6 +576,27 @@ mod tests {
         assert_eq!(fuse_config.max_readahead, 64 * 1024);
         assert_eq!(fuse_config.max_background, 32);
         assert!(fuse_config.expose_metrics);
+    }
+
+    #[test]
+    fn keep_cache_flag_forms() {
+        use clap::Parser;
+        let parse = |extra: &[&str]| {
+            let mut argv = vec!["musefs", "mount", "/mnt/muse", "--db", "/tmp/x.db"];
+            argv.extend_from_slice(extra);
+            let cli = Cli::try_parse_from(argv).unwrap();
+            let Command::Mount(args) = cli.command else {
+                panic!("expected Mount");
+            };
+            parse_mount_config(&args).1.keep_cache
+        };
+        // Absent → default on (#432).
+        assert!(parse(&[]));
+        // Bare flag stays a backward-compatible "on".
+        assert!(parse(&["--keep-cache"]));
+        // Explicit value opts out / in.
+        assert!(!parse(&["--keep-cache", "false"]));
+        assert!(parse(&["--keep-cache", "true"]));
     }
 
     #[test]

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -59,7 +59,7 @@ fn parses_mode_and_revalidate_flags() {
             assert_eq!(args.attr_ttl_ms, 1000); // default
             assert_eq!(args.max_readahead_kib, 512); // default
             assert_eq!(args.max_background, 64); // default
-            assert!(!args.keep_cache); // default off
+            assert!(args.keep_cache); // #432: default on
         }
         Command::Scan { .. } => panic!("expected mount"),
     }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -52,9 +52,11 @@ pub struct FuseConfig {
     /// Caps that class of work delivered to the pool; foreground reads are
     /// bounded separately by `MAX_INFLIGHT_READS` (#308), not by this.
     pub max_background: u16,
-    /// Keep the kernel page cache across opens (`FOPEN_KEEP_CACHE`). An external
-    /// re-tag auto-invalidates the affected inode on refresh (`poll_refresh_notify`
-    /// → `inval_inode`), so cached bytes are dropped when content changes.
+    /// Keep the kernel page cache across opens (`FOPEN_KEEP_CACHE`). On by
+    /// default (#432): the one measured storage win (~3× faster repeat-open on
+    /// HDD/NFS). An external re-tag auto-invalidates the affected inode on
+    /// refresh (`poll_refresh_notify` → `inval_inode`), so cached bytes are
+    /// dropped when content changes.
     pub keep_cache: bool,
     /// uid presented for every entry (the marker, synthetic dirs, real files).
     pub uid: u32,
@@ -81,7 +83,7 @@ impl Default for FuseConfig {
             ttl: Duration::from_secs(1),
             max_readahead: 512 * 1024,
             max_background: 64,
-            keep_cache: false,
+            keep_cache: true,
             uid: rustix::process::getuid().as_raw(),
             gid: rustix::process::getgid().as_raw(),
             file_mode: 0o444,
@@ -1049,7 +1051,8 @@ mod tests {
         assert_eq!(c.ttl, Duration::from_secs(1));
         assert_eq!(c.max_readahead, 512 * 1024);
         assert_eq!(c.max_background, 64);
-        assert!(!c.keep_cache);
+        // #432: keep-cache is the one measured storage win and is now on by default.
+        assert!(c.keep_cache);
         assert_eq!(c.file_mode, 0o444);
         assert_eq!(c.dir_mode, 0o555);
         assert_eq!(c.uid, rustix::process::getuid().as_raw());


### PR DESCRIPTION
Two sibling follow-ups to the storage-tunables investigation (#256): #432 acts on its one measured win, #433 closes a gap in what it measured. Design spec in `docs/superpowers/specs/2026-06-15-storage-tunables-432-433-design.md`.

## #432 — Default keep-cache on

`FuseConfig::keep_cache` defaulted to `false`, so `FOPEN_KEEP_CACHE` was omitted and the kernel dropped the page cache on every close. #256 (BENCHMARKS.md) measured `--keep-cache` as the one real storage win (~3× faster repeat-open on HDD/NFS), and the inode-invalidation machinery that keeps it consistent under external retags already exists (`poll_refresh_notify` → `inval_inode`), so the conservative default is no longer justified.

- Flip the default to `true`.
- Make the CLI flag value-taking (`num_args = 0..=1` + `default_missing_value`) so all three forms work: the new default, a bare `--keep-cache` (backward-compatible "on"), and `--keep-cache false` to opt out. The value form also fixes the latently-broken `--keep-cache false` call in `storage_tunables_bench.sh`.
- Tests updated/added (default-on, all three flag forms); README, BENCHMARKS.md note, and doc comments updated.

Fixes #432

## #433 — Internal window cap on HDD: benchmarked, no change

The read-amplification window doubles up to `WINDOW_ABS_CAP` (8 MiB, a compile-time const). #256 found large *kernel* `max_readahead` hurts on HDD but never measured this daemon-internal cap.

- Added a `window-cap` sweep mode to `storage_tunables_bench.sh` that builds one release binary per cap value (patching the const in place, restoring it after each build and on exit), reflinks the corpus, and only needs `sudo` for `drop_caches`.
- Swept 1/2/4/8/16 MiB on a real btrfs HDD corpus. **No measurable cap effect:** within-cap run-to-run spread (~50–140 MB/s for the same file) dwarfs every between-cap median gap, and the apparent ordering is a measurement-order artifact — sweeping in reverse reverses the "trend"; cap=8 sits at ~61 MB/s either way.
- **No production change.** `WINDOW_ABS_CAP` stays at 8 MiB, which earns its keep on high-RTT NFS/remote (~6× single-stream amplification win), with nothing to gain on HDD. Full table + methodology in BENCHMARKS.md.

Fixes #433

## Validation

- `cargo fmt`, `clippy --all-targets -D warnings`, full workspace tests (1114 passed), mutant-anchor check — all green post-rebase on `v1.1-prep`.
- In-diff mutation gate (#432, vs `v1.1-prep`): 0 mutants — the changed files are all in the `mutants.toml` exclude globs by design. #433 changes no production Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
