### PR TITLE
Audit hygiene follow-ups: MSRV, cargo-deny, --verbose, docs, vendor-sync gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,11 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
       - name: Install cargo-deny
-        # Unpinned, like cargo-mutants/cargo-fuzz: a pinned --locked install
-        # periodically breaks on the current toolchain. Known-good: 0.19.x.
-        run: cargo install cargo-deny --locked
+        # Pinned to the 0.19 line: `deny` is a required gate, and cargo-deny's
+        # config schema changes across minor releases, so an unpinned install
+        # could fail unrelated PRs on a breaking upstream bump. Bump this
+        # together with the deny.toml schema.
+        run: cargo install cargo-deny --locked --version '^0.19'
       - name: cargo-deny check
         run: cargo deny check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,26 @@ jobs:
       - name: Core metrics-feature tests
         run: cargo test -p musefs-core --features metrics
 
+  deny:
+    # Supply-chain gate cargo audit doesn't cover: the license allow-list (plus
+    # bans/sources, and advisories as defense in depth alongside audit.yml).
+    # deny.toml is the source of truth. `cargo deny` reads metadata only — it
+    # runs no build scripts, so it needs no libfuse/SQLite toolchain.
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+      - name: Install cargo-deny
+        # Unpinned, like cargo-mutants/cargo-fuzz: a pinned --locked install
+        # periodically breaks on the current toolchain. Known-good: 0.19.x.
+        run: cargo install cargo-deny --locked
+      - name: cargo-deny check
+        run: cargo deny check
+
   interop:
     # Property 5: an independent ecosystem reader (mutagen) reads the tags we
     # synthesize. Emits synthesized files via reader::read_at (no FUSE mount),
@@ -189,6 +209,12 @@ jobs:
         # module), NOT the system `picard`/Qt package, so they run here with no
         # system-Picard env — verified: contrib/picard/tests/test_path_gate.py:12.
         run: python -m pytest contrib/picard/tests -m musefs_bin -v
+      - name: picard vendor-sync gate (pure file compare, no Qt/Picard)
+        # test_vendor_sync.py is unmarked, so the heavyweight system-Picard
+        # `picard` job is otherwise its only runner. It imports only the bundled
+        # `musefs._common`, so it runs on this Qt-free runner too — gate it here
+        # so a forgotten vendor_to_picard.py re-vendor can't merge.
+        run: python -m pytest contrib/picard/tests/test_vendor_sync.py -v
       - name: Python -> Rust synthesis round trip
         run: bash scripts/contract-roundtrip.sh
 
@@ -522,7 +548,7 @@ jobs:
   # if any failed or was cancelled.
   ci-ok:
     if: always()
-    needs: [changes, check, interop, contract, python-musefs, beets, lidarr, picard, e2e, macos, freebsd, asan]
+    needs: [changes, check, deny, interop, contract, python-musefs, beets, lidarr, picard, e2e, macos, freebsd, asan]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate required-job results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`-v`/`--verbose` flag:** a global verbosity flag (`-v` = info, `-vv` =
+  debug, `-vvv` = trace; default `warn`) on `scan` and `mount`, so diagnosing a
+  run no longer requires knowing the `RUST_LOG` env var. An explicit `RUST_LOG`
+  still takes precedence.
 - **`mount --dry-run`:** validate the `--template` and configuration and print a
   sample of the paths the mount would expose (with total file and directory
   counts), then exit without mounting — a way to check a template before
@@ -57,6 +61,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Declared MSRV (`rust-version = "1.95"`):** the workspace now states a
+  minimum supported Rust version so a too-old toolchain fails with a clear cargo
+  message instead of mid-compile. It is best-effort and tracks recent stable
+  (the bundled-SQLite dependency requires it); not CI-gated.
+- **Supply-chain license gate:** a `deny.toml` + `cargo deny` CI job enforces a
+  permissive-license allow-list (and bans/sources), closing the gap left by the
+  advisory-only `cargo audit` check.
 - **Strict template validation:** an unclosed `[ … ]` section or an unterminated
   `${` / `$!{` field is now rejected at mount time with an error naming the
   problem, instead of silently folding the rest of the template into the open

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,13 @@ exclude = ["fuzz"]
 [workspace.package]
 version = "1.0.0"
 edition = "2024"
