### PR TITLE
ci(perf): split the A/B bench across two runners for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,16 +438,27 @@ jobs:
     if: needs.changes.outputs.lidarr == 'true'
     uses: ./.github/workflows/lidarr-smoke.yml
 
-  perf-ab:
-    name: Read A/B (warn-only)
+  perf-bench:
+    name: Read A/B bench (${{ matrix.which }})
     needs: changes
-    # PR-only: on push/tag events `pull_request.base.sha` is empty, so the A/B
-    # script has no base to bench against. The job is informational anyway.
+    # PR-only: on push/tag events `pull_request.base.sha` is empty, so there is
+    # no base to bench against. The A/B job is informational anyway.
     if: needs.changes.outputs.perf == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+    strategy:
+      # Base and PR bench independently on their own runners, in parallel — the
+      # two halves of the old back-to-back A/B. perf-ab joins their baselines.
+      # Don't cancel the other half if one fails, so its status still reports
+      # which ref broke (a failed leg leaves perf-ab skipped — a red signal).
+      fail-fast: false
+      matrix:
+        include:
+          - which: base
+            ref: ${{ github.event.pull_request.base.sha }}
+          - which: pr
+            ref: HEAD
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -457,8 +468,44 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libfuse3-dev
       - name: Install critcmp
         run: cargo install critcmp --locked --version 0.1.8
-      - name: Run A/B
-        run: scripts/perf-ab.sh "${{ github.event.pull_request.base.sha }}" "$RUNNER_TEMP/perf-ab.md"
+      - name: Bench ${{ matrix.which }}
+        run: scripts/perf-bench-one.sh "${{ matrix.ref }}" "${{ matrix.which }}" "$RUNNER_TEMP/${{ matrix.which }}.json"
+      - name: Upload baseline
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: perf-baseline-${{ matrix.which }}
+          path: ${{ runner.temp }}/${{ matrix.which }}.json
+          if-no-files-found: error
+
+  perf-ab:
+    name: Read A/B (warn-only)
+    needs: [changes, perf-bench]
+    if: needs.changes.outputs.perf == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Install critcmp
+        run: cargo install critcmp --locked --version 0.1.8
+      - name: Download baselines
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: ${{ runner.temp }}/baselines
+          pattern: perf-baseline-*
+          merge-multiple: true
+      - name: Compare
+        run: >-
+          scripts/perf-ab-compare.sh
+          "$RUNNER_TEMP/baselines/base.json"
+          "$RUNNER_TEMP/baselines/pr.json"
+          "${{ github.event.pull_request.base.sha }}"
+          "$(git rev-parse HEAD)"
+          "$RUNNER_TEMP/perf-ab.md"
+          "Base and PR benched on separate GH runners — cross-runner variance adds noise; treat <10% moves as noise."
       - name: Comment (same-repo PRs)
         if: github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -73,9 +73,10 @@ in three lanes:
 1. **Counter gate (every non-doc PR, hard).** `perf_counters.rs` +
    `tree.rs` golden work-counter assertions under `--features metrics`. Catches
    algorithmic regressions (extra copy, whole-file slurp, O(N) tree rebuild).
-2. **A/B wall-clock (warn-only, core `src` PRs).** The `perf-ab` job benches the
-   base and PR commits back-to-back on one runner and posts a `critcmp` delta as
-   a PR comment. Never blocks.
+2. **A/B wall-clock (warn-only, core `src` PRs).** The `perf-bench` matrix job
+   benches the base and PR commits in parallel on separate runners; the `perf-ab`
+   job then diffs the two exported baselines and posts a `critcmp` delta as a PR
+   comment. Never blocks.
 3. **Release record.** The `benchmarks` job runs the full bench suite at the
    `ci` tier on a tag and uploads the numbers as an artifact for curation here.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,11 +376,13 @@ read/ingest/refresh work must update the golden numbers in the same PR. They run
 on every non-doc PR via CI's `check` job. Constant-factor (wall-clock) changes
 are surfaced separately by the warn-only `perf-ab` job (below).
 
-The `perf-ab` job runs only when `musefs-core/src/**` or `musefs-format/src/**`
-change. It benches the base and PR commits back-to-back on one runner and posts a
-`critcmp` delta as a sticky PR comment. It is **warn-only** and not a required
-check — GH runner noise makes wall-clock unfit for hard gating. Reproduce locally
-with `scripts/perf-ab.sh <base-sha> out.md`.
+The A/B benchmark runs only when `musefs-core/src/**` or `musefs-format/src/**`
+change. The `perf-bench` matrix job benches the base and PR commits in parallel
+on separate runners (one ref each), then the `perf-ab` job downloads both
+exported baselines and posts a `critcmp` delta as a sticky PR comment. It is
+**warn-only** and not a required check — GH runner noise (now including
+cross-runner variance) makes wall-clock unfit for hard gating. Reproduce locally
+on one machine with `scripts/perf-ab.sh <base-sha> out.md`.
 
 ### Concurrency + sanitizers
 

