### PR TITLE
fix: resolve 2026-06-16 audit issues #502-#509

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -341,7 +341,7 @@ exclude_re = [
     # initializers — the equivalence rests on unobservability, not on the
     # const being out of reach.)
     # guard: op="/" fn="" rows=2
-    'musefs-core/src/reader\.rs:71:60: replace / with [%*]',
+    'musefs-core/src/reader\.rs:76:60: replace / with [%*]',
     # read_segments_into splice loop's overlap guard `if ov_start < ov_end`,
     # `<`->`<=`: the same equivalence class as serve_ogg_window's overlap-emit
     # guards above. When the bound is equal the overlap is empty (n = ov_end -

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -220,6 +220,53 @@ ALTER TABLE tracks ADD COLUMN fingerprint  TEXT
 ALTER TABLE tracks ADD COLUMN content_hash TEXT
     CHECK (content_hash IS NULL OR length(content_hash) = 64);
 CREATE INDEX tracks_fingerprint_idx ON tracks(fingerprint);
+
+-- Rebuild `tags` with a byte-accurate value cap (#505). SQLite's length() on
+-- TEXT counts characters, so the V1 `CHECK (length(value) <= 262144)` was up to
+-- ~4x looser than the documented 256 KiB byte bound; length(CAST(value AS BLOB))
+-- counts bytes. SQLite cannot alter a CHECK in place, so recreate the table
+-- (V2 is unreleased — this is folded in rather than added as a new migration).
+-- Pre-existing over-cap rows (only reachable on an upgraded store) are dropped:
+-- the read-time guard already counts bytes, so they were unreadable anyway, and
+-- carrying them would abort the rebuild on the new CHECK.
+CREATE TABLE tags_new (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(CAST(value AS BLOB)) <= 262144),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+INSERT INTO tags_new (track_id, key, value, ordinal, value_blob)
+    SELECT track_id, key, value, ordinal, value_blob FROM tags
+    WHERE length(CAST(value AS BLOB)) <= 262144;
+DROP TABLE tags;
+ALTER TABLE tags_new RENAME TO tags;
+
+-- DROP TABLE tags dropped its INSERT/UPDATE/DELETE triggers; recreate them
+-- verbatim so the content_version/updated_at bump contract is unchanged.
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
 PRAGMA user_version = 2;
 """
 

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -217,6 +217,53 @@ ALTER TABLE tracks ADD COLUMN fingerprint  TEXT
 ALTER TABLE tracks ADD COLUMN content_hash TEXT
     CHECK (content_hash IS NULL OR length(content_hash) = 64);
 CREATE INDEX tracks_fingerprint_idx ON tracks(fingerprint);
+
+-- Rebuild `tags` with a byte-accurate value cap (#505). SQLite's length() on
+-- TEXT counts characters, so the V1 `CHECK (length(value) <= 262144)` was up to
+-- ~4x looser than the documented 256 KiB byte bound; length(CAST(value AS BLOB))
+-- counts bytes. SQLite cannot alter a CHECK in place, so recreate the table
+-- (V2 is unreleased — this is folded in rather than added as a new migration).
+-- Pre-existing over-cap rows (only reachable on an upgraded store) are dropped:
+-- the read-time guard already counts bytes, so they were unreadable anyway, and
+-- carrying them would abort the rebuild on the new CHECK.
+CREATE TABLE tags_new (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(CAST(value AS BLOB)) <= 262144),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+INSERT INTO tags_new (track_id, key, value, ordinal, value_blob)
+    SELECT track_id, key, value, ordinal, value_blob FROM tags
+    WHERE length(CAST(value AS BLOB)) <= 262144;
+DROP TABLE tags;
+ALTER TABLE tags_new RENAME TO tags;
+
+-- DROP TABLE tags dropped its INSERT/UPDATE/DELETE triggers; recreate them
+-- verbatim so the content_version/updated_at bump contract is unchanged.
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
 PRAGMA user_version = 2;
 """
 

--- a/docs/src/architecture/serving.md
+++ b/docs/src/architecture/serving.md
@@ -30,10 +30,15 @@ sum to the served file size. Six variants:
 segments and splicing: inline bytes are copied, art and binary-tag payloads
 are read from the DB in chunks, backing audio comes from positioned reads of
 the original file, and Ogg pages are renumbered and CRC-patched in flight.
-This is how the cardinal invariant holds end to end. Layouts that stream
-binary tags are flagged (`RegionLayout::has_binary_tag`) so the reader can
-wrap those reads in a transactional `content_version` guard — a concurrent
-retag cannot interleave bytes from two generations of a tag.
+This is how the cardinal invariant holds end to end. Layouts that stream any
+payload from the DB by rowid — binary tags **and** art (`ArtImage` /
+`OggArtSlice`) — are flagged (`RegionLayout::streams_db_rowid`) so the reader
+wraps those reads in a single WAL snapshot with a `content_version` recheck.
+A concurrent retag (delete + reinsert reusing a freed rowid) cannot interleave
+bytes from two generations of a tag or splice the wrong image. Both the
+per-handle fast path and the stateless no-fh fallback apply the guard, and the
+fallback re-validates its freshly opened backing fd against the resolved
+stamp.
 
 ### Backing read-ahead
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -61,12 +61,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Per-field `--fallback` case-insensitivity:** fallback keys are now ASCII
   lowercased to match template field names, so `--fallback AlbumArtist=…` (any
   uppercase) is honored instead of silently never matching (#504).
-- **Tag value byte cap:** the read-time `tags.value` guard now counts bytes, not
-  UTF-8 characters, so the 256 KiB materialized-memory bound is exact rather than
-  up to ~4x looser for multibyte text (#505).
+- **Tag value byte cap:** both the schema `CHECK` (rebuilt in the `MIGRATION_V2`
+  upgrade) and the read-time `tags.value` guard now count bytes, not UTF-8
+  characters, so the 256 KiB materialized-memory bound is exact rather than up to
+  ~4x looser for multibyte text. The upgrade drops any pre-existing over-cap rows
+  (already unreadable under the byte-counting reader guard) (#505).
 - **Embedded NUL in ID3 metadata:** synthesized ID3 frames now reject a
-  DB-sourced tag value, art mime, or art description containing an embedded NUL
-  instead of emitting a frame a downstream parser would misread (#506).
+  DB-sourced tag key, tag value, art mime, or art description containing an
+  embedded NUL instead of emitting a frame a downstream parser would misread
+  (#506).
 - **Orphan-art GC NULL safety:** `gc_orphan_art` uses `NOT EXISTS` rather than
   `NOT IN (subquery)`, so a NULL `art_id` could not silently turn the GC into a
   no-op (#507).

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -50,6 +50,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Art/serve rowid-reuse consistency:** the read fast path's WAL-snapshot +
+  `content_version` guard, previously gated only on binary-tag layouts, now
+  covers all DB-rowid segments (art `ArtImage`/`OggArtSlice` too) via
+  `RegionLayout::streams_db_rowid`, and the stateless no-fh read fallback now
+  applies the same snapshot/recheck and re-validates its freshly opened backing
+  fd against the resolved stamp. A concurrent external retag + `gc_orphan_art` +
+  reinsert can no longer splice a wrong image or stale tag bytes mid-read (the
+  audio-bytes invariant was never affected) (#502, #503).
+- **Per-field `--fallback` case-insensitivity:** fallback keys are now ASCII
+  lowercased to match template field names, so `--fallback AlbumArtist=…` (any
+  uppercase) is honored instead of silently never matching (#504).
+- **Tag value byte cap:** the read-time `tags.value` guard now counts bytes, not
+  UTF-8 characters, so the 256 KiB materialized-memory bound is exact rather than
+  up to ~4x looser for multibyte text (#505).
+- **Embedded NUL in ID3 metadata:** synthesized ID3 frames now reject a
+  DB-sourced tag value, art mime, or art description containing an embedded NUL
+  instead of emitting a frame a downstream parser would misread (#506).
+- **Orphan-art GC NULL safety:** `gc_orphan_art` uses `NOT EXISTS` rather than
+  `NOT IN (subquery)`, so a NULL `art_id` could not silently turn the GC into a
+  no-op (#507).
+- **Mount usability:** `mount` now warns when the mountpoint is non-empty (its
+  contents are shadowed for the mount's lifetime), and a permission-denied mount
+  (e.g. an AppArmor-restricted prefix) prints actionable guidance instead of a
+  bare "Permission denied" (#508, #509).
 - **Silent mp4 oversize drops:** oversized embedded `covr` cover art and binary
   freeform (`----`) values in `.m4a`/`.m4b` files are skipped in the format layer
   before materialization (to avoid building a large image out of a large `moov`),

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -354,7 +354,16 @@ fn effective_allow_other(flag: bool, owner: Option<u32>, group: Option<u32>) -> 
 pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseConfig) {
     let config = MountConfig {
         template: args.template.clone(),
-        fallbacks: args.fallbacks.iter().cloned().collect(),
+        // Field names are case-insensitive everywhere else (the template parser
+        // and `tags_to_fields` ASCII-lowercase them), so a fallback keyed under
+        // any uppercase letter would never match at render time (#504). Normalize
+        // the key the same way; later duplicates win, matching `collect`'s prior
+        // last-write semantics.
+        fallbacks: args
+            .fallbacks
+            .iter()
+            .map(|(field, value)| (field.to_ascii_lowercase(), value.clone()))
+            .collect(),
         default_fallback: args.default_fallback.clone(),
         mode: args.mode.into(),
         poll_interval: std::time::Duration::from_millis(args.poll_interval_ms),
@@ -379,6 +388,22 @@ pub fn parse_mount_config(args: &MountArgs) -> (MountConfig, musefs_fuse::FuseCo
     (config, fuse_config)
 }
 
+/// Actionable hint appended to a permission-denied mount failure. Covers the
+/// common AppArmor case (Ubuntu 24.04+ / libfuse >= 3.17 restrict unprivileged
+/// FUSE mounts to whitelisted prefixes); mirrors `ALLOW_OTHER_HELP`'s role for
+/// the `user_allow_other` denial. See `docs/src/guide/mounting.md`.
+const MOUNT_DENIED_HELP: &str = "the mount was denied; on Ubuntu 24.04+ / libfuse >= 3.17 the fusermount3 \
+AppArmor profile only permits unprivileged FUSE mounts under whitelisted prefixes ($HOME, /mnt, /media, /tmp, ...). \
+Mount under a permitted prefix, or whitelist yours in /etc/apparmor.d/local/fusermount3 (check the kernel audit \
+log for an apparmor=\"DENIED\" ... profile=\"fusermount3\" line). See the mounting guide for details.";
+
+/// True if `mountpoint` is a directory containing at least one entry. A read
+/// failure is treated as "empty" — the warning is advisory, and the mount will
+/// surface any real access error itself.
+fn mountpoint_is_nonempty(mountpoint: &std::path::Path) -> bool {
+    std::fs::read_dir(mountpoint).is_ok_and(|mut entries| entries.next().is_some())
+}
+
 /// Build a `Musefs` from the DB at `args.db` and mount it (blocking) at
 /// `args.mountpoint`. Unlike `scan`, mount never creates the store: a missing
 /// database path is a configuration error (a typo would otherwise silently
@@ -399,6 +424,16 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
             args.mountpoint.display()
         );
     }
+    // The mountpoint help says "Empty directory", but FUSE happily mounts over a
+    // populated one and shadows its contents for the mount's lifetime. Warn so a
+    // typo (or reusing a real music folder) doesn't silently hide files (#508).
+    if !args.dry_run && mountpoint_is_nonempty(&args.mountpoint) {
+        eprintln!(
+            "warning: mountpoint {} is not empty; its existing contents will be \
+             hidden behind the virtual tree until you unmount",
+            args.mountpoint.display()
+        );
+    }
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
     let (config, fuse_config) = parse_mount_config(args);
@@ -413,8 +448,21 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     }
     signal::install_unmount_on_signal(args.mountpoint.clone())
         .context("installing the stop-signal unmount handler")?;
-    musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config)
-        .with_context(|| format!("mounting at {}", args.mountpoint.display()))?;
+    musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config).map_err(|e| {
+        // A bare EACCES from fusermount3 (e.g. an AppArmor-denied prefix) is
+        // otherwise opaque. Append actionable guidance — but not when the
+        // allow_other preflight already produced its own self-contained message
+        // (it names /etc/fuse.conf), to avoid stacking two different hints (#509).
+        let add_hint = e.kind() == std::io::ErrorKind::PermissionDenied
+            && !e.to_string().contains("/etc/fuse.conf");
+        let err =
+            anyhow::Error::new(e).context(format!("mounting at {}", args.mountpoint.display()));
+        if add_hint {
+            err.context(MOUNT_DENIED_HELP)
+        } else {
+            err
+        }
+    })?;
     Ok(())
 }
 
@@ -533,6 +581,35 @@ mod tests {
         };
         let (config, _) = parse_mount_config(&args);
         assert_eq!(config.read_ahead_budget, 128 * 1024 * 1024);
+    }
+
+    #[test]
+    fn mountpoint_is_nonempty_detects_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            !mountpoint_is_nonempty(dir.path()),
+            "fresh tempdir is empty"
+        );
+        std::fs::write(dir.path().join("stray.mp3"), b"x").unwrap();
+        assert!(
+            mountpoint_is_nonempty(dir.path()),
+            "a populated dir is non-empty (#508)"
+        );
+    }
+
+    #[test]
+    fn mountpoint_is_nonempty_is_false_on_unreadable_path() {
+        // A nonexistent path can't be read; the advisory check fails safe to
+        // "empty" rather than erroring.
+        assert!(!mountpoint_is_nonempty(std::path::Path::new(
+            "/nonexistent/musefs/mountpoint"
+        )));
+    }
+
+    #[test]
+    fn mount_denied_help_points_at_apparmor_and_the_fix() {
+        assert!(MOUNT_DENIED_HELP.contains("AppArmor"));
+        assert!(MOUNT_DENIED_HELP.contains("/etc/apparmor.d/local/fusermount3"));
     }
 
     #[test]

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -311,6 +311,40 @@ fn parse_mount_config_populates_per_field_fallbacks() {
 }
 
 #[test]
+fn fallback_keys_are_lowercased_to_match_template_fields() {
+    // Regression for #504: template field names are case-insensitive (the
+    // parser lowercases `$AlbumArtist` to `albumartist`), so a fallback keyed
+    // with uppercase letters must be lowercased too or it could never match.
+    let cli = Cli::parse_from([
+        "musefs",
+        "mount",
+        "/mnt/x",
+        "--db",
+        "/tmp/m.db",
+        "--fallback",
+        "AlbumArtist=Unknown Artist",
+        "--fallback",
+        "GENRE=Misc",
+    ]);
+    let args = match cli.command {
+        Command::Mount(args) => args,
+        Command::Scan { .. } => panic!("expected mount"),
+    };
+    let (config, _) = parse_mount_config(&args);
+    assert_eq!(
+        config.fallbacks.get("albumartist").map(String::as_str),
+        Some("Unknown Artist"),
+        "uppercase fallback key must normalize to the lowercased field name"
+    );
+    assert_eq!(
+        config.fallbacks.get("genre").map(String::as_str),
+        Some("Misc")
+    );
+    // The verbatim uppercase key must NOT be present.
+    assert!(!config.fallbacks.contains_key("AlbumArtist"));
+}
+
+#[test]
 fn fallback_value_may_contain_equals_and_last_duplicate_wins() {
     let cli = Cli::parse_from([
         "musefs",

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -511,9 +511,10 @@ impl Musefs {
                     // genuine drift is terminal — propagate, don't retry the loop.
                     validate_opened_backing(&h.file, r)?;
                     let served = self.pool.with(|db| -> Result<Option<()>> {
-                        if r.has_binary_tag {
-                            // Snapshot-consistent: version check + blob reads see one
-                            // WAL snapshot, so a reused rowid can't be served.
+                        if r.streams_db_rowid {
+                            // Snapshot-consistent: version check + DB-rowid reads
+                            // (binary tags AND art) see one WAL snapshot, so a
+                            // reused rowid can't be served mid-read (#502).
                             db.begin_read()?;
                             let res = (|| {
                                 // A test seam forces the first N checks stale to

--- a/musefs-core/src/facade/tests.rs
+++ b/musefs-core/src/facade/tests.rs
@@ -28,13 +28,14 @@ fn validate_opened_backing_rejects_mismatched_descriptor_metadata() {
     let resolved = ResolvedFile {
         layout: RegionLayout::validated(vec![Segment::BackingAudio { offset: 0, len: 8 }]).unwrap(),
         total_len: 8,
+        track_id: 1,
         content_version: 1,
         backing_path: expected_path,
         stamp: crate::freshness::BackingStamp::from_metadata(&expected_meta),
         mtime_secs: crate::freshness::BackingStamp::from_metadata(&expected_meta).display_secs(),
         last_page: std::sync::Mutex::new(None),
         cache_bytes: 0,
-        has_binary_tag: false,
+        streams_db_rowid: false,
     };
 
     assert!(matches!(

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -22,6 +22,10 @@ use crate::ogg_index::serve_ogg_window;
 pub struct ResolvedFile {
     pub layout: RegionLayout,
     pub total_len: u64,
+    /// Track id this entry resolves. Lets the stateless read path recheck the
+    /// live `content_version` under its WAL snapshot (#502), mirroring the
+    /// handle fast path's use of the handle's `track_id`.
+    pub track_id: i64,
     pub content_version: i64,
     pub backing_path: PathBuf,
     pub stamp: BackingStamp,
@@ -34,10 +38,11 @@ pub struct ResolvedFile {
     /// Approximate resident bytes this entry costs the cache (sum of `Inline`
     /// segment bytes; backing/art/ogg-audio bytes are not resident).
     pub cache_bytes: u64,
-    /// Precomputed from the layout: true if any segment streams an opaque binary
-    /// tag payload from the DB. Gates the transactional `content_version` guard in
-    /// the read fast path so plain Inline/BackingAudio layouts pay no per-read cost.
-    pub has_binary_tag: bool,
+    /// Precomputed from the layout: true if any segment is streamed from the DB
+    /// by a rowid (`BinaryTag`/`ArtImage`/`OggArtSlice`). Gates the transactional
+    /// `content_version` guard in the read fast path so plain Inline/BackingAudio
+    /// layouts pay no per-read cost (#502).
+    pub streams_db_rowid: bool,
 }
 
 /// Weighs an entry by its resident inline bytes. The `.max(1)` is load-bearing:
@@ -332,17 +337,18 @@ impl HeaderCache {
                 _ => 0,
             })
             .sum::<u64>();
-        let has_binary_tag = layout.has_binary_tag();
+        let streams_db_rowid = layout.streams_db_rowid();
         Ok(Arc::new(ResolvedFile {
             layout,
             total_len,
+            track_id: track.id,
             content_version: track.content_version,
             backing_path: PathBuf::from(&track.backing_path),
             stamp: BackingStamp::from_track(track),
             mtime_secs: mtime_secs_val,
             last_page: Mutex::new(None),
             cache_bytes,
-            has_binary_tag,
+            streams_db_rowid,
         }))
     }
     /// Current number of cached resolved-file entries.
@@ -367,8 +373,6 @@ impl HeaderCache {
     }
 }
 
-/// Read `size` bytes at virtual `offset` into `out` (appended), opening the
-/// backing file once for this call if the layout needs it.
 pub fn read_at_into<M>(
     resolved: &ResolvedFile,
     db: &Db<M>,
@@ -384,17 +388,71 @@ pub fn read_at_into<M>(
         .segments()
         .iter()
         .any(|s| matches!(s, Segment::BackingAudio { .. } | Segment::OggAudio { .. }));
-    if needs_file {
+    // Open and re-validate the backing fd against the stamp the layout was
+    // resolved from (#503): between the resolve-time stat and this open the file
+    // can be rename-replaced or rewritten in place, which would otherwise splice
+    // bytes from a different/modified file behind the stamped header (or
+    // short-read against a stale size). The handle fast path validates per read
+    // via `validate_opened_backing`; this stateless fallback must too.
+    let file = if needs_file {
         crate::metrics::on_open();
-        let file = std::fs::File::open(&resolved.backing_path)?;
-        let pool = crate::readahead::ReadAheadPool::new(0);
-        let buf = std::sync::Arc::new(std::sync::Mutex::new(crate::readahead::ReadAhead::new(0)));
-        let backing_len = resolved.stamp.size;
-        let epoch = std::sync::atomic::AtomicU64::new(0);
-        let br = crate::readahead::BackingReader::new(&file, &buf, &pool, 0, backing_len, &epoch);
-        read_segments_into(resolved, db, Some(&br), offset, size, out)
+        let f = std::fs::File::open(&resolved.backing_path)?;
+        if BackingStamp::from_metadata(&f.metadata()?) != resolved.stamp {
+            return Err(CoreError::BackingChanged(
+                resolved.backing_path.to_string_lossy().into_owned(),
+            ));
+        }
+        Some(f)
     } else {
-        read_segments_into(resolved, db, None, offset, size, out)
+        None
+    };
+
+    // DB-rowid segments (binary tags AND art) must be read under one WAL
+    // snapshot with a `content_version` recheck so a concurrent rowid-reuse
+    // (delete + reinsert reusing a freed rowid) can't splice a wrong blob
+    // mid-read (#502). Only the rare rowid-streaming layout pays this cost.
+    if resolved.streams_db_rowid {
+        db.begin_read()?;
+        let res = (|| {
+            if db.track_content_version(resolved.track_id)? != resolved.content_version {
+                // Stale resolve: the layout no longer matches the live row.
+                // Surface a retryable error rather than risk wrong bytes.
+                return Err(CoreError::BackingChanged(
+                    resolved.backing_path.to_string_lossy().into_owned(),
+                ));
+            }
+            read_with_optional_backing(resolved, db, file.as_ref(), offset, size, out)
+        })();
+        let _ = db.end_read(); // always release the snapshot
+        res
+    } else {
+        read_with_optional_backing(resolved, db, file.as_ref(), offset, size, out)
+    }
+}
+
+/// Build the optional `BackingReader` from an already-validated `file` and run
+/// the segment-splicing loop. Shared by `read_at_into`'s snapshot and
+/// non-snapshot branches so the backing-reader wiring lives in one place.
+fn read_with_optional_backing<M>(
+    resolved: &ResolvedFile,
+    db: &Db<M>,
+    file: Option<&std::fs::File>,
+    offset: u64,
+    size: u64,
+    out: &mut Vec<u8>,
+) -> Result<()> {
+    match file {
+        Some(file) => {
+            let pool = crate::readahead::ReadAheadPool::new(0);
+            let buf =
+                std::sync::Arc::new(std::sync::Mutex::new(crate::readahead::ReadAhead::new(0)));
+            let backing_len = resolved.stamp.size;
+            let epoch = std::sync::atomic::AtomicU64::new(0);
+            let br =
+                crate::readahead::BackingReader::new(file, &buf, &pool, 0, backing_len, &epoch);
+            read_segments_into(resolved, db, Some(&br), offset, size, out)
+        }
+        None => read_segments_into(resolved, db, None, offset, size, out),
     }
 }
 
@@ -579,17 +637,16 @@ mod ogg_serve_tests {
         let resolved = ResolvedFile {
             layout,
             total_len: total,
+            track_id: 1,
             content_version: 0,
             backing_path: path.clone(),
-            stamp: BackingStamp {
-                size: 0,
-                mtime_ns: 0,
-                ctime_ns: 0,
-            },
+            // Stamp the real file so the fallback's backing-fd re-validation
+            // (#503) passes; a dummy stamp would now read as a changed backing.
+            stamp: BackingStamp::from_metadata(&std::fs::metadata(&path).unwrap()),
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 8,
-            has_binary_tag: false,
+            streams_db_rowid: false,
         };
 
         // Read the whole virtual file; needs a Db only for ArtImage (unused here).
@@ -925,6 +982,7 @@ mod ogg_art_serve_tests {
         let resolved = ResolvedFile {
             layout,
             total_len: total,
+            track_id: 1,
             content_version: 0,
             backing_path: std::path::PathBuf::from("/dev/null"),
             stamp: BackingStamp {
@@ -935,7 +993,7 @@ mod ogg_art_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
-            has_binary_tag: false,
+            streams_db_rowid: false,
         };
 
         // Full read.
@@ -976,6 +1034,7 @@ mod ogg_art_serve_tests {
         let resolved = ResolvedFile {
             layout,
             total_len: total,
+            track_id: 1,
             content_version: 0,
             backing_path: std::path::PathBuf::from("/dev/null"),
             stamp: BackingStamp {
@@ -986,7 +1045,7 @@ mod ogg_art_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
-            has_binary_tag: false,
+            streams_db_rowid: false,
         };
         let got = read_at(&resolved, &db, 10, 50).unwrap();
         assert_eq!(got, image[10..60]);
@@ -1050,6 +1109,7 @@ mod cache_bound_tests {
         Arc::new(ResolvedFile {
             layout: RegionLayout::new_unchecked(vec![Segment::Inline(vec![0u8; inline_len])]),
             total_len: inline_len as u64,
+            track_id: 1,
             content_version,
             backing_path: std::path::PathBuf::from("/nonexistent"),
             stamp: BackingStamp {
@@ -1060,7 +1120,7 @@ mod cache_bound_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: inline_len as u64,
-            has_binary_tag: false,
+            streams_db_rowid: false,
         })
     }
 
@@ -1485,7 +1545,10 @@ mod binary_tag_serve_tests {
             }])
             .unwrap(),
             total_len: 4,
-            content_version: 0,
+            track_id: id,
+            // Match the live row: set_binary_tags bumps content_version via
+            // trigger, and the rowid-streaming read path rechecks it (#502).
+            content_version: db.track_content_version(id).unwrap(),
             backing_path: PathBuf::from("/x.mp3"),
             stamp: BackingStamp {
                 size: 0,
@@ -1495,11 +1558,102 @@ mod binary_tag_serve_tests {
             mtime_secs: 0,
             last_page: Mutex::new(None),
             cache_bytes: 0,
-            has_binary_tag: true,
+            streams_db_rowid: true,
         };
         // No BackingAudio segment, so read_at opens no file.
         let got = read_at(&resolved, &db, 1, 2).unwrap();
         assert_eq!(got, vec![20, 30]);
+    }
+
+    #[test]
+    fn fallback_read_rejects_changed_backing() {
+        // #503: the stateless read path must re-validate the freshly opened
+        // backing fd against the resolved stamp, like the handle fast path does.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.mp3");
+        std::fs::write(&path, vec![0u8; 100]).unwrap();
+        let db = Db::open_in_memory().unwrap();
+        let layout = RegionLayout::validated(vec![
+            Segment::Inline(vec![1, 2, 3]),
+            Segment::BackingAudio {
+                offset: 0,
+                len: 100,
+            },
+        ])
+        .unwrap();
+        let total = layout.total_len();
+        let resolved = ResolvedFile {
+            layout,
+            total_len: total,
+            track_id: 1,
+            content_version: 0,
+            backing_path: path.clone(),
+            stamp: BackingStamp::from_metadata(&std::fs::metadata(&path).unwrap()),
+            mtime_secs: 0,
+            last_page: Mutex::new(None),
+            cache_bytes: 3,
+            streams_db_rowid: false,
+        };
+        // Matching stamp: the read succeeds.
+        assert!(read_at(&resolved, &db, 0, total).is_ok());
+        // Replace the backing file with a different size -> stamp mismatch.
+        std::fs::write(&path, vec![0u8; 200]).unwrap();
+        let err = read_at(&resolved, &db, 0, total).unwrap_err();
+        assert!(matches!(err, CoreError::BackingChanged(_)), "{err:?}");
+    }
+
+    #[test]
+    fn fallback_read_of_art_rechecks_content_version() {
+        // #502: an art-only layout (no BinaryTag) must take the snapshot +
+        // content_version recheck path on the stateless fallback, so a stale
+        // resolve cannot stream a reused art rowid's bytes.
+        let db = Db::open_in_memory().unwrap();
+        let id = db
+            .upsert_track(&NewTrack {
+                backing_path: "/y.mp3".into(),
+                format: Format::Mp3,
+                audio_offset: 0,
+                audio_length: 0,
+                backing_size: 0,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
+            })
+            .unwrap();
+        let art_id = db
+            .upsert_art(&musefs_db::NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![1, 2, 3, 4],
+            })
+            .unwrap();
+        let layout = RegionLayout::validated(vec![Segment::ArtImage {
+            art_id,
+            len: musefs_format::BlobLen::new(4).unwrap(),
+        }])
+        .unwrap();
+        let live_cv = db.track_content_version(id).unwrap();
+        let mk = |content_version| ResolvedFile {
+            layout: layout.clone(),
+            total_len: 4,
+            track_id: id,
+            content_version,
+            backing_path: PathBuf::from("/y.mp3"),
+            stamp: BackingStamp {
+                size: 0,
+                mtime_ns: 0,
+                ctime_ns: 0,
+            },
+            mtime_secs: 0,
+            last_page: Mutex::new(None),
+            cache_bytes: 0,
+            streams_db_rowid: true,
+        };
+        // Live content_version: art bytes are served.
+        assert_eq!(read_at(&mk(live_cv), &db, 0, 4).unwrap(), vec![1, 2, 3, 4]);
+        // Stale content_version: the recheck (now covering art) rejects.
+        let err = read_at(&mk(live_cv + 1), &db, 0, 4).unwrap_err();
+        assert!(matches!(err, CoreError::BackingChanged(_)), "{err:?}");
     }
 }
 

--- a/musefs-core/tests/read_at.rs
+++ b/musefs-core/tests/read_at.rs
@@ -98,6 +98,7 @@ fn read_at_streams_art_image_segments() {
     let resolved = ResolvedFile {
         layout,
         total_len,
+        track_id: 0,
         content_version: 0,
         backing_path: std::path::PathBuf::from("/unused"),
         stamp: BackingStamp {
@@ -108,7 +109,9 @@ fn read_at_streams_art_image_segments() {
         mtime_secs: 0,
         last_page: std::sync::Mutex::new(None),
         cache_bytes: 0,
-        has_binary_tag: false,
+        // Splicing test: bypass the snapshot/version-recheck path (no real track
+        // row backs this hand-built entry).
+        streams_db_rowid: false,
     };
 
     // Whole read: inline framing then the streamed art bytes.

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -202,9 +202,15 @@ impl Db<ReadWrite> {
 
     /// Delete `art` rows no longer referenced by any `track_art`. Returns the
     /// number of rows removed.
+    ///
+    /// Uses `NOT EXISTS` rather than `NOT IN (subquery)`: SQLite's `NOT IN`
+    /// evaluates to UNKNOWN for the whole row if any subquery value is NULL,
+    /// which would silently delete nothing should a NULL `art_id` ever reach
+    /// `track_art` (#507). `NOT EXISTS` is NULL-safe.
     pub fn gc_orphan_art(&self) -> Result<usize> {
         let removed = self.conn.execute(
-            "DELETE FROM art WHERE id NOT IN (SELECT art_id FROM track_art)",
+            "DELETE FROM art WHERE NOT EXISTS \
+             (SELECT 1 FROM track_art WHERE track_art.art_id = art.id)",
             [],
         )?;
         Ok(removed)
@@ -368,6 +374,46 @@ mod guard_tests {
         assert_eq!(
             super::sha256_hex(b"abc"),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn gc_orphan_art_not_exists_is_null_safe() {
+        // Regression for #507: the orphan-art GC must use NOT EXISTS, not
+        // NOT IN (subquery). With a NULL in the subquery, SQLite's NOT IN
+        // evaluates to UNKNOWN for every row and deletes nothing; NOT EXISTS
+        // is unaffected. The live schema's NOT NULL on `track_art.art_id`
+        // makes this unreachable today, so the NULL is reproduced on a relaxed
+        // scratch schema to pin the pattern choice against regression.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE art (id INTEGER PRIMARY KEY);
+             CREATE TABLE track_art (art_id INTEGER);
+             INSERT INTO art (id) VALUES (1), (2);
+             INSERT INTO track_art (art_id) VALUES (1), (NULL);",
+        )
+        .unwrap();
+
+        // The buggy NOT IN form deletes nothing because of the NULL.
+        let not_in = conn
+            .execute(
+                "DELETE FROM art WHERE id NOT IN (SELECT art_id FROM track_art)",
+                [],
+            )
+            .unwrap();
+        assert_eq!(not_in, 0, "NOT IN deletes nothing when a NULL is present");
+
+        // The shipped NOT EXISTS form removes the genuine orphan (id 2).
+        let not_exists = conn
+            .execute(
+                "DELETE FROM art WHERE NOT EXISTS \
+                 (SELECT 1 FROM track_art WHERE track_art.art_id = art.id)",
+                [],
+            )
+            .unwrap();
+        assert_eq!(
+            not_exists, 1,
+            "NOT EXISTS removes the orphan despite the NULL"
         );
     }
 }

--- a/musefs-db/src/limits.rs
+++ b/musefs-db/src/limits.rs
@@ -10,11 +10,11 @@
 
 /// Max `tags.key` length. Compared against SQLite `length()` (i64).
 pub const MAX_TAG_KEY_LEN: i64 = 256;
-/// Max `tags.value` length in bytes — 256 KiB. The read-time guard counts
-/// bytes (`length(CAST(value AS BLOB))`) so the materialized-memory bound is
-/// exact (#505). The schema `CHECK` counts UTF-8 *characters*, so it is a
-/// coarser write-time fast-reject (up to ~4x looser for multibyte text); the
-/// byte-accurate enforcement is the reader guard in [`crate::tags`].
+/// Max `tags.value` length in bytes — 256 KiB. Both the schema `CHECK`
+/// (`length(CAST(value AS BLOB)) <= 262144`) and the read-time guard in
+/// [`crate::tags`] count bytes, not UTF-8 characters, so the
+/// materialized-memory bound is exact rather than ~4x looser for multibyte
+/// text (#505).
 pub const MAX_TAG_VALUE_LEN: i64 = 262_144;
 /// Max `art.mime` length.
 pub const MAX_ART_MIME_LEN: i64 = 255;

--- a/musefs-db/src/limits.rs
+++ b/musefs-db/src/limits.rs
@@ -10,7 +10,11 @@
 
 /// Max `tags.key` length. Compared against SQLite `length()` (i64).
 pub const MAX_TAG_KEY_LEN: i64 = 256;
-/// Max `tags.value` length in bytes — 256 KiB.
+/// Max `tags.value` length in bytes — 256 KiB. The read-time guard counts
+/// bytes (`length(CAST(value AS BLOB))`) so the materialized-memory bound is
+/// exact (#505). The schema `CHECK` counts UTF-8 *characters*, so it is a
+/// coarser write-time fast-reject (up to ~4x looser for multibyte text); the
+/// byte-accurate enforcement is the reader guard in [`crate::tags`].
 pub const MAX_TAG_VALUE_LEN: i64 = 262_144;
 /// Max `art.mime` length.
 pub const MAX_ART_MIME_LEN: i64 = 255;

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -215,6 +215,53 @@ ALTER TABLE tracks ADD COLUMN fingerprint  TEXT
 ALTER TABLE tracks ADD COLUMN content_hash TEXT
     CHECK (content_hash IS NULL OR length(content_hash) = 64);
 CREATE INDEX tracks_fingerprint_idx ON tracks(fingerprint);
+
+-- Rebuild `tags` with a byte-accurate value cap (#505). SQLite's length() on
+-- TEXT counts characters, so the V1 `CHECK (length(value) <= 262144)` was up to
+-- ~4x looser than the documented 256 KiB byte bound; length(CAST(value AS BLOB))
+-- counts bytes. SQLite cannot alter a CHECK in place, so recreate the table
+-- (V2 is unreleased — this is folded in rather than added as a new migration).
+-- Pre-existing over-cap rows (only reachable on an upgraded store) are dropped:
+-- the read-time guard already counts bytes, so they were unreadable anyway, and
+-- carrying them would abort the rebuild on the new CHECK.
+CREATE TABLE tags_new (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(CAST(value AS BLOB)) <= 262144),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+INSERT INTO tags_new (track_id, key, value, ordinal, value_blob)
+    SELECT track_id, key, value, ordinal, value_blob FROM tags
+    WHERE length(CAST(value AS BLOB)) <= 262144;
+DROP TABLE tags;
+ALTER TABLE tags_new RENAME TO tags;
+
+-- DROP TABLE tags dropped its INSERT/UPDATE/DELETE triggers; recreate them
+-- verbatim so the content_version/updated_at bump contract is unchanged.
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
 ";
 
 /// Ring capacity of the `track_changes` changelog. Must match the literal in
@@ -415,6 +462,10 @@ mod baseline_tests {
         let sql = super::MIGRATION_V1;
         assert!(sql.contains(&format!("length(key) <= {MAX_TAG_KEY_LEN}")));
         assert!(sql.contains(&format!("length(value) <= {MAX_TAG_VALUE_LEN}")));
+        // V2 rebuilds `tags` with a byte-accurate value cap (#505).
+        assert!(super::MIGRATION_V2.contains(&format!(
+            "length(CAST(value AS BLOB)) <= {MAX_TAG_VALUE_LEN}"
+        )));
         assert!(sql.contains(&format!("length(value_blob) <= {MAX_BINARY_TAG_BYTES}")));
         assert!(sql.contains(&format!("length(mime) <= {MAX_ART_MIME_LEN}")));
         assert!(sql.contains(&format!("byte_len <= {MAX_ART_BYTES}")));
@@ -660,6 +711,72 @@ mod schema_py_tests {
         assert_eq!(
             user_version(&conn),
             i64::try_from(MIGRATIONS.len()).unwrap()
+        );
+    }
+
+    #[test]
+    fn v2_rebuild_enforces_byte_cap_and_drops_oversize_rows() {
+        // #505: V2 rebuilds `tags` with a byte-accurate value cap. Simulate a v1
+        // store, plant an over-cap multibyte value (legal under V1's char-counting
+        // CHECK: 150_000 chars / 300_000 bytes) plus a normal one, then upgrade.
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(MIGRATIONS[0]).unwrap(); // V1 only
+        conn.pragma_update(None, "user_version", 1i64).unwrap();
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime_ns, backing_ctime_ns, updated_at) \
+             VALUES ('/a.flac','flac',0,0,0,0,0,0)",
+            [],
+        )
+        .unwrap();
+        let big = "é".repeat(150_000);
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'big',?1,0)",
+            rusqlite::params![big],
+        )
+        .expect("V1 char-counting CHECK accepts a 150_000-char value");
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'ok','fine',0)",
+            [],
+        )
+        .unwrap();
+
+        super::migrate(&mut conn).expect("upgrade to v2");
+
+        // The over-cap row is dropped; the valid row survives.
+        let keys: Vec<String> = {
+            let mut stmt = conn.prepare("SELECT key FROM tags ORDER BY key").unwrap();
+            let rows = stmt.query_map([], |r| r.get(0)).unwrap();
+            rows.collect::<rusqlite::Result<_>>().unwrap()
+        };
+        assert_eq!(keys, vec!["ok".to_string()]);
+
+        // The rebuilt CHECK now rejects an over-cap multibyte value at write.
+        assert!(
+            conn.execute(
+                "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'big2',?1,0)",
+                rusqlite::params![big],
+            )
+            .is_err(),
+            "byte-accurate CHECK must reject the write"
+        );
+
+        // The tag triggers were recreated: an insert still bumps content_version.
+        let cv = |c: &Connection| -> i64 {
+            c.query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        let before = cv(&conn);
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'extra','v',0)",
+            [],
+        )
+        .unwrap();
+        assert!(
+            cv(&conn) > before,
+            "tags_ai trigger must survive the rebuild"
         );
     }
 

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -4,8 +4,10 @@ use crate::models::{BinaryTag, BinaryTagRow, Tag};
 use crate::{Db, ReadWrite, Result};
 use rusqlite::params;
 
-/// Reject an over-cap text-tag row from its `length(key)`/`length(value)`
-/// columns *before* the strings are materialized. Routes through the shared
+/// Reject an over-cap text-tag row from its `length(key)` /
+/// `length(CAST(value AS BLOB))` columns *before* the strings are
+/// materialized. `value` is measured in bytes (not characters, #505) so the
+/// materialized-memory bound is exact. Routes through the shared
 /// `check_field_len`, so the allocation-free guarantee is the same one its
 /// unit test pins (spec N13).
 fn check_tag_lengths(key_len: i64, value_len: i64) -> Result<()> {
@@ -17,7 +19,8 @@ fn check_tag_lengths(key_len: i64, value_len: i64) -> Result<()> {
 /// Columns the grouped tag readers project: `track_id` followed by the five
 /// columns `read_tag_row` consumes. Kept in lockstep with `read_tag_row`'s
 /// offset arithmetic.
-const GROUPED_TAG_COLS: &str = "track_id, length(key), length(value), key, value, ordinal";
+const GROUPED_TAG_COLS: &str =
+    "track_id, length(key), length(CAST(value AS BLOB)), key, value, ordinal";
 
 /// Read one text-tag row laid out as `length(key), length(value), key, value,
 /// ordinal` starting at column `base`; length-guards the row before its strings
@@ -49,7 +52,7 @@ fn collect_grouped_tags(
 impl<M> Db<M> {
     pub fn get_tags(&self, track_id: i64) -> Result<Vec<Tag>> {
         let mut stmt = self.conn.prepare_cached(
-            "SELECT length(key), length(value), key, value, ordinal FROM tags \
+            "SELECT length(key), length(CAST(value AS BLOB)), key, value, ordinal FROM tags \
              WHERE track_id = ?1 AND value_blob IS NULL ORDER BY key, ordinal",
         )?;
         let mut rows = stmt.query(params![track_id])?;
@@ -424,6 +427,31 @@ mod tags_for_tracks_tests {
             )
             .unwrap();
         assert_eq!(db.get_tags(a).unwrap()[0].value.len(), 262_144);
+    }
+
+    #[test]
+    fn get_tags_rejects_multibyte_value_over_byte_cap() {
+        // Regression for #505: the read guard counts bytes, not characters. A
+        // value of 150_000 two-byte chars is 150_000 chars (under the schema's
+        // char-counting CHECK, so an honest writer stores it) but 300_000 bytes
+        // (over the 256 KiB materialized-memory bound). The byte-accurate guard
+        // must reject it.
+        let db = open_mem();
+        let a = db.upsert_track(&new_track("/a.flac")).unwrap();
+        let multibyte = "é".repeat(150_000);
+        assert!(multibyte.chars().count() < 262_144, "under the char CHECK");
+        assert!(multibyte.len() > 262_144, "over the byte cap");
+        db.conn
+            .execute(
+                "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, 'k', ?2, 0)",
+                rusqlite::params![a, multibyte],
+            )
+            .unwrap();
+        let err = db.get_tags(a).unwrap_err();
+        assert!(
+            matches!(err, crate::DbError::FieldTooLarge { field: "value", .. }),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -430,17 +430,31 @@ mod tags_for_tracks_tests {
     }
 
     #[test]
-    fn get_tags_rejects_multibyte_value_over_byte_cap() {
-        // Regression for #505: the read guard counts bytes, not characters. A
-        // value of 150_000 two-byte chars is 150_000 chars (under the schema's
-        // char-counting CHECK, so an honest writer stores it) but 300_000 bytes
-        // (over the 256 KiB materialized-memory bound). The byte-accurate guard
-        // must reject it.
+    fn multibyte_value_over_byte_cap_is_rejected_at_write_and_read() {
+        // Regression for #505: the cap counts bytes, not characters. 150_000
+        // two-byte chars is 150_000 chars (under the old char-counting CHECK)
+        // but 300_000 bytes (over the 256 KiB materialized-memory bound).
         let db = open_mem();
         let a = db.upsert_track(&new_track("/a.flac")).unwrap();
         let multibyte = "é".repeat(150_000);
-        assert!(multibyte.chars().count() < 262_144, "under the char CHECK");
+        assert!(multibyte.chars().count() < 262_144, "under the char count");
         assert!(multibyte.len() > 262_144, "over the byte cap");
+
+        // Write path: the byte-accurate schema CHECK rejects the honest insert.
+        let write_err = db.conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, 'k', ?2, 0)",
+            rusqlite::params![a, multibyte],
+        );
+        assert!(
+            write_err.is_err(),
+            "byte-accurate CHECK must reject the write"
+        );
+
+        // Read path (defense-in-depth): a crafted DB that bypasses the CHECK is
+        // still rejected by the byte-counting reader guard.
+        db.conn
+            .execute_batch("PRAGMA ignore_check_constraints=ON")
+            .unwrap();
         db.conn
             .execute(
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, 'k', ?2, 0)",

--- a/musefs-format/src/error.rs
+++ b/musefs-format/src/error.rs
@@ -20,6 +20,8 @@ pub enum FormatError {
     ProducerBug(&'static str),
     #[error("failed to read art {art_id} bytes for synthesis")]
     ArtRead { art_id: i64 },
+    #[error("DB-sourced {field} contains an embedded NUL byte (crafted or corrupt DB)")]
+    EmbeddedNul { field: &'static str },
 }
 
 pub type Result<T> = std::result::Result<T, FormatError>;

--- a/musefs-format/src/layout.rs
+++ b/musefs-format/src/layout.rs
@@ -134,6 +134,21 @@ impl RegionLayout {
             .any(|s| matches!(s, Segment::BinaryTag { .. }))
     }
 
+    /// True if any segment is streamed from the DB by a rowid at read time —
+    /// `BinaryTag` (a `tags` rowid), `ArtImage`, or `OggArtSlice` (both an `art`
+    /// rowid). These are the segments exposed to the rowid-reuse hazard (a
+    /// concurrent delete + reinsert reusing a freed rowid), so the serve path
+    /// must read them under a single WAL snapshot with a `content_version`
+    /// recheck. `BackingAudio`/`OggAudio`/`Inline` carry no DB rowid.
+    pub fn streams_db_rowid(&self) -> bool {
+        self.segments.iter().any(|s| {
+            matches!(
+                s,
+                Segment::BinaryTag { .. } | Segment::ArtImage { .. } | Segment::OggArtSlice { .. }
+            )
+        })
+    }
+
     /// Total size of the synthesized virtual file in bytes (stored at construction).
     pub fn total_len(&self) -> u64 {
         self.total_len
@@ -312,5 +327,40 @@ mod tests {
             !without.has_binary_tag(),
             "layout with no BinaryTag must report false"
         );
+    }
+
+    #[test]
+    fn streams_db_rowid_detects_all_rowid_streamed_segments() {
+        // #502: the snapshot guard must cover every DB-rowid segment, not only
+        // BinaryTag — ArtImage and OggArtSlice are streamed by `art` rowid too.
+        let bin = Segment::BinaryTag {
+            payload_id: 1,
+            len: BlobLen::new(3).unwrap(),
+        };
+        let art = Segment::ArtImage {
+            art_id: 1,
+            len: BlobLen::new(3).unwrap(),
+        };
+        let ogg_art = Segment::OggArtSlice {
+            art_id: 1,
+            offset: 0,
+            len: BlobLen::new(3).unwrap(),
+            base64: true,
+            art_total: 3,
+        };
+        for seg in [bin, art, ogg_art] {
+            let layout = RegionLayout::new(vec![seg.clone(), Segment::Inline(vec![0])]);
+            assert!(
+                layout.streams_db_rowid(),
+                "layout with {seg:?} must report a DB-rowid stream"
+            );
+        }
+
+        // A plain inline + backing-audio layout streams no DB rowid.
+        let plain = RegionLayout::new(vec![
+            Segment::Inline(vec![1, 2, 3]),
+            Segment::BackingAudio { offset: 0, len: 8 },
+        ]);
+        assert!(!plain.streams_db_rowid());
     }
 }

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -217,6 +217,19 @@ fn is_id3_text_frame_id(key: &str) -> bool {
             .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
 }
 
+/// Reject a DB-sourced string with an embedded NUL before it is spliced into an
+/// ID3 frame. ID3 uses NUL as a field terminator/separator — the mime and
+/// description terminators in APIC, the value separator between multi-value text
+/// frames — so a NUL in the payload desyncs a downstream parser (#506).
+/// Length-prefixed formats (FLAC/Vorbis/MP4) are unaffected, so this guard is
+/// ID3-specific.
+fn reject_embedded_nul(field: &'static str, s: &str) -> Result<()> {
+    if s.as_bytes().contains(&0) {
+        return Err(FormatError::EmbeddedNul { field });
+    }
+    Ok(())
+}
+
 /// APIC frame data up to (but excluding) the image bytes:
 /// `[encoding][mime\0][picture type][description\0]`.
 fn apic_framing(art: &ArtInput) -> Vec<u8> {
@@ -274,6 +287,16 @@ pub fn build_id3v2_segments(
     binary_tags: &[BinaryTagInput],
     arts: &[ArtInput],
 ) -> Result<(Vec<Segment>, u64)> {
+    // ID3 splices these DB-sourced strings between NUL terminators/separators,
+    // so a NUL in any of them would corrupt the frame; reject up front (#506).
+    for t in tags {
+        reject_embedded_nul("tag value", &t.value)?;
+    }
+    for art in arts {
+        reject_embedded_nul("art mime", &art.mime)?;
+        reject_embedded_nul("art description", &art.description)?;
+    }
+
     // Pull the promoted scalar values out of `tags`: first `rating` /
     // `musicbrainz_trackid` wins, `playcount` takes the last parseable value. A
     // single POPM/UFID is the norm, so this only diverges from "first wins" for
@@ -1103,6 +1126,47 @@ mod tests {
             build_id3v2_segments(&[], &[], &[mk(boundary_data_len + 1)]).err(),
             Some(FormatError::TooLarge),
             "one byte past boundary must be rejected"
+        );
+    }
+
+    #[test]
+    fn build_id3v2_segments_rejects_embedded_nul() {
+        // Regression for #506: a NUL in any DB-sourced text field would desync an
+        // ID3 frame's terminators/separators, so synthesis must reject it.
+        let nul_value = build_id3v2_segments(&[TagInput::new("TIT2", "a\0b")], &[], &[]);
+        assert_eq!(
+            nul_value.err(),
+            Some(FormatError::EmbeddedNul { field: "tag value" })
+        );
+
+        let art = |mime: &str, desc: &str| ArtInput {
+            art_id: 1,
+            mime: mime.to_string(),
+            description: desc.to_string(),
+            picture_type: PictureType::new(3).unwrap(),
+            width: 0,
+            height: 0,
+            data_len: BlobLen::new(16).unwrap(),
+        };
+        assert_eq!(
+            build_id3v2_segments(&[], &[], &[art("image/png\0junk", "")]).err(),
+            Some(FormatError::EmbeddedNul { field: "art mime" })
+        );
+        assert_eq!(
+            build_id3v2_segments(&[], &[], &[art("image/png", "front\0cover")]).err(),
+            Some(FormatError::EmbeddedNul {
+                field: "art description"
+            })
+        );
+
+        // A clean tag/art with no NUL still synthesizes.
+        assert!(
+            build_id3v2_segments(
+                &[TagInput::new("TIT2", "ok")],
+                &[],
+                &[art("image/png", "front")]
+            )
+            .is_ok()
         );
     }
 

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -289,7 +289,11 @@ pub fn build_id3v2_segments(
 ) -> Result<(Vec<Segment>, u64)> {
     // ID3 splices these DB-sourced strings between NUL terminators/separators,
     // so a NUL in any of them would corrupt the frame; reject up front (#506).
+    // The key is checked too: an unmapped key is serialized as a TXXX
+    // description (`txxx_frame_data(key, value)`), and the `tags.key` CHECK
+    // rejects control chars 1..=31 but not NUL.
     for t in tags {
+        reject_embedded_nul("tag key", &t.key)?;
         reject_embedded_nul("tag value", &t.value)?;
     }
     for art in arts {
@@ -1133,6 +1137,12 @@ mod tests {
     fn build_id3v2_segments_rejects_embedded_nul() {
         // Regression for #506: a NUL in any DB-sourced text field would desync an
         // ID3 frame's terminators/separators, so synthesis must reject it.
+        let nul_key = build_id3v2_segments(&[TagInput::new("bad\0key", "ok")], &[], &[]);
+        assert_eq!(
+            nul_key.err(),
+            Some(FormatError::EmbeddedNul { field: "tag key" })
+        );
+
         let nul_value = build_id3v2_segments(&[TagInput::new("TIT2", "a\0b")], &[], &[]);
         assert_eq!(
             nul_value.err(),


### PR DESCRIPTION
Works through the eight open issues from the 2026-06-16 audit (#502–#509) in a single PR.

## Serve-path consistency (#502, #503)
- The read fast path wrapped DB-rowid reads in a WAL snapshot + `content_version` recheck only when the layout had a `BinaryTag`. Art (`ArtImage`/`OggArtSlice`) is also streamed by `art` rowid and was unguarded, so a concurrent external retag + `gc_orphan_art` + reinsert (reusing a freed rowid) could splice a wrong image mid-read. Generalized the gate to `RegionLayout::streams_db_rowid` (binary tags **and** art); renamed `ResolvedFile.has_binary_tag` → `streams_db_rowid`.
- The stateless no-fh read fallback (`read_at_into`) had **no** snapshot/recheck and skipped the #186 backing-fd re-validation entirely. It now takes the same snapshot + recheck and re-validates the freshly opened backing fd against the resolved stamp. Added `track_id` to `ResolvedFile` so the fallback can recheck the live `content_version`.
- The audio-bytes invariant was never affected (audio always comes from the untouched backing file); these are metadata/art consistency fixes.

## CLI (#504, #508, #509)
- Per-field `--fallback` keys are ASCII-lowercased, so `--fallback AlbumArtist=…` (any uppercase) is honored instead of silently never matching the lowercased template field.
- `mount` warns when the mountpoint is non-empty (its contents are shadowed for the mount's lifetime), matching the "Empty directory" help.
- A permission-denied mount (e.g. an AppArmor-restricted prefix on Ubuntu 24.04+ / libfuse ≥ 3.17) prints actionable guidance instead of a bare "Permission denied", mirroring the existing `user_allow_other` preflight.

## DB / format (#505, #506, #507)
- Both the schema `CHECK` (rebuilt in the unreleased `MIGRATION_V2`) and the read-time `tags.value` guard now count bytes (`length(CAST(value AS BLOB))`), not UTF-8 characters, so the 256 KiB materialized-memory bound is exact. The V2 upgrade drops pre-existing over-cap rows (already unreadable under the byte-counting reader guard) and recreates the `tags` triggers; `user_version` stays 2.
- Synthesized ID3 frames reject a DB-sourced tag key, tag value, art mime, or art description containing an embedded NUL (NUL is an ID3 terminator/separator; length-prefixed formats are unaffected, so the guard is ID3-specific).
- `gc_orphan_art` uses `NOT EXISTS` instead of `NOT IN (subquery)` so a NULL `art_id` cannot silently turn the GC into a no-op.

## Testing
Regression tests added for each issue (including a v1→v2 migration upgrade test). Full workspace suite green (`cargo test --workspace`: 1161 passed); `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, the mutant-anchor drift guard, and ruff all pass via the pre-commit hook. Also ran `cargo test -p musefs-core --features metrics` and regenerated + re-vendored the Picard `schema.py` mirror.

Fixes #502
Fixes #503
Fixes #504
Fixes #505
Fixes #506
Fixes #507
Fixes #508
Fixes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mount now warns when mounting to a non-empty directory (unless `--dry-run`).

* **Bug Fixes**
  * Improved permission-denied mount error messages with added guidance.
  * Fixed `--fallback` field handling to be case-insensitive.
  * Corrected tag `value` size enforcement to use byte length (not character count).
  * Reject embedded NUL characters in synthesized ID3 metadata.
  * Improved NULL-safety for art garbage collection and strengthened art snapshot consistency during concurrent operations (including safer fallback reads).

* **Documentation**
  * Updated serving (“cardinal invariant”) documentation and the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