+# Best-effort MSRV. The bundled-SQLite dependency (libsqlite3-sys) tracks the
+# newest stdlib — its build script uses `cfg_select!` — so the real floor
+# follows recent stable. Verified: the workspace builds on 1.95 but not 1.94.
+# Deliberately NOT CI-gated (it would churn on every such dep bump); a too-old
+# toolchain still fails clearly via cargo's rust-version check. Bump when a
+# dependency raises the floor.
+rust-version = "1.95"
 license = "MIT"
 repository = "https://github.com/Sohex/musefs"
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ musefs scan ~/Music --db library.db        # ingest your library
 mkdir -p ~/mnt/music
 musefs mount ~/mnt/music --db library.db \
     --template '$albumartist/$album/$title'
-# mount blocks until unmounted: fusermount -u ~/mnt/music (or Ctrl-C)
+# mount blocks until unmounted: fusermount3 -u ~/mnt/music (or Ctrl-C)
 ```
 
 `~/mnt/music` now serves your library as

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,57 @@
+# cargo-deny configuration: license allow-list + supply-chain bans.
+# Run locally with `cargo deny check`; CI runs it in audit.yml.
+# Advisories are also covered by rustsec/audit-check in audit.yml; cargo-deny
+# adds the license gate (which audit-check does not do) plus source/ban checks.
+
+[graph]
+all-features = true
+
+[licenses]
+# musefs is MIT. Allow only OSI-permissive / public-domain licenses compatible
+# with redistributing an MIT binary. Every entry below is present in the current
+# dependency tree (or a permissive arm of a multi-license `OR` expression);
+# weak-copyleft MPL-2.0 is file-level and fine to link. Copyleft licenses
+# (GPL/LGPL/AGPL) are intentionally absent — they only ever appear as the
+# non-selected arm of an `OR`, so the resolver picks a permissive arm instead.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "0BSD",
+    "ISC",
+    "Zlib",
+    "Unlicense",
+    "Unicode-3.0",
+    "MPL-2.0",
+]
+confidence-threshold = 0.9
+
+[bans]
+# Duplicate versions are a hygiene smell, not a correctness bug here (the known
+# duplicates are test-only — see the audit notes), so warn.
+multiple-versions = "warn"
+# Forbid `version = "*"` deps, but exempt the internal workspace path crates
+# (musefs-core/-fuse/... are referenced by path with no version on purpose).
+wildcards = "deny"
+allow-wildcard-paths = true
+# A copyleft runtime dep would be a licensing problem; keep the door shut even
+# though none is present today.
+deny = []
+
+[advisories]
+# Advisories are primarily gated by rustsec/audit-check in audit.yml; cargo-deny
+# re-checks them here as defense in depth. Keep yanked crates a hard error.
+yanked = "deny"
+ignore = [
+    # paste 1.0.15 is archived/unmaintained (via tikv-jemalloc-ctl, the default
+    # allocator); no safe upgrade exists and it is a build-time proc-macro only.
+    "RUSTSEC-2024-0436",
+]
+
+[sources]
+# Only crates.io. A git or altern-registry dependency must be added here
+# deliberately.
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,5 @@
 # cargo-deny configuration: license allow-list + supply-chain bans.
-# Run locally with `cargo deny check`; CI runs it in audit.yml.
+# Run locally with `cargo deny check`; CI runs it in .github/workflows/ci.yml.
 # Advisories are also covered by rustsec/audit-check in audit.yml; cargo-deny
 # adds the license gate (which audit-check does not do) plus source/ban checks.
 

--- a/docs/src/guide/mounting.md
+++ b/docs/src/guide/mounting.md
@@ -10,7 +10,7 @@ musefs mount /path/to/mountpoint --db library.db \
     --mode synthesis        # or: structure-only
 ```
 