--- a/scripts/perf-ab-compare.sh
+++ b/scripts/perf-ab-compare.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Diff two exported critcmp baselines into a warn-only markdown report. The
+# baselines may come from one machine (perf-ab.sh) or two separate CI runners
+# (perf-bench-one.sh); see those for context.
+#
+# Usage: scripts/perf-ab-compare.sh <base-json> <pr-json> <base-sha> <head-sha> <out-md> [note]
+# Requires: critcmp on PATH.
+set -euo pipefail
+
+BASE_JSON="${1:?base baseline json required}"
+PR_JSON="${2:?pr baseline json required}"
+BASE_SHA="${3:?base sha required}"
+HEAD_SHA="${4:?head sha required}"
+OUT="${5:?output markdown path required}"
+NOTE="${6:-Treat <10% moves as noise.}"
+
+{
+  echo "### Read-path A/B (warn-only)"
+  echo
+  echo "Base \`${BASE_SHA:0:12}\` vs PR \`${HEAD_SHA:0:12}\`. $NOTE"
+  echo
+  base_n="$(critcmp "$BASE_JSON" 2>/dev/null | tail -n +2 | grep -c . || true)"
+  pr_n="$(critcmp "$PR_JSON" 2>/dev/null | tail -n +2 | grep -c . || true)"
+  common="$(critcmp "$BASE_JSON" "$PR_JSON" 2>/dev/null | tail -n +2 | grep -c . || true)"
+  if [ "$common" -eq 0 ]; then
+    echo "> ⚠️ No comparable benchmarks (benchmark IDs differ between base and PR"
+    echo "> — a harness/bench rename?). Nothing to compare."
+  else
+    echo '```'
+    critcmp "$BASE_JSON" "$PR_JSON"
+    echo '```'
+    echo
+    echo "_base benches: ${base_n}, pr benches: ${pr_n}, compared: ${common}._"
+  fi
+} > "$OUT"
+
+echo "Wrote $OUT" >&2

--- a/scripts/perf-ab.sh
+++ b/scripts/perf-ab.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Same-runner A/B wall-clock comparison of the read_throughput criterion bench.
 # Benches the base ref and HEAD back-to-back on ONE machine (robust to
-# runner-to-runner variance), then diffs with critcmp. The job that invokes this
-# is informational (excluded from the ci-ok gate); a build/bench failure here
-# surfaces as a red job rather than being swallowed.
+# runner-to-runner variance), then diffs with critcmp. This is the local-dev /
+# single-machine entry point; CI instead splits the two bench runs across
+# separate runners (perf-bench-one.sh) for wall-clock and joins them with the
+# same perf-ab-compare.sh. The A/B job is informational (excluded from the ci-ok
+# gate); a build/bench failure surfaces as a red job rather than being swallowed.
 #
 # Usage: scripts/perf-ab.sh <base-sha> <out-markdown-file>
 # Requires: cargo, critcmp on PATH. Run from the repo root with a clean tree.
@@ -11,42 +13,14 @@ set -euo pipefail
 
 BASE_SHA="${1:?base sha required}"
 OUT="${2:?output markdown path required}"
-BENCH=(cargo bench -p musefs-core --bench read_throughput --)
+here="$(dirname "$0")"
 
 head_sha="$(git rev-parse HEAD)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
 
-run_baseline() {
-  local name="$1"
-  "${BENCH[@]}" --save-baseline "$name" >/dev/null 2>&1
-}
+"$here/perf-bench-one.sh" "$BASE_SHA" base "$tmp/base.json"
+"$here/perf-bench-one.sh" "$head_sha" pr "$tmp/pr.json"
 
