### PR TITLE
ci(fuzz,audit): harden the fuzz/audit security CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - '**/Cargo.toml'
       - 'Cargo.lock'
+      - 'fuzz/Cargo.lock'
       - '.github/workflows/audit.yml'
   pull_request:
     paths:
       - '**/Cargo.toml'
       - 'Cargo.lock'
+      - 'fuzz/Cargo.lock'
       - '.github/workflows/audit.yml'
 
 jobs:
@@ -28,3 +30,14 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      # audit-check above scans only the root Cargo.lock. The fuzz crate is a
+      # separate workspace (root Cargo.toml: exclude = ["fuzz"]) carrying its own
+      # pinned fuzz/Cargo.lock, so a RUSTSEC advisory or yanked crate there is
+      # invisible to both this job and the ci.yml cargo-deny gate. Re-run the root
+      # deny.toml advisory + yanked checks against the fuzz lockfile (metadata
+      # only, no build). Pinned to the same 0.19 line as the ci.yml deny job.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - name: Scan fuzz lockfile (advisories + yanked)
+        run: |
+          cargo install cargo-deny --locked --version '^0.19'
+          cargo deny --manifest-path fuzz/Cargo.toml check --config deny.toml advisories

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,9 +36,12 @@ jobs:
         with:
           workspaces: 'fuzz'
       - name: Install cargo-fuzz
-        # Not --locked: cargo-fuzz's pinned Cargo.lock has an old rustix that
-        # fails to compile on current nightly; let cargo resolve newer deps.
-        run: cargo install cargo-fuzz
+        # Pin the version (the 0.13 line) so provisioning the security harness is
+        # reproducible and a breaking upstream bump can't silently change behavior
+        # between runs of the same commit. Not --locked: cargo-fuzz's pinned
+        # Cargo.lock has an old rustix that fails to compile on current nightly,
+        # so cargo still re-resolves the dep tree within the pinned version.
+        run: cargo install cargo-fuzz --version '^0.13'
       - name: Build targets
         run: cargo +nightly fuzz build
       - name: Replay committed reproducers (-runs=0)
@@ -58,7 +61,7 @@ jobs:
           exit $status
       - name: Smoke-run each target
         run: |
-          for t in flac mp3 mp4 ogg wav ogg_page b64 vorbiscomment; do
+          for t in flac mp3 mp4 ogg wav ogg_page b64 vorbiscomment serve; do
             echo "== $t =="
             cargo +nightly fuzz run "$t" -- -max_len=131072 -rss_limit_mb=2048 -max_total_time=15
           done
@@ -84,9 +87,12 @@ jobs:
         with:
           workspaces: 'fuzz'
       - name: Install cargo-fuzz
-        # Not --locked: cargo-fuzz's pinned Cargo.lock has an old rustix that
-        # fails to compile on current nightly; let cargo resolve newer deps.
-        run: cargo install cargo-fuzz
+        # Pin the version (the 0.13 line) so provisioning the security harness is
+        # reproducible and a breaking upstream bump can't silently change behavior
+        # between runs of the same commit. Not --locked: cargo-fuzz's pinned
+        # Cargo.lock has an old rustix that fails to compile on current nightly,
+        # so cargo still re-resolves the dep tree within the pinned version.
+        run: cargo install cargo-fuzz --version '^0.13'
       # Corpus accumulates across scheduled runs via artifacts, not the Actions
       # cache. A cache is evicted after 7 days of no access and the cron is also
       # 7 days, so a single skipped/delayed/failed run (or LRU eviction under the


### PR DESCRIPTION
Closes three independent gaps in the fuzz / supply-chain audit CI surfaced by the 2026-06-17 audit.

## #548 — per-PR fuzz smoke omitted `serve`
The smoke loop (`fuzz.yml`) ran every target *except* `serve` — the largest one, exercising the `read_at` splicing path across `musefs-core`/`musefs-db` and the most likely to silently drift on a format/core API change. `cargo fuzz build` caught compile breaks, but a target that builds yet aborts on trivial input was only detected by the weekly cron. Added `serve` to the smoke list (matching the scheduled matrix order).

## #552 — cargo-fuzz installed unpinned
Both fuzz jobs ran `cargo install cargo-fuzz` with no version pin, so each run provisioned whatever was latest and re-resolved the dep tree — nondeterministic provisioning of the memory-safety harness. Pinned to `^0.13`, mirroring the existing cargo-deny `^0.19` convention. `--locked` intentionally stays off (cargo-fuzz's pinned lockfile has an old rustix that fails on current nightly).

## #553 — `fuzz/Cargo.lock` was never advisory- or yanked-scanned
`audit.yml` triggered on `Cargo.lock` (root only) and `ci.yml`'s cargo-deny reads the workspace, which excludes the fuzz crate. The fuzz crate's own pinned `fuzz/Cargo.lock` was invisible to both gates. Added `fuzz/Cargo.lock` to `audit.yml`'s path triggers and a fuzz-scoped `cargo deny check --config deny.toml advisories` step (covers advisories **and** yanked, reusing the root `deny.toml`), riding the existing weekly cron.

## Verification
- `yamllint` clean on both workflows.
- Ran the new fuzz-scoped cargo-deny command locally against `fuzz/Cargo.lock`: `advisories ok`, exit 0.
- Pre-commit hook (full workspace test suite + fmt + clippy + shell/YAML lints) passed.

Fixes #548
Fixes #552
Fixes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)