### PR TITLE
fix(scan,cli,beets): quieter symlink skips, FUSE-missing hint, prune only on --revalidate

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-    'musefs-core/src/scan\.rs:660:31:',
+    'musefs-core/src/scan\.rs:664:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:667:30:',
+    'musefs-core/src/scan\.rs:671:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,14 +127,14 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:678:21:',
+    'musefs-core/src/scan\.rs:682:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-    'musefs-core/src/scan\.rs:683:17:',
+    'musefs-core/src/scan\.rs:687:17:',
     # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
     # per oversized mp4 `covr` / `----` payload the format layer skipped before
     # materialization (#343) and returns nothing. With no log-capture harness in the
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1402:46:',
+    'musefs-core/src/scan\.rs:1406:46:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -160,21 +160,21 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1533:29:',
+    'musefs-core/src/scan\.rs:1537:29:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1535:32:',
+    'musefs-core/src/scan\.rs:1539:32:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1535:47:',
+    'musefs-core/src/scan\.rs:1539:47:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1535:62:',
+    'musefs-core/src/scan\.rs:1539:62:',
     # guard: op="+=" fn="run_pipeline" rows=2
-    'musefs-core/src/scan\.rs:1543:37:',
+    'musefs-core/src/scan\.rs:1547:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1545:40:',
+    'musefs-core/src/scan\.rs:1549:40:',
     # guard: op="||" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1545:55:',
+    'musefs-core/src/scan\.rs:1549:55:',
     # guard: op=">=" fn="run_pipeline" rows=1
-    'musefs-core/src/scan\.rs:1545:70:',
+    'musefs-core/src/scan\.rs:1549:70:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -182,11 +182,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1673:29:',
+    'musefs-core/src/scan\.rs:1677:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-    'musefs-core/src/scan\.rs:1682:33:',
+    'musefs-core/src/scan\.rs:1686:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-    'musefs-core/src/scan\.rs:1737:29: replace \+ with -',
+    'musefs-core/src/scan\.rs:1741:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ musefs mount ~/mnt/music --db library.db \
 # mount blocks until unmounted: fusermount3 -u ~/mnt/music (or Ctrl-C)
 ```
 
+Mounting needs the `fuse3` runtime installed (`apt install fuse3` /
+`apk add fuse3` / `dnf install fuse3`) and `/dev/fuse` present — see
+[Installation](https://sohex.github.io/musefs/guide/installation.html).
+
 `~/mnt/music` now serves your library as
 `Album Artist/Album/Title.flac` — with each file's metadata generated fresh
 from the database, spliced in front of your original, untouched audio.

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -13,11 +13,8 @@ from musefs_common import (
     SyncStats,
     check_schema_version,
     connect,
-    prune_missing,
-    realpath_key,
     run_scan,
     sync_files,
-    track_id_for_path,
 )
 
 from beetsplug import _core
@@ -37,7 +34,8 @@ class MusefsPlugin(BeetsPlugin):
         # beets has no file-move event, and `after_write` fires *before* a move
         # (at the old path). So imports/writes are recorded and reconciled once
         # at cli_exit, when each item's path is final. Reconcile only syncs; it
-        # never prunes (pruning is a deliberate act — see `_reconcile_pending`).
+        # never prunes. Pruning is a deliberate act owned by `musefs scan
+        # --revalidate` (reachable via `beet musefs --revalidate`).
         self._pending = []
         self.register_listener("after_write", self._record)
         self.register_listener("item_imported", self._record)
@@ -69,6 +67,14 @@ class MusefsPlugin(BeetsPlugin):
             default=False,
             help="when a tag is removed in beets, let the backing file's value reappear",
         )
+        cmd.parser.add_option(
+            "--revalidate",
+            dest="revalidate",
+            action="store_true",
+            default=False,
+            help="forward --revalidate to `musefs scan`, pruning rows whose backing "
+            "file is gone and GCing orphaned art (the only way this plugin prunes)",
+        )
         cmd.func = self._command
         return [cmd]
 
@@ -87,22 +93,22 @@ class MusefsPlugin(BeetsPlugin):
 
         query = self._query_from_args(args)
         items = list(lib.items(query))
