### PR TITLE
Resolve open issues #518–#531

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -259,19 +259,6 @@ exclude_re = [
     # forever instead of returning false.
     'replace == with != in VirtualTree::ancestor_in',
 
-    # SP4 storage-aware serving — equivalent mutant in serve_ogg_window's last-page
-    # memo. `total_len = header_len + payload_len` only sets the memoized page's
-    # [start, start+total_len) range, which find_page_start uses to decide whether to
-    # short-circuit. `+`->`*` only ever makes total_len LARGER (real pages) or 0
-    # (payload_len 0), never landing find_page_start on a page AFTER the true one:
-    # too-large only widens the range so the forward walk STARTS at an
-    # earlier-or-equal page (its overlap clipping then emits the identical bytes), and
-    # 0 disables the short-circuit (falls to the scan, also correct). So the served
-    # output is byte-identical either way. (`+`->`-` underflows and is caught.) Pinned
-    # by line:col — one of several `+` in this fn; the others ARE caught.
-    # guard: op="+" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:256:41: replace \+ with \* in serve_ogg_window',
-
     # SP4 crc_shift_zeros — equivalent mutants inherent to the loop/matrix hybrid.
     # crc_shift_zeros has two code paths (a per-step loop and a GF(2) matrix-power)
     # that compute the IDENTICAL value; the differential test pins the result, but no
@@ -314,9 +301,9 @@ exclude_re = [
     # were reported TIMEOUT under the parallel gate's load, not as a real hang. Pinned
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:235:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:239:15: replace < with <= in serve_ogg_window',
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:244:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:248:15: replace < with <= in serve_ogg_window',
 
     # Phase 4 poll debounce (#89) — equivalent `<`->`<=` on the two wall-clock
     # gates (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <
@@ -467,7 +454,7 @@ exclude_re = [
     # the ring under the read lock); the fn's other two `+` are the observable fills
     # counters and stay killable, so this one is pinned by coordinate, not by fn.
     # guard: op="+" fn="BackingReader<'a>::read_exact_at" rows=2
-    'musefs-core/src/readahead\.rs:612:68:',
+    'musefs-core/src/readahead\.rs:613:68:',
     #
     # More hang-class (TIMEOUT-only, CANCEL the in-diff job): `len() -> 1` /
     # `clear() -> 1` force a constant resident size, so `evict_one_coldest` keeps

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -286,14 +286,11 @@ exclude_re = [
     # shift), so anchored line-agnostically.
     'musefs-format/src/ogg/crc\.rs:\d+:\d+: replace > with >= in crc_shift_zeros',
 
-    # SP4 serve_ogg_window / find_page_start loop mutants.
-    # Non-terminating (reported TIMEOUT, never a clean kill): `i -= 1` -> `i /= 1`
-    # leaves the backward-scan index unchanged (infinite loop), and `pos += ...` ->
-    # `pos *= ...` stays 0 forever once the first page is at offset 0. Like the SP2
-    # tree.rs timeouts, these can only ever flag via the timeout budget. Each is the
-    # sole `-=` / `+=` in its function, so anchored line-agnostically.
+    # SP4 find_page_start loop mutant. Non-terminating (reported TIMEOUT, never a
+    # clean kill): `i -= 1` -> `i /= 1` leaves the backward-scan index unchanged
+    # (infinite loop). Like the SP2 tree.rs timeouts, it can only ever flag via the
+    # timeout budget. The sole `-=` in its function, so anchored line-agnostically.
     'musefs-core/src/ogg_index\.rs:\d+:\d+: replace -= with /= in find_page_start',
-    'musefs-core/src/ogg_index\.rs:\d+:\d+: replace \+= with \*= in serve_ogg_window',
     # Overlap-emit guards `if hs < he` / `if ps < pe`, `<`->`<=`: when the bound is
     # equal the extra branch emits an empty `[a..b]` slice / reads 0 payload bytes —
     # a no-op, so the served output is byte-identical (verified: the ogg tests and the
@@ -301,9 +298,9 @@ exclude_re = [
     # were reported TIMEOUT under the parallel gate's load, not as a real hang. Pinned
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:239:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:247:15: replace < with <= in serve_ogg_window',
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:248:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:256:15: replace < with <= in serve_ogg_window',
 
     # Phase 4 poll debounce (#89) — equivalent `<`->`<=` on the two wall-clock
     # gates (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
  "anyhow",
  "clap",
  "indicatif",
+ "log",
  "musefs-core",
  "musefs-db",
  "musefs-fuse",

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -56,8 +56,8 @@ MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
 #MUSEFS_READ_AHEAD_PREFETCH=false
 # Max outstanding background (readahead/async) requests the kernel queues.
 #MUSEFS_MAX_BACKGROUND=64
-# Keep the kernel page cache across opens.
-#MUSEFS_KEEP_CACHE=false
+# Keep the kernel page cache across opens. Default: true.
+#MUSEFS_KEEP_CACHE=true
 
 # --- Mount: ownership & permissions ----------------------------------------
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -46,6 +46,12 @@ the target needs the FUSE userspace tools and `/dev/fuse`:
 
 No glibc/libfuse install is needed for the musl binaries beyond `fuse3`.
 
+> **Note:** On Ubuntu 24.04+ (libfuse ≥ 3.17) the `fusermount3` AppArmor
+> profile only permits unprivileged mounts under whitelisted prefixes
+> (`$HOME/**`, `/mnt`, `/media`, `/tmp`, …). Mounting elsewhere fails with
+> `fusermount3: mount failed: Permission denied` — see
+> [Mounting](mounting.md#mounting) for the whitelist and the fix.
+
 ## Building from source
 
 `cargo install musefs` compiles the latest release; building needs a stable

--- a/fuzz/fuzz_targets/b64.rs
+++ b/fuzz/fuzz_targets/b64.rs
@@ -18,7 +18,8 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
     let total = b64_len(img.len() as u64);
-    let full = encode_b64_slice(&img, 0, total as usize);
+    let full = encode_b64_slice(&img, 0, total as usize)
+        .expect("full-length window lies within the encoded output");
     // img is non-empty so total >= 4; checked_sub keeps each bound
     // underflow-safe on its own, independent of statement order.
     let Some(max_off) = total.checked_sub(1) else {
@@ -47,7 +48,8 @@ fuzz_target!(|data: &[u8]| {
         &img[win.in_start as usize..(win.in_start + win.in_len) as usize],
         win.skip,
         take as usize,
-    );
+    )
+    .expect("window lies within the encoded output");
     assert_eq!(windowed.len(), take as usize, "windowed length != take");
     assert_eq!(
         windowed.as_slice(),

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["filesystem", "multimedia::audio", "command-line-utilities"]
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
+log = "0.4"
 musefs-db = { path = "../musefs-db", version = "1.0.0" }
 musefs-core = { path = "../musefs-core", version = "1.0.0" }
 musefs-fuse = { path = "../musefs-fuse", version = "1.0.0" }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -449,10 +449,11 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     }
     signal::install_unmount_on_signal(args.mountpoint.clone())
         .context("installing the stop-signal unmount handler")?;
-    // The "is it serving the right library?" context, alongside the mount-success
-    // line `mount_with` emits with the file/dir counts (#522).
+    // The "is it serving the right library?" context, logged before the blocking
+    // mount call; `mount_with` emits the success line with the file/dir counts once
+    // the session is actually serving (#522).
     log::info!(
-        "serving database {} at {} (template {:?})",
+        "mounting database {} at {} (template {:?})",
         args.db.display(),
         args.mountpoint.display(),
         template,

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -437,6 +437,7 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
     let (config, fuse_config) = parse_mount_config(args);
+    let template = config.template.clone();
     for (flag, mode) in [("file-mode", args.file_mode), ("dir-mode", args.dir_mode)] {
         if let Some(w) = mode.and_then(|m| write_bit_warning(flag, m)) {
             eprintln!("warning: {w}");
@@ -448,6 +449,14 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     }
     signal::install_unmount_on_signal(args.mountpoint.clone())
         .context("installing the stop-signal unmount handler")?;
+    // The "is it serving the right library?" context, alongside the mount-success
+    // line `mount_with` emits with the file/dir counts (#522).
+    log::info!(
+        "serving database {} at {} (template {:?})",
+        args.db.display(),
+        args.mountpoint.display(),
+        template,
+    );
     musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config).map_err(|e| {
         // A bare EACCES from fusermount3 (e.g. an AppArmor-denied prefix) is
         // otherwise opaque. Append actionable guidance — but not when the

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -22,6 +22,12 @@ pub enum CoreError {
     },
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("backing file I/O at {path}: {source}")]
+    BackingIo {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("backing file changed since scan: {0}")]
     BackingChanged(String),
     #[error(
@@ -55,6 +61,19 @@ pub enum CoreError {
     NotADir(u64),
     #[error("handle table full")]
     HandleTableFull,
+}
+
+impl CoreError {
+    /// Attach the backing-file path to an I/O error. A moved, permission-denied,
+    /// or failing backing file is the most common passthrough failure; carrying
+    /// the path makes the warn log and any surfaced error name the file rather
+    /// than collapsing to a bare `EIO` (#521).
+    pub(crate) fn backing_io(path: impl AsRef<std::path::Path>, source: std::io::Error) -> Self {
+        CoreError::BackingIo {
+            path: path.as_ref().to_path_buf(),
+            source,
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, CoreError>;

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -123,7 +123,9 @@ struct SizeEntry {
 }
 
 fn validate_opened_backing(file: &std::fs::File, resolved: &ResolvedFile) -> Result<()> {
-    let meta = file.metadata()?;
+    let meta = file
+        .metadata()
+        .map_err(|e| CoreError::backing_io(&resolved.backing_path, e))?;
     if BackingStamp::from_metadata(&meta) != resolved.stamp {
         return Err(CoreError::BackingChanged(
             resolved.backing_path.to_string_lossy().into_owned(),
@@ -340,7 +342,8 @@ impl Musefs {
                 // getattr advertise stale attrs — the one metadata surface that
                 // could outrun a backing change (read/open already re-stat).
                 crate::metrics::on_stat();
-                let meta = std::fs::metadata(&backing_path)?;
+                let meta = std::fs::metadata(&backing_path)
+                    .map_err(|err| CoreError::backing_io(&backing_path, err))?;
                 if BackingStamp::from_metadata(&meta) != e.stamp {
                     return Err(CoreError::BackingChanged(backing_path));
                 }
@@ -392,7 +395,7 @@ impl Musefs {
     fn serve_backing<M>(
         &self,
         h: &Handle,
-        db: &musefs_db::Db<M>,
+        db: Option<&musefs_db::Db<M>>,
         r: &ResolvedFile,
         offset: u64,
         size: u64,
@@ -510,11 +513,11 @@ impl Musefs {
                     // unchanged, so this is the only check that catches it. A
                     // genuine drift is terminal — propagate, don't retry the loop.
                     validate_opened_backing(&h.file, r)?;
-                    let served = self.pool.with(|db| -> Result<Option<()>> {
-                        if r.streams_db_rowid {
-                            // Snapshot-consistent: version check + DB-rowid reads
-                            // (binary tags AND art) see one WAL snapshot, so a
-                            // reused rowid can't be served mid-read (#502).
+                    let served = if r.streams_db_rowid {
+                        // Snapshot-consistent: version check + DB-rowid reads
+                        // (binary tags AND art) see one WAL snapshot, so a reused
+                        // rowid can't be served mid-read (#502).
+                        self.pool.with(|db| -> Result<Option<()>> {
                             db.begin_read()?;
                             let res = (|| {
                                 // A test seam forces the first N checks stale to
@@ -534,16 +537,20 @@ impl Musefs {
                                 {
                                     return Ok(None); // stale layout — retry after re-resolve
                                 }
-                                self.serve_backing(&h, db, r, offset, size, out)?;
+                                self.serve_backing(&h, Some(db), r, offset, size, out)?;
                                 Ok(Some(()))
                             })();
                             let _ = db.end_read(); // always release the snapshot
                             res
-                        } else {
-                            self.serve_backing(&h, db, r, offset, size, out)?;
-                            Ok(Some(()))
-                        }
-                    })?;
+                        })?
+                    } else {
+                        // No DB-backed segment (the steady state once the header is
+                        // served, where the remainder is a single backing/Ogg-audio
+                        // segment): the read is pure positioned backing I/O and never
+                        // touches the connection, so skip the pool lookup+lock (#520).
+                        self.serve_backing::<musefs_db::ReadOnly>(&h, None, r, offset, size, out)?;
+                        Some(())
+                    };
                     if served.is_some() {
                         return Ok(());
                     }
@@ -607,7 +614,10 @@ impl Musefs {
         let generation = self.refresh_gen.load(Ordering::Acquire);
         let resolved = self.pool.with(|db| self.cache.resolve(db, track_id))?;
         crate::metrics::on_open();
-        let file = Arc::new(std::fs::File::open(&resolved.backing_path)?);
+        let file = Arc::new(
+            std::fs::File::open(&resolved.backing_path)
+                .map_err(|e| CoreError::backing_io(&resolved.backing_path, e))?,
+        );
         validate_opened_backing(&file, &resolved)?;
         let key = self.handles.insert(Arc::new(Handle {
             track_id,
@@ -670,6 +680,13 @@ impl Musefs {
     /// The mount's serving mode (how file contents are produced).
     pub fn mode(&self) -> Mode {
         self.config.mode
+    }
+
+    /// `(files, directories)` in the current virtual tree — the operator's
+    /// "is it serving the right library?" answer, surfaced on a successful
+    /// mount so an empty or wrong DB is not silent (#522).
+    pub fn entry_counts(&self) -> (u64, u64) {
+        self.tree.load().entry_counts()
     }
 
     /// Snapshot the core-owned telemetry for the `.musefs-metrics` surface (#394).

--- a/musefs-core/src/facade/tests.rs
+++ b/musefs-core/src/facade/tests.rs
@@ -925,6 +925,49 @@ fn full_rebuild_gives_bare_colliding_name_to_lower_id() {
 }
 
 #[test]
+fn entry_counts_reports_files_and_dirs() {
+    use musefs_db::{Format, NewTrack, Tag};
+    use std::collections::BTreeMap;
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    // Two tracks under two distinct artist dirs -> 2 files, 2 dirs. Both counts
+    // are >1, so this distinguishes the real result from every entry_counts
+    // constant-return mutant ((0,0)/(0,1)/(1,0)/(1,1)).
+    for (path, artist, title) in [("/a.flac", "Alice", "One"), ("/b.flac", "Bob", "Two")] {
+        let id = db
+            .upsert_track(&NewTrack {
+                backing_path: path.into(),
+                format: Format::Flac,
+                audio_offset: 0,
+                audio_length: 1,
+                backing_size: 1,
+                backing_mtime_ns: 0,
+                backing_ctime_ns: 0,
+            })
+            .unwrap();
+        db.replace_tags(
+            id,
+            &[Tag::new("artist", artist, 0), Tag::new("title", title, 0)],
+        )
+        .unwrap();
+    }
+
+    let cfg = MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
+        read_ahead_budget: 0,
+        read_ahead_prefetch: false,
+        skip_on_missing: false,
+    };
+    let fs = Musefs::open(db, cfg).unwrap();
+    assert_eq!(fs.entry_counts(), (2, 2));
+}
+
+#[test]
 fn getattr_size_cache_hit_detects_backing_change() {
     use crate::scan::scan_directory;
     use id3::TagLike;

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -7,7 +7,6 @@ mod lock;
 mod mapping;
 pub mod metrics;
 mod ogg_index;
-#[allow(dead_code)]
 mod readahead;
 mod reader;
 mod refresh_diff;

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -230,8 +230,16 @@ pub fn serve_ogg_window(
             patch_page_header_algebraic(&hdr_buf[..header_len], new_seq)?
         };
 
-        let hdr_end = page_rel + header_len as u64;
-        let page_end = hdr_end + payload_len as u64;
+        // Fail closed on the offset arithmetic (DB-derived bounds are semi-trusted):
+        // checked_add rather than wrap/panic, matching the bounds above.
+        let header_len_u64 = header_len as u64;
+        let payload_len_u64 = payload_len as u64;
+        let hdr_end = page_rel
+            .checked_add(header_len_u64)
+            .ok_or(musefs_format::FormatError::Malformed)?;
+        let page_end = hdr_end
+            .checked_add(payload_len_u64)
+            .ok_or(musefs_format::FormatError::Malformed)?;
 
         // Header overlap.
         let hs = rstart.max(page_rel);
@@ -250,26 +258,29 @@ pub fn serve_ogg_window(
             let n = usize_from(pe - ps);
             let start = out.len();
             out.resize(start + n, 0);
-            backing.read_exact_at(&mut out[start..], pos + header_len as u64 + within)?;
+            backing.read_exact_at(&mut out[start..], pos + header_len_u64 + within)?;
         }
 
-        // Remember this page as the memo entry to write once after the loop (the
-        // patched header is moved in, not cloned). Recorded before the integrity
-        // guard so the last good page is still memoized when a later page overruns.
-        let total_len = (header_len + payload_len) as u64;
-        last_entry = Some((page_rel, total_len, patched_hdr));
+        let total_len = header_len_u64
+            .checked_add(payload_len_u64)
+            .ok_or(musefs_format::FormatError::Malformed)?;
+        let next_pos = pos
+            .checked_add(total_len)
+            .ok_or(musefs_format::FormatError::Malformed)?;
 
-        pos += total_len;
-
-        // Integrity guard: a page whose declared length pushes past the declared
-        // audio region means the file is truncated/misaligned or the DB bounds are
-        // stale. Hard error (matches the removed build_index consumed-check).
-        if pos > audio_end {
-            if let Some(m) = memo {
-                *crate::lock::lock_or_clear(m, "ogg last-page memo") = last_entry.take();
-            }
+        // Integrity guard BEFORE memoizing: a page whose declared length pushes past
+        // the declared audio region means the file is truncated/misaligned or the DB
+        // bounds are stale. Hard error (matches the removed build_index
+        // consumed-check), and the memo is left holding the last VALID page rather
+        // than caching this overrunning one.
+        if next_pos > audio_end {
             return Err(musefs_format::FormatError::Malformed.into());
         }
+
+        // Remember only validated pages as the memo entry to write once after the
+        // loop (the patched header is moved in, not cloned).
+        last_entry = Some((page_rel, total_len, patched_hdr));
+        pos = next_pos;
     }
 
     if let Some((m, e)) = memo.zip(last_entry) {

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -185,6 +185,17 @@ pub fn serve_ogg_window(
 
     // Reused across pages — refilled per page, never exceeds MAX_OGG_HEADER_BYTES.
     let mut hdr_buf: Vec<u8> = Vec::new();
+    // Snapshot the memoized patched header ONCE up front: it can be reused for the
+    // single page it was recorded against (the boundary-straddling page a sequential
+    // read re-touches). The loop then collects the last page in `last_entry` and
+    // writes the memo ONCE after the walk — instead of locking the per-file memo
+    // twice per page and cloning the header on every hit (#528).
+    let mut carried: Option<(u64, Vec<u8>)> = memo.and_then(|m| {
+        crate::lock::lock_or_clear(m, "ogg last-page memo")
+            .as_ref()
+            .map(|(rel, _, h)| (*rel, h.clone()))
+    });
+    let mut last_entry: Option<(u64, u64, Vec<u8>)> = None;
     while pos < audio_end {
         let page_rel = pos - audio_offset;
         if page_rel >= rend {
@@ -205,19 +216,12 @@ pub fn serve_ogg_window(
         }
         let payload_len: usize = hdr_buf[27..header_len].iter().map(|&b| b as usize).sum();
 
-        // Reuse the patched header if this is the page the last serve ended on
-        // (sequential reads re-touch the page straddling each chunk boundary). The
-        // header for a given page_rel is deterministic for the life of the resolved
-        // file (immutable backing + fixed seq_delta), so a one-entry memo is always
-        // correct. The lock is released before patching so concurrent readers never
-        // serialize on the CRC work.
-        let cached = memo.and_then(|m| {
-            let g = crate::lock::lock_or_clear(m, "ogg last-page memo");
-            g.as_ref()
-                .filter(|(mp, _, _)| *mp == page_rel)
-                .map(|(_, _, h)| h.clone())
-        });
-        let patched_hdr = if let Some(h) = cached {
+        // Reuse the snapshotted patched header for the one page it was memoized
+        // against (the boundary-straddling page sequential reads re-touch); every
+        // other page is freshly patched. The header for a given page_rel is
+        // deterministic for the life of the resolved file (immutable backing + fixed
+        // seq_delta), so reusing it is always correct.
+        let patched_hdr = if let Some((_, h)) = carried.take_if(|(rel, _)| *rel == page_rel) {
             h
         } else {
             let old_seq = u32::from_le_bytes(hdr_buf[18..22].try_into().unwrap());
@@ -249,25 +253,28 @@ pub fn serve_ogg_window(
             backing.read_exact_at(&mut out[start..], pos + header_len as u64 + within)?;
         }
 
-        // Record this page in the memo (the patched header is moved in, not
-        // cloned). Written before the integrity guard so the last good page is
-        // memoized for the next serve even when a later page overruns the region.
-        if let Some(m) = memo {
-            let total_len = (header_len + payload_len) as u64;
-            *crate::lock::lock_or_clear(m, "ogg last-page memo") =
-                Some((page_rel, total_len, patched_hdr));
-        }
+        // Remember this page as the memo entry to write once after the loop (the
+        // patched header is moved in, not cloned). Recorded before the integrity
+        // guard so the last good page is still memoized when a later page overruns.
+        let total_len = (header_len + payload_len) as u64;
+        last_entry = Some((page_rel, total_len, patched_hdr));
 
-        pos += (header_len + payload_len) as u64;
+        pos += total_len;
 
         // Integrity guard: a page whose declared length pushes past the declared
         // audio region means the file is truncated/misaligned or the DB bounds are
         // stale. Hard error (matches the removed build_index consumed-check).
         if pos > audio_end {
+            if let Some(m) = memo {
+                *crate::lock::lock_or_clear(m, "ogg last-page memo") = last_entry.take();
+            }
             return Err(musefs_format::FormatError::Malformed.into());
         }
     }
 
+    if let Some((m, e)) = memo.zip(last_entry) {
+        *crate::lock::lock_or_clear(m, "ogg last-page memo") = Some(e);
+    }
     Ok(())
 }
 

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -85,9 +85,18 @@ impl ReadAheadPool {
     }
 
     /// Mark `key` as most-recently-served (LRU bump). No-op if unregistered.
+    ///
+    /// Best-effort: a `try_lock` that SKIPS rather than blocks on contention. It
+    /// runs at the end of every backing pread, on every stream, so a blocking
+    /// `lock` here serializes all concurrent playback on this one registry mutex
+    /// (#519). A skipped bump only leaves a stamp slightly stale, at worst evicting
+    /// a marginally-warmer stream — and eviction is already best-effort
+    /// (`try_lock` + skip), so the LRU order was never exact to begin with.
     pub fn touch(&self, key: usize) {
         let stamp = self.clock.fetch_add(1, O::Relaxed);
-        if let Some(e) = self.streams.lock().unwrap().get_mut(&key) {
+        if let Ok(mut g) = self.streams.try_lock()
+            && let Some(e) = g.get_mut(&key)
+        {
             e.last_served = stamp;
         }
     }
@@ -449,8 +458,6 @@ pub struct PrefetchJob {
 
 pub struct PrefetchWorkers {
     tx: crossbeam_channel::Sender<PrefetchJob>,
-    #[cfg(test)]
-    handles: Vec<std::thread::JoinHandle<()>>,
 }
 
 impl PrefetchWorkers {
@@ -459,21 +466,15 @@ impl PrefetchWorkers {
         // blocks in `recv` independently, so job hand-off and wake-ups fan out
         // across all threads instead of serializing behind one shared lock (#430).
         let (tx, rx) = crossbeam_channel::bounded::<PrefetchJob>(threads * 4);
-        let mut handles = Vec::new();
         for _ in 0..threads {
             let rx = rx.clone();
-            let h = std::thread::spawn(move || {
+            std::thread::spawn(move || {
                 while let Ok(job) = rx.recv() {
                     Self::run_job(job);
                 }
             });
-            handles.push(h);
         }
-        PrefetchWorkers {
-            tx,
-            #[cfg(test)]
-            handles,
-        }
+        PrefetchWorkers { tx }
     }
 
     #[expect(clippy::needless_pass_by_value)]

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -88,9 +88,10 @@ fn read_front(path: &Path, n: u64) -> crate::Result<Vec<u8>> {
         });
     }
     crate::metrics::on_open();
-    let mut f = std::fs::File::open(path)?;
+    let mut f = std::fs::File::open(path).map_err(|e| CoreError::backing_io(path, e))?;
     let mut buf = vec![0u8; usize_from(n)];
-    f.read_exact(&mut buf)?;
+    f.read_exact(&mut buf)
+        .map_err(|e| CoreError::backing_io(path, e))?;
     Ok(buf)
 }
 
@@ -123,7 +124,8 @@ impl HeaderCache {
         // Always validate the backing file first — a stale file is an error even
         // on a cache hit, because the audio region may have shifted.
         crate::metrics::on_stat();
-        let meta = std::fs::metadata(&track.backing_path)?;
+        let meta = std::fs::metadata(&track.backing_path)
+            .map_err(|e| CoreError::backing_io(&track.backing_path, e))?;
         if BackingStamp::from_metadata(&meta) != BackingStamp::from_track(&track) {
             return Err(CoreError::BackingChanged(track.backing_path.clone()));
         }
@@ -242,12 +244,15 @@ impl HeaderCache {
                         // to reach it. The resulting layout's leading inline `head` ends
                         // in a deliberately truncated `mdat` header whose payload is the
                         // backing-audio tail.
-                        let mut f = std::fs::File::open(&track.backing_path)?;
+                        let mut f = std::fs::File::open(&track.backing_path)
+                            .map_err(|e| CoreError::backing_io(&track.backing_path, e))?;
                         // `meta` was validated against the tracked size/mtime above,
                         // so reuse it rather than issuing a second fstat.
                         let len = meta.len();
                         let scan = mp4::read_structure_from(&mut f, len).map_err(|e| match e {
-                            mp4::Mp4ScanError::Io(io) => CoreError::Io(io),
+                            mp4::Mp4ScanError::Io(io) => {
+                                CoreError::backing_io(&track.backing_path, io)
+                            }
                             mp4::Mp4ScanError::Format(fe) => CoreError::Format(fe),
                             // Unreachable in practice (an ingested file already
                             // passed the cap at scan, and backing-file drift is
@@ -396,8 +401,12 @@ pub fn read_at_into<M>(
     // via `validate_opened_backing`; this stateless fallback must too.
     let file = if needs_file {
         crate::metrics::on_open();
-        let f = std::fs::File::open(&resolved.backing_path)?;
-        if BackingStamp::from_metadata(&f.metadata()?) != resolved.stamp {
+        let f = std::fs::File::open(&resolved.backing_path)
+            .map_err(|e| CoreError::backing_io(&resolved.backing_path, e))?;
+        let f_meta = f
+            .metadata()
+            .map_err(|e| CoreError::backing_io(&resolved.backing_path, e))?;
+        if BackingStamp::from_metadata(&f_meta) != resolved.stamp {
             return Err(CoreError::BackingChanged(
                 resolved.backing_path.to_string_lossy().into_owned(),
             ));
@@ -450,9 +459,9 @@ fn read_with_optional_backing<M>(
             let epoch = std::sync::atomic::AtomicU64::new(0);
             let br =
                 crate::readahead::BackingReader::new(file, &buf, &pool, 0, backing_len, &epoch);
-            read_segments_into(resolved, db, Some(&br), offset, size, out)
+            read_segments_into(resolved, Some(db), Some(&br), offset, size, out)
         }
-        None => read_segments_into(resolved, db, None, offset, size, out),
+        None => read_segments_into(resolved, Some(db), None, offset, size, out),
     }
 }
 
@@ -479,10 +488,13 @@ pub fn read_at<M>(resolved: &ResolvedFile, db: &Db<M>, offset: u64, size: u64) -
 
 /// The single segment-splicing loop. `backing` is `Some` whenever the layout has a
 /// `BackingAudio`/`OggAudio` segment (guaranteed by `read_at`/`read_at_with_file`);
-/// the backing arms treat `None` as a contract violation.
+/// `db` is `Some` whenever the layout has a DB-backed segment
+/// (`ArtImage`/`BinaryTag`/`OggArtSlice`, i.e. `streams_db_rowid`). Both arms treat
+/// `None` as a contract violation, so a pure-backing layout can be served without a
+/// pooled DB connection at all (#520).
 fn read_segments_into<M>(
     resolved: &ResolvedFile,
-    db: &Db<M>,
+    db: Option<&Db<M>>,
     backing: Option<&crate::readahead::BackingReader>,
     offset: u64,
     size: u64,
@@ -515,12 +527,14 @@ fn read_segments_into<M>(
                     br.read_exact_at(&mut out[start..], bo + within)?;
                 }
                 Segment::ArtImage { art_id, .. } => {
+                    let db = db.expect("art segment requires a DB connection");
                     let start = out.len();
                     out.resize(start + n, 0);
                     db.read_art_chunk_into(*art_id, within, &mut out[start..])?;
                     crate::metrics::on_art_chunk();
                 }
                 Segment::BinaryTag { payload_id, .. } => {
+                    let db = db.expect("binary-tag segment requires a DB connection");
                     let start = out.len();
                     out.resize(start + n, 0);
                     db.read_binary_tag_chunk_into(*payload_id, within, &mut out[start..])?;
@@ -550,14 +564,20 @@ fn read_segments_into<M>(
                     art_total,
                     ..
                 } => {
+                    let db = db.expect("ogg-art segment requires a DB connection");
                     if *base64 {
                         let w =
                             musefs_format::ogg::b64_window(*offset + within, n as u64, *art_total);
                         let raw = db.read_art_chunk(*art_id, w.in_start, usize_from(w.in_len))?;
                         crate::metrics::on_art_chunk();
-                        out.extend_from_slice(&musefs_format::ogg::encode_b64_slice(
-                            &raw, w.skip, n,
-                        ));
+                        let slice = musefs_format::ogg::encode_b64_slice(&raw, w.skip, n)
+                            .ok_or_else(|| {
+                                CoreError::BackingChanged(format!(
+                                    "art {} shorter than its indexed base64 window",
+                                    *art_id
+                                ))
+                            })?;
+                        out.extend_from_slice(&slice);
                     } else {
                         let start = out.len();
                         out.resize(start + n, 0);
@@ -575,10 +595,12 @@ fn read_segments_into<M>(
     Ok(())
 }
 
-/// Serve into `out` from an already-open backing reader (per-handle path).
+/// Serve into `out` from an already-open backing reader (per-handle path). `db`
+/// is `None` for a pure-backing layout (no `streams_db_rowid` segment), letting
+/// the caller serve without a pooled DB connection (#520).
 pub fn read_at_with_file_into<M>(
     resolved: &ResolvedFile,
-    db: &Db<M>,
+    db: Option<&Db<M>>,
     backing: &crate::readahead::BackingReader,
     offset: u64,
     size: u64,
@@ -596,7 +618,7 @@ pub fn read_at_with_file<M>(
     size: u64,
 ) -> Result<Vec<u8>> {
     let mut out = Vec::new();
-    read_at_with_file_into(resolved, db, backing, offset, size, &mut out)?;
+    read_at_with_file_into(resolved, Some(db), backing, offset, size, &mut out)?;
     Ok(out)
 }
 
@@ -954,7 +976,8 @@ mod ogg_art_serve_tests {
             &image,
             0,
             usize_from(musefs_format::ogg::b64_len(image.len() as u64)),
-        );
+        )
+        .expect("full-length window lies within the encoded output");
 
         let db = musefs_db::Db::open_in_memory().unwrap();
         let art_id = db
@@ -1765,9 +1788,20 @@ mod serve_cap_tests {
         // `> -> >=` mutant.
         let err = read_front(std::path::Path::new("/nonexistent/musefs/front"), CAP).unwrap_err();
         assert!(
-            matches!(err, CoreError::Io(_)),
-            "expected Io error at the cap boundary, got {err:?}"
+            matches!(err, CoreError::BackingIo { .. }),
+            "expected a backing-file Io error at the cap boundary, got {err:?}"
         );
+    }
+
+    #[test]
+    fn read_front_io_error_carries_the_backing_path() {
+        // The most common passthrough failure (a moved/inaccessible backing file)
+        // must name the path rather than collapse to a pathless `Io`/EIO (#521).
+        let p = std::path::Path::new("/nonexistent/musefs/backing.flac");
+        match read_front(p, 16).unwrap_err() {
+            CoreError::BackingIo { path, .. } => assert_eq!(path, p),
+            other => panic!("expected BackingIo carrying the path, got {other:?}"),
+        }
     }
 }
 
@@ -1876,7 +1910,7 @@ mod readahead_differential_tests {
             while off < total {
                 let n = size.min(total - off);
                 let mut via = Vec::new();
-                read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+                read_segments_into(&resolved, Some(&db), Some(&br), off, n, &mut via).unwrap();
                 let mut direct = Vec::new();
                 oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
                 assert_eq!(via, direct, "mismatch at off={off} size={size}");
@@ -1898,7 +1932,7 @@ mod readahead_differential_tests {
         while off < total {
             let n = 65536u64.min(total - off);
             let mut via = Vec::new();
-            read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+            read_segments_into(&resolved, Some(&db), Some(&br), off, n, &mut via).unwrap();
             let mut direct = Vec::new();
             oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
             assert_eq!(via, direct, "eviction mismatch at {off}");
@@ -1921,7 +1955,7 @@ mod readahead_differential_tests {
                 continue;
             }
             let mut via = Vec::new();
-            read_segments_into(&resolved, &db, Some(&br), off, n, &mut via).unwrap();
+            read_segments_into(&resolved, Some(&db), Some(&br), off, n, &mut via).unwrap();
             let mut direct = Vec::new();
             oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
             assert_eq!(via, direct, "partial-seek mismatch at {off}+{n}");

--- a/musefs-core/src/telemetry.rs
+++ b/musefs-core/src/telemetry.rs
@@ -40,6 +40,7 @@ pub struct FuseTelemetry {
     pub uptime_seconds: u64,
     pub reads_inflight: u64,
     pub reads_inflight_max: u64,
+    pub read_errors: u64,
     pub dir_handles: u64,
     pub dir_handles_max: u64,
     pub pool_workers: u64,
@@ -105,6 +106,12 @@ pub fn render_prometheus(
         "musefs_reads_inflight_max",
         "Cap before reads are rejected with EAGAIN.",
         fuse.reads_inflight_max,
+    );
+    counter(
+        &mut out,
+        "musefs_read_errors_total",
+        "Reads that failed: EAGAIN load-sheds plus error replies from the read worker.",
+        fuse.read_errors,
     );
     gauge(
         &mut out,
@@ -363,6 +370,7 @@ mod tests {
             uptime_seconds: 60,
             reads_inflight: 1,
             reads_inflight_max: 1024,
+            read_errors: 7,
             dir_handles: 2,
             dir_handles_max: 1024,
             pool_workers: 8,
@@ -381,6 +389,9 @@ mod tests {
         assert!(out.contains("# TYPE musefs_handles_open gauge\nmusefs_handles_open 3\n"));
         assert!(out.contains("musefs_reads_inflight 1\n"));
         assert!(out.contains("musefs_reads_inflight_max 1024\n"));
+        assert!(
+            out.contains("# TYPE musefs_read_errors_total counter\nmusefs_read_errors_total 7\n")
+        );
         assert!(out.contains("musefs_pool_queued 0\n"));
         assert!(out.contains("musefs_readahead_budget_bytes 67108864\n"));
         assert!(out.contains("musefs_readahead_charged_bytes 8192\n"));

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -8,6 +8,17 @@ fn fold(name: &str) -> String {
     name.to_lowercase()
 }
 
+/// Split a rendered path into the components the tree actually materializes:
+/// non-empty, and never `.`/`..`. A plain (non-`$!{}`) template field whose tag
+/// value is exactly `.` or `..` survives `sanitize_into` as a literal component,
+/// so `insert_file`, the dirty-set gate, and `deepest_existing_ancestor` must all
+/// reason over this same sequence or an incremental refresh diverges from a fresh
+/// build (#518).
+fn path_components(path: &str) -> impl Iterator<Item = &str> {
+    path.split('/')
+        .filter(|c| !c.is_empty() && *c != "." && *c != "..")
+}
+
 /// Why an incremental tree mutation could not complete; the caller falls back to
 /// a full rebuild. Carries diagnostics instead of `()` (#95).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -210,6 +221,19 @@ impl VirtualTree {
         matches!(self.nodes.get(&inode).map(|n| &n.kind), Some(NodeKind::Dir))
     }
 
+    /// `(files, directories)` currently materialized: files are tracks, dirs are
+    /// every directory node except the synthetic root. O(nodes), no path
+    /// rendering — cheap enough to surface on mount (#522).
+    pub fn entry_counts(&self) -> (u64, u64) {
+        let files = self.track_to_inode.len() as u64;
+        let dir_nodes = self
+            .nodes
+            .values()
+            .filter(|n| matches!(n.kind, NodeKind::Dir))
+            .count() as u64;
+        (files, dir_nodes.saturating_sub(1))
+    }
+
     pub fn track_id(&self, inode: u64) -> Option<i64> {
         match self.nodes.get(&inode).map(|n| &n.kind) {
             Some(NodeKind::File { track_id }) => Some(*track_id),
@@ -223,10 +247,7 @@ impl VirtualTree {
     }
 
     fn insert_file(&mut self, track_id: i64, path: &str, alloc: &mut InodeAllocator) {
-        let comps: Vec<&str> = path
-            .split('/')
-            .filter(|c| !c.is_empty() && *c != "." && *c != "..")
-            .collect();
+        let comps: Vec<&str> = path_components(path).collect();
         if comps.is_empty() {
             return;
         }
@@ -695,7 +716,7 @@ impl VirtualTree {
                 .get(&id)
                 .map(|s| s.path.as_str())
                 .ok_or(RebuildError::MissingRenderedPath(id))?;
-            let comps: Vec<&str> = rendered.split('/').filter(|c| !c.is_empty()).collect();
+            let comps: Vec<&str> = path_components(rendered).collect();
             let (d, consumed) = self.deepest_existing_ancestor(rendered);
             // The first new component is the only insertion into existing
             // structure; it can shift siblings only if its base key is occupied
@@ -739,12 +760,7 @@ impl VirtualTree {
             .collect();
         // Shallow first, by component count: ROOT's path is "" (0 components),
         // which must sort before single-component dirs ("A", also 0 slashes).
-        live_dirty.sort_by_key(|d| {
-            self.path_of(*d)
-                .split('/')
-                .filter(|c| !c.is_empty())
-                .count()
-        });
+        live_dirty.sort_by_key(|d| path_components(&self.path_of(*d)).count());
         let mut done: HashSet<u64> = HashSet::new();
         let mut rebuilds = 0usize;
         for d in live_dirty {
@@ -768,7 +784,7 @@ impl VirtualTree {
     /// components it consumed — `components[consumed]` is the first component that
     /// would be newly created. Returns (ROOT, 0) if nothing below root exists.
     fn deepest_existing_ancestor(&self, rendered: &str) -> (u64, usize) {
-        let comps: Vec<&str> = rendered.split('/').filter(|c| !c.is_empty()).collect();
+        let comps: Vec<&str> = path_components(rendered).collect();
         let mut dir = Self::ROOT;
         let mut consumed = 0;
         // walk dir components only (exclude the final filename component)
@@ -974,6 +990,19 @@ mod tests {
         assert_eq!(t.inode_of_track(10), Some(song));
         assert!(t.inode_of_track(20).is_some());
         assert_eq!(t.inode_of_track(999), None);
+    }
+
+    #[test]
+    fn entry_counts_counts_files_and_non_root_dirs() {
+        // Two tracks under two album dirs plus a nested dir: 3 files, 3 dirs
+        // (Alice, Bob, Bob/Live) — the synthetic root is never counted.
+        let t = VirtualTree::build(&[
+            (10, "Alice/Song.flac".into()),
+            (20, "Bob/Tune.flac".into()),
+            (30, "Bob/Live/Encore.flac".into()),
+        ]);
+        assert_eq!(t.entry_counts(), (3, 3));
+        assert_eq!(VirtualTree::build(&[]).entry_counts(), (0, 0));
     }
 
     #[test]
@@ -1581,6 +1610,26 @@ mod tests {
             paths_of(&t).keys().collect::<Vec<_>>(),
             paths_of(&reference).keys().collect::<Vec<_>>(),
         );
+    }
+
+    #[test]
+    fn apply_changes_dot_component_collision_matches_build() {
+        // id 2's rendered path carries a literal "." component (a plain field whose
+        // tag value sanitized to exactly "."). `insert_file` strips it to "A/t.flac",
+        // colliding with id 1 — so the dirty-set gate must strip it too and mark "A"
+        // for rebuild. Before the unify, the gate reasoned over ["A", ".", "t.flac"]
+        // and skipped the rebuild, diverging from a fresh build (#518).
+        let before = vec![(1, "A/t.flac".to_string())];
+        let after = vec![(1, "A/t.flac".to_string()), (2, "A/./t.flac".to_string())];
+        assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
+    }
+
+    #[test]
+    fn apply_changes_dotdot_component_collision_matches_build() {
+        // Same as above for a literal ".." component.
+        let before = vec![(1, "A/t.flac".to_string())];
+        let after = vec![(1, "A/t.flac".to_string()), (2, "A/../t.flac".to_string())];
+        assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 
     #[test]

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -154,6 +154,16 @@ fn find_box(buf: &[u8], kind: &[u8; 4]) -> Result<Option<BoxRef>> {
     Ok(child_boxes(buf)?.into_iter().find(|b| &b.kind == kind))
 }
 
+/// Like [`find_box`] but lenient: scans only the well-formed prefix
+/// ([`child_boxes_lenient`]), so a malformed trailing child of a `----` atom
+/// can't drop a valid `name`/`mean` that precedes it — keeping the metadata
+/// extractors' "seed what you can" contract end-to-end (#524).
+fn find_box_lenient(buf: &[u8], kind: &[u8; 4]) -> Option<BoxRef> {
+    child_boxes_lenient(buf)
+        .into_iter()
+        .find(|b| &b.kind == kind)
+}
+
 /// Descend a path of box types; return `(payload_start, payload_len)` relative to
 /// `buf` for the box at the end of the path, or None if any step is missing.
 fn find_path(buf: &[u8], path: &[&[u8; 4]]) -> Result<Option<(usize, usize)>> {
@@ -361,7 +371,7 @@ fn ilst_region(buf: &[u8]) -> Option<(usize, usize)> {
 /// convention; binary-typed `data` boxes are left to [`read_binary_tags`]. Empty
 /// if malformed.
 fn read_freeform(inner: &[u8]) -> Vec<(String, String)> {
-    let Some(name_box) = find_box(inner, b"name").ok().flatten() else {
+    let Some(name_box) = find_box_lenient(inner, b"name") else {
         return Vec::new();
     };
     let np = name_box.payload(inner);
@@ -372,17 +382,14 @@ fn read_freeform(inner: &[u8]) -> Vec<(String, String)> {
     let Ok(name) = std::str::from_utf8(&np[4..]) else {
         return Vec::new();
     };
-    let mean = find_box(inner, b"mean")
-        .ok()
-        .flatten()
-        .map_or("com.apple.iTunes", |m| {
-            let p = m.payload(inner);
-            if p.len() >= 4 {
-                std::str::from_utf8(&p[4..]).unwrap_or("com.apple.iTunes")
-            } else {
-                "com.apple.iTunes"
-            }
-        });
+    let mean = find_box_lenient(inner, b"mean").map_or("com.apple.iTunes", |m| {
+        let p = m.payload(inner);
+        if p.len() >= 4 {
+            std::str::from_utf8(&p[4..]).unwrap_or("com.apple.iTunes")
+        } else {
+            "com.apple.iTunes"
+        }
+    });
     let key = crate::tagmap::mp4_freeform_to_key(mean, name)
         .map_or_else(|| name.to_string(), str::to_string);
     let mut out = Vec::new();
@@ -576,7 +583,7 @@ pub fn read_binary_tags_reporting(
         }
         let inner = atom.payload(ilst);
         // name/mean payloads carry a 4-byte FullBox prefix; default mean to iTunes.
-        let Some(name) = find_box(inner, b"name").ok().flatten().and_then(|n| {
+        let Some(name) = find_box_lenient(inner, b"name").and_then(|n| {
             let p = n.payload(inner);
             (p.len() >= 4)
                 .then(|| std::str::from_utf8(&p[4..]).ok())
@@ -584,17 +591,14 @@ pub fn read_binary_tags_reporting(
         }) else {
             continue;
         };
-        let mean = find_box(inner, b"mean")
-            .ok()
-            .flatten()
-            .map_or("com.apple.iTunes", |m| {
-                let p = m.payload(inner);
-                if p.len() >= 4 {
-                    std::str::from_utf8(&p[4..]).unwrap_or("com.apple.iTunes")
-                } else {
-                    "com.apple.iTunes"
-                }
-            });
+        let mean = find_box_lenient(inner, b"mean").map_or("com.apple.iTunes", |m| {
+            let p = m.payload(inner);
+            if p.len() >= 4 {
+                std::str::from_utf8(&p[4..]).unwrap_or("com.apple.iTunes")
+            } else {
+                "com.apple.iTunes"
+            }
+        });
         let key = format!("----:{mean}:{name}");
         // Iterate every `data` sub-box, mirroring the text path: a `----` atom can
         // carry a type-1 text value and a separate binary value, so inspecting only

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -134,6 +134,22 @@ fn child_boxes(buf: &[u8]) -> Result<Vec<BoxRef>> {
     Ok(out)
 }
 
+/// Like [`child_boxes`] but lenient: stops at the first unreadable box and
+/// returns the well-formed ones parsed so far, rather than discarding the whole
+/// list. Box sizes chain, so a malformed box leaves no reliable way to find the
+/// next — the prefix is the most that can be recovered. Used by the metadata
+/// extractors, whose contract is to seed what they can and skip the rest (#524).
+fn child_boxes_lenient(buf: &[u8]) -> Vec<BoxRef> {
+    let mut out = Vec::new();
+    let mut pos = 0;
+    while pos + 8 <= buf.len() {
+        let Ok(b) = read_box(buf, pos) else { break };
+        pos = b.end();
+        out.push(b);
+    }
+    out
+}
+
 fn find_box(buf: &[u8], kind: &[u8; 4]) -> Result<Option<BoxRef>> {
     Ok(child_boxes(buf)?.into_iter().find(|b| &b.kind == kind))
 }
@@ -370,7 +386,7 @@ fn read_freeform(inner: &[u8]) -> Vec<(String, String)> {
     let key = crate::tagmap::mp4_freeform_to_key(mean, name)
         .map_or_else(|| name.to_string(), str::to_string);
     let mut out = Vec::new();
-    for data in child_boxes(inner).unwrap_or_default() {
+    for data in child_boxes_lenient(inner) {
         if &data.kind != b"data" {
             continue;
         }
@@ -425,14 +441,14 @@ pub fn read_tags(buf: &[u8]) -> Vec<(String, String)> {
     };
     let ilst = &buf[start..start + len];
     let mut out = Vec::new();
-    for atom in child_boxes(ilst).unwrap_or_default() {
+    for atom in child_boxes_lenient(ilst) {
         let inner = atom.payload(ilst);
         if &atom.kind == b"----" {
             out.extend(read_freeform(inner));
             continue;
         }
         let text_key = crate::tagmap::mp4_atom_to_key(&atom.kind);
-        for data in child_boxes(inner).unwrap_or_default() {
+        for data in child_boxes_lenient(inner) {
             if &data.kind != b"data" {
                 continue;
             }
@@ -489,12 +505,12 @@ pub fn read_pictures_reporting(
     let ilst = &buf[start..start + len];
     let mut out = Vec::new();
     let mut dropped = Vec::new();
-    for atom in child_boxes(ilst).unwrap_or_default() {
+    for atom in child_boxes_lenient(ilst) {
         if &atom.kind != b"covr" {
             continue;
         }
         let inner = atom.payload(ilst);
-        for data in child_boxes(inner).unwrap_or_default() {
+        for data in child_boxes_lenient(inner) {
             if &data.kind != b"data" {
                 continue;
             }
@@ -554,24 +570,11 @@ pub fn read_binary_tags_reporting(
     let ilst = &buf[start..start + len];
     let mut out = Vec::new();
     let mut dropped = Vec::new();
-    for atom in child_boxes(ilst).unwrap_or_default() {
+    for atom in child_boxes_lenient(ilst) {
         if &atom.kind != b"----" {
             continue;
         }
         let inner = atom.payload(ilst);
-        let Ok(Some(data)) = find_box(inner, b"data") else {
-            continue;
-        };
-        let dp = data.payload(inner);
-        if dp.len() < 8 {
-            continue;
-        }
-        // `data` body is `[type: u32][locale: u32][value]`; type 1 == UTF-8 text,
-        // which is the text path's job. Everything else is opaque binary.
-        let type_code = u32::from_be_bytes([dp[0], dp[1], dp[2], dp[3]]);
-        if type_code == 1 {
-            continue;
-        }
         // name/mean payloads carry a 4-byte FullBox prefix; default mean to iTunes.
         let Some(name) = find_box(inner, b"name").ok().flatten().and_then(|n| {
             let p = n.payload(inner);
@@ -593,28 +596,46 @@ pub fn read_binary_tags_reporting(
                 }
             });
         let key = format!("----:{mean}:{name}");
-        if dp.len() - 8 > max_binary_tag_bytes {
-            dropped.push(OversizeDrop {
-                descriptor: key,
-                bytes: dp.len() - 8,
+        // Iterate every `data` sub-box, mirroring the text path: a `----` atom can
+        // carry a type-1 text value and a separate binary value, so inspecting only
+        // the first `data` would lose the binary one (#525).
+        for data in child_boxes_lenient(inner) {
+            if &data.kind != b"data" {
+                continue;
+            }
+            let dp = data.payload(inner);
+            if dp.len() < 8 {
+                continue;
+            }
+            // `data` body is `[type: u32][locale: u32][value]`; type 1 == UTF-8 text,
+            // which is the text path's job. Everything else is opaque binary.
+            let type_code = u32::from_be_bytes([dp[0], dp[1], dp[2], dp[3]]);
+            if type_code == 1 {
+                continue;
+            }
+            if dp.len() - 8 > max_binary_tag_bytes {
+                dropped.push(OversizeDrop {
+                    descriptor: key.clone(),
+                    bytes: dp.len() - 8,
+                });
+                continue;
+            }
+            out.push(EmbeddedBinaryTag {
+                key: key.clone(),
+                payload: dp[8..].to_vec(),
             });
-            continue;
         }
-        out.push(EmbeddedBinaryTag {
-            key,
-            payload: dp[8..].to_vec(),
-        });
     }
     (out, dropped)
 }
 
 /// Extract opaque (non-text) MP4 `----` freeform atoms for binary-tag passthrough.
-/// One `EmbeddedBinaryTag` per `----` atom whose first `data` sub-box is
-/// binary-typed (type code != 1): key `----:<mean>:<name>`, payload the `data`
-/// value bytes (after the 8-byte `[type][locale]` header). Text freeform atoms
-/// (type 1) are handled by `read_tags`, so the two paths never double-store.
-/// Lenient: malformed atoms are skipped. Only the first `data` sub-box is read
-/// (multi-value freeform is rare; mirrors `read_freeform`).
+/// One `EmbeddedBinaryTag` per binary-typed (type code != 1) `data` sub-box of
+/// each `----` atom: key `----:<mean>:<name>`, payload the `data` value bytes
+/// (after the 8-byte `[type][locale]` header). Text freeform atoms (type 1) are
+/// handled by `read_tags`, so the two paths never double-store. Lenient:
+/// malformed atoms are skipped. Every `data` sub-box is inspected, so a mixed
+/// atom carrying both a text and a binary value recovers the binary one.
 ///
 /// `max_binary_tag_bytes` caps each value: a `data` payload whose value bytes
 /// (after the 8-byte `[type][locale]` header) exceed it is skipped before any

--- a/musefs-format/src/mp4/tests.rs
+++ b/musefs-format/src/mp4/tests.rs
@@ -1599,6 +1599,46 @@ fn read_binary_tags_recovers_binary_after_a_text_data() {
 }
 
 #[test]
+fn read_freeform_recovers_before_malformed_trailing_child() {
+    // A `----` atom with a valid `name` + text `data` followed by a malformed
+    // trailing child: the lenient `name` lookup must still recover the value
+    // rather than the strict `find_box` dropping the whole atom (#524).
+    let mut name_body = 0u32.to_be_bytes().to_vec();
+    name_body.extend_from_slice(b"My Custom Field");
+    let mut inner = boxed(b"name", &name_body).unwrap();
+    inner.extend(data_atom(1, b"ok"));
+    inner.extend_from_slice(&[0, 0, 0, 99, b'b', b'a', b'd', b'!']); // overruns the buffer
+    assert_eq!(
+        read_freeform(&inner),
+        vec![("My Custom Field".to_string(), "ok".to_string())]
+    );
+}
+
+#[test]
+fn read_binary_tags_recovers_before_malformed_trailing_child() {
+    // A `----` atom with valid mean/name/binary-data followed by a malformed
+    // trailing child: the lenient name/mean lookup must still recover the tag (#524).
+    let mut mean_body = 0u32.to_be_bytes().to_vec();
+    mean_body.extend_from_slice(b"com.serato.dj");
+    let mut name_body = 0u32.to_be_bytes().to_vec();
+    name_body.extend_from_slice(b"analysis");
+    let mut inner = boxed(b"mean", &mean_body).unwrap();
+    inner.extend(boxed(b"name", &name_body).unwrap());
+    inner.extend(data_atom(0, &[0xDE, 0xAD]));
+    inner.extend_from_slice(&[0, 0, 0, 99, b'b', b'a', b'd', b'!']); // overruns the buffer
+    let atom = boxed(b"----", &inner).unwrap();
+    let moov = moov_with_ilst(&atom);
+    let tags = read_binary_tags(&moov, usize::MAX);
+    assert_eq!(
+        tags.len(),
+        1,
+        "valid binary tag survives a malformed sibling"
+    );
+    assert_eq!(tags[0].key, "----:com.serato.dj:analysis");
+    assert_eq!(tags[0].payload, vec![0xDE, 0xAD]);
+}
+
+#[test]
 fn read_binary_tags_reporting_reports_oversize_drop() {
     // A 5-byte value over the 4-byte cap: skipped from the tags, but reported
     // as a drop with its `----:<mean>:<name>` key and exact byte size.

--- a/musefs-format/src/mp4/tests.rs
+++ b/musefs-format/src/mp4/tests.rs
@@ -1529,6 +1529,76 @@ fn read_binary_tags_accepts_payload_exactly_at_budget() {
 }
 
 #[test]
+fn child_boxes_lenient_recovers_prefix_before_malformed() {
+    // A well-formed box followed by one claiming a size that overruns the buffer:
+    // the strict `child_boxes` errors, but the lenient walk returns the prefix.
+    let mut buf = bx(b"free", b"ok");
+    buf.extend_from_slice(&[0, 0, 0, 99, b'b', b'a', b'd', b'!']); // claims 99, 8 present
+    assert!(child_boxes(&buf).is_err());
+    let boxes = child_boxes_lenient(&buf);
+    assert_eq!(
+        boxes.len(),
+        1,
+        "the good box before the malformed one survives"
+    );
+    assert_eq!(&boxes[0].kind, b"free");
+}
+
+#[test]
+fn read_tags_recovers_atoms_before_a_malformed_sibling() {
+    // ilst = [good ©nam title][malformed atom]. One garbled atom must not discard
+    // the well-formed tags that precede it (#524).
+    let mut ilst = bx(b"\xa9nam", &data_atom(1, b"Title One"));
+    ilst.extend_from_slice(&[0, 0, 0, 99, b'b', b'a', b'd', b'!']); // overruns buffer
+    let moov = moov_with_ilst(&ilst);
+    let tags = read_tags(&moov);
+    assert!(
+        tags.contains(&("title".to_string(), "Title One".to_string())),
+        "title before the malformed atom is recovered: {tags:?}"
+    );
+}
+
+#[test]
+fn read_tags_recovers_data_before_a_malformed_data_sibling() {
+    // A good `data` followed by a malformed `data` inside one atom: the inner walk
+    // must keep the good value rather than discarding the whole atom (#524).
+    let mut inner = data_atom(1, b"Good");
+    inner.extend_from_slice(&[0, 0, 0, 99, b'd', b'a', b't', b'a']); // overruns buffer
+    let ilst = bx(b"\xa9nam", &inner);
+    let moov = moov_with_ilst(&ilst);
+    let tags = read_tags(&moov);
+    assert!(
+        tags.contains(&("title".to_string(), "Good".to_string())),
+        "the good data box before the malformed one is recovered: {tags:?}"
+    );
+}
+
+#[test]
+fn read_binary_tags_recovers_binary_after_a_text_data() {
+    // A `----` atom whose first `data` is type-1 text and a later one is binary:
+    // the binary path must inspect every `data`, not just the first (#525).
+    let mut mean_body = 0u32.to_be_bytes().to_vec();
+    mean_body.extend_from_slice(b"com.apple.iTunes");
+    let mut name_body = 0u32.to_be_bytes().to_vec();
+    name_body.extend_from_slice(b"MIXED");
+    let mut inner = boxed(b"mean", &mean_body).unwrap();
+    inner.extend(boxed(b"name", &name_body).unwrap());
+    inner.extend(data_atom(1, b"text-value")); // type 1 text first
+    inner.extend(data_atom(0, &[0xDE, 0xAD])); // binary second
+    let atom = boxed(b"----", &inner).unwrap();
+    let moov = moov_with_ilst(&atom);
+
+    let tags = read_binary_tags(&moov, usize::MAX);
+    assert_eq!(
+        tags.len(),
+        1,
+        "the binary value after the text one is recovered"
+    );
+    assert_eq!(tags[0].key, "----:com.apple.iTunes:MIXED");
+    assert_eq!(tags[0].payload, vec![0xDE, 0xAD]);
+}
+
+#[test]
 fn read_binary_tags_reporting_reports_oversize_drop() {
     // A 5-byte value over the 4-byte cap: skipped from the tags, but reported
     // as a drop with its `----:<mean>:<name>` key and exact byte size.

--- a/musefs-format/src/ogg/b64.rs
+++ b/musefs-format/src/ogg/b64.rs
@@ -34,10 +34,15 @@ pub fn b64_window(out_offset: u64, take: u64, img_total: u64) -> B64Window {
 }
 
 /// Encode `raw` (the bytes named by a `B64Window`) and return exactly `take`
-/// output chars starting at `skip`.
-pub fn encode_b64_slice(raw: &[u8], skip: usize, take: usize) -> Vec<u8> {
+/// output chars starting at `skip`. Returns `None` when the encoded output is
+/// shorter than `skip + take` — i.e. `raw` was shorter than the window the
+/// caller resolved against `art_total` (a truncated art blob). A checked read
+/// rather than a panic, so the serve path can surface this as `BackingChanged`
+/// like the other base64-art arms (#526).
+pub fn encode_b64_slice(raw: &[u8], skip: usize, take: usize) -> Option<Vec<u8>> {
     let enc = base64::engine::general_purpose::STANDARD.encode(raw);
-    enc.as_bytes()[skip..skip + take].to_vec()
+    let end = skip.checked_add(take)?;
+    enc.as_bytes().get(skip..end).map(<[u8]>::to_vec)
 }
 
 /// Total base64 output length for an image of `img_total` bytes, or `None` if it
@@ -80,7 +85,8 @@ mod tests {
                     let w = b64_window(o, take, img_total);
                     let raw = &img[crate::convert::usize_from(w.in_start)
                         ..crate::convert::usize_from(w.in_start + w.in_len)];
-                    let got = encode_b64_slice(raw, w.skip, crate::convert::usize_from(take));
+                    let got = encode_b64_slice(raw, w.skip, crate::convert::usize_from(take))
+                        .expect("window lies within the encoded output");
                     assert_eq!(
                         got,
                         &full[crate::convert::usize_from(o)..crate::convert::usize_from(o + take)],
@@ -89,6 +95,17 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn encode_b64_slice_returns_none_when_window_exceeds_output() {
+        // A 3-byte blob encodes to exactly 4 base64 chars ("YWJj"). A window that
+        // runs past that — as it would for an art blob shorter than its resolved
+        // `art_total` — must return None rather than panic on an out-of-range
+        // slice (#526).
+        assert_eq!(encode_b64_slice(b"abc", 0, 4), Some(b"YWJj".to_vec()));
+        assert_eq!(encode_b64_slice(b"abc", 2, 4), None);
+        assert_eq!(encode_b64_slice(b"abc", 5, 1), None);
     }
 
     #[test]

--- a/musefs-format/src/ogg/mod.rs
+++ b/musefs-format/src/ogg/mod.rs
@@ -989,11 +989,10 @@ mod tests {
                     let w = b64_window(*offset, len.get(), *art_total);
                     let raw = &image[crate::convert::usize_from(w.in_start)
                         ..crate::convert::usize_from(w.in_start + w.in_len)];
-                    bytes.extend_from_slice(&encode_b64_slice(
-                        raw,
-                        w.skip,
-                        crate::convert::usize_from(len.get()),
-                    ));
+                    bytes.extend_from_slice(
+                        &encode_b64_slice(raw, w.skip, crate::convert::usize_from(len.get()))
+                            .expect("window lies within the encoded output"),
+                    );
                 }
                 Segment::OggAudio { .. } => break, // header region ends here
                 other => panic!("unexpected {other:?}"),
@@ -1027,11 +1026,10 @@ mod tests {
                         let w = b64_window(*offset, len.get(), *art_total);
                         let raw = &img[crate::convert::usize_from(w.in_start)
                             ..crate::convert::usize_from(w.in_start + w.in_len)];
-                        bytes.extend_from_slice(&encode_b64_slice(
-                            raw,
-                            w.skip,
-                            crate::convert::usize_from(len.get()),
-                        ));
+                        bytes.extend_from_slice(
+                            &encode_b64_slice(raw, w.skip, crate::convert::usize_from(len.get()))
+                                .expect("window lies within the encoded output"),
+                        );
                     } else {
                         bytes.extend_from_slice(
                             &img[crate::convert::usize_from(*offset)

--- a/musefs-format/src/ogg/page.rs
+++ b/musefs-format/src/ogg/page.rs
@@ -412,7 +412,8 @@ fn crc_feed_art(
         let w = crate::ogg::b64::b64_window(out_off, out_len as u64, art_total);
         let mut raw = vec![0u8; crate::convert::usize_from(w.in_len)];
         src.read_window(art_id, w.in_start, &mut raw)?;
-        let enc = crate::ogg::b64::encode_b64_slice(&raw, w.skip, out_len);
+        let enc = crate::ogg::b64::encode_b64_slice(&raw, w.skip, out_len)
+            .ok_or(crate::error::FormatError::ArtRead { art_id })?;
         *crc = crc32_update(*crc, &enc);
     } else {
         let mut raw = vec![0u8; out_len];
@@ -655,7 +656,8 @@ mod tests {
             &image,
             0,
             crate::convert::usize_from(crate::ogg::b64::b64_len(image.len() as u64)),
-        );
+        )
+        .expect("full-length window lies within the encoded output");
         let tail = vec![0xB0u8; 10];
         let chunks = vec![
             PayloadChunk::Bytes(head.clone()),

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -14,8 +14,8 @@ use threadpool::ThreadPool;
 use crate::convert::{assemble_dir_listing, to_file_attr};
 use fuser::{
     BackgroundSession, Config, FileHandle, FileType, Filesystem, FopenFlags, Generation, INodeNo,
-    InitFlags, KernelConfig, LockOwner, Notifier, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory,
-    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyXattr, Request, Session,
+    InitFlags, KernelConfig, LockOwner, Notifier, OpenAccMode, OpenFlags, ReplyAttr, ReplyData,
+    ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyXattr, Request, Session,
 };
 use musefs_core::CoreError;
 use musefs_core::Fh;
@@ -177,6 +177,9 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         CoreError::NotADir(_) => fuser::Errno::ENOTDIR,
         CoreError::HandleTableFull => fuser::Errno::ENFILE,
         CoreError::Io(e) => fuser::Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)),
+        CoreError::BackingIo { source, .. } => {
+            fuser::Errno::from_i32(source.raw_os_error().unwrap_or(libc::EIO))
+        }
         CoreError::BackingChanged(_)
         | CoreError::Db(_)
         | CoreError::DbOpen { .. }
@@ -384,6 +387,11 @@ pub struct MusefsFs {
     /// over `MAX_INFLIGHT_READS` the read is rejected with `EAGAIN`, capping the
     /// otherwise-unbounded pool queue (#308).
     inflight_reads: Arc<AtomicUsize>,
+    /// Reads that failed rather than served bytes: an `EAGAIN` load-shed under
+    /// read-slot saturation, or any error reply from the read worker (EIO and
+    /// friends). Surfaced as `musefs_read_errors_total` — read-error rate is one
+    /// of the two most-wanted production metrics for a passthrough FS (#523).
+    read_errors: Arc<AtomicU64>,
     /// Per-open rendered `.musefs-metrics/metrics` buffers, keyed by the fh handed
     /// out at `open` (#394). Each open snapshots once; reads slice it by absolute
     /// offset; `release` drops it. Empty/untouched unless `expose_metrics` is on.
@@ -416,6 +424,7 @@ impl MusefsFs {
             dir_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
             dir_fh: Arc::new(AtomicU64::new(1)),
             inflight_reads: Arc::new(AtomicUsize::new(0)),
+            read_errors: Arc::new(AtomicU64::new(0)),
             metrics_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
             metrics_fh: Arc::new(AtomicU64::new(1)),
         }
@@ -485,6 +494,7 @@ impl MusefsFs {
             uptime_seconds: self.mount_time.elapsed().map_or(0, |d| d.as_secs()),
             reads_inflight: self.inflight_reads.load(Ordering::Relaxed) as u64,
             reads_inflight_max: MAX_INFLIGHT_READS as u64,
+            read_errors: self.read_errors.load(Ordering::Relaxed),
             dir_handles,
             dir_handles_max: MAX_DIR_HANDLES as u64,
             pool_workers: self.pool.max_count() as u64,
@@ -603,7 +613,13 @@ impl Filesystem for MusefsFs {
         });
     }
 
-    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+        // Read-only filesystem: refuse write-intent opens at the daemon. The mount
+        // also carries MountOption::RO so the kernel VFS blocks writes, but the
+        // daemon should not itself hand back a handle for O_WRONLY/O_RDWR (#527).
+        if flags.acc_mode() != OpenAccMode::O_RDONLY {
+            return reply.error(fuser::Errno::EROFS);
+        }
         if platform::spotlight::is_marker(ino.0) {
             // Stateless empty file: fh 0 means `release` skips it (its
             // NonZeroU64 guard) and `read` short-circuits on `is_marker`.
@@ -618,6 +634,10 @@ impl Filesystem for MusefsFs {
             // Check + id + insert under one lock hold: concurrent opens can't race
             // the count past the cap, and a rejected open burns no id (#394).
             if handles.len() >= MAX_METRICS_HANDLES {
+                log::warn!(
+                    "open({}) rejected: ENFILE — metrics-handle table full at {MAX_METRICS_HANDLES}",
+                    ino.0
+                );
                 return reply.error(fuser::Errno::ENFILE);
             }
             let fh = self.metrics_fh.fetch_add(1, Ordering::Relaxed);
@@ -667,9 +687,14 @@ impl Filesystem for MusefsFs {
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 try_admit_dir_handle(&mut guard, &counter, MAX_DIR_HANDLES, listing)
             };
-            match admitted {
-                Some(fh) => reply.opened(FileHandle(fh), FopenFlags::empty()),
-                None => reply.error(fuser::Errno::ENFILE),
+            if let Some(fh) = admitted {
+                reply.opened(FileHandle(fh), FopenFlags::empty());
+            } else {
+                log::warn!(
+                    "opendir({ino}) rejected: ENFILE — dir-handle table full at {MAX_DIR_HANDLES}",
+                    ino = ino.0
+                );
+                reply.error(fuser::Errno::ENFILE);
             }
         });
     }
@@ -806,9 +831,15 @@ impl Filesystem for MusefsFs {
         // Reserve a slot on the dispatch thread before enqueuing; over the cap,
         // reject with EAGAIN so the unbounded pool queue can't grow (#308).
         let Some(slot) = reserve_read_slot(&self.inflight_reads, MAX_INFLIGHT_READS) else {
+            self.read_errors.fetch_add(1, Ordering::Relaxed);
+            log::warn!(
+                "read({}) rejected: EAGAIN — {MAX_INFLIGHT_READS} reads already in flight (load-shedding)",
+                ino.0
+            );
             return reply.error(fuser::Errno::EAGAIN);
         };
         let core = Arc::clone(&self.core);
+        let read_errors = Arc::clone(&self.read_errors);
         self.pool.execute(move || {
             // `_slot` (named) holds the guard until the read completes or the
             // worker panics, then releases it. Do NOT simplify to bare `_`: that
@@ -834,7 +865,12 @@ impl Filesystem for MusefsFs {
                 );
                 match outcome {
                     Ok(()) => reply.data(&buf),
-                    Err(e) => reply.error(e),
+                    Err(e) => {
+                        // read_outcome already logged the cause (via reply_errno or
+                        // the panic handler); count it for the read-error rate (#523).
+                        read_errors.fetch_add(1, Ordering::Relaxed);
+                        reply.error(e);
+                    }
                 }
                 if buf.capacity() > MAX_RETAINED_READ_BUF {
                     buf.shrink_to(MAX_RETAINED_READ_BUF);
@@ -939,11 +975,19 @@ pub fn mount_with(
     config: FuseConfig,
 ) -> std::io::Result<()> {
     let allow_other = config.allow_other;
+    let (files, dirs) = core.entry_counts();
+    let mode = core.mode();
     let fs = MusefsFs::new(core, config);
     let cell = fs.notifier_cell();
     let session = new_session(fs, mountpoint, fs_name, allow_other)?;
     let _ = cell.set(session.notifier());
     let bg = session.spawn()?;
+    // Mount succeeded and the session is serving: surface what was mounted so an
+    // empty or wrong DB is distinguishable from a correctly serving one (#522).
+    log::info!(
+        "musefs mounted at {}: {files} files in {dirs} directories ({mode:?})",
+        mountpoint.display()
+    );
     bg.join()
 }
 


### PR DESCRIPTION
Resolves all 14 open issues across bug fixes, observability, performance, and docs. Six themed commits; every commit passes the full pre-commit gate (fmt, clippy `-D warnings`, full workspace tests, mutant-anchor guard). Also verified: `cargo test -p musefs-core --features metrics` (501 passed) and `cargo +nightly fuzz build` (all targets).

## Bugs
- **#518** tree: `insert_file`, the dirty-set gate, and `deepest_existing_ancestor` now share `path_components`, so an incremental refresh can't diverge from a fresh build on a tag value that renders a literal `.`/`..` component.
- **#524** mp4: `child_boxes_lenient` keeps the well-formed prefix instead of discarding all tags/pictures when one atom (or inner `data` box) is garbled.
- **#525** mp4: the binary-tag reader iterates every `data` sub-box, so a `----` atom mixing a text and a binary value keeps the binary one.
- **#526** ogg: `encode_b64_slice` returns `None` (checked read) instead of panicking on a truncated art blob; callers map it to a clean error.

## Observability
- **#521** `CoreError::BackingIo` carries the backing-file path — the most common passthrough failure now logs path+errno, not a bare EIO.
- **#522** a successful mount logs the db/template and file/dir counts (`Musefs::entry_counts`), so an empty/wrong DB is no longer silent.
- **#523** `musefs_read_errors_total` counts EAGAIN load-sheds and read-worker error replies; the EAGAIN/ENFILE load-shedding paths now log.

## Performance
- **#519** `ReadAheadPool::touch` is best-effort (`try_lock` + skip), so concurrent multi-stream playback no longer serializes every pread on one process-wide mutex.
- **#520** pure backing-audio reads skip the DB connection pool entirely (`read_segments_into` takes `Option<&Db>`).
- **#528** `serve_ogg_window` snapshots the per-file page memo once per serve instead of locking it twice per page with a header clone on each hit.

## Cleanup / docs
- **#527** `open()` rejects write-intent opens with EROFS at the daemon.
- **#529** drop the blanket `#[allow(dead_code)]` on `mod readahead` (removed one genuinely dead field it was hiding).
- **#530** systemd example: `MUSEFS_KEEP_CACHE` default is `true`.
- **#531** installation.md cross-references the fusermount3 AppArmor prerequisite.

Fixes #518
Fixes #519
Fixes #520
Fixes #521
Fixes #522
Fixes #523
Fixes #524
Fixes #525
Fixes #526
Fixes #527
Fixes #528
Fixes #529
Fixes #530
Fixes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entry count statistics now available for filesystem monitoring.
  * Read error telemetry tracking for improved diagnostics.

* **Bug Fixes**
  * Enhanced recovery from malformed MP4 metadata structures.
  * Improved error messages for backing file I/O failures.
  * Fixed file reading for layouts without database backing.

* **Performance**
  * Reduced contention in prefetch thread scheduling.

* **Documentation**
  * Added Ubuntu 24.04+ AppArmor mounting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->