### PR TITLE
fix: preserve M4A/MP3 tag fields lost on round-trip (#511–#515)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -629,6 +629,12 @@ exclude_re = [
     'musefs-format/src/mp4\.rs:\d+:\d+: replace \+= with \*= in read_structure_from',
     'musefs-format/src/mp4\.rs:\d+:\d+: replace \+ with \* in BoxRef::end',
     'musefs-format/src/mp4\.rs:\d+:\d+: replace BoxRef::end -> usize with [01]',
+    # read_tags' integer-atom decode assembles a big-endian value byte by byte:
+    # `n = (n << 8) | u64::from(b)`. After each `<< 8` the low byte of `n` is
+    # zero where `b` lands, so `|` and `^` are bit-for-bit identical for every
+    # input (same equivalence class as classify_binary_frame / synchsafe_decode).
+    # The `<<`->`>>` sibling IS caught (bpm 300 = [1,44] decodes to 44, not 300).
+    'musefs-format/src/mp4\.rs:\d+:\d+: replace \| with \^ in read_tags',
 
     # Ogg page lacer/reader advance freezes — hang-class plus the #266 OOM bomb.
     # total_len() -> 0, the `lace_pos < laces.len()` loop bounds, and the

--- a/docs/src/formats/m4a.md
+++ b/docs/src/formats/m4a.md
@@ -15,8 +15,16 @@ layouts plug into, see [the segment model](../architecture/serving.md#the-segmen
   the `com.apple.iTunes` mean, matched case-insensitively.
 - **Other text freeform atoms** round-trip keyed by their verbatim `name`,
   original casing preserved.
-- **Track and disc numbers**: the binary `trkn`/`disk` atoms are decoded
-  positionally to `tracknumber`/`discnumber` and rebuilt as binary atoms.
+- **Track and disc numbers, with totals**: the binary `trkn`/`disk` atoms are
+  decoded to `tracknumber`/`discnumber` as `"N"` or `"N/M"` (the "N of M" total,
+  matching ID3 `TRCK`/`TPOS`) and rebuilt as binary atoms with the total filled
+  in.
+- **Integer atoms**: `tmpo`/`cpil`/`pgap` map to the canonical `bpm`/
+  `compilation`/`gapless` keys (shared with ID3 `TBPM`/`TCMP` and Vorbis) and
+  are rebuilt as type-21 integer atoms.
+- **Multi-value atoms**: every `data` sub-box of an atom is read (the iTunes
+  multiple-`data` convention), so a multi-valued atom round-trips all its
+  values, not just the first.
 - **Opaque binary freeform atoms, byte-exact**: a `----` atom whose payload
   is binary-typed is captured verbatim under the key `----:<mean>:<name>`
   (so the mean survives) and re-emitted streamed from the DB (`BinaryTag`
@@ -27,18 +35,13 @@ layouts plug into, see [the segment model](../architecture/serving.md#the-segmen
 
 ## Lossy edges
 
-- **Track/disc totals are dropped.** Only the number itself is read from
-  `trkn`/`disk` (the "x of N" total is not), and synthesis writes the total
-  as zero.
 - A *text* freeform atom under a mean other than `com.apple.iTunes` is
   re-emitted with the `com.apple.iTunes` mean (the scan keys text freeform
   by name only). Binary freeform atoms keep their mean via the
   `----:<mean>:<name>` key.
-- **Multi-value atoms round-trip only their first value**: synthesis writes
-  one `data` sub-box per value, but the scan reads only the first `data`
-  sub-box of each atom.
-- Binary `ilst` atoms other than `trkn`/`disk` and `----` (e.g. `tmpo`,
-  `cpil`, `pgap`) are dropped at scan time.
+- Binary `ilst` atoms outside the handled set (`trkn`/`disk`, the
+  `tmpo`/`cpil`/`pgap` integer atoms, and `----` freeform) are dropped at scan
+  time, since they are not re-emitted on synthesis.
 - `covr` ingestion accepts only JPEG (type 13) and PNG (type 14) artwork;
   other type codes are skipped. MP4 has no picture-type or description
   fields: scanned art becomes "front cover" with an empty description, and

--- a/docs/src/formats/mp3.md
+++ b/docs/src/formats/mp3.md
@@ -21,8 +21,12 @@ described here is shared with WAV's embedded `id3 ` chunk — see
   synthesized tag.
 - **Other user-defined keys** round-trip as `TXXX` frames keyed by their own
   description, original casing preserved.
-- **Comments and lyrics** (`COMM`/`USLT`): the text content, one tag row per
-  frame.
+- **Comments and lyrics** (`COMM`/`USLT`): one tag row per frame. A frame with a
+  placeholder language (`XXX`/`und`/empty) and no descriptor folds to the shared
+  `comment`/`lyrics` key; one carrying a real language or descriptor is keyed
+  `id3:COMM:<lang>:<desc>` / `id3:USLT:<lang>:<desc>` so per-language or
+  description-keyed frames stay distinct, and both fields are restored on
+  synthesis.
 - **Ratings and play counts**: a `POPM` frame is promoted at scan time to
   `rating` (the raw 0–255 byte) and `playcount` (omitted when 0) text tags,
   and rebuilt as a `POPM` frame on synthesis.
@@ -39,10 +43,10 @@ described here is shared with WAV's embedded `id3 ` chunk — see
 
 - The synthesized tag is always **ID3v2.4**, regardless of the source tag's
   version (v2.2/v2.3 tags are parsed but never re-emitted as such).
-- `COMM`/`USLT` language codes and descriptions are not preserved: every
-  comment/lyric is written back with language `XXX` and an empty description.
-  The *text* of multiple comment frames survives (one `COMM` per value), but
-  frames distinguished only by language/description become indistinguishable.
+- A `COMM`/`USLT` frame folded to the shared `comment`/`lyrics` key (placeholder
+  language, no descriptor) is re-emitted with language `XXX` and an empty
+  descriptor, so a source `und` placeholder comes back as `XXX`. Frames carrying
+  a real language or descriptor are preserved (see above).
 - `POPM`: the owner ("email to user") field is dropped by design. Multiple
   `POPM` frames collapse to one (first rating wins, last parseable play
   count wins); counters above `u32::MAX` clamp to 4 bytes.

--- a/docs/src/formats/ogg.md
+++ b/docs/src/formats/ogg.md
@@ -48,8 +48,9 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
 - Ogg carries no binary-tag slot: only text comments and pictures exist, so
   there is nothing else to preserve.
 - **Embedded picture descriptions are right-padded with up to two trailing
-  spaces.** The FLAC PICTURE block body is built with its description padded so
-  the body length is a multiple of 3 (`picture_prefix`,
+  spaces.** The FLAC PICTURE block is built with its description padded so the
+  *prefix* length — `32 + mime.len() + description.len()`, i.e. everything
+  before the image bytes — is a multiple of 3 (`picture_prefix`,
   `musefs-format/src/ogg/mod.rs`), which is what makes
   `base64(prefix ++ image) == base64(prefix) ++ base64(image)` and lets the
   image's base64 be served as an independent, incrementally-streamable

--- a/docs/src/formats/wav.md
+++ b/docs/src/formats/wav.md
@@ -38,8 +38,8 @@ precedence** and INFO filling gaps; only chunk headers are walked — the
   understand *only* INFO see just those fields. Everything still rides in
   the `id3 ` chunk.
 - All of MP3's ID3 lossy edges apply to the `id3 ` chunk: ID3v2.4-only
-  output, `COMM`/`USLT` language/description reset, `POPM` owner dropped,
-  ID3v1 ignored, the OOM-guard skips (the authoritative list lives in
+  output, placeholder-language `COMM`/`USLT` reset to `XXX`, `POPM` owner
+  dropped, ID3v1 ignored, the OOM-guard skips (the authoritative list lives in
   [MP3's lossy edges](mp3.md#lossy-edges)).
 - **Tags trailing a very large `data` payload are not seen.** When the `data`
   payload pushes any `LIST`/`INFO` or `id3 ` chunk beyond the scan probe

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -195,15 +195,57 @@ fn txxx_frame_data(desc: &str, value: &str) -> Vec<u8> {
     d
 }
 
-/// COMM/USLT share a body layout: `[enc][lang(3)][descriptor NUL][text]`. We
-/// write UTF-8 with an unknown language (`XXX`) and empty descriptor; the
-/// original language code and descriptor are not preserved on round-trip.
-fn comm_like_frame_data(value: &str) -> Vec<u8> {
+/// COMM/USLT share a body layout: `[enc][lang(3)][descriptor NUL][text]`. The
+/// language is written as exactly three bytes (padded with `X` when the supplied
+/// value is shorter); `lang`/`description` come from the tag key (see
+/// [`comm_like_key`]), defaulting to `XXX` / empty for the shared `comment` /
+/// `lyrics` key.
+fn comm_like_frame_data(lang: &str, description: &str, value: &str) -> Vec<u8> {
+    let l = lang.as_bytes();
     let mut d = vec![ENC_UTF8];
-    d.extend_from_slice(b"XXX"); // language: unknown
-    d.push(0x00); // empty content descriptor, NUL-terminated
+    d.extend_from_slice(&[
+        *l.first().unwrap_or(&b'X'),
+        *l.get(1).unwrap_or(&b'X'),
+        *l.get(2).unwrap_or(&b'X'),
+    ]);
+    d.extend_from_slice(description.as_bytes());
+    d.push(0x00); // content descriptor terminator
     d.extend_from_slice(value.as_bytes());
     d
+}
+
+/// ID3 languages treated as "no specific language": a COMM/USLT frame with one
+/// of these and an empty descriptor folds to the shared `comment`/`lyrics` key.
+fn is_placeholder_lang(lang: &str) -> bool {
+    matches!(lang.to_ascii_lowercase().as_str(), "" | "xxx" | "und")
+}
+
+/// Canonical key for a COMM/USLT frame. The common case (placeholder language,
+/// empty descriptor) folds to `default_key` (`comment`/`lyrics`), shared with
+/// MP4/Vorbis. A frame carrying a real language or descriptor keeps both under
+/// `id3:<FRAME>:<lang>:<descriptor>` so per-language / description-keyed frames
+/// stay distinct across a round-trip; only MP3/WAV re-emit that key.
+fn comm_like_key(frame: &str, lang: &str, description: &str, default_key: &str) -> String {
+    if description.is_empty() && is_placeholder_lang(lang) {
+        default_key.to_string()
+    } else {
+        format!("id3:{frame}:{lang}:{description}")
+    }
+}
+
+/// Inverse of [`comm_like_key`]: parse `id3:COMM:<lang>:<desc>` /
+/// `id3:USLT:<lang>:<desc>` into `(frame_id, lang, descriptor)`; the descriptor
+/// may itself contain `:`. None for any other key.
+fn parse_comm_like_key(key: &str) -> Option<(&'static [u8; 4], &str, &str)> {
+    let rest = key.strip_prefix("id3:")?;
+    let (frame, langdesc) = rest.split_once(':')?;
+    let frame_id: &'static [u8; 4] = match frame {
+        "COMM" => b"COMM",
+        "USLT" => b"USLT",
+        _ => return None,
+    };
+    let (lang, desc) = langdesc.split_once(':')?;
+    Some((frame_id, lang, desc))
 }
 
 /// True if `key` is shaped like an ID3v2 text frame id (`T` + 3 upper/digit),
@@ -353,7 +395,7 @@ pub fn build_id3v2_segments(
             }
             Some(crate::tagmap::Id3Slot::Comment) => {
                 for value in values {
-                    let data = comm_like_frame_data(value);
+                    let data = comm_like_frame_data("XXX", "", value);
                     push_frame_header(&mut buf, b"COMM", data.len())?;
                     buf.extend_from_slice(&data);
                     frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
@@ -361,7 +403,7 @@ pub fn build_id3v2_segments(
             }
             Some(crate::tagmap::Id3Slot::Lyrics) => {
                 for value in values {
-                    let data = comm_like_frame_data(value);
+                    let data = comm_like_frame_data("XXX", "", value);
                     push_frame_header(&mut buf, b"USLT", data.len())?;
                     buf.extend_from_slice(&data);
                     frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
@@ -376,11 +418,20 @@ pub fn build_id3v2_segments(
                 frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
             }
             None => {
-                for value in values {
-                    let data = txxx_frame_data(key, value);
-                    push_frame_header(&mut buf, b"TXXX", data.len())?;
-                    buf.extend_from_slice(&data);
-                    frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
+                if let Some((frame_id, lang, desc)) = parse_comm_like_key(key) {
+                    for value in values {
+                        let data = comm_like_frame_data(lang, desc, value);
+                        push_frame_header(&mut buf, frame_id, data.len())?;
+                        buf.extend_from_slice(&data);
+                        frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
+                    }
+                } else {
+                    for value in values {
+                        let data = txxx_frame_data(key, value);
+                        push_frame_header(&mut buf, b"TXXX", data.len())?;
+                        buf.extend_from_slice(&data);
+                        frames_len = size::checked_add(frames_len, 10 + data.len() as u64)?;
+                    }
                 }
             }
         }
@@ -611,9 +662,15 @@ pub fn read_tags(data: &[u8]) -> Vec<(String, String)> {
                 .map_or_else(|| et.description.clone(), str::to_string);
             out.push((key, et.value.clone()));
         } else if let Some(c) = content.comment() {
-            out.push(("comment".to_string(), c.text.clone()));
+            out.push((
+                comm_like_key("COMM", &c.lang, &c.description, "comment"),
+                c.text.clone(),
+            ));
         } else if let Some(l) = content.lyrics() {
-            out.push(("lyrics".to_string(), l.text.clone()));
+            out.push((
+                comm_like_key("USLT", &l.lang, &l.description, "lyrics"),
+                l.text.clone(),
+            ));
         } else if let Some(text) = content.text() {
             let id = frame.id();
             let key =
@@ -906,7 +963,7 @@ mod tests {
 
         let mut tag = Tag::new();
         tag.set_text("TIT2", "Song");
-        tag.set_text("TBPM", "120"); // standard frame, not in vocabulary
+        tag.set_text("TKEY", "120"); // standard frame, not in vocabulary
         tag.add_frame(ExtendedText {
             description: "MOOD".into(),
             value: "happy".into(),
@@ -916,12 +973,12 @@ mod tests {
             value: "-6.5 dB".into(),
         });
         tag.add_frame(Comment {
-            lang: "eng".into(),
+            lang: "XXX".into(),
             description: String::new(),
             text: "nice".into(),
         });
         tag.add_frame(Lyrics {
-            lang: "eng".into(),
+            lang: "XXX".into(),
             description: String::new(),
             text: "la la".into(),
         });
@@ -931,7 +988,7 @@ mod tests {
 
         let tags = read_tags(&buf);
         assert!(tags.contains(&("title".to_string(), "Song".to_string())));
-        assert!(tags.contains(&("TBPM".to_string(), "120".to_string())));
+        assert!(tags.contains(&("TKEY".to_string(), "120".to_string())));
         assert!(tags.contains(&("MOOD".to_string(), "happy".to_string())));
         assert!(tags.contains(&("replaygain_track_gain".to_string(), "-6.5 dB".to_string())));
         assert!(tags.contains(&("comment".to_string(), "nice".to_string())));
@@ -942,7 +999,7 @@ mod tests {
     fn synthesize_round_trips_arbitrary_id3_tags() {
         let tags = vec![
             TagInput::new("title", "Song"),
-            TagInput::new("TBPM", "120"),     // unmapped standard frame
+            TagInput::new("TKEY", "120"),     // unmapped standard frame
             TagInput::new("MyRating", "5"),   // user-defined -> TXXX
             TagInput::new("comment", "nice"), // -> COMM
             TagInput::new("lyrics", "la la"), // -> USLT
@@ -958,7 +1015,7 @@ mod tests {
         let read = read_tags(&buf);
         for expected in [
             ("title", "Song"),
-            ("TBPM", "120"),
+            ("TKEY", "120"),
             ("MyRating", "5"),
             ("comment", "nice"),
             ("lyrics", "la la"),
@@ -969,6 +1026,108 @@ mod tests {
                 "missing {expected:?} in {read:?}"
             );
         }
+    }
+
+    #[test]
+    fn read_tags_preserves_comm_uslt_language_and_descriptor() {
+        use id3::frame::{Comment, Lyrics};
+        use id3::{Tag, TagLike, Version};
+
+        let mut tag = Tag::new();
+        // Placeholder language + empty descriptor folds to the shared key.
+        tag.add_frame(Comment {
+            lang: "XXX".into(),
+            description: String::new(),
+            text: "plain".into(),
+        });
+        // A real language is preserved under a format-specific key.
+        tag.add_frame(Comment {
+            lang: "deu".into(),
+            description: String::new(),
+            text: "hallo".into(),
+        });
+        // A descriptor is preserved too (e.g. an iTunes-keyed comment).
+        tag.add_frame(Comment {
+            lang: "eng".into(),
+            description: "note".into(),
+            text: "see liner".into(),
+        });
+        // Per-language lyrics stay distinct rather than colliding under `lyrics`.
+        tag.add_frame(Lyrics {
+            lang: "eng".into(),
+            description: String::new(),
+            text: "verse".into(),
+        });
+        tag.add_frame(Lyrics {
+            lang: "deu".into(),
+            description: String::new(),
+            text: "strophe".into(),
+        });
+
+        let mut buf = Vec::new();
+        tag.write_to(&mut buf, Version::Id3v24).unwrap();
+        let tags = read_tags(&buf);
+
+        assert!(
+            tags.contains(&("comment".into(), "plain".into())),
+            "got {tags:?}"
+        );
+        assert!(
+            tags.contains(&("id3:COMM:deu:".into(), "hallo".into())),
+            "got {tags:?}"
+        );
+        assert!(
+            tags.contains(&("id3:COMM:eng:note".into(), "see liner".into())),
+            "got {tags:?}"
+        );
+        assert!(
+            tags.contains(&("id3:USLT:eng:".into(), "verse".into())),
+            "got {tags:?}"
+        );
+        assert!(
+            tags.contains(&("id3:USLT:deu:".into(), "strophe".into())),
+            "got {tags:?}"
+        );
+    }
+
+    #[test]
+    fn synthesize_round_trips_comm_uslt_language_and_descriptor() {
+        let tags = vec![
+            TagInput::new("comment", "plain"),
+            TagInput::new("id3:COMM:deu:", "hallo"),
+            TagInput::new("id3:COMM:eng:note", "see liner"),
+            TagInput::new("id3:USLT:eng:Chorus", "la la"),
+        ];
+        let (segments, _len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
+        let mut buf = Vec::new();
+        for seg in &segments {
+            if let Segment::Inline(bytes) = seg {
+                buf.extend_from_slice(bytes);
+            }
+        }
+        // Assert real COMM/USLT frames (with the right lang/descriptor) are emitted,
+        // not generic TXXX frames that would happen to round-trip the key/value.
+        let tag = id3::Tag::read_from2(std::io::Cursor::new(&buf)).unwrap();
+        assert!(
+            tag.comments()
+                .any(|c| c.text == "plain" && c.description.is_empty()),
+            "plain COMM missing"
+        );
+        assert!(
+            tag.comments()
+                .any(|c| c.lang == "deu" && c.description.is_empty() && c.text == "hallo"),
+            "deu COMM missing"
+        );
+        assert!(
+            tag.comments()
+                .any(|c| c.lang == "eng" && c.description == "note" && c.text == "see liner"),
+            "descriptor-keyed COMM missing"
+        );
+        assert!(
+            tag.lyrics()
+                .any(|l| l.lang == "eng" && l.description == "Chorus" && l.text == "la la"),
+            "USLT missing"
+        );
     }
 
     #[test]

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -1098,13 +1098,16 @@ mod tests {
             TagInput::new("id3:COMM:eng:note", "see liner"),
             TagInput::new("id3:USLT:eng:Chorus", "la la"),
         ];
-        let (segments, _len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
+        let (segments, len) = build_id3v2_segments(&tags, &[], &[]).unwrap();
         let mut buf = Vec::new();
         for seg in &segments {
             if let Segment::Inline(bytes) = seg {
                 buf.extend_from_slice(bytes);
             }
         }
+        // No streamed segments here, so the reported length is the whole tag:
+        // pins each frame's `10 + data.len()` accounting (kills `+` -> `*`).
+        assert_eq!(len, buf.len() as u64);
         // Assert real COMM/USLT frames (with the right lang/descriptor) are emitted,
         // not generic TXXX frames that would happen to round-trip the key/value.
         let tag = id3::Tag::read_from2(std::io::Cursor::new(&buf)).unwrap();

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -339,26 +339,23 @@ fn ilst_region(buf: &[u8]) -> Option<(usize, usize)> {
     Some((start, il.total_len - il.header_len))
 }
 
-/// Parse a `----` freeform atom payload into `(key, value)`. Folds (mean, name)
-/// to a canonical key via the vocabulary, else keys on the verbatim `name`. Only
-/// the first `data` atom is read (multi-value freeform is rare). None if malformed.
-fn read_freeform(inner: &[u8]) -> Option<(String, String)> {
-    let name_box = find_box(inner, b"name").ok()??;
-    let data_box = find_box(inner, b"data").ok()??;
+/// Parse a `----` freeform atom payload into `(key, value)` pairs. Folds
+/// (mean, name) to a canonical key via the vocabulary, else keys on the verbatim
+/// `name`. One pair per UTF-8 (`type 1`) `data` sub-box — the iTunes multi-value
+/// convention; binary-typed `data` boxes are left to [`read_binary_tags`]. Empty
+/// if malformed.
+fn read_freeform(inner: &[u8]) -> Vec<(String, String)> {
+    let Some(name_box) = find_box(inner, b"name").ok().flatten() else {
+        return Vec::new();
+    };
     let np = name_box.payload(inner);
-    let dp = data_box.payload(inner);
-    if np.len() < 4 || dp.len() < 8 {
-        return None;
-    }
-    // The `data` box is `[type: u32][locale: u32][value]`; type 1 == UTF-8 text.
-    // Binary-typed freeform values are not text tags, so skip them.
-    let type_code = u32::from_be_bytes([dp[0], dp[1], dp[2], dp[3]]);
-    if type_code != 1 {
-        return None;
+    if np.len() < 4 {
+        return Vec::new();
     }
     // name/mean payloads start with a 4-byte FullBox [version 1][flags 3] prefix.
-    let name = std::str::from_utf8(&np[4..]).ok()?;
-    let value = std::str::from_utf8(&dp[8..]).ok()?;
+    let Ok(name) = std::str::from_utf8(&np[4..]) else {
+        return Vec::new();
+    };
     let mean = find_box(inner, b"mean")
         .ok()
         .flatten()
@@ -372,14 +369,52 @@ fn read_freeform(inner: &[u8]) -> Option<(String, String)> {
         });
     let key = crate::tagmap::mp4_freeform_to_key(mean, name)
         .map_or_else(|| name.to_string(), str::to_string);
-    Some((key, value.to_string()))
+    let mut out = Vec::new();
+    for data in child_boxes(inner).unwrap_or_default() {
+        if &data.kind != b"data" {
+            continue;
+        }
+        let dp = data.payload(inner);
+        if dp.len() < 8 {
+            continue;
+        }
+        // The `data` box is `[type: u32][locale: u32][value]`; type 1 == UTF-8 text.
+        // Binary-typed freeform values are not text tags, so skip them.
+        let type_code = u32::from_be_bytes([dp[0], dp[1], dp[2], dp[3]]);
+        if type_code != 1 {
+            continue;
+        }
+        if let Ok(value) = std::str::from_utf8(&dp[8..]) {
+            out.push((key.clone(), value.to_string()));
+        }
+    }
+    out
+}
+
+/// Format a `trkn`/`disk` value body `[reserved 2][number 2][total 2]…` as the
+/// canonical `"N"` or `"N/M"` string. The `"N/M"` form matches how ID3
+/// `TRCK`/`TPOS` carry the total in the shared `tracknumber`/`discnumber` value;
+/// a zero or absent total drops the `/M`. Caller guarantees `value.len() >= 4`.
+fn number_total(value: &[u8]) -> String {
+    let number = u16::from_be_bytes([value[2], value[3]]);
+    let total = if value.len() >= 6 {
+        u16::from_be_bytes([value[4], value[5]])
+    } else {
+        0
+    };
+    if total != 0 {
+        format!("{number}/{total}")
+    } else {
+        number.to_string()
+    }
 }
 
 /// Lenient: returns empty / skips any malformed atom and never errors — this only
 /// seeds metadata from existing files, so a missing or garbled tag must simply be
 /// absent. Text atoms map via the vocabulary; `trkn`/`disk` yield track/disc
-/// numbers; `----` freeform atoms key on their name (folded when known). Other
-/// atoms are skipped.
+/// numbers as `"N"`/`"N/M"`; `----` freeform atoms key on their name (folded when
+/// known). Every `data` sub-box of an atom is read, so multi-value atoms recover
+/// all their values. Other atoms are skipped.
 pub fn read_tags(buf: &[u8]) -> Vec<(String, String)> {
     let Some((start, len)) = ilst_region(buf) else {
         return Vec::new();
@@ -389,33 +424,35 @@ pub fn read_tags(buf: &[u8]) -> Vec<(String, String)> {
     for atom in child_boxes(ilst).unwrap_or_default() {
         let inner = atom.payload(ilst);
         if &atom.kind == b"----" {
-            if let Some(pair) = read_freeform(inner) {
-                out.push(pair);
-            }
+            out.extend(read_freeform(inner));
             continue;
         }
-        let Ok(Some(data)) = find_box(inner, b"data") else {
-            continue;
-        };
-        let dp = data.payload(inner);
-        if dp.len() < 8 {
-            continue;
-        }
-        let value = &dp[8..]; // skip [type 4][locale 4]
-        if let Some(key) = crate::tagmap::mp4_atom_to_key(&atom.kind) {
-            if let Ok(s) = std::str::from_utf8(value) {
-                out.push((key.to_string(), s.to_string()));
+        let text_key = crate::tagmap::mp4_atom_to_key(&atom.kind);
+        for data in child_boxes(inner).unwrap_or_default() {
+            if &data.kind != b"data" {
+                continue;
             }
-        } else if &atom.kind == b"trkn" && value.len() >= 4 {
-            out.push((
-                "tracknumber".into(),
-                u16::from_be_bytes([value[2], value[3]]).to_string(),
-            ));
-        } else if &atom.kind == b"disk" && value.len() >= 4 {
-            out.push((
-                "discnumber".into(),
-                u16::from_be_bytes([value[2], value[3]]).to_string(),
-            ));
+            let dp = data.payload(inner);
+            if dp.len() < 8 {
+                continue;
+            }
+            let value = &dp[8..]; // skip [type 4][locale 4]
+            if let Some(key) = text_key {
+                if let Ok(s) = std::str::from_utf8(value) {
+                    out.push((key.to_string(), s.to_string()));
+                }
+            } else if &atom.kind == b"trkn" && value.len() >= 4 {
+                out.push(("tracknumber".into(), number_total(value)));
+            } else if &atom.kind == b"disk" && value.len() >= 4 {
+                out.push(("discnumber".into(), number_total(value)));
+            } else if let Some(key) = crate::tagmap::mp4_integer_atom_to_key(&atom.kind) {
+                // tmpo/cpil/pgap: a big-endian unsigned integer in the value bytes.
+                let mut n: u64 = 0;
+                for &b in value.iter().take(8) {
+                    n = (n << 8) | u64::from(b);
+                }
+                out.push((key.to_string(), n.to_string()));
+            }
         }
     }
     out

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -396,6 +396,10 @@ fn read_freeform(inner: &[u8]) -> Vec<(String, String)> {
 /// `TRCK`/`TPOS` carry the total in the shared `tracknumber`/`discnumber` value;
 /// a zero or absent total drops the `/M`. Caller guarantees `value.len() >= 4`.
 fn number_total(value: &[u8]) -> String {
+    debug_assert!(
+        value.len() >= 4,
+        "number_total requires the 4-byte number prefix"
+    );
     let number = u16::from_be_bytes([value[2], value[3]]);
     let total = if value.len() >= 6 {
         u16::from_be_bytes([value[4], value[5]])

--- a/musefs-format/src/mp4/synth.rs
+++ b/musefs-format/src/mp4/synth.rs
@@ -66,9 +66,9 @@ fn parse_number_total(raw: &str) -> (Option<u16>, u16) {
 }
 
 /// Emit a `----` freeform atom: a `mean` and `name` sub-box (each with a 4-byte
-/// FullBox prefix) followed by one UTF-8 `data` sub-box per value. Note that the
-/// scan path (`read_freeform`) only recovers the first value on read-back, so
-/// multi-value freeform tags round-trip only their first value.
+/// FullBox prefix) followed by one UTF-8 `data` sub-box per value (the iTunes
+/// multi-value convention). The scan path (`read_freeform`) reads every `data`
+/// sub-box, so multi-value freeform tags round-trip completely.
 fn freeform_atom(mean: &str, name: &str, values: &[&str]) -> Result<Vec<u8>> {
     let mut inner = Vec::new();
     let mut mean_body = 0u32.to_be_bytes().to_vec(); // version/flags

--- a/musefs-format/src/mp4/synth.rs
+++ b/musefs-format/src/mp4/synth.rs
@@ -29,18 +29,40 @@ fn text_atom(kind: &[u8; 4], values: &[&str]) -> Result<Vec<u8>> {
     boxed(kind, &inner)
 }
 
-fn number_atom(kind: &[u8; 4], n: u16, width: usize) -> Result<Vec<u8>> {
+fn number_atom(kind: &[u8; 4], number: u16, total: u16, width: usize) -> Result<Vec<u8>> {
     debug_assert!(
-        width >= 4,
-        "number_atom width must hold the 4-byte reserved+value prefix"
+        width >= 6,
+        "number_atom width must hold the 2-byte reserved prefix + number + total"
     );
     let mut data = 0u32.to_be_bytes().to_vec(); // type 0 = binary
     data.extend_from_slice(&0u32.to_be_bytes()); // locale
     let mut body = vec![0u8, 0];
-    body.extend_from_slice(&n.to_be_bytes());
+    body.extend_from_slice(&number.to_be_bytes());
+    body.extend_from_slice(&total.to_be_bytes());
     body.resize(width, 0);
     data.extend_from_slice(&body);
     boxed(kind, &boxed(b"data", &data)?)
+}
+
+/// Emit an iTunes integer atom (`tmpo`/`cpil`/`pgap`): a `data` sub-box of type
+/// code 21 (signed big-endian integer) carrying the low `width` bytes of `n`.
+fn integer_atom(kind: &[u8; 4], n: u64, width: usize) -> Result<Vec<u8>> {
+    debug_assert!(
+        (1..=8).contains(&width),
+        "integer_atom width must be 1..=8 bytes"
+    );
+    let mut data = 21u32.to_be_bytes().to_vec(); // type 21 = signed BE integer
+    data.extend_from_slice(&0u32.to_be_bytes()); // locale
+    data.extend_from_slice(&n.to_be_bytes()[8 - width..]);
+    boxed(kind, &boxed(b"data", &data)?)
+}
+
+/// Parse a canonical `tracknumber`/`discnumber` value into `(number, total)`.
+/// Accepts `"N"` or `"N/M"` (the ID3 `TRCK`/`TPOS` shape). A missing/unparseable
+/// number yields `None` (caller drops the atom); a missing/unparseable total is 0.
+fn parse_number_total(raw: &str) -> (Option<u16>, u16) {
+    let (num_str, total_str) = raw.split_once('/').unwrap_or((raw, ""));
+    (num_str.parse().ok(), total_str.parse().unwrap_or(0))
 }
 
 /// Emit a `----` freeform atom: a `mean` and `name` sub-box (each with a 4-byte
@@ -133,8 +155,14 @@ pub(super) fn build_udta(
                 ilst_inline.extend(text_atom(atom, values)?);
             }
             Some(crate::tagmap::Mp4Slot::Number(atom, width)) => {
-                if let Ok(n) = values.first().copied().unwrap_or("").parse::<u16>() {
-                    ilst_inline.extend(number_atom(atom, n, width)?);
+                let (number, total) = parse_number_total(values.first().copied().unwrap_or(""));
+                if let Some(n) = number {
+                    ilst_inline.extend(number_atom(atom, n, total, width)?);
+                }
+            }
+            Some(crate::tagmap::Mp4Slot::Integer(atom, width)) => {
+                if let Ok(n) = values.first().copied().unwrap_or("").parse::<u64>() {
+                    ilst_inline.extend(integer_atom(atom, n, width)?);
                 }
             }
             Some(crate::tagmap::Mp4Slot::Freeform(mean, name)) => {

--- a/musefs-format/src/mp4/tests.rs
+++ b/musefs-format/src/mp4/tests.rs
@@ -204,6 +204,68 @@ fn reads_text_and_track_tags() {
 }
 
 #[test]
+fn read_tags_reads_all_values_of_multi_value_text_atom() {
+    // A single text atom may carry several `data` sub-boxes (the iTunes
+    // multiple-value convention); every value must round-trip, not just the first.
+    let atoms = bx(
+        b"\xa9gen",
+        &[data_atom(1, b"Rock"), data_atom(1, b"Pop")].concat(),
+    );
+    let buf = mp4_with_ilst(&atoms, true);
+    let tags = read_tags(&buf);
+    assert!(tags.contains(&("genre".into(), "Rock".into())));
+    assert!(tags.contains(&("genre".into(), "Pop".into())));
+}
+
+#[test]
+fn read_tags_trkn_includes_total_as_n_of_m() {
+    // trkn body: [reserved 2][number 2][total 2][reserved 2]; "3 of 12" -> "3/12".
+    let atoms = bx(b"trkn", &data_atom(0, &[0, 0, 0, 3, 0, 12, 0, 0]));
+    let buf = mp4_with_ilst(&atoms, true);
+    let tags = read_tags(&buf);
+    assert!(tags.contains(&("tracknumber".into(), "3/12".into())));
+}
+
+#[test]
+fn read_tags_trkn_zero_total_is_bare_number() {
+    let atoms = bx(b"trkn", &data_atom(0, &[0, 0, 0, 3, 0, 0, 0, 0]));
+    let buf = mp4_with_ilst(&atoms, true);
+    let tags = read_tags(&buf);
+    assert!(tags.contains(&("tracknumber".into(), "3".into())));
+}
+
+#[test]
+fn read_tags_disk_includes_total_as_n_of_m() {
+    let atoms = bx(b"disk", &data_atom(0, &[0, 0, 0, 1, 0, 2]));
+    let buf = mp4_with_ilst(&atoms, true);
+    let tags = read_tags(&buf);
+    assert!(tags.contains(&("discnumber".into(), "1/2".into())));
+}
+
+#[test]
+fn read_tags_decodes_integer_atoms() {
+    // iTunes binary integer atoms (type code 21): tmpo (BPM, u16), cpil & pgap
+    // (boolean flags). These were previously dropped at scan time.
+    let atoms = [
+        bx(b"tmpo", &data_atom(21, &300u16.to_be_bytes())),
+        bx(b"cpil", &data_atom(21, &[1])),
+        bx(b"pgap", &data_atom(21, &[1])),
+    ]
+    .concat();
+    let buf = mp4_with_ilst(&atoms, true);
+    let tags = read_tags(&buf);
+    assert!(tags.contains(&("bpm".into(), "300".into())), "got {tags:?}");
+    assert!(
+        tags.contains(&("compilation".into(), "1".into())),
+        "got {tags:?}"
+    );
+    assert!(
+        tags.contains(&("gapless".into(), "1".into())),
+        "got {tags:?}"
+    );
+}
+
+#[test]
 fn reads_cover_art() {
     let jpeg = [0xff, 0xd8, 0xff, 0xe0, 1, 2, 3];
     let buf = mp4_with_ilst(&bx(b"covr", &data_atom(13, &jpeg)), false);
@@ -693,9 +755,10 @@ fn read_freeform_extracts_name_and_value() {
     inner.extend(boxed(b"name", &name_body).unwrap());
     inner.extend(boxed(b"data", &data).unwrap());
 
-    let (key, value) = read_freeform(&inner).unwrap();
-    assert_eq!(key, "musicbrainz_albumid"); // folded via vocabulary
-    assert_eq!(value, "abc-123");
+    assert_eq!(
+        read_freeform(&inner),
+        vec![("musicbrainz_albumid".to_string(), "abc-123".to_string())]
+    );
 }
 
 #[test]
@@ -711,9 +774,27 @@ fn read_freeform_unknown_name_passes_through_verbatim() {
     inner.extend(boxed(b"name", &name_body).unwrap());
     inner.extend(boxed(b"data", &data).unwrap());
 
-    let (key, value) = read_freeform(&inner).unwrap();
-    assert_eq!(key, "My Custom Field"); // not in vocabulary -> verbatim name
-    assert_eq!(value, "hello");
+    assert_eq!(
+        read_freeform(&inner),
+        vec![("My Custom Field".to_string(), "hello".to_string())]
+    );
+}
+
+#[test]
+fn read_freeform_reads_all_data_boxes() {
+    // A `----` atom with two UTF-8 `data` sub-boxes must yield both values.
+    let mut name_body = 0u32.to_be_bytes().to_vec();
+    name_body.extend_from_slice(b"My Custom Field");
+    let mut inner = boxed(b"name", &name_body).unwrap();
+    inner.extend(data_atom(1, b"one"));
+    inner.extend(data_atom(1, b"two"));
+    assert_eq!(
+        read_freeform(&inner),
+        vec![
+            ("My Custom Field".to_string(), "one".to_string()),
+            ("My Custom Field".to_string(), "two".to_string()),
+        ]
+    );
 }
 
 #[test]
@@ -726,7 +807,7 @@ fn read_freeform_skips_binary_typed_data() {
     let mut inner = boxed(b"name", &name_body).unwrap();
     inner.extend(boxed(b"data", &data).unwrap());
 
-    assert!(read_freeform(&inner).is_none()); // binary-typed data is skipped
+    assert!(read_freeform(&inner).is_empty()); // binary-typed data is skipped
 }
 
 #[test]
@@ -755,6 +836,63 @@ fn build_udta_round_trips_freeform_and_vocabulary() {
             "missing {expected:?} in {tags:?}"
         );
     }
+}
+
+#[test]
+fn build_udta_round_trips_track_and_disc_totals() {
+    // A "N/M" tracknumber/discnumber must emit the total into the trkn/disk atom
+    // and read back unchanged (the prior code parsed only "N" and wrote total 0,
+    // and dropped a "N/M" value entirely on parse failure).
+    let tags = vec![
+        TagInput::new("tracknumber", "3/12"),
+        TagInput::new("discnumber", "1/2"),
+    ];
+    let (segs, _streamed) = build_udta(&tags, &[], &[]).unwrap();
+    let udta = materialize_udta(&segs);
+    let moov = boxed(b"moov", &udta).unwrap();
+    let tags = read_tags(&moov);
+    assert!(
+        tags.contains(&("tracknumber".to_string(), "3/12".to_string())),
+        "got {tags:?}"
+    );
+    assert!(
+        tags.contains(&("discnumber".to_string(), "1/2".to_string())),
+        "got {tags:?}"
+    );
+}
+
+#[test]
+fn build_udta_round_trips_integer_atoms() {
+    // bpm 300 has a non-zero high byte, so a big-endian decode is required (a
+    // byte-swapped read would yield 44, not 300).
+    let tags = vec![
+        TagInput::new("bpm", "300"),
+        TagInput::new("compilation", "1"),
+        TagInput::new("gapless", "1"),
+    ];
+    let (segs, _s) = build_udta(&tags, &[], &[]).unwrap();
+    let udta = materialize_udta(&segs);
+    // Emitted as the real iTunes atoms, not generic `----` freeform atoms, with
+    // exact widths: 8 (atom hdr) + 8 (data hdr) + 8 (type+locale) + value bytes.
+    let atom_size = |kind: &[u8; 4]| -> u32 {
+        let pos = udta.windows(4).position(|w| w == &kind[..]).unwrap();
+        u32::from_be_bytes(udta[pos - 4..pos].try_into().unwrap())
+    };
+    assert_eq!(atom_size(b"tmpo"), 26, "tmpo value must be 2 bytes");
+    assert_eq!(atom_size(b"cpil"), 25, "cpil value must be 1 byte");
+    assert_eq!(atom_size(b"pgap"), 25, "pgap value must be 1 byte");
+
+    let moov = boxed(b"moov", &udta).unwrap();
+    let read = read_tags(&moov);
+    assert!(read.contains(&("bpm".into(), "300".into())), "got {read:?}");
+    assert!(
+        read.contains(&("compilation".into(), "1".into())),
+        "got {read:?}"
+    );
+    assert!(
+        read.contains(&("gapless".into(), "1".into())),
+        "got {read:?}"
+    );
 }
 
 #[test]
@@ -885,9 +1023,7 @@ fn read_freeform_accepts_minimal_name_and_data() {
     data.extend_from_slice(&0u32.to_be_bytes()); // locale -> dp.len() == 8
     let mut inner = boxed(b"name", &name_body).unwrap();
     inner.extend(boxed(b"data", &data).unwrap());
-    let (key, value) = read_freeform(&inner).unwrap();
-    assert_eq!(key, ""); // empty name, not in vocabulary -> verbatim ""
-    assert_eq!(value, "");
+    assert_eq!(read_freeform(&inner), vec![(String::new(), String::new())]);
 }
 
 #[test]
@@ -900,7 +1036,7 @@ fn read_freeform_short_name_returns_none() {
     data.extend_from_slice(&0u32.to_be_bytes());
     let mut inner = boxed(b"name", &name_body).unwrap();
     inner.extend(boxed(b"data", &data).unwrap());
-    assert!(read_freeform(&inner).is_none());
+    assert!(read_freeform(&inner).is_empty());
 }
 
 #[test]
@@ -917,9 +1053,10 @@ fn read_freeform_mean_payload_exactly_4_uses_empty_mean() {
     let mut inner = boxed(b"mean", &mean_body).unwrap();
     inner.extend(boxed(b"name", &name_body).unwrap());
     inner.extend(boxed(b"data", &data).unwrap());
-    let (key, value) = read_freeform(&inner).unwrap();
-    assert_eq!(key, "MusicBrainz Album Id"); // empty mean -> not folded
-    assert_eq!(value, "abc-123");
+    assert_eq!(
+        read_freeform(&inner),
+        vec![("MusicBrainz Album Id".to_string(), "abc-123".to_string())]
+    );
 }
 
 #[test]

--- a/musefs-format/src/tagmap.rs
+++ b/musefs-format/src/tagmap.rs
@@ -24,6 +24,10 @@ pub(crate) enum Mp4Slot {
     Text(&'static [u8; 4]),
     /// A binary number atom (`trkn`/`disk`); the `usize` is the `data` body width.
     Number(&'static [u8; 4], usize),
+    /// A binary integer atom (`tmpo`/`cpil`/`pgap`), `data` type code 21; the
+    /// `usize` is the big-endian value width in bytes (2 for `tmpo`, 1 for the
+    /// boolean flags).
+    Integer(&'static [u8; 4], usize),
     /// A `----` freeform atom: `(mean, name)`.
     Freeform(&'static str, &'static str),
 }
@@ -168,6 +172,24 @@ const VOCAB: &[Entry] = &[
         mp4: Mp4Slot::Freeform("com.apple.iTunes", "MusicBrainz Artist Id"),
         vorbis: "MUSICBRAINZ_ARTISTID",
     },
+    Entry {
+        key: "bpm",
+        id3: Id3Slot::Text(b"TBPM"),
+        mp4: Mp4Slot::Integer(b"tmpo", 2),
+        vorbis: "BPM",
+    },
+    Entry {
+        key: "compilation",
+        id3: Id3Slot::Text(b"TCMP"),
+        mp4: Mp4Slot::Integer(b"cpil", 1),
+        vorbis: "COMPILATION",
+    },
+    Entry {
+        key: "gapless",
+        id3: Id3Slot::Txxx("GAPLESS"),
+        mp4: Mp4Slot::Integer(b"pgap", 1),
+        vorbis: "GAPLESS",
+    },
 ];
 
 /// ID3 text frame id (e.g. "TIT2") -> canonical key, for `Text` slots only.
@@ -198,6 +220,14 @@ pub(crate) fn key_to_id3(key: &str) -> Option<Id3Slot> {
 pub(crate) fn mp4_atom_to_key(atom: &[u8; 4]) -> Option<&'static str> {
     VOCAB.iter().find_map(|e| match e.mp4 {
         Mp4Slot::Text(a) if a == atom => Some(e.key),
+        _ => None,
+    })
+}
+
+/// MP4 integer atom (`tmpo`/`cpil`/`pgap`) -> canonical key, for `Integer` slots.
+pub(crate) fn mp4_integer_atom_to_key(atom: &[u8; 4]) -> Option<&'static str> {
+    VOCAB.iter().find_map(|e| match e.mp4 {
+        Mp4Slot::Integer(a, _) if a == atom => Some(e.key),
         _ => None,
     })
 }
@@ -260,6 +290,15 @@ mod tests {
         for e in VOCAB {
             if let Mp4Slot::Text(a) = e.mp4 {
                 assert_eq!(mp4_atom_to_key(a), Some(e.key));
+            }
+        }
+    }
+
+    #[test]
+    fn mp4_integer_round_trips() {
+        for e in VOCAB {
+            if let Mp4Slot::Integer(a, _) = e.mp4 {
+                assert_eq!(mp4_integer_atom_to_key(a), Some(e.key));
             }
         }
     }


### PR DESCRIPTION
Resolves the five open metadata round-trip issues. All fixes hold the cardinal invariant — original audio bytes are never copied or modified.

Fixes #511
Fixes #512
Fixes #513
Fixes #514
Fixes #515

## What changed

- **#511 — M4A binary integer atoms.** `tmpo`/`cpil`/`pgap` (BPM, compilation, gapless), previously dropped at scan, now map to canonical `bpm`/`compilation`/`gapless` keys via a new `Mp4Slot::Integer` slot — shared cross-format with ID3 `TBPM`/`TCMP` and Vorbis — and are re-emitted as type-21 integer atoms.
- **#512 — M4A multi-value atoms.** `read_tags`/`read_freeform` now read *every* `data` sub-box of an atom (the iTunes multiple-`data` convention), so a multi-valued atom round-trips all its values instead of just the first. `read_freeform` returns `Vec`.
- **#513 — MP3/WAV `COMM`/`USLT` language + descriptor.** Frames with a placeholder language (`XXX`/`und`/empty) and empty descriptor still fold to the shared `comment`/`lyrics` keys; frames carrying a real language or descriptor are preserved under `id3:COMM:<lang>:<desc>` / `id3:USLT:<lang>:<desc>` and restored on synthesis. WAV inherits this (its `read_tags`/builder delegate to the MP3 code).
- **#514 — docs.** `ogg.md`: the picture-padding note now correctly describes the PICTURE *prefix* length (`32 + mime + description`) being padded to a multiple of 3, not the "body length".
- **#515 — M4A trkn/disk totals.** Scan decodes the "of N" total into a `"N/M"` value (matching ID3 `TRCK`/`TPOS`); `number_atom` writes the total field. Also fixes a latent bug where an MP3-sourced `"3/12"` value was dropped entirely on M4A synthesis (it failed `u16` parse).

## Design decisions

- **#511** uses semantic cross-format vocab mapping (bpm/compilation/gapless) rather than opaque byte passthrough.
- **#513** keeps the shared `comment`/`lyrics` key for the common case and reserves the `id3:` namespace key only for frames with distinguishing language/descriptor.

Per-format docs (`m4a.md`, `mp3.md`, `wav.md`) updated to match the new round-trip and lossy-edge behavior.

## Verification

`cargo fmt`, `cargo clippy --all-targets -D warnings`, full workspace `cargo test` (1172 passed), the mutant-anchor drift guard, and ruff all pass via the pre-commit gate. Each fix was developed test-first (failing test → fix → green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MP3, MP4, OGG, and WAV format docs with more precise tag round-trip and lossy-edge behavior.

* **Improvements**
  * MP3: Preserve COMM/USLT language and descriptor details instead of collapsing variants.
  * MP4: Read and synthesize multi-value iTunes-style fields, including all freeform text values.
  * MP4: Track/disc values now round-trip totals (N/M) correctly.
  * MP4: Improved support for integer tags for BPM, compilation, and gapless.

* **Tests**
  * Expanded and adjusted MP4 test coverage to match the updated reading/synthesis behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->