-        if self._autoscan() and not opts.dry_run:
+        revalidate = bool(opts.revalidate)
+        # A scan runs when autoscan is on, or whenever --revalidate is requested:
+        # revalidation IS a scan operation — pruning gone backing files and GCing
+        # orphaned art live entirely in `musefs scan --revalidate`. The plugin
+        # never prunes on its own; this is the only path that removes rows.
+        if (self._autoscan() or revalidate) and not opts.dry_run:
             # Full sync: one scan of the music dir. Query: scan only the matched
             # files, so non-matched rows aren't re-seeded from their files.
             targets = (
                 [os.fsdecode(i.path) for i in items] if query else [os.fsdecode(lib.directory)]
             )
-            self._run_scan(db_path, targets)
+            self._run_scan(db_path, targets, revalidate=revalidate)
         restore_backing = bool(opts.restore_backing) or self._restore_backing()
         stats = self._sync(db_path, items, dry_run=opts.dry_run, restore_backing=restore_backing)
-        if opts.dry_run:
-            pruned = 0
-        else:
-            prune_items = items if query else None
-            pruned = self._prune_missing(db_path, items=prune_items)
         # ui.print_ (not self._log) so the summary always shows, not only at -v.
-        ui.print_(f"musefs: {stats.summary()} pruned={pruned}")
+        ui.print_(f"musefs: {stats.summary()}")
 
     # --- event listeners -------------------------------------------------
 
@@ -190,13 +196,15 @@ class MusefsPlugin(BeetsPlugin):
     def _bin(self):
         return self.config["bin"].get(str) or "musefs"
 
-    def _run_scan(self, db_path, targets):
-        """Run `musefs scan <target...> --db <db>` once for the whole batch.
-        Creates the DB if missing and fills the structural columns the plugin
-        can't compute itself. Raises ui.UserError on failure."""
+    def _run_scan(self, db_path, targets, revalidate=False):
+        """Run `musefs scan <target...> --db <db> [--revalidate]` once for the
+        whole batch. Creates the DB if missing and fills the structural columns
+        the plugin can't compute itself. With ``revalidate``, the scanner also
+        prunes rows whose backing file is gone and GCs orphaned art. Raises
+        ui.UserError on failure."""
         binary = self._bin()
         try:
-            run_scan(binary, db_path, targets, timeout=SCAN_TIMEOUT_SECONDS)
+            run_scan(binary, db_path, targets, revalidate=revalidate, timeout=SCAN_TIMEOUT_SECONDS)
         except ScanError as exc:
             raise self._scan_user_error(exc)
 
@@ -213,39 +221,6 @@ class MusefsPlugin(BeetsPlugin):
             f"musefs: `{exc.binary} scan` failed for {exc.target} "
             f"(exit {exc.returncode}):\n{exc.stderr}"
         )
-
-    @staticmethod
-    def _track_ids_for_items(conn, items):
-        ids = []
-        for item in items:
-            key = realpath_key(item.path)
-            track_id = track_id_for_path(conn, key)
-            if track_id is not None:
-                ids.append(track_id)
-        return ids
-
-    def _prune_missing(self, db_path, items=None):
-        """Drop rows whose backing file no longer exists (moved/deleted).
-        When ``items`` is provided, only their musefs track rows are checked.
-        Returns the number pruned.
-
-        Guarded by ``check_schema_version`` (#545): an out-of-date plugin must
-        not delete rows from a store schema it does not understand. A mismatch
-        surfaces as ``ui.UserError`` — the explicit ``beet musefs`` command
-        aborts with the message; the passive reconcile path swallows it."""
-        if not os.path.exists(db_path):
-            return 0
-        conn = connect(db_path)
-        try:
-            check_schema_version(conn)
-            track_ids = None if items is None else self._track_ids_for_items(conn, items)
-            pruned = prune_missing(conn, track_ids)
-            conn.commit()
-            return pruned
-        except SchemaMismatch as exc:
-            raise ui.UserError(f"musefs: {exc}")
-        finally:
-            conn.close()
 
     def _sync(self, db_path, items, dry_run=False, restore_backing=False):
         if not os.path.exists(db_path):

--- a/contrib/beets/tests/test_e2e.py
+++ b/contrib/beets/tests/test_e2e.py
@@ -529,9 +529,10 @@ def test_e2e_move_reconcile(tmp_path):
 
     # A write-back modify renames/moves the FLAC. The passive cli_exit reconcile
     # scans the new path but never prunes (#538: pruning is a deliberate act), so
