### PR TITLE
fix(python-musefs): fail loudly on duplicate backing_path in bulk lookup

### DIFF
--- a/contrib/picard/musefs/_common/store.py
+++ b/contrib/picard/musefs/_common/store.py
@@ -123,6 +123,14 @@ def track_ids_for_paths(conn, keys):
             chunk,
         )
         for backing_path, track_id in rows:
+            if backing_path in out:
+                # backing_path is UNIQUE in the schema, so a duplicate means a
+                # non-conformant DB; collapsing it would silently hide a track
+                # from prune (#478). Fail loudly instead.
+                raise ValueError(
+                    f"duplicate backing_path {backing_path!r} in tracks "
+                    f"(ids {out[backing_path]} and {track_id})"
+                )
             out[backing_path] = track_id
     return out
 

--- a/contrib/python-musefs/src/musefs_common/store.py
+++ b/contrib/python-musefs/src/musefs_common/store.py
@@ -120,6 +120,14 @@ def track_ids_for_paths(conn, keys):
             chunk,
         )
         for backing_path, track_id in rows:
+            if backing_path in out:
+                # backing_path is UNIQUE in the schema, so a duplicate means a
+                # non-conformant DB; collapsing it would silently hide a track
+                # from prune (#478). Fail loudly instead.
+                raise ValueError(
+                    f"duplicate backing_path {backing_path!r} in tracks "
+                    f"(ids {out[backing_path]} and {track_id})"
+                )
             out[backing_path] = track_id
     return out
 

--- a/contrib/python-musefs/tests/test_store_db.py
+++ b/contrib/python-musefs/tests/test_store_db.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import pytest
 from conftest import insert_track
 
@@ -147,5 +149,22 @@ def test_track_ids_for_paths_chunks_past_variable_limit(db_path):
         expected = {path: insert_track(conn, path) for path in paths}
         conn.commit()
         assert track_ids_for_paths(conn, paths) == expected
+    finally:
+        conn.close()
+
+
+def test_track_ids_for_paths_raises_on_duplicate_backing_path():
+    from musefs_common import track_ids_for_paths
+
+    # backing_path is UNIQUE in the real schema, so the {key: id} dict can never
+    # collapse against a conformant DB. Guard against a non-conformant one anyway:
+    # silently dropping a duplicate row would hide a track from prune (#478).
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE tracks (id INTEGER PRIMARY KEY, backing_path TEXT)")
+        conn.execute("INSERT INTO tracks (id, backing_path) VALUES (1, '/m/a.flac')")
+        conn.execute("INSERT INTO tracks (id, backing_path) VALUES (2, '/m/a.flac')")
+        with pytest.raises(ValueError):
+            track_ids_for_paths(conn, ["/m/a.flac"])
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

`track_ids_for_paths` (`contrib/python-musefs/src/musefs_common/store.py`) returns a `{backing_path: id}` dict. If two `tracks` rows shared a `backing_path`, the dict kept only the last id, and `prune_missing(conn, list(ids.values()))` then operated on an incomplete id set — a duplicate-path track could be silently missed (the behavioural narrowing vs the `fetchall()` the Lidarr code originally used).

`backing_path` is `UNIQUE` in the schema, so this can't occur against a conformant DB, but the collapse was silent. This makes it loud: a duplicate now raises `ValueError` instead of dropping a row. The `{key: id}` public API and the sole consumer (`sync_rename_prune`) are unchanged, and no new exception type is introduced.

## Changes

- `store.py`: guard the dict build, raising on a duplicate `backing_path`.
- `contrib/picard/musefs/_common/store.py`: re-vendored via `vendor_to_picard.py`.
- `test_store_db.py`: TDD test feeding a non-conformant (no-`UNIQUE`) DB to exercise the guard.

## Verification

python-musefs 74 passed · lidarr 80 passed · picard vendor-sync 2 passed · ruff clean · full pre-commit (fmt/clippy/workspace tests/ruff) green.

Fixes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)