### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   cue=10, log=8, <none>=4`), logged at `warn` so it shows by default, so a large
   skip count is diagnosable — expected sidecars versus genuinely unexpected
   files. Log-only; the `ScanStats` struct and CLI summary are unchanged (#341).
+- **`musefs vacuum` command:** compact the SQLite store, reclaiming free pages
+  left by prunes, orphan-art GC, and the schema migration. Runs `VACUUM` + a WAL
+  checkpoint and reports the space reclaimed; run it while unmounted (#566).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-17
+
 ### Added
 
 - **`-v`/`--verbose` flag:** a global verbosity flag (`-v` = info, `-vv` =

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "musefs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arc-swap",
  "base16ct",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-db"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base16ct",
  "log",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-format"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "crc",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-fuse"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "fuser",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-latencyfs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "fuser",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["musefs-db", "musefs-format", "musefs-core", "musefs-fuse", "musefs-c
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 # Best-effort MSRV. The bundled-SQLite dependency (libsqlite3-sys) tracks the
 # newest stdlib — its build script uses `cfg_select!` — so the real floor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 [![CI](https://github.com/Sohex/musefs/actions/workflows/ci.yml/badge.svg)](https://github.com/Sohex/musefs/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/Sohex/musefs/branch/main/graph/badge.svg)](https://codecov.io/gh/Sohex/musefs)
-[![Release](https://img.shields.io/github/v/release/Sohex/musefs?sort=semver)](https://github.com/Sohex/musefs/releases/latest)
+[![crates.io](https://img.shields.io/crates/v/musefs.svg?logo=rust)](https://crates.io/crates/musefs)
+[![PyPI](https://img.shields.io/pypi/v/python-musefs.svg?logo=pypi&logoColor=white&label=python-musefs)](https://pypi.org/project/python-musefs/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A read-only FUSE filesystem that presents a re-tagged, reorganized view of

--- a/contrib/CHANGELOG.md
+++ b/contrib/CHANGELOG.md
@@ -10,6 +10,8 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-17
+
 ### Changed
 
 - **beets: pruning is now a deliberate act.** The passive `cli_exit` reconcile

--- a/contrib/beets/pyproject.toml
+++ b/contrib/beets/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "beets-musefs"
-version = "1.0.0"
+version = "1.1.0"
 description = "Sync beets metadata into the musefs SQLite store"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Conor Futro" }]
-dependencies = ["python-musefs>=1.0.0", "beets>=1.6"]
+dependencies = ["python-musefs>=1.1.0", "beets>=1.6"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/contrib/lidarr/pyproject.toml
+++ b/contrib/lidarr/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lidarr-musefs"
-version = "1.0.0"
+version = "1.1.0"
 description = "Sync Lidarr metadata into the musefs SQLite store"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Conor Futro" }]
-dependencies = ["python-musefs>=1.0.0"]
+dependencies = ["python-musefs>=1.1.0"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/contrib/lidarr/src/musefs_lidarr/__init__.py
+++ b/contrib/lidarr/src/musefs_lidarr/__init__.py
@@ -1,3 +1,3 @@
 """Lidarr integration for syncing metadata into musefs."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/contrib/lidarr/tests/test_smoke.py
+++ b/contrib/lidarr/tests/test_smoke.py
@@ -3,5 +3,5 @@ from musefs_lidarr.errors import MusefsLidarrError
 
 
 def test_package_imports():
-    assert __version__ == "1.0.0"
+    assert __version__ == "1.1.0"
     assert str(MusefsLidarrError("problem")) == "problem"

--- a/contrib/picard/musefs/__init__.py
+++ b/contrib/picard/musefs/__init__.py
@@ -38,7 +38,7 @@ PLUGIN_DESCRIPTION = (
     "Right-click a file/album → 'Sync to musefs' to push Picard's tags and "
     "cover images into a musefs SQLite store, without rewriting the audio file."
 )
-PLUGIN_VERSION = "1.0.0"
+PLUGIN_VERSION = "1.1.0"
 # Floor: 2.0 — all required APIs (BaseAction, register_*_action, OptionsPage,
 # register_options_page, config.TextOption/BoolOption, thread.run_task,
 # iterfiles, metadata.images, is_front_image) are present since Picard 2.0.0.

--- a/contrib/picard/musefs/_common/__init__.py
+++ b/contrib/picard/musefs/_common/__init__.py
@@ -31,7 +31,7 @@ from .store import (
 )
 from .sync import ArtImage, Record, SyncStats, sync_files, sync_one
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "EXPECTED_USER_VERSION",

--- a/contrib/picard/pyproject.toml
+++ b/contrib/picard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "musefs-picard"
-version = "1.0.0"
+version = "1.1.0"
 description = "Sync MusicBrainz Picard metadata into the musefs SQLite store"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/contrib/python-musefs/pyproject.toml
+++ b/contrib/python-musefs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-musefs"
-version = "1.0.0"
+version = "1.1.0"
 description = "Shared musefs SQLite-store contract for the beets and Picard plugins"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/contrib/python-musefs/src/musefs_common/__init__.py
+++ b/contrib/python-musefs/src/musefs_common/__init__.py
@@ -28,7 +28,7 @@ from .store import (
 )
 from .sync import ArtImage, Record, SyncStats, sync_files, sync_one
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "EXPECTED_USER_VERSION",

--- a/contrib/python-musefs/tests/test_public_api.py
+++ b/contrib/python-musefs/tests/test_public_api.py
@@ -2,7 +2,7 @@ import musefs_common
 
 
 def test_version_is_package_semver_not_schema_version():
-    assert musefs_common.__version__ == "1.0.0"
+    assert musefs_common.__version__ == "1.1.0"
     assert musefs_common.__version__ != str(musefs_common.EXPECTED_USER_VERSION)
 
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -49,5 +49,6 @@
 # Reference
 
 - [Benchmarks](benchmarks.md)
+- [Release notes](release-notes.md)
 - [Changelog](changelog.md)
 - [Security](security.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Scanning](guide/scanning.md)
 - [Mounting & path templates](guide/mounting.md)
 - [Tuning & metrics](guide/tuning.md)
+- [Maintenance](guide/maintenance.md)
 - [Ownership, permissions & config](guide/configuration.md)
 - [FAQ](guide/faq.md)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > The `contrib/` Python packages have their own decoupled version and changelog:
 > see [the contrib changelog](integrations/overview.md#contrib-changelog).
 
+For curated, upgrade-focused notes (highlights and per-version migration steps),
+see the [Release notes](release-notes.md).
+
 ## [Unreleased]
+
+## [1.1.0] - 2026-06-17
 
 ### Added
 
@@ -237,7 +242,8 @@ First public release.
   `synthesis` / `structure-only` mount modes, auto-refresh, `scan` /
   `scan --revalidate`). Never published publicly; superseded by 0.2.0.
 
-[Unreleased]: https://github.com/Sohex/musefs/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Sohex/musefs/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/Sohex/musefs/releases/tag/v1.1.0
 [1.0.0]: https://github.com/Sohex/musefs/releases/tag/v1.0.0
 [0.2.0]: https://github.com/Sohex/musefs/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Sohex/musefs/releases/tag/v0.1.0

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -52,6 +52,9 @@ see the [Release notes](release-notes.md).
   cue=10, log=8, <none>=4`), logged at `warn` so it shows by default, so a large
   skip count is diagnosable — expected sidecars versus genuinely unexpected
   files. Log-only; the `ScanStats` struct and CLI summary are unchanged (#341).
+- **`musefs vacuum` command:** compact the SQLite store, reclaiming free pages
+  left by prunes, orphan-art GC, and the schema migration. Runs `VACUUM` + a WAL
+  checkpoint and reports the space reclaimed; run it while unmounted (#566).
 
 ### Fixed
 

--- a/docs/src/formats/flac.md
+++ b/docs/src/formats/flac.md
@@ -30,6 +30,10 @@ model these layouts plug into, see
 
 - `PADDING` blocks are dropped — the synthesized file carries no padding.
 - Metadata blocks of unknown/reserved types are dropped at scan time.
+- A `PICTURE` block whose picture type falls outside the standard `0`–`20`
+  range is clamped to `0` (`Other`) at scan time, matching the store's
+  `track_art.picture_type` `CHECK`. This shared `PICTURE` parser also serves
+  FLAC-in-Ogg, so the same clamp applies there.
 - The `VORBIS_COMMENT` vendor string is replaced with musefs's own.
 - Vorbis field names are case-insensitive by spec; musefs re-emits canonical
   keys under their conventional uppercase names and upper-cases unknown

--- a/docs/src/formats/mp3.md
+++ b/docs/src/formats/mp3.md
@@ -65,6 +65,9 @@ described here is shared with WAV's embedded `id3 ` chunk — see
   files still mount and serve; they just contribute no scanned tags.
 - ID3v2.2 binary frames are not extracted (3-char ids; text and art still
   parse). `APIC` width/height are not recorded at scan time.
+- An `APIC` picture type outside the standard `0`–`20` range (the `id3`
+  crate's `Undefined(u8)` variant can exceed 20) is clamped to `0` (`Other`)
+  at scan time, matching the store's `track_art.picture_type` `CHECK`.
 
 ## How synthesis works
 

--- a/docs/src/formats/ogg.md
+++ b/docs/src/formats/ogg.md
@@ -47,6 +47,9 @@ Verified by `musefs-format/tests/proptest_ogg.rs` (crate feature `fuzzing`),
   upper-cased on synthesis.
 - Ogg carries no binary-tag slot: only text comments and pictures exist, so
   there is nothing else to preserve.
+- Embedded pictures are parsed through FLAC's `PICTURE` block reader, so a
+  picture type outside the standard `0`–`20` range is clamped to `0` (`Other`)
+  at scan time, matching the store's `track_art.picture_type` `CHECK`.
 - **Embedded picture descriptions are right-padded with up to two trailing
   spaces.** The FLAC PICTURE block is built with its description padded so the
   *prefix* length — `32 + mime.len() + description.len()`, i.e. everything

--- a/docs/src/guide/maintenance.md
+++ b/docs/src/guide/maintenance.md
@@ -1,0 +1,42 @@
+# Maintenance
+
+## Compacting the store (`musefs vacuum`)
+
+The SQLite store only grows as you use it: deleting tracks (beets/Lidarr
+prunes), garbage-collecting orphaned art, and the schema migration all leave
+free pages behind that are not automatically reclaimed. Because embedded art is
+stored inline (up to ~16 MiB per image), a library that has churned art can
+carry significant dead space.
+
+`musefs vacuum` compacts the store and reports how much it reclaimed:
+
+```bash
+musefs vacuum --db library.db        # or: MUSEFS_DB=library.db musefs vacuum
+```
+
+```text
+vacuumed library.db: 412.7 MiB → 318.2 MiB (reclaimed 94.5 MiB)
+```
+
+It runs SQLite's `VACUUM` followed by a WAL checkpoint, rewriting the database
+into a compact form.
+
+### Run it while unmounted
+
+`VACUUM` needs a write lock on the store and rewrites the whole file. Run it when
+nothing else is using the database — no mount, no scan. If the store is in use,
+the command fails with an actionable error rather than fighting for the lock:
+
+```text
+error: the store is in use — unmount the filesystem or stop any scan before vacuuming
+```
+
+### Notes
+
+- **Full rewrite.** Each run rewrites the entire database and transiently needs
+  free disk space roughly equal to the store size (it builds a complete copy
+  before swapping). Running it again on an already-compact store is safe and
+  reports `(already compact)`.
+- **May upgrade the schema.** Like every musefs command that opens the store for
+  writing, `vacuum` migrates an older store to the current schema version before
+  compacting.

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -42,6 +42,10 @@ v1.0.0](#upgrading-from-v100) before you update an existing store.
 - **Per-extension skip breakdown.** End-of-scan summary breaks the `skipped`
   count down by lowercased extension (e.g. `skipped 42: jpg=20, cue=10, log=8`)
   so a large skip count is diagnosable. Log-only; the counters are unchanged.
+- **`musefs vacuum`.** A maintenance command that compacts the SQLite store —
+  reclaiming the free pages that prunes, orphan-art GC, and the migration leave
+  behind — and reports the space reclaimed. Run it while unmounted. See
+  [Maintenance](guide/maintenance.md).
 
 Plus a substantial round of correctness and robustness fixes across the read
 fast path (rowid-reuse consistency for art segments), the MP4/QuickTime

--- a/docs/src/release-notes.md
+++ b/docs/src/release-notes.md
@@ -1,0 +1,104 @@
+# Release notes
+
+Curated, upgrade-focused notes for each release. For the exhaustive,
+per-change list see the [Changelog](changelog.md); for the external-writer
+`contrib/` packages (which version independently) see the
+[contrib changelog](integrations/overview.md#contrib-changelog).
+
+## v1.1.0
+
+A feature-and-hardening release on top of the v1.0.0 stable line. No CLI flags
+or store columns were removed, but the on-disk schema steps to **version 2** and
+a few defaults change observable behavior — read [Upgrading from
+v1.0.0](#upgrading-from-v100) before you update an existing store.
+
+### Highlights
+
+- **Runtime telemetry.** An opt-in `--expose-metrics` (env
+  `MUSEFS_EXPOSE_METRICS`) surfaces a synthetic `.musefs-metrics/` directory at
+  the mount root whose `metrics` file renders Prometheus-format counters for
+  getattr/read/open activity, backing read-ahead behavior, and (with the
+  jemalloc build) allocator stats. Off by default. See
+  [Tuning & metrics](guide/tuning.md#metrics).
+- **Scan progress indicator.** `scan` and `scan --revalidate` render a live
+  progress bar on an interactive terminal and fall back to periodic
+  `ingested N/M (P%)` lines when output is redirected. A new `--quiet`/`-q`
+  suppresses it.
+- **`--skip-on-missing` template flag.** Opt-in (env `MUSEFS_SKIP_ON_MISSING`):
+  drops a track from the mount when a top-level template field stays unresolved,
+  instead of substituting `--default-fallback`. The motivating case is
+  `--template '$!{beets_path}' --skip-on-missing`, hiding tracks beets left
+  without a `beets_path` rather than collapsing them into an `Unknown` bucket.
+- **`--read-ahead-prefetch` flag.** Opt-in background prefetch threads layered on
+  read amplification, default off — benchmarks found amplification alone
+  delivers the read-ahead win, so enable this only when profiling a backend where
+  a single large read does not self-pipeline.
+- **riscv64 release platform.** Prebuilt `riscv64gc-unknown-linux-{gnu,musl}`
+  binaries and `linux/riscv64` Docker images now ship with each tagged release.
+  Container bases moved to current stable (Debian trixie, Alpine 3.23).
+- **`statfs` reply.** The mount now reports a synthetic non-zero capacity with
+  ample free space, so `df` no longer shows a 0-byte filesystem and
+  capacity-checking importers (Lidarr et al.) no longer balk.
+- **Per-extension skip breakdown.** End-of-scan summary breaks the `skipped`
+  count down by lowercased extension (e.g. `skipped 42: jpg=20, cue=10, log=8`)
+  so a large skip count is diagnosable. Log-only; the counters are unchanged.
+
+Plus a substantial round of correctness and robustness fixes across the read
+fast path (rowid-reuse consistency for art segments), the MP4/QuickTime
+metadata walk, ID3 synthesis, and the prune/delete paths — see the
+[Changelog](changelog.md#110---2026-06-17) for the full list.
+
+### Upgrading from v1.0.0
+
+**1. Back up your store.** The schema migration below is one-way. While no scan
+or external writer is touching the database, copy `musefs.db` (and its `-wal` /
+`-shm` sidecars if present). A v1.0.0 binary has no guard against a newer store
+and may misread one that has been migrated, so keep the backup if you might roll
+back. From v1.1.0 onward a binary instead **refuses** to open a store whose
+schema is newer than it understands, with a clear error.
+
+**2. Automatic schema migration (`user_version` 1 → 2).** The first time a
+v1.1.0 binary opens the store — for example `musefs scan` — it migrates in a
+single transaction. The migration:
+
+- Adds scanner-owned `tracks.fingerprint` and `tracks.content_hash` columns
+  (nullable SHA-256 hex, non-unique by design) plus a `fingerprint` index. They
+  start `NULL` and are populated on the next scan; external writers do not set
+  them.
+- Rebuilds the `tags` table so the 256 KiB `value` cap counts bytes rather than
+  characters (the v1 `CHECK` was up to ~4× looser for multibyte text). Any row
+  that was already over the byte cap is dropped in the rebuild (this only reaches
+  genuinely pathological data — a single tag value larger than 256 KiB of bytes,
+  which a real library never has, and such rows were already unreadable under the
+  byte-counting read guard anyway; in practice no store is affected).
+
+The migration applies automatically the first time a v1.1.0 binary opens the
+store, but you should still run `musefs scan --db <store>` once after upgrading:
+that is what populates the new `fingerprint` / `content_hash` columns, which the
+scanner's content-identity refind logic relies on. Then remount. See
+[The SQLite store](architecture/store.md) for the full schema contract.
+
+**3. Behavior changes to check.**
+
+- **`scan` exit code.** `scan`/`scan --revalidate` now exit `2` when any file
+  fails to parse or ingest (previously always `0` on a non-fatal run). A clean
+  scan still exits `0`; a hard error still exits `1`. Pipelines that key off the
+  exit status — e.g. `musefs scan … && musefs mount …` — will now correctly stop
+  on a partial-ingest failure; update any script that assumed `0`.
+- **`--fallback` keys are case-insensitive.** A per-field `--fallback
+  AlbumArtist=…` (or any non-lowercase key) is now matched against the template
+  field instead of silently never applying. If you worked around the old bug by
+  lowercasing keys, no change is needed; uppercase keys now take effect.
+- **`df` on the mount** now shows a synthetic capacity instead of zeros.
+- **Extended attributes** (`getxattr`/`setxattr`/…) now return `ENOTSUP`
+  explicitly on the read-only mount; the caller-visible result is unchanged, but
+  the per-probe `[Not Implemented]` warning is gone.
+
+**4. External writers** (beets, Picard, Lidarr, `python-musefs`) version
+independently and need no change for this upgrade: the new `fingerprint` /
+`content_hash` columns are scanner-owned and nullable, so the external-writer
+contract is unchanged. Update those packages on their own cadence.
+
+## Earlier releases
+
+For v1.0.0 and earlier, see the [Changelog](changelog.md).

--- a/docs/superpowers/plans/2026-06-17-vacuum-command.md
+++ b/docs/superpowers/plans/2026-06-17-vacuum-command.md
@@ -1,0 +1,565 @@
+# `musefs vacuum` Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `musefs vacuum --db <store>` subcommand that compacts the SQLite store (reclaims free pages left by deletions) and reports bytes reclaimed.
+
+**Architecture:** A `Db::<ReadWrite>::vacuum()` method in `musefs-db` runs `VACUUM` then `PRAGMA wal_checkpoint(TRUNCATE)` and maps SQLite BUSY/locked to a typed `DbError::StoreInUse`. The CLI adds a thin `Command::Vacuum` + `run_vacuum` that guards an existing store (like `mount --db`), measures the on-disk footprint before/after, and prints a summary. Layering stays `db → cli`.
+
+**Tech Stack:** Rust, rusqlite (bundled SQLite), clap (derive), anyhow (CLI only), indicatif (`HumanBytes`), thiserror, tempfile (dev).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-17-vacuum-command-design.md`.
+- Work happens on the existing `release/v1.1.0` branch (folds into PR #566). Do **not** create a worktree or new branch.
+- The pre-commit hook runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, the **full workspace test suite**, and ruff — every commit must be green. Non-docs commits run the cargo gate; docs-only commits (all staged paths under `docs/` or `*.md`) skip it.
+- Integer-cast convention: widenings via `From`/`u64::from`; `as` only under a reasoned `#[expect]`. The code in this plan uses no narrowing casts.
+- Error convention: `musefs-db` returns `DbError`; the CLI is the only `anyhow` consumer.
+- No schema change: this feature adds no table/column/migration, so the Python schema mirror is untouched and needs no regen.
+- `with_raw_conn` is `#[cfg(feature = "fuzzing")]` — not usable here; the method uses `self.conn` directly (every other `Db<ReadWrite>` write method does).
+- Mutant-anchor pre-commit guard covers only `musefs-core`/`musefs-format` src — editing `musefs-db`/`musefs-cli` shifts no anchors.
+
+---
+
+### Task 1: `musefs-db` — `vacuum()`, `StoreInUse`, `map_vacuum_err`
+
+**Files:**
+- Create: `musefs-db/src/maintenance.rs`
+- Modify: `musefs-db/src/lib.rs` (add `mod maintenance;` to the module list, lines 1-10)
+- Modify: `musefs-db/src/error.rs` (add `StoreInUse` variant after `StoreTooNew`, ~line 24)
+
+**Interfaces:**
+- Consumes: `Db<ReadWrite>` with field `conn: Connection` (`lib.rs:93-97`); `Db::open<P: AsRef<Path>>(path) -> Result<Db>`; `Db::open_in_memory() -> Result<Db>`; `DbError` (`error.rs`); `NewArt { mime, width, height, data }`, `NewTrack { .. }` (`models.rs`); `upsert_art(&NewArt) -> Result<i64>`, `gc_orphan_art() -> Result<usize>` (`art.rs`); `pub type Result<T> = std::result::Result<T, DbError>`.
+- Produces:
+  - `DbError::StoreInUse(rusqlite::Error)` — new enum variant.
+  - `Db::<ReadWrite>::vacuum(&self) -> Result<()>` — runs VACUUM + TRUNCATE checkpoint.
+  - `fn map_vacuum_err(err: rusqlite::Error) -> DbError` (module-private to `maintenance`) — BUSY/locked → `StoreInUse`, else `Sqlite`.
+
+- [ ] **Step 1: Add the `StoreInUse` error variant**
+
+In `musefs-db/src/error.rs`, insert after the `StoreTooNew { .. }` variant (after line 24, before `FieldTooLarge`):
+
+```rust
+    #[error(
+        "the store is in use — unmount the filesystem or stop any scan before vacuuming"
+    )]
+    StoreInUse(#[source] rusqlite::Error),
+```
+
+- [ ] **Step 2: Register the module**
+
+In `musefs-db/src/lib.rs`, add `mod maintenance;` between `pub mod limits;` and `mod models;` (keep the existing alphabetical grouping):
+
+```rust
+pub mod limits;
+mod maintenance;
+mod models;
+```
+
+- [ ] **Step 3: Write the failing tests (create `maintenance.rs` with tests only)**
+
+Create `musefs-db/src/maintenance.rs` with exactly this content (the `impl`/`fn` come in Step 5; this step is the test module plus stub signatures so it compiles-and-fails meaningfully):
+
+```rust
+//! Store maintenance operations: compaction (`VACUUM` + WAL checkpoint).
+
+use crate::{Db, DbError, ReadWrite, Result};
+
+impl Db<ReadWrite> {
+    /// Compact the store: reclaim free pages left by deletions, then truncate
+    /// the WAL. Runs a full `VACUUM` (rewrites the whole database — transiently
+    /// needs free disk roughly equal to the store size) followed by
+    /// `PRAGMA wal_checkpoint(TRUNCATE)`. The TRUNCATE checkpoint *after* VACUUM
+    /// is what actually shrinks the main `.db` file on disk and zeroes the
+    /// `-wal`. A busy/locked store (e.g. a live mount) maps to
+    /// [`DbError::StoreInUse`].
+    pub fn vacuum(&self) -> Result<()> {
+        self.conn.execute_batch("VACUUM").map_err(map_vacuum_err)?;
+        self.conn
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .map_err(map_vacuum_err)?;
+        Ok(())
+    }
+}
+
+/// Translate a VACUUM/checkpoint error: a SQLite busy/locked failure means the
+/// store is open elsewhere (a mount or scan), surfaced as the actionable
+/// [`DbError::StoreInUse`]; everything else flows through the transparent
+/// rusqlite variant.
+fn map_vacuum_err(err: rusqlite::Error) -> DbError {
+    if let rusqlite::Error::SqliteFailure(e, _) = &err {
+        if matches!(
+            e.code,
+            rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+        ) {
+            return DbError::StoreInUse(err);
+        }
+    }
+    DbError::Sqlite(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_vacuum_err;
+    use crate::models::NewArt;
+    use crate::{Db, DbError};
+
+    fn sidecar(path: &std::path::Path, suffix: &str) -> std::path::PathBuf {
+        let mut p = path.to_path_buf().into_os_string();
+        p.push(suffix);
+        std::path::PathBuf::from(p)
+    }
+
+    #[test]
+    fn vacuum_shrinks_file_and_truncates_wal_after_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.db");
+        let db = Db::open(&path).unwrap();
+
+        // Allocate many pages: 16 distinct 256 KiB art blobs (~4 MiB).
+        for i in 0..16u8 {
+            db.upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![i; 256 * 1024],
+            })
+            .unwrap();
+        }
+        // None are linked to a track, so they are all orphan: free their pages.
+        assert_eq!(db.gc_orphan_art().unwrap(), 16);
+
+        // Settle the WAL so the pre-vacuum main-file size reflects the deletes.
+        db.conn
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        let before = std::fs::metadata(&path).unwrap().len();
+
+        db.vacuum().unwrap();
+
+        let after = std::fs::metadata(&path).unwrap().len();
+        assert!(after < before, "expected shrink: {before} -> {after}");
+
+        let freelist: i64 = db
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(freelist, 0, "vacuum must leave no free pages");
+
+        // The TRUNCATE checkpoint inside vacuum() must zero the WAL file.
+        let wal = std::fs::metadata(sidecar(&path, "-wal"))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        assert_eq!(wal, 0, "vacuum must truncate the -wal file");
+    }
+
+    #[test]
+    fn vacuum_on_empty_store_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Db::open(dir.path().join("t.db")).unwrap();
+        db.vacuum().unwrap();
+    }
+
+    #[test]
+    fn map_vacuum_err_maps_busy_and_locked_to_store_in_use() {
+        use rusqlite::{ffi, Error};
+        let busy = Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_BUSY), None);
+        assert!(matches!(map_vacuum_err(busy), DbError::StoreInUse(_)));
+        let locked = Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_LOCKED), None);
+        assert!(matches!(map_vacuum_err(locked), DbError::StoreInUse(_)));
+    }
+
+    #[test]
+    fn map_vacuum_err_passes_through_other_errors() {
+        use rusqlite::{ffi, Error};
+        let corrupt = Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), None);
+        assert!(matches!(map_vacuum_err(corrupt), DbError::Sqlite(_)));
+    }
+}
+```
+
+Note: Step 3 already contains the implementation (the `impl`/`map_vacuum_err`) because the tests and impl live in one small file and must compile together. The "failing" state in Step 4 is the pre-edit baseline — confirm the module did not exist before. If you prefer strict red-first, temporarily stub `vacuum` to `Ok(())` without the pragmas and watch `vacuum_shrinks_file...` fail, then restore the body shown above.
+
+- [ ] **Step 4: Run the tests to verify they pass (after Steps 1-3)**
+
+Run: `cargo test -p musefs-db maintenance`
+Expected: PASS — `vacuum_shrinks_file_and_truncates_wal_after_deletion`, `vacuum_on_empty_store_is_ok`, `map_vacuum_err_maps_busy_and_locked_to_store_in_use`, `map_vacuum_err_passes_through_other_errors` all green.
+
+If `vacuum_shrinks_file...` fails on `after < before`: confirm the `gc_orphan_art` returned 16 and the pre-vacuum checkpoint ran (the main file must be bloated before vacuuming).
+
+- [ ] **Step 5: Lint**
+
+Run: `cargo clippy -p musefs-db --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add musefs-db/src/maintenance.rs musefs-db/src/lib.rs musefs-db/src/error.rs
+git commit -m "feat(db): add Db::vacuum() store compaction (VACUUM + WAL truncate)"
+```
+
+(The pre-commit hook runs the full workspace suite; expect it green.)
+
+---
+
+### Task 2: `musefs-cli` — `vacuum` subcommand and `run_vacuum`
+
+**Files:**
+- Modify: `musefs-cli/src/lib.rs` — import (line 10), `Command` enum (after the `Mount(MountArgs)` arm, ~line 217), new `run_vacuum`/`store_footprint`/`vacuum_summary` (after `run_mount`, before `run`), dispatch arm in `run` (~line 607), tests (in `mod tests`, ~line 612).
+
+**Interfaces:**
+- Consumes: `Db::open` and `Db::<ReadWrite>::vacuum()` from Task 1; `musefs_db::{Db, NewArt}`; `indicatif::HumanBytes`; `anyhow::{Context, Result, bail}`; `std::process::ExitCode`.
+- Produces: `Command::Vacuum { db: PathBuf }`; `pub fn run_vacuum(db: &Path) -> anyhow::Result<()>`; private `fn store_footprint(db: &Path) -> u64`; private `fn vacuum_summary(path: &Path, before: u64, after: u64) -> String`.
+
+- [ ] **Step 1: Add the `HumanBytes` import**
+
+In `musefs-cli/src/lib.rs` line 10, change:
+
+```rust
+use indicatif::HumanDuration;
+```
+to:
+```rust
+use indicatif::{HumanBytes, HumanDuration};
+```
+
+- [ ] **Step 2: Add the `Vacuum` command variant**
+
+In the `Command` enum, after the `Mount(MountArgs)` arm (the last arm, ~line 217), add:
+
+```rust
+    /// Compact the SQLite store, reclaiming free pages left by deletions
+    /// (prunes, orphan-art GC, the schema migration). Run while unmounted; this
+    /// may also upgrade an older store's schema to the current version.
+    Vacuum {
+        /// Path to the SQLite database.
+        #[arg(long, env = "MUSEFS_DB")]
+        db: PathBuf,
+    },
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+In `musefs-cli/src/lib.rs`, inside `mod tests` (after the existing `read_ahead_budget_flag_maps_to_mount_config` test), add:
+
+```rust
+    #[test]
+    fn vacuum_command_parses_db_path() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "vacuum", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Vacuum { db } = cli.command else {
+            panic!("expected Vacuum");
+        };
+        assert_eq!(db, PathBuf::from("/tmp/x.db"));
+    }
+
+    #[test]
+    fn run_vacuum_errors_on_missing_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.db");
+        assert!(run_vacuum(&missing).is_err());
+    }
+
+    #[test]
+    fn run_vacuum_compacts_a_bloated_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lib.db");
+        {
+            let db = musefs_db::Db::open(&path).unwrap();
+            for i in 0..16u8 {
+                db.upsert_art(&musefs_db::NewArt {
+                    mime: "image/png".into(),
+                    width: None,
+                    height: None,
+                    data: vec![i; 256 * 1024],
+                })
+                .unwrap();
+            }
+            assert_eq!(db.gc_orphan_art().unwrap(), 16);
+        }
+        let before = std::fs::metadata(&path).unwrap().len();
+        run_vacuum(&path).unwrap();
+        let after = std::fs::metadata(&path).unwrap().len();
+        assert!(after < before, "expected shrink: {before} -> {after}");
+    }
+
+    #[test]
+    fn vacuum_summary_reports_reclaimed_then_compact() {
+        let p = Path::new("/x.db");
+        assert!(vacuum_summary(p, 1000, 400).contains("reclaimed"));
+        // Equal sizes => already compact.
+        assert!(vacuum_summary(p, 400, 400).contains("already compact"));
+        // VACUUM can grow a tiny file; saturating delta must not go negative.
+        assert!(vacuum_summary(p, 400, 410).contains("already compact"));
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cargo test -p musefs-cli vacuum`
+Expected: FAIL — compile errors (`run_vacuum`, `vacuum_summary`, `Command::Vacuum` not found) until Steps 2 and 5 land. (Step 2 adds the variant; the parse test still fails to compile without Step 5's functions.)
+
+- [ ] **Step 5: Implement `run_vacuum`, `store_footprint`, `vacuum_summary`**
+
+In `musefs-cli/src/lib.rs`, after `run_mount` and before `pub fn run`, add:
+
+```rust
+/// Total on-disk footprint of the store: the main `.db` plus its `-wal`/`-shm`
+/// sidecars (a missing sidecar counts as 0). Summing the WAL/SHM keeps the
+/// reclaimed figure honest — a TRUNCATE checkpoint reclaims WAL bytes too.
+fn store_footprint(db: &Path) -> u64 {
+    let main = std::fs::metadata(db).map(|m| m.len()).unwrap_or(0);
+    let side: u64 = ["-wal", "-shm"]
+        .iter()
+        .map(|suffix| {
+            let mut p = db.as_os_str().to_os_string();
+            p.push(suffix);
+            std::fs::metadata(p).map(|m| m.len()).unwrap_or(0)
+        })
+        .sum();
+    main + side
+}
+
+/// One-line summary for a completed vacuum. `after >= before` (VACUUM can grow
+/// an already-compact file slightly) reports `(already compact)` rather than a
+/// zero or negative delta.
+fn vacuum_summary(path: &Path, before: u64, after: u64) -> String {
+    let reclaimed = before.saturating_sub(after);
+    if reclaimed == 0 {
+        format!(
+            "vacuumed {}: {} (already compact)",
+            path.display(),
+            HumanBytes(after)
+        )
+    } else {
+        format!(
+            "vacuumed {}: {} → {} (reclaimed {})",
+            path.display(),
+            HumanBytes(before),
+            HumanBytes(after),
+            HumanBytes(reclaimed)
+        )
+    }
+}
+
+/// Compact the SQLite store at `db`. Best-effort: a store in use (a live mount
+/// or a running scan) surfaces `DbError::StoreInUse`'s actionable message.
+pub fn run_vacuum(db: &Path) -> Result<()> {
+    if !db.exists() {
+        anyhow::bail!("database not found: {} (nothing to vacuum)", db.display());
+    }
+    let before = store_footprint(db);
+    let store = Db::open(db).with_context(|| format!("opening store {}", db.display()))?;
+    store.vacuum()?;
+    let after = store_footprint(db);
+    println!("{}", vacuum_summary(db, before, after));
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Wire the dispatch arm**
+
+In `pub fn run`, after the `Command::Mount(args) => ...` arm (~line 607), add:
+
+```rust
+        Command::Vacuum { db } => run_vacuum(&db).map(|()| ExitCode::SUCCESS),
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cargo test -p musefs-cli vacuum`
+Expected: PASS — `vacuum_command_parses_db_path`, `run_vacuum_errors_on_missing_db`, `run_vacuum_compacts_a_bloated_store`, `vacuum_summary_reports_reclaimed_then_compact`.
+
+- [ ] **Step 8: Lint**
+
+Run: `cargo clippy -p musefs-cli --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 9: Manual smoke (optional but recommended)**
+
+```bash
+cargo run -q -p musefs -- vacuum --db /nonexistent.db   # expect: error: database not found ...
+```
+Expected: the not-found error, exit non-zero.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add musefs-cli/src/lib.rs
+git commit -m "feat(cli): add 'musefs vacuum' subcommand"
+```
+
+---
+
+### Task 3: Docs & changelog
+
+**Files:**
+- Create: `docs/src/guide/maintenance.md`
+- Modify: `docs/src/SUMMARY.md` (User Guide section)
+- Modify: `CHANGELOG.md` (root, the `## [1.1.0] - 2026-06-17` `### Added` list)
+- Modify: `docs/src/changelog.md` (full, the `## [1.1.0] - 2026-06-17` `### Added` list)
+- Modify: `docs/src/release-notes.md` (v1.1.0 Highlights list)
+
+**Interfaces:** none (documentation only).
+
+- [ ] **Step 1: Create the maintenance page**
+
+Create `docs/src/guide/maintenance.md`:
+
+```markdown
+# Maintenance
+
+## Compacting the store (`musefs vacuum`)
+
+The SQLite store only grows as you use it: deleting tracks (beets/Lidarr
+prunes), garbage-collecting orphaned art, and the schema migration all leave
+free pages behind that are not automatically reclaimed. Because embedded art is
+stored inline (up to ~16 MiB per image), a library that has churned art can
+carry significant dead space.
+
+`musefs vacuum` compacts the store and reports how much it reclaimed:
+
+```bash
+musefs vacuum --db library.db        # or: MUSEFS_DB=library.db musefs vacuum
+```
+
+```text
+vacuumed library.db: 412.7 MiB → 318.2 MiB (reclaimed 94.5 MiB)
+```
+
+It runs SQLite's `VACUUM` followed by a WAL checkpoint, rewriting the database
+into a compact form.
+
+### Run it while unmounted
+
+`VACUUM` needs a write lock on the store and rewrites the whole file. Run it when
+nothing else is using the database — no mount, no scan. If the store is in use,
+the command fails with an actionable error rather than fighting for the lock:
+
+```text
+error: the store is in use — unmount the filesystem or stop any scan before vacuuming
+```
+
+### Notes
+
+- **Full rewrite.** Each run rewrites the entire database and transiently needs
+  free disk space roughly equal to the store size (it builds a complete copy
+  before swapping). Running it again on an already-compact store is safe and
+  reports `(already compact)`.
+- **May upgrade the schema.** Like every musefs command that opens the store for
+  writing, `vacuum` migrates an older store to the current schema version before
+  compacting.
+```
+
+- [ ] **Step 2: Add the page to the table of contents**
+
+In `docs/src/SUMMARY.md`, under the `# User Guide` section, add a `Maintenance` entry after `Tuning & metrics`:
+
+```markdown
+- [Tuning & metrics](guide/tuning.md)
+- [Maintenance](guide/maintenance.md)
+- [Ownership, permissions & config](guide/configuration.md)
+```
+
+- [ ] **Step 3: Add the changelog entry (root `CHANGELOG.md`)**
+
+In `CHANGELOG.md`, under `## [1.1.0] - 2026-06-17` → `### Added`, append this bullet at the end of the Added list (before the `### Changed` heading):
+
+```markdown
+- **`musefs vacuum` command:** compact the SQLite store, reclaiming free pages
+  left by prunes, orphan-art GC, and the schema migration. Runs `VACUUM` + a WAL
+  checkpoint and reports the space reclaimed; run it while unmounted (#566).
+```
+
+- [ ] **Step 4: Add the changelog entry (full `docs/src/changelog.md`)**
+
+In `docs/src/changelog.md`, under `## [1.1.0] - 2026-06-17` → `### Added`, append the same bullet at the end of the Added list (before the `### Fixed` heading):
+
+```markdown
+- **`musefs vacuum` command:** compact the SQLite store, reclaiming free pages
+  left by prunes, orphan-art GC, and the schema migration. Runs `VACUUM` + a WAL
+  checkpoint and reports the space reclaimed; run it while unmounted (#566).
+```
+
+- [ ] **Step 5: Add a release-notes highlight**
+
+In `docs/src/release-notes.md`, in the **v1.1.0 → Highlights** bullet list, add as the last bullet (after the "Per-extension skip breakdown" item, before the "Plus a substantial round…" paragraph):
+
+```markdown
+- **`musefs vacuum`.** A maintenance command that compacts the SQLite store —
+  reclaiming the free pages that prunes, orphan-art GC, and the migration leave
+  behind — and reports the space reclaimed. Run it while unmounted. See
+  [Maintenance](guide/maintenance.md).
+```
+
+- [ ] **Step 6: Build the docs to check links**
+
+Run: `cd docs && mdbook build >/dev/null && echo OK`
+Expected: `OK` (no broken-link errors; the new `guide/maintenance.md` resolves).
+
+- [ ] **Step 7: Commit (docs-only — cargo gate skipped)**
+
+```bash
+git add docs/src/guide/maintenance.md docs/src/SUMMARY.md CHANGELOG.md docs/src/changelog.md docs/src/release-notes.md
+git commit -m "docs: document the musefs vacuum command"
+```
+
+---
+
+### Task 4: Full verification & fold into PR #566
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Full workspace test suite**
+
+Run: `cargo test --workspace`
+Expected: all green (this mirrors what the pre-commit hook already ran on each commit).
+
+- [ ] **Step 2: Metrics-feature tests (CI `check` job covers this; local default skips it)**
+
+Run: `cargo test -p musefs-core --features metrics`
+Expected: green. (This feature touches no getattr/read counters, so it should pass untouched — run it to be sure.)
+
+- [ ] **Step 3: Workspace lint**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 4: Format check**
+
+Run: `cargo fmt --all --check`
+Expected: clean (exit 0).
+
+- [ ] **Step 5: Local in-diff mutation gate**
+
+Run the in-diff mutation gate against the new code (serial, in-place, `/tmp` TMPDIR), per the repo's documented local procedure:
+
+```bash
+cargo mutants --in-place --in-diff <(git diff origin/main...HEAD -- musefs-db musefs-cli) -- --offline
+```
+Expected: no surviving mutants in `maintenance.rs` / the new CLI functions. The shrink+wal-truncate assertions kill the `VACUUM`/checkpoint-removal mutants; the `map_vacuum_err` tests kill the predicate mutants; `vacuum_summary_reports_reclaimed_then_compact` kills the `saturating_sub`/comparison mutants.
+
+If a mutant survives and is genuinely equivalent or hang/OOM-class, add a documented `exclude_re`/anchor to `.cargo/mutants.toml` in the same commit (per the repo convention) — do **not** weaken a test to pass.
+
+- [ ] **Step 6: Push the branch (updates PR #566)**
+
+```bash
+git push origin release/v1.1.0
+```
+Expected: the three new commits land on the open PR; CI (`ci-ok` + `coverage-ok`) re-runs.
+
+- [ ] **Step 7: Confirm the PR reflects the new command**
+
+Verify on PR #566 that the diff now includes `musefs vacuum`, and that the PR body's feature summary mentions it (edit the PR body to add a `vacuum` line if it helps reviewers — optional).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** scope (VACUUM + checkpoint) → Task 1; best-effort BUSY handling → Task 1 (`map_vacuum_err`/`StoreInUse`); CLI `--db` + existing-store guard + reclaimed report → Task 2; total-footprint measurement → Task 2 (`store_footprint`); migrate-on-open + inherited failure modes → Task 2 (`run_vacuum` opens via `Db::open`) and Task 3 docs; dedicated maintenance page → Task 3; no-schema-change note → Global Constraints + Task 4 (no schema-py regen); test plan (shrink, compact branch, BUSY mapping, parse, missing-db) → Tasks 1-2; mutation gate → Task 4. All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code; every command shows expected output.
+- **Type consistency:** `vacuum(&self) -> Result<()>`, `map_vacuum_err(rusqlite::Error) -> DbError`, `DbError::StoreInUse(rusqlite::Error)`, `run_vacuum(&Path) -> anyhow::Result<()>`, `store_footprint(&Path) -> u64`, `vacuum_summary(&Path, u64, u64) -> String`, `Command::Vacuum { db: PathBuf }` — used identically across tasks. `NewArt { mime, width, height, data }` and `gc_orphan_art() -> Result<usize>` match `models.rs`/`art.rs`.
+```

--- a/docs/superpowers/plans/2026-06-17-vacuum-command.md
+++ b/docs/superpowers/plans/2026-06-17-vacuum-command.md
@@ -104,12 +104,6 @@ mod tests {
     use crate::models::NewArt;
     use crate::{Db, DbError};
 
-    fn sidecar(path: &std::path::Path, suffix: &str) -> std::path::PathBuf {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(suffix);
-        std::path::PathBuf::from(p)
-    }
-
     #[test]
     fn vacuum_shrinks_file_and_truncates_wal_after_deletion() {
         let dir = tempfile::tempdir().unwrap();
@@ -146,11 +140,17 @@ mod tests {
             .unwrap();
         assert_eq!(freelist, 0, "vacuum must leave no free pages");
 
-        // The TRUNCATE checkpoint inside vacuum() must zero the WAL file.
-        let wal = std::fs::metadata(sidecar(&path, "-wal"))
-            .map(|m| m.len())
-            .unwrap_or(0);
-        assert_eq!(wal, 0, "vacuum must truncate the -wal file");
+        // The TRUNCATE checkpoint inside vacuum() must drain the WAL: a
+        // subsequent checkpoint reports 0 frames in the log (column 1 of
+        // `PRAGMA wal_checkpoint` is the WAL frame count). Deterministic, and
+        // unlike a `-wal` file-size check it does not depend on WAL internals.
+        // Without the in-method checkpoint, VACUUM's frames are still pending
+        // here, so this is non-zero and the checkpoint-removal mutant dies.
+        let wal_frames: i64 = db
+            .conn
+            .query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |r| r.get(1))
+            .unwrap();
+        assert_eq!(wal_frames, 0, "vacuum must checkpoint the WAL");
     }
 
     #[test]
@@ -178,9 +178,14 @@ mod tests {
 }
 ```
 
-Note: Step 3 already contains the implementation (the `impl`/`map_vacuum_err`) because the tests and impl live in one small file and must compile together. The "failing" state in Step 4 is the pre-edit baseline — confirm the module did not exist before. If you prefer strict red-first, temporarily stub `vacuum` to `Ok(())` without the pragmas and watch `vacuum_shrinks_file...` fail, then restore the body shown above.
+**TDD note (recommended red-first):** `vacuum()`, `map_vacuum_err`, and the tests live in one small file and must compile together. To observe a real red, first paste the module with `vacuum`'s body stubbed — `pub fn vacuum(&self) -> Result<()> { Ok(()) }` (drop the two `execute_batch` lines; keep `map_vacuum_err` so the mapping tests still compile) — run Step 4a, and watch `vacuum_shrinks_file_and_truncates_wal_after_deletion` fail (no shrink, `freelist_count != 0`) while the three other tests pass. Then restore the real two-statement body shown above and run Step 4b.
 
-- [ ] **Step 4: Run the tests to verify they pass (after Steps 1-3)**
+- [ ] **Step 4a: Run with the stub — verify the shrink test fails (red)**
+
+Run: `cargo test -p musefs-db maintenance`
+Expected: FAIL — `vacuum_shrinks_file_and_truncates_wal_after_deletion` fails on `after < before` (the stub does not compact); the two `map_vacuum_err` tests and `vacuum_on_empty_store_is_ok` PASS.
+
+- [ ] **Step 4b: Restore the real body — verify all pass (green)**
 
 Run: `cargo test -p musefs-db maintenance`
 Expected: PASS — `vacuum_shrinks_file_and_truncates_wal_after_deletion`, `vacuum_on_empty_store_is_ok`, `map_vacuum_err_maps_busy_and_locked_to_store_in_use`, `map_vacuum_err_passes_through_other_errors` all green.
@@ -309,13 +314,15 @@ In `musefs-cli/src/lib.rs`, after `run_mount` and before `pub fn run`, add:
 /// sidecars (a missing sidecar counts as 0). Summing the WAL/SHM keeps the
 /// reclaimed figure honest — a TRUNCATE checkpoint reclaims WAL bytes too.
 fn store_footprint(db: &Path) -> u64 {
-    let main = std::fs::metadata(db).map(|m| m.len()).unwrap_or(0);
+    // `.map_or`, not `.map(..).unwrap_or(..)`: the latter trips
+    // `clippy::map_unwrap_or` (pedantic), which the `-D warnings` gate rejects.
+    let main = std::fs::metadata(db).map_or(0, |m| m.len());
     let side: u64 = ["-wal", "-shm"]
         .iter()
         .map(|suffix| {
             let mut p = db.as_os_str().to_os_string();
             p.push(suffix);
-            std::fs::metadata(p).map(|m| m.len()).unwrap_or(0)
+            std::fs::metadata(p).map_or(0, |m| m.len())
         })
         .sum();
     main + side
@@ -540,7 +547,16 @@ Run the in-diff mutation gate against the new code (serial, in-place, `/tmp` TMP
 ```bash
 cargo mutants --in-place --in-diff <(git diff origin/main...HEAD -- musefs-db musefs-cli) -- --offline
 ```
-Expected: no surviving mutants in `maintenance.rs` / the new CLI functions. The shrink+wal-truncate assertions kill the `VACUUM`/checkpoint-removal mutants; the `map_vacuum_err` tests kill the predicate mutants; `vacuum_summary_reports_reclaimed_then_compact` kills the `saturating_sub`/comparison mutants.
+
+Diff-base note: PR #566's base is `main`, and the release-prep commits on this
+branch touched no `musefs-db`/`musefs-cli` **src** (only `Cargo.toml` versions,
+which `cargo mutants` ignores), so `origin/main...HEAD` restricted to those two
+crates yields exactly the three vacuum src files. If you instead want only the
+vacuum commits, diff against the commit before Task 1 (e.g. `git diff
+<task1-parent>...HEAD -- musefs-db musefs-cli`). Run `git fetch origin` first so
+`origin/main` is current.
+
+Expected: no surviving mutants in `maintenance.rs` / the new CLI functions. The `after < before` shrink assertion kills the `VACUUM`-removal mutant, and the `PRAGMA wal_checkpoint(PASSIVE)` frame-count assertion (`wal_frames == 0`) kills the checkpoint-removal mutant; the `map_vacuum_err` tests kill the predicate mutants; `vacuum_summary_reports_reclaimed_then_compact` kills the `saturating_sub`/comparison mutants.
 
 If a mutant survives and is genuinely equivalent or hang/OOM-class, add a documented `exclude_re`/anchor to `.cargo/mutants.toml` in the same commit (per the repo convention) — do **not** weaken a test to pass.
 

--- a/docs/superpowers/specs/2026-06-17-vacuum-command-design.md
+++ b/docs/superpowers/specs/2026-06-17-vacuum-command-design.md
@@ -55,8 +55,9 @@ the store.
 ### DB layer (`musefs-db`)
 
 New method on `impl Db<ReadWrite>`, in a new `musefs-db/src/maintenance.rs`
-module (matching the one-file-per-concern split of `art.rs`/`tags.rs`/
-`tracks.rs`/`bulk.rs`/`structural.rs`; `is_busy` and any future
+module (declared with `mod maintenance;` in `lib.rs`, matching the
+one-file-per-concern split of `art.rs`/`tags.rs`/`tracks.rs`/`bulk.rs`/
+`structural.rs`; the `map_vacuum_err` helper and any future
 `incremental_vacuum` live here too):
 
 ```rust
@@ -70,18 +71,21 @@ Behavior:
   WAL mode the VACUUM rewrite lands in the `-wal`, so the TRUNCATE checkpoint
   *after* VACUUM is what actually shrinks the main `.db` file on disk and zeroes
   the `-wal`.
-- BUSY mapping: a small pure helper `fn is_busy(err: &rusqlite::Error) -> bool`
-  returns true for `rusqlite::Error::SqliteFailure` whose code is
-  `DatabaseBusy` or `DatabaseLocked`. When `vacuum()` hits a busy/locked error
-  it returns a new typed error variant:
+- BUSY mapping: error translation is factored into a small free function
+  `fn map_vacuum_err(err: rusqlite::Error) -> DbError`, so the branch is
+  unit-testable from constructed errors with no real lock contention. It maps a
+  `rusqlite::Error::SqliteFailure` whose code is `DatabaseBusy` or
+  `DatabaseLocked` to a new typed variant `DbError::StoreInUse`, and defers
+  every other error to the existing transparent `#[from]` rusqlite variant.
+  `vacuum()` applies it via `.map_err(map_vacuum_err)` on each statement. The
+  new variant is added to the `DbError` enum in `musefs-db/src/error.rs`:
 
   ```
   DbError::StoreInUse  // #[error("the store is in use — unmount the filesystem
                        //          or stop any scan before vacuuming")]
   ```
 
-  carrying the underlying `rusqlite::Error` as its `#[source]`. All other errors
-  continue to flow through the existing transparent rusqlite `DbError` variant.
+  carrying the underlying `rusqlite::Error` as its `#[source]`.
 
 The method uses `self.conn` directly (the existing `Db` field that every other
 `Db<ReadWrite>` write method already uses); `with_raw_conn` is fuzzing-gated and
@@ -104,36 +108,55 @@ is not used here.
   1. `if !db.exists()` → `bail!` with a not-found message (mirrors the
      `mount --db` existing-store guard); vacuuming a nonexistent store is
      meaningless.
-  2. Stat the file size (`before`).
-  3. `Db::open(db)` (this runs `migrate()` as every open does — see note below).
+  2. Measure the store's on-disk footprint (`before`) — the sum of the `.db`,
+     `-wal`, and `-shm` file sizes (a missing sidecar counts as 0). Summing the
+     WAL/SHM makes the figure honest: a TRUNCATE checkpoint reclaims WAL bytes
+     too, and the main `.db` alone can understate real usage when a large WAL is
+     pending.
+  3. `Db::open(db)` (this runs `migrate()` + `validate_identity()` as every open
+     does — see note below).
   4. `store.vacuum()?` — `DbError::StoreInUse` surfaces its own actionable
      message through anyhow.
-  5. Re-stat the file size (`after`).
-  6. Print one stdout line:
-     `vacuumed <path>: <before> → <after> (reclaimed <delta>)` using a small
-     `human_bytes(u64) -> String` helper. If `after >= before`, report
-     `(already compact)` instead of a negative/zero delta (use saturating
-     subtraction).
+  5. Re-measure the footprint (`after`) — same three-file sum, now post-vacuum
+     and post-TRUNCATE (so `-wal` is ~0).
+  6. Print one stdout line via `indicatif::HumanBytes` (already a dependency;
+     binary KiB/MiB units, matching the CLI's existing `HumanDuration` usage and
+     the codebase's MiB/KiB vocabulary):
+     `vacuumed <path>: <before> → <after> (reclaimed <delta>)`. Compute `delta`
+     with saturating subtraction; if `after >= before`, print `(already
+     compact)` instead of a zero/negative delta. Using `HumanBytes` removes the
+     need for a hand-rolled formatter and its boundary tests.
 - Dispatch: `Command::Vacuum { db } => run_vacuum(&db).map(|()| ExitCode::SUCCESS)`.
   Success exits `0`; any error exits `1` via the existing anyhow→main path.
-  No exit-code `2` semantics.
+  Vacuum has no "partial" outcome (it either compacts or errors), so `0`/`1` is
+  the complete set — unlike `scan`, which adds exit `2` for partial ingest.
 
-The reported sizes are the main `.db` file (the dominant component and the
-user's actual concern); the `-wal`/`-shm` files are not summed into the figure.
+**Open-time behavior & inherited failure modes.** `run_vacuum` opens through
+`Db::open`, so it inherits all of `configure()`'s behavior
+(`musefs-db/src/lib.rs`):
 
-**Migrate-on-open note.** Because `Db::open` always migrates, vacuuming a
-v1.0.0-schema store also upgrades it to schema v2 as a side effect. This is
-benign and consistent with every other write entry point; it will be called out
-in one line in the command help and the maintenance docs.
+- It always migrates, so vacuuming a v1.0.0-schema store also upgrades it to
+  schema v2 — which itself can drop over-cap tag rows. Benign and consistent
+  with every other write entry point, but it means `vacuum` is not a pure
+  read-shrink. The command help and the maintenance page state explicitly that
+  vacuum may upgrade the schema.
+- It runs `validate_identity()`, so pointing `--db` at a non-musefs or tampered
+  file fails at *open* with `DbError::SchemaMismatch` (not a vacuum-specific
+  message), and a store written by a newer build fails with
+  `DbError::StoreTooNew`. Both surface acceptably through anyhow; the plan
+  should not special-case them.
 
 ### Docs & changelog
 
 - New `docs/src/guide/maintenance.md`: a short "Maintenance" page documenting
   `musefs vacuum` — what it reclaims, the "run while unmounted" caveat, the
-  reclaimed-bytes output, and the migrate-on-open note. Add it to
-  `docs/src/SUMMARY.md` under **User Guide**.
-- README: add `vacuum` to the command list only if the README enumerates
-  subcommands; otherwise leave it to the guide.
+  reclaimed-bytes output, the migrate-may-upgrade-schema note, and a warning
+  that VACUUM does a full rewrite each run and transiently needs free disk space
+  roughly equal to the store size (it builds a complete copy before swapping).
+  Add it to `docs/src/SUMMARY.md` under **User Guide**.
+- README: no change. Its CLI block is a minimal scan→mount getting-started
+  example, not a command reference, so `vacuum` is documented in the maintenance
+  guide and changelog rather than added there.
 - Changelog: add a `### Added` bullet to the already-promoted **[1.1.0]**
   section of both `CHANGELOG.md` (root, curated) and `docs/src/changelog.md`
   (full), and add a bullet to the v1.1.0 highlights in
@@ -144,25 +167,45 @@ in one line in the command help and the maintenance docs.
 Tests are written TDD-first and every commit lands green (the pre-commit hook
 runs the full workspace suite).
 
-- **`musefs-db`** (temp-file store — file-size shrink needs a real file, not
-  in-memory):
-  - Insert tracks/tags/art, delete a chunk, assert `PRAGMA freelist_count > 0`;
-    call `vacuum()`; assert `freelist_count == 0` and the on-disk `.db` size
-    shrank.
-  - `vacuum()` on a fresh/empty store returns `Ok`.
-  - `is_busy` mapping is unit-tested directly by constructing a
-    `SqliteFailure` with `DatabaseBusy` and asserting it maps to
-    `DbError::StoreInUse` (deterministic; avoids racy real-lock contention).
+- **`musefs-db`** (temp-file store — file-size shrink needs a real on-disk file,
+  not in-memory):
+  - *Shrink, robustly.* Insert enough rows to span many pages — several art
+    blobs (art bytes are large) guarantees multi-page allocation — then delete
+    them and checkpoint. Capture a settled pre-vacuum `.db` size, call
+    `vacuum()`, and assert two robust post-conditions: `PRAGMA freelist_count == 0`
+    and the on-disk `.db` strictly smaller than the settled pre-vacuum size. Do
+    **not** gate on a `freelist_count > 0` precondition (not guaranteed for small
+    inserts; it can make the test flaky, and the pre-commit hook runs the full
+    suite, so a flaky test blocks every commit).
+  - *Compact branch.* `vacuum()` on a fresh/empty (already-compact) store returns
+    `Ok`; the CLI test below asserts this prints `(already compact)`, killing the
+    `after >= before` comparison mutant.
+  - *BUSY mapping.* `map_vacuum_err` is unit-tested directly: a constructed
+    `SqliteFailure { DatabaseBusy }` (and `DatabaseLocked`) maps to
+    `DbError::StoreInUse`; a non-busy `SqliteFailure` falls through to the
+    transparent variant. Deterministic and fast — this exercises the exact branch
+    `vacuum()` uses, with no racy or 5-second real-lock contention test.
 - **`musefs-cli`:**
-  - `run_vacuum` on a temp store returns `Ok` (and shrinks / prints a summary).
-  - `run_vacuum` on a missing `--db` path errors.
+  - `run_vacuum` on a temp store with deleted rows returns `Ok`, shrinks the
+    file, and prints the reclaimed summary.
+  - `run_vacuum` on an already-compact store prints `(already compact)`.
+  - `run_vacuum` on a missing `--db` path errors (the `db.exists()` guard).
   - Clap parse test: `vacuum --db <path>` parses to `Command::Vacuum`.
-- **Mutation gate:** the new `musefs-db`/`musefs-cli` code falls in the CI
-  in-diff mutation gate's scope. The delete-then-shrink assertion kills the
-  `VACUUM -> ()` / checkpoint mutants; the `is_busy` test kills the predicate
-  mutants. Run the local in-diff gate before pushing; add a documented
+- **No schema change.** This feature adds no table/column/migration (VACUUM and a
+  checkpoint pragma touch no DDL), so the Python schema mirror
+  (`contrib/python-musefs/.../schema.py`) is untouched and the gating
+  `schema_py_fixture_is_fresh` test needs no regeneration. Confirm `MIGRATIONS`
+  and all `CREATE` statements are unchanged.
+- **Mutation gate.** The new `musefs-db`/`musefs-cli` code is in the CI in-diff
+  gate's scope. The delete-then-shrink assertion kills the `VACUUM -> ()` /
+  checkpoint-removal mutants; the `map_vacuum_err` tests kill the predicate
+  mutants; the `(already compact)` test kills the comparison mutant. Adopting
+  `indicatif::HumanBytes` avoids hand-rolled arithmetic and its mutation surface.
+  Run the local in-diff gate before pushing; add a documented
   `.cargo/mutants.toml` exclude only if a mutant proves equivalent or
-  hang/OOM-class.
+  hang/OOM-class. (The mutant-anchor pre-commit guard covers only
+  `musefs-core`/`musefs-format` src, so editing `musefs-db`/`musefs-cli` shifts
+  no existing anchors.)
 
 ## Out of scope / future
 

--- a/docs/superpowers/specs/2026-06-17-vacuum-command-design.md
+++ b/docs/superpowers/specs/2026-06-17-vacuum-command-design.md
@@ -1,0 +1,171 @@
+# Design: `musefs vacuum` command
+
+Date: 2026-06-17
+Status: approved (brainstorming)
+Target release: v1.1.0 (folded into the open release-prep PR #566)
+
+## Problem
+
+The SQLite store does no compaction today — there is no `VACUUM`, no
+`auto_vacuum`, and no checkpoint-truncate anywhere in `musefs-db`,
+`musefs-core`, or `musefs-cli`. The store therefore only grows: every deletion
+path leaves free pages that are never reclaimed. The deletion paths are real and
+several:
+
+- beets/Lidarr prunes of moved-away or deleted tracks,
+- `gc_orphan_art` reclaiming unreferenced art rows,
+- the v1.1.0 `MIGRATION_V2` upgrade dropping any over-cap tag rows.
+
+Because art blobs are stored inline (up to ~16 MiB each), a library that has
+churned art can carry substantial dead space with no way to recover it. A
+`musefs vacuum` maintenance command gives operators an explicit way to compact
+the store.
+
+## Goals
+
+- Add a `musefs vacuum --db <store>` subcommand that compacts the SQLite store
+  and reports how much space was reclaimed.
+- Keep the SQLite work in the `musefs-db` layer; keep the CLI thin.
+
+## Non-goals (YAGNI)
+
+- No `ANALYZE`, no `integrity_check`, no orphan-art GC or prune folded in — the
+  command is a vacuum, not a general "maintenance" umbrella. (GC/prune already
+  live in `scan --revalidate`.)
+- No `auto_vacuum` mode change (it must be set at store-creation time and would
+  require a full vacuum to switch anyway).
+- No new locking machinery to detect a live mount, and no `-q`/`--quiet` flag.
+- Only one argument: `--db` (env `MUSEFS_DB`).
+
+## Decisions (from brainstorming)
+
+1. **Scope:** `VACUUM` + `PRAGMA wal_checkpoint(TRUNCATE)`, reporting bytes
+   reclaimed (before → after). Minimal and true to the name.
+2. **In-use handling:** best-effort. Rely on SQLite's existing 5 s
+   `busy_timeout`; on a busy/locked error, fail with an actionable message
+   telling the user to unmount/stop scanning. Documented as an offline
+   maintenance command. No active pre-flight lock guard.
+3. **Structure:** Approach A — a `Db::<ReadWrite>::vacuum()` method in
+   `musefs-db`; the CLI wires it, stats the file, and prints the summary.
+4. **Docs:** a dedicated `docs/src/guide/maintenance.md` page (not folded into
+   `scanning.md`).
+
+## Design
+
+### DB layer (`musefs-db`)
+
+New method on `impl Db<ReadWrite>`, in a new `musefs-db/src/maintenance.rs`
+module (matching the one-file-per-concern split of `art.rs`/`tags.rs`/
+`tracks.rs`/`bulk.rs`/`structural.rs`; `is_busy` and any future
+`incremental_vacuum` live here too):
+
+```rust
+pub fn vacuum(&self) -> Result<()>
+```
+
+Behavior:
+
+- Run `self.conn.execute_batch("VACUUM")`, then
+  `self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")`. Order matters: in
+  WAL mode the VACUUM rewrite lands in the `-wal`, so the TRUNCATE checkpoint
+  *after* VACUUM is what actually shrinks the main `.db` file on disk and zeroes
+  the `-wal`.
+- BUSY mapping: a small pure helper `fn is_busy(err: &rusqlite::Error) -> bool`
+  returns true for `rusqlite::Error::SqliteFailure` whose code is
+  `DatabaseBusy` or `DatabaseLocked`. When `vacuum()` hits a busy/locked error
+  it returns a new typed error variant:
+
+  ```
+  DbError::StoreInUse  // #[error("the store is in use — unmount the filesystem
+                       //          or stop any scan before vacuuming")]
+  ```
+
+  carrying the underlying `rusqlite::Error` as its `#[source]`. All other errors
+  continue to flow through the existing transparent rusqlite `DbError` variant.
+
+The method uses `self.conn` directly (the existing `Db` field that every other
+`Db<ReadWrite>` write method already uses); `with_raw_conn` is fuzzing-gated and
+is not used here.
+
+### CLI layer (`musefs-cli`)
+
+- New `Command` variant:
+
+  ```rust
+  /// Compact the SQLite store, reclaiming free pages left by deletions
+  /// (prunes, orphan-art GC, the schema migration). Run while unmounted.
+  Vacuum {
+      #[arg(long, env = "MUSEFS_DB")]
+      db: PathBuf,
+  },
+  ```
+
+- New `run_vacuum(db: &Path) -> anyhow::Result<()>`:
+  1. `if !db.exists()` → `bail!` with a not-found message (mirrors the
+     `mount --db` existing-store guard); vacuuming a nonexistent store is
+     meaningless.
+  2. Stat the file size (`before`).
+  3. `Db::open(db)` (this runs `migrate()` as every open does — see note below).
+  4. `store.vacuum()?` — `DbError::StoreInUse` surfaces its own actionable
+     message through anyhow.
+  5. Re-stat the file size (`after`).
+  6. Print one stdout line:
+     `vacuumed <path>: <before> → <after> (reclaimed <delta>)` using a small
+     `human_bytes(u64) -> String` helper. If `after >= before`, report
+     `(already compact)` instead of a negative/zero delta (use saturating
+     subtraction).
+- Dispatch: `Command::Vacuum { db } => run_vacuum(&db).map(|()| ExitCode::SUCCESS)`.
+  Success exits `0`; any error exits `1` via the existing anyhow→main path.
+  No exit-code `2` semantics.
+
+The reported sizes are the main `.db` file (the dominant component and the
+user's actual concern); the `-wal`/`-shm` files are not summed into the figure.
+
+**Migrate-on-open note.** Because `Db::open` always migrates, vacuuming a
+v1.0.0-schema store also upgrades it to schema v2 as a side effect. This is
+benign and consistent with every other write entry point; it will be called out
+in one line in the command help and the maintenance docs.
+
+### Docs & changelog
+
+- New `docs/src/guide/maintenance.md`: a short "Maintenance" page documenting
+  `musefs vacuum` — what it reclaims, the "run while unmounted" caveat, the
+  reclaimed-bytes output, and the migrate-on-open note. Add it to
+  `docs/src/SUMMARY.md` under **User Guide**.
+- README: add `vacuum` to the command list only if the README enumerates
+  subcommands; otherwise leave it to the guide.
+- Changelog: add a `### Added` bullet to the already-promoted **[1.1.0]**
+  section of both `CHANGELOG.md` (root, curated) and `docs/src/changelog.md`
+  (full), and add a bullet to the v1.1.0 highlights in
+  `docs/src/release-notes.md`.
+
+## Test plan
+
+Tests are written TDD-first and every commit lands green (the pre-commit hook
+runs the full workspace suite).
+
+- **`musefs-db`** (temp-file store — file-size shrink needs a real file, not
+  in-memory):
+  - Insert tracks/tags/art, delete a chunk, assert `PRAGMA freelist_count > 0`;
+    call `vacuum()`; assert `freelist_count == 0` and the on-disk `.db` size
+    shrank.
+  - `vacuum()` on a fresh/empty store returns `Ok`.
+  - `is_busy` mapping is unit-tested directly by constructing a
+    `SqliteFailure` with `DatabaseBusy` and asserting it maps to
+    `DbError::StoreInUse` (deterministic; avoids racy real-lock contention).
+- **`musefs-cli`:**
+  - `run_vacuum` on a temp store returns `Ok` (and shrinks / prints a summary).
+  - `run_vacuum` on a missing `--db` path errors.
+  - Clap parse test: `vacuum --db <path>` parses to `Command::Vacuum`.
+- **Mutation gate:** the new `musefs-db`/`musefs-cli` code falls in the CI
+  in-diff mutation gate's scope. The delete-then-shrink assertion kills the
+  `VACUUM -> ()` / checkpoint mutants; the `is_busy` test kills the predicate
+  mutants. Run the local in-diff gate before pushing; add a documented
+  `.cargo/mutants.toml` exclude only if a mutant proves equivalent or
+  hang/OOM-class.
+
+## Out of scope / future
+
+- `auto_vacuum=INCREMENTAL` + an `incremental_vacuum` variant (lighter, online,
+  but needs store-creation-time setup) could be revisited later if online
+  compaction is ever wanted.

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["filesystem", "multimedia::audio", "command-line-utilities"]
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 log = "0.4"
-musefs-db = { path = "../musefs-db", version = "1.0.0" }
-musefs-core = { path = "../musefs-core", version = "1.0.0" }
-musefs-fuse = { path = "../musefs-fuse", version = "1.0.0" }
+musefs-db = { path = "../musefs-db", version = "1.1.0" }
+musefs-core = { path = "../musefs-core", version = "1.1.0" }
+musefs-fuse = { path = "../musefs-fuse", version = "1.1.0" }
 signal-hook = "0.4"
 uzers = "0.12"
 indicatif = { version = "0.18", default-features = false }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use indicatif::HumanDuration;
+use indicatif::{HumanBytes, HumanDuration};
 use musefs_core::{MountConfig, Musefs};
 use musefs_db::Db;
 
@@ -216,6 +216,14 @@ pub enum Command {
     },
     /// Mount a read-only FUSE view of the store.
     Mount(MountArgs),
+    /// Compact the SQLite store, reclaiming free pages left by deletions
+    /// (prunes, orphan-art GC, the schema migration). Run while unmounted; this
+    /// may also upgrade an older store's schema to the current version.
+    Vacuum {
+        /// Path to the SQLite database.
+        #[arg(long, env = "MUSEFS_DB")]
+        db: PathBuf,
+    },
 }
 
 /// Open (creating/migrating) the DB at `db_path` once, then scan each target in
@@ -504,6 +512,60 @@ pub fn run_mount(args: &MountArgs) -> Result<()> {
     Ok(())
 }
 
+/// Total on-disk footprint of the store: the main `.db` plus its `-wal`/`-shm`
+/// sidecars (a missing sidecar counts as 0). Summing the WAL/SHM keeps the
+/// reclaimed figure honest — a TRUNCATE checkpoint reclaims WAL bytes too.
+fn store_footprint(db: &Path) -> u64 {
+    // `.map_or`, not `.map(..).unwrap_or(..)`: the latter trips
+    // `clippy::map_unwrap_or` (pedantic), which the `-D warnings` gate rejects.
+    let main = std::fs::metadata(db).map_or(0, |m| m.len());
+    let side: u64 = ["-wal", "-shm"]
+        .iter()
+        .map(|suffix| {
+            let mut p = db.as_os_str().to_os_string();
+            p.push(suffix);
+            std::fs::metadata(p).map_or(0, |m| m.len())
+        })
+        .sum();
+    main + side
+}
+
+/// One-line summary for a completed vacuum. `after >= before` (VACUUM can grow
+/// an already-compact file slightly) reports `(already compact)` rather than a
+/// zero or negative delta.
+fn vacuum_summary(path: &Path, before: u64, after: u64) -> String {
+    let reclaimed = before.saturating_sub(after);
+    if reclaimed == 0 {
+        format!(
+            "vacuumed {}: {} (already compact)",
+            path.display(),
+            HumanBytes(after)
+        )
+    } else {
+        format!(
+            "vacuumed {}: {} → {} (reclaimed {})",
+            path.display(),
+            HumanBytes(before),
+            HumanBytes(after),
+            HumanBytes(reclaimed)
+        )
+    }
+}
+
+/// Compact the SQLite store at `db`. Best-effort: a store in use (a live mount
+/// or a running scan) surfaces `DbError::StoreInUse`'s actionable message.
+pub fn run_vacuum(db: &Path) -> Result<()> {
+    if !db.exists() {
+        anyhow::bail!("database not found: {} (nothing to vacuum)", db.display());
+    }
+    let before = store_footprint(db);
+    let store = Db::open(db).with_context(|| format!("opening store {}", db.display()))?;
+    store.vacuum()?;
+    let after = store_footprint(db);
+    println!("{}", vacuum_summary(db, before, after));
+    Ok(())
+}
+
 /// Print a sample of the paths a `mount --dry-run` would expose, walking the
 /// already-built virtual tree so the preview reflects the exact rendering the
 /// real mount uses.
@@ -605,6 +667,7 @@ pub fn run(cli: Cli) -> Result<ExitCode> {
             })
         }
         Command::Mount(args) => run_mount(&args).map(|()| ExitCode::SUCCESS),
+        Command::Vacuum { db } => run_vacuum(&db).map(|()| ExitCode::SUCCESS),
     }
 }
 
@@ -735,6 +798,7 @@ mod tests {
                 assert_eq!(targets, vec![PathBuf::from("/m")]);
             }
             Command::Mount(..) => panic!("expected Scan"),
+            Command::Vacuum { .. } => unreachable!(),
         }
     }
 
@@ -745,6 +809,7 @@ mod tests {
         match cli.command {
             Command::Scan { quiet, .. } => assert!(!quiet),
             Command::Mount(..) => panic!("expected Scan"),
+            Command::Vacuum { .. } => unreachable!(),
         }
         for arg in ["--quiet", "-q"] {
             let cli =
@@ -752,6 +817,7 @@ mod tests {
             match cli.command {
                 Command::Scan { quiet, .. } => assert!(quiet),
                 Command::Mount(..) => panic!("expected Scan"),
+                Command::Vacuum { .. } => unreachable!(),
             }
         }
     }
@@ -773,6 +839,7 @@ mod tests {
                 follow_symlinks, ..
             } => assert!(follow_symlinks),
             Command::Mount(..) => panic!("expected scan command"),
+            Command::Vacuum { .. } => unreachable!(),
         }
     }
 
@@ -785,6 +852,7 @@ mod tests {
                 follow_symlinks, ..
             } => assert!(!follow_symlinks),
             Command::Mount(..) => panic!("expected scan command"),
+            Command::Vacuum { .. } => unreachable!(),
         }
     }
 
@@ -805,6 +873,7 @@ mod tests {
                 );
             }
             Command::Mount(..) => panic!("expected Scan"),
+            Command::Vacuum { .. } => unreachable!(),
         }
     }
 
@@ -1061,5 +1130,55 @@ mod tests {
         };
         let (_config, fuse_config) = parse_mount_config(&args);
         assert!(fuse_config.allow_other);
+    }
+
+    #[test]
+    fn vacuum_command_parses_db_path() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["musefs", "vacuum", "--db", "/tmp/x.db"]).unwrap();
+        let Command::Vacuum { db } = cli.command else {
+            panic!("expected Vacuum");
+        };
+        assert_eq!(db, PathBuf::from("/tmp/x.db"));
+    }
+
+    #[test]
+    fn run_vacuum_errors_on_missing_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.db");
+        assert!(run_vacuum(&missing).is_err());
+    }
+
+    #[test]
+    fn run_vacuum_compacts_a_bloated_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lib.db");
+        {
+            let db = musefs_db::Db::open(&path).unwrap();
+            for i in 0..16u8 {
+                db.upsert_art(&musefs_db::NewArt {
+                    mime: "image/png".into(),
+                    width: None,
+                    height: None,
+                    data: vec![i; 256 * 1024],
+                })
+                .unwrap();
+            }
+            assert_eq!(db.gc_orphan_art().unwrap(), 16);
+        }
+        let before = std::fs::metadata(&path).unwrap().len();
+        run_vacuum(&path).unwrap();
+        let after = std::fs::metadata(&path).unwrap().len();
+        assert!(after < before, "expected shrink: {before} -> {after}");
+    }
+
+    #[test]
+    fn vacuum_summary_reports_reclaimed_then_compact() {
+        let p = Path::new("/x.db");
+        assert!(vacuum_summary(p, 1000, 400).contains("reclaimed"));
+        // Equal sizes => already compact.
+        assert!(vacuum_summary(p, 400, 400).contains("already compact"));
+        // VACUUM can grow a tiny file; saturating delta must not go negative.
+        assert!(vacuum_summary(p, 400, 410).contains("already compact"));
     }
 }

--- a/musefs-cli/tests/cli.rs
+++ b/musefs-cli/tests/cli.rs
@@ -10,6 +10,7 @@ fn parses_scan_and_mount_invocations() {
             assert_eq!(db.to_str(), Some("/tmp/m.db"));
         }
         Command::Mount(..) => panic!("expected scan"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 
     let cli = Cli::parse_from([
@@ -32,6 +33,7 @@ fn parses_scan_and_mount_invocations() {
             assert_eq!(args.default_fallback, "Unknown"); // default applied
         }
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 }
 
@@ -51,6 +53,7 @@ fn parses_mode_and_revalidate_flags() {
     match cli.command {
         Command::Mount(args) => assert_eq!(args.mode, CliMode::StructureOnly),
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 
     // Mode defaults to synthesis; tuning knobs have conservative defaults.
@@ -65,6 +68,7 @@ fn parses_mode_and_revalidate_flags() {
             assert!(args.keep_cache); // #432: default on
         }
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 
     // Tuning flags parse to their given values.
@@ -93,6 +97,7 @@ fn parses_mode_and_revalidate_flags() {
             assert!(args.keep_cache);
         }
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 
     // Scan --revalidate flag.
@@ -107,11 +112,13 @@ fn parses_mode_and_revalidate_flags() {
     match cli.command {
         Command::Scan { revalidate, .. } => assert!(revalidate),
         Command::Mount(..) => panic!("expected scan"),
+        Command::Vacuum { .. } => unreachable!(),
     }
     let cli = Cli::parse_from(["musefs", "scan", "/music", "--db", "/tmp/m.db"]);
     match cli.command {
         Command::Scan { revalidate, .. } => assert!(!revalidate),
         Command::Mount(..) => panic!("expected scan"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 }
 
@@ -139,6 +146,7 @@ fn scan_parses_checksum_and_strictness_flags() {
             assert!(!fast);
         }
         Command::Mount(..) => panic!("expected scan"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 }
 
@@ -167,6 +175,7 @@ fn dry_run_does_not_require_a_mountpoint() {
             assert_eq!(args.mountpoint, None);
         }
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 }
 
@@ -195,6 +204,7 @@ fn boolish_mount_flags_work_as_bare_switches() {
             assert!(args.read_ahead_prefetch);
         }
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 }
 
@@ -326,6 +336,7 @@ fn parses_repeatable_fallback_flag() {
             ]
         ),
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     }
 }
 
@@ -388,6 +399,7 @@ fn fallback_keys_are_lowercased_to_match_template_fields() {
     let args = match cli.command {
         Command::Mount(args) => args,
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     };
     let (config, _) = parse_mount_config(&args);
     assert_eq!(
@@ -421,6 +433,7 @@ fn fallback_value_may_contain_equals_and_last_duplicate_wins() {
     let args = match cli.command {
         Command::Mount(args) => args,
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     };
     // Only the first '=' separates; the value keeps the rest verbatim.
     assert_eq!(
@@ -470,6 +483,7 @@ fn mount_fails_on_missing_db_without_creating_it() {
     let args = match cli.command {
         Command::Mount(args) => args,
         Command::Scan { .. } => panic!("expected mount"),
+        Command::Vacuum { .. } => unreachable!(),
     };
 
     let err = musefs_cli::run_mount(&args).unwrap_err();

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -16,8 +16,8 @@ crossbeam-channel = "0.5"
 dashmap = "6"
 im = "15"
 log = "0.4"
-musefs-db = { path = "../musefs-db", version = "1.0.0" }
-musefs-format = { path = "../musefs-format", version = "1.0.0" }
+musefs-db = { path = "../musefs-db", version = "1.1.0" }
+musefs-format = { path = "../musefs-format", version = "1.1.0" }
 once_cell = "1"
 parking_lot = "0.12"
 quick_cache = { version = "0.6.23", features = ["stats"] }

--- a/musefs-db/src/error.rs
+++ b/musefs-db/src/error.rs
@@ -22,6 +22,8 @@ pub enum DbError {
          (max {supported}); upgrade musefs to read this store"
     )]
     StoreTooNew { found: i64, supported: i64 },
+    #[error("the store is in use — unmount the filesystem or stop any scan before vacuuming")]
+    StoreInUse(#[source] rusqlite::Error),
     #[error("{table}.{field} length {len} exceeds the {max} cap (crafted or corrupt DB)")]
     FieldTooLarge {
         table: &'static str,

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -3,6 +3,7 @@ mod bulk;
 pub mod convert;
 mod error;
 pub mod limits;
+mod maintenance;
 mod models;
 mod schema;
 mod structural;

--- a/musefs-db/src/maintenance.rs
+++ b/musefs-db/src/maintenance.rs
@@ -1,0 +1,115 @@
+//! Store maintenance operations: compaction (`VACUUM` + WAL checkpoint).
+
+use crate::{Db, DbError, ReadWrite, Result};
+
+impl Db<ReadWrite> {
+    /// Compact the store: reclaim free pages left by deletions, then truncate
+    /// the WAL. Runs a full `VACUUM` (rewrites the whole database — transiently
+    /// needs free disk roughly equal to the store size) followed by
+    /// `PRAGMA wal_checkpoint(TRUNCATE)`. The TRUNCATE checkpoint *after* VACUUM
+    /// is what actually shrinks the main `.db` file on disk and zeroes the
+    /// `-wal`. A busy/locked store (e.g. a live mount) maps to
+    /// [`DbError::StoreInUse`].
+    pub fn vacuum(&self) -> Result<()> {
+        self.conn.execute_batch("VACUUM").map_err(map_vacuum_err)?;
+        self.conn
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .map_err(map_vacuum_err)?;
+        Ok(())
+    }
+}
+
+/// Translate a VACUUM/checkpoint error: a SQLite busy/locked failure means the
+/// store is open elsewhere (a mount or scan), surfaced as the actionable
+/// [`DbError::StoreInUse`]; everything else flows through the transparent
+/// rusqlite variant.
+fn map_vacuum_err(err: rusqlite::Error) -> DbError {
+    if let rusqlite::Error::SqliteFailure(e, _) = &err
+        && matches!(
+            e.code,
+            rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+        )
+    {
+        return DbError::StoreInUse(err);
+    }
+    DbError::Sqlite(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_vacuum_err;
+    use crate::models::NewArt;
+    use crate::{Db, DbError};
+
+    #[test]
+    fn vacuum_shrinks_file_and_truncates_wal_after_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.db");
+        let db = Db::open(&path).unwrap();
+
+        // Allocate many pages: 16 distinct 256 KiB art blobs (~4 MiB).
+        for i in 0..16u8 {
+            db.upsert_art(&NewArt {
+                mime: "image/png".into(),
+                width: None,
+                height: None,
+                data: vec![i; 256 * 1024],
+            })
+            .unwrap();
+        }
+        // None are linked to a track, so they are all orphan: free their pages.
+        assert_eq!(db.gc_orphan_art().unwrap(), 16);
+
+        // Settle the WAL so the pre-vacuum main-file size reflects the deletes.
+        db.conn
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        let before = std::fs::metadata(&path).unwrap().len();
+
+        db.vacuum().unwrap();
+
+        let after = std::fs::metadata(&path).unwrap().len();
+        assert!(after < before, "expected shrink: {before} -> {after}");
+
+        let freelist: i64 = db
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(freelist, 0, "vacuum must leave no free pages");
+
+        // The TRUNCATE checkpoint inside vacuum() must drain the WAL: a
+        // subsequent checkpoint reports 0 frames in the log (column 1 of
+        // `PRAGMA wal_checkpoint` is the WAL frame count). Deterministic, and
+        // unlike a `-wal` file-size check it does not depend on WAL internals.
+        // Without the in-method checkpoint, VACUUM's frames are still pending
+        // here, so this is non-zero and the checkpoint-removal mutant dies.
+        let wal_frames: i64 = db
+            .conn
+            .query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |r| r.get(1))
+            .unwrap();
+        assert_eq!(wal_frames, 0, "vacuum must checkpoint the WAL");
+    }
+
+    #[test]
+    fn vacuum_on_empty_store_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Db::open(dir.path().join("t.db")).unwrap();
+        db.vacuum().unwrap();
+    }
+
+    #[test]
+    fn map_vacuum_err_maps_busy_and_locked_to_store_in_use() {
+        use rusqlite::{Error, ffi};
+        let busy = Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_BUSY), None);
+        assert!(matches!(map_vacuum_err(busy), DbError::StoreInUse(_)));
+        let locked = Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_LOCKED), None);
+        assert!(matches!(map_vacuum_err(locked), DbError::StoreInUse(_)));
+    }
+
+    #[test]
+    fn map_vacuum_err_passes_through_other_errors() {
+        use rusqlite::{Error, ffi};
+        let corrupt = Error::SqliteFailure(ffi::Error::new(ffi::SQLITE_CORRUPT), None);
+        assert!(matches!(map_vacuum_err(corrupt), DbError::Sqlite(_)));
+    }
+}

--- a/musefs-format/Cargo.toml
+++ b/musefs-format/Cargo.toml
@@ -22,7 +22,7 @@ metaflac = "0.2"
 mp4 = "0.14"
 crc = "3"
 hound = "3"
-musefs-db = { path = "../musefs-db", version = "1.0.0" }
+musefs-db = { path = "../musefs-db", version = "1.1.0" }
 proptest = "1"
 # Self-dependency: turns the `fuzzing` feature on for this crate's own test
 # builds, so tests/ can use fuzz_check and the proptests run without an

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -16,7 +16,7 @@ fuser = { version = "0.17", default-features = false }
 libc = "0.2"
 log = "0.4"
 rustix = { version = "1", features = ["process"] }
-musefs-core = { path = "../musefs-core", version = "1.0.0" }
+musefs-core = { path = "../musefs-core", version = "1.1.0" }
 threadpool = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/musefs/Cargo.toml
+++ b/musefs/Cargo.toml
@@ -21,10 +21,10 @@ jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "tikv-jemalloc-ctl
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-musefs-cli = { path = "../musefs-cli", version = "1.0.0" }
+musefs-cli = { path = "../musefs-cli", version = "1.1.0" }
 # Direct dep only under `jemalloc`: the binary installs the allocator-stats probe
 # (`musefs_fuse::set_alloc_probe`) since it owns the jemalloc global allocator.
-musefs-fuse = { path = "../musefs-fuse", version = "1.0.0", optional = true }
+musefs-fuse = { path = "../musefs-fuse", version = "1.1.0", optional = true }
 tikv-jemallocator = { version = "0.7", optional = true }
 tikv-jemalloc-ctl = { version = "0.7", optional = true }
 log = { version = "0.4", optional = true }

--- a/scripts/bump_python_version.py
+++ b/scripts/bump_python_version.py
@@ -3,9 +3,10 @@
 
 Single source of truth for the unified Python package version (decoupled from
 the Rust workspace version). Rewrites every pyproject.toml version, the
-__version__ in the packages that carry one, the python-musefs dependency floor
-in the dependents, and re-vendors python-musefs into the Picard plugin so the
-vendored copy's __version__ stays in lockstep. Does not commit or tag.
+__version__ in the packages that carry one, the Picard PLUGIN_VERSION constant,
+the pinned versions in the version-tripwire tests, the python-musefs dependency
+floor in the dependents, and re-vendors python-musefs into the Picard plugin so
+the vendored copy's __version__ stays in lockstep. Does not commit or tag.
 
 Usage: python scripts/bump_python_version.py <version>
 """
@@ -34,10 +35,23 @@ DEPENDENTS = [
     "contrib/lidarr/pyproject.toml",
 ]
 VENDOR_SCRIPT = "contrib/python-musefs/vendor_to_picard.py"
+# The Picard plugin carries its own PLUGIN_VERSION constant (shown in Picard's
+# plugin manager), separate from its pyproject version.
+PLUGIN_VERSION_FILES = [
+    "contrib/picard/musefs/__init__.py",
+]
+# Tests that pin the released __version__ as a drift tripwire; bumped in lockstep
+# so a release does not leave them asserting the old version.
+TEST_VERSION_FILES = [
+    "contrib/lidarr/tests/test_smoke.py",
+    "contrib/python-musefs/tests/test_public_api.py",
+]
 
 _VERSION_RE = re.compile(r'(?m)^version = "[^"]*"')
 _INIT_VERSION_RE = re.compile(r'(?m)^__version__ = "[^"]*"')
 _DEP_FLOOR_RE = re.compile(r"python-musefs>=[^\"]*")
+_PLUGIN_VERSION_RE = re.compile(r'(?m)^PLUGIN_VERSION = "[^"]*"')
+_TEST_VERSION_RE = re.compile(r'__version__ == "[^"]*"')
 _PEP440_RE = re.compile(r"^[0-9]+(\.[0-9]+)*((?:a|b|c|rc)[0-9]+|\.[a-z0-9.]+)?$")
 
 
@@ -90,6 +104,30 @@ def set_dep_floor(text: str, version: str) -> str:
     return new
 
 
+def set_plugin_version(text: str, version: str) -> str:
+    """Replace the module-level ``PLUGIN_VERSION`` string via ``_PLUGIN_VERSION_RE``.
+
+    Raises ``ValueError`` if no ``PLUGIN_VERSION`` line is present.
+    """
+    new, n = _PLUGIN_VERSION_RE.subn(f'PLUGIN_VERSION = "{version}"', text, count=1)
+    if n != 1:
+        raise ValueError("no PLUGIN_VERSION line found")
+    return new
+
+
+def set_test_version(text: str, version: str) -> str:
+    """Bump every pinned ``__version__ == "<v>"`` assertion to ``version``.
+
+    These hardcoded assertions are release tripwires that must move with the
+    bump. Replaces all matches of ``_TEST_VERSION_RE``. Raises ``ValueError`` if
+    no such assertion is present.
+    """
+    new, n = _TEST_VERSION_RE.subn(f'__version__ == "{version}"', text)
+    if n < 1:
+        raise ValueError("no __version__ == assertion found")
+    return new
+
+
 def bump(version: str, root: Path = REPO_ROOT, run_vendor: bool = True) -> None:
     for rel in PYPROJECTS:
         p = root / rel
@@ -100,6 +138,12 @@ def bump(version: str, root: Path = REPO_ROOT, run_vendor: bool = True) -> None:
     for rel in DEPENDENTS:
         p = root / rel
         p.write_text(set_dep_floor(p.read_text(), version))
+    for rel in PLUGIN_VERSION_FILES:
+        p = root / rel
+        p.write_text(set_plugin_version(p.read_text(), version))
+    for rel in TEST_VERSION_FILES:
+        p = root / rel
+        p.write_text(set_test_version(p.read_text(), version))
     if run_vendor:
         subprocess.run([sys.executable, str(root / VENDOR_SCRIPT)], check=True)
 

--- a/scripts/test_bump_python_version.py
+++ b/scripts/test_bump_python_version.py
@@ -28,6 +28,32 @@ def test_set_dep_floor_keeps_siblings():
     )
 
 
+def test_set_plugin_version():
+    assert (
+        bp.set_plugin_version('PLUGIN_VERSION = "0.1.0"\n', "0.2.0") == 'PLUGIN_VERSION = "0.2.0"\n'
+    )
+
+
+def test_set_plugin_version_missing_raises():
+    with pytest.raises(ValueError):
+        bp.set_plugin_version("PLUGIN_NAME = 'x'\n", "0.2.0")
+
+
+def test_set_test_version_bumps_pinned_assertions():
+    assert bp.set_test_version('assert __version__ == "0.1.0"\n', "0.2.0") == (
+        'assert __version__ == "0.2.0"\n'
+    )
+    # Works through an attribute prefix, too.
+    assert bp.set_test_version('assert pkg.__version__ == "0.1.0"\n', "0.2.0") == (
+        'assert pkg.__version__ == "0.2.0"\n'
+    )
+
+
+def test_set_test_version_missing_raises():
+    with pytest.raises(ValueError):
+        bp.set_test_version("assert True\n", "0.2.0")
+
+
 def test_bump_rewrites_tree(tmp_path):
     pyproject_beets = (
         '[project]\nversion = "0.1.0"\ndependencies = ["python-musefs>=0.1.0", "beets>=1.6"]\n'
@@ -42,6 +68,11 @@ def test_bump_rewrites_tree(tmp_path):
         "contrib/picard/pyproject.toml": ('[project]\nname = "musefs-picard"\nversion = "0.1.0"\n'),
         "contrib/python-musefs/src/musefs_common/__init__.py": ('__version__ = "0.1.0"\n'),
         "contrib/lidarr/src/musefs_lidarr/__init__.py": ('__version__ = "0.1.0"\n'),
+        "contrib/picard/musefs/__init__.py": ('PLUGIN_VERSION = "0.1.0"\n'),
+        "contrib/lidarr/tests/test_smoke.py": ('assert __version__ == "0.1.0"\n'),
+        "contrib/python-musefs/tests/test_public_api.py": (
+            'assert musefs_common.__version__ == "0.1.0"\n'
+        ),
     }
     for rel, content in files.items():
         p = tmp_path / rel
@@ -56,6 +87,10 @@ def test_bump_rewrites_tree(tmp_path):
         assert '__version__ = "0.2.0"' in (tmp_path / rel).read_text()
     for rel in bp.DEPENDENTS:
         assert "python-musefs>=0.2.0" in (tmp_path / rel).read_text()
+    for rel in bp.PLUGIN_VERSION_FILES:
+        assert 'PLUGIN_VERSION = "0.2.0"' in (tmp_path / rel).read_text()
+    for rel in bp.TEST_VERSION_FILES:
+        assert '__version__ == "0.2.0"' in (tmp_path / rel).read_text()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Release-prep for **v1.1.0** — version bumps, release notes, changelog promotion, and a few doc-accuracy fixes — **plus a new `musefs vacuum` maintenance command**. No tagging here; cutting `v1.1.0` / `py-v1.1.0` (which triggers the publish workflows) is a deliberate follow-up.

### `musefs vacuum` (new command)

Compacts the SQLite store, reclaiming the free pages that prunes, orphan-art GC, and the schema migration leave behind. Runs `VACUUM` followed by `PRAGMA wal_checkpoint(TRUNCATE)` and reports bytes reclaimed (total footprint: `.db` + `-wal` + `-shm`).

- **`musefs-db`:** `Db::<ReadWrite>::vacuum()` plus a typed `DbError::StoreInUse` — a SQLite BUSY/locked failure becomes an actionable "unmount the filesystem or stop any scan before vacuuming" message. Lives in a new `maintenance.rs`.
- **`musefs-cli`:** the `vacuum --db <store>` subcommand (`run_vacuum`), guarding an existing store like `mount --db`; `--db` honors `MUSEFS_DB`. Prints e.g. `vacuumed library.db: 412.7 MiB → 318.2 MiB (reclaimed 94.5 MiB)`, or `(already compact)`.
- **Behavior:** best-effort concurrency — it's an offline maintenance command (run while unmounted); opening the store may also migrate an older schema to v2.
- **Docs:** a new `docs/src/guide/maintenance.md` page, a `[1.1.0]` changelog entry, and a release-notes highlight.
- Developed brainstorming → spec → plan → implementation, with the spec and plan each reviewed by the spec-plan reviewer before coding.

### Versions
- Bump the Rust workspace version and every internal `musefs-*` path-dependency pin `1.0.0` → `1.1.0` (`cargo metadata` resolves all 7 crates at 1.1.0); `Cargo.lock` synced to match.
- Bump the `contrib/` Python packages (`python-musefs`, `beets-musefs`, `lidarr-musefs`, `musefs-picard`) to 1.1.0 via `scripts/bump_python_version.py`, re-vendoring the Picard `_common` copy in lockstep.

### Changelogs
- Promote `## [Unreleased]` → `## [1.1.0] - 2026-06-17` in the root `CHANGELOG.md`, the docs-site `docs/src/changelog.md` (compare/tag link refs updated), and `contrib/CHANGELOG.md`. A fresh empty `## [Unreleased]` is retained in each.

### Docs
- Add `docs/src/release-notes.md`: curated v1.1.0 highlights plus an **Upgrading from v1.0.0** guide — the automatic `user_version` 1→2 schema migration (adds `fingerprint`/`content_hash`, rebuilds the byte-accurate tag cap), the `scan` exit-code change (now `2` on ingest failure), and other behavior changes. Wired into `SUMMARY.md` and linked from the changelog (anchor build-verified against mdBook output).
- Document the picture-type clamp (out-of-range → `0`) as a lossy edge in the FLAC, MP3, and Ogg format docs, matching the store's `track_art.picture_type BETWEEN 0 AND 20` CHECK.

### README
- Replace the GitHub-releases badge with a crates.io version badge; add a PyPI version badge for `python-musefs`.

## Verification
- Pre-commit hook passed in full on every commit: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, the entire workspace test suite, and ruff.
- `musefs vacuum`: 8 unit/integration tests (db + cli) pass; the in-diff mutation gate is clean on `maintenance.rs` (0 surviving mutants; `musefs-cli/**` is excluded from mutation by repo policy); the `metrics`-feature suite (511 tests) is green.
- `cargo metadata` validates the bumped manifests; mdBook builds and emits the expected `id="110---2026-06-17"` anchor.

## Follow-up
- Tag `v1.1.0` (Rust crates) and `py-v1.1.0` (Python packages) to publish. The crates.io / PyPI README badges will read 1.1.0 once those workflows run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `musefs vacuum` command to compact the SQLite-backed store and report reclaimed disk space (must run while the filesystem is unmounted)

* **Documentation**
  * Added comprehensive maintenance guide explaining database compaction procedure
  * Published v1.1.0 release notes with detailed upgrade guidance
  * Documented picture type handling in FLAC, MP3, and Ogg audio formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
