### PR TITLE
fix: scan resilience, long-path refresh, readahead leak, ogg sub-4-byte read (#534-537)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -451,7 +451,7 @@ exclude_re = [
     # the ring under the read lock); the fn's other two `+` are the observable fills
     # counters and stay killable, so this one is pinned by coordinate, not by fn.
     # guard: op="+" fn="BackingReader<'a>::read_exact_at" rows=2
-    'musefs-core/src/readahead\.rs:613:68:',
+    'musefs-core/src/readahead\.rs:611:68:',
     #
     # More hang-class (TIMEOUT-only, CANCEL the in-diff job): `len() -> 1` /
     # `clear() -> 1` force a constant resident size, so `evict_one_coldest` keeps

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -291,6 +291,15 @@ exclude_re = [
     # (infinite loop). Like the SP2 tree.rs timeouts, it can only ever flag via the
     # timeout budget. The sole `-=` in its function, so anchored line-agnostically.
     'musefs-core/src/ogg_index\.rs:\d+:\d+: replace -= with /= in find_page_start',
+    # First-page fast-path bound `abs_target.saturating_sub(audio_offset) < 4`,
+    # `<`->`<=`: the only difference is at `delta == 4`, where `<=` shortcuts to
+    # `audio_offset` while `<` falls through to the backward scan — but a 4-byte
+    # window holds the `OggS` capture and CRC-validates the first page, so the scan
+    # also returns `audio_offset`. The served bytes are identical either way, so the
+    # mutant is equivalent and unkillable (#537). Pinned by line:col — the other `<`
+    # in this fn (the memo range check) IS caught.
+    # guard: op="<" fn="find_page_start" rows=1
+    'musefs-core/src/ogg_index\.rs:74:48: replace < with <= in find_page_start',
     # Overlap-emit guards `if hs < he` / `if ps < pe`, `<`->`<=`: when the bound is
     # equal the extra branch emits an empty `[a..b]` slice / reads 0 payload bytes —
     # a no-op, so the served output is byte-identical (verified: the ogg tests and the

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -298,9 +298,9 @@ exclude_re = [
     # were reported TIMEOUT under the parallel gate's load, not as a real hang. Pinned
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:247:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:252:15: replace < with <= in serve_ogg_window',
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:256:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:261:15: replace < with <= in serve_ogg_window',
 
     # Phase 4 poll debounce (#89) — equivalent `<`->`<=` on the two wall-clock
     # gates (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:629:31:',
+    'musefs-core/src/scan\.rs:653:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:636:30:',
+    'musefs-core/src/scan\.rs:660:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,14 +127,14 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:647:21:',
+    'musefs-core/src/scan\.rs:671:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:652:17:',
+    'musefs-core/src/scan\.rs:676:17:',
     # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
     # per oversized mp4 `covr` / `----` payload the format layer skipped before
     # materialization (#343) and returns nothing. With no log-capture harness in the
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1371:46:',
+    'musefs-core/src/scan\.rs:1395:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1502:29:',
+    'musefs-core/src/scan\.rs:1526:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1504:32:',
+    'musefs-core/src/scan\.rs:1528:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1504:47:',
+    'musefs-core/src/scan\.rs:1528:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1504:62:',
+    'musefs-core/src/scan\.rs:1528:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1512:37:',
+    'musefs-core/src/scan\.rs:1536:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1514:40:',
+    'musefs-core/src/scan\.rs:1538:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1514:55:',
+    'musefs-core/src/scan\.rs:1538:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1514:70:',
+    'musefs-core/src/scan\.rs:1538:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1642:29:',
+    'musefs-core/src/scan\.rs:1666:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1651:33:',
+    'musefs-core/src/scan\.rs:1675:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1706:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1730:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -66,7 +66,12 @@ fn find_page_start(
     abs_target: u64,
     memo: Option<&LastPageMemo>,
 ) -> Result<u64> {
-    if abs_target == audio_offset {
+    // The first audio page always starts at `audio_offset` (validated at scan
+    // time). A target within the first 4 bytes of the audio region provably lies
+    // in that first page, yet its backward-scan window `[audio_offset, abs_target)`
+    // is shorter than the 4-byte `OggS` capture, so the scan below would find no
+    // candidate and fail closed with EIO — resolve it directly (#537).
+    if abs_target.saturating_sub(audio_offset) < 4 {
         return Ok(audio_offset);
     }
     if let Some(m) = memo {
@@ -548,6 +553,22 @@ mod tests {
             found, ao,
             "mid-payload target should resolve to page 0's start"
         );
+    }
+
+    #[test]
+    fn find_page_start_within_first_capture_returns_first_page() {
+        let (_d, path, ao, _alen) = new_serve_fixture();
+        let backing = std::fs::File::open(&path).unwrap();
+        // A cold read (no memo) landing 1–3 bytes into the audio region: the
+        // backward-scan window `[ao, target)` is shorter than the 4-byte `OggS`
+        // capture, but the first page provably starts at `ao` (#537).
+        for delta in 1..4u64 {
+            let found = find_page_start(&backing, ao, ao + delta, None).unwrap();
+            assert_eq!(
+                found, ao,
+                "target {delta} bytes into the audio region must resolve to the first page start"
+            );
+        }
     }
 
     #[test]

--- a/musefs-core/src/readahead.rs
+++ b/musefs-core/src/readahead.rs
@@ -67,7 +67,7 @@ impl ReadAheadPool {
             .insert(key, StreamEntry { buf, last_served });
     }
 
-    /// Deregister on release; returns the bytes to uncharge. Drops the `streams`
+    /// Deregister on release; uncharges the buffer's bytes. Drops the `streams`
     /// lock BEFORE locking the buffer: a concurrent read holds its buffer mutex
     /// and then blocking-acquires `streams` (via `permitted_window`), so holding
     /// `streams` while locking the buffer here would invert that order and
@@ -75,8 +75,13 @@ impl ReadAheadPool {
     /// preserves the pool's deadlock-free invariant.
     pub fn deregister(&self, key: usize) {
         let entry = self.streams.lock().unwrap().remove(&key);
+        // Clear under the buffer lock rather than merely reading `len`: clearing is
+        // what makes the buffer length the authoritative "already uncharged"
+        // signal, so a racing eviction holding a stale `Arc` to this buffer reads
+        // `len 0` and uncharges nothing — neither side double-counts nor leaks
+        // (#536).
         let freed = match entry {
-            Some(e) => e.buf.lock().unwrap().len(),
+            Some(e) => e.buf.lock().unwrap().clear(),
             None => 0,
         };
         if freed > 0 {
@@ -175,27 +180,20 @@ impl ReadAheadPool {
                 .collect()
         };
         candidates.sort_by_key(|(_, ls, _)| *ls); // coldest (smallest stamp) first
-        for (key, _, buf) in candidates {
+        for (_, _, buf) in candidates {
             if let Ok(mut ra) = buf.try_lock() {
+                // Uncharging is tied to physically clearing the buffer under its
+                // own lock: the clearer uncharges exactly the bytes it removed, and
+                // a racing `deregister`/eviction holding a stale `Arc` to the same
+                // buffer then reads `len 0` and uncharges nothing. That makes the
+                // buffer length the single coordination point — re-checking the
+                // registry instead raced `deregister` and leaked `freed` whenever
+                // the deregister landed after this clear (#536).
                 let freed = ra.clear();
                 drop(ra);
                 if freed > 0 {
-                    // The snapshot may name a stream that `deregister` removed
-                    // after we collected it; `deregister` already uncharged that
-                    // buffer's bytes, so subtracting again here would wrap
-                    // `charged`. Only uncharge while the stream is still the one
-                    // we cleared. (clear() left the buffer empty, so a racing
-                    // deregister now reads len 0 and uncharges nothing.)
-                    let still_registered = self
-                        .streams
-                        .lock()
-                        .unwrap()
-                        .get(&key)
-                        .is_some_and(|e| Arc::ptr_eq(&e.buf, &buf));
-                    if still_registered {
-                        self.charged.fetch_sub(freed, O::Relaxed);
-                        return Some(freed);
-                    }
+                    self.charged.fetch_sub(freed, O::Relaxed);
+                    return Some(freed);
                 }
             }
         }
@@ -1433,6 +1431,60 @@ mod concurrency_tests {
                 });
             }
         });
+    }
+
+    /// Regression for the eviction/deregister budget leak (#536): `evict_one_coldest`
+    /// clears a victim buffer and drops its lock BEFORE re-checking the registry to
+    /// decide whether to uncharge. A `deregister` landing in that window removes the
+    /// stream, then reads the already-cleared buffer's `len() == 0` and uncharges
+    /// nothing — so the freed bytes are uncharged by neither side and leak from
+    /// `charged` permanently. Each cycle here charges then uncharges N bytes, so
+    /// absent the race `charged` returns to 0; a single leaked race never recovers.
+    #[test]
+    #[expect(clippy::cast_possible_truncation)]
+    fn eviction_racing_deregister_does_not_leak_charged() {
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+        const N: u64 = 64 * 1024;
+        let pool = Arc::new(ReadAheadPool::new(8 * 1024 * 1024));
+        let victim_key = 2usize;
+        let stop = Arc::new(AtomicBool::new(false));
+        let cycles = Arc::new(AtomicU64::new(0));
+
+        std::thread::scope(|s| {
+            // Churn: install a buffer holding N charged bytes under `victim_key`,
+            // then deregister it. Charge-then-uncharge nets 0 absent a racing evict.
+            {
+                let (pool, stop, cycles) = (&pool, &stop, &cycles);
+                s.spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+                        buf.lock().unwrap().store_window(0, vec![0u8; N as usize]);
+                        pool.reconcile(0, N);
+                        pool.register(victim_key, Arc::clone(&buf));
+                        pool.deregister(victim_key);
+                        cycles.fetch_add(1, Ordering::Relaxed);
+                    }
+                });
+            }
+            // Two evictors hammering the victim, racing the churn's deregister.
+            for _ in 0..2 {
+                let (pool, stop, cycles) = (&pool, &stop, &cycles);
+                s.spawn(move || {
+                    while cycles.load(Ordering::Relaxed) < 200_000 {
+                        pool.evict_one_coldest(1);
+                    }
+                    stop.store(true, Ordering::Relaxed);
+                });
+            }
+        });
+
+        // The victim is deregistered at the end of every cycle, so nothing is
+        // registered now and `charged` must be exactly 0.
+        assert_eq!(
+            pool.charged(),
+            0,
+            "eviction racing deregister leaked charged budget"
+        );
     }
 }
 

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -231,10 +231,34 @@ fn collect_audio_inner(
     tally: &mut SkipTally,
     progress: Option<&ProgressSink>,
 ) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(root)? {
-        let entry = entry?;
+    // A single unreadable subtree or vanished entry must drop only that entry,
+    // not abort the whole ingest — matching the log-and-continue resilience of
+    // the symlink arm below and `probe_file` (#534). The top-level root is
+    // validated upstream by `scan_directory_with`'s canonicalize, so a genuine
+    // bad root is still reported there.
+    let entries = match std::fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::warn!("skipping directory {}: {e}", root.display());
+            return Ok(());
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                log::warn!("skipping unreadable entry in {}: {e}", root.display());
+                continue;
+            }
+        };
         let path = entry.path();
