### PR TITLE
docs: audit pass — accuracy, heading hierarchy, platform/case-insensitive, AI disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ your music library — without modifying or duplicating a single byte of the
 original audio. Fix tags, art, and folder structure in a SQLite store; the
 mount shows a clean library while your files stay exactly as they are.
 
+Runs on **Linux**, **FreeBSD**, and **macOS\*** &mdash; *\*macOS builds and
+passes unit tests, but mounted end-to-end behaviour is not yet validated.*
+
 ## Quick start
 
 ```bash
@@ -61,3 +64,7 @@ Lidarr. With thanks to **[Komiku](https://loyaltyfreakmusic.com/)** (Loyalty
 Freak Music), whose track *"The calling"* (from *The Adventure Goes On, Vol. 1*)
 is dedicated to the public domain under [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)
 and vendored as that test's fixture — thank you for releasing music freely.
+
+## AI Disclaimer
+
+This project was developed using AI, primarily Claude Opus and MiMo v2.5.

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -3,9 +3,9 @@
 This is the technical reference for musefs internals: how a virtual file is
 assembled, how the workspace is layered, what the SQLite store guarantees, and
 how external edits become visible without a remount. For usage, see the
-[README](../../../README.md); for the development workflow, see
-[CONTRIBUTING](../contributing/setup.md); for per-format behavior, see the format docs
-under `docs/`.
+[User Guide](../guide/quick-start.md); for the development workflow, see
+[Contributing](../contributing/setup.md); for per-format behavior, see the
+[format docs](../formats/overview.md).
 
 ## Design overview
 

--- a/docs/src/architecture/store.md
+++ b/docs/src/architecture/store.md
@@ -2,8 +2,10 @@
 
 ## The SQLite store
 
-`musefs-db/src/schema.rs` defines the schema as a single baseline migration
-(`MIGRATIONS`); `user_version` records the schema version (1).
+`musefs-db/src/schema.rs` defines the schema as an ordered list of migrations
+(`MIGRATIONS`: the `MIGRATION_V1` baseline plus `MIGRATION_V2`, which adds the
+scanner-owned `fingerprint`/`content_hash` columns); `user_version` records the
+schema version (2).
 The store is the **interface external tools write to** — the beets and Picard
 plugins under `contrib/` write tags and art here out-of-band.
 

--- a/docs/src/contributing/plugins.md
+++ b/docs/src/contributing/plugins.md
@@ -4,21 +4,21 @@
 
 The four packages share one drift-guarded contract; see
 [the contrib ecosystem](../architecture/tree-scanning.md#the-contrib-ecosystem) for the layout and
-each README for plugin-specific setup.
+the [integration pages](../integrations/overview.md) for plugin-specific setup.
 
 ```bash
 # python-musefs: self-contained
 cd contrib/python-musefs && python -m pytest && ruff check . && ruff format --check .
 
-# beets: python-musefs is UNPUBLISHED — install the local lib first or
-# dependency resolution fails (see contrib/beets/README.md for the venv flow)
+# beets: install the local python-musefs first so the suite tests the working
+# tree, not the PyPI release (see the beets integration page for the venv flow)
 cd contrib/beets && pip install -e ../python-musefs && pip install -e ".[test]" && python -m pytest tests
 
 # picard: no install needed (vendored + pythonpath=".")
 cd contrib/picard && python -m pytest tests
 
