### PR TITLE
fix(lidarr): scope API key, cap art size, enforce error contract

### DIFF
--- a/contrib/lidarr/src/musefs_lidarr/api.py
+++ b/contrib/lidarr/src/musefs_lidarr/api.py
@@ -8,6 +8,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from musefs_common import MAX_ART_BYTES
+
 from .errors import ConfigError, LidarrApiError
 
 # Lidarr custom scripts are fire-and-forget: a transient API error or a restart
@@ -91,10 +93,15 @@ class LidarrClient:
 
         ``url`` is the server-relative path from an album's ``images`` entry
         (e.g. ``/MediaCover/Albums/20/cover.jpg``); an absolute ``remoteUrl`` is
-        used as-is. Retries transient failures like :meth:`get_json`.
+        used as-is. The API key is sent only for server-local paths — absolute
+        URLs point at third-party hosts (coverartarchive.org, etc.) and must not
+        carry the Lidarr key. The body is capped at ``MAX_ART_BYTES`` so a
+        third-party host cannot make us buffer an unbounded image. Retries
+        transient failures like :meth:`get_json`.
         """
-        full = url if url.startswith(("http://", "https://")) else f"{self._base}{url}"
-        return self._request(full)
+        if url.startswith(("http://", "https://")):
+            return self._request(url, send_key=False, max_bytes=MAX_ART_BYTES)
+        return self._request(f"{self._base}{url}", max_bytes=MAX_ART_BYTES)
 
     def _url(self, path: str, params: dict[str, object] | None = None) -> str:
         query = ""
@@ -104,31 +111,64 @@ class LidarrClient:
                 query = "?" + urlencode(clean, doseq=True)
         return f"{self._base}{path}{query}"
 
-    def _request(self, url: str) -> bytes:
-        """GET ``url`` with the API key, returning the raw response body.
+    def _request(self, url: str, *, send_key: bool = True, max_bytes: int | None = None) -> bytes:
+        """GET ``url``, returning the raw response body.
+
+        The ``X-Api-Key`` header is sent only when ``send_key`` is true, so an
+        absolute third-party URL never carries the Lidarr key. When ``max_bytes``
+        is set, a response whose declared or actual length exceeds it fails with
+        ``LidarrApiError`` rather than being buffered in full.
 
         Retries up to ``self._retries`` attempts with exponential backoff on
         transient failures (network errors, timeouts, and the 5xx/429/408 HTTP
-        statuses); non-transient HTTP errors fail fast.
+        statuses); non-transient HTTP errors fail fast. Every failing path raises
+        ``LidarrApiError``.
         """
-        request = Request(url, headers={"X-Api-Key": self._api_key})
+        headers = {"X-Api-Key": self._api_key} if send_key else {}
+        request = Request(url, headers=headers)
+        last_exc: Exception | None = None
+        message = "Lidarr API request failed"
         for attempt in range(self._retries):
-            last = attempt + 1 == self._retries
             try:
                 with self._opener(request, timeout=self._timeout) as response:
-                    return response.read()
+                    return self._read_capped(response, max_bytes)
             except HTTPError as exc:
-                if last or exc.code not in _RETRYABLE_STATUS:
-                    raise LidarrApiError(
-                        f"Lidarr API request failed with HTTP {exc.code}; "
-                        f"api_key={redacted(self._api_key)}"
-                    ) from exc
+                message = (
+                    f"Lidarr API request failed with HTTP {exc.code}; "
+                    f"api_key={redacted(self._api_key)}"
+                )
+                if exc.code not in _RETRYABLE_STATUS:
+                    raise LidarrApiError(message) from exc
+                last_exc = exc
             except (URLError, TimeoutError) as exc:
-                if last:
-                    reason = getattr(exc, "reason", exc)
-                    raise LidarrApiError(f"Lidarr API request failed: {reason}") from exc
-            self._sleep(_RETRY_BACKOFF_BASE * (2**attempt))
-        raise AssertionError("unreachable")  # pragma: no cover
+                last_exc = exc
+                message = f"Lidarr API request failed: {getattr(exc, 'reason', exc)}"
+            if attempt + 1 < self._retries:
+                self._sleep(_RETRY_BACKOFF_BASE * (2**attempt))
+        raise LidarrApiError(message) from last_exc
+
+    def _read_capped(self, response, max_bytes: int | None) -> bytes:
+        """Read ``response`` body, rejecting one larger than ``max_bytes``.
+
+        A declared ``Content-Length`` over the cap fails before any body is read;
+        otherwise at most ``max_bytes + 1`` bytes are buffered to detect overrun.
+        """
+        if max_bytes is None:
+            return response.read()
+        declared = response.headers.get("Content-Length")
+        if declared is not None:
+            try:
+                declared_len = int(declared)
+            except ValueError:
+                declared_len = None
+            if declared_len is not None and declared_len > max_bytes:
+                raise LidarrApiError(
+                    f"Lidarr cover art exceeds {max_bytes} bytes (Content-Length {declared_len})"
+                )
+        body = response.read(max_bytes + 1)
+        if len(body) > max_bytes:
+            raise LidarrApiError(f"Lidarr cover art exceeds {max_bytes} bytes")
+        return body
 
     def media_management_config(self):
         """Return Lidarr's media-management config."""

--- a/contrib/lidarr/tests/test_api.py
+++ b/contrib/lidarr/tests/test_api.py
@@ -2,6 +2,7 @@ import json
 from urllib.error import HTTPError, URLError
 
 import pytest
