### PR TITLE
Strict template validation + mount --dry-run (audit follow-ups)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -467,7 +467,7 @@ exclude_re = [
     # the ring under the read lock); the fn's other two `+` are the observable fills
     # counters and stay killable, so this one is pinned by coordinate, not by fn.
     # guard: op="+" fn="BackingReader<'a>::read_exact_at" rows=2
-    'musefs-core/src/readahead\.rs:606:68:',
+    'musefs-core/src/readahead\.rs:612:68:',
     #
     # More hang-class (TIMEOUT-only, CANCEL the in-diff job): `len() -> 1` /
     # `clear() -> 1` force a constant resident size, so `evict_one_coldest` keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`mount --dry-run`:** validate the `--template` and configuration and print a
+  sample of the paths the mount would expose (with total file and directory
+  counts), then exit without mounting — a way to check a template before
+  committing to a mount.
 - **Runtime telemetry (`.musefs-metrics`):** an opt-in `--expose-metrics` flag
   (env `MUSEFS_EXPOSE_METRICS`) surfaces a synthetic `.musefs-metrics` file at
   the mount root rendering Prometheus-format counters — getattr/read/open
@@ -51,8 +55,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   skip count is diagnosable — expected sidecars versus genuinely unexpected
   files. Log-only; the `ScanStats` struct and CLI summary are unchanged (#341).
 
+### Changed
+
+- **Strict template validation:** an unclosed `[ … ]` section or an unterminated
+  `${` / `$!{` field is now rejected at mount time with an error naming the
+  problem, instead of silently folding the rest of the template into the open
+  construct — which turned a typo'd bracket into a surprising directory tree.
+
 ### Fixed
 
+- **Clearer mount errors:** a missing or non-directory mountpoint is reported
+  with an actionable message before FUSE setup (previously a bare `os error 2`,
+  or a misleading "Permission denied" when the path was a regular file), and
+  I/O errors no longer print their OS string twice.
 - **Silent mp4 oversize drops:** oversized embedded `covr` cover art and binary
   freeform (`----`) values in `.m4a`/`.m4b` files are skipped in the format layer
   before materialization (to avoid building a large image out of a large `moov`),

--- a/docs/src/guide/mounting.md
+++ b/docs/src/guide/mounting.md
@@ -80,3 +80,11 @@ suffix. Every rendered component is capped at 255 bytes (NAME_MAX, truncated on
 a UTF-8 boundary, extension preserved), and a plain field whose value is
 exactly `.` or `..` is dropped rather than creating an unusable directory. The
 default template is `$albumartist/$album/$title`.
+
+Brackets and braces must be balanced: an unclosed `[` section or an
+unterminated `${` / `$!{` field is rejected at mount time with an error naming
+the problem, rather than silently folding the rest of the template into the
+open construct. To check a template before committing to a mount, add
+`--dry-run`: it validates the template, prints a sample of the paths the mount
+would expose along with the total file and directory counts, then exits without
+mounting.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -7,6 +7,13 @@ edition = "2024"
 [package.metadata]
 cargo-fuzz = true
 
+# This crate is excluded from the main workspace (libfuzzer needs its own
+# crate), so the workspace-wide `unsafe_code = "deny"` does not reach it. A fuzz
+# harness is exactly where an `unsafe` transmute of arbitrary bytes is tempting,
+# and CI only `fuzz build`s these (no clippy/lint pass), so re-declare it here.
+[lints.rust]
+unsafe_code = "deny"
+
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -165,6 +165,11 @@ pub struct MountArgs {
     /// cargo feature, which adds the syscall counters.
     #[arg(long, env = "MUSEFS_EXPOSE_METRICS", value_parser = clap::builder::BoolishValueParser::new())]
     pub expose_metrics: bool,
+    /// Validate the template and config and print a sample of the paths the
+    /// mount would expose, then exit without mounting. Use this to check a
+    /// `--template` before committing to a mount.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -378,6 +383,18 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     if !args.db.exists() {
         anyhow::bail!("database does not exist: {}", args.db.display());
     }
+    if !args.dry_run && !args.mountpoint.is_dir() {
+        if args.mountpoint.exists() {
+            anyhow::bail!(
+                "mountpoint is not a directory: {}",
+                args.mountpoint.display()
+            );
+        }
+        anyhow::bail!(
+            "mountpoint does not exist (create it first): {}",
+            args.mountpoint.display()
+        );
+    }
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
     let (config, fuse_config) = parse_mount_config(args);
@@ -387,10 +404,78 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
         }
     }
     let core = Musefs::open(db, config).context("building the virtual filesystem")?;