-# lidarr: python-musefs is UNPUBLISHED — install the local lib first or
-# dependency resolution fails (see contrib/lidarr/README.md for the env flow)
+# lidarr: install the local python-musefs first so the suite tests the working
+# tree, not the PyPI release (see the lidarr integration page for the env flow)
 cd contrib/lidarr && pip install -e ../python-musefs && pip install -e ".[test]" && python -m pytest tests
 ```
 

--- a/docs/src/contributing/setup.md
+++ b/docs/src/contributing/setup.md
@@ -2,7 +2,7 @@
 
 The working manual for building, testing, and landing a change. For what the
 pieces *are*, read [the architecture overview](../architecture/overview.md) first; for per-format
-behavior, the docs under [`docs/`](../formats/overview.md).
+behavior, the [format docs](../formats/overview.md).
 
 Map of this document:
 

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -1,6 +1,6 @@
 # Ownership, permissions & config
 
-### Ownership and permissions
+## Ownership and permissions
 
 By default the mount presents the launching process's uid/gid and read-only
 permission bits (`555` dirs, `444` files), and is reachable only by the user who
@@ -47,20 +47,21 @@ user. This surprises root-run tooling (Ansible, boot scripts):
   fails with EACCES/EEXIST on every run after the first. Create the directory
   before mounting, or run such tasks as the mounting user.
 
-### Configuring with environment variables
+## Configuring with environment variables
 
 Every scalar `mount` and `scan` flag can also be set with a `MUSEFS_*`
 environment variable — uppercase the long flag and turn dashes into
 underscores (e.g. `--poll-interval-ms` → `MUSEFS_POLL_INTERVAL_MS`, the
 `mount` mountpoint → `MUSEFS_MOUNTPOINT`). An explicit flag always overrides
-its env var, which overrides the default. Boolean flags (`MUSEFS_KEEP_CACHE`,
-`MUSEFS_REVALIDATE`, `MUSEFS_FOLLOW_SYMLINKS`, `MUSEFS_QUIET`,
-`MUSEFS_ALLOW_OTHER`, `MUSEFS_CASE_INSENSITIVE`, `MUSEFS_EXPOSE_METRICS`) accept a case-insensitive
-boolish value — `true`/`false`, `yes`/`no`, `on`/`off`, `1`/`0` — and reject
-anything else. The repeatable `--fallback` and the
+its env var, which overrides the default. Boolean flags (e.g.
+`MUSEFS_KEEP_CACHE`, `MUSEFS_REVALIDATE`, `MUSEFS_FOLLOW_SYMLINKS`,
+`MUSEFS_QUIET`, `MUSEFS_ALLOW_OTHER`, `MUSEFS_CASE_INSENSITIVE`,
+`MUSEFS_EXPOSE_METRICS`, `MUSEFS_FAST`, `MUSEFS_STRICT`) accept a
+case-insensitive boolish value — `true`/`false`, `yes`/`no`, `on`/`off`,
+`1`/`0` — and reject anything else. The repeatable `--fallback` and the
 `scan` targets are command-line only. See
 [`contrib/systemd/musefs.conf.example`](../../../contrib/systemd/musefs.conf.example)
-for the full, canonical list.
+for a commented example covering the common settings.
 
 These variables are read the same way no matter how musefs is launched:
 exported into the shell before running the binary directly
@@ -69,7 +70,7 @@ exported into the shell before running the binary directly
 The configuration surface is identical across all three; the sections below
 just show the per-deployment wiring.
 
-### Running as a systemd user service
+## Running as a systemd user service
 
 To run musefs on the host at login, drop-in units live in
 [`contrib/systemd/`](../integrations/systemd.md): a `musefs.service` mount daemon, an
@@ -78,5 +79,5 @@ optional `musefs-scan.timer` for periodic re-scans, and a commented
 `~/.config/systemd/user/`, copy the config to `~/.config/musefs/musefs.conf`,
 edit `MUSEFS_MOUNTPOINT` and `MUSEFS_DB`, then
 `systemctl --user enable --now musefs.service`. See
-[`contrib/systemd/README.md`](../integrations/systemd.md) for the full walkthrough
-and the `PATH` / linger gotchas.
+[the systemd integration guide](../integrations/systemd.md) for the full
+walkthrough and the `PATH` / linger gotchas.

--- a/docs/src/guide/containers.md
+++ b/docs/src/guide/containers.md
@@ -1,6 +1,6 @@
 # Running in containers
 
-### Container images
+## Container images
 
 Each tagged release also publishes multi-arch images to the GitHub Container
 Registry:
@@ -20,7 +20,7 @@ ordinary FUSE daemon and the image exists mainly to colocate musefs with
 containerized media managers (e.g. Lidarr). If you do containerize, mind the
 gotchas below.
 
-#### Required flags
+### Required flags
 
 musefs mounts via FUSE, so the container needs `/dev/fuse` and the matching
 capability:
@@ -46,7 +46,7 @@ denied`. Under rootless Podman the capability is confined to the container's use
 namespace rather than the host, so its blast radius is smaller, but it is still
 required. Running musefs on the host needs no such capability at all.
 