+from musefs_common import MAX_ART_BYTES
 
 from musefs_lidarr.api import (
     LidarrClient,
@@ -100,8 +101,9 @@ def test_config_requires_url_and_key_together():
 
 
 class RawResponse:
-    def __init__(self, payload: bytes):
+    def __init__(self, payload: bytes, headers: dict | None = None):
         self.payload = payload
+        self.headers = headers or {}
 
     def __enter__(self):
         return self
@@ -109,8 +111,18 @@ class RawResponse:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def read(self):
-        return self.payload
+    def read(self, amount=None):
+        return self.payload if amount is None else self.payload[:amount]
+
+
+class _CountingResponse(RawResponse):
+    def __init__(self, payload: bytes, reads: list, headers: dict | None = None):
+        super().__init__(payload, headers)
+        self._reads = reads
+
+    def read(self, amount=None):
+        self._reads.append(amount)
+        return super().read(amount)
 
 
 def _flaky_opener(failures):
@@ -203,3 +215,72 @@ def test_media_cover_fetches_raw_bytes_with_api_key():
     assert data == b"\xff\xd8\xff\xe0jpegdata"
     assert captured["url"] == "http://lidarr.local/MediaCover/Albums/20/cover.jpg?lastModified=1"
     assert captured["headers"]["X-api-key"] == "secret"
+
+
+def test_media_cover_absolute_url_omits_api_key():
+    captured = {}
+
+    def opener(request, timeout):
+        captured["url"] = request.full_url
+        captured["headers"] = dict(request.header_items())
+        return RawResponse(b"\xff\xd8\xff\xe0jpegdata")
+
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local/", api_key="secret"), opener=opener
+    )
+
+    data = client.media_cover("https://coverartarchive.org/release/abc/front.jpg")
+
+    assert data == b"\xff\xd8\xff\xe0jpegdata"
+    assert captured["url"] == "https://coverartarchive.org/release/abc/front.jpg"
+    assert "X-api-key" not in captured["headers"]
+
+
+def test_media_cover_rejects_oversized_body():
+    def opener(request, timeout):
+        return RawResponse(b"x" * (MAX_ART_BYTES + 1))
+
+    client = LidarrClient(LidarrConfig(url="http://lidarr.local", api_key="secret"), opener=opener)
+
+    with pytest.raises(LidarrApiError, match="exceeds"):
+        client.media_cover("/MediaCover/Albums/1/cover.jpg")
+
+
+def test_media_cover_rejects_oversized_content_length():
+    reads = []
+
+    def opener(request, timeout):
+        return _CountingResponse(b"x", reads, headers={"Content-Length": str(MAX_ART_BYTES + 1)})
+
+    client = LidarrClient(LidarrConfig(url="http://lidarr.local", api_key="secret"), opener=opener)
+
+    with pytest.raises(LidarrApiError, match="Content-Length"):
+        client.media_cover("/MediaCover/Albums/1/cover.jpg")
+    assert reads == []
+
+
+def test_media_cover_accepts_body_at_cap():
+    data = b"y" * MAX_ART_BYTES
+
+    def opener(request, timeout):
+        return RawResponse(data, headers={"Content-Length": str(MAX_ART_BYTES)})
+
+    client = LidarrClient(LidarrConfig(url="http://lidarr.local", api_key="secret"), opener=opener)
+
+    assert client.media_cover("/MediaCover/Albums/1/cover.jpg") == data
+
+
+def test_request_exhausts_retries_raising_api_error_not_assertion():
+    err = HTTPError("http://lidarr.local/api/v1/album/1", 503, "Service Unavailable", None, None)
+    opener, calls = _flaky_opener([err, err, err])
+    client = LidarrClient(
+        LidarrConfig(url="http://lidarr.local", api_key="secret"),
+        opener=opener,
+        retries=3,
+        sleep=lambda _: None,
+    )
+
+    with pytest.raises(LidarrApiError) as exc:
+        client.get_json("/api/v1/album/1")
+    assert len(calls) == 3
+    assert "503" in str(exc.value)


### PR DESCRIPTION
Three fixes on the Lidarr API client's cover-art fetch path, where `media_cover` can fetch an absolute third-party `remoteUrl` (coverartarchive.org, images.lidarr.audio) pulled from album metadata.

- **#476 — API key leak.** `_request` set `X-Api-Key` on every request, sending the Lidarr key to third-party hosts. It now takes `send_key`; `media_cover` sends the key only for server-local paths and omits it for absolute URLs.
- **#477 — unbounded buffering.** The response body was read in full with no size guard, letting a third-party host control how much memory we allocate. `media_cover` now caps at `MAX_ART_BYTES`: an oversized `Content-Length` is rejected before any body is read, otherwise at most `cap + 1` bytes are buffered to detect overrun — both raising `LidarrApiError`.
- **#480 — wrong failure type.** `_request` ended in `raise AssertionError("unreachable")` behind `# pragma: no cover`, breaking the documented `LidarrApiError`-on-failure contract. The retry loop now falls through to a reachable, tested `raise LidarrApiError(...) from last_exc`.

Public `media_cover(url)` is unchanged, so `sync.py` and its test fakes are unaffected.

## Testing
- `python -m pytest contrib/lidarr/tests` — 85 passed
- New tests cover: absolute URL omits the key, oversized body rejected, oversized `Content-Length` rejected before any read, body at the cap accepted, and exhausted retries raising `LidarrApiError` (not `AssertionError`)
- ruff check / format clean; full pre-commit suite (cargo fmt/clippy/test, ruff) green

Fixes #476
Fixes #477
Fixes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)