### PR TITLE
fix(lidarr-e2e): mock_metadata must answer HEAD so Lidarr fetches cover art

### DIFF
--- a/scripts/lidarr-e2e/mock_metadata.py
+++ b/scripts/lidarr-e2e/mock_metadata.py
@@ -35,20 +35,34 @@ def make_handler():
     album = _load("album.json")
 
     class Handler(BaseHTTPRequestHandler):
+        # Lidarr's MediaCoverService issues a HEAD before downloading cover art;
+        # an unhandled HEAD returns 501, so the cover never downloads. do_HEAD
+        # replays do_GET's routing/headers with the body suppressed.
+        _head = False
+
         def _send(self, obj, code=200):
             body = json.dumps(obj).encode()
             self.send_response(code)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            if not self._head:
+                self.wfile.write(body)
 
         def _send_bytes(self, data, ctype):
             self.send_response(200)
             self.send_header("Content-Type", ctype)
             self.send_header("Content-Length", str(len(data)))
             self.end_headers()
-            self.wfile.write(data)
+            if not self._head:
+                self.wfile.write(data)
+
+        def do_HEAD(self):  # noqa: N802
+            self._head = True
+            try:
+                self.do_GET()
+            finally:
+                self._head = False
 
         def do_GET(self):  # noqa: N802
             path = urlparse(self.path).path


### PR DESCRIPTION
## Problem

The `lidarr-e2e` workflow fails at the cover-art assertion added in `2f90078` (#423):

```
[ok] store track_art rows: 0
AssertionError: 0
FAIL: store carries no album art
```

That assertion had never actually passed in CI — the only previously-green run predated it, so this manual run was its first real exercise.

## Root cause

Lidarr's `MediaCoverService` issues an HTTP **`HEAD`** against a cover URL before downloading it. `scripts/lidarr-e2e/mock_metadata.py` only defined `do_GET`, and Python's `BaseHTTPRequestHandler` answers **501 Not Implemented** for any method without a handler. The decisive lines from a local reproduction:

```
[HEAD] http://host.containers.internal:9701/cover.jpg: 501.NotImplemented
MediaCoverService|Couldn't download media cover ... [501:NotImplemented] [HEAD]
→ MediaCoverMapper|File /config/MediaCover/Albums/1/cover.jpg not found
→ sync_wrapper.sh|musefs-lidarr-sync: art fetch failed for album 1: ... HTTP 404
```

So Lidarr never cached the cover → its local `/MediaCover/...` URL 404'd → `musefs-lidarr-sync`'s art fetch caught the failure and wrote nothing → `track_art` stayed empty. The sync and assertion code are both correct; only the mock was at fault.

## Fix

Add `do_HEAD` to `mock_metadata.py` that replays `do_GET`'s routing/headers with the body suppressed.

## Verification

Reproduced end-to-end locally against the same pinned Lidarr image as CI. After the fix Lidarr logs `Downloading Cover ...`, the store gets `track_art count: 1`, and `run-e2e.sh` reports `lidarr-e2e: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)