### PR TITLE
Resolve mutation campaign #266: tests for killable survivors, exclusions for hang/OOM/equivalent

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -596,4 +596,87 @@ exclude_re = [
     # isolating a directory fsync would hang on the dropped reply. The counter's
     # real contract is pinned by the fsync tests.
     'replace <impl fuser::Filesystem for PassthroughFs>::fsyncdir with \(\)',
+
+    # ── Campaign #266 findings ──────────────────────────────────────────────
+    # Hang-class (non-terminating, TIMEOUT-only) advance/loop freezes and one
+    # allocation bomb, plus equivalent boundary/capacity mutants. The 9 genuinely
+    # killable survivors the same campaign found got TESTS instead of exclusions.
+
+    # VirtualTree::disambiguate candidate search assumes each ` (k)`-ranked
+    # candidate is a distinct, eventually-free key. Forcing `taken` always-true, or
+    # dropping the `!` that selects the free branch, spins the search forever
+    # (TIMEOUT-only) — the suffix_candidate / ancestor_in family. The
+    # `taken -> false` sibling IS caught and stays in scope.
+    'replace VirtualTree::taken -> bool with true',
+    # The `!` at col 16 (not the sibling at col 12, which IS caught); pinned by
+    # column like the ingest_unit `delete !` above. `delete` has no operator, so a
+    # line:col guard can't apply — column-anchored count instead.
+    # guard: count=1
+    'musefs-core/src/tree\.rs:\d+:16: delete ! in VirtualTree::disambiguate',
+    # fold (case-fold) and join_path (node-path builder) const-returns: hang-class,
+    # the InodeAllocator::key precedent. A constant fold/path collapses every node
+    # onto one key, so path_of's `while cur != ROOT` walk self-loops forever. Real
+    # behavior is pinned by the rebuild / inode-stability tests. One site each (two
+    # const-return mutants).
+    'musefs-core/src/tree\.rs:\d+:\d+: replace fold -> String with',
+    'musefs-core/src/tree\.rs:\d+:\d+: replace join_path -> String with',
+
+    # mp4 box-walk advance freezes (hang-class, the wav walk_chunks precedent).
+    # read_structure_from's `pos += total` and BoxRef::end's `start + total_len`
+    # (or a constant `end`) pin the seeking walk's position forever while it
+    # re-reads the same box. The `+= -=` / `+ -` siblings underflow to a panic and
+    # ARE caught. One site each.
+    'musefs-format/src/mp4\.rs:\d+:\d+: replace \+= with \*= in read_structure_from',
+    'musefs-format/src/mp4\.rs:\d+:\d+: replace \+ with \* in BoxRef::end',
+    'musefs-format/src/mp4\.rs:\d+:\d+: replace BoxRef::end -> usize with [01]',
+
+    # Ogg page lacer/reader advance freezes — hang-class plus the #266 OOM bomb.
+    # total_len() -> 0, the `lace_pos < laces.len()` loop bounds, and the
+    # `lace_pos += seg_count` / `+= chunk` advances each pin a page-walk index so
+    # the loop never terminates. lace_packet / lace_chunks_to_segments spin CPU-
+    # bound (TIMEOUT); read_packets's `pos += total_len` is the ALLOCATION BOMB: a
+    # continued page-0 packet makes `cur.extend_from_slice` grow without bound,
+    # OOMing the runner before the timeout fires (observed canceling shard 25/27 of
+    # campaign #266). The `+= -=` / `-> 1` siblings underflow-panic / still advance
+    # and ARE caught. One site each.
+    'musefs-format/src/ogg/page\.rs:\d+:\d+: replace PageHeader::total_len -> usize with 0',
+    'musefs-format/src/ogg/page\.rs:\d+:\d+: replace < with (<=|==) in lace_packet',
+    'musefs-format/src/ogg/page\.rs:\d+:\d+: replace < with (<=|==) in lace_chunks_to_segments',
+    # The lace_pos / pos advances specifically (cols pinned): the sibling
+    # `payload_pos`/`pages`/`seq`/`seg` advances at adjacent lines do not gate loop
+    # termination and ARE caught.
+    # guard: op="+=" fn="lace_packet" rows=1
+    'musefs-format/src/ogg/page\.rs:124:18: replace \+= with \*= in lace_packet',
+    # guard: op="+=" fn="lace_chunks_to_segments" rows=1
+    'musefs-format/src/ogg/page\.rs:351:18: replace \+= with \*= in lace_chunks_to_segments',
+    # guard: op="+=" fn="read_packets" rows=1
+    'musefs-format/src/ogg/page\.rs:189:13: replace \+= with \*= in read_packets',
+
+    # Equivalent mutants from #266.
+    # push_block_header `(if is_last {0x80} else {0}) | (block_type & 0x7F)`,
+    # `|`->`^`: bit-disjoint operands (bit 7 vs bits 0-6), so `|`/`^` are identical
+    # — the fixtures::flac_block equivalence above.
+    'musefs-format/src/flac\.rs:\d+:\d+: replace \| with \^ in push_block_header',
+    # parse_picture_block mime/desc length-bound guards `mime_end > body.len()` /
+    # `desc_end > body.len()`, `>`->`>=`: at the boundary (a field ending exactly at
+    # body end) the original proceeds and the next field read goes out of bounds ->
+    # Malformed, the same error `>=` returns directly. The data_end guard below them
+    # IS behavioral (a picture whose data fills the body exactly is valid) and stays
+    # IN scope, so these two are pinned by line:col.
+    # guard: op=">" fn="parse_picture_block" rows=1
+    'musefs-format/src/flac\.rs:475:17: replace > with >= in parse_picture_block',
+    # guard: op=">" fn="parse_picture_block" rows=1
+    'musefs-format/src/flac\.rs:483:17: replace > with >= in parse_picture_block',
+    # lace_chunks_to_segments `header_len = 27 + seg_count`, `+`->`*`: header_len
+    # only sizes a `Vec::with_capacity` hint; the header is built by `extend`, so
+    # any capacity is behavior-identical (the CACHE_ESTIMATED_ITEMS precedent). The
+    # `lace_pos + seg_count` slice `+` elsewhere IS caught, so pinned by line:col.
+    # guard: op="+" fn="lace_chunks_to_segments" rows=1
+    'musefs-format/src/ogg/page\.rs:332:29: replace \+ with \* in lace_chunks_to_segments',
+    # crc_feed_payload / emit_segments overlap guards `if os < oe`, `<`->`<=`: at
+    # os==oe the overlap is empty, so the branch folds a zero-length slice / reads 0
+    # art bytes — byte-identical CRC and segments (the serve_ogg_window empty-overlap
+    # equivalence). One `<` per fn, so description-anchored.
+    'musefs-format/src/ogg/page\.rs:\d+:\d+: replace < with <= in crc_feed_payload',
+    'musefs-format/src/ogg/page\.rs:\d+:\d+: replace < with <= in emit_segments',
 ]

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -645,6 +645,24 @@ mod schema_py_tests {
         );
     }
 