+    if args.dry_run {
+        return print_dry_run(&core);
+    }
     signal::install_unmount_on_signal(args.mountpoint.clone())
         .context("installing the stop-signal unmount handler")?;
     musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
         .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
+    Ok(())
+}
+
+/// Print a sample of the paths a `mount --dry-run` would expose, walking the
+/// already-built virtual tree so the preview reflects the exact rendering the
+/// real mount uses.
+fn print_dry_run(core: &Musefs) -> Result<()> {
+    // The virtual tree root is inode 1 (the FUSE root id).
+    const ROOT_INODE: u64 = 1;
+    const SAMPLE: usize = 30;
+    let mut sample: Vec<String> = Vec::new();
+    let (mut files, mut dirs) = (0u64, 0u64);
+    walk_preview(
+        core,
+        ROOT_INODE,
+        "",
+        SAMPLE,
+        &mut sample,
+        &mut files,
+        &mut dirs,
+    )?;
+    if files == 0 {
+        println!(
+            "dry run: this template produces no files (the store is empty, or every track was dropped by --skip-on-missing)."
+        );
+        return Ok(());
+    }
+    println!("dry run: {files} files across {dirs} directories. Sample paths:");
+    for path in &sample {
+        println!("  {path}");
+    }
+    if files > sample.len() as u64 {
+        println!("  ... and {} more", files - sample.len() as u64);
+    }
+    Ok(())
+}
+
+/// Depth-first walk of the virtual tree. `readdir` returns name-sorted children,
+/// so `sample` collects the first `cap` file paths in lexicographic order while
+/// `files`/`dirs` accumulate the totals.
+fn walk_preview(
+    core: &Musefs,
+    inode: u64,
+    prefix: &str,
+    cap: usize,
+    sample: &mut Vec<String>,
+    files: &mut u64,
+    dirs: &mut u64,
+) -> Result<()> {
+    for (name, child, is_dir) in core.readdir(inode)? {
+        let path = if prefix.is_empty() {
+            name
+        } else {
+            format!("{prefix}/{name}")
+        };
+        if is_dir {
+            *dirs += 1;
+            walk_preview(core, child, &path, cap, sample, files, dirs)?;
+        } else {
+            *files += 1;
+            if sample.len() < cap {
+                sample.push(path);
+            }
+        }
+    }
     Ok(())
 }
 

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -167,6 +167,7 @@ fn parse_mount_config_defaults_are_sensible() {
         read_ahead_prefetch: false,
         skip_on_missing: false,
         expose_metrics: false,
+        dry_run: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.template, "$artist/$title");
@@ -204,6 +205,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
         read_ahead_prefetch: false,
         skip_on_missing: false,
         expose_metrics: false,
+        dry_run: false,
     };
     let (config, fuse_config) = parse_mount_config(&args);
     assert_eq!(config.mode, Mode::StructureOnly);
@@ -237,6 +239,7 @@ fn parse_mount_config_saturating_readahead() {
         read_ahead_prefetch: false,
         skip_on_missing: false,
         expose_metrics: false,
+        dry_run: false,
     };
     let (_, fuse_config) = parse_mount_config(&args);
     assert_eq!(fuse_config.max_readahead, u32::MAX);
