### PR TITLE
fix(contrib): prune/delete safety across beets + Lidarr (#538, #539, #545, #546)

### DIFF
--- a/contrib/CHANGELOG.md
+++ b/contrib/CHANGELOG.md
@@ -10,7 +10,36 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **beets: pruning is now a deliberate act.** The passive `cli_exit` reconcile
+  hook no longer prunes store rows — it only syncs touched items. Previously
+  every command ran an unscoped, existence-based `prune_missing` over the whole
+  library, so a transient backing-storage loss (an unmounted share, an offline
+  drive, a momentary realpath divergence) mass-deleted plugin-written metadata.
+  Pruning rows for moved-away/deleted files now happens only on the explicit
+  `beet musefs` command (or `musefs scan`); the `item_removed`/`album_removed`
+  listeners are removed (#538).
+
 ### Fixed
+
+- **Lidarr deletes no longer touch unmanaged tracks.** `prune_deleted` mapped an
+  Album/Artist delete to store rows by `musicbrainz_albumid` /
+  `musicbrainz_artistid`, which also matched ids the *scanner* seeded from a
+  file's own native tags. Lidarr now stamps a `musefs_lidarr_managed=1` ownership
+  marker on every track it writes and only deletes rows carrying it, so an
+  unrelated delete can't drop an unmanaged track's metadata. The marker is a
+  normal text tag and appears in served files (#546).
+- **Lidarr no longer records duplicate album/artist tags for single-file
+  releases.** A backing file linking multiple tracks (cue-style) emitted the
+  album/artist-level fields (`artist`, `album`, `date`, the MBIDs, genres) once
+  per linked track, so the store held N duplicate copies. Album/artist-level tags
+  are now emitted once per file; only track-level tags repeat per track (#539).
+- **Schema guard now covers the destructive prune/delete paths.** beets
+  `_prune_missing`, and Lidarr `sync_rename_prune` / `prune_deleted`, ran without
+  `check_schema_version`, so an out-of-date plugin could still mass-delete/prune
+  a store whose schema it does not understand. These paths now refuse on a
+  `user_version` mismatch (#545).
 
 - **Duplicate rendered tags from case-only key differences:** a `musefs scan`
   seeds an unmapped tag under the backing file's native key case (e.g. Vorbis

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -36,15 +36,12 @@ class MusefsPlugin(BeetsPlugin):
         })
         # beets has no file-move event, and `after_write` fires *before* a move
         # (at the old path). So imports/writes are recorded and reconciled once
-        # at cli_exit, when each item's path is final, where we also prune rows
-        # whose backing file has moved away.
+        # at cli_exit, when each item's path is final. Reconcile only syncs; it
+        # never prunes (pruning is a deliberate act — see `_reconcile_pending`).
         self._pending = []
-        self._saw_removal = False
         self.register_listener("after_write", self._record)
         self.register_listener("item_imported", self._record)
         self.register_listener("album_imported", self._record_album)
-        self.register_listener("item_removed", self._on_removed)
-        self.register_listener("album_removed", self._on_removed)
         self.register_listener("cli_exit", self._reconcile_pending)
 
     # --- command ---------------------------------------------------------
@@ -117,33 +114,30 @@ class MusefsPlugin(BeetsPlugin):
         if album is not None:
             self._pending.extend(album.items())
 
-    def _on_removed(self, **kwargs):
-        # item_removed/album_removed only flip the reconcile guard so a
-        # removals-only command still runs the end-of-command prune. We do not
-        # scan or sync removed items; the unscoped prune_missing handles them.
-        self._saw_removal = True
-
     def _reconcile_pending(self, lib=None, **kwargs):
-        """End-of-command reconcile: sync every touched item at its final path,
-        then prune rows whose backing file is gone (moved away or deleted at the
-        source). Best-effort — a passive hook must never abort the beets
-        operation, so errors become warnings."""
+        """End-of-command reconcile: sync every touched item at its final path.
+        Best-effort — a passive hook must never abort the beets operation, so
+        errors become warnings.
+
+        It never prunes. Pruning is a deliberate act (#538): an unscoped
+        existence-based prune at every ``cli_exit`` would mass-delete plugin
+        metadata on a transient backing-storage loss (an unmounted share or a
+        momentary realpath divergence). Removing rows for moved-away/deleted
+        files is left to the explicit ``beet musefs`` command (and ``musefs
+        scan``)."""
         pending, self._pending = self._pending, []
-        saw_removal, self._saw_removal = self._saw_removal, False
         # Dedup by final on-disk path (an item may fire several events).
         items = list({os.fsdecode(i.path): i for i in pending if i is not None}.values())
-        if not items and not saw_removal:
+        if not items:
             return
         db_path = self._db_path()
         if not db_path:
             self._log.warning("musefs: no `musefs.db` configured; skipping sync")
             return
         try:
-            if items:
-                if self._autoscan():
-                    self._run_scan(db_path, [os.fsdecode(i.path) for i in items])
-                self._sync(db_path, items, restore_backing=self._restore_backing())
-            self._prune_missing(db_path)
+            if self._autoscan():
+                self._run_scan(db_path, [os.fsdecode(i.path) for i in items])
+            self._sync(db_path, items, restore_backing=self._restore_backing())
         except (ui.UserError, sqlite3.Error, OSError, subprocess.SubprocessError) as exc:
             # A passive cli_exit hook must never abort the beets operation for an
             # environmental failure (locked DB, vanished file, wedged scan); those
@@ -233,15 +227,23 @@ class MusefsPlugin(BeetsPlugin):
     def _prune_missing(self, db_path, items=None):
         """Drop rows whose backing file no longer exists (moved/deleted).
         When ``items`` is provided, only their musefs track rows are checked.
-        Returns the number pruned."""
+        Returns the number pruned.
+
+        Guarded by ``check_schema_version`` (#545): an out-of-date plugin must
+        not delete rows from a store schema it does not understand. A mismatch
+        surfaces as ``ui.UserError`` — the explicit ``beet musefs`` command
+        aborts with the message; the passive reconcile path swallows it."""
         if not os.path.exists(db_path):
             return 0
         conn = connect(db_path)
         try:
+            check_schema_version(conn)
             track_ids = None if items is None else self._track_ids_for_items(conn, items)
             pruned = prune_missing(conn, track_ids)
             conn.commit()
             return pruned
+        except SchemaMismatch as exc:
+            raise ui.UserError(f"musefs: {exc}")
         finally:
             conn.close()
 

--- a/contrib/beets/tests/test_e2e.py
+++ b/contrib/beets/tests/test_e2e.py
@@ -527,15 +527,17 @@ def test_e2e_move_reconcile(tmp_path):
     cfg, env, db, mnt, library = _imported_library(tmp_path)
     _beet(cfg, env, "musefs")  # initial sync (original tags)
 
-    # A write-back modify renames/moves the FLAC. The plugin's cli_exit reconcile
-    # must scan the new path and prune the row left at the old one.
+    # A write-back modify renames/moves the FLAC. The passive cli_exit reconcile
+    # scans the new path but never prunes (#538: pruning is a deliberate act), so
+    # the explicit `beet musefs` is what removes the row left at the old path.
     _beet(cfg, env, "modify", "-w", "-y", "format:FLAC", "title=Relocated FLAC")
+    _beet(cfg, env, "musefs")  # deliberate prune of the moved-away row
 
     with _mounted(mnt, db, "$albumartist/$album/$title"):
         new = mnt / "Test AA" / "Orig Album" / "Relocated FLAC.flac"
         old = mnt / "Test AA" / "Orig Album" / "Orig FLAC.flac"
         assert new.exists(), sorted(p.name for p in mnt.rglob("*.flac"))
-        assert not old.exists()  # stale entry was pruned, not duplicated
+        assert not old.exists()  # stale entry pruned by the explicit sync
         assert len(list(mnt.rglob("*.flac"))) == 1
 
         ft = mutagen.File(str(new), easy=True)

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -233,12 +233,12 @@ def test_reconcile_at_cli_exit_syncs_recorded_items(
         conn.close()
 
 
-def test_reconcile_prunes_moved_away_row(db_path, make_track, fake_item, tmp_path, monkeypatch):
-    """Verify reconcile prunes rows whose backing file moved."""
-    # Reconcile uses a full-table prune so stale rows from renames/moves
-    # (whose backing file no longer exists) are cleaned up even though the
-    # pending items only carry the new path.
-    make_track("/old/moved-away.flac")  # stale: file gone
+def test_reconcile_does_not_prune_only_syncs(db_path, make_track, fake_item, tmp_path, monkeypatch):
+    """Pruning is a deliberate act (#538): the passive cli_exit reconcile syncs
+    touched items but never prunes, so a transient backing-storage loss can no
+    longer mass-delete plugin metadata. Stale rows are left for the explicit
+    ``beet musefs`` command / ``musefs scan``."""
+    make_track("/old/moved-away.flac")  # stale: backing file gone
     real, tid, item = _real_track(tmp_path, make_track, fake_item, title="Now")
     plugin, _ = _autoscan_plugin(db_path, monkeypatch)
     plugin._record(item=item)
@@ -247,7 +247,7 @@ def test_reconcile_prunes_moved_away_row(db_path, make_track, fake_item, tmp_pat
     conn = connect(db_path)
     try:
         paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
-        assert "/old/moved-away.flac" not in paths  # stale row pruned
+        assert "/old/moved-away.flac" in paths  # NOT pruned — reconcile never prunes
         assert real in paths  # new path kept + synced
         assert (
             conn.execute(
@@ -255,6 +255,31 @@ def test_reconcile_prunes_moved_away_row(db_path, make_track, fake_item, tmp_pat
             ).fetchone()[0]
             == "Now"
         )
+    finally:
+        conn.close()
+
+
+def test_prune_missing_refuses_on_schema_mismatch(db_path, make_track, tmp_path):
+    """The destructive prune path honours the schema guard (#545): an out-of-date
+    plugin must not delete rows from a store schema it cannot understand."""
+    from beets import ui
+
+    gone = tmp_path / "gone.flac"  # never created == missing == would be pruned
+    make_track(str(gone))
+    conn = connect(db_path)
+    try:
+        conn.execute("PRAGMA user_version = 99999")  # diverged schema
+        conn.commit()
+    finally:
+        conn.close()
+
+    plugin = MusefsPlugin.__new__(MusefsPlugin)
+    with pytest.raises(ui.UserError):
+        plugin._prune_missing(db_path)
+
+    conn = connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0] == 1
     finally:
         conn.close()
 

--- a/contrib/beets/tests/test_reconcile.py
+++ b/contrib/beets/tests/test_reconcile.py
@@ -25,11 +25,9 @@ def _plugin(monkeypatch, *, sync_raises=None):
     plugin = MusefsPlugin.__new__(MusefsPlugin)
     plugin._log = FakeLog()
     plugin._pending = [SimpleNamespace(path=b"/music/a.flac")]
-    plugin._saw_removal = False
     plugin._db_path = lambda: "/db.sqlite"
     plugin._autoscan = lambda: False
     plugin._restore_backing = lambda: False
-    plugin._prune_missing = lambda db: None
 
     def _sync(db, items, **kwargs):
         if sync_raises is not None:
@@ -116,21 +114,11 @@ def test_run_scan_passes_shared_timeout(monkeypatch):
     assert captured["timeout"] == musefs_mod.SCAN_TIMEOUT_SECONDS == 120
 
 
-def _removal_plugin(db_path):
-    """A MusefsPlugin (init bypassed) wired to a real DB, real _prune_missing,
-    and no pending writes — the removals-only reconcile path."""
-    plugin = MusefsPlugin.__new__(MusefsPlugin)
-    plugin._log = FakeLog()
-    plugin._pending = []
-    plugin._saw_removal = False
-    plugin._db_path = lambda: db_path
-    plugin._autoscan = lambda: False
-    plugin._restore_backing = lambda: False
-    return plugin
-
-
-def test_removal_triggers_reconcile_and_prunes_deleted_file(db_path, tmp_path):
-    # A removed-and-deleted backing file is pruned even with no writes pending.
+def test_removal_only_command_does_not_prune(db_path, tmp_path):
+    # Pruning is a deliberate act (#538): the plugin no longer reacts to
+    # item/album removals, and a passive cli_exit with no writes pending is a
+    # no-op. A removed-and-deleted backing file's row survives until an explicit
+    # `beet musefs` / `musefs scan` — a transient mount blip can't mass-delete.
     gone = tmp_path / "gone.flac"  # never created on disk == already deleted
     conn = musefs_connect(db_path)
     try:
@@ -139,31 +127,11 @@ def test_removal_triggers_reconcile_and_prunes_deleted_file(db_path, tmp_path):
     finally:
         conn.close()
 
-    plugin = _removal_plugin(db_path)
-    plugin._on_removed(item=SimpleNamespace(path=str(gone).encode()))
-    plugin._reconcile_pending()  # no writes pending; runs because a removal fired
-
-    conn = musefs_connect(db_path)
-    try:
-        assert conn.execute("SELECT COUNT(*) FROM tracks WHERE id=?", (tid,)).fetchone()[0] == 0
-    finally:
-        conn.close()
-
-
-def test_removal_keeps_row_when_file_still_present(db_path, tmp_path):
-    # `beet remove` without -d leaves the file on disk -> existence-based prune keeps it.
-    present = tmp_path / "present.flac"
-    present.write_bytes(b"audio")
-    conn = musefs_connect(db_path)
-    try:
-        tid = insert_track(conn, str(present))
-        conn.commit()
-    finally:
-        conn.close()
-
-    plugin = _removal_plugin(db_path)
-    plugin._on_removed(item=SimpleNamespace(path=str(present).encode()))
-    plugin._reconcile_pending()
+    plugin = MusefsPlugin.__new__(MusefsPlugin)
+    plugin._log = FakeLog()
+    plugin._pending = []
+    plugin._db_path = lambda: db_path
+    plugin._reconcile_pending()  # no writes pending -> no-op (no prune)
 
     conn = musefs_connect(db_path)
     try:

--- a/contrib/lidarr/src/musefs_lidarr/mapping.py
+++ b/contrib/lidarr/src/musefs_lidarr/mapping.py
@@ -16,6 +16,16 @@ class SkippedPath:
     reason: str
 
 
+# Ownership marker stamped on every track this plugin writes. ``prune_deleted``
+# matches a Lidarr album/artist deletion to store rows by MusicBrainz id, but a
+# scanner-seeded ``musicbrainz_albumid`` (read from the file's own native tags)
+# is an indistinguishable text tag. The marker scopes deletion to rows Lidarr
+# actually managed (#546). It is a normal text tag, so it DOES appear in served
+# files (e.g. a ``MUSEFS_LIDARR_MANAGED`` Vorbis comment) — see the Lidarr docs.
+MANAGED_KEY = "musefs_lidarr_managed"
+MANAGED_VALUE = "1"
+
+
 def _text(value) -> str | None:
     """Stringify and strip ``value``; return None if empty."""
     if value is None:
@@ -38,21 +48,29 @@ def _append(pairs: list[tuple[str, str]], key: str, value) -> None:
         pairs.append((key, text))
 
 
-def build_pairs(*, track: dict, album: dict, artist: dict) -> list[tuple[str, str]]:
-    """Map Lidarr track/album/artist fields to musefs ``(key, value)`` tag pairs."""
+def _track_pairs(track: dict) -> list[tuple[str, str]]:
+    """Track-level ``(key, value)`` tags — the fields that legitimately repeat
+    once per linked track of a single-file (cue-style) release."""
+    pairs: list[tuple[str, str]] = []
+    _append(pairs, "title", track.get("title"))
+    _append(pairs, "tracknumber", track.get("trackNumber") or track.get("absoluteTrackNumber"))
+    _append(pairs, "discnumber", track.get("mediumNumber"))
+    _append(pairs, "musicbrainz_trackid", track.get("foreignTrackId"))
+    _append(pairs, "musicbrainz_releasetrackid", track.get("foreignRecordingId"))
+    return pairs
+
+
+def _album_artist_pairs(album: dict, artist: dict) -> list[tuple[str, str]]:
+    """Album/artist-level ``(key, value)`` tags — emitted once per backing file,
+    not once per linked track (#539)."""
     pairs: list[tuple[str, str]] = []
     artist_name = artist.get("artistName") or artist.get("name")
-    _append(pairs, "title", track.get("title"))
     _append(pairs, "artist", artist_name)
     _append(pairs, "albumartist", artist_name)
     _append(pairs, "album", album.get("title"))
-    _append(pairs, "tracknumber", track.get("trackNumber") or track.get("absoluteTrackNumber"))
-    _append(pairs, "discnumber", track.get("mediumNumber"))
     _append(pairs, "date", _date(album.get("releaseDate")))
     _append(pairs, "musicbrainz_artistid", artist.get("foreignArtistId") or artist.get("mbId"))
     _append(pairs, "musicbrainz_albumid", album.get("foreignAlbumId"))
-    _append(pairs, "musicbrainz_trackid", track.get("foreignTrackId"))
-    _append(pairs, "musicbrainz_releasetrackid", track.get("foreignRecordingId"))
 
     seen_genres = set()
     for genre in list(album.get("genres") or []) + list(artist.get("genres") or []):
@@ -61,6 +79,14 @@ def build_pairs(*, track: dict, album: dict, artist: dict) -> list[tuple[str, st
             seen_genres.add(text)
             pairs.append(("genre", text))
     return pairs
+
+
+def build_pairs(*, track: dict, album: dict, artist: dict) -> list[tuple[str, str]]:
+    """Map one Lidarr track plus its album/artist to musefs ``(key, value)`` tag
+    pairs. ``records_for_paths`` does not call this for multi-track files — it
+    combines :func:`_album_artist_pairs` (once) with :func:`_track_pairs` (per
+    linked track) so album/artist fields are not duplicated (#539)."""
+    return _track_pairs(track) + _album_artist_pairs(album, artist)
 
 
 def match_track_file(path_key: str, track_files: list[dict]) -> dict | None:
@@ -136,9 +162,12 @@ def records_for_paths(
         if album is None or artist is None:
             skipped.append(SkippedPath(path=path, reason="album or artist metadata unavailable"))
             continue
-        pairs = []
+        # Album/artist-level tags are emitted once per file; only track-level
+        # tags repeat per linked track (a single-file/cue-style release) (#539).
+        pairs = _album_artist_pairs(album, artist)
+        pairs.append((MANAGED_KEY, MANAGED_VALUE))  # ownership marker (#546)
         for track in linked:
-            pairs.extend(build_pairs(track=track, album=album, artist=artist))
+            pairs.extend(_track_pairs(track))
         art = art_by_album_id.get(int(track_file["albumId"]))
         records.append(Record(key=key, pairs=pairs, art=[art] if art else None))
     return records, skipped

--- a/contrib/lidarr/src/musefs_lidarr/sync.py
+++ b/contrib/lidarr/src/musefs_lidarr/sync.py
@@ -24,7 +24,7 @@ from musefs_common import (
 from .errors import ConfigError, LidarrApiError
 from .events import EventType, LidarrEvent
 from .import_link import LinkMode, parse_link_mode
-from .mapping import _album_cover_url, records_for_paths
+from .mapping import MANAGED_KEY, MANAGED_VALUE, _album_cover_url, records_for_paths
 
 
 @dataclass(frozen=True)
@@ -185,6 +185,7 @@ def sync_rename_prune(*, config: SyncConfig, previous_paths: list[str]) -> int:
     previous_keys = [realpath_key(path) for path in previous_paths]
     conn = connect(config.db_path)
     try:
+        check_schema_version(conn)  # never prune a store schema we don't understand (#545)
         ids = track_ids_for_paths(conn, previous_keys)
         pruned = prune_missing(conn, list(ids.values()))
         conn.commit()
@@ -204,6 +205,12 @@ def prune_deleted(*, config: SyncConfig, event: LidarrEvent) -> int:
     matching the stored ``musicbrainz_albumid`` / ``musicbrainz_artistid`` tag
     against the id Lidarr reports in the delete event. Returns the count deleted.
 
+    Deletion is scoped to rows this plugin actually wrote, identified by the
+    ``MANAGED_KEY`` ownership marker (#546): a ``musicbrainz_albumid`` the
+    *scanner* seeded from a file's own native tags is an indistinguishable text
+    tag, and an unrelated Lidarr delete must not cascade away an unmanaged
+    track's metadata.
+
     The caller guarantees the relevant MBID is present (see ``cli_sync``); an
     album event matches ``musicbrainz_albumid``, an artist event
     ``musicbrainz_artistid``.
@@ -215,7 +222,10 @@ def prune_deleted(*, config: SyncConfig, event: LidarrEvent) -> int:
 
     conn = connect(config.db_path)
     try:
-        deleted = delete_tracks(conn, track_ids_by_tag(conn, key, value))
+        check_schema_version(conn)  # never delete from a store schema we don't understand (#545)
+        managed = set(track_ids_by_tag(conn, MANAGED_KEY, MANAGED_VALUE))
+        matched = track_ids_by_tag(conn, key, value)
+        deleted = delete_tracks(conn, [tid for tid in matched if tid in managed])
         conn.commit()
         return deleted
     except Exception:

--- a/contrib/lidarr/tests/test_cli.py
+++ b/contrib/lidarr/tests/test_cli.py
@@ -254,6 +254,7 @@ def test_sync_cli_album_deleted_prunes_without_api(tmp_path, capsys):
     from musefs_common.schema import SCHEMA_SQL
     from musefs_common.store import replace_tags
     from musefs_lidarr.cli_sync import run
+    from musefs_lidarr.mapping import MANAGED_KEY, MANAGED_VALUE
 
     db = tmp_path / "musefs.db"
     raw = sqlite3.connect(str(db))
@@ -267,7 +268,7 @@ def test_sync_cli_album_deleted_prunes_without_api(tmp_path, capsys):
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
             "backing_size, backing_mtime_ns, updated_at) VALUES ('/m/a.flac', 'flac', 0, 0, 0, 0, 0)"
         ).lastrowid
-        replace_tags(conn, tid, [("musicbrainz_albumid", "rg-1")])
+        replace_tags(conn, tid, [("musicbrainz_albumid", "rg-1"), (MANAGED_KEY, MANAGED_VALUE)])
         conn.commit()
     finally:
         conn.close()

--- a/contrib/lidarr/tests/test_mapping.py
+++ b/contrib/lidarr/tests/test_mapping.py
@@ -123,6 +123,59 @@ def test_records_for_paths_emits_multitrack_pairs_in_lidarr_order(
     assert titles == ["Wildlife Analysis", "Second linked track"]
 
 
+def test_records_for_paths_emits_album_artist_pairs_once_per_file(
+    sample_artist, sample_album, sample_track, sample_track_file
+):
+    # A single-file release linking N tracks (cue-style) must not duplicate the
+    # album/artist-level tags N times (#539); only track-level fields repeat.
+    second_track = dict(sample_track, id=41, title="Second linked track", trackNumber="2")
+
+    records, skipped = records_for_paths(
+        paths=[sample_track_file["path"]],
+        track_files=[sample_track_file],
+        tracks=[sample_track, second_track],
+        albums_by_id={20: sample_album},
+        artists_by_id={10: sample_artist},
+    )
+
+    assert skipped == []
+    pairs = records[0].pairs
+    keys = [key for key, _ in pairs]
+    for once_key in (
+        "artist",
+        "albumartist",
+        "album",
+        "date",
+        "musicbrainz_artistid",
+        "musicbrainz_albumid",
+    ):
+        assert keys.count(once_key) == 1, f"{once_key} duplicated: {pairs!r}"
+    # Genres (album + artist, deduped) also appear once apiece, not per track.
+    assert keys.count("genre") == 2
+    # Track-level fields still repeat per linked track.
+    assert keys.count("title") == 2
+    assert [v for k, v in pairs if k == "tracknumber"] == ["1", "2"]
+
+
+def test_records_for_paths_marks_records_as_lidarr_managed(
+    sample_artist, sample_album, sample_track, sample_track_file
+):
+    # Lidarr stamps an ownership marker so prune_deleted never touches rows it
+    # did not write (scanner-seeded MBIDs look identical otherwise) (#546).
+    from musefs_lidarr.mapping import MANAGED_KEY, MANAGED_VALUE
+
+    records, _ = records_for_paths(
+        paths=[sample_track_file["path"]],
+        track_files=[sample_track_file],
+        tracks=[sample_track],
+        albums_by_id={20: sample_album},
+        artists_by_id={10: sample_artist},
+    )
+
+    pairs = records[0].pairs
+    assert pairs.count((MANAGED_KEY, MANAGED_VALUE)) == 1
+
+
 def test_records_for_paths_returns_reason_for_missing_linked_tracks(
     sample_artist, sample_album, sample_track_file
 ):

--- a/contrib/lidarr/tests/test_sync.py
+++ b/contrib/lidarr/tests/test_sync.py
@@ -507,6 +507,7 @@ def test_prune_deleted_album_removes_matching_rows(db_path, tmp_path):
     from musefs_common.store import replace_tags
     from musefs_lidarr.events import EventType, LidarrEvent
     from musefs_lidarr.import_link import LinkMode
+    from musefs_lidarr.mapping import MANAGED_KEY, MANAGED_VALUE
     from musefs_lidarr.sync import SyncConfig, prune_deleted
 
     backing = tmp_path / "a.flac"
@@ -523,8 +524,8 @@ def test_prune_deleted_album_removes_matching_rows(db_path, tmp_path):
             "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
             "backing_size, backing_mtime_ns, updated_at) VALUES ('/m/b.flac', 'flac', 0, 0, 0, 0, 0)",
         ).lastrowid
-        replace_tags(conn, a, [("musicbrainz_albumid", "rg-1")])
-        replace_tags(conn, b, [("musicbrainz_albumid", "rg-2")])
+        replace_tags(conn, a, [("musicbrainz_albumid", "rg-1"), (MANAGED_KEY, MANAGED_VALUE)])
+        replace_tags(conn, b, [("musicbrainz_albumid", "rg-2"), (MANAGED_KEY, MANAGED_VALUE)])
         conn.commit()
     finally:
         conn.close()
@@ -550,6 +551,7 @@ def test_prune_deleted_artist_removes_all_artist_rows(db_path):
     from musefs_common.store import replace_tags
     from musefs_lidarr.events import EventType, LidarrEvent
     from musefs_lidarr.import_link import LinkMode
+    from musefs_lidarr.mapping import MANAGED_KEY, MANAGED_VALUE
     from musefs_lidarr.sync import SyncConfig, prune_deleted
 
     conn = connect(db_path)
@@ -561,7 +563,7 @@ def test_prune_deleted_artist_removes_all_artist_rows(db_path):
                 "backing_size, backing_mtime_ns, updated_at) VALUES (?, 'flac', 0, 0, 0, 0, 0)",
                 (f"/m/{i}.flac",),
             ).lastrowid
-            replace_tags(conn, tid, [("musicbrainz_artistid", art)])
+            replace_tags(conn, tid, [("musicbrainz_artistid", art), (MANAGED_KEY, MANAGED_VALUE)])
             ids.append(tid)
         conn.commit()
     finally:
@@ -572,3 +574,114 @@ def test_prune_deleted_artist_removes_all_artist_rows(db_path):
         event_type=EventType.ARTIST_DELETED, raw_type="ArtistDeleted", artist_mbid="art-1"
     )
     assert prune_deleted(config=config, event=event) == 2
+
+
+def test_prune_deleted_spares_unmanaged_scanner_seeded_mbid(db_path):
+    # A track that carries the deleted album's MBID only from its own native
+    # tags (scanner-seeded, never managed by Lidarr) must survive a Lidarr
+    # delete event — prune_deleted is scoped to the ownership marker (#546).
+    from musefs_common import connect
+    from musefs_common.store import replace_tags
+    from musefs_lidarr.events import EventType, LidarrEvent
+    from musefs_lidarr.import_link import LinkMode
+    from musefs_lidarr.mapping import MANAGED_KEY, MANAGED_VALUE
+    from musefs_lidarr.sync import SyncConfig, prune_deleted
+
+    conn = connect(db_path)
+    try:
+        managed = conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
+            "backing_size, backing_mtime_ns, updated_at) VALUES ('/m/managed.flac', 'flac', "
+            "0, 0, 0, 0, 0)"
+        ).lastrowid
+        unmanaged = conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
+            "backing_size, backing_mtime_ns, updated_at) VALUES ('/m/unmanaged.flac', 'flac', "
+            "0, 0, 0, 0, 0)"
+        ).lastrowid
+        replace_tags(
+            conn, managed, [("musicbrainz_albumid", "rg-1"), (MANAGED_KEY, MANAGED_VALUE)]
+        )
+        replace_tags(conn, unmanaged, [("musicbrainz_albumid", "rg-1")])  # no marker
+        conn.commit()
+    finally:
+        conn.close()
+
+    config = SyncConfig(db_path=db_path, link_mode=LinkMode.SYMLINK)
+    event = LidarrEvent(
+        event_type=EventType.ALBUM_DELETED, raw_type="AlbumDeleted", album_mbid="rg-1"
+    )
+
+    assert prune_deleted(config=config, event=event) == 1
+    conn = connect(db_path)
+    try:
+        ids = {row[0] for row in conn.execute("SELECT id FROM tracks")}
+        assert ids == {unmanaged}  # only the Lidarr-managed row was deleted
+    finally:
+        conn.close()
+
+
+def test_prune_deleted_refuses_on_schema_mismatch(db_path):
+    # The most dangerous (row-removing) path must honour the schema guard: an
+    # out-of-date plugin must not mass-delete a store it cannot understand (#545).
+    import pytest
+    from musefs_common import connect
+    from musefs_common.errors import SchemaMismatch
+    from musefs_common.store import replace_tags
+    from musefs_lidarr.events import EventType, LidarrEvent
+    from musefs_lidarr.import_link import LinkMode
+    from musefs_lidarr.mapping import MANAGED_KEY, MANAGED_VALUE
+    from musefs_lidarr.sync import SyncConfig, prune_deleted
+
+    conn = connect(db_path)
+    try:
+        tid = conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, "
+            "backing_size, backing_mtime_ns, updated_at) VALUES ('/m/a.flac', 'flac', "
+            "0, 0, 0, 0, 0)"
+        ).lastrowid
+        replace_tags(conn, tid, [("musicbrainz_albumid", "rg-1"), (MANAGED_KEY, MANAGED_VALUE)])
+        conn.execute("PRAGMA user_version = 99999")  # diverged schema
+        conn.commit()
+    finally:
+        conn.close()
+
+    config = SyncConfig(db_path=db_path, link_mode=LinkMode.SYMLINK)
+    event = LidarrEvent(
+        event_type=EventType.ALBUM_DELETED, raw_type="AlbumDeleted", album_mbid="rg-1"
+    )
+    with pytest.raises(SchemaMismatch):
+        prune_deleted(config=config, event=event)
+
+    conn = connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_sync_rename_prune_refuses_on_schema_mismatch(db_path, make_track, tmp_path):
+    import pytest
+    from musefs_common import connect
+    from musefs_common.errors import SchemaMismatch
+    from musefs_lidarr.import_link import LinkMode
+    from musefs_lidarr.sync import SyncConfig, sync_rename_prune
+
+    old_path = tmp_path / "old.flac"  # never created == missing == would prune
+    make_track(str(old_path))
+    conn = connect(db_path)
+    try:
+        conn.execute("PRAGMA user_version = 99999")
+        conn.commit()
+    finally:
+        conn.close()
+
+    config = SyncConfig(db_path=db_path, link_mode=LinkMode.HARDLINK)
+    with pytest.raises(SchemaMismatch):
+        sync_rename_prune(config=config, previous_paths=[str(old_path)])
+
+    conn = connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0] == 1
+    finally:
+        conn.close()

--- a/docs/src/integrations/beets.md
+++ b/docs/src/integrations/beets.md
@@ -81,10 +81,12 @@ musefs mount ~/mnt --db ~/musefs.db --template '$!{beets_path}'
 Imports and tag write-backs auto-sync via event hooks: `beet import` and
 `beet modify -w …` record the touched items and reconcile them once the command
 finishes — when each file's path is final (beets has no move event, and a write
-fires *before* its move). The reconcile scans the new path and prunes the row
-left behind at the old one. A metadata-only `beet modify` (no `-w`) doesn't fire
-a hook — re-run `beet musefs`. With `autoscan: no`, run `musefs scan` yourself
-first; the hooks then skip gracefully if the DB is missing.
+fires *before* its move). The reconcile scans the new path and writes its tags,
+but it **never prunes** — pruning is a deliberate act (see below). A move
+therefore leaves the old path's row behind until you run `beet musefs`. A
+metadata-only `beet modify` (no `-w`) doesn't fire a hook — re-run `beet musefs`.
+With `autoscan: no`, run `musefs scan` yourself first; the hooks then skip
+gracefully if the DB is missing.
 
 ## Never writing to your backing audio files
 
@@ -143,14 +145,17 @@ A few plugins ignore that gate or are redundant in this mode:
   engine can't express. Set `write_path: no` in the `musefs:` config to skip it.
   Do not add an extension in a template that consumes `beets_path`. See the
   computed-tag workflow in [the architecture overview](../architecture/overview.md).
-- **Moves & on-disk deletes:** every sync (the command and the end-of-command
-  reconcile) prunes track rows whose backing file is gone from disk, so
-  renames/moves don't leave stale entries. Caveat: a file that's merely offline
-  at sync time (e.g. an unmounted network share) is also pruned — sync while
-  the library is available.
-- **Removals prune the store.** `beet remove -d` deletes the backing file, so the
-  store row is pruned at the end of the command. A bare `beet remove` (which keeps
-  the file on disk) leaves the row in place — musefs can still serve those bytes.
+- **Pruning is a deliberate act.** Only the explicit `beet musefs` command prunes
+  track rows whose backing file is gone from disk (renames/moves/deletes). The
+  passive end-of-command reconcile (`beet import` / `beet modify -w`) syncs but
+  never prunes, so a transient backing-storage loss — an unmounted network share,
+  an offline drive, a momentary realpath divergence — can no longer mass-delete
+  plugin metadata. Run `beet musefs` (or `musefs scan`) while the library is
+  available to clear stale rows left by a move or an on-disk delete.
+- **Removals are not auto-pruned.** `beet remove` / `beet remove -d` no longer
+  prunes the store; run `beet musefs` afterwards to drop the rows whose backing
+  file is now gone. A bare `beet remove` (which keeps the file on disk) leaves a
+  servable row in place even then — musefs can still serve those bytes.
 - **Orphaned art:** replacing art can orphan old blobs; `musefs scan --revalidate`
   garbage-collects them.
 - **Schema version:** the plugin refuses to run if the DB's `user_version` differs

--- a/docs/src/integrations/lidarr.md
+++ b/docs/src/integrations/lidarr.md
@@ -198,12 +198,22 @@ binary are importable/on `PATH`.
 - **Schema version:** the sync refuses to run if the DB's `user_version`
   differs from the version it targets — rebuild the store after upgrading
   musefs.
-- **Deletions prune by MusicBrainz id.** On an Album/Artist delete, the sync
-  removes the matching store rows (`musicbrainz_albumid` / `musicbrainz_artistid`)
-  so the mount stops presenting them. The backing audio is never touched —
-  pruning only drops the store rows, not the files Lidarr keeps in the backing
-  directory. A delete event for a release with no MusicBrainz id cannot be mapped
-  and is logged and skipped; those rows clear on the next scan/reconcile.
+- **Deletions prune by MusicBrainz id, scoped to rows this plugin owns.** On an
+  Album/Artist delete, the sync removes the matching store rows
+  (`musicbrainz_albumid` / `musicbrainz_artistid`) so the mount stops presenting
+  them. The backing audio is never touched — pruning only drops the store rows,
+  not the files Lidarr keeps in the backing directory. A delete event for a
+  release with no MusicBrainz id cannot be mapped and is logged and skipped.
+- **Ownership marker.** Every track the sync writes is stamped with a
+  `musefs_lidarr_managed=1` tag, and a delete only removes rows carrying that
+  marker. Without it, a `musicbrainz_albumid` the *scanner* seeded from a file's
+  own native tags is indistinguishable from one Lidarr wrote, so an unrelated
+  Lidarr delete could drop an unmanaged track's metadata. The marker is a normal
+  text tag, so it **does appear in served files** (e.g. as a
+  `MUSEFS_LIDARR_MANAGED` Vorbis comment / a `TXXX` frame / an iTunes freeform
+  atom). A track imported under an older plugin version (before the marker
+  existed) is treated as unmanaged and is left in place on delete — re-sync it to
+  stamp the marker.
 - **CI coverage:** a fast smoke (real Lidarr exec path + mocked API) gates PRs,
   and a full real-instance download-client import e2e gates the Python
   releases — see


### PR DESCRIPTION
Handles four open `contrib/` plugin issues, all around prune/delete safety. No Rust/core changes — everything stays in `contrib/` (Python) + docs.

## #538 — beets pruning is now a deliberate act
The passive `cli_exit` reconcile hook no longer prunes; it only syncs touched items. Previously every beets command ran an unscoped, existence-based `prune_missing` over the whole library, so a transient backing-storage loss (unmounted share, offline drive, momentary realpath divergence) mass-deleted plugin metadata. Pruning moved-away/deleted rows now happens only via the explicit `beet musefs` command (or `musefs scan`); the `item_removed`/`album_removed` listeners are removed.

## #546 — Lidarr deletes no longer touch unmanaged tracks
`prune_deleted` mapped an Album/Artist delete to store rows by `musicbrainz_albumid` / `musicbrainz_artistid`, which also matched ids the *scanner* seeded from a file's own native tags. Lidarr now stamps a `musefs_lidarr_managed=1` ownership marker on every track it writes and only deletes marked rows. The marker is a normal text tag and **appears in served files** (e.g. a `MUSEFS_LIDARR_MANAGED` Vorbis comment / `TXXX` frame / iTunes freeform atom) — documented in `lidarr.md`.

## #539 — Lidarr duplicate album/artist tags for single-file releases
A backing file linking multiple tracks (cue-style) emitted album/artist-level fields (`artist`, `album`, `date`, MBIDs, genres) once per linked track, leaving N duplicate copies in the store. `build_pairs` is split into track-level and album/artist-level helpers; album/artist tags are now emitted once per file, track tags per track.

## #545 — schema guard on the destructive prune/delete paths
beets `_prune_missing` and Lidarr `sync_rename_prune` / `prune_deleted` ran without `check_schema_version`, so an out-of-date plugin could mass-delete/prune a store schema it doesn't understand. These paths now refuse on a `user_version` mismatch (beets surfaces it as `ui.UserError` — explicit command aborts, passive path swallows).

## Tests
TDD throughout (each test watched fail, then pass). All contrib suites green: beets 66, lidarr 98, python-musefs 79. Behavior-encoding tests that asserted the old passive-prune model were rewritten (`test_reconcile_prunes_moved_away_row` → `test_reconcile_does_not_prune_only_syncs`, the removal tests, and the `test_e2e_move_reconcile` e2e). Docs + contrib changelog updated.

Historical design docs under `docs/superpowers/specs|plans/` still describe the old removal-prune design and were left as historical records.

Fixes #538
Fixes #539
Fixes #545
Fixes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pruning now occurs only via explicit `beet musefs`/`musefs scan` commands, not at CLI exit.
  * Lidarr deletions now only remove "managed" tracks, preventing accidental removal of unmanaged tracks.
  * Album/artist tag duplication eliminated for multi-track files.
  * Case-insensitive key matching prevents duplicate scan entries.
  * Schema version validation prevents data loss on mismatches.
  * Reconciliation failures now display error messages.

* **Documentation**
  * Updated beets and Lidarr integration guides with revised pruning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->