+    #[test]
+    fn migrate_does_not_reapply_an_already_applied_step() {
+        // A DB sitting at version 1 (only V1 applied) must receive ONLY the
+        // remaining steps on the next migrate. `current < target` skips the
+        // already-applied V1; `<=` would re-run V1 (`CREATE TABLE tracks` ->
+        // "table already exists"), so a clean upgrade to the latest version proves
+        // the loop never re-applies a step it already ran. (The current==latest
+        // case can't exercise this — migrate fast-paths out before the loop.)
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(MIGRATIONS[0]).unwrap(); // apply V1 only
+        conn.pragma_update(None, "user_version", 1i64).unwrap();
+        super::migrate(&mut conn).expect("upgrading from v1 must apply only the remaining steps");
+        assert_eq!(
+            user_version(&conn),
+            i64::try_from(MIGRATIONS.len()).unwrap()
+        );
+    }
+
     /// NOT #[ignore]d on purpose: the compare path must run under plain
     /// `cargo test` or the CI drift gate doesn't exist. Only the write
     /// behavior is env-gated.

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -731,6 +731,44 @@ mod tests {
         );
     }
 
+    /// Minimal ID3v2.4 tag: header + one frame header whose 4-byte synchsafe size
+    /// is `frame_size`. The declared tag-body size is 10 (just the frame header),
+    /// so the frame walk reaches the size validation with the buffer ending right
+    /// after the 4 size bytes. All size bytes are 0x00/0x80, so the decoded size
+    /// (low 7 bits) is 0 — only the high-bit guard at line 514 can reject.
+    fn v24_tag_one_frame(frame_size: [u8; 4]) -> Vec<u8> {
+        let mut t = Vec::new();
+        t.extend_from_slice(b"ID3");
+        t.extend_from_slice(&[4, 0, 0]); // v2.4, no flags
+        t.extend_from_slice(&[0, 0, 0, 10]); // synchsafe tag-body size = 10
+        t.extend_from_slice(b"TIT2"); // frame id (non-zero, not CHAP/CTOC)
+        t.extend_from_slice(&frame_size); // the guarded size bytes
+        t.extend_from_slice(&[0, 0]); // frame flags = 0
+        t
+    }
+
+    #[test]
+    fn alloc_safe_rejects_v24_frame_with_nonsynchsafe_size() {
+        // The v2.4 guard, `b4 | b5 | b6 | b7 >= 0x80`, must reject a frame whose
+        // synchsafe size has the high bit set in ANY byte (a non-synchsafe size the
+        // id3 crate could OOM on). Replacing a `|` with `&`/`^` reshapes the chain
+        // (both bind tighter than `|`, so `b4 | b5 & b6 | b7` is `b4 | (b5 & b6) | b7`),
+        // letting an even/dominated high-bit pattern slip through. Each input below
+        // pins one such weakening at a distinct position.
+        for size in [
+            [0x80, 0x00, 0x00, 0x00], // b4 high
+            [0x00, 0x80, 0x00, 0x00], // b5 high
+            [0x00, 0x00, 0x80, 0x00], // b6 high
+            [0x00, 0x80, 0x80, 0x00], // b5,b6 high
+            [0x00, 0x00, 0x80, 0x80], // b6,b7 high
+        ] {
+            assert!(
+                !id3v2_alloc_safe(&v24_tag_one_frame(size)),
+                "v2.4 frame size {size:02x?} has a high bit set and must be rejected"
+            );
+        }
+    }
+
     /// A buffer that does not start with "ID3" must be rejected by the guard.
     /// id3::Tag::read_from2 scans forward to locate a tag, so any non-ID3-prefixed
     /// buffer is unsafe regardless of what bytes appear later.

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -539,6 +539,25 @@ mod tests {
     }
 
     #[test]
