### PR TITLE
fix(core,db): harden read fallback, scan tally, snapshot leak + prefetch race (#541,#544,#549,#550,#551)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:653:31:',
+    'musefs-core/src/scan\.rs:660:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:660:30:',
+    'musefs-core/src/scan\.rs:667:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,14 +127,14 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:671:21:',
+    'musefs-core/src/scan\.rs:678:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:676:17:',
+    'musefs-core/src/scan\.rs:683:17:',
     # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
     # per oversized mp4 `covr` / `----` payload the format layer skipped before
     # materialization (#343) and returns nothing. With no log-capture harness in the
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1395:46:',
+    'musefs-core/src/scan\.rs:1402:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1526:29:',
+    'musefs-core/src/scan\.rs:1533:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1528:32:',
+    'musefs-core/src/scan\.rs:1535:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1528:47:',
+    'musefs-core/src/scan\.rs:1535:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1528:62:',
+    'musefs-core/src/scan\.rs:1535:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1536:37:',
+    'musefs-core/src/scan\.rs:1543:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1538:40:',
+    'musefs-core/src/scan\.rs:1545:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1538:55:',
+    'musefs-core/src/scan\.rs:1545:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1538:70:',
+    'musefs-core/src/scan\.rs:1545:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1666:29:',
+    'musefs-core/src/scan\.rs:1673:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1675:33:',
+    'musefs-core/src/scan\.rs:1682:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1730:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1737:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ name = "musefs-db"
 version = "1.0.0"
 dependencies = [
  "base16ct",
+ "log",
  "rusqlite",
  "sha2",
  "strum",

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -441,14 +441,24 @@ impl Musefs {
         let cap = self.readahead_pool.per_stream_cap();
         let (start, window) = br.prefetch_plan();
         let depth = crate::readahead::prefetch_depth(cap, window);
-        let (starts, upto) = crate::readahead::plan_prefetch(
-            h.prefetched_upto.load(Ordering::Relaxed),
-            start,
-            window,
-            depth,
-            backing_len,
-        );
-        h.prefetched_upto.store(upto, Ordering::Relaxed);
+        // Publish the advanced watermark with a CAS rather than a non-atomic
+        // load-plan-store: FUSE dispatches reads on one fh concurrently across
+        // workers, so two reads observing the same `prefetched_upto` would both
+        // plan and enqueue the same windows (duplicate preads), and a plain
+        // `store` could clobber a more-advanced watermark from the other read.
+        // On contention, re-plan against the watermark the winner published so
+        // we enqueue only the still-unclaimed tail (#550).
+        let starts = loop {
+            let prev = h.prefetched_upto.load(Ordering::Relaxed);
+            let (starts, upto) =
+                crate::readahead::plan_prefetch(prev, start, window, depth, backing_len);
+            if h.prefetched_upto
+                .compare_exchange_weak(prev, upto, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break starts;
+            }
+        };
         if starts.is_empty() {
             return Ok(());
         }
@@ -572,11 +582,45 @@ impl Musefs {
             }
         }
         // Fallback (no prior open, or unknown handle): resolve by inode and open.
+        // Bounded retry mirrors the handle fast path: a refresh or same-track
+        // re-tag landing between the resolve and the snapshot's content_version
+        // recheck makes `read_at_into` return a retryable `BackingChanged`;
+        // re-resolving (a cheap content_version-cache hit when unchanged) picks
+        // up the new version and re-serves transparently, rather than mapping a
+        // perfectly servable file to a spurious EIO (#541). A genuine backing
+        // drift re-resolves to the same stale stamp and surfaces after the bound.
         let track_id = self.track_id_for(inode)?;
-        self.pool.with(|db| {
-            let resolved = self.cache.resolve(db, track_id)?;
-            read_at_into(&resolved, db, offset, size, out)
-        })
+        let mut last = None;
+        for _attempt in 0..4 {
+            out.clear();
+            // A test seam forces the first N attempts stale to drive the
+            // retry-exhaustion path deterministically; compiled out of release.
+            #[cfg(test)]
+            let forced = self
+                .force_version_mismatch
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| n.checked_sub(1))
+                .is_ok();
+            #[cfg(not(test))]
+            let forced = false;
+            let r = self.pool.with(|db| -> Result<()> {
+                let resolved = self.cache.resolve(db, track_id)?;
+                if forced {
+                    return Err(CoreError::BackingChanged(
+                        resolved.backing_path.to_string_lossy().into_owned(),
+                    ));
+                }
+                read_at_into(&resolved, db, offset, size, out)
+            });
+            match r {
+                Ok(()) => return Ok(()),
+                // Stale layout under the race — re-resolve next iteration.
+                Err(e @ CoreError::BackingChanged(_)) => last = Some(e),
+                Err(e) => return Err(e),
+            }
+        }
+        // Pathological constant re-tagging raced every attempt; surface the
+        // retryable error rather than risk wrong bytes.
+        Err(last.expect("the retry loop runs at least once"))
     }
 
     /// Allocating form of `read_into`.