-    # the explicit `beet musefs` is what removes the row left at the old path.
+    # an explicit `beet musefs --revalidate` is what removes the row left at the
+    # old path (it forwards --revalidate to `musefs scan`).
     _beet(cfg, env, "modify", "-w", "-y", "format:FLAC", "title=Relocated FLAC")
-    _beet(cfg, env, "musefs")  # deliberate prune of the moved-away row
+    _beet(cfg, env, "musefs", "--revalidate")  # deliberate prune of the moved-away row
 
     with _mounted(mnt, db, "$albumartist/$album/$title"):
         new = mnt / "Test AA" / "Orig Album" / "Relocated FLAC.flac"

--- a/contrib/beets/tests/test_plugin.py
+++ b/contrib/beets/tests/test_plugin.py
@@ -59,7 +59,7 @@ class FakeLib:
 
 def _real_track(tmp_path, make_track, fake_item, name="a.flac", **fields):
     """Create a real file + its track row + a matching fake item. A real path
-    matters now that sync prunes rows whose backing file is missing."""
+    is needed so sync can resolve the item's realpath to its track row."""
     p = tmp_path / name
     p.write_bytes(b"x")
     real = os.path.realpath(str(p))
@@ -78,7 +78,11 @@ def _autoscan_plugin(db_path, monkeypatch):
         raising=False,
     )
     calls = []
-    monkeypatch.setattr(plugin, "_run_scan", lambda db, targets: calls.append(list(targets)))
+    monkeypatch.setattr(
+        plugin,
+        "_run_scan",
+        lambda db, targets, revalidate=False: calls.append(list(targets)),
+    )
     return plugin, calls
 
 
@@ -169,42 +173,61 @@ def test_command_dry_run_skips_autoscan(db_path, fake_item, monkeypatch):
     assert calls == []  # dry-run must not mutate the DB via scan
 
 
-def test_command_query_preserves_unrelated_missing_rows(
+def test_command_plain_sync_never_prunes(
     db_path,
     make_track,
     fake_item,
     tmp_path,
     monkeypatch,
 ):
-    """Verify query-scoped prune keeps unrelated rows."""
+    """Without --revalidate, `beet musefs` only syncs — it never prunes, so a
+    stale row whose backing file is gone survives (pruning belongs solely to
+    `musefs scan --revalidate`)."""
     make_track("/gone/x.flac")  # a stale row: its backing file does not exist
     real, _tid, item = _real_track(tmp_path, make_track, fake_item, title="Song")
     plugin, _ = _autoscan_plugin(db_path, monkeypatch)
-    cmd, opts, args = _musefs_cmd(plugin, ["title:Song"])
+    cmd, opts, args = _musefs_cmd(plugin, [])  # full sync, no --revalidate
     cmd.func(FakeLib([item]), opts, args)
 
     conn = connect(db_path)
     try:
         paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
-        assert "/gone/x.flac" in paths
+        assert "/gone/x.flac" in paths  # NOT pruned — plain sync never prunes
         assert real in paths
     finally:
         conn.close()
 
 
-def test_command_full_sync_prunes_missing_rows(db_path, make_track, fake_item, monkeypatch):
-    """Verify full sync prunes stale rows."""
-    make_track("/gone/x.flac")  # a stale row: its backing file does not exist
-    plugin, _ = _autoscan_plugin(db_path, monkeypatch)
-    cmd, opts, args = _musefs_cmd(plugin, [])
+def test_command_revalidate_forwards_to_scan(db_path, fake_item, monkeypatch):
+    """`beet musefs --revalidate` forwards --revalidate to the autoscan, where the
+    Rust scanner owns pruning gone backing files + GCing orphaned art."""
+    plugin = MusefsPlugin()
+    monkeypatch.setattr(
+        plugin,
+        "config",
+        FakeConfigView({"db": db_path, "fields": {}, "autoscan": True, "write_path": True}),
+        raising=False,
+    )
+    calls = []
+    monkeypatch.setattr(
+        plugin,
+        "_run_scan",
+        lambda db, targets, revalidate=False: calls.append((list(targets), revalidate)),
+    )
+    cmd, opts, args = _musefs_cmd(plugin, ["--revalidate"])
+    cmd.func(FakeLib([fake_item(os.fsencode("/music/a.flac"))], directory=b"/music"), opts, args)
+
+    assert calls == [(["/music"], True)]  # revalidate forwarded to the directory scan
+
+
+def test_command_revalidate_dry_run_skips_scan(db_path, fake_item, monkeypatch):
+    """--revalidate is destructive (it prunes via the scanner), so dry-run must
+    not run the scan at all."""
+    plugin, calls = _autoscan_plugin(db_path, monkeypatch)
+    cmd, opts, args = _musefs_cmd(plugin, ["--revalidate", "-n"])
     cmd.func(FakeLib([fake_item(os.fsencode("/music/a.flac"))]), opts, args)
 
-    conn = connect(db_path)
-    try:
-        paths = [r[0] for r in conn.execute("SELECT backing_path FROM tracks")]
-        assert "/gone/x.flac" not in paths
-    finally:
-        conn.close()
+    assert calls == []  # no scan on dry-run, even with --revalidate
 
 
 def test_reconcile_at_cli_exit_syncs_recorded_items(
@@ -255,31 +278,6 @@ def test_reconcile_does_not_prune_only_syncs(db_path, make_track, fake_item, tmp
             ).fetchone()[0]
             == "Now"
         )
-    finally:
-        conn.close()
-
-
-def test_prune_missing_refuses_on_schema_mismatch(db_path, make_track, tmp_path):
-    """The destructive prune path honours the schema guard (#545): an out-of-date
-    plugin must not delete rows from a store schema it cannot understand."""
-    from beets import ui
-
-    gone = tmp_path / "gone.flac"  # never created == missing == would be pruned
-    make_track(str(gone))
-    conn = connect(db_path)
-    try:
-        conn.execute("PRAGMA user_version = 99999")  # diverged schema
-        conn.commit()
-    finally:
-        conn.close()
-
-    plugin = MusefsPlugin.__new__(MusefsPlugin)
-    with pytest.raises(ui.UserError):
-        plugin._prune_missing(db_path)
-
-    conn = connect(db_path)
-    try:
-        assert conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0] == 1
     finally:
         conn.close()
 

