### PR TITLE
chore(audit): allow-list RUSTSEC-2024-0436 (paste unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+# cargo-audit / rustsec-audit-check configuration.
+
+[advisories]
+# RUSTSEC-2024-0436: `paste` is unmaintained. This is an unmaintained advisory,
+# not a vulnerability. `paste` is a transitive, compile-time-only dependency
+# (paste -> tikv-jemalloc-ctl -> the musefs binary's jemalloc allocator); it is
+# a proc-macro with fully determined input and output and no runtime or security
+# surface. Upstream has declined to remove it on those grounds and recommends
+# downstream consumers allow-list the advisory: tikv/jemallocator#123.
+ignore = ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
## What

Adds `.cargo/audit.toml` allow-listing `RUSTSEC-2024-0436` so the weekly
`rustsec/audit-check` workflow stops re-flagging the unmaintained `paste` crate.

## Why

`paste` is **not a direct dependency**. It reaches us only transitively as a
compile-time proc-macro:

```
paste v1.0.15 (proc-macro)
└── tikv-jemalloc-ctl v0.7.0
    └── musefs (binary, jemalloc allocator)
```

The advisory is **unmaintained, not a vulnerability**. Upstream has already
considered and declined removal (tikv/jemallocator#123, #129), on the grounds
that `paste` is a determined-I/O compile-time macro with no runtime or security
surface, and explicitly recommends downstream consumers allow-list it. Their
published `Cargo.toml` still depends on `paste = "1"`, so no upstream fix is
pending.

The allow-list comment links the upstream decision as the standing justification.
If `tikv-jemalloc-ctl` ever drops `paste`, the advisory simply stops firing and
the entry can be removed.

Resolves #485 (closed as by-design, with an explanatory comment on the issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency audit configuration to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->