### PR TITLE
fix(cli): boolish env flags, dry-run without mountpoint, M4B in scan help

### DIFF
--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -75,9 +75,10 @@ pub struct Cli {
 #[derive(clap::Args, Debug)]
 #[allow(clippy::struct_excessive_bools)] // independent CLI toggles, not a state machine
 pub struct MountArgs {
-    /// Empty directory to mount at.
-    #[arg(env = "MUSEFS_MOUNTPOINT")]
-    pub mountpoint: PathBuf,
+    /// Empty directory to mount at. Not required with `--dry-run`, which only
+    /// previews the template and never touches a target (#555).
+    #[arg(env = "MUSEFS_MOUNTPOINT", required_unless_present = "dry_run")]
+    pub mountpoint: Option<PathBuf>,
     /// Path to the SQLite database (must already exist; unlike `scan`, mount
     /// never creates it).
     #[arg(long, env = "MUSEFS_DB")]
@@ -103,7 +104,7 @@ pub struct MountArgs {
     /// substituting `--default-fallback` (per-field `--fallback` chains and
     /// `[...]` sections still apply). Useful when an external writer only tags a
     /// subset of tracks, e.g. skipping tracks beets left without a `beets_path`.
-    #[arg(long, env = "MUSEFS_SKIP_ON_MISSING", default_value_t = false)]
+    #[arg(long, env = "MUSEFS_SKIP_ON_MISSING", value_parser = clap::builder::BoolishValueParser::new())]
     pub skip_on_missing: bool,
     /// How file contents are served.
     #[arg(long, value_enum, env = "MUSEFS_MODE", default_value_t = CliMode::Synthesis)]
@@ -125,7 +126,7 @@ pub struct MountArgs {
     /// Enable Phase-2 background prefetch threads (advanced). Off by default:
     /// read amplification alone carries the read-ahead win; the threads add
     /// overhead without benefit on tested backends (NFS, SSD). See the benchmarks docs: https://sohex.github.io/musefs/benchmarks.html
-    #[arg(long, env = "MUSEFS_READ_AHEAD_PREFETCH", default_value_t = false)]
+    #[arg(long, env = "MUSEFS_READ_AHEAD_PREFETCH", value_parser = clap::builder::BoolishValueParser::new())]
     pub read_ahead_prefetch: bool,
     /// Max outstanding background (readahead/async) requests the kernel queues.
     #[arg(long, env = "MUSEFS_MAX_BACKGROUND", default_value_t = 64)]
@@ -179,7 +180,7 @@ pub struct MountArgs {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Walk backing files or directories, ingesting supported audio
-    /// (FLAC, MP3, M4A, Ogg, WAV) into the SQLite store.
+    /// (FLAC, MP3, M4A/M4B, Ogg, WAV) into the SQLite store.
     Scan {
         /// One or more files or directories to scan (directories recurse).
         #[arg(required = true, num_args = 1..)]
@@ -412,27 +413,32 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     if !args.db.exists() {
         anyhow::bail!("database does not exist: {}", args.db.display());
     }
-    if !args.dry_run && !args.mountpoint.is_dir() {
-        if args.mountpoint.exists() {
+    // `--dry-run` previews a template and never mounts, so it needs no
+    // mountpoint (#555); clap guarantees one for every other invocation.
+    if !args.dry_run {
+        let mountpoint = args
+            .mountpoint
+            .as_deref()
+            .expect("clap requires a mountpoint unless --dry-run");
+        if !mountpoint.is_dir() {
+            if mountpoint.exists() {
+                anyhow::bail!("mountpoint is not a directory: {}", mountpoint.display());
+            }
             anyhow::bail!(
-                "mountpoint is not a directory: {}",
-                args.mountpoint.display()
+                "mountpoint does not exist (create it first): {}",
+                mountpoint.display()
             );
         }
-        anyhow::bail!(
-            "mountpoint does not exist (create it first): {}",
-            args.mountpoint.display()
-        );
-    }
-    // The mountpoint help says "Empty directory", but FUSE happily mounts over a
-    // populated one and shadows its contents for the mount's lifetime. Warn so a
-    // typo (or reusing a real music folder) doesn't silently hide files (#508).
-    if !args.dry_run && mountpoint_is_nonempty(&args.mountpoint) {
-        eprintln!(
-            "warning: mountpoint {} is not empty; its existing contents will be \
-             hidden behind the virtual tree until you unmount",
-            args.mountpoint.display()
-        );
+        // The mountpoint help says "Empty directory", but FUSE happily mounts over a
+        // populated one and shadows its contents for the mount's lifetime. Warn so a
+        // typo (or reusing a real music folder) doesn't silently hide files (#508).
+        if mountpoint_is_nonempty(mountpoint) {
+            eprintln!(
+                "warning: mountpoint {} is not empty; its existing contents will be \
+                 hidden behind the virtual tree until you unmount",
+                mountpoint.display()
+            );
+        }
     }
     let db =
         Db::open(&args.db).with_context(|| format!("opening database at {}", args.db.display()))?;
@@ -447,7 +453,11 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     if args.dry_run {
         return print_dry_run(&core);
     }
-    signal::install_unmount_on_signal(args.mountpoint.clone())
+    let mountpoint = args
+        .mountpoint
+        .as_deref()
+        .expect("clap requires a mountpoint unless --dry-run");
+    signal::install_unmount_on_signal(mountpoint.to_path_buf())
         .context("installing the stop-signal unmount handler")?;
     // The "is it serving the right library?" context, logged before the blocking
     // mount call; `mount_with` emits the success line with the file/dir counts once
@@ -455,18 +465,17 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     log::info!(
         "mounting database {} at {} (template {:?})",
         args.db.display(),
-        args.mountpoint.display(),
+        mountpoint.display(),
         template,
     );
-    musefs_fuse::mount_with(core, &args.mountpoint, "musefs", fuse_config).map_err(|e| {
+    musefs_fuse::mount_with(core, mountpoint, "musefs", fuse_config).map_err(|e| {
         // A bare EACCES from fusermount3 (e.g. an AppArmor-denied prefix) is
         // otherwise opaque. Append actionable guidance — but not when the
         // allow_other preflight already produced its own self-contained message
         // (it names /etc/fuse.conf), to avoid stacking two different hints (#509).
         let add_hint = e.kind() == std::io::ErrorKind::PermissionDenied
             && !e.to_string().contains("/etc/fuse.conf");
-        let err =
-            anyhow::Error::new(e).context(format!("mounting at {}", args.mountpoint.display()));
+        let err = anyhow::Error::new(e).context(format!("mounting at {}", mountpoint.display()));
         if add_hint {
             err.context(MOUNT_DENIED_HELP)
         } else {

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -23,7 +23,10 @@ fn parses_scan_and_mount_invocations() {
     ]);
     match cli.command {
         Command::Mount(args) => {
-            assert_eq!(args.mountpoint.to_str(), Some("/mnt/x"));
+            assert_eq!(
+                args.mountpoint.as_deref().and_then(|p| p.to_str()),
+                Some("/mnt/x")
+            );
             assert_eq!(args.db.to_str(), Some("/tmp/m.db"));
             assert_eq!(args.template, "$album/$title");
             assert_eq!(args.default_fallback, "Unknown"); // default applied
@@ -139,6 +142,62 @@ fn scan_parses_checksum_and_strictness_flags() {
     }
 }
 
+#[test]
+fn scan_help_lists_m4b_format() {
+    use clap::CommandFactory;
+    let cmd = Cli::command();
+    let scan = cmd
+        .get_subcommands()
+        .find(|c| c.get_name() == "scan")
+        .expect("scan subcommand exists");
+    let about = scan.get_about().expect("scan has help text").to_string();
+    assert!(
+        about.contains("M4B"),
+        "scan help should advertise M4B; got: {about}"
+    );
+}
+
+#[test]
+fn dry_run_does_not_require_a_mountpoint() {
+    let cli = Cli::try_parse_from(["musefs", "mount", "--db", "/tmp/m.db", "--dry-run"])
+        .expect("dry-run should parse without a mountpoint");
+    match cli.command {
+        Command::Mount(args) => {
+            assert!(args.dry_run);
+            assert_eq!(args.mountpoint, None);
+        }
+        Command::Scan { .. } => panic!("expected mount"),
+    }
+}
+
+#[test]
+fn mount_without_dry_run_still_requires_a_mountpoint() {
+    let err = Cli::try_parse_from(["musefs", "mount", "--db", "/tmp/m.db"])
+        .expect_err("a real mount must demand a mountpoint");
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn boolish_mount_flags_work_as_bare_switches() {
+    let cli = Cli::try_parse_from([
+        "musefs",
+        "mount",
+        "/mnt/x",
+        "--db",
+        "/tmp/m.db",
+        "--skip-on-missing",
+        "--read-ahead-prefetch",
+    ])
+    .expect("bare boolish switches should still parse");
+    match cli.command {
+        Command::Mount(args) => {
+            assert!(args.skip_on_missing);
+            assert!(args.read_ahead_prefetch);
+        }
+        Command::Scan { .. } => panic!("expected mount"),
+    }
+}
+
 use musefs_cli::parse_mount_config;
 use musefs_core::Mode;
 use std::time::Duration;
@@ -146,7 +205,7 @@ use std::time::Duration;
 #[test]
 fn parse_mount_config_defaults_are_sensible() {
     let args = MountArgs {
-        mountpoint: "/mnt/x".into(),
+        mountpoint: Some("/mnt/x".into()),
         db: "/tmp/x.db".into(),
         template: "$artist/$title".to_string(),
         default_fallback: "Unknown".to_string(),
@@ -184,7 +243,7 @@ fn parse_mount_config_defaults_are_sensible() {
 #[test]
 fn parse_mount_config_keep_cache_sets_flag() {
     let args = MountArgs {
-        mountpoint: "/mnt/x".into(),
+        mountpoint: Some("/mnt/x".into()),
         db: "/tmp/x.db".into(),
         template: "$title".to_string(),
         default_fallback: "Unknown".to_string(),
@@ -218,7 +277,7 @@ fn parse_mount_config_keep_cache_sets_flag() {
 #[test]
 fn parse_mount_config_saturating_readahead() {
     let args = MountArgs {
-        mountpoint: "/mnt/x".into(),
+        mountpoint: Some("/mnt/x".into()),
         db: "/tmp/x.db".into(),
         template: "$title".to_string(),
         default_fallback: "Unknown".to_string(),
@@ -273,7 +332,7 @@ fn parses_repeatable_fallback_flag() {
 #[test]
 fn parse_mount_config_populates_per_field_fallbacks() {
     let args = MountArgs {
-        mountpoint: "/mnt/x".into(),
+        mountpoint: Some("/mnt/x".into()),
         db: "/tmp/x.db".into(),
         template: "$albumartist/$title".to_string(),
         default_fallback: "Unknown".to_string(),


### PR DESCRIPTION
Fixes three CLI papercuts where the binary's behavior lagged its own documentation. Fixes #540, fixes #555, fixes #556

## #540 — boolish env flags rejected their documented values
`skip_on_missing` and `read_ahead_prefetch` were declared as plain clap `bool`s without the `BoolishValueParser` every other boolean flag uses, so via their env var they accepted only `true`/`false` and hard-errored on `1`/`0`/`yes`/`no`/`on`/`off` — crash-looping a systemd mount that followed the documented contract (`MUSEFS_SKIP_ON_MISSING=1`). Both now use `BoolishValueParser`, matching `allow_other`/`expose_metrics`. Bare `--skip-on-missing`/`--read-ahead-prefetch` switches still work; invalid env values still get a clean rejection.

## #555 — `mount --dry-run` required a throwaway mountpoint
`--dry-run` validates the template and walks the virtual tree without mounting, but `mountpoint` was a required positional. It is now `Option<PathBuf>` with `required_unless_present = "dry_run"`, so a template can be previewed with no target; a real mount still demands one (clap `MissingRequiredArgument`). `run_mount` resolves the mountpoint only on the mounting path.

## #556 — `scan --help` omitted M4B
The scanner accepts `.m4b` and the docs advertise it, but the `scan` doc-comment listed `(FLAC, MP3, M4A, Ogg, WAV)`. Now `(FLAC, MP3, M4A/M4B, Ogg, WAV)`.

## Tests
Added CLI tests: M4B in scan help, dry-run-without-mountpoint, mount-still-requires-mountpoint, bare-boolish-switches. Env boolish parsing (unreachable from unit tests without unsafe `set_var` on edition 2024) verified against the real binary. Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)