### PR TITLE
fix(picard): drop zero-valued movement like sibling numeric keys

### DIFF
--- a/contrib/picard/musefs/_core.py
+++ b/contrib/picard/musefs/_core.py
@@ -34,6 +34,7 @@ _DROP_IF_ZERO = {
     "discnumber",
     "tracktotal",
     "disctotal",
+    "movement",
     "compilation",
     "bpm",
 }

--- a/contrib/picard/tests/test_map_fields.py
+++ b/contrib/picard/tests/test_map_fields.py
@@ -106,6 +106,8 @@ def test_movement_swap(fake_metadata):
     d = dict(map_fields(fake_metadata(movement="Allegro", movementnumber="1")))
     assert d["movementname"] == "Allegro"
     assert d["movement"] == "1"
+    z = dict(map_fields(fake_metadata(movementnumber="0")))
+    assert "movement" not in z
 
 
 def test_totals_renamed_and_zero_dropped(fake_metadata):


### PR DESCRIPTION
## What

Picard's `_DROP_IF_ZERO` set (`contrib/picard/musefs/_core.py`) dropped zero-valued track/disc numbers but not `movement` — the store key that Picard's `movementnumber` renames to via `RENAME`. A literal `movementnumber=0` therefore persisted a `"0"` movement row, asymmetric with its sibling numeric keys (`tracknumber`, `discnumber`, `tracktotal`, `disctotal`).

This adds `movement` to the set so a zero movement is dropped like its siblings. (beets doesn't map `movementnumber`, so no parity change is needed there.)

## Test

`test_movement_swap` now asserts `movementnumber="0"` drops the `movement` key. Verified failing before the fix, passing after; full Picard suite + workspace pre-commit gate green.

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