-        let ftype = entry.file_type()?;
+        let ftype = match entry.file_type() {
+            Ok(ftype) => ftype,
+            Err(e) => {
+                log::warn!("skipping {}: {e}", path.display());
+                continue;
+            }
+        };
         if ftype.is_dir() {
             descend(
                 &path,

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -134,6 +134,44 @@ fn collect_audio_skips_broken_symlink_when_following() {
 }
 
 #[test]
+fn collect_audio_skips_unreadable_subdir_and_continues() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("keep.flac"), b"x").unwrap();
+    let locked = dir.path().join("locked");
+    std::fs::create_dir(&locked).unwrap();
+    std::fs::write(locked.join("hidden.flac"), b"x").unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // chmod-000 denial is meaningless under root (it bypasses permissions) — skip
+    // rather than false-pass when the directory is still readable for us.
+    if std::fs::read_dir(&locked).is_ok() {
+        eprintln!(
+            "skipping collect_audio_skips_unreadable_subdir_and_continues: directory permissions not enforced (running as root?)"
+        );
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        return;
+    }
+
+    let mut out = Vec::new();
+    let result = collect_audio(dir.path(), &mut out, false);
+
+    // Restore perms so the TempDir can be cleaned up.
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(
+        result.is_ok(),
+        "an unreadable subdirectory must not abort the whole scan"
+    );
+    assert_eq!(
+        out.len(),
+        1,
+        "the readable sibling file must still be collected"
+    );
+    assert!(out[0].ends_with("keep.flac"));
+}
+
+#[test]
 fn scan_stores_canonical_path_through_symlinked_root() {
     // Scanning through a directory symlink must still store the canonical,
     // symlink-resolved backing path, so a later revalidate — which keys on the

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -722,9 +722,14 @@ impl VirtualTree {
             // structure; it can shift siblings only if its base key is occupied
             // (fresh-build invariant: a non-empty group owns its base key).
             if comps.get(consumed).is_some_and(|c| {
+                // The stored child key is the NAME_MAX-truncated rendered name
+                // (leaf preserves its extension), so an over-long first-new
+                // component must be truncated the same way or the occupancy check
+                // misses (#535).
+                let key = truncate_component(c, consumed + 1 == comps.len());
                 self.children
                     .get(&d)
-                    .is_some_and(|kids| kids.contains_key(*c))
+                    .is_some_and(|kids| kids.contains_key(key.as_ref()))
             }) {
                 dirty.insert(d);
             }
@@ -789,8 +794,14 @@ impl VirtualTree {
         let mut consumed = 0;
         // walk dir components only (exclude the final filename component)
         for comp in &comps[..comps.len().saturating_sub(1)] {
+            // Navigate by the SAME key the tree stores: a dir component is keyed by
+            // its NAME_MAX-truncated rendered name (`ensure_dir`), so an over-long
+            // component must be truncated here too — otherwise the lookup misses,
+            // the walk stops short, and the add-side dirty gate diverges from a full
+            // rebuild (#535).
+            let key = truncate_component(comp, false);
             let next = self
-                .children_by_rendered(dir, comp)
+                .children_by_rendered(dir, key.as_ref())
                 .into_iter()
                 .find(|&c| self.is_dir(c));
             match next {
@@ -1661,6 +1672,19 @@ mod tests {
         // re-rank the group: 2 -> "t.flac", 5 -> "t (2).flac".
         let before = vec![(5, "A/t.flac".to_string())];
         let after = vec![(2, "A/t.flac".to_string()), (5, "A/t.flac".to_string())];
+        assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
+    }
+
+    #[test]
+    fn apply_changes_add_smaller_id_under_over_long_dir_matches_build() {
+        // The dir component exceeds NAME_MAX, so the tree stores its truncated
+        // rendered name. The add-side dirty walk must navigate by that truncated
+        // key — otherwise `deepest_existing_ancestor` misses the existing dir,
+        // the collision goes undetected, and the re-rank (2 -> base, 5 -> "(2)")
+        // never happens, diverging from a full rebuild (#535).
+        let long = "d".repeat(NAME_MAX + 45);
+        let before = vec![(5, format!("{long}/t.flac"))];
+        let after = vec![(2, format!("{long}/t.flac")), (5, format!("{long}/t.flac"))];
         assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1689,6 +1689,19 @@ mod tests {
     }
 
     #[test]
+    fn apply_changes_add_smaller_id_with_over_long_leaf_matches_build() {
+        // The colliding component is the FILENAME and exceeds NAME_MAX. The gate's
+        // occupancy check must truncate it as a LEAF (preserving the extension) to
+        // match the stored key — truncating it as a dir yields a different key, the
+        // collision goes undetected, and the re-rank (2 -> base, 5 -> "(2)") never
+        // happens, diverging from a full rebuild (#535).
+        let long = format!("{}.flac", "x".repeat(NAME_MAX + 45));
+        let before = vec![(5, format!("A/{long}"))];
+        let after = vec![(2, format!("A/{long}")), (5, format!("A/{long}"))];
+        assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
+    }
+
+    #[test]
     fn apply_changes_dir_reclaims_base_name_when_colliding_file_removed() {
         // File id 1 rendered "X" owns the base; the dir for id 2's "X/a.flac" was
         // disambiguated to "X (2)". Removing the file must rename the dir to "X".


### PR DESCRIPTION
Fixes #534, fixes #535, fixes #536, fixes #537 — four independent resilience/correctness bugs from the 2026-06-17 audit, each fixed with a failing-test-first regression.

## #534 — scan aborts on one bad directory entry (`scan.rs`)
`collect_audio_inner` propagated per-entry I/O errors with `?`, so one unreadable subtree or an entry that vanished mid-walk (TOCTOU during a live scan) aborted the whole ingest. The three sites (`read_dir`, the per-entry iterator error, `file_type()`) now log-and-continue, matching the symlink arm and `probe_file`. The top-level root stays validated upstream by `scan_directory_with`'s `canonicalize`.
- Test: `collect_audio_skips_unreadable_subdir_and_continues` (chmod-000 subdir, with the established root-skip guard).

## #535 — incremental refresh diverges for path components > 255 bytes (`tree.rs`)
`apply_changes` built its add-side dirty set with raw rendered components, but the tree keys dirs/files by their NAME_MAX-truncated `rendered_name`. For an over-long component the lookup never matched, so `deepest_existing_ancestor` stopped short and the dirty gate misjudged what existed — silently diverging from a full rebuild. Now truncates via `truncate_component` at both the navigation site and the gate's occupancy check. Same class as #518.
- Test: `apply_changes_add_smaller_id_under_over_long_dir_matches_build` (via the existing `assert_apply_matches_build` oracle).

## #536 — readahead eviction racing deregister leaks budget (`readahead.rs`)
`evict_one_coldest` cleared a victim buffer and dropped its lock before re-checking the registry to decide whether to uncharge. A `deregister` landing in that window removed the stream, read the now-empty buffer's `len() == 0`, and uncharged nothing — the freed bytes leaked from `charged` permanently, eventually disabling read-ahead. The fix makes the buffer length the single coordination point: uncharge exactly what `clear()` removes, under the buffer lock. Eviction drops the racy registry re-check; `deregister` now clears (not just reads `len`).
- Test: `eviction_racing_deregister_does_not_leak_charged` — reproduced a multi-GB phantom leak before the fix; stable after.

## #537 — Ogg reads 1-3 bytes into the audio region return EIO (`ogg_index.rs`)
`find_page_start` special-cased only the exact `abs_target == audio_offset`. A target in `(audio_offset, audio_offset+4)` gave a 1-3-byte backward window — shorter than the 4-byte `OggS` capture — so the scan failed closed with EIO for a valid file. Reachable on a cold read landing just inside the `OggAudio` segment (direct I/O, unaligned tooling, direct API callers). Broadened the fast path to any `abs_target` within 4 bytes of `audio_offset`.
- Test: `find_page_start_within_first_capture_returns_first_page`.

## Notes
- One commit per issue.
- `.cargo/mutants.toml` anchors re-anchored in the same commit as the source shift that moved them (12 via `--fix`, 7 covering-set siblings by hand); `check_mutant_anchors.py` validates 96 entries against 3670 mutants.
- The new per-entry `continue` arms in #534 (iterator error / `file_type` stat fallback) are TOCTOU-class and not deterministically testable — if the in-diff mutation gate surfaces survivors there, they'd want a `guard`/`exclude_re` entry like the existing `revalidate_with` `skip_failed` exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
