### PR TITLE
Kill/exclude latencyfs mutation survivors; shard the full campaign per ~50 mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -544,4 +544,56 @@ exclude_re = [
     # anchor (the literal-coord detector needs `:digits:digits:`), so count=1 applies.
     # guard: count=1
     'musefs-core/src/scan\.rs:\d+:16: delete ! in ingest_unit',
+
+    # --- musefs-latencyfs: bench-only passthrough FUSE adapter survivors ---
+    # The bench harness's logic-bearing mutants (the inode map, latency table,
+    # attr mapping, the readdir kind-classification and parent-inode synthesis,
+    # the read splice) ARE killed by the mounted `#[ignore]`d tests run in the
+    # crate's own mutation leg (`-- -- --include-ignored`, scripts/mutants.sh).
+    # The entries below are the residue: the thin `fuser::Filesystem` reply
+    # plumbing — the exact class `musefs-fuse/src/lib.rs` is excluded wholesale
+    # for (exclude_globs above). They split into two unkillable kinds.
+    #
+    # Hang-class (TIMEOUT-only, the SP3 non-terminating-loop precedent): these
+    # never produce a clean kill, only flag on the timeout budget, and OOM/cancel
+    # the leg rather than fail an assertion.
+    #
+    # usize_from const-return (`-> 0` / `-> 1`, one site): the crate's sanctioned
+    # u64->usize cast, used for `read`'s buffer size and readdir's skip offset.
+    # The exact MACHINE-KILLER class as musefs-format's convert.rs usize_from
+    # above — a constant size makes `read` return 0/1 bytes forever so the mounted
+    # reader loops. Pinned functionally by every read/readdir consumer.
+    'musefs-latencyfs/src/lib\.rs:\d+:\d+: replace usize_from -> usize',
+    # readdir entry-cookie `(i + 1)` -> `(i * 1)`: the kernel re-requests the
+    # same offset forever (the cookie never advances), an infinite readdir. The
+    # `+`->`-` sibling underflows to a panic at i==0 and IS caught. Sole `+` in
+    # readdir, so description-anchored.
+    'replace \+ with \* in <impl fuser::Filesystem for PassthroughFs>::readdir',
+    # read -> (): drops the `ReplyData` without responding, so the `read()`
+    # syscall blocks forever waiting on the FUSE reply. The read I/O itself
+    # (buffer fill, offset splice) is pinned by reads_a_file_through_the_mount;
+    # only the whole-body drop hangs.
+    'replace <impl fuser::Filesystem for PassthroughFs>::read with \(\)',
+    #
+    # Unwaited-ack / unobservable thin-adapter (MISSED): replacing these bodies
+    # with () drops a reply the kernel never blocks on (release/releasedir are
+    # fire-and-forget) or skips state with no observable effect — so a clean
+    # mounted run can't distinguish them, and any test that DID invoke them on a
+    # waited reply (access/flush/fsyncdir) would hang on the dropped reply rather
+    # than fail, i.e. hang-class again.
+    #
+    # releasedir/access: bodies are literally just `reply.ok()` — pure acks.
+    'replace <impl fuser::Filesystem for PassthroughFs>::releasedir with \(\)',
+    'replace <impl fuser::Filesystem for PassthroughFs>::access with \(\)',
+    # flush: only skips a `nap()` (latency injection) before the ack — timing,
+    # not correctness.
+    'replace <impl fuser::Filesystem for PassthroughFs>::flush with \(\)',
+    # release: leaks one entry in the `handles` map (no accessor exposes it and
+    # the bench never exhausts fds), otherwise an unwaited ack.
+    'replace <impl fuser::Filesystem for PassthroughFs>::release with \(\)',
+    # fsyncdir: increments the `fsyncs` counter, but it shares that counter with
+    # `fsync` (which dominates every fsync-counting test, keeping it `> 0`), and
+    # isolating a directory fsync would hang on the dropped reply. The counter's
+    # real contract is pinned by the fsync tests.
+    'replace <impl fuser::Filesystem for PassthroughFs>::fsyncdir with \(\)',
 ]

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -209,30 +209,65 @@ jobs:
       - name: Canary (check-only) run of the harness
         run: MUTANTS_CANARY=1 scripts/mutants.sh musefs-db
 
