### PR TITLE
fix(scan): coalesce per-batch budget releases into one wakeup (#436)

### DIFF
--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1196,7 +1196,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
         let mut bw = db.bulk_writer()?;
         // Budget weights are released only after commit, and ingest_bulk consumes
         // the Probed — capture each unit's weight before the move (#68).
-        let mut weights = Vec::with_capacity(batch.len());
+        let mut released = 0u64;
         // `Ingested` reports committed files, so buffer the paths and emit only
         // after `bw.commit()` succeeds — a failed commit aborts the scan without
         // having advanced the progress bar past unpersisted files.
@@ -1208,7 +1208,7 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
             weight,
         } in batch.drain(..)
         {
-            weights.push(weight);
+            released += weight;
             ingest_bulk(&mut bw, &abs_path, stamp, probed)?;
             committed.push(abs_path);
         }
@@ -1223,9 +1223,9 @@ fn run_pipeline(db: &Db, files: Vec<PathBuf>, opts: &ScanOptions) -> Result<Scan
                 });
             }
         }
-        for w in weights {
-            budget.release(w);
-        }
+        // Coalesce into one wakeup: the commit frees the whole batch, so a single
+        // release avoids waking every blocked producer once per committed file.
+        budget.release(released);
         *batch_bytes = 0;
         Ok(())
     };


### PR DESCRIPTION
## What

The scan pipeline writer released the in-flight art-byte budget once per **committed file** (`run_pipeline` flush closure, `musefs-core/src/scan.rs`), so every flush fired *N* `notify_all`s — each freeing only one file's bytes and waking every blocked producer when at most one could proceed. That is the thundering-herd wake on the scan backpressure path described in #436.

## Change

Accumulate the batch's weights into a running total and call `budget.release` **once** after `bw.commit()`. One wakeup per flush now frees the whole committed batch at once, so waking blocked producers is warranted (there is room for many) and the per-file herd is gone. Also drops the per-flush `Vec<u64>` allocation. Release still happens strictly after commit (preserves #68).

`ByteBudget::release` keeps `notify_all` deliberately: it is correct for the heterogeneous reservation sizes here — a naive `notify_one` would risk a lost-wakeup stall (a woken producer may still not fit while a smaller one that would fit stays asleep). The waste was the caller's release *granularity*, not the primitive.

## Verification

- `cargo test -p musefs-core` — 453 passed, including `tests/pipeline_backpressure.rs` which exercises this exact path with a tiny `batch_bytes: 8` cap (producers block and get released).
- `cargo clippy -p musefs-core --all-targets` — clean.
- In-diff mutation gate (`cargo mutants --in-diff`) — 2 caught, 1 unviable, **0 missed / 0 timeout**.
- The edit is net-zero on line count, so the `run_pipeline` mutant anchors at `scan.rs:1245/1247/1255/1257` did not shift — the pre-commit anchor-drift guard validated 66 entries clean.

Fixes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)