-#### Runs as a non-root user
+### Runs as a non-root user
 
 The images run as a dedicated unprivileged user (default uid/gid 1000), not
 root — musefs mounts via the setuid `fusermount3` helper and needs no root of
@@ -64,7 +64,7 @@ its own. Consequences for the commands above:
   containers or users, below) passes musefs's pre-flight check. See
   [Ownership and permissions](configuration.md#ownership-and-permissions).
 
-#### The mount-visibility gotcha (read this before sharing the mount)
+### The mount-visibility gotcha (read this before sharing the mount)
 
 A FUSE mount made inside a container lives in that container's mount namespace.
 By default neither the host nor other containers can see it, so pointing a second
@@ -113,7 +113,7 @@ consumer gets `Permission denied` on the mount. See
 Both the glibc and musl images carry the `fuse3` userspace tools; pick `:musl`
 if your other containers are Alpine-based, otherwise the default tags are fine.
 
-#### Sharing a host mount into a container
+### Sharing a host mount into a container
 
 Running musefs on the host instead of in a container is simpler and needs no
 `CAP_SYS_ADMIN`. Mark the mount point as shared and mount musefs there with

--- a/docs/src/guide/faq.md
+++ b/docs/src/guide/faq.md
@@ -30,5 +30,5 @@ via FUSE passthrough (needs `CAP_SYS_ADMIN`).
 
 **A file in the mount won't open / reads error — why?**
 The most common cause is a backing file that changed since its last scan
-(musefs refuses to serve a file whose size or mtime drifted, rather than
-splice at stale offsets). Run `musefs scan --revalidate` to re-probe it.
+(musefs refuses to serve a file whose size, mtime, or ctime drifted, rather
+than splice at stale offsets). Run `musefs scan --revalidate` to re-probe it.

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -75,3 +75,10 @@ build against the system allocator instead with
 
 On platforms without kernel passthrough, `--mode structure-only` still serves
 the original bytes, just through the daemon instead of the kernel.
+
+Filename **case-folding** is platform-aware: `--case-insensitive <true|false>`
+defaults to `true` on macOS and `false` on Linux/FreeBSD. When enabled,
+filenames are compared case-insensitively — case-variant directories merge into
+one (first-seen casing wins) and case-variant files get a numeric suffix (e.g.
+`Song (2)`); case-insensitive mounts refresh via a full rebuild rather than the
+incremental fast path.

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -10,7 +10,7 @@ Whichever you pick, mounting needs a 64-bit FUSE-capable OS (Linux, FreeBSD, mac
 >
 > At present AMD64, AARCH64, and RISC-V 64 are supported. If you'd like 32-bit support please open an issue.
 
-### Prebuilt binaries
+## Prebuilt binaries
 
 Each tagged release attaches static/portable Linux binaries for six targets:
 
@@ -46,7 +46,7 @@ the target needs the FUSE userspace tools and `/dev/fuse`:
 
 No glibc/libfuse install is needed for the musl binaries beyond `fuse3`.
 
-### Building from source
+## Building from source
 
 `cargo install musefs` compiles the latest release; building needs a stable
 Rust toolchain (2024 edition) plus the FUSE headers (`libfuse3-dev`) and
@@ -65,7 +65,7 @@ build against the system allocator instead with
 `cargo build -p musefs --no-default-features` (or `cargo install musefs
 --no-default-features`).
 
-### Platform support
+## Platform support
 
 | Platform | FUSE | Kernel passthrough (StructureOnly) | Notes |
 | --- | --- | --- | --- |

--- a/docs/src/guide/mounting.md
+++ b/docs/src/guide/mounting.md
@@ -1,6 +1,6 @@
 # Mounting & path templates
 
-### Mount
+## Mount
 
 ```bash
 musefs mount /path/to/mountpoint --db library.db \
@@ -46,7 +46,7 @@ beets/Picard/Lidarr sync, raw SQL) and the view refreshes automatically.
 
 Run `musefs <command> --help` for the full flag list.
 
-#### Path templates
+### Path templates
 
 Paths come from a beets-style template (matched case-insensitively;
 any tag key in the store works):

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -3,7 +3,7 @@
 `musefs --version` (or `-V`) prints the build version; `--help` on the root or
 any subcommand lists its flags.
 
-### Scan
+## Scan
 
 ```bash
 musefs scan /path/to/music --db library.db            # ingest (dirs recurse)
@@ -43,7 +43,7 @@ rescan.
 **preserving any tag edits you made in the store** — prunes tracks whose
 backing file is gone, and garbage-collects orphaned art.
 
-#### Content checksums and move re-identification
+### Content checksums and move re-identification
 
 `--checksum=none|fingerprint|full` (env `MUSEFS_CHECKSUM`, default
 `fingerprint`) controls what content checksums `scan` computes and stores.

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -1,6 +1,6 @@
 # Tuning & metrics
 
-### Tuning
+## Tuning
 
 The defaults are sensible for most setups, including the two measured storage wins —
 daemon-level backing read-ahead (`--read-ahead-budget-mib`, the single biggest win for
@@ -22,7 +22,7 @@ and numbers).
 Filename case-folding (`--case-insensitive`) is platform behaviour rather than
 a performance knob — see [Platform support](installation.md#platform-support).
 
-### Metrics
+## Metrics
 
 `musefs mount` optionally exposes runtime telemetry through a synthetic
 `.musefs-metrics/` directory at the mount root:

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -18,7 +18,9 @@ and numbers).
 | `--attr-ttl-ms` | `1000` | How long the kernel may trust cached entry/attr lookups. Higher cuts `lookup`/`getattr` traffic — useful for metadata-heavy clients (library scanners) over high-latency backing — but bounds how fast external edits become visible. |
 | `--max-readahead-kib` | `512` | *Kernel* read-ahead window (clamped to the kernel maximum). Distinct from `--read-ahead-budget-mib` (the daemon-level read-ahead, which is the effective one): this kernel knob does **not** speed up musefs streaming, since reads reach the daemon in fixed FUSE-sized chunks regardless. On HDD, values well above the default can even hurt. Leave at the default unless your own profiling shows otherwise. |
 | `--max-background` | `64` | Max outstanding background (read-ahead/async) requests the kernel keeps in flight. Does **not** bound foreground reads (those scale with client concurrency), so it has little effect on read throughput; left for completeness. |
-| `--case-insensitive <true\|false>` | OS default | Compare filenames case-insensitively. Case-variant directories merge into one (first-seen casing wins) and case-variant files get a numeric suffix (e.g. `Song (2)`). Defaults to `true` on macOS and `false` on Linux/FreeBSD; case-insensitive mounts refresh via a full rebuild rather than the incremental fast path. |
+
+Filename case-folding (`--case-insensitive`) is platform behaviour rather than
+a performance knob — see [Platform support](installation.md#platform-support).
 
 ### Metrics
 

--- a/docs/src/integrations/python-musefs.md
+++ b/docs/src/integrations/python-musefs.md
@@ -208,12 +208,18 @@ for a custom write loop)
   extension.
 - `prune_missing(conn, track_ids=None)` → count — delete tracks whose backing
   file no longer exists (every track, or just `track_ids`).
+- `delete_tracks(conn, track_ids)` → count — unconditionally delete the given
+  track rows (intent-based, unlike `prune_missing`'s on-disk existence check);
+  their `tags` and `track_art` rows cascade away.
 
 **Reading**
 
 - `track_ids_for_paths(conn, keys)` → `{key: id}` — bulk `backing_path` → track
   id; keys with no matching row are omitted. Chunked under SQLite's parameter
   cap, so arbitrarily large lookups are safe (the bulk `track_id_for_path`).
+- `track_ids_by_tag(conn, key, value)` → `[id, …]` — track ids whose plugin-owned
+  text tag `(key, value)` matches (scanner-written binary tags never match);
+  maps a source's "I deleted this album/artist" signal back to the rows it tagged.
 - `tags_for_track(conn, track_id)` → `[TagRow, …]` ordered by key then ordinal,
   covering both plugin-owned text tags and scanner-written binary tags.
 - `TagRow(key, value, value_blob)` — one read-back tag row. Text tags have

--- a/docs/src/integrations/systemd.md
+++ b/docs/src/integrations/systemd.md
@@ -78,9 +78,11 @@ sandboxing is possible. The two units differ sharply:
   `musefs.conf` EnvironmentFile does **not** expand `%h` or `~` — use absolute
   paths there, and never paste `~/...` into a unit directive (it is taken
   literally).
-- **Settings.** `musefs.conf.example` is the full, canonical list of
-  `MUSEFS_*` variables. Explicit flags override env vars; `--fallback` and scan
-  targets are command-line only (set them in `ExecStart`).
+- **Settings.** `musefs.conf.example` is a commented example of the common
+  `MUSEFS_*` mount/scan variables (every scalar `mount`/`scan` flag has a
+  `MUSEFS_*` form — uppercase the long flag, dashes to underscores). Explicit
+  flags override env vars; `--fallback` and scan targets are command-line only
+  (set them in `ExecStart`).
 - **Inline overrides.** Prefer `systemctl --user edit musefs` to add
   `Environment=` lines in a drop-in; it survives reinstalls.
 - **Headless servers.** A `--user` timer only fires while your user manager


### PR DESCRIPTION
## What

A documentation audit pass on the new mdBook site (structure, formatting, accuracy), plus three targeted fixes.

## Requested fixes

- **`--case-insensitive` moved to Platform support.** It defaults to `true` on macOS and `false` on Linux/FreeBSD — platform behaviour, not a tuning knob — so it now lives on the Platform support page, with a pointer left on the Tuning page.
- **README platform support.** States Linux, FreeBSD, and macOS\* support (\*macOS builds and passes unit tests but is not yet end-to-end tested).
- **AI Disclaimer** section added to the README.

## Audit fixes

**Accuracy (verified against the code):**
- `architecture/store.md`: schema is `MIGRATION_V1` + `MIGRATION_V2`, `user_version` **2** (was described as a single baseline migration / version 1 — which also contradicted the `fingerprint`/`content_hash` columns V2 adds).
- `contributing/plugins.md`: `python-musefs` is published to PyPI — reworded the stale "UNPUBLISHED" dev-install rationale and pointed at the integration pages rather than the README shims.
- `guide/configuration.md` & `integrations/systemd.md`: the `MUSEFS_*` env-var lists are illustrative, not exhaustive — softened "full/canonical list" wording (and added the missing `MUSEFS_FAST`/`MUSEFS_STRICT`).
- `guide/faq.md`: the backing-file drift guard checks size, mtime, **and ctime**.
- `integrations/python-musefs.md`: documented the exported `delete_tracks` and `track_ids_by_tag` helpers.

**Structure / UX:**
- **Heading hierarchy:** all eight User Guide pages skipped `H1` → `H3` (the migration pasted README `###`/`####` subsections under a new `#`). Demoted them to nest properly `H1` → `H2` → `H3`, fixing the mdBook page table-of-contents nesting and the accessibility heading-skip. Heading slugs are text-derived, so every inbound anchor is preserved (build + anchors verified).
- Fixed stale "see the README / docs under `docs/`" prose in the architecture overview, and replaced a couple of misleading bare-path link labels with natural text.

**Deliberately not changed:** the mild duplicate-title stacks on `contributing/testing.md` and `plugins.md` — their `H2` anchors (`#test-tiers-beyond-cargo-test`, `#python-plugins-contrib`) are load-bearing (linked from `CLAUDE.md`, `SECURITY.md`, and scripts), so renaming would break those links.

`mdbook build docs` is clean; linkcheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