--- a/contrib/beets/tests/test_reconcile.py
+++ b/contrib/beets/tests/test_reconcile.py
@@ -101,8 +101,9 @@ def test_reconcile_surfaces_permission_error_loudly(monkeypatch):
 def test_run_scan_passes_shared_timeout(monkeypatch):
     captured = {}
 
-    def fake_run_scan(binary, db_path, targets, *, timeout=None):
+    def fake_run_scan(binary, db_path, targets, *, revalidate=False, timeout=None):
         captured["targets"] = targets
+        captured["revalidate"] = revalidate
         captured["timeout"] = timeout
 
     monkeypatch.setattr(musefs_mod, "run_scan", fake_run_scan)
@@ -111,6 +112,7 @@ def test_run_scan_passes_shared_timeout(monkeypatch):
     plugin._run_scan("/db.sqlite", ["/a.flac", "/b.flac"])
 
     assert captured["targets"] == ["/a.flac", "/b.flac"]  # one call, full list
+    assert captured["revalidate"] is False  # reconcile/plain scan never revalidates
     assert captured["timeout"] == musefs_mod.SCAN_TIMEOUT_SECONDS == 120
 
 
@@ -118,7 +120,8 @@ def test_removal_only_command_does_not_prune(db_path, tmp_path):
     # Pruning is a deliberate act (#538): the plugin no longer reacts to
     # item/album removals, and a passive cli_exit with no writes pending is a
     # no-op. A removed-and-deleted backing file's row survives until an explicit
-    # `beet musefs` / `musefs scan` — a transient mount blip can't mass-delete.
+    # `beet musefs --revalidate` / `musefs scan --revalidate` — a transient mount
+    # blip can't mass-delete.
     gone = tmp_path / "gone.flac"  # never created on disk == already deleted
     conn = musefs_connect(db_path)
     try:

--- a/contrib/picard/musefs/_common/scan.py
+++ b/contrib/picard/musefs/_common/scan.py
@@ -7,19 +7,23 @@ import subprocess
 from .errors import ScanError
 
 