+  full-plan:
+    # Scheduled or manually dispatched: size the campaign the SAME way in-diff-plan
+    # sizes the PR gate — a fresh runner per ~50 mutants. Each crate is listed with
+    # the exact --file scoping + config scripts/mutants.sh runs (MUTANTS_LIST=1
+    # forwards --list; parse-only, no build/tests), then split into n = ceil(count
+    # / 50) shards. Capping every runner at ~50 mutants isolates a single
+    # allocation-bomb mutant (the OOM-the-runner class) to one ~50-mutant shard
+    # instead of canceling a whole multi-hundred-mutant leg, so the survivor
+    # reports of the unaffected shards still come back.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - name: Install cargo-mutants
+        # Unpinned (like fuzz.yml installs cargo-fuzz) for toolchain-compat;
+        # known-good version is 27.0.0 (documented in scripts/mutants.sh).
+        run: cargo install cargo-mutants
+      - name: Plan campaign shards
+        id: plan
+        run: |
+          set -euo pipefail
+          # Per-crate mutant counts via the same scoping the run uses; grep keeps
+          # only mutant lines (file:line:col:), dropping the "== mutants: crate =="
+          # headers run_crate echoes. `|| true` guards `set -e` against grep's
+          # exit-1 on a (hypothetical) zero-mutant crate.
+          pairs=""
+          for crate in musefs-db musefs-core musefs-format musefs-fuse musefs-latencyfs; do
+            count="$(MUTANTS_LIST=1 scripts/mutants.sh "$crate" 2>/dev/null | grep -cE ':[0-9]+:[0-9]+:' || true)"
+            echo "$crate: $count mutants"
+            pairs="$pairs $crate:$count"
+          done
+          # n = ceil(count / 50) shards per crate. `shard` is cargo-mutants' 0-indexed
+          # i/n (fed to MUTANTS_SHARD); `label` is the human 1-indexed form for the
+          # job name; `name` is the slash-free artifact suffix. Mirrors in-diff-plan's
+          # matrix shape (an `include:` array). One-liner to dodge YAML/Python indent.
+          matrix="$(python3 -c 'import json,math,sys; toks=[t.rsplit(":",1) for t in sys.argv[1].split()]; out=[{"crate":c,"shard":f"{i}/{n}","label":f"{c} {i+1}/{n}","name":f"{c}-{i+1}-of-{n}"} for c,cnt in toks for n in [max(1,math.ceil(int(cnt)/50))] for i in range(n)]; print(json.dumps(out,separators=(",",":")))' "$pairs")"
+          echo "shards: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   full:
-    # Scheduled or manually dispatched: full per-crate campaign.
+    # Scheduled or manually dispatched: full per-crate campaign, fanned across the
+    # ~50-mutant shards full-plan sized. Each shard is a disjoint subset of its
+    # crate's mutants (cargo-mutants randomizes order within a shard only); their
+    # survivor reports are concatenated when (re)building the inventory.
+    needs: full-plan
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # db and core are quick (~5m / ~16m). musefs-format alone ran ~2h as a
-        # single serial leg (75% of the whole campaign's wall-clock), so it is
-        # split into 4 shards (~30m each) via cargo-mutants --shard. Each shard
-        # is a disjoint subset of the format mutants; their survivor reports are
-        # concatenated when (re)building the inventory.
-        include:
-          - { crate: musefs-db, label: musefs-db }
-          - { crate: musefs-core, label: musefs-core }
-          - { crate: musefs-format, label: musefs-format-0, shard: 0/4 }
-          - { crate: musefs-format, label: musefs-format-1, shard: 1/4 }
-          - { crate: musefs-format, label: musefs-format-2, shard: 2/4 }
-          - { crate: musefs-format, label: musefs-format-3, shard: 3/4 }
-          - { crate: musefs-fuse, label: musefs-fuse }
-          # musefs-latencyfs carries real logic (inode map, latency table, attr
-          # mapping, passthrough ops); scripts/mutants.sh runs its mounted
-          # #[ignore]d tests, so this leg needs libfuse + /dev/fuse.
-          - { crate: musefs-latencyfs, label: musefs-latencyfs }
+        include: ${{ fromJSON(needs.full-plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -249,9 +284,9 @@ jobs:
         # Unpinned (like fuzz.yml installs cargo-fuzz) for toolchain-compat;
         # known-good version is 27.0.0 (documented in scripts/mutants.sh).
         run: cargo install cargo-mutants
-      - name: Run mutation campaign
-        # Empty for the db/core legs (no `shard` key) → MUTANTS_SHARD unset →
-        # whole crate. Set to "k/4" for the format shards.
+      - name: Run mutation campaign (shard ${{ matrix.label }})
+        # Every shard carries an i/n (single-shard crates get "0/1"), so
+        # MUTANTS_SHARD is always set; scripts/mutants.sh forwards it as --shard.
         env:
           MUTANTS_SHARD: ${{ matrix.shard }}
         run: scripts/mutants.sh "${{ matrix.crate }}"
@@ -259,7 +294,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          # Per-shard artifact names (a slash in matrix.shard is illegal here).
-          name: mutants-${{ matrix.label }}
+          # Per-shard artifact names; matrix.name is the slash-free "crate-k-of-n"
+          # form (a slash, as in matrix.shard, is illegal in an artifact name).
+          name: mutants-${{ matrix.name }}
           path: mutants-out/${{ matrix.crate }}
           if-no-files-found: warn

--- a/musefs-latencyfs/tests/passthrough.rs
+++ b/musefs-latencyfs/tests/passthrough.rs
@@ -108,3 +108,51 @@ fn mkdir_rmdir_and_statfs_through_the_mount() {
     let s = rustix::fs::statvfs(mp).unwrap();
     assert!(s.f_blocks > 0, "statfs should report real block counts");
 }
+
+/// Read a directory's raw dirents through the mount as `(name, d_ino)` pairs,
+/// including the synthetic `.`/`..` entries that `std::fs::read_dir` hides.
+fn raw_dirents(dir: &std::path::Path) -> Vec<(String, u64)> {
+    let f = std::fs::File::open(dir).unwrap();
+    let mut out = Vec::new();
+    for entry in rustix::fs::Dir::read_from(&f).unwrap() {
+        let entry = entry.unwrap();
+        out.push((
+            entry.file_name().to_string_lossy().into_owned(),
+            entry.ino(),
+        ));
+    }
+    out
+}
+
+#[test]
+#[ignore = "requires /dev/fuse; run with --ignored"]
+fn readdir_dotdot_resolves_to_the_real_parent() {
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::create_dir(backing.path().join("sub")).unwrap();
+    let mount = LatencyMount::new(backing.path(), "ssd").unwrap();
+    let mp = mount.path();
+
+    let ino = |ents: &[(String, u64)], name: &str| -> u64 {
+        ents.iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("missing dirent {name}"))
+            .1
+    };
+
+    // `readdir` synthesizes the `..` entry's inode from the directory's parent:
+    // the root short-circuits to itself, every other dir interns its true
+    // parent. A subdir's `..` must therefore point at the mount root, never at
+    // the subdir itself (which is what an inverted root check would produce).
+    let root = raw_dirents(&mp);
+    let sub = raw_dirents(&mp.join("sub"));
+    assert_eq!(
+        ino(&sub, ".."),
+        ino(&root, "."),
+        "sub/.. must resolve to the mount root"
+    );
+    assert_ne!(
+        ino(&sub, ".."),
+        ino(&sub, "."),
+        "sub/.. must not be self-referential"
+    );
+}


### PR DESCRIPTION
Two changes from the latest full mutation campaign.

## `test(mutants)` — latencyfs survivors
The campaign's `musefs-latencyfs` leg surfaced ten survivors, all in the thin `fuser::Filesystem` reply plumbing (the logic-bearing mutants — inode map, latency table, attr mapping, readdir kind-classification, read splice — are already killed by the mounted `#[ignore]`d tests).

- The one genuinely-behavioral survivor (`== -> !=` at the readdir root check — makes a subdir's `..` point at itself) is now killed by a new mounted test that reads raw dirents via `rustix::fs::Dir` and asserts `sub/..` resolves to the mount root. Verified it passes unmutated and fails under the mutant.
- The other nine are unkillable and excluded, documented per class: hang-class (`usize_from` const-return, the readdir cookie `+ -> *`, `read -> ()`) and unwaited-ack / unobservable thin-adapter (`releasedir`/`access`/`flush`/`release`/`fsyncdir -> ()`) — the same class `musefs-fuse`'s adapter is excluded wholesale for.

All 78 `exclude_re` anchors validate against the live mutant set.

## `ci(mutants)` — shard the full campaign per ~50 mutants
The scheduled campaign used a static matrix with `musefs-format` hard-split into 4 fixed shards (~330 mutants each). When a single allocation-bomb mutant OOMs its runner, GitHub cancels the whole job and that shard's survivor report is lost — and a 4-way split gives no resolution on which mutant did it.

Replaced with the same dynamic plan the per-PR in-diff gate already uses: a new `full-plan` job lists each crate's mutants (`MUTANTS_LIST=1 scripts/mutants.sh`, so `--file` scoping + config stay single-sourced) and emits an `include:` matrix of `ceil(count / 50)` shards per crate. Every runner now tests ≤50 mutants, so an OOM-the-runner mutant is isolated to one ~50-mutant shard and the surviving shards still report. (musefs-format: 4 fixed shards → ~27 of ≤50.)

## Context / follow-ups (not in this PR)
The campaign also interrupted a format shard via an OOM bomb; this sharding is what will pin it (locally I confirmed the two OGG lacer `+= -> *=` mutants are non-terminating hang-class → TIMEOUT, and that shard 2/4 is clean). A weekly-fuzz `workflow_dispatch` and an mp4 fuzz crash found by the latest weekly run are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)