+    fn oggflac_following_packets_accepts_minimal_9_byte_packet() {
+        // The 16-bit count lives in bytes [7],[8], so a 9-byte first packet is the
+        // minimum valid input (`len < 9` rejects anything shorter). `<=` would
+        // wrongly reject this exact-length packet.
+        let mut pkt = [0u8; 9];
+        pkt[7] = 0x00;
+        pkt[8] = 0x03; // 3 following metadata-block packets
+        assert_eq!(oggflac_following_packets(&pkt).unwrap(), 3);
+    }
+
+    #[test]
+    fn comment_body_accepts_packet_with_empty_body() {
+        // A packet exactly `prefix` bytes long has an empty (but valid) comment
+        // body: `&packet[prefix..]` is the empty slice. `len < prefix` rejects only
+        // shorter packets; `<=` would wrongly reject this one. Opus prefix = 8.
+        assert!(comment_body(Codec::Opus, b"OpusTags").unwrap().is_empty());
+    }
+
+    #[test]
     fn read_tags_opus() {
         // Build an OpusTags packet with one real comment via the shared builder.
         let body =

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -748,6 +748,19 @@ mod tests {
     }
 
     #[test]
+    fn parse_page_accepts_27_byte_zero_segment_page() {
+        // A zero-segment page is exactly the 27-byte fixed header (no lacing table,
+        // no payload). `pos + 27 == buf.len()` is the valid boundary; `>=` would
+        // wrongly reject a page that fills the buffer exactly.
+        let mut page = vec![0u8; 27];
+        page[0..4].copy_from_slice(CAPTURE); // "OggS"
+        page[26] = 0; // seg_count = 0
+        let h = parse_page(&page, 0).unwrap();
+        assert_eq!(h.seg_count, 0);
+        assert_eq!(h.total_len(), 27);
+    }
+
+    #[test]
     fn patch_page_header_rejects_truncated_page() {
         let (page, _) = lace_packet(0xCAFE, 1, false, 0, &vec![0x42u8; 300]);
         let h = parse_page(&page, 0).unwrap();


### PR DESCRIPTION
Resolves everything the full mutation campaign (run #266) surfaced. The per-50 sharding from #497 worked: the OOM was isolated to a single shard (25/27, ~50 mutants) while the other 46 reported cleanly. Findings split into killable gaps (→ tests) and unkillable mutants (→ documented exclusions).

## `test(mutants)` — 9 killable survivors covered
Of 15 MISSED, 9 are genuine behavioral gaps:
- **schema `migrate < -> <=`**: a DB at version 1 must get only the remaining migration, never re-run V1 (`CREATE TABLE` → "already exists"). The current==latest case can't show it — migrate fast-paths before the loop, so the test seeds a v1 DB.
- **ogg `oggflac_following_packets`/`comment_body < -> <=`**: a 9-byte first packet and an empty-but-valid comment body are accepted.
- **ogg `parse_page > -> >=`**: a 27-byte zero-segment page parses.
- **mp3 `id3v2_alloc_safe | -> &/^` (×5)**: the v2.4 frame-size guard rejects a high bit in any synchsafe byte. `&`/`^` bind tighter than `|`, reshaping the OR chain, so three crafted size patterns pin every position.

Each verified to fail under its mutant and pass clean.

## `chore(mutants)` — hang/OOM/equivalent exclusions
- **OOM bomb**: ogg/page `read_packets pos += total_len -> *=` freezes the page walk on a continued page-0 packet, growing `cur` unbounded and OOMing the runner before the timeout — this canceled shard 25/27. Reproduced locally.
- **Hang-class (TIMEOUT-only)**: tree `disambiguate`/`taken`/`fold`/`join_path`, mp4 `read_structure_from`/`BoxRef::end`, ogg/page lacer `total_len`/loop-bound/advance freezes. Killable siblings (`-=` underflow-panic, `taken -> false`) stay in scope.
- **Equivalent**: flac `push_block_header | -> ^` (bit-disjoint), `parse_picture_block > -> >=` (boundary still errors), ogg/page `header_len + -> *` (capacity hint), `crc_feed_payload`/`emit_segments < -> <=` (empty-overlap no-op).

All 97 `exclude_re` anchors validate against the live mutant set; full pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for audio format parsing and validation across MP3 ID3v2.4 frames, OggFLAC packets, and Ogg page boundaries.
  * Added migration verification tests to ensure database schema upgrades apply consistently without duplication.
  * Enhanced mutation testing configuration for improved code quality analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->