### PR TITLE
chore: sync fuzz/Cargo.lock to the v1.1.0 workspace version

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arc-swap",
  "base16ct",
@@ -506,9 +506,10 @@ dependencies = [
 
 [[package]]
 name = "musefs-db"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base16ct",
+ "log",
  "rusqlite",
  "sha2",
  "strum",
@@ -517,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "musefs-format"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "id3",


### PR DESCRIPTION
`ba41c9f` synced the root `Cargo.lock` to 1.1.0 when preparing the v1.1.0
release, but left `fuzz/Cargo.lock` pinning the internal crates
(`musefs-core` / `musefs-db` / `musefs-format`) at `1.0.0`. The `fuzz/`
crate lives outside the workspace, so the version bump isn't picked up
automatically — `cargo +nightly fuzz build` regenerates it to 1.1.0.

Not a release blocker: `fuzz.yml` deliberately runs **without** `--locked`
(so CI regenerates the lockfile), and the fuzz crate is never published.
This just keeps the tracked lockfile honest ahead of the v1.1.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)