-`mount` blocks until the filesystem is unmounted (`fusermount -u`, or
+`mount` blocks until the filesystem is unmounted (`fusermount3 -u`, or
 Ctrl-C).
 
 > **`mount` never creates the store** — unlike `scan`, it requires a populated

--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -9,7 +9,7 @@ musefs scan ~/Music --db library.db        # ingest your library
 mkdir -p ~/mnt/music
 musefs mount ~/mnt/music --db library.db \
     --template '$albumartist/$album/$title'
-# mount blocks until unmounted: fusermount -u ~/mnt/music (or Ctrl-C)
+# mount blocks until unmounted: fusermount3 -u ~/mnt/music (or Ctrl-C)
 ```
 
 `~/mnt/music` now serves your library as

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -16,7 +16,7 @@ files or directories, and `--jobs N` controls probe parallelism.
 `--follow-symlinks` walks symlinked files and directories (off by default, so
 symlinks are logged and skipped). `--quiet`
 (`-q`) suppresses the per-target summary for scripting; scan failures still
-surface on stderr (raise detail with `RUST_LOG=info`).
+surface on stderr (raise detail with `-v`/`-vv`, or `RUST_LOG=info`).
 
 `scan` and `scan --revalidate` show a live progress indicator: on an interactive
 terminal, a discovery spinner followed by a determinate bar (position, percent,

--- a/docs/src/integrations/beets.md
+++ b/docs/src/integrations/beets.md
@@ -174,7 +174,7 @@ python -m pytest -m e2e                   # full beets -> mount -> playback end-
 
 The `musefs_bin` gate shells out to the real `musefs` binary, so build it first
 from the repo root (`cargo build`) and run it against a fresh build. The `e2e`
-tier additionally needs `ffmpeg` and `/dev/fuse` + `fusermount`: it generates
+tier additionally needs `ffmpeg` and `/dev/fuse` + `fusermount3`: it generates
 audio, imports it with beets, retags, syncs, mounts via FUSE, and verifies the
 mount's tags and byte-identical audio (including a move-reconcile case). Both
 tiers are deselected from the default run and skip cleanly if their tools are

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs-cli"
 description = "musefs command-line interface: scan a music library and mount a re-tagged virtual view."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords = ["fuse", "music", "metadata", "filesystem", "audio"]

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -64,6 +64,10 @@ impl From<ChecksumMode> for musefs_core::ChecksumTier {
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
+    /// Increase log verbosity: `-v` = info, `-vv` = debug, `-vvv` = trace
+    /// (default: warn). An explicit `RUST_LOG` takes precedence over this.
+    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
+    pub verbose: u8,
 }
 
 /// Flags for `musefs mount`, grouped so the mount plumbing passes one value

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs-core"
 description = "Orchestration for musefs: virtual tree, tag resolution, and scanning."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs-db"
 description = "SQLite store and schema for musefs (tracks, tags, content-addressed art)."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/musefs-format/Cargo.toml
+++ b/musefs-format/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs-format"
 description = "On-the-fly audio metadata synthesis and byte-layout for musefs (FLAC/MP3/MP4/Ogg/WAV)."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs-fuse"
 description = "FUSE adapter for musefs (fuser)."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/musefs-latencyfs/Cargo.toml
+++ b/musefs-latencyfs/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs-latencyfs"
 description = "Bench-only passthrough FUSE with per-op latency injection for musefs benchmarks."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish = false

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -3,6 +3,7 @@ name = "musefs"
 description = "Read-only FUSE filesystem presenting a re-tagged virtual view of a music library."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "../README.md"

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -34,16 +34,24 @@ fn jemalloc_stats() -> Option<musefs_fuse::AllocatorStats> {
 }
 
 fn main() {
+    let cli = Cli::parse();
     // The library crates report serve-path failures through the `log` facade;
-    // without a sink they vanish. Default to `warn` so they surface on stderr,
-    // overridable via RUST_LOG.
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+    // without a sink they vanish. Default to `warn` so they surface on stderr;
+    // `-v`/`-vv`/`-vvv` raise the floor, and an explicit RUST_LOG overrides both.
+    let default_level = match cli.verbose {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default_level))
+        .init();
     #[cfg(feature = "jemalloc")]
     {
         enable_jemalloc_background_thread();
         musefs_fuse::set_alloc_probe(jemalloc_stats);
     }
-    if let Err(e) = run(Cli::parse()) {
+    if let Err(e) = run(cli) {
         eprintln!("musefs: {e:#}");
         std::process::exit(1);
     }


### PR DESCRIPTION
The remaining low-priority hygiene items from the codebase audit. Each is self-contained.

## MSRV declaration
Declares `rust-version = "1.95"` in `[workspace.package]`. I verified the floor empirically rather than guessing: the workspace builds on **1.95 but not 1.94** (the bundled `libsqlite3-sys` build script uses `cfg_select!`, stabilized only recently), so the MSRV tracks recent stable. It is **documentation-only and deliberately not CI-gated** — a pinned MSRV job would churn on nearly every dependency bump for little benefit over cargo's existing clear `rust-version` error. (1.85 through 1.94 all fail to build, confirming there is no meaningful low MSRV here.)

## Supply-chain license gate (`deny.toml` + CI)
Adds `deny.toml` (a permissive-license allow-list, plus bans/sources, with advisories as defense-in-depth) and a required `deny` job in `ci.yml`, closing the gap that the advisory-only `cargo audit` (`rustsec/audit-check`) leaves. `cargo deny check` passes clean. The one unmaintained advisory (`paste`, pulled transitively by jemalloc, no upgrade available) is ignored with justification. Wildcard internal path-crates are exempted via `allow-wildcard-paths`.

## `-v` / `--verbose`
A global verbosity flag (`-v` = info, `-vv` = debug, `-vvv` = trace; default `warn`) on `scan` and `mount`, so diagnosing a run no longer requires knowing the `RUST_LOG` env var. An explicit `RUST_LOG` still takes precedence. Verified it shows in `--help` and on subcommands.

## `fusermount3` docs
The unmount hint (`fusermount -u`) and a beets runtime note said `fusermount`, but the documented runtime requirement is the `fuse3` package's `fusermount3` (matching the signal handler and the install docs). Updated README, quick-start, mounting, and beets pages.

## Picard schema-mirror gate
The vendored `contrib/picard/musefs/_common` is guarded by `test_vendor_sync.py`, but that test is unmarked and therefore ran only in the heavyweight system-Picard `picard` job. It's a pure file comparison that imports only the bundled `musefs._common`, so this runs it in the always-on `contract` job too — a forgotten `vendor_to_picard.py` re-vendor can no longer merge. (The python-musefs copy was already gated by the Rust `schema_py_fixture_is_fresh` test.)

## Verification
- Full pre-commit gate passed: `cargo fmt --check`, `clippy --all-targets -D warnings` (incl. MSRV-aware `incompatible_msrv`), full workspace `cargo test`, yamllint, ruff.
- `cargo deny check`: all four checks (licenses/bans/sources/advisories) pass.
- `cargo +1.95 check --workspace --all-targets`: succeeds; `+1.94` fails.
- `test_vendor_sync.py`: 2 passed; mirrors confirmed byte-identical.
- `-v`/`--verbose` exercised against the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global `-v`/`--verbose` to increase `scan`/`mount` logging verbosity (default: warn; `RUST_LOG` still takes precedence).
* **Documentation**
  * Updated unmount commands and guides to use `fusermount3`.
  * Refined scanning and integration (beets) documentation.
* **Chores**
  * Added MSRV enforcement at Rust 1.95 and aligned crate manifests.
  * Introduced license-allow-list checks in CI and added a Picard vendor consistency gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->