@@ -294,6 +297,7 @@ fn parse_mount_config_populates_per_field_fallbacks() {
         read_ahead_prefetch: false,
         skip_on_missing: false,
         expose_metrics: false,
+        dry_run: false,
     };
     let (config, _) = parse_mount_config(&args);
     assert_eq!(

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -20,7 +20,7 @@ pub enum CoreError {
         size: u64,
         cap: u64,
     },
-    #[error("io error: {0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("backing file changed since scan: {0}")]
     BackingChanged(String),

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -331,7 +331,13 @@ impl ReadAhead {
         } else {
             self.window = WINDOW_FLOOR.min(self.cap);
         }
-        debug_assert!(off < backing_len && off + len as u64 <= backing_len);
+        // A read straddling EOF (`off + len > backing_len`) would clamp `want`
+        // below `len` and panic on `buf[..len]` below. The serve path never
+        // requests past the backing length, but this is a `pub` method, so fail
+        // closed with `read_exact` semantics rather than panic in release.
+        if off >= backing_len || off.saturating_add(len as u64) > backing_len {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+        }
         let want = self
             .window
             .max(len as u64)
@@ -709,6 +715,22 @@ mod window_tests {
             off + len as u64 <= 700 * 1024,
             "fill must not read past EOF"
         );
+    }
+
+    #[test]
+    fn read_straddling_eof_errors_not_panics() {
+        let mut fake = Fake::new(1000);
+        let mut ra = ReadAhead::new(WINDOW_ABS_CAP);
+        let backing_len = fake.data.len() as u64;
+        // Range ends past EOF: off=990, len=20 → 1010 > 1000.
+        let mut dst = vec![0u8; 20];
+        let err = ra
+            .read_into(&mut dst, 990, backing_len, |b, o| fake.fill(b, o))
+            .expect_err("a read past EOF must fail, not panic");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        // A read ending exactly at EOF is still valid.
+        let ok = ra.read_into(&mut dst, 980, backing_len, |b, o| fake.fill(b, o));
+        assert!(ok.is_ok(), "off+len == backing_len is in range");
     }
 }
 

--- a/musefs-core/src/template.rs
+++ b/musefs-core/src/template.rs
@@ -27,6 +27,14 @@ pub enum TemplateError {
     /// not a valid POSIX path-component byte.
     #[error("template literal contains control byte {byte:#04x}")]
     ControlByte { byte: u8 },
+    /// A `${`/`$!{` field was opened but never closed by `}` before the end of
+    /// the template, e.g. `${albumartist`.
+    #[error("template has an unterminated '${{' field (missing '}}')")]
+    UnterminatedField,
+    /// A `[...]` section was opened but never closed by `]` before the end of
+    /// the template, e.g. `$album[ - $disc`.
+    #[error("template has an unclosed '[' section (missing ']')")]
+    UnclosedSection,
 }
 
 /// A parsed path template: literal runs, `$field` / `${field}` substitutions
