### PR TITLE
fix(mp4,cli,release): lenient ilst walk, QuickTime meta, scan exit code, smoke audio invariant

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -88,6 +88,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   falling through to fuser's default, which logged a `[Not Implemented]` warn on
   every xattr probe (`ls -l`, indexers, backup tools). The caller-visible result
   is unchanged (#364).
+- **MP4 path-to-`ilst` leniency:** the walk to `moov/udta/meta/ilst` now uses the
+  same lenient box scan as the metadata extractors, so a single malformed or
+  truncated sibling box anywhere on the path no longer suppresses an otherwise
+  well-formed `ilst` and silently drops every tag and cover. The audio/structure
+  path stays strict (#542).
+- **QuickTime bare `meta` atoms:** the `meta` parser only consumes the 4-byte
+  FullBox version/flags prefix when it is actually present (a zero word), so a
+  QuickTime-style bare `meta` — which has no such prefix — is read instead of
+  landing mid-header and dropping all tags and art (#543).
+- **`scan` exit code on ingest failure:** `scan`/`scan --revalidate` now exit `2`
+  when any file fails to parse/ingest (`failed > 0`), instead of always exiting
+  `0`. A pipeline such as `musefs scan … && musefs mount …` can now detect a
+  partial or total ingest failure; a clean scan still exits `0` and a hard error
+  still exits `1` (#554).
+- **Release smoke audio-bytes check:** `scripts/smoke-binary.sh` (the per-arch
+  release gate) now compares the served file's encoded audio stream against the
+  untouched backing file, asserting the cardinal byte-identical-audio invariant
+  rather than only checking the `fLaC` magic — so a target-specific positioned-read
+  or offset regression in a cross-compiled binary is caught (#547).
 
 ## [1.0.0] - 2026-06-12
 

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -39,6 +39,14 @@ to the wrong parser, fails, and is counted here rather than retried. Renaming
 files across formats makes them vanish from the mount; fix the extension and
 rescan.
 
+If any file fails (`failed Y` with `Y > 0`), `scan` exits **2** even though the
+batch otherwise completes and the parseable files are ingested — so a pipeline
+like `musefs scan … && musefs mount …` stops on a partial or total ingest
+failure rather than mounting an incomplete library. A successful scan exits `0`;
+a hard error (a missing target, an unreadable DB) still exits `1`. The exit code
+is the only machine-detectable signal; per-file failures otherwise surface only
+on stderr.
+
 `--revalidate` is the maintenance pass: it skips unchanged files —
 **preserving any tag edits you made in the store** — prunes tracks whose
 backing file is gone, and garbage-collects orphaned art.

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -2,6 +2,7 @@
 //! SQLite store) and `mount` (serve a read-only FUSE view of that store).
 
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
@@ -223,6 +224,11 @@ pub enum Command {
 /// ingest. With `quiet`, suppress the per-target summary on stdout. Fails fast:
 /// the first failing target aborts the batch; targets already scanned stay
 /// committed (ingest is an idempotent upsert).
+///
+/// Returns the total per-file `failed` count across all targets. Per-file
+/// failures (an unparseable/uningestible entry) do not abort the batch — only a
+/// hard `Err` does — so the caller inspects the returned count to signal partial
+/// or total ingest failure via the process exit code (#554).
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub fn run_scan(
     db_path: &Path,
@@ -234,7 +240,7 @@ pub fn run_scan(
     checksum: ChecksumMode,
     fast: bool,
     strict: bool,
-) -> Result<()> {
+) -> Result<u64> {
     let strictness = match (fast, strict) {
         (true, true) => anyhow::bail!("--fast and --strict are mutually exclusive"),
         (true, false) => musefs_core::MatchStrictness::Fast,
@@ -252,12 +258,14 @@ pub fn run_scan(
         strictness,
         ..Default::default()
     };
+    let mut total_failed = 0u64;
     for target in targets {
         reporter.start_target();
         let start = Instant::now();
         if revalidate {
             let stats = musefs_core::revalidate_with(&db, target, &opts)
                 .with_context(|| format!("revalidating {}", target.display()))?;
+            total_failed += stats.failed;
             if !quiet {
                 println!(
                     "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed in {}",
@@ -272,6 +280,7 @@ pub fn run_scan(
         } else {
             let stats = musefs_core::scan_directory_with(&db, target, &opts)
                 .with_context(|| format!("scanning {}", target.display()))?;
+            total_failed += stats.failed;
             if !quiet {
                 println!(
                     "scanned {}: {} file(s), skipped {}, failed {} in {}",
@@ -285,7 +294,7 @@ pub fn run_scan(
         }
     }
     reporter.finish();
-    Ok(())
+    Ok(total_failed)
 }
 
 /// Split a `--fallback FIELD=VALUE` argument. The value may contain '=' (only
@@ -550,8 +559,7 @@ fn walk_preview(
     Ok(())
 }
 
-/// Dispatch a parsed CLI invocation.
-pub fn run(cli: Cli) -> Result<()> {
+pub fn run(cli: Cli) -> Result<ExitCode> {
     match cli.command {
         Command::Scan {
             targets,
@@ -563,18 +571,30 @@ pub fn run(cli: Cli) -> Result<()> {
             checksum,
             fast,
             strict,
-        } => run_scan(
-            &db,
-            &targets,
-            revalidate,
-            jobs,
-            follow_symlinks,
-            quiet,
-            checksum,
-            fast,
-            strict,
-        ),
-        Command::Mount(args) => run_mount(&args),
+        } => {
+            let failed = run_scan(
+                &db,
+                &targets,
+                revalidate,
+                jobs,
+                follow_symlinks,
+                quiet,
+                checksum,
+                fast,
+                strict,
+            )?;
+            // Per-file ingest failures are not a hard error (they don't abort the
+            // batch), but a pipeline like `scan && mount` needs a machine-detectable
+            // signal that not everything ingested. Exit 2 marks any per-file failure
+            // (partial or total); it overlaps clap's usage-error code, but only ever
+            // fires after a successful parse + run (#554).
+            Ok(if failed > 0 {
+                ExitCode::from(2)
+            } else {
+                ExitCode::SUCCESS
+            })
+        }
+        Command::Mount(args) => run_mount(&args).map(|()| ExitCode::SUCCESS),
     }
 }
 

--- a/musefs-cli/tests/scan.rs
+++ b/musefs-cli/tests/scan.rs
@@ -140,6 +140,39 @@ fn scan_fails_fast_on_a_bad_target() {
     assert!(result.is_err());
 }
 
+#[test]
+fn scan_returns_per_file_failed_count() {
+    // A per-file parse failure does not abort the batch (that stays an Ok return);
+    // instead it is tallied and surfaced via the returned `failed` count so the CLI
+    // can signal partial/total ingest failure with a non-zero exit (#554).
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(
+        backing.path().join("good.flac"),
+        make_flac(&["TITLE=Good"], &[0xAB; 32]),
+    )
+    .unwrap();
+    std::fs::write(backing.path().join("bad.flac"), b"not a flac at all").unwrap();
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("musefs.db");
+
+    let failed = run_scan(
+        &db_path,
+        &[backing.path().to_path_buf()],
+        false,
+        0,
+        false,
+        false,
+        ChecksumMode::Fingerprint,
+        false,
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(failed, 1, "the one unparseable file must be tallied");
+    let db = musefs_db::Db::open(&db_path).unwrap();
+    assert_eq!(db.list_tracks().unwrap().len(), 1, "the good file ingested");
+}
+
 fn write_n_flacs(dir: &std::path::Path, n: usize) {
     for i in 0..n {
         let title = format!("TITLE=T{i}");

--- a/musefs-format/src/mp4.rs
+++ b/musefs-format/src/mp4.rs
@@ -350,18 +350,35 @@ pub fn read_structure_from<R: Read + Seek>(
     })
 }
 
-/// Locate `moov/udta/meta/ilst`; `meta` is a FullBox (4 version/flags bytes before
-/// its children). Returns the ilst payload range absolute within `buf`.
+/// Locate `moov/udta/meta/ilst` and return the ilst payload range absolute within
+/// `buf`. The walk is lenient ([`find_box_lenient`]) at every level: a single
+/// malformed sibling box anywhere on the path must not suppress an otherwise
+/// well-formed `ilst`, matching the metadata extractors' "seed what you can"
+/// contract (#542). Strictness is reserved for the audio/structure path.
+///
+/// `meta` is normally an ISO FullBox — 4 version/flags bytes precede its children —
+/// but QuickTime also uses a bare `meta` with no such prefix. Per ISO 14496-12 the
+/// version/flags word is always zero, so a zero first word marks the FullBox variant
+/// (skip 4) and any other value marks the bare variant (skip 0) (#543). A bare
+/// first child declaring `size == 0` ("extends to end") is the one ambiguous case
+/// and is misread as a FullBox, mirroring the wider tooling's heuristic.
 fn ilst_region(buf: &[u8]) -> Option<(usize, usize)> {
-    let moov = find_box(buf, b"moov").ok()??;
+    let moov = find_box_lenient(buf, b"moov")?;
     let mp = moov.payload(buf);
     let base = moov.payload_start();
-    let (up, ul) = find_path(mp, &[b"udta"]).ok()??;
-    let udta = &mp[up..up + ul];
-    let meta = find_box(udta, b"meta").ok()??;
-    let meta_children = udta.get(meta.payload_start() + 4..meta.end())?;
-    let il = find_box(meta_children, b"ilst").ok()??;
-    let start = base + up + meta.payload_start() + 4 + il.payload_start();
+    let udta = find_box_lenient(mp, b"udta")?;
+    let up = udta.payload_start();
+    let udta_payload = udta.payload(mp);
+    let meta = find_box_lenient(udta_payload, b"meta")?;
+    let meta_payload = meta.payload(udta_payload);
+    let prefix = if meta_payload.get(..4) == Some(&[0, 0, 0, 0][..]) {
+        4
+    } else {
+        0
+    };
+    let meta_children = meta_payload.get(prefix..)?;
+    let il = find_box_lenient(meta_children, b"ilst")?;
+    let start = base + up + meta.payload_start() + prefix + il.payload_start();
     Some((start, il.total_len - il.header_len))
 }
 

--- a/musefs-format/src/mp4/tests.rs
+++ b/musefs-format/src/mp4/tests.rs
@@ -303,6 +303,52 @@ fn read_side_never_panics_on_garbage() {
 }
 
 #[test]
+fn read_tags_survives_malformed_box_after_ilst() {
+    // A single malformed sibling box trailing `ilst` inside `meta` must not
+    // suppress the well-formed `ilst`: the path-to-ilst walk is lenient, matching
+    // the metadata extractors' "seed what you can" contract (#542).
+    let ilst = bx(b"ilst", &bx(b"\xa9nam", &data_atom(1, b"Song")));
+    let mut hdlr = vec![0u8; 8];
+    hdlr.extend_from_slice(b"mdir");
+    hdlr.extend_from_slice(b"appl");
+    hdlr.extend_from_slice(&[0u8; 9]);
+    let mut meta = vec![0u8; 4]; // FullBox version/flags
+    meta.extend(bx(b"hdlr", &hdlr));
+    meta.extend(ilst);
+    meta.extend_from_slice(&100u32.to_be_bytes()); // box claims 100 bytes...
+    meta.extend_from_slice(b"junk"); // ...but only 8 are present -> malformed
+    let udta = bx(b"udta", &bx(b"meta", &meta));
+    let moov = bx(b"moov", &[bx(b"mvhd", &[0u8; 8]), udta].concat());
+    let buf = [bx(b"ftyp", b"M4A "), moov, bx(b"mdat", b"AUDIO")].concat();
+    let tags = read_tags(&buf);
+    assert!(
+        tags.contains(&("title".into(), "Song".into())),
+        "got {tags:?}"
+    );
+}
+
+#[test]
+fn read_tags_reads_quicktime_bare_meta() {
+    // A QuickTime-style `meta` has no FullBox version/flags prefix; its children
+    // begin immediately. The +4 FullBox skip would land mid-header and drop every
+    // tag, so the version/flags prefix is only consumed when present (#543).
+    let ilst = bx(b"ilst", &bx(b"\xa9nam", &data_atom(1, b"Song")));
+    let mut hdlr = vec![0u8; 8];
+    hdlr.extend_from_slice(b"mdir");
+    hdlr.extend_from_slice(b"appl");
+    hdlr.extend_from_slice(&[0u8; 9]);
+    let meta = [bx(b"hdlr", &hdlr), ilst].concat(); // no version/flags prefix
+    let udta = bx(b"udta", &bx(b"meta", &meta));
+    let moov = bx(b"moov", &[bx(b"mvhd", &[0u8; 8]), udta].concat());
+    let buf = [bx(b"ftyp", b"M4A "), moov, bx(b"mdat", b"AUDIO")].concat();
+    let tags = read_tags(&buf);
+    assert!(
+        tags.contains(&("title".into(), "Song".into())),
+        "got {tags:?}"
+    );
+}
+
+#[test]
 fn build_udta_no_art_round_trips() {
     let tags = vec![
         TagInput::new("title", "Song"),

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -33,7 +33,7 @@ fn jemalloc_stats() -> Option<musefs_fuse::AllocatorStats> {
     })
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
     // The library crates report serve-path failures through the `log` facade;
     // without a sink they vanish. Default to `warn` so they surface on stderr;
@@ -51,9 +51,12 @@ fn main() {
         enable_jemalloc_background_thread();
         musefs_fuse::set_alloc_probe(jemalloc_stats);
     }
-    if let Err(e) = run(cli) {
-        eprintln!("musefs: {e:#}");
-        std::process::exit(1);
+    match run(cli) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("musefs: {e:#}");
+            std::process::ExitCode::from(1)
+        }
     }
 }
 

--- a/musefs/tests/cli_process.rs
+++ b/musefs/tests/cli_process.rs
@@ -150,6 +150,43 @@ fn scan_succeeds_and_ingests_through_the_binary() {
 }
 
 #[test]
+fn scan_with_a_failing_file_exits_two() {
+    // A per-file ingest failure does not abort the batch, but it must surface as a
+    // non-zero exit so a pipeline like `scan && mount` can detect partial/total
+    // ingest failure. Exit 2 is the chosen signal (#554).
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("library");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::write(
+        target.join("good.flac"),
+        make_flac(&["TITLE=Good"], &[0xAB; 32]),
+    )
+    .unwrap();
+    std::fs::write(target.join("bad.flac"), b"not a flac at all").unwrap();
+    let db = dir.path().join("library.db");
+
+    let out = musefs()
+        .arg("scan")
+        .arg(&target)
+        .arg("--db")
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "a scan with a failing file should exit 2, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The good file still ingested; the failure is a signal, not a rollback.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("failed 1"),
+        "expected the summary to report one failure, stdout: {stdout}"
+    );
+}
+
+#[test]
 fn scan_with_checksum_full_exits_zero() {
     let (_dir, target, db) = library_with_one_flac();
     let out = musefs()

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -51,6 +51,24 @@ BYTES="$(wc -c < "$SONG")"
 if [ "$BYTES" -le 0 ]; then echo "FAIL: served file is empty"; exit 1; fi
 echo "smoke: read $BYTES bytes from $SONG (fLaC OK)"
 
+# The cardinal invariant: original audio bytes are served byte-identical. The
+# synthesized header legitimately differs (re-tagged metadata blocks), so compare
+# only the encoded audio packets ('-map 0:a -c copy'), which must match the
+# untouched backing file bit-for-bit. A target-specific positioned-read/offset bug
+# that corrupts the spliced audio region passes the fLaC-magic check above but is
+# caught here.
+audio_md5() {
+  ffmpeg -hide_banner -loglevel error -i "$1" -map 0:a -c copy -f md5 - 2>/dev/null
+}
+SERVED_AUDIO="$(audio_md5 "$SONG")"
+BACKING_AUDIO="$(audio_md5 "$WORK/backing/a.flac")"
+if [ -z "$SERVED_AUDIO" ]; then echo "FAIL: could not hash served audio stream"; exit 1; fi
+if [ "$SERVED_AUDIO" != "$BACKING_AUDIO" ]; then
+  echo "FAIL: served audio bytes differ from backing (served=$SERVED_AUDIO backing=$BACKING_AUDIO)"
+  exit 1
+fi
+echo "smoke: served audio stream matches backing ($SERVED_AUDIO)"
+
 # Exercise the SIGTERM graceful-unmount handler on the real binary.
 kill -TERM "$PID"
 i=0


### PR DESCRIPTION
Handles four issues across the MP4 format layer, the scan CLI, and the release smoke gate. Each fix is test-first; the full workspace suite, clippy `-D warnings`, fmt, shellcheck, ruff, and the mutant-anchor guard all pass via the pre-commit hook.

## #542 — MP4 path-to-`ilst` used the strict walk
`ilst_region` now walks `moov/udta/meta/ilst` with the lenient box scan (`find_box_lenient`) at every level, matching the metadata extractors' "seed what you can" contract. A single malformed/truncated sibling box anywhere on the path no longer suppresses an otherwise well-formed `ilst` and silently drops all tags/art. The audio/structure path (`validate_moov`/`locate`/synth) stays strict.
Test: `read_tags_survives_malformed_box_after_ilst`.

## #543 — QuickTime-style bare `meta` dropped all metadata
The `meta` parser consumes the 4-byte FullBox version/flags prefix only when present (a zero word, per ISO 14496-12); a non-zero first word marks a QuickTime bare `meta`, which is now read instead of landing mid-header. The one ambiguous edge (a bare first child declaring `size == 0`) is documented as misread, mirroring ffmpeg's heuristic.
Test: `read_tags_reads_quicktime_bare_meta`.

## #554 — `scan` exited 0 even when every file failed
`run_scan` now returns the total per-file `failed` count; `run`/`main` map `failed > 0` → exit **2** (clean scan → 0, hard error → 1). This gives a machine-detectable signal so a pipeline like `musefs scan … && musefs mount …` stops on partial or total ingest failure. Exit 2 overlaps clap's usage-error code, but only ever fires after a successful parse + run (noted in code).
Tests: `scan_returns_per_file_failed_count` (lib), `scan_with_a_failing_file_exits_two` (process boundary).

## #547 — release smoke verified FLAC magic but not the audio invariant
`scripts/smoke-binary.sh` now compares the served file's encoded audio stream (`-map 0:a -c copy`, excluding the legitimately re-synthesized metadata) against the untouched backing file, asserting the cardinal byte-identical-audio invariant rather than only the `fLaC` magic — catching a target-specific positioned-read/offset regression in a cross-compiled binary. Verified locally end-to-end.

## Docs
- `docs/src/changelog.md` — four `[Unreleased] → Fixed` entries.
- `docs/src/guide/scanning.md` — documents the new scan exit-code behavior.

Fixes #542
Fixes #543
Fixes #547
Fixes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved MP4 parsing robustness to handle malformed or truncated sibling boxes without suppressing valid metadata.
  * Enhanced QuickTime metadata format compatibility for bare `meta` boxes.
  * `scan` command now exits with code 2 when file parsing failures occur.
  * Strengthened audio stream validation to detect corruption beyond magic header checks.

* **Documentation**
  * Updated scan command exit code documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->