@@ -614,6 +658,8 @@ impl Musefs {
         let generation = self.refresh_gen.load(Ordering::Acquire);
         let resolved = self.pool.with(|db| self.cache.resolve(db, track_id))?;
         crate::metrics::on_open();
+        // Opens the semi-trusted DB path verbatim — see the trust-boundary note
+        // on `ResolvedFile::backing_path` in `HeaderCache::build` (#551).
         let file = Arc::new(
             std::fs::File::open(&resolved.backing_path)
                 .map_err(|e| CoreError::backing_io(&resolved.backing_path, e))?,

--- a/musefs-core/src/facade/tests.rs
+++ b/musefs-core/src/facade/tests.rs
@@ -455,6 +455,88 @@ fn same_track_retag_storm_exhausts_read_retry_into_backing_changed() {
     fs.release_handle(fh);
 }
 
+/// The stateless fallback path (`read` with no open handle — a freshly
+/// looked-up inode) must absorb a mid-read `content_version` race the same way
+/// the handle fast path does: re-resolve and re-serve up to the bound rather
+/// than surfacing a spurious `BackingChanged`/EIO for a perfectly servable
+/// file. Three forced misses still serve on the final attempt; a fourth
+/// exhausts the loop and errors. (#541)
+#[test]
+fn no_handle_fallback_retries_content_version_race_before_backing_changed() {
+    use crate::scan::scan_directory;
+    use id3::frame::{Content, Unknown};
+    use id3::{Encoder, Frame, TagLike, Version};
+    use std::collections::BTreeMap;
+
+    let needle = [0xDEu8, 0xAD, 0xBE, 0xEF];
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let mut tag = id3::Tag::new();
+        tag.add_frame(Frame::with_content(
+            "PRIV",
+            Content::Unknown(Unknown {
+                data: needle.to_vec(),
+                version: Version::Id3v24,
+            }),
+        ));
+        let mut bytes = Vec::new();
+        Encoder::new()
+            .version(Version::Id3v24)
+            .encode(&tag, &mut bytes)
+            .unwrap();
+        bytes.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00, 0, 0, 0, 0]);
+        std::fs::write(dir.path().join("a.mp3"), &bytes).unwrap();
+    }
+
+    let db_path = dir.path().join("m.db");
+    {
+        let db = musefs_db::Db::open(&db_path).unwrap();
+        scan_directory(&db, dir.path()).unwrap();
+    }
+    let cfg = MountConfig {
+        template: "$artist/$title".to_string(),
+        fallbacks: BTreeMap::new(),
+        default_fallback: "Unknown".to_string(),
+        mode: Mode::Synthesis,
+        poll_interval: std::time::Duration::ZERO,
+        case_insensitive: false,
+        read_ahead_budget: 64 * 1024 * 1024,
+        read_ahead_prefetch: false,
+        skip_on_missing: false,
+    };
+    let fs = Musefs::open(musefs_db::Db::open(&db_path).unwrap(), cfg).unwrap();
+
+    let artist = fs
+        .lookup(VirtualTree::ROOT, "Unknown")
+        .expect("fallback artist dir");
+    let (_, file_inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+
+    // No `open_handle` — every read here exercises the stateless fallback.
+    let baseline = fs.read(file_inode, None, 0, 1 << 20).unwrap();
+    assert!(
+        baseline.windows(needle.len()).any(|w| w == needle),
+        "baseline fallback read must serve the binary-tag layout"
+    );
+
+    // bound-1 forced misses: the fallback retries and serves on the final attempt.
+    fs.force_version_mismatches_for_test(3);
+    let after_three = fs
+        .read(file_inode, None, 0, 1 << 20)
+        .expect("three retries must still serve on the final attempt");
+    assert_eq!(after_three, baseline);
+
+    // One miss per attempt: the loop exhausts and surfaces the retryable error.
+    fs.force_version_mismatches_for_test(4);
+    match fs.read(file_inode, None, 0, 1 << 20) {
+        Err(CoreError::BackingChanged(_)) => {}
+        other => panic!("exhausted fallback retry must return BackingChanged, got {other:?}"),
+    }
+
+    // Seam drained: the fallback serves again.
+    let recovered = fs.read(file_inode, None, 0, 1 << 20).unwrap();
+    assert_eq!(recovered, baseline, "fallback must recover after the storm");
+}
+
 #[test]
 fn render_entries_returns_paths_and_snapshot() {
     use crate::scan::scan_directory;

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -348,6 +348,16 @@ impl HeaderCache {
             total_len,
             track_id: track.id,
             content_version: track.content_version,
+            // Trust boundary: `backing_path` is taken verbatim from the DB row
+            // and later opened with default flags (O_RDONLY, symlinks followed)
+            // at the serve sites below. The external-writer store contract
+            // treats the DB as semi-trusted, so a buggy/hostile writer could
+            // point this at an arbitrary path the mount uid can read. There is
+            // deliberately no realpath/containment check here: musefs has no
+            // serve-time library-root to contain against, and the audio-bytes
+            // invariant (served bytes are byte-identical to the named file)
+            // still holds — the served bytes are simply *some* file's, not a
+            // guaranteed-intended one. Documented, not enforced (#551).
             backing_path: PathBuf::from(&track.backing_path),
             stamp: BackingStamp::from_track(track),
             mtime_secs: mtime_secs_val,
@@ -401,6 +411,8 @@ pub fn read_at_into<M>(
     // via `validate_opened_backing`; this stateless fallback must too.
     let file = if needs_file {
         crate::metrics::on_open();
+        // Opens the semi-trusted DB path verbatim — see the trust-boundary note
+        // on `ResolvedFile::backing_path` in `HeaderCache::build` (#551).
         let f = std::fs::File::open(&resolved.backing_path)
             .map_err(|e| CoreError::backing_io(&resolved.backing_path, e))?;
         let f_meta = f

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -314,6 +314,13 @@ fn collect_audio_inner(
                     log::warn!("skipping broken symlink {}: {e}", path.display());
                 }
             }
+        } else {
+            // A direct special file (FIFO, char/block device, socket) — not a
+            // file, dir, or symlink. The audio invariant is unaffected (it is
+            // never opened), but tally it so it surfaces in the skip breakdown
+            // rather than vanishing without a trace, matching unsupported
+            // regular files above (#544).
+            tally.record(&path);
         }
     }
     Ok(())

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -235,6 +235,29 @@ fn collect_audio_ignores_symlink_to_non_file_target_when_following() {
 }
 
 #[test]
+fn collect_audio_tallies_direct_special_file_with_audio_extension() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    // A FIFO named like a track is a special file reached *directly* by the walk
+    // (not behind a symlink): it is neither a regular file, dir, nor symlink, so
+    // it must be tallied as a skip rather than vanishing without a trace (#544).
+    let fifo = dir.path().join("track.flac");
+    let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    #[expect(unsafe_code, reason = "libc::mkfifo FFI; no std equivalent")]
+    let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+    assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+
+    let mut out = Vec::new();
+    let tally = collect_audio(dir.path(), &mut out, false).unwrap();
+    assert!(out.is_empty(), "a special file must never be collected");
+    assert_eq!(
+        tally.total, 1,
+        "a direct special file must be tallied as skipped"
+    );
+}
+
+#[test]
 fn probe_returns_none_for_supported_ext_with_garbage_contents() {
     let dir = tempfile::tempdir().unwrap();
     for name in ["bad.flac", "bad.mp3", "bad.m4a", "bad.wav", "bad.opus"] {

--- a/musefs-db/Cargo.toml
+++ b/musefs-db/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 base16ct = "1.0"
 # fallible_uint enables the checked FromSql/ToSql impls for u64/usize, which
 # validate non-negative row columns at the boundary (the cast-convention spec).
+log = "0.4"
 rusqlite = { version = "0.40", features = ["bundled", "blob", "fallible_uint"] }
 sha2 = "0.11"
 strum = { version = "0.28", features = ["derive"] }

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -213,6 +213,20 @@ impl<M> Db<M> {
     /// a single consistent snapshot until `end_read`. Used to make a binary-tag
     /// read's content_version check and its blob reads mutually consistent.
     pub fn begin_read(&self) -> Result<()> {
+        // Defense-in-depth: if a prior snapshot leaked — its `end_read` ROLLBACK
+        // failed and the error was swallowed (the core callers do `let _ =
+        // db.end_read()`), or a future caller forgot the pairing — the connection
+        // is still mid-transaction and a raw BEGIN would fail with rusqlite's
+        // opaque "cannot start a transaction within a transaction", pointing at
+        // the symptom rather than the leak. Self-heal by rolling the stale
+        // snapshot back first, with a diagnostic naming the actual cause (#549).
+        if !self.conn.is_autocommit() {
+            log::warn!(
+                "begin_read found a leaked read transaction on this connection; \
+                 rolling it back (a prior end_read likely failed to release the snapshot)"
+            );
+            self.conn.execute_batch("ROLLBACK")?;
+        }
         self.conn.execute_batch("BEGIN DEFERRED")?;
         Ok(())
     }
@@ -556,6 +570,23 @@ mod render_key_tests {
         reader.end_read().unwrap();
         // After the snapshot ends, the reader sees the new version.
         assert_eq!(reader.track_content_version(id).unwrap(), 1);
+    }
+
+    /// A leaked read snapshot — a `begin_read` whose `end_read` ROLLBACK never
+    /// ran (the core callers swallow `end_read`'s error) — leaves the connection
+    /// mid-transaction. The next `begin_read` must self-heal rather than fail
+    /// with rusqlite's opaque "cannot start a transaction within a transaction"
+    /// (#549).
+    #[test]
+    fn begin_read_self_heals_a_leaked_prior_snapshot() {
+        let db = open_mem();
+        db.begin_read().unwrap();
+        // Leak it: no end_read.
+        assert!(
+            db.begin_read().is_ok(),
+            "a leaked read snapshot must self-heal, not surface an opaque error"
+        );
+        db.end_read().unwrap();
     }
 }
 


### PR DESCRIPTION
Five independent serve/scan hardening fixes. Each has a dedicated test (except #550, see note) and no audio-bytes-invariant impact.

## #541 — no-fh stateless read fallback returns EIO on a concurrent re-tag
`Fixes #541`
The stateless fallback (`read_into` with no open handle) now wraps resolve + `read_at_into` in the same bounded 4-attempt retry as the handle fast path, re-resolving on a `BackingChanged` `content_version` race instead of mapping a perfectly servable file to a spurious EIO. A genuine backing drift still surfaces after the bound.
Test: `no_handle_fallback_retries_content_version_race_before_backing_changed`.

## #544 — direct special files silently dropped and not tallied
`Fixes #544`
`collect_audio_inner` gains the missing terminal `else` arm, so a direct FIFO/device/socket with an audio extension is tallied (and surfaces in the end-of-scan skip breakdown) instead of vanishing without a trace, matching how unsupported regular files are handled. Still never opened.
Test: `collect_audio_tallies_direct_special_file_with_audio_extension`.

## #549 — leaked read transaction surfaces as an opaque error
`Fixes #549`
`begin_read` now self-heals: if the connection is mid-transaction (`!is_autocommit()`) it logs a diagnostic naming the leak and rolls the stale snapshot back before `BEGIN`, instead of failing with rusqlite's opaque "cannot start a transaction within a transaction". Adds the `log` facade to `musefs-db`.
Test: `begin_read_self_heals_a_leaked_prior_snapshot`.

## #550 — non-atomic prefetch watermark dispatches duplicate preads
`Fixes #550`
`serve_backing` publishes `prefetched_upto` via a `compare_exchange` loop instead of a non-atomic load-plan-store, so concurrent reads on one fh don't both plan the same windows (duplicate preads) or clobber a more-advanced watermark; on contention it re-plans against the winner's value. Efficiency-only — correctness is already covered by `concurrent_reads_same_handle_match_oracle`; a deterministic duplicate-pread regression test isn't feasible without invasive instrumentation.

## #551 — backing_path opened verbatim from the semi-trusted DB
`Fixes #551`
Documents the trust boundary at `HeaderCache::build` (where the semi-trusted DB path becomes the served path) and at the two open sites: the path is opened verbatim with default flags, there is no serve-time library root to contain against, and the audio-bytes invariant still holds. Documented, not enforced (per discussion).

---

Closes #541 Closes #544 Closes #549 Closes #550 Closes #551

Re-anchored `.cargo/mutants.toml` for the `scan.rs` line shift (12 via `--fix`, 4 covering-set entries manually). Pre-commit (fmt, clippy -D warnings, full workspace tests, mutant-anchor guard, ruff) green; `cargo test -p musefs-core --features metrics` also green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry logic for read operations when file backing changes, improving resilience
  * Improved database transaction handling with automatic recovery from leaked snapshots
  * Enhanced scan results to properly account for special files like FIFOs and device nodes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->