-def run_scan(binary, db_path, target, *, timeout=None):
-    """Run ``<binary> scan <target...> --db <db_path>``. ``target`` is a single
-    path or an iterable of paths; all targets precede the ``--db`` flag and are
-    scanned under one process (one DB open). Creates the DB if absent and fills
-    the structural columns a plugin can't compute. Raises ``ScanError`` (with
-    ``kind`` in ``"not_found" | "timeout" | "failed"``) on failure; the caller
-    formats its own user-facing message from the exception attributes."""
+def run_scan(binary, db_path, target, *, revalidate=False, timeout=None):
+    """Run ``<binary> scan <target...> --db <db_path> [--revalidate]``. ``target``
+    is a single path or an iterable of paths; all targets precede the ``--db``
+    flag and are scanned under one process (one DB open). Creates the DB if
+    absent and fills the structural columns a plugin can't compute. With
+    ``revalidate``, the scanner re-checks stamps, prunes rows whose backing file
+    is gone, and GCs orphaned art. Raises ``ScanError`` (with ``kind`` in
+    ``"not_found" | "timeout" | "failed"``) on failure; the caller formats its
+    own user-facing message from the exception attributes."""
     if isinstance(target, (str, os.PathLike)):
         targets = [target]
     else:
         targets = list(target)
     display = str(targets[0]) if len(targets) == 1 else f"{len(targets)} target(s)"
     argv = [binary, "scan", *(str(t) for t in targets), "--db", str(db_path)]
+    if revalidate:
+        argv.append("--revalidate")
     try:
         result = subprocess.run(argv, capture_output=True, timeout=timeout)
     except FileNotFoundError as exc:

--- a/contrib/python-musefs/src/musefs_common/scan.py
+++ b/contrib/python-musefs/src/musefs_common/scan.py
@@ -4,19 +4,23 @@ import subprocess
 from .errors import ScanError
 
 
-def run_scan(binary, db_path, target, *, timeout=None):
-    """Run ``<binary> scan <target...> --db <db_path>``. ``target`` is a single
-    path or an iterable of paths; all targets precede the ``--db`` flag and are
-    scanned under one process (one DB open). Creates the DB if absent and fills
-    the structural columns a plugin can't compute. Raises ``ScanError`` (with
-    ``kind`` in ``"not_found" | "timeout" | "failed"``) on failure; the caller
-    formats its own user-facing message from the exception attributes."""
+def run_scan(binary, db_path, target, *, revalidate=False, timeout=None):
+    """Run ``<binary> scan <target...> --db <db_path> [--revalidate]``. ``target``
+    is a single path or an iterable of paths; all targets precede the ``--db``
+    flag and are scanned under one process (one DB open). Creates the DB if
+    absent and fills the structural columns a plugin can't compute. With
+    ``revalidate``, the scanner re-checks stamps, prunes rows whose backing file
+    is gone, and GCs orphaned art. Raises ``ScanError`` (with ``kind`` in
+    ``"not_found" | "timeout" | "failed"``) on failure; the caller formats its
+    own user-facing message from the exception attributes."""
     if isinstance(target, (str, os.PathLike)):
         targets = [target]
     else:
         targets = list(target)
     display = str(targets[0]) if len(targets) == 1 else f"{len(targets)} target(s)"
     argv = [binary, "scan", *(str(t) for t in targets), "--db", str(db_path)]
+    if revalidate:
+        argv.append("--revalidate")
     try:
         result = subprocess.run(argv, capture_output=True, timeout=timeout)
     except FileNotFoundError as exc:

--- a/docs/src/architecture/store.md
+++ b/docs/src/architecture/store.md
@@ -156,11 +156,15 @@ scanned track, are synthesized by the Rust serve path and read back by an
 independent reader.
 
 External writers prune in one of two ways depending on how they own files.
-In-place writers (e.g. the beets plugin) prune by file existence — a removed
-backing file drops its row via `prune_missing`. Link-tree writers (e.g. the
-Lidarr integration) never delete the backing files they point at, so they prune
-by identity instead: a source-reported album/artist deletion removes the rows
-carrying the matching MusicBrainz id.
+For in-place writers (e.g. the beets plugin), existence-based pruning — dropping
+the row of a removed backing file — is a deliberate act owned by `musefs scan
+--revalidate`; the plugin never prunes on its own (it exposes the revalidate
+scan via `beet musefs --revalidate`). The `prune_missing` helper in
+`musefs_common` implements the same by-existence delete for writers that prefer
+to own pruning themselves. Link-tree writers (e.g. the Lidarr integration) never
+delete the backing files they point at, so they prune by identity instead: a
+source-reported album/artist deletion removes the rows carrying the matching
+MusicBrainz id.
 
 Connections are mode-typed (`Db<ReadWrite>` / `Db<ReadOnly>`), opened in WAL
 mode with a busy timeout. The serve path uses a `DbPool` whose per-thread