-echo "Benching base ($BASE_SHA)…" >&2
-git checkout --quiet --detach "$BASE_SHA"
-run_baseline base
-
-echo "Benching head ($head_sha)…" >&2
-git checkout --quiet --detach "$head_sha"
-run_baseline pr
-
-{
-  echo "### Read-path A/B (same-runner, warn-only)"
-  echo
-  echo "Base \`${BASE_SHA:0:12}\` vs PR \`${head_sha:0:12}\`. Wall-clock on a"
-  echo "shared GH runner — treat <10% moves as noise."
-  echo
-  base_n="$(critcmp --list 2>/dev/null | grep -c '^base' || true)"
-  pr_n="$(critcmp --list 2>/dev/null | grep -c '^pr' || true)"
-  common="$(critcmp base pr 2>/dev/null | tail -n +2 | grep -c . || true)"
-  if [ "$common" -eq 0 ]; then
-    echo "> ⚠️ No comparable benchmarks (benchmark IDs differ between base and PR"
-    echo "> — a harness/bench rename?). Nothing to compare."
-  else
-    echo '```'
-    critcmp base pr
-    echo '```'
-    echo
-    echo "_base benches: ${base_n}, pr benches: ${pr_n}, compared: ${common}._"
-  fi
-} > "$OUT"
-
-echo "Wrote $OUT" >&2
+"$here/perf-ab-compare.sh" "$tmp/base.json" "$tmp/pr.json" "$BASE_SHA" "$head_sha" "$OUT" \
+  "Benched back-to-back on one machine. Treat <10% moves as noise."

--- a/scripts/perf-bench-one.sh
+++ b/scripts/perf-bench-one.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Bench one ref's read_throughput criterion baseline and export it to JSON.
+# In CI each ref benches on its own runner in parallel (base on one, PR on
+# another); perf-ab-compare.sh then diffs the two exported baselines. Splitting
+# trades same-machine stability for wall-clock — the A/B job is warn-only and
+# already treats <10% moves as noise.
+#
+# Usage: scripts/perf-bench-one.sh <ref> <baseline-name> <out-json>
+# Requires: cargo, critcmp on PATH. Run from the repo root with a clean tree.
+set -euo pipefail
+
+REF="${1:?ref required}"
+NAME="${2:?baseline name required}"
+OUT="${3:?output json path required}"
+BENCH=(cargo bench -p musefs-core --bench read_throughput --)
+
+echo "Benching $NAME ($REF)…" >&2
+git checkout --quiet --detach "$REF"
+"${BENCH[@]}" --save-baseline "$NAME" >/dev/null 2>&1
+critcmp --export "$NAME" > "$OUT"
+echo "Exported $NAME baseline to $OUT" >&2


### PR DESCRIPTION
## What

The warn-only read-path A/B job benched base and PR **back-to-back on one
runner**. The wall-clock cost is the two bench runs (not the build), so they
ran serially — roughly double the necessary time.

This splits the work:

- **`perf-bench`** — a `fail-fast: false` matrix (`base` / `pr`) that benches
  one ref per runner, in parallel, and uploads each `critcmp` baseline as an
  artifact.
- **`perf-ab`** — a light join job that downloads both baselines, diffs them,
  and posts the same sticky PR comment (`perf-ab` header preserved).

PR wall-clock drops to ~one bench run.

## Script refactor

Factored the old monolith into reusable pieces, no behavior change for local use:

- `scripts/perf-bench-one.sh` — bench one ref → export JSON (per CI runner).
- `scripts/perf-ab-compare.sh` — diff two baselines → markdown (join job).
- `scripts/perf-ab.sh` — kept as the local single-machine wrapper that calls both,
  so `scripts/perf-ab.sh <base-sha> out.md` still works for dev.

## Tradeoff

Cross-runner variance now feeds the delta (the old same-runner setup avoided
this). Acceptable here — the job is **warn-only**, excluded from the `ci-ok`
gate, and the comment already treats <10% moves as noise. The note in the PR
comment and the docs call this out.

The **release** lane is untouched: the `benchmarks` job (`perf-release-bench.sh`)
benches HEAD alone on one runner and records absolute numbers — it's not an A/B,
so cross-runner variance doesn't apply.

## Verification

- `shellcheck`, `yamllint`, `bash -n` clean on all three scripts.
- `ci-ok` aggregator still does **not** depend on `perf-bench`/`perf-ab` — the
  A/B remains non-blocking.
- Full pre-commit suite (fmt, clippy, workspace tests) green.
- **Not exercised end-to-end:** the actual `cargo bench` + `critcmp` run was not
  run locally (critcmp not installed; a real run takes minutes). The split rests
  on `critcmp --export` + file-path baseline args. Note this PR does **not** touch
  `musefs-core/src/**` or `musefs-format/src/**`, so the A/B job is gated off and
  will be skipped on this PR — it won't self-validate here. First live run will be
  the next PR that touches the read/synthesis surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