@@ -55,7 +63,9 @@ enum Part {
 impl Template {
     /// Parse a beets-style template. Returns `Err` for a template that cannot
     /// produce valid path components: control/NUL bytes in literal text
-    /// (#275) or `[...]` nesting deeper than [`MAX_SECTION_DEPTH`] (#304).
+    /// (#275), `[...]` nesting deeper than [`MAX_SECTION_DEPTH`] (#304), an
+    /// unterminated `${`/`$!{` field (no closing `}`), or an unclosed `[`
+    /// section (no closing `]`).
     ///
     /// - `$field` / `${field}` substitute a tag field; `${a|b|c}` is a fallback
     ///   chain (first present wins). Names are matched case-insensitively.
@@ -63,9 +73,9 @@ impl Template {
     ///   separators (each segment sanitized; empty / `.` / `..` dropped).
     /// - `[...]` is a conditional section, suppressed when every field it
     ///   references is empty. `$[` and `$]` emit literal brackets.
-    /// - A `$` not followed by a recognized form stays literal; an unterminated
-    ///   `${`/`$!{` consumes the rest as the name; an unterminated `[` runs to
-    ///   end of input.
+    /// - A `$` not followed by a recognized form stays literal. An unterminated
+    ///   `${`/`$!{` (missing `}`) or an unclosed `[` section (missing `]`) is a
+    ///   parse error.
     pub fn parse(template: &str) -> Result<Template, TemplateError> {
         let mut chars = template.chars().peekable();
         let parts = parse_parts(&mut chars, 0)?;
@@ -121,14 +131,18 @@ impl Template {
 }
 
 /// Parse parts until a closing `]` (when `depth > 0`) or end of input. `depth`
-/// is the current `[...]` nesting level (0 = top level).
+/// is the current `[...]` nesting level (0 = top level). A section opened at
+/// `depth > 0` that reaches end of input without its `]` is rejected as
+/// [`TemplateError::UnclosedSection`].
 fn parse_parts(chars: &mut Peekable<Chars>, depth: usize) -> Result<Vec<Part>, TemplateError> {
     let mut parts = Vec::new();
     let mut literal = String::new();
+    let mut closed = false;
     while let Some(&c) = chars.peek() {
         match c {
             ']' if depth > 0 => {
                 chars.next(); // consume the closing ']'
+                closed = true;
                 break;
             }
             '[' => {
@@ -155,7 +169,7 @@ fn parse_parts(chars: &mut Peekable<Chars>, depth: usize) -> Result<Vec<Part>, T
                     }
                     Some('{') => {
                         chars.next();
-                        let names = parse_braced_names(chars);
+                        let names = parse_braced_names(chars)?;
                         push_literal(&mut parts, &mut literal);
                         parts.push(Part::Field { names, raw: false });
                     }
@@ -163,7 +177,7 @@ fn parse_parts(chars: &mut Peekable<Chars>, depth: usize) -> Result<Vec<Part>, T
                         chars.next(); // consume '!'
                         if chars.peek() == Some(&'{') {
                             chars.next(); // consume '{'
-                            let names = parse_braced_names(chars);
+                            let names = parse_braced_names(chars)?;
                             push_literal(&mut parts, &mut literal);
                             parts.push(Part::Field { names, raw: true });
                         } else {
@@ -192,6 +206,9 @@ fn parse_parts(chars: &mut Peekable<Chars>, depth: usize) -> Result<Vec<Part>, T
         }
     }
     push_literal(&mut parts, &mut literal);
+    if depth > 0 && !closed {
+        return Err(TemplateError::UnclosedSection);
+    }
     Ok(parts)
 }
 
@@ -201,17 +218,23 @@ fn push_literal(parts: &mut Vec<Part>, literal: &mut String) {
     }
 }
 
-/// Consume up to the next `}` (or end of input) and split on `|` into the
-/// candidate name list, lowercased for case-insensitive lookup.
-fn parse_braced_names(chars: &mut Peekable<Chars>) -> Vec<String> {
+/// Consume up to the next `}` and split on `|` into the candidate name list,
+/// lowercased for case-insensitive lookup. Reaching end of input before the
+/// closing `}` is a [`TemplateError::UnterminatedField`].
+fn parse_braced_names(chars: &mut Peekable<Chars>) -> Result<Vec<String>, TemplateError> {
     let mut content = String::new();
+    let mut closed = false;
     for nc in chars.by_ref() {
         if nc == '}' {
+            closed = true;
             break;
         }
         content.push(nc);
     }
-    content.split('|').map(str::to_ascii_lowercase).collect()
+    if !closed {
+        return Err(TemplateError::UnterminatedField);
+    }
+    Ok(content.split('|').map(str::to_ascii_lowercase).collect())
 }
 
 fn parse_unbraced_name(chars: &mut Peekable<Chars>) -> String {
@@ -395,7 +418,7 @@ mod tests {
 
     #[test]
     fn nesting_at_limit_parses_one_past_limit_rejected() {
-        let at_limit = "[".repeat(MAX_SECTION_DEPTH);
+        let at_limit = "[".repeat(MAX_SECTION_DEPTH) + &"]".repeat(MAX_SECTION_DEPTH);
         assert!(
             Template::parse(&at_limit).is_ok(),
             "{MAX_SECTION_DEPTH} deep parses"

--- a/musefs-core/tests/template.rs
+++ b/musefs-core/tests/template.rs
@@ -54,10 +54,16 @@ fn lone_dollar_stays_literal() {
 }
 
 #[test]
-fn unterminated_brace_consumes_rest_as_field_name() {
-    let f = fields(&[("album", "X")]);
-    let path = parse("${album").render(&f, &BTreeMap::new(), "Unknown", "ogg");
-    assert_eq!(path, "X.ogg");
+fn unterminated_brace_is_rejected() {
+    assert!(matches!(
+        Template::parse("${album"),
+        Err(TemplateError::UnterminatedField)
+    ));
+    // A `$!{` path field is equally strict.
+    assert!(matches!(
+        Template::parse("$!{beets_path"),
+        Err(TemplateError::UnterminatedField)
+    ));
 }
 
 #[test]
@@ -204,9 +210,14 @@ fn stray_closing_bracket_is_literal() {
 }
 
 #[test]
-fn unterminated_section_runs_to_end_of_input() {
+fn unclosed_section_is_rejected() {
+    assert!(matches!(
+        Template::parse("$album[ CD $disc"),
+        Err(TemplateError::UnclosedSection)
+    ));
+    // A balanced section still parses and renders.
     let f = fields(&[("album", "LP"), ("disc", "2")]);
-    let path = parse("$album[ CD $disc").render(&f, &BTreeMap::new(), "Unknown", "flac");
+    let path = parse("$album[ CD $disc]").render(&f, &BTreeMap::new(), "Unknown", "flac");
     assert_eq!(path, "LP CD 2.flac");
 }
 


### PR DESCRIPTION
Follow-ups from a codebase audit, focused on the CLI / template UX and a couple of robustness nits. The audit found no critical/high security, performance, or correctness issues; these are the actionable smaller items.

## Template engine
- **Strict bracket/brace validation.** An unclosed `[ … ]` section (`TemplateError::UnclosedSection`) and an unterminated `${` / `$!{` field (`TemplateError::UnterminatedField`) are now rejected at parse time instead of silently folding the rest of the template into the open construct — a typo'd bracket previously produced a surprising directory tree with no feedback. The two cases are now consistent with each other. Updated the two tests that pinned the old lenient behavior and the nesting-depth unit test.

## CLI
- **`musefs mount --dry-run`.** Validates the template/config, prints a lexicographically-sorted sample of the paths the mount would expose plus total file/directory counts, then exits without mounting. Walks the already-built virtual tree via the public `readdir` API, so the preview matches the exact rendering a real mount uses. Together with strict validation this lets a `--template` be checked before committing to a mount.
- **Clearer mount errors.** A missing or non-directory mountpoint is reported with an actionable message before FUSE setup (previously a bare `os error 2`, or a misleading `Permission denied` when the path was a regular file), matching the existing DB-path preflight.

## Robustness
- **`error`:** `CoreError::Io` is now `#[error(transparent)]`, so the anyhow context chain no longer prints the OS error string twice.
- **`readahead`:** `ReadAhead::read_into` returns `UnexpectedEof` on a read straddling EOF instead of panicking on `buf[..len]` in a release build (a release-compiled `debug_assert` previously masked it). Unreachable from the serve path today, but it's a `pub` method. Re-anchored the `read_exact_at` `+` mutant coordinate for the line shift.
- **`fuzz`:** re-declared `unsafe_code = "deny"` in the out-of-workspace fuzz crate so the workspace-wide ban reaches the harnesses. No fuzz source uses `unsafe` today (verified); this is preventative and does not break `cargo +nightly fuzz build`.

## Verification
- Full workspace `cargo test`, `clippy --all-targets -D warnings`, `cargo fmt --check`, mutant-anchor guard, and ruff all pass (pre-commit gate).
- `cargo test -p musefs-core --features metrics`: green.
- `cargo +nightly fuzz build`: exit 0 with the new lint.
- Exercised `--dry-run` and both strict-template errors against a real 4427-track library.

Example:
\`\`\`
$ musefs mount … --template '\$album[ - \$disc' --dry-run
musefs: building the virtual filesystem: template has an unclosed '[' section (missing ']')   # exit 1
$ musefs mount … --dry-run
dry run: 4427 files across 507 directories. Sample paths:
  AJJ/Can't Maintain/Evil.flac
  …
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` flag to validate mount configuration and preview exposed paths with file/directory counts before mounting.

* **Bug Fixes**
  * Stricter template validation now rejects unbalanced brackets and unterminated field constructs with clear error descriptions.
  * Improved mount-time error reporting for missing mountpoints and I/O failures.
  * Fixed EOF handling during read operations to prevent unexpected failures.

* **Documentation**
  * Updated mounting guide with template validation requirements and `--dry-run` usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->