--- a/docs/src/integrations/beets.md
+++ b/docs/src/integrations/beets.md
@@ -69,6 +69,7 @@ pip install -e "contrib/beets[test]"       # plugin + test deps
 beet musefs                      # everything
 beet musefs albumartist:"Boards of Canada"   # a subset (scans just those files)
 beet musefs -n                   # dry run: report counts, write nothing
+beet musefs --revalidate         # also prune rows whose backing file is gone
 
 # Mount the re-tagged view.
 musefs mount ~/mnt --db ~/musefs.db \
@@ -83,10 +84,10 @@ Imports and tag write-backs auto-sync via event hooks: `beet import` and
 finishes — when each file's path is final (beets has no move event, and a write
 fires *before* its move). The reconcile scans the new path and writes its tags,
 but it **never prunes** — pruning is a deliberate act (see below). A move
-therefore leaves the old path's row behind until you run `beet musefs`. A
-metadata-only `beet modify` (no `-w`) doesn't fire a hook — re-run `beet musefs`.
-With `autoscan: no`, run `musefs scan` yourself first; the hooks then skip
-gracefully if the DB is missing.
+therefore leaves the old path's row behind until you run `beet musefs
+--revalidate`. A metadata-only `beet modify` (no `-w`) doesn't fire a hook —
+re-run `beet musefs`. With `autoscan: no`, run `musefs scan` yourself first; the
+hooks then skip gracefully if the DB is missing.
 
 ## Never writing to your backing audio files
 
@@ -145,17 +146,19 @@ A few plugins ignore that gate or are redundant in this mode:
   engine can't express. Set `write_path: no` in the `musefs:` config to skip it.
   Do not add an extension in a template that consumes `beets_path`. See the
   computed-tag workflow in [the architecture overview](../architecture/overview.md).
-- **Pruning is a deliberate act.** Only the explicit `beet musefs` command prunes
-  track rows whose backing file is gone from disk (renames/moves/deletes). The
-  passive end-of-command reconcile (`beet import` / `beet modify -w`) syncs but
-  never prunes, so a transient backing-storage loss — an unmounted network share,
-  an offline drive, a momentary realpath divergence — can no longer mass-delete
-  plugin metadata. Run `beet musefs` (or `musefs scan`) while the library is
-  available to clear stale rows left by a move or an on-disk delete.
-- **Removals are not auto-pruned.** `beet remove` / `beet remove -d` no longer
-  prunes the store; run `beet musefs` afterwards to drop the rows whose backing
-  file is now gone. A bare `beet remove` (which keeps the file on disk) leaves a
-  servable row in place even then — musefs can still serve those bytes.
+- **Pruning is a deliberate act.** The plugin never prunes on its own. Pruning
+  track rows whose backing file is gone from disk (renames/moves/deletes) is owned
+  entirely by `musefs scan --revalidate`, reachable from beets as `beet musefs
+  --revalidate` (which forwards the flag to the auto-scan). Plain `beet musefs` and
+  the passive end-of-command reconcile (`beet import` / `beet modify -w`) only
+  sync, so a transient backing-storage loss — an unmounted network share, an
+  offline drive, a momentary realpath divergence — can never mass-delete plugin
+  metadata. Run `beet musefs --revalidate` (or `musefs scan --revalidate`) while
+  the library is available to clear stale rows left by a move or an on-disk delete.
+- **Removals are not auto-pruned.** `beet remove` / `beet remove -d` does not
+  prune the store; run `beet musefs --revalidate` afterwards to drop the rows whose
+  backing file is now gone. A bare `beet remove` (which keeps the file on disk)
+  leaves a servable row in place even then — musefs can still serve those bytes.
 - **Orphaned art:** replacing art can orphan old blobs; `musefs scan --revalidate`
   garbage-collects them.
 - **Schema version:** the plugin refuses to run if the DB's `user_version` differs

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -407,6 +407,10 @@ AppArmor profile only permits unprivileged FUSE mounts under whitelisted prefixe
 Mount under a permitted prefix, or whitelist yours in /etc/apparmor.d/local/fusermount3 (check the kernel audit \
 log for an apparmor=\"DENIED\" ... profile=\"fusermount3\" line). See the mounting guide for details.";
 
+const MOUNT_NO_FUSE_HELP: &str = "the FUSE userspace appears to be missing; mounting needs the `fuse3` package \
+(fusermount3 on PATH), the `fuse` kernel module loaded, and /dev/fuse present. Install it (e.g. `apt install fuse3` \
+/ `apk add fuse3` / `dnf install fuse3`) and ensure /dev/fuse exists. See the installation guide for runtime requirements.";
+
 /// True if `mountpoint` is a directory containing at least one entry. A read
 /// failure is treated as "empty" — the warning is advisory, and the mount will
 /// surface any real access error itself.
@@ -482,11 +486,17 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
         // otherwise opaque. Append actionable guidance — but not when the
         // allow_other preflight already produced its own self-contained message
         // (it names /etc/fuse.conf), to avoid stacking two different hints (#509).
-        let add_hint = e.kind() == std::io::ErrorKind::PermissionDenied
+        let denied_hint = e.kind() == std::io::ErrorKind::PermissionDenied
             && !e.to_string().contains("/etc/fuse.conf");
+        // A missing FUSE userspace (no fusermount3 on PATH, kernel module not
+        // loaded, or /dev/fuse absent) surfaces as NotFound with an opaque
+        // message — the most common first-run failure on a fresh host/container.
+        let no_fuse_hint = !denied_hint && e.kind() == std::io::ErrorKind::NotFound;
         let err = anyhow::Error::new(e).context(format!("mounting at {}", mountpoint.display()));
-        if add_hint {
+        if denied_hint {
             err.context(MOUNT_DENIED_HELP)
+        } else if no_fuse_hint {
+            err.context(MOUNT_NO_FUSE_HELP)
         } else {
             err
         }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -277,7 +277,11 @@ fn collect_audio_inner(
             }
         } else if ftype.is_symlink() {
             if !follow_symlinks {
-                log::warn!(
+                // Routine and expected (symlinks are off by default); a library
+                // sitting next to symlinked dirs would otherwise flood stderr at
+                // the default `warn` floor. The end-of-scan skip tally still
+                // surfaces what was passed over.
+                log::debug!(
                     "skipping symlink {} (pass --follow-symlinks to scan it)",
                     path.display()
                 );


### PR DESCRIPTION
## Summary

Follow-ups from a full security/performance/usability audit. The audit (five read-only domain subagents: security, performance, format-synthesis correctness, usability/CLI, contrib/CI) found **no security or correctness issues** — the cardinal audio-byte invariant holds and recent fix series closed everything expected. These are the actionable usability items it surfaced, plus a behavior change to beets pruning requested on top.

## Changes

- **scan: quieter symlink skips.** Demote the routine `skipping symlink … (pass --follow-symlinks)` log from `warn` to `debug`. At the default `warn` floor it flooded stderr (one line per symlink), burying the scan summary on any library sitting near symlinked dirs. The end-of-scan skip tally still surfaces what was passed over.
- **cli: actionable FUSE-missing hint.** Add a `NotFound` arm to the mount error mapping with install guidance (missing `fuse3` / `fusermount3` / `/dev/fuse`) — the most common fresh-host failure previously got the least help (only `PermissionDenied` was enriched).
- **README: runtime prereq.** Note that mounting needs the `fuse3` *runtime* package, not just the build deps the quick-start already listed.
- **beets: prune only on `--revalidate`.** Remove the implicit prune from `beet musefs`. Pruning rows whose backing file is gone (and orphaned-art GC) is now owned solely by `musefs scan --revalidate`, reachable from beets via the new `beet musefs --revalidate` flag (forwarded to the auto-scan). Plain `beet musefs` and the passive reconcile only sync, so a transient backing-storage loss (unmounted share, offline drive) can never mass-delete metadata. The `prune_missing` helper in `musefs_common` stays for writers that own pruning themselves.

## Testing

- Full workspace `cargo test` + `clippy -D warnings` + `fmt` (via pre-commit hook) — green.
- beets plugin/reconcile suites and python-musefs scan/store/public-api suites — green; `ruff` clean.
- Mutant-anchor drift guard re-validated (re-anchored the shifted `scan.rs` coordinates in the same commit).
- Not run: the FUSE e2e move/reconcile test (needs a real mount); its change is the added `--revalidate` arg, and `revalidate_with` is confirmed to prune within the scanned root.
