### PR TITLE
Fix the v1.3.0 audit findings (#616-#629)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -175,19 +175,28 @@ exclude_re = [
     # guard: op="+=" fn="run_pipeline" rows=2
 'musefs-core/src/scan\.rs:1629:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1665:32:',
+'musefs-core/src/scan\.rs:1668:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1665:47:',
+'musefs-core/src/scan\.rs:1668:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1665:62:',
+'musefs-core/src/scan\.rs:1668:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1673:37:',
+'musefs-core/src/scan\.rs:1682:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1675:40:',
+'musefs-core/src/scan\.rs:1684:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1675:55:',
+'musefs-core/src/scan\.rs:1684:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1675:70:',
+'musefs-core/src/scan\.rs:1684:71:',
+    # Same cadence class, one level up: each threshold flush is a let-chain
+    # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
+    # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
+    # IS met — deferring the commit to the flush-on-empty / final flush, which
+    # persist the identical track set and still surface a flush error (#618).
+    # guard: op="&&" fn="run_pipeline" rows=1
+'musefs-core/src/scan\.rs:1669:21:',
+    # guard: op="&&" fn="run_pipeline" rows=1
+'musefs-core/src/scan\.rs:1685:29:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -195,11 +204,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:1805:29:',
+'musefs-core/src/scan\.rs:1830:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:1814:33:',
+'musefs-core/src/scan\.rs:1839:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:1870:29: replace \+ with -',
+'musefs-core/src/scan\.rs:1895:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -147,7 +147,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1532:46:',
+'musefs-core/src/scan\.rs:1530:46:',
     # probe_body's tail-read predicate
     # `has_ext(mp3) || (has_ext(flac) && has_leading_id3(prefix))`, the inner `&&`
     # (col 66) -> `||`: widening it makes every .flac pay the 128-byte tail read,
@@ -173,30 +173,30 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1629:22:',
+'musefs-core/src/scan\.rs:1627:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1668:33:',
+'musefs-core/src/scan\.rs:1666:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1668:48:',
+'musefs-core/src/scan\.rs:1666:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1668:63:',
+'musefs-core/src/scan\.rs:1666:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1682:37:',
+'musefs-core/src/scan\.rs:1680:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1684:41:',
+'musefs-core/src/scan\.rs:1682:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1684:56:',
+'musefs-core/src/scan\.rs:1682:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1684:71:',
+'musefs-core/src/scan\.rs:1682:71:',
     # Same cadence class, one level up: each threshold flush is a let-chain
     # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
     # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
     # IS met — deferring the commit to the flush-on-empty / final flush, which
     # persist the identical track set and still surface a flush error (#618).
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1669:21:',
+'musefs-core/src/scan\.rs:1667:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1685:29:',
+'musefs-core/src/scan\.rs:1683:29:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable
@@ -204,11 +204,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:1830:29:',
+'musefs-core/src/scan\.rs:1828:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:1839:33:',
+'musefs-core/src/scan\.rs:1837:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:1895:29: replace \+ with -',
+'musefs-core/src/scan\.rs:1893:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -427,15 +427,15 @@ exclude_re = [
     # #305 folded-inode allocator — hang-class (TIMEOUT-only) mutants, the SP3
     # non-terminating-loop precedent. InodeAllocator::key() transforms a path into
     # the inode map key (case-folded on folded mounts, identity otherwise).
-    # Replacing its body with ANY constant — empty or "xyzzy", borrowed or owned —
-    # makes every path intern to one key, so every node collapses onto a single
-    # inode and becomes its own parent; path_of's `while cur != ROOT` walk then
-    # spins forever (observed canceling the in-diff CI job). All four const-returns
-    # share site 52:9 (one distinct site). key()'s real behavior is pinned
-    # functionally: the fold-vs-identity branch is exercised by
+    # Replacing its body with a constant — `Default::default()` is the empty
+    # `Arc<str>` since #629 made the key a shared handle — makes every path intern
+    # to one key, so every node collapses onto a single inode and becomes its own
+    # parent; path_of's `while cur != ROOT` walk then spins forever (observed
+    # canceling the in-diff CI job). One const-return at one site. key()'s real
+    # behavior is pinned functionally: the fold-vs-identity branch is exercised by
     # folded_dir_recase_keeps_survivor_inode (folded) and
     # case_sensitive_keeps_both_dirs_separate (identity).
-    'musefs-core/src/tree\.rs:\d+:\d+: replace InodeAllocator::key -> Cow<.a, str> with',
+    'musefs-core/src/tree\.rs:\d+:\d+: replace InodeAllocator::key -> RenderedPath with',
     # intern const-returns `-> 0` / `-> 1`: same hang-class. A constant inode for
     # every path collides all nodes (inode 0, or ROOT for 1) into a self-parenting
     # cycle, so path_of loops forever. intern's real contract — a fresh inode per

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -324,7 +324,7 @@ exclude_re = [
     # mutant is equivalent and unkillable (#537). Pinned by line:col — the other `<`
     # in this fn (the memo range check) IS caught.
     # guard: op="<" fn="find_page_start" rows=1
-    'musefs-core/src/ogg_index\.rs:74:48: replace < with <= in find_page_start',
+    'musefs-core/src/ogg_index\.rs:90:48: replace < with <= in find_page_start',
     # Overlap-emit guards `if hs < he` / `if ps < pe`, `<`->`<=`: when the bound is
     # equal the extra branch emits an empty `[a..b]` slice / reads 0 payload bytes —
     # a no-op, so the served output is byte-identical (verified: the ogg tests and the
@@ -332,9 +332,9 @@ exclude_re = [
     # were reported TIMEOUT under the parallel gate's load, not as a real hang. Pinned
     # by line:col — several `<` in this fn (the loop/length guards) ARE caught.
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:252:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:275:15: replace < with <= in serve_ogg_window',
     # guard: op="<" fn="serve_ogg_window" rows=1
-    'musefs-core/src/ogg_index\.rs:261:15: replace < with <= in serve_ogg_window',
+    'musefs-core/src/ogg_index\.rs:284:15: replace < with <= in serve_ogg_window',
 
     # Phase 4 poll debounce (#89) — equivalent `<`->`<=` on the two wall-clock
     # gates (`last_poll.elapsed() < poll_interval`, `last_failed.elapsed() <

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -197,6 +197,19 @@ exclude_re = [
 'musefs-core/src/scan\.rs:1667:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
 'musefs-core/src/scan\.rs:1683:29:',
+    # `ByteBudget::acquire`'s wait guard (`!st.closed && in_flight != 0 && ...`),
+    # the FIRST `&&`->`||`. `&&` binds tighter than `||`, so the guard becomes
+    # `!closed || (in_flight != 0 && over_cap)` and every reservation against an
+    # OPEN budget waits forever. That is a genuine break, but it can only ever
+    # surface as a hang rather than a failure: roughly a dozen `scan::*` tests
+    # reserve through `scan_directory_with`, so the test binary stalls and
+    # cargo-mutants scores TIMEOUT — which fails the gate — instead of CAUGHT.
+    # Verified locally: the `byte_budget` unit tests can be made to fail fast, but
+    # the scan tests still hang, so killing it properly would mean putting a
+    # deadline on every scan test. The hang is the detection (#618). The second
+    # `&&` on the same line is caught by `oversized_item_admitted_when_idle`.
+    # guard: op="&&" fn="ByteBudget::acquire" rows=1
+'musefs-core/src/byte_budget\.rs:39:26:',
     # revalidate_with `skip_failed += 1`: unreachable defensive accounting.
     # collect_audio yields only existing regular files, so a just-collected file's
     # metadata()/canonicalize() fails solely under a TOCTOU race — not reachable

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Review routing. One maintainer today, so a single catch-all rule covers the
+# repository; per-area rules go below it (last matching rule wins) when there is
+# more than one owner to route to.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @Sohex

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+name: Bug report
+description: Something musefs serves, scans, or mounts is wrong.
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. musefs never copies or rewrites audio bytes, so a
+        report is almost always pinned down by the same four facts: the mount
+        mode, the backing format, who wrote the store, and the log.
+
+        Before filing, please check the
+        [format notes](https://sohex.github.io/musefs/formats/overview.html)
+        — some differences from the source file (dropped non-standard frames,
+        re-ordered tags) are documented lossy edges rather than bugs.
+
+  - type: input
+    id: version
+    attributes:
+      label: musefs version
+      description: Output of `musefs --version`. For a build from source, the commit sha.
+      placeholder: musefs 1.3.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Mount mode (`--mode`)
+      description: |
+        `synthesis` serves a freshly generated metadata region in front of the
+        audio; `structure-only` serves the backing file's bytes unchanged.
+      options:
+        - synthesis (default)
+        - structure-only
+        - not a mount problem (scan, CLI, or plugin)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: format
+    attributes:
+      label: Backing format
+      description: The container of the file that misbehaves.
+      multiple: true
+      options:
+        - FLAC
+        - MP3
+        - M4A / M4B
+        - Ogg (Vorbis / Opus)
+        - WAV
+        - other / not format specific
+    validations:
+      required: true
+
+  - type: dropdown
+    id: writer
+    attributes:
+      label: Who wrote the store?
+      description: |
+        The SQLite store is the source of truth for tags and art, and external
+        writers go through a documented
+        [contract](https://sohex.github.io/musefs/architecture/store.html#the-external-writer-contract).
+        A store written by another tool narrows triage a lot.
+      options:
+        - musefs itself (`musefs scan` only)
+        - beets plugin
+        - Picard plugin
+        - Lidarr integration
+        - python-musefs directly
+        - another tool / hand-written SQL
+        - not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what you expected instead
+      description: Include the affected path under the mount if there is one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: |
+        The exact `musefs scan` / `musefs mount` invocations, and how you read
+        the file back (player, `ffprobe`, `cmp`, mutagen, ...).
+      placeholder: |
+        1. musefs scan --db ... --library ...
+        2. musefs mount --db ... --mode synthesis ~/mnt/music
+        3. ffprobe ~/mnt/music/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output
+      description: |
+        Re-run with `RUST_LOG=info` (or `RUST_LOG=debug` for a read-path
+        problem) and paste the relevant lines. This is rendered as a code
+        block, so no backticks needed.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: OS and kernel, plus the libfuse version if the problem is a mount.
+      placeholder: Debian 13, Linux 6.12, libfuse 3.17
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# Free-form issues stay available: not everything is a bug or a request.
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://sohex.github.io/musefs/
+    about: Usage, per-format synthesis behaviour, internals, and the FAQ.
+  - name: Contributing guide
+    url: https://sohex.github.io/musefs/contributing/setup.html
+    about: Getting set up, the test tiers, conventions, and adding a format.
+  - name: Security
+    url: https://sohex.github.io/musefs/security.html
+    about: Report a security issue privately rather than in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature or format request
+description: Ask for a new capability, or for musefs to support another container.
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two shapes of request live here: "musefs should support format X" and
+        "musefs should be able to do Y". Say which below.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of request is this?
+      options:
+        - Support for a new audio format / container
+        - A new or changed capability in an existing area
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: What should musefs do?
+      description: |
+        For a format request, name the container and extensions, and say which
+        tag scheme it carries (Vorbis comments, ID3v2, MP4 atoms, ...) and how
+        cover art is embedded. For anything else, describe the behaviour you
+        want and the situation it comes up in.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why does the current behaviour not cover it?
+      description: |
+        What you tried, and where it fell short. Existing behaviour per format
+        is documented in the
+        [format notes](https://sohex.github.io/musefs/formats/overview.html).
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### If you would like to implement it
+
+        Adding a format is a well-trodden path in this codebase — the
+        [Adding a format](https://sohex.github.io/musefs/contributing/conventions.html#adding-a-format)
+        section walks through the synthesis trait, the segment layout, and the
+        test tiers a new format has to clear (including the round trip through
+        an independent reader). Start from
+        [Getting set up](https://sohex.github.io/musefs/contributing/setup.html).
+
+        The hard constraint for any format: the original audio bytes are never
+        copied or modified. A container whose audio payload cannot be served by
+        positioned reads of the untouched backing file does not fit musefs.
+
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to work on this myself.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+Thanks for contributing. The checklist below is short on purpose: it covers
+the steps that are easy to forget and that silently break something later.
+Everything in it is explained in the contributing guide:
+https://sohex.github.io/musefs/contributing/setup.html
+-->
+
+## What and why
+
+<!-- What this changes, and the problem it solves. Link the issue: Closes #NNN -->
+
+## Checklist
+
+- [ ] The **pre-commit hook ran** on every commit (no `--no-verify`): `cargo
+      fmt`, `cargo clippy --all-targets -- -D warnings`, the full workspace
+      test suite, `shellcheck`/`yamllint`, and `ruff`.
+      ([Build & test](https://sohex.github.io/musefs/contributing/setup.html#build--test))
+- [ ] If the **format-layer API changed**: `cargo +nightly fuzz build` passes.
+      `fuzz/` is outside the workspace, so `cargo test` cannot catch a break
+      there.
+      ([Coverage-guided fuzzing](https://sohex.github.io/musefs/contributing/testing.html#coverage-guided-fuzzing))
+- [ ] If the **`musefs-db` schema changed**: the Python mirror was regenerated
+      with `MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py` and
+      re-vendored to the plugins.
+      ([Python plugins](https://sohex.github.io/musefs/contributing/plugins.html))
+- [ ] **Changelog entry** added under `## [Unreleased]` in `CHANGELOG.md` for
+      anything user-visible (`contrib/` has its own changelog).
+- [ ] **Docs updated** under `docs/src/` if behaviour, flags, or the store
+      contract changed.
+- [ ] Commit subjects follow **conventional commits** (`fix(cli): ...`,
+      `feat(format): ...`, `ci: ...`), and the body says what changed and why.
+      ([Conventions](https://sohex.github.io/musefs/contributing/conventions.html#code-conventions))
+
+## The invariant
+
+- [ ] This change does not copy or modify original audio bytes. A served file
+      is still generated metadata spliced in front of positioned reads of the
+      untouched backing file.
+
+<!--
+Adding a format? It has its own path through the guide — the synthesis trait,
+the segment layout, and the test tiers a new format must clear:
+https://sohex.github.io/musefs/contributing/conventions.html#adding-a-format
+-->

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -40,4 +40,14 @@ jobs:
       - name: Scan fuzz lockfile (advisories + yanked)
         run: |
           cargo install cargo-deny --locked --version '^0.19'
-          cargo deny --manifest-path fuzz/Cargo.toml check --config deny.toml advisories
+          # `--allow advisory-not-detected`: deny.toml's ignore list is authored
+          # against the root graph, and the ci.yml deny job promotes that
+          # diagnostic there to keep the list honest. This job reuses the same
+          # config over a *different* graph, where a root-only entry (currently
+          # RUSTSEC-2024-0436 / `paste`, reached via the jemalloc allocator the
+          # fuzz crate does not pull in) is legitimately unmatched — off the
+          # authoring graph the diagnostic is noise, not a rot signal. If the
+          # fuzz lockfile ever needs an exemption of its own, give it a separate
+          # config rather than widening the root list.
+          cargo deny --manifest-path fuzz/Cargo.toml check --config deny.toml \
+            --allow advisory-not-detected advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,17 @@ jobs:
         # together with the deny.toml schema.
         run: cargo install cargo-deny --locked --version '^0.19'
       - name: cargo-deny check
-        run: cargo deny check
+        # `advisory-not-detected` / `license-not-encountered` are promoted to
+        # errors so deny.toml's ignore and allow lists cannot rot: an entry that
+        # stops matching the graph fails this gate instead of emitting a warning
+        # into a log that nothing reads, which is how a stale entry ends up
+        # silently pre-exempting the next real advisory for the same crate. This
+        # is the graph both lists are authored against; audit.yml's fuzz-lockfile
+        # scan is not, and allows the advisory diagnostic accordingly.
+        run: |
+          cargo deny check \
+            --deny advisory-not-detected \
+            --deny license-not-encountered
 
   interop:
     # Property 5: an independent ecosystem reader (mutagen) reads the tags we

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,42 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `musefs_dir_handle_rejections_total` counts `opendir` calls that could not be
+  given a cached directory snapshot, so directory-handle pressure stays visible
+  after a burst rather than only as a gauge that reads healthy between samples.
+
+### Changed
+
+- The virtual tree stores each node name in one shared allocation instead of
+  five copies, cutting about a quarter of its resident cost (~1.7 KB to ~1.3 KB
+  per track, measured over 200,000 tracks). The tuning guide now documents the
+  footprint and how to size a host against it.
+- Full tree rebuilds and the head of every scan read only the columns they use
+  instead of materializing whole track rows.
+
+### Fixed
+
+- A parallel directory walk over a large mount no longer loses entries. Once
+  1024 directory handles were open, further `opendir` calls were rejected with
+  `ENFILE` — `bfs` over a 200,000-track mount silently lost about 9% of the
+  tree. Over-cap directories are now served without a cached snapshot instead,
+  so listings stay complete.
+- Unmount helpers (`fusermount3`, `fusermount`, `umount`) are resolved to an
+  absolute path before being spawned, so a daemon running as root can no longer
+  be made to execute an attacker-supplied binary from a writable `PATH` entry
+  when it receives `SIGTERM`.
+- A scan whose batch commit fails no longer leaves worker threads parked on the
+  byte budget forever. They are woken and joined before the error propagates, so
+  an embedder that catches the error and keeps running no longer leaks a thread
+  and its in-flight art bytes per failed scan.
+- Locating an Ogg page for a seeking read now bounds how many candidate pages it
+  will CRC-validate, so a file whose audio region is packed with false `OggS`
+  markers cannot amplify a single read into thousands of positioned reads.
+- `access` is implemented, so a mount no longer logs a `[Not Implemented]`
+  warning from fuser.
+
 ## [1.3.0] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   five copies, cutting about a quarter of its resident cost (~1.7 KB to ~1.3 KB
   per track, measured over 200,000 tracks). The tuning guide now documents the
   footprint and how to size a host against it.
+- Each entry's rendered path is stored once and shared between the inode
+  allocator and the refresh snapshot instead of being allocated twice, taking a
+  further ~7% off the tree's resident cost. The saving tracks path length, so a
+  deeper `--template` gains proportionally more.
 - Full tree rebuilds and the head of every scan read only the columns they use
   instead of materializing whole track rows.
 

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,11 @@ all-features = true
 # weak-copyleft MPL-2.0 is file-level and fine to link. Copyleft licenses
 # (GPL/LGPL/AGPL) are intentionally absent — they only ever appear as the
 # non-selected arm of an `OR`, so the resolver picks a permissive arm instead.
+#
+# The "every entry is present" claim above is enforced, not aspirational: the
+# ci.yml deny job promotes `license-not-encountered` to an error, so an entry
+# that stops matching — a dep drops it, a bump relicenses — fails the gate and
+# has to be dropped rather than accumulating as a silent pre-approval.
 allow = [
     "MIT",
     "Apache-2.0",
@@ -20,7 +25,6 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "0BSD",
-    "ISC",
     "Zlib",
     "Unlicense",
     "Unicode-3.0",
@@ -45,12 +49,18 @@ deny = []
 # re-checks them here as defense in depth. Keep yanked crates a hard error.
 #
 # Every `ignore` entry below must still match a crate in the graph — a stale one
-# silently pre-exempts the next real advisory for the same crate, so drop it as
-# soon as `cargo deny check` reports `advisory-not-detected` for it. That
-# diagnostic is deliberately left a warning rather than promoted to an error:
-# this config is also run against `fuzz/Cargo.lock` (audit.yml), where a
-# legitimately-ignored root advisory need not be present, so promoting it would
-# fail that job for an entry that is not stale at all.
+# silently pre-exempts the next real advisory for the same crate. The ci.yml
+# deny job promotes `advisory-not-detected` to an error, so a stale entry fails
+# the gate instead of warning into a log nobody reads.
+#
+# That promotion is scoped to the root graph, which is the graph this list is
+# authored against. audit.yml runs this same config over `fuzz/Cargo.lock` — a
+# different graph, where RUSTSEC-2024-0436 (`paste`, reached via the jemalloc
+# allocator the fuzz crate does not pull in) is legitimately unmatched. That job
+# passes `--allow advisory-not-detected` because off the authoring graph the
+# diagnostic carries no rot signal, only noise. If the fuzz lockfile ever needs
+# an exemption of its own, give it a separate config so each list stays strictly
+# checked against the graph it was written for — do not widen this one.
 yanked = "deny"
 ignore = [
     # paste 1.0.15 is archived/unmaintained (via tikv-jemalloc-ctl, the default

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,14 @@ deny = []
 [advisories]
 # Advisories are primarily gated by rustsec/audit-check in audit.yml; cargo-deny
 # re-checks them here as defense in depth. Keep yanked crates a hard error.
+#
+# Every `ignore` entry below must still match a crate in the graph — a stale one
+# silently pre-exempts the next real advisory for the same crate, so drop it as
+# soon as `cargo deny check` reports `advisory-not-detected` for it. That
+# diagnostic is deliberately left a warning rather than promoted to an error:
+# this config is also run against `fuzz/Cargo.lock` (audit.yml), where a
+# legitimately-ignored root advisory need not be present, so promoting it would
+# fail that job for an entry that is not stale at all.
 yanked = "deny"
 ignore = [
     # paste 1.0.15 is archived/unmaintained (via tikv-jemalloc-ctl, the default
@@ -55,11 +63,6 @@ ignore = [
     # virtual tree). The maintained imbl fork still depends on it, so there is no
     # upgrade path; the suggested replacements are not drop-in for SparseChunk.
     "RUSTSEC-2026-0247",
-    # Unsound bitmaps >= 3.2.0 `TryFrom<&[u8]>`/`AsMut<[u8]>` impls for `Bitmap`.
-    # Unreachable: imbl-sized-chunks builds bitmaps only via
-    # `Bitmap::{new, default}` and mutates them only through `set`, never from
-    # bytes; the archived crate has no patched release.
-    "RUSTSEC-2025-0167",
 ]
 
 [sources]

--- a/docs/src/architecture/serving.md
+++ b/docs/src/architecture/serving.md
@@ -96,11 +96,12 @@ handles so a client that opens directories without closing them cannot pin
 unbounded memory.
 
 Over that cap, `opendir` degrades rather than failing: it returns the stateless
-handle, and `readdir` falls back to rebuilding the listing on each call.
-Listings stay complete — parallel walkers routinely exceed 1024 concurrent
-directory handles on a large mount — at the cost of that rebuild.
-`musefs_dir_handle_rejections_total` counts the opens that
-took the fallback; the `musefs_dir_handles` gauge cannot show this, because
+handle, and `readdir` falls back to rebuilding the listing on each call (on the
+worker pool, like every other blocking operation, not on the single fuser
+dispatch thread). Listings stay complete — parallel walkers routinely exceed
+1024 concurrent directory handles on a large mount — at the cost of that
+rebuild. `musefs_dir_handle_rejections_total` counts the opens that took the
+fallback; the `musefs_dir_handles` gauge cannot show this, because
 saturation is bursty enough to read healthy in every sample while thousands of
 opens are degraded between them.
 

--- a/docs/src/architecture/serving.md
+++ b/docs/src/architecture/serving.md
@@ -87,6 +87,23 @@ silently. Freshness for a passthrough handle is open-time-only — it is a
 plain POSIX fd onto the backing file. In `Synthesis` mode no single fd
 represents the spliced bytes, so passthrough never applies.
 
+## Directory listings
+
+`opendir` builds a directory's entries once and snapshots them, so a paginated
+`readdir` is a map lookup rather than a fresh tree walk per call — enumeration
+stays O(n) in the directory, not O(n²). Snapshots are capped at 1024 concurrent
+handles so a client that opens directories without closing them cannot pin
+unbounded memory.
+
+Over that cap, `opendir` degrades rather than failing: it returns the stateless
+handle, and `readdir` falls back to rebuilding the listing on each call.
+Listings stay complete — parallel walkers routinely exceed 1024 concurrent
+directory handles on a large mount — at the cost of that rebuild.
+`musefs_dir_handle_rejections_total` counts the opens that
+took the fallback; the `musefs_dir_handles` gauge cannot show this, because
+saturation is bursty enough to read healthy in every sample while thousands of
+opens are degraded between them.
+
 ## Synthetic telemetry namespace
 
 When `--expose-metrics` is on, the root directory gains a synthetic

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,6 +12,99 @@ see the [Release notes](release-notes.md).
 
 ## [Unreleased]
 
+### Added
+
+- `musefs_dir_handle_rejections_total` ([#626](https://github.com/Sohex/musefs/issues/626)), a monotonic counter of
+  `opendir` calls that could not be given a cached directory snapshot. The
+  existing `musefs_dir_handles` gauge cannot stand in for it: saturation is
+  bursty, and a walk that produced 7,525 rejections never showed a gauge sample
+  above 593. It is also the signal that the stateless path from
+  [#616](https://github.com/Sohex/musefs/issues/616) is in use and directories are being rebuilt on every
+  `readdir`.
+
+### Changed
+
+- The virtual tree interns each node name into one shared `Arc<str>` rather than
+  storing it separately in `Node.name`, `Node.rendered_name`, the `children` key
+  and both `rendered_children` keys ([#617](https://github.com/Sohex/musefs/issues/617)). Measured over 200,000
+  tracks / 222,001 nodes: ~1713 to ~1284 bytes per track (~84 MiB, -25%), with
+  tree build 10-15% faster from the removed allocations. A case-insensitive
+  mount saves more, since `folded_children` held a sixth copy. The tuning guide
+  gained a "Memory footprint" section. The full rendered paths are still stored
+  twice; that remainder is tracked in [#629](https://github.com/Sohex/musefs/issues/629).
+- Full tree rebuilds and the head of every scan read projected columns instead
+  of materializing a whole `Track` per row ([#621](https://github.com/Sohex/musefs/issues/621)) — roughly 40 MB of
+  transient allocation on a 200,000-track store, on a path already holding a
+  pool connection.
+- `readdir`'s unknown-`fh` fallback runs on the worker pool instead of inline on
+  the fuser dispatch thread ([#623](https://github.com/Sohex/musefs/issues/623)), matching the offload every other
+  blocking operation already used. This matters more now that over-cap `opendir`
+  makes that fallback the normal path for large directories.
+
+### Fixed
+
+- Over-cap `opendir` degrades to a stateless directory handle instead of
+  replying `ENFILE` ([#616](https://github.com/Sohex/musefs/issues/616)). The 1024-handle cap was assumed to sit
+  well above any real client, but `bfs` — an ordinary parallel `find`, and the
+  default `find` in several distributions — exceeded it immediately: 7,525
+  rejections over a 200,000-track mount, 17,910 files never enumerated. The
+  rejection surfaced to the operator as "Too many open files in system", which
+  points at the kernel rather than the mount, and an indexer that logs and
+  continues would simply present an incomplete library. Serving over-cap
+  directories through the existing stateless fallback keeps listings complete
+  and preserves the memory bound the cap was added for, at the cost of an O(N)
+  rebuild per `readdir`.
+- Unmount helpers are resolved against `/usr/bin`, `/bin` and `/usr/local/bin`
+  before falling back to a bare-name `PATH` lookup ([#620](https://github.com/Sohex/musefs/issues/620)). The
+  mounting guide steers operators toward running as root for kernel passthrough
+  in `StructureOnly` mode, and nothing sanitizes `PATH` there, so a writable
+  `PATH` entry meant attacker-chosen code executed as root on `SIGTERM`.
+- A failed batch commit during a scan winds the pipeline down before the error
+  propagates ([#618](https://github.com/Sohex/musefs/issues/618)). `ByteBudget` gained a `close()` that wakes
+  waiters, so a worker parked in `acquire` on a condvar only `flush` ever
+  signalled is no longer stranded. This was benign for the CLI, where process
+  exit reaps everything, but `scan_directory_with` / `revalidate_with` are
+  public API and an embedder that caught the error accumulated leaked threads
+  and their in-flight art bytes. The two state-mutex `unwrap()`s adopted the
+  daemon's `lock_recover` policy at the same time, retiring the open note in
+  `lock.rs`.
+- `find_page_start` bounds the number of candidate pages it CRC-validates per
+  call ([#619](https://github.com/Sohex/musefs/issues/619)). The header pre-filter almost never admits a false
+  `OggS` on real audio, but a file whose audio region is deliberately packed
+  with `OggS\x00\x00` cleared it at every offset, allowing up to ~65,000 CRC
+  validations — each with its own positioned reads — for a single seeking read.
+  Hardening rather than a live vulnerability: the attacker is whoever can place
+  a file in the scanned library.
+- `access` is implemented and replies `ok` ([#624](https://github.com/Sohex/musefs/issues/624)), so fuser's default
+  no longer logs `[Not Implemented]` per mount. The mount carries `RO` and, with
+  `allow_other`, `DefaultPermissions`, so the kernel already enforces the
+  presented mode bits.
+
+### Internal
+
+- The `ogg_page` fuzz target round-trips the page machinery the serve path
+  actually depends on — `verify_page_crc` and `patch_page_header_algebraic` —
+  instead of only decoding a header ([#625](https://github.com/Sohex/musefs/issues/625)). Coverage against the
+  committed seed rose from 51 edges / 69 features to 129 / 267.
+- The read-ahead budget invariant restored by #536 now has a concurrent
+  regression test that the ASan and TSan CI legs actually reach
+  ([#628](https://github.com/Sohex/musefs/issues/628)). The sanitizer legs previously ran a test that builds
+  `ReadAheadPool::new(0)`, leaving the pool disabled throughout. No live bug was
+  found; this closes the coverage gap.
+- `deny.toml`'s allow and ignore lists can no longer rot ([#622](https://github.com/Sohex/musefs/issues/622)). A
+  stale `RUSTSEC-2025-0167` ignore and an unmatched `ISC` license allowance both
+  warned and exited 0, so neither surfaced on a PR — which is how an entry ends
+  up silently pre-exempting the next real advisory for the same crate. Both were
+  dropped, and `advisory-not-detected` / `license-not-encountered` are now
+  errors in the `deny` job. The promotion is scoped to the root graph, which is
+  what the lists are authored against; the fuzz-lockfile scan in `audit.yml`
+  allows the advisory diagnostic explicitly, since off that graph it is noise.
+- Issue, pull-request and `CODEOWNERS` templates ([#627](https://github.com/Sohex/musefs/issues/627)). The PR
+  checklist covers the steps that are easy to forget and silently break
+  something: the pre-commit hook, `cargo +nightly fuzz build` after a
+  format-layer API change, regenerating the Python schema mirror after a
+  `musefs-db` change, and a changelog entry.
+
 ## [1.3.0] - 2026-08-19
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -30,8 +30,17 @@ see the [Release notes](release-notes.md).
   tracks / 222,001 nodes: ~1713 to ~1284 bytes per track (~84 MiB, -25%), with
   tree build 10-15% faster from the removed allocations. A case-insensitive
   mount saves more, since `folded_children` held a sixth copy. The tuning guide
-  gained a "Memory footprint" section. The full rendered paths are still stored
-  twice; that remainder is tracked in [#629](https://github.com/Sohex/musefs/issues/629).
+  gained a "Memory footprint" section. The full rendered paths were still stored
+  twice at this point; the next entry shares those as well.
+- Each entry's rendered path is stored once and shared between the inode
+  allocator's map key and `TrackRenderState.path`, rather than allocated
+  independently by each ([#629](https://github.com/Sohex/musefs/issues/629)). Measured over 200,000 tracks with
+  41-byte paths: 1150 to 1078 bytes per track (-6%); with 137-byte paths the
+  saving is -14%. What it removes is exactly one whole path per track, so the
+  gain tracks path length and template depth rather than track count — a flat
+  `--template` gains little. Sharing is conditional: a disambiguated leaf keeps
+  its own allocation, since keying it on the path its bare-named sibling already
+  interned would collapse two nodes onto one inode.
 - Full tree rebuilds and the head of every scan read projected columns instead
   of materializing a whole `Track` per row ([#621](https://github.com/Sohex/musefs/issues/621)) — roughly 40 MB of
   transient allocation on a 200,000-track store, on a path already holding a
@@ -91,6 +100,14 @@ see the [Release notes](release-notes.md).
   ([#628](https://github.com/Sohex/musefs/issues/628)). The sanitizer legs previously ran a test that builds
   `ReadAheadPool::new(0)`, leaving the pool disabled throughout. No live bug was
   found; this closes the coverage gap.
+- `musefs-core/tests/tree_footprint.rs` gates the virtual tree's per-track
+  resident cost ([#629](https://github.com/Sohex/musefs/issues/629)), turning #617's throwaway probe into a
+  committed ceiling. It samples `VmRSS` either side of `VirtualTree::build_with`
+  with the rendered paths materialized beforehand, so the delta is the tree's
+  own marginal cost. The ceiling is deliberately loose — a gate that catches
+  only a large regression is worth more than one that reddens on a loaded
+  runner — and a floor assertion keeps a broken measurement from passing
+  vacuously.
 - `deny.toml`'s allow and ignore lists can no longer rot ([#622](https://github.com/Sohex/musefs/issues/622)). A
   stale `RUSTSEC-2025-0167` ignore and an unmatched `ISC` license allowance both
   warned and exited 0, so neither surfaced on a PR — which is how an entry ends

--- a/docs/src/contributing/testing.md
+++ b/docs/src/contributing/testing.md
@@ -223,9 +223,10 @@ cargo test -p musefs-fuse --test concurrent_reads -- --ignored  # mount: DbPool:
 The core binary also carries the read-ahead pool's budget-accounting stress
 (`readahead_*`, #628): 16 threads register/read/deregister streams against a
 4 MiB budget so eviction fires constantly, then assert
-`charged == Σ(registered buffers' bytes.len())` at quiescence — the invariant
-#536 restored. It lives in this binary precisely so the sanitizer legs below
-reach it; the serve-path tests around it run with read-ahead disabled. Rounds
+`charged == Σ(registered buffers' bytes.len())` at quiescence — the
+invariant #536 restored. It lives in this binary precisely so the sanitizer
+legs below reach it; the serve-path tests around it run with read-ahead
+disabled. Rounds
 default to a sanitizer-friendly 24 per thread;
 `MUSEFS_READAHEAD_STRESS_ROUNDS=200` soaks it locally.
 

--- a/docs/src/contributing/testing.md
+++ b/docs/src/contributing/testing.md
@@ -220,6 +220,15 @@ cargo test -p musefs-core --test concurrent_reads          # core: HeaderCache +
 cargo test -p musefs-fuse --test concurrent_reads -- --ignored  # mount: DbPool::PerThread (needs /dev/fuse)
 ```
 
+The core binary also carries the read-ahead pool's budget-accounting stress
+(`readahead_*`, #628): 16 threads register/read/deregister streams against a
+4 MiB budget so eviction fires constantly, then assert
+`charged == Σ(registered buffers' bytes.len())` at quiescence — the invariant
+#536 restored. It lives in this binary precisely so the sanitizer legs below
+reach it; the serve-path tests around it run with read-ahead disabled. Rounds
+default to a sanitizer-friendly 24 per thread;
+`MUSEFS_READAHEAD_STRESS_ROUNDS=200` soaks it locally.
+
 CI runs the core test under **AddressSanitizer** as a required gate (`asan` job)
 and both tests under **ThreadSanitizer** as a non-required best-effort signal
 (`tsan` job, `continue-on-error`). TSan cannot instrument the system C libraries

--- a/docs/src/contributing/testing.md
+++ b/docs/src/contributing/testing.md
@@ -247,6 +247,19 @@ RUSTFLAGS="-Zsanitizer=thread" TSAN_OPTIONS="halt_on_error=0" \
   cargo +nightly test -p musefs-core -Zbuild-std --test concurrent_reads --target x86_64-unknown-linux-gnu
 ```
 
+The uninstrumented-C caveat is not theoretical, and it reaches the core test —
+not just the mounted one. The `tsan` leg intermittently reports a `data race` on
+a `memcpy` inside `walIndexWriteHdr` / `walIndexTryHdr` (`sqlite3.c`), reached
+through `Db::open_readonly` from the serve-path tests. That is SQLite's
+WAL-index header, guarded by barriers of its own that TSan cannot see — a false
+positive, not a musefs defect. Every test still passes when it fires; the leg
+reddens only because TSan exits 66 whenever it emits a warning at all. It is
+probabilistic, so it shows up on some runs and not others.
+
+So before treating a red `tsan` leg as a finding, check whether any frame in the
+reported stacks names musefs code. Pure `sqlite3.c` stacks are this known noise;
+a frame in `musefs_core` is worth investigating.
+
 ### Dependency advisories & licenses
 
 Two supply-chain gates run in CI and are worth reproducing locally before a

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -22,6 +22,31 @@ and numbers).
 Filename case-folding (`--case-insensitive`) is platform behaviour rather than
 a performance knob — see [Platform support](installation.md#platform-support).
 
+## Memory footprint
+
+`--read-ahead-budget-mib` is the only memory knob, but on a sizeable library it is
+not the biggest number: the virtual tree — one node per rendered file and directory,
+plus the inode allocator's path map — is held resident for the lifetime of the mount
+and scales with the **track count**, not with I/O. Measured on Linux, release build:
+
+| Library | Steady-state RSS | Peak RSS | Per track | Tree build |
+| ------- | ---------------- | -------- | --------- | ---------- |
+| 200,000 tracks / 22,000 directories | 451 MB | 475 MB | ~2.31 KB | 2.3 s |
+
+Size a host at **~2.3 KB of RAM per track** — ~230 MB at 100,000 tracks, ~2.3 GB at a
+million — on top of the read-ahead budget (64 MiB by default) and SQLite's page cache.
+The peak above steady state is the transient of building the tree, so it reappears
+whenever a refresh takes the full-rebuild path. The cost is dominated by rendered
+names and paths rather than by audio, so a deeply nested `--template` (more path
+components, longer names) raises it and a flatter one lowers it.
+
+Two gauges in the metrics surface below size a live mount:
+`musefs_tree_nodes` (live virtual-tree inodes: files plus directories) and
+`musefs_inode_paths` (paths interned by the inode allocator — up to 2× the live node
+count between prunes, since retired paths are kept until they outnumber live ones).
+On a `jemalloc` build, `musefs_alloc_resident_bytes` reports the allocator's resident
+total as an RSS proxy.
+
 ## Metrics
 
 `musefs mount` optionally exposes runtime telemetry through a synthetic

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -31,14 +31,19 @@ and scales with the **track count**, not with I/O. Measured on Linux, release bu
 
 | Library | Steady-state RSS | Peak RSS | Per track | Tree build |
 | ------- | ---------------- | -------- | --------- | ---------- |
-| 200,000 tracks / 22,000 directories | 451 MB | 475 MB | ~2.31 KB | 2.3 s |
+| 200,000 tracks / 22,000 directories (v1.3.0) | 451 MB | 475 MB | ~2.31 KB | 2.3 s |
 
-Size a host at **~2.3 KB of RAM per track** — ~230 MB at 100,000 tracks, ~2.3 GB at a
+Size a host at **~2 KB of RAM per track** — ~200 MB at 100,000 tracks, ~2 GB at a
 million — on top of the read-ahead budget (64 MiB by default) and SQLite's page cache.
 The peak above steady state is the transient of building the tree, so it reappears
 whenever a refresh takes the full-rebuild path. The cost is dominated by rendered
 names and paths rather than by audio, so a deeply nested `--template` (more path
 components, longer names) raises it and a flatter one lowers it.
+
+Since v1.3.0 the tree stores each name once and shares that one allocation with every
+index keyed on it, which cut the tree's own resident cost from 1.71 KB to 1.28 KB per
+track (−25%) on a 200,000-track build — so the v1.3.0 row above is an upper bound
+until the next full-mount measurement.
 
 Two gauges in the metrics surface below size a live mount:
 `musefs_tree_nodes` (live virtual-tree inodes: files plus directories) and

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -33,10 +33,14 @@ and scales with the **track count**, not with I/O. Measured on Linux, release bu
 | ------- | ---------------- | -------- | --------- | ---------- |
 | 200,000 tracks / 22,000 directories (v1.3.0) | 451 MB | 475 MB | ~2.31 KB | 2.3 s |
 
-Size a host at **~2 KB of RAM per track** — ~200 MB at 100,000 tracks, ~2 GB at a
-million — on top of the read-ahead budget (64 MiB by default) and SQLite's page cache.
-The peak above steady state is the transient of building the tree, so it reappears
-whenever a refresh takes the full-rebuild path. The cost is dominated by rendered
+Size a host against the **peak** — **~2.4 KB of RAM per track**, so ~240 MB at
+100,000 tracks and ~2.4 GB at a million — on top of the read-ahead budget (64 MiB by
+default) and SQLite's page cache. Size against the peak rather than the steady state
+because the peak is the transient of building the tree, and it recurs whenever a
+refresh takes the full-rebuild path rather than being a one-off at mount. The
+reductions described below cut the tree's own share of this, but the table is the
+last end-to-end mount measurement, so it remains the number to size against until a
+mount is measured again. The cost is dominated by rendered
 names and paths rather than by audio, so a deeply nested `--template` (more path
 components, longer names) raises it and a flatter one lowers it.
 

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -42,8 +42,17 @@ components, longer names) raises it and a flatter one lowers it.
 
 Since v1.3.0 the tree stores each name once and shares that one allocation with every
 index keyed on it, which cut the tree's own resident cost from 1.71 KB to 1.28 KB per
-track (−25%) on a 200,000-track build — so the v1.3.0 row above is an upper bound
-until the next full-mount measurement.
+track (−25%) on a 200,000-track build. Rendered paths are now shared the same way:
+the inode allocator's key and the refresh snapshot's entry for a track are one
+allocation rather than two, so the tree carries one fewer whole path per track. That
+is worth −78 B/track (−7%) on a short `$artist/$album/$title` corpus and −173 B/track
+(−14%) when the same three levels carry long names — the saving is one full path, so
+it grows with the template's depth and with name length. Both figures leave the
+v1.3.0 row above an upper bound until the next full-mount measurement.
+
+`musefs-core/tests/tree_footprint.rs` re-measures the per-track cost on every
+`cargo test` run and fails above a ceiling, so a regression surfaces without a
+full-mount run; set `MUSEFS_TREE_FOOTPRINT_TRACKS` to re-measure at library scale.
 
 Two gauges in the metrics surface below size a live mount:
 `musefs_tree_nodes` (live virtual-tree inodes: files plus directories) and

--- a/fuzz/fuzz_targets/ogg_page.rs
+++ b/fuzz/fuzz_targets/ogg_page.rs
@@ -1,11 +1,92 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use musefs_format::ogg::{parse_page, patch_page_header_algebraic, verify_page_crc};
 use musefs_fuzz::MAX_INPUT;
 
-// parse_page must never panic on arbitrary bytes at an arbitrary position.
+// parse_page must never panic on arbitrary bytes at an arbitrary position, and the
+// page machinery the serve path leans on must round-trip: re-sequencing a page
+// algebraically preserves its payload, its geometry, and its CRC validity (#625).
 fuzz_target!(|data: &[u8]| {
     if data.len() > MAX_INPUT {
         return;
     }
-    let _ = musefs_format::ogg::parse_page(data, 0);
+    let Ok(h) = parse_page(data, 0) else {
+        return;
+    };
+    let total = h.total_len();
+    if data.len() < total {
+        // Below total_len the page is truncated, and the CRC helper must say so
+        // rather than verify a partial page.
+        assert!(
+            verify_page_crc(data).is_err(),
+            "verify_page_crc accepted a truncated page: len={} total_len={total}",
+            data.len(),
+        );
+        return;
+    }
+    let page = &data[..total];
+    let valid = verify_page_crc(page).expect("a whole parsed page has verifiable geometry");
+
+    // The new sequence number comes from whatever bytes trail the page; inputs that
+    // are exactly one page fall back to a neighbouring seq so they stay productive.
+    let tail = &data[total..];
+    let new_seq = match tail.get(..4) {
+        Some(b) => u32::from_le_bytes(b.try_into().expect("4 bytes")),
+        None => h.seq.wrapping_add(1),
+    };
+
+    let patched = patch_page_header_algebraic(&page[..h.header_len], new_seq)
+        .expect("a parsed page's header is exactly header_len bytes");
+
+    // The header keeps its shape: same length, same segment table, same identity
+    // fields. Only seq (18..22) and crc (22..26) may move.
+    assert_eq!(patched.len(), h.header_len, "patched header changed length");
+    assert_eq!(
+        &patched[..18],
+        &page[..18],
+        "patched header changed capture/version/type/granule/serial",
+    );
+    assert_eq!(
+        &patched[26..],
+        &page[26..h.header_len],
+        "patched header changed the segment table",
+    );
+    let ph = parse_page(&patched, 0).expect("a patched header re-parses");
+    assert_eq!(ph.seq, new_seq, "patched header carries the wrong seq");
+    assert_eq!(
+        ph.payload_len, h.payload_len,
+        "patched header changed the derived payload length",
+    );
+
+    // The serve path splices the payload verbatim from the backing file, so the
+    // page it emits is the patched header followed by the original payload bytes.
+    // That page must be exactly as CRC-valid as the original — the equivalence is
+    // what lets musefs re-sequence pages without ever touching audio bytes.
+    let mut repaged = patched;
+    repaged.extend_from_slice(&page[h.header_len..]);
+    assert_eq!(
+        repaged.len(),
+        total,
+        "re-paged length != original page length"
+    );
+    assert_eq!(
+        &repaged[h.header_len..],
+        &page[h.header_len..],
+        "re-paging altered the payload",
+    );
+    assert_eq!(
+        verify_page_crc(&repaged).expect("the re-paged page has the original geometry"),
+        valid,
+        "the algebraic patch changed the page's CRC validity",
+    );
+
+    // Patching back to the original sequence number restores the header byte for
+    // byte: the algebraic CRC update is its own inverse.
+    let restored = patch_page_header_algebraic(&repaged[..h.header_len], h.seq)
+        .expect("the patched header is still header_len bytes");
+    assert_eq!(
+        restored.as_slice(),
+        &page[..h.header_len],
+        "re-sequencing back to the original seq did not restore the header",
+    );
 });

--- a/musefs-cli/src/signal.rs
+++ b/musefs-cli/src/signal.rs
@@ -25,15 +25,46 @@ use std::time::Duration;
 /// `TimeoutStopSec` (90s) so we exit well before it would SIGKILL us.
 const GRACE: Duration = Duration::from_secs(5);
 
+/// Directories searched, in order, for an unmount helper before falling back to
+/// a bare-name `PATH` lookup.
+const HELPER_DIRS: [&str; 3] = ["/usr/bin", "/bin", "/usr/local/bin"];
+
+/// Resolve an unmount helper to an absolute path, preferring [`HELPER_DIRS`] in
+/// order and falling back to the bare name — i.e. a `PATH` lookup performed by
+/// `Command::new` — when the helper is in none of them.
+///
+/// The mounting guide steers operators toward a privileged daemon (uid 0, for
+/// kernel passthrough in `StructureOnly` mode) and nothing sanitizes `PATH`
+/// there, so a bare program name lets a writable `PATH` entry choose what we
+/// execute as root on `SIGTERM`. Pinning the usual install locations closes
+/// that; the fallback keeps unusual layouts (NixOS store paths, `/sbin`-only
+/// busybox) working.
+///
+/// `exists` is injected so the preference order is testable without depending on
+/// the host's layout.
+fn resolve_helper(name: &str, exists: impl Fn(&Path) -> bool) -> PathBuf {
+    HELPER_DIRS
+        .iter()
+        .map(|dir| Path::new(dir).join(name))
+        .find(|candidate| exists(candidate))
+        .unwrap_or_else(|| PathBuf::from(name))
+}
+
+/// [`resolve_helper`] against the real filesystem.
+fn helper(name: &str) -> PathBuf {
+    resolve_helper(name, Path::exists)
+}
+
 /// Unmount commands tried in order, most-preferred first, as `(program, args)`.
 /// `fusermount3`/`fusermount` are the unprivileged FUSE unmount tools; `umount`
-/// is the last resort.
-fn unmount_commands(mountpoint: &Path) -> Vec<(&'static str, Vec<OsString>)> {
+/// is the last resort. Each program is resolved by [`resolve_helper`] rather
+/// than left to a `PATH` lookup.
+fn unmount_commands(mountpoint: &Path) -> Vec<(PathBuf, Vec<OsString>)> {
     let mp = mountpoint.as_os_str().to_owned();
     vec![
-        ("fusermount3", vec!["-u".into(), mp.clone()]),
-        ("fusermount", vec!["-u".into(), mp.clone()]),
-        ("umount", vec![mp]),
+        (helper("fusermount3"), vec!["-u".into(), mp.clone()]),
+        (helper("fusermount"), vec!["-u".into(), mp.clone()]),
+        (helper("umount"), vec![mp]),
     ]
 }
 
@@ -59,7 +90,7 @@ fn run_unmount(mountpoint: &Path) {
 /// mountpoint from the namespace even while it is busy. The escalation step
 /// before a forced exit.
 fn lazy_detach(mountpoint: &Path) {
-    let _ = std::process::Command::new("fusermount3")
+    let _ = std::process::Command::new(helper("fusermount3"))
         .args([OsStr::new("-u"), OsStr::new("-z"), mountpoint.as_os_str()])
         .status();
 }
@@ -116,13 +147,19 @@ pub fn install_unmount_on_signal(mountpoint: PathBuf) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::path::Path;
 
     #[test]
     fn unmount_commands_try_fusermount3_then_fallbacks() {
         let cmds = unmount_commands(Path::new("/mnt/x"));
-        let progs: Vec<&str> = cmds.iter().map(|(p, _)| *p).collect();
+        // A program is absolute (pinned) or bare (PATH fallback) depending on the
+        // host layout, so compare the file names: the helper *order* is what this
+        // pins down.
+        let progs: Vec<&OsStr> = cmds
+            .iter()
+            .map(|(p, _)| p.file_name().expect("helper has a file name"))
+            .collect();
         assert_eq!(progs, ["fusermount3", "fusermount", "umount"]);
         // fusermount variants pass `-u <mp>`; umount passes just `<mp>`.
         assert_eq!(
@@ -130,5 +167,44 @@ mod tests {
             vec![OsString::from("-u"), OsString::from("/mnt/x")]
         );
         assert_eq!(cmds[2].1, vec![OsString::from("/mnt/x")]);
+    }
+
+    #[test]
+    fn unmount_commands_pin_installed_helpers_to_an_absolute_path() {
+        // Whatever the host layout, a helper present in one of the pinned
+        // directories must be spawned by absolute path — never via `PATH`.
+        for (prog, _) in unmount_commands(Path::new("/mnt/x")) {
+            let name = prog.file_name().expect("helper has a file name");
+            if HELPER_DIRS
+                .iter()
+                .any(|dir| Path::new(dir).join(name).exists())
+            {
+                assert!(prog.is_absolute(), "{} was not pinned", prog.display());
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_helper_prefers_the_first_directory_holding_it() {
+        assert_eq!(
+            resolve_helper("fusermount3", |_| true),
+            Path::new("/usr/bin/fusermount3")
+        );
+        assert_eq!(
+            resolve_helper("fusermount3", |c| c != Path::new("/usr/bin/fusermount3")),
+            Path::new("/bin/fusermount3")
+        );
+        assert_eq!(
+            resolve_helper("umount", |c| c == Path::new("/usr/local/bin/umount")),
+            Path::new("/usr/local/bin/umount")
+        );
+    }
+
+    #[test]
+    fn resolve_helper_falls_back_to_a_bare_path_lookup() {
+        // Unusual layouts (NixOS store paths, /sbin-only busybox) must keep
+        // working, so a helper in none of the pinned directories degrades to the
+        // bare name.
+        assert_eq!(resolve_helper("umount", |_| false), Path::new("umount"));
     }
 }

--- a/musefs-core/src/byte_budget.rs
+++ b/musefs-core/src/byte_budget.rs
@@ -2,11 +2,20 @@
 //! blocking until the in-flight total would stay within the cap; the consumer
 //! releases bytes after persisting. Bounds peak in-flight art memory.
 
+use crate::lock::{lock_recover, wait_recover};
 use std::sync::{Condvar, Mutex};
+
+/// The guarded scalars: bytes currently reserved, plus the one-way shutdown flag
+/// `close` sets. Both are replace-only writes, hence the `lock_recover` policy.
+#[derive(Default)]
+struct State {
+    in_flight: u64,
+    closed: bool,
+}
 
 pub struct ByteBudget {
     cap: u64,
-    state: Mutex<u64>,
+    state: Mutex<State>,
     cv: Condvar,
 }
 
@@ -14,28 +23,38 @@ impl ByteBudget {
     pub fn new(cap: u64) -> Self {
         Self {
             cap,
-            state: Mutex::new(0),
+            state: Mutex::new(State::default()),
             cv: Condvar::new(),
         }
     }
 
     /// Reserve `n` bytes, blocking until they fit (a single item larger than the
     /// cap is admitted alone once in-flight is zero, to guarantee progress).
+    /// Once the budget is closed every reservation is admitted immediately.
     pub fn acquire(&self, n: u64) {
-        let mut in_flight = self.state.lock().unwrap();
+        let mut st = lock_recover(&self.state, "byte budget");
         // `saturating_add` mirrors `release`'s saturating style; art weights are
         // file-bounded so this never saturates in practice, but it keeps the
         // guard total-order-safe regardless.
-        while *in_flight != 0 && in_flight.saturating_add(n) > self.cap {
-            in_flight = self.cv.wait(in_flight).unwrap();
+        while !st.closed && st.in_flight != 0 && st.in_flight.saturating_add(n) > self.cap {
+            st = wait_recover(&self.cv, &self.state, st, "byte budget");
         }
-        *in_flight = in_flight.saturating_add(n);
+        st.in_flight = st.in_flight.saturating_add(n);
     }
 
     /// Release `n` previously reserved bytes.
     pub fn release(&self, n: u64) {
-        let mut in_flight = self.state.lock().unwrap();
-        *in_flight = in_flight.saturating_sub(n);
+        let mut st = lock_recover(&self.state, "byte budget");
+        st.in_flight = st.in_flight.saturating_sub(n);
+        self.cv.notify_all();
+    }
+
+    /// Stop gating: wake every waiter and admit every later reservation without
+    /// blocking. Called when a scan aborts — the failed batch never releases what
+    /// it reserved, so a producer parked here would otherwise wait forever and
+    /// outlive the pipeline, holding its probed buffers (#618).
+    pub fn close(&self) {
+        lock_recover(&self.state, "byte budget").closed = true;
         self.cv.notify_all();
     }
 }
@@ -76,7 +95,7 @@ mod tests {
     /// progress). Run on a worker: the `!=`→`==` and `&&`→`||` mutants both turn
     /// this into an infinite wait (`0 == 0 && 1000 > 10` / `0 != 0 || 1000 > 10`
     /// both stay true with nothing to release), so a hang here means CAUGHT.
-    // kills byte_budget L29 `!=`→`==` and `&&`→`||`
+    // kills byte_budget L39 `!=`→`==` and `&&`→`||`
     #[test]
     fn oversized_item_admitted_when_idle() {
         let b = Arc::new(ByteBudget::new(10));
@@ -87,8 +106,8 @@ mod tests {
     }
 
     /// A blocked reservation proceeds once enough is released. Pins `release`
-    /// (line 37): if it is a no-op the worker never unblocks → not completed.
-    // kills byte_budget L37 release→no-op
+    /// (line 47): if it is a no-op the worker never unblocks → not completed.
+    // kills byte_budget L47 release→no-op
     #[test]
     fn blocked_acquire_proceeds_after_release() {
         let b = Arc::new(ByteBudget::new(10));
@@ -114,12 +133,12 @@ mod tests {
     }
 
     /// Accumulation must be additive: from idle, `acquire(4)` then `acquire(7)`
-    /// (4+7=11 > cap 10) MUST block. Pins `*in_flight += n` (line 32) and the
+    /// (4+7=11 > cap 10) MUST block. Pins the in-flight add (line 42) and the
     /// acquire body:
     ///   - no-op (`acquire` body → `()`): in_flight stays 0, so the 2nd acquire
     ///     sees 0 and admits 7 → would NOT block → killed.
-    ///   - `+=`→`*=`: first acquire makes 0*4 = 0, so in_flight stays 0 → killed.
-    // kills byte_budget L25 acquire→no-op and L32 `+=`→`*=`
+    ///   - `+`→`*`: first acquire makes 0*4 = 0, so in_flight stays 0 → killed.
+    // kills byte_budget L35 acquire→no-op and L42 `+`→`*`
     #[test]
     fn accumulates_additively_then_blocks() {
         let b = Arc::new(ByteBudget::new(10));
@@ -132,9 +151,9 @@ mod tests {
 
     /// Boundary: `in_flight + n == cap` is admitted (guard is strictly `> cap`).
     /// From idle, `acquire(6)` then `acquire(4)` → 6+4 == 10, `10 > 10` false →
-    /// must NOT block. Kills L29 `>`→`>=` (`10>=10` true → block) and `>`→`==`
+    /// must NOT block. Kills L39 `>`→`>=` (`10>=10` true → block) and `>`→`==`
     /// (`10==10` true → block).
-    // kills byte_budget L29 `>`→`>=` and `>`→`==`
+    // kills byte_budget L39 `>`→`>=` and `>`→`==`
     #[test]
     fn exact_cap_is_admitted() {
         let b = Arc::new(ByteBudget::new(10));
@@ -146,8 +165,8 @@ mod tests {
     }
 
     /// Over cap blocks: `acquire(6)` then `acquire(8)` → 6+8=14, `14 > 10` true →
-    /// must block. Kills L29 `>`→`<` (`14 < 10` false → wrongly admitted).
-    // kills byte_budget L29 `>`→`<`
+    /// must block. Kills L39 `>`→`<` (`14 < 10` false → wrongly admitted).
+    // kills byte_budget L39 `>`→`<`
     #[test]
     fn over_cap_blocks() {
         let b = Arc::new(ByteBudget::new(10));
@@ -155,6 +174,48 @@ mod tests {
         assert!(
             !completes_within(&b, 8, WAIT),
             "6+8=14 > cap 10 must block; if it completed, the guard admitted an over-cap reservation"
+        );
+    }
+
+    /// `close` releases the gate: a reservation already parked in `acquire` must
+    /// wake and complete, even though nothing is ever released. This is the
+    /// aborted-scan path — pins `close` (line 57) against a no-op mutation, which
+    /// would leave the worker blocked exactly as pre-#618.
+    // kills byte_budget L57 close→no-op
+    #[test]
+    fn close_wakes_a_blocked_acquire() {
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(10); // idle → admitted inline; the budget is now full
+        let done = Arc::new(AtomicBool::new(false));
+        let b2 = Arc::clone(&b);
+        let done2 = Arc::clone(&done);
+        std::thread::spawn(move || {
+            b2.acquire(5); // 10+5 > 10 → blocks
+            done2.store(true, Ordering::SeqCst);
+        });
+        std::thread::sleep(WAIT);
+        assert!(
+            !done.load(Ordering::SeqCst),
+            "acquire(5) must block while full"
+        );
+        b.close();
+        std::thread::sleep(WAIT);
+        assert!(
+            done.load(Ordering::SeqCst),
+            "close must wake a blocked acquire; without it the producer waits for a release that never comes"
+        );
+    }
+
+    /// A closed budget no longer gates: an over-cap reservation made after `close`
+    /// must not block either, so a worker that reaches `acquire` late still exits.
+    #[test]
+    fn closed_budget_admits_later_acquires() {
+        let b = Arc::new(ByteBudget::new(10));
+        b.acquire(6); // idle → admitted inline; in_flight = 6
+        b.close();
+        assert!(
+            completes_within(&b, 8, WAIT),
+            "a closed budget must admit 6+8 > cap 10 without blocking"
         );
     }
 }

--- a/musefs-core/src/facade/refresh.rs
+++ b/musefs-core/src/facade/refresh.rs
@@ -85,7 +85,7 @@ impl Musefs {
         db: &Db<M>,
         template: &Template,
         config: &MountConfig,
-    ) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
+    ) -> Result<(Vec<(i64, Arc<str>)>, HashMap<i64, TrackRenderState>)> {
         // The projection this loop actually reads: a full `list_tracks` would
         // materialize every row's path and checksum strings unused (#621).
         let tracks = db.list_render_keys()?;
@@ -99,12 +99,16 @@ impl Musefs {
             let Some(path) = Self::render_one(template, config, format, &tags) else {
                 continue;
             };
+            // One allocation per rendered path, shared by the snapshot entry, the
+            // build's entry list, and — when the materialized path matches — the
+            // inode allocator's key for it (#629).
+            let path: Arc<str> = Arc::from(path);
             snapshot.insert(
                 id,
                 TrackRenderState {
                     content_version,
                     format,
-                    path: path.clone(),
+                    path: Arc::clone(&path),
                 },
             );
             entries.push((id, path));
@@ -118,7 +122,7 @@ impl Musefs {
     /// move into the build primitive, whose `tree.rs` tests feed it id-unordered
     /// entries on purpose. Kept as a pure helper so its sort is observable (and
     /// mutation-testable) independent of `list_render_keys`'s incidental `ORDER BY id`.
-    pub(crate) fn order_entries(mut entries: Vec<(i64, String)>) -> Vec<(i64, String)> {
+    pub(crate) fn order_entries(mut entries: Vec<(i64, Arc<str>)>) -> Vec<(i64, Arc<str>)> {
         entries.sort_by_key(|(id, _)| *id);
         entries
     }
@@ -300,7 +304,7 @@ impl Musefs {
                             TrackRenderState {
                                 content_version: cv,
                                 format: fmt,
-                                path,
+                                path: Arc::from(path),
                             },
                         )
                     })
@@ -358,8 +362,10 @@ impl Musefs {
                 #[cfg(debug_assertions)]
                 {
                     let mut ref_alloc = alloc.clone();
-                    let mut entries: Vec<(i64, String)> =
-                        snap.iter().map(|(&id, s)| (id, s.path.clone())).collect();
+                    let mut entries: Vec<(i64, Arc<str>)> = snap
+                        .iter()
+                        .map(|(&id, s)| (id, Arc::clone(&s.path)))
+                        .collect();
                     entries.sort_by_key(|(id, _)| *id);
                     let reference = VirtualTree::build_with_ci(
                         &entries,
@@ -377,8 +383,10 @@ impl Musefs {
                 log::warn!(
                     "incremental tree mutation failed ({reason:?}); falling back to full rebuild"
                 );
-                let mut entries: Vec<(i64, String)> =
-                    snap.iter().map(|(&id, s)| (id, s.path.clone())).collect();
+                let mut entries: Vec<(i64, Arc<str>)> = snap
+                    .iter()
+                    .map(|(&id, s)| (id, Arc::clone(&s.path)))
+                    .collect();
                 entries.sort_by_key(|(id, _)| *id);
                 VirtualTree::build_with_ci(&entries, &mut alloc, self.config.case_insensitive)
             }

--- a/musefs-core/src/facade/refresh.rs
+++ b/musefs-core/src/facade/refresh.rs
@@ -73,7 +73,7 @@ impl Musefs {
     ///
     /// The returned entries are ordered by `order_entries` (ascending by track
     /// `id`), which is what makes both full-rebuild paths establish disambiguation
-    /// order locally rather than inheriting it from `list_tracks`'s `ORDER BY id`
+    /// order locally rather than inheriting it from `list_render_keys`'s `ORDER BY id`
     /// (#188): the build path's insertion order decides which member of a colliding
     /// path keeps the bare name, and that must match the incremental path's min-id
     /// rule regardless of the source query's ordering.
@@ -86,26 +86,28 @@ impl Musefs {
         template: &Template,
         config: &MountConfig,
     ) -> Result<(Vec<(i64, String)>, HashMap<i64, TrackRenderState>)> {
-        let tracks = db.list_tracks()?;
+        // The projection this loop actually reads: a full `list_tracks` would
+        // materialize every row's path and checksum strings unused (#621).
+        let tracks = db.list_render_keys()?;
         let field_names = template.referenced_fields();
         let keys: Vec<&str> = field_names.iter().map(String::as_str).collect();
         let mut tags_by_track = db.tags_grouped_for_keys(&keys)?;
         let mut entries = Vec::with_capacity(tracks.len());
         let mut snapshot = HashMap::with_capacity(tracks.len());
-        for t in &tracks {
-            let tags = tags_by_track.remove(&t.id).unwrap_or_default();
-            let Some(path) = Self::render_one(template, config, t.format, &tags) else {
+        for &(id, content_version, format) in &tracks {
+            let tags = tags_by_track.remove(&id).unwrap_or_default();
+            let Some(path) = Self::render_one(template, config, format, &tags) else {
                 continue;
             };
             snapshot.insert(
-                t.id,
+                id,
                 TrackRenderState {
-                    content_version: t.content_version,
-                    format: t.format,
+                    content_version,
+                    format,
                     path: path.clone(),
                 },
             );
-            entries.push((t.id, path));
+            entries.push((id, path));
         }
         Ok((Self::order_entries(entries), snapshot))
     }
@@ -115,7 +117,7 @@ impl Musefs {
     /// keeps the bare name in `build_with_ci`'s insertion order (#188); it must NOT
     /// move into the build primitive, whose `tree.rs` tests feed it id-unordered
     /// entries on purpose. Kept as a pure helper so its sort is observable (and
-    /// mutation-testable) independent of `list_tracks`'s incidental `ORDER BY id`.
+    /// mutation-testable) independent of `list_render_keys`'s incidental `ORDER BY id`.
     pub(crate) fn order_entries(mut entries: Vec<(i64, String)>) -> Vec<(i64, String)> {
         entries.sort_by_key(|(id, _)| *id);
         entries

--- a/musefs-core/src/facade/tests.rs
+++ b/musefs-core/src/facade/tests.rs
@@ -574,9 +574,9 @@ fn render_entries_returns_paths_and_snapshot() {
     )
     .unwrap();
     assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].1, "Pix/Song.mp3");
+    assert_eq!(&*entries[0].1, "Pix/Song.mp3");
     let id = entries[0].0;
-    assert_eq!(snapshot[&id].path, "Pix/Song.mp3");
+    assert_eq!(&*snapshot[&id].path, "Pix/Song.mp3");
     assert!(snapshot[&id].content_version >= 1);
 }
 
@@ -622,7 +622,7 @@ fn render_entries_skips_tracks_missing_top_level_field_when_enabled() {
     )
     .unwrap();
     assert_eq!(entries.len(), 1, "the artist-less track must be skipped");
-    assert_eq!(entries[0].1, "Pix/Song.mp3");
+    assert_eq!(&*entries[0].1, "Pix/Song.mp3");
     let id = entries[0].0;
     assert_eq!(snapshot.len(), 1);
     assert!(snapshot.contains_key(&id));
@@ -921,9 +921,9 @@ fn order_entries_sorts_ascending_by_id() {
     // ORDER BY id), so this descending input is constructed directly to pin
     // the sort itself. Deleting/mutating order_entries' sort fails this test.
     let unordered = vec![
-        (9_i64, "z.flac".to_string()),
-        (2_i64, "a.flac".to_string()),
-        (5_i64, "m.flac".to_string()),
+        (9_i64, "z.flac".into()),
+        (2_i64, "a.flac".into()),
+        (5_i64, "m.flac".into()),
     ];
     let ordered = Musefs::order_entries(unordered);
     let ids: Vec<i64> = ordered.iter().map(|(id, _)| *id).collect();
@@ -936,9 +936,9 @@ fn order_entries_sorts_ascending_by_id() {
     assert_eq!(
         ordered,
         vec![
-            (2_i64, "a.flac".to_string()),
-            (5_i64, "m.flac".to_string()),
-            (9_i64, "z.flac".to_string()),
+            (2_i64, "a.flac".into()),
+            (5_i64, "m.flac".into()),
+            (9_i64, "z.flac".into()),
         ]
     );
 }

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -30,7 +30,7 @@ pub use telemetry::{
     AllocatorStats, CoreTelemetry, FuseTelemetry, PassthroughTelemetry, render_prometheus,
 };
 pub use template::{Template, TemplateError};
-pub use tree::{Node, NodeKind, VirtualTree};
+pub use tree::{InodeAllocator, Node, NodeKind, VirtualTree};
 
 #[cfg(test)]
 mod cross_layer_caps {

--- a/musefs-core/src/lock.rs
+++ b/musefs-core/src/lock.rs
@@ -16,16 +16,18 @@
 //!                                    internal locking; no std::sync::Mutex to poison.
 //!   ResolvedFile::last_page (reader.rs:32, locked in ogg_index.rs as LastPageMemo)
 //!                                 -> cat 1 (clear): deterministic one-entry cache, re-derived.
-//! Out of scope (handled elsewhere): byte_budget.rs (#93, currently panics on
-//! poison), db_pool.rs (#94), scan.rs work-queue (scan-internal, not on the
-//! FUSE serving path).
+//! Off the serving path but on the same policy since #618:
+//!   byte_budget.rs `state`        -> cat 3 (recover + `wait_recover`): in-flight
+//!                                    total and the shutdown flag, both replace-only.
+//! Out of scope (handled elsewhere): db_pool.rs (#94), scan.rs work-queue
+//! (scan-internal, not on the FUSE serving path).
 //!
 //! Recovery is one-shot: each helper calls `Mutex::clear_poison` after restoring
 //! the guarded state to a known-good value, so normal (non-clearing) operation
 //! resumes on the next acquisition rather than degrading permanently.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Condvar, Mutex, MutexGuard};
 
 /// State that can be reset to empty for `lock_or_clear`.
 pub(crate) trait Clearable {
@@ -42,6 +44,23 @@ impl<T> Clearable for Option<T> {
 pub(crate) fn lock_recover<'a, T>(m: &'a Mutex<T>, what: &str) -> MutexGuard<'a, T> {
     m.lock().unwrap_or_else(|e| {
         log::error!("recovered poisoned scalar lock ({what}); continuing on inner value");
+        m.clear_poison();
+        e.into_inner()
+    })
+}
+
+/// Category 3 across a condvar wait: the wait re-locks `m` (which must be the
+/// mutex `g` came from), so it carries the same poison policy as `lock_recover`.
+pub(crate) fn wait_recover<'a, T>(
+    cv: &Condvar,
+    m: &Mutex<T>,
+    g: MutexGuard<'a, T>,
+    what: &str,
+) -> MutexGuard<'a, T> {
+    cv.wait(g).unwrap_or_else(|e| {
+        log::error!(
+            "recovered poisoned scalar lock ({what}) across a condvar wait; continuing on inner value"
+        );
         m.clear_poison();
         e.into_inner()
     })
@@ -97,6 +116,32 @@ mod tests {
         let m = Arc::new(Mutex::new(7u32));
         poison(&m);
         assert_eq!(*lock_recover(&m, "scalar"), 7);
+        assert!(!m.is_poisoned(), "poison cleared after recovery");
+    }
+
+    #[test]
+    fn wait_recover_returns_inner_after_poison() {
+        use std::sync::atomic::AtomicBool;
+        let m = Arc::new(Mutex::new(7u32));
+        let cv = Arc::new(Condvar::new());
+        poison(&m);
+        // Take the guard without clearing the poison, so the wait's re-lock is the
+        // acquisition that has to recover.
+        let g = m.lock().unwrap_err().into_inner();
+        // Notify repeatedly: a single notify racing ahead of the wait would be lost.
+        let woken = Arc::new(AtomicBool::new(false));
+        let (cv2, woken2) = (Arc::clone(&cv), Arc::clone(&woken));
+        let notifier = std::thread::spawn(move || {
+            while !woken2.load(Ordering::Acquire) {
+                cv2.notify_all();
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+        });
+        let g = wait_recover(&cv, &m, g, "scalar");
+        assert_eq!(*g, 7);
+        drop(g);
+        woken.store(true, Ordering::Release);
+        notifier.join().unwrap();
         assert!(!m.is_poisoned(), "poison cleared after recovery");
     }
 

--- a/musefs-core/src/ogg_index.rs
+++ b/musefs-core/src/ogg_index.rs
@@ -27,6 +27,19 @@ pub type LastPageMemo = std::sync::Mutex<Option<(u64, u64, Vec<u8>)>>;
 const MAX_OGG_PAGE_BYTES: u64 = 65_307;
 /// Maximum Ogg page header size: 27 fixed + 255 seg-table.
 const MAX_OGG_HEADER_BYTES: usize = 282;
+/// Maximum full-page CRC validations one `find_page_start` backwards scan may pay.
+///
+/// Each validation is two positioned reads of up to ~64 KiB (#619). The cheap
+/// header pre-filter is what normally keeps the count at one: a coincidental `OggS`
+/// in audio payload also has to carry a zero version byte and a zero-topped
+/// header-type byte, so a real file resolves on its first surviving candidate. A
+/// backing file whose audio region is packed with `OggS\x00\x00` clears the
+/// pre-filter at every offset instead, and without a bound a single non-sequential
+/// read would pay one validation per window byte — up to ~65,000. This budget caps
+/// that at a fixed, small multiple of the legitimate cost while leaving orders of
+/// magnitude more headroom than any real stream needs; past it the scan fails
+/// closed like every other file-derived value on this path.
+const MAX_CRC_CHECKS: usize = 64;
 
 /// Positioned read that records serve-path pread metrics (count + bytes).
 /// Counts on the attempt, like `on_open` — a failed read is still a round-trip.
@@ -53,7 +66,10 @@ fn read_counted(f: &std::fs::File, buf: &mut [u8], offset: u64) -> std::io::Resu
 /// a byte scan and a full-page CRC per OggS candidate — is paid only on
 /// non-sequential reads; sequential playback rides the memo fast path below. It is
 /// accepted as-is (#437) rather than reintroducing the page index this stateless
-/// design deliberately removed.
+/// design deliberately removed. The CRC validations are capped at
+/// `MAX_CRC_CHECKS` per invocation, so a backing file crafted to clear the cheap
+/// pre-filter at every offset cannot amplify one seek into ~65,000 full-page reads
+/// — the scan errors `Malformed` past the budget (#619).
 ///
 /// Fast path: if `memo` holds a page whose `[start, start+total_len)` region
 /// contains `abs_target`, return that start directly — skipping both the backward
@@ -100,6 +116,7 @@ fn find_page_start(
 
     // Scan backwards for the rightmost CRC-valid OggS capture.
     let mut i = window_len.saturating_sub(4);
+    let mut crc_checks = 0usize;
     loop {
         if window[i..].starts_with(b"OggS") {
             // Cheap pre-filter on whatever header bytes fall inside the window.
@@ -110,6 +127,12 @@ fn find_page_start(
             let cheap_ok = window.get(i + 4).is_none_or(|&v| v == 0)       // version == 0
                 && window.get(i + 5).is_none_or(|&ht| ht & 0xF8 == 0); // header_type
             if cheap_ok {
+                // Spend from the CRC budget before the I/O, so a packed region can
+                // never amplify one seek into ~65,000 full-page reads (#619).
+                if crc_checks == MAX_CRC_CHECKS {
+                    return Err(musefs_format::FormatError::Malformed.into());
+                }
+                crc_checks += 1;
                 let candidate = scan_start + i as u64;
                 if page_crc_ok(backing, candidate)? {
                     return Ok(candidate);
@@ -530,6 +553,36 @@ mod tests {
 
     // ── find_page_start tests ─────────────────────────────────────────────────
 
+    /// A complete 27-byte fake page header: OggS | ver(1)=0 | htype(1)=0 |
+    /// granule(8)=0 | serial(4) | seq(4) | crc(4)=garbage | seg_count(1)=0. It clears
+    /// `find_page_start`'s cheap pre-filter (version 0, header_type 0) so every copy
+    /// costs a full `page_crc_ok` round trip, then fails the CRC and is rejected.
+    const FAKE_PAGE_HEADER: &[u8; 27] =
+        b"OggS\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9a\x9a\x9a\x9a\x11\x22\x33\x44\xde\xad\xbe\xef\x00";
+
+    /// Write `[16 pad bytes][one real Ogg page][`fakes` × `FAKE_PAGE_HEADER`]` and
+    /// return `(dir, path, audio_offset, end_of_file)`. Scanning backwards from
+    /// end-of-file hits every fake — one CRC validation each — before reaching the
+    /// real page start at `audio_offset`.
+    fn packed_false_oggs_fixture(
+        fakes: usize,
+    ) -> (tempfile::TempDir, std::path::PathBuf, u64, u64) {
+        let (audio, _) = lace_packet_pub(0xABCD, 5, false, 100, &[0u8; 64]);
+        let mut file = vec![0u8; 16];
+        file.extend_from_slice(&audio);
+        for _ in 0..fakes {
+            file.extend_from_slice(FAKE_PAGE_HEADER);
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("packed.ogg");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(&file)
+            .unwrap();
+        let end = file.len() as u64;
+        (dir, path, 16, end)
+    }
+
     #[test]
     fn find_page_start_at_audio_offset_returns_immediately() {
         let (_d, path, ao, _alen) = new_serve_fixture();
@@ -594,12 +647,7 @@ mod tests {
         // backward scan finds this fake first (it is to the right of the real start),
         // must reject it via the CRC guard, and return the real page start.
         let mut payload = vec![0u8; 600];
-        // A complete 27-byte fake header: OggS | ver(1)=0 | htype(1)=0 | granule(8)=0
-        // | serial(4) | seq(4) | crc(4)=garbage | seg_count(1)=0. Passes the cheap
-        // checks (version 0, header_type 0, seg_count 0) but its CRC field is garbage.
-        let fake: &[u8] =
-            b"OggS\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9a\x9a\x9a\x9a\x11\x22\x33\x44\xde\xad\xbe\xef\x00";
-        assert_eq!(fake.len(), 27);
+        let fake = FAKE_PAGE_HEADER;
         payload[100..100 + fake.len()].copy_from_slice(fake);
         let (audio, _) = lace_packet_pub(0xABCD, 5, false, 100, &payload);
         let dir = tempfile::tempdir().unwrap();
@@ -619,6 +667,30 @@ mod tests {
         assert_eq!(
             found, ao,
             "must reject the CRC-invalid fake OggS and return the real start"
+        );
+    }
+
+    #[test]
+    fn find_page_start_bounds_crc_validations() {
+        // One short of the budget: every fake is rejected in turn and the real page
+        // start — the MAX_CRC_CHECKS-th validation — still resolves. This is the
+        // keep-scanning-past-false-positives behaviour the bound must not break.
+        let (_d, path, ao, target) = packed_false_oggs_fixture(MAX_CRC_CHECKS - 1);
+        let backing = std::fs::File::open(&path).unwrap();
+        assert_eq!(
+            find_page_start(&backing, ao, target, None).unwrap(),
+            ao,
+            "{} false candidates must still leave budget for the real page start",
+            MAX_CRC_CHECKS - 1,
+        );
+        // One more fake exhausts the budget before the scan reaches the real start,
+        // so it fails closed rather than paying an unbounded number of full-page
+        // reads for a single seek into a crafted region (#619).
+        let (_d, path, ao, target) = packed_false_oggs_fixture(MAX_CRC_CHECKS);
+        let backing = std::fs::File::open(&path).unwrap();
+        assert!(
+            find_page_start(&backing, ao, target, None).is_err(),
+            "the CRC-validation budget must fail closed on a packed OggS region",
         );
     }
 

--- a/musefs-core/src/refresh_diff.rs
+++ b/musefs-core/src/refresh_diff.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use musefs_db::Format;
 
@@ -6,11 +7,18 @@ use musefs_db::Format;
 /// re-render. `(content_version, format)` is the render key (the only track-level
 /// inputs to `Template::render`); `path` is the last rendered path, reused verbatim for
 /// unchanged tracks. See SP2 Component 1/2.
+///
+/// `path` is refcounted rather than owned outright: the inode allocator keys its
+/// map on the same rendered path, and one snapshot entry plus one allocator entry
+/// per track used to mean two independent copies of a string that scales with
+/// tree depth. Both now share this allocation (#629). `Arc<str>` compares by
+/// value, so the equality this derives — and through it the incremental-vs-fresh
+/// equivalence oracle — is unaffected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrackRenderState {
     pub content_version: i64,
     pub format: Format,
-    pub path: String,
+    pub path: Arc<str>,
 }
 
 /// The result of partitioning a changelog read against the previous snapshot.

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1657,23 +1657,35 @@ fn run_pipeline(
     // that, whenever the channel momentarily drains we flush the pending batch —
     // releasing the budget so blocked producers proceed — *before* blocking on the
     // next item.
+    // A fatal flush error leaves the loop through `fatal` rather than `?`: the
+    // pipeline must be torn down (below) before it propagates.
+    let mut fatal: Option<crate::error::CoreError> = None;
     loop {
         match rx.try_recv() {
             Ok(unit) => {
                 batch_bytes += unit.weight;
                 batch.push(unit);
-                if batch.len() >= BATCH_FILES || batch_bytes >= cap {
-                    flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+                if (batch.len() >= BATCH_FILES || batch_bytes >= cap)
+                    && let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned)
+                {
+                    fatal = Some(e);
+                    break;
                 }
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
-                flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+                if let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned) {
+                    fatal = Some(e);
+                    break;
+                }
                 match rx.recv() {
                     Ok(unit) => {
                         batch_bytes += unit.weight;
                         batch.push(unit);
-                        if batch.len() >= BATCH_FILES || batch_bytes >= cap {
-                            flush(&mut batch, &mut batch_bytes, &mut scanned)?;
+                        if (batch.len() >= BATCH_FILES || batch_bytes >= cap)
+                            && let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned)
+                        {
+                            fatal = Some(e);
+                            break;
                         }
                     }
                     Err(_) => break, // all workers finished; channel closed
@@ -1682,14 +1694,27 @@ fn run_pipeline(
             Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
         }
     }
-    flush(&mut batch, &mut batch_bytes, &mut scanned)?;
-    // A fatal flush error above returns via `?` *before* this join, abandoning the
-    // worker threads — acceptable because a DB-write failure aborts the whole scan.
+    let outcome = match fatal {
+        Some(e) => Err(e),
+        None => flush(&mut batch, &mut batch_bytes, &mut scanned),
+    };
+    if outcome.is_err() {
+        // A DB-write failure aborts the whole scan, but the workers must still be
+        // wound down before the error propagates: `scan_directory_with` /
+        // `revalidate_with` are public API, and an embedder that catches the error
+        // and carries on would otherwise leak a thread — plus its in-flight art
+        // bytes — per worker parked in `budget.acquire`, waiting on a release the
+        // failed batch will never make (#618). Dropping the receiver unblocks
+        // `send`; closing the budget unblocks `acquire`; both make the workers exit.
+        drop(rx);
+        budget.close();
+    }
     // On the success path every worker has already exited (the work queue drained
     // and `drop(tx)` closed the channel), so these joins return promptly.
     for w in workers {
         let _ = w.join();
     }
+    outcome?;
 
     Ok(ScanStats {
         scanned,

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1460,11 +1460,9 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
     }
     let mut already_present = 0u64;
     if !opts.force {
-        let existing: HashSet<String> = db
-            .list_tracks()?
-            .into_iter()
-            .map(|t| t.backing_path)
-            .collect();
+        // Projected to the one column this set needs: a full `list_tracks` would
+        // materialize every row's checksum strings just to drop them (#621).
+        let existing: HashSet<String> = db.list_backing_paths()?.into_iter().collect();
         let before = files.len();
         files.retain(|path| {
             let key = if opts.follow_symlinks {

--- a/musefs-core/src/telemetry.rs
+++ b/musefs-core/src/telemetry.rs
@@ -43,6 +43,7 @@ pub struct FuseTelemetry {
     pub read_errors: u64,
     pub dir_handles: u64,
     pub dir_handles_max: u64,
+    pub dir_handle_rejections: u64,
     pub pool_workers: u64,
     pub pool_active: u64,
     pub pool_queued: u64,
@@ -124,6 +125,12 @@ pub fn render_prometheus(
         "musefs_dir_handles_max",
         "Cap before opendir is rejected with ENFILE.",
         fuse.dir_handles_max,
+    );
+    counter(
+        &mut out,
+        "musefs_dir_handle_rejections_total",
+        "opendir calls rejected because the dir-handle table was full.",
+        fuse.dir_handle_rejections,
     );
 
     gauge(
@@ -373,6 +380,7 @@ mod tests {
             read_errors: 7,
             dir_handles: 2,
             dir_handles_max: 1024,
+            dir_handle_rejections: 11,
             pool_workers: 8,
             pool_active: 1,
             pool_queued: 0,
@@ -392,6 +400,9 @@ mod tests {
         assert!(
             out.contains("# TYPE musefs_read_errors_total counter\nmusefs_read_errors_total 7\n")
         );
+        assert!(out.contains(
+            "# TYPE musefs_dir_handle_rejections_total counter\nmusefs_dir_handle_rejections_total 11\n"
+        ));
         assert!(out.contains("musefs_pool_queued 0\n"));
         assert!(out.contains("musefs_readahead_budget_bytes 67108864\n"));
         assert!(out.contains("musefs_readahead_charged_bytes 8192\n"));

--- a/musefs-core/src/telemetry.rs
+++ b/musefs-core/src/telemetry.rs
@@ -123,13 +123,13 @@ pub fn render_prometheus(
     gauge(
         &mut out,
         "musefs_dir_handles_max",
-        "Cap before opendir is rejected with ENFILE.",
+        "Directory snapshots retained before opendir degrades to stateless listing.",
         fuse.dir_handles_max,
     );
     counter(
         &mut out,
         "musefs_dir_handle_rejections_total",
-        "opendir calls rejected because the dir-handle table was full.",
+        "opendir calls that found the dir-handle table full and were served statelessly.",
         fuse.dir_handle_rejections,
     );
 

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1,11 +1,24 @@
 use imbl::{HashMap as ImHashMap, OrdMap};
 use std::borrow::Cow;
+use std::sync::Arc;
 
 /// Case-fold a name for case-insensitive comparison. Unicode-aware lowercasing;
 /// ASCII is the floor. Applied identically to every comparison (collision,
 /// disambiguation, lookup) - never compare a folded value against an unfolded one.
 fn fold(name: &str) -> String {
     name.to_lowercase()
+}
+
+/// The folded-index key for an already-interned `name`: `name`'s own allocation
+/// when folding leaves it unchanged (an all-lowercase name), a fresh one
+/// otherwise — so a folded mount pays for a second copy only where it must.
+fn fold_key(name: &Name) -> Name {
+    let folded = fold(name);
+    if folded == **name {
+        Arc::clone(name)
+    } else {
+        Name::from(folded)
+    }
 }
 
 /// Split a rendered path into the components the tree actually materializes:
@@ -109,11 +122,18 @@ pub enum NodeKind {
     File { track_id: i64 },
 }
 
+/// A name as the tree stores it: one refcounted allocation shared by the node
+/// and by every map keyed on that name. A leaf name is held in five places
+/// (six on a folded mount), which at ~200k tracks was the dominant resident
+/// cost of the mount (#617); `Arc<str>` compares, orders and hashes by value,
+/// so sharing is invisible to lookups and to the equivalence oracle.
+type Name = Arc<str>;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Node {
     pub parent: u64,
-    pub name: String,          // disambiguated name
-    pub rendered_name: String, // pre-disambiguation base name
+    pub name: Name,          // disambiguated name
+    pub rendered_name: Name, // pre-disambiguation base name
     pub kind: NodeKind,
 }
 
@@ -122,8 +142,8 @@ pub struct Node {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtualTree {
     nodes: ImHashMap<u64, Node>,
-    children: ImHashMap<u64, OrdMap<String, u64>>,
-    rendered_children: ImHashMap<u64, OrdMap<String, OrdMap<String, u64>>>,
+    children: ImHashMap<u64, OrdMap<Name, u64>>,
+    rendered_children: ImHashMap<u64, OrdMap<Name, OrdMap<Name, u64>>>,
     /// `parent -> fold(name) -> inode`, populated ONLY when `case_insensitive`.
     /// Kept in sync with `children` on every insert AND removal, so a folded
     /// `lookup` never resolves a stale inode even if the tree is mutated in place
@@ -131,7 +151,7 @@ pub struct VirtualTree {
     /// `build_with_ci` + mutators must stay consistent). Gives O(1) folded lookup
     /// and collision checks. Part of structural equality; built deterministically,
     /// so fresh and re-rendered folded trees compare equal.
-    folded_children: ImHashMap<u64, ImHashMap<String, u64>>,
+    folded_children: ImHashMap<u64, ImHashMap<Name, u64>>,
     track_to_inode: ImHashMap<i64, u64>,
     /// When true, names are compared case-insensitively (dirs merge, files
     /// disambiguate). Defaults to false (exact matching, identical to Linux).
@@ -171,8 +191,8 @@ impl VirtualTree {
             Self::ROOT,
             Node {
                 parent: Self::ROOT,
-                name: String::new(),
-                rendered_name: String::new(),
+                name: Name::from(""),
+                rendered_name: Name::from(""),
                 kind: NodeKind::Dir,
             },
         );
@@ -210,12 +230,12 @@ impl VirtualTree {
     /// Callers wanting a single entry by name have `lookup`.
     pub fn children(&self, inode: u64) -> Option<impl ExactSizeIterator<Item = (&str, u64)>> {
         self.child_map(inode)
-            .map(|kids| kids.iter().map(|(name, &ino)| (name.as_str(), ino)))
+            .map(|kids| kids.iter().map(|(name, &ino)| (&**name, ino)))
     }
 
     /// The backing child map, for in-crate callers that need `OrdMap`'s
     /// by-name lookups rather than a walk.
-    fn child_map(&self, inode: u64) -> Option<&OrdMap<String, u64>> {
+    fn child_map(&self, inode: u64) -> Option<&OrdMap<Name, u64>> {
         self.children.get(&inode)
     }
 
@@ -223,7 +243,7 @@ impl VirtualTree {
         if self.case_insensitive {
             self.folded_children
                 .get(&parent)
-                .and_then(|b| b.get(&fold(name)).copied())
+                .and_then(|b| b.get(fold(name).as_str()).copied())
         } else {
             self.children
                 .get(&parent)
@@ -275,7 +295,7 @@ impl VirtualTree {
         let raw_name = comps[comps.len() - 1];
         let truncated = truncate_component(raw_name, true);
         let raw_name = truncated.as_ref();
-        let name = self.disambiguate(dir, raw_name);
+        let (name, rendered) = self.intern_names(dir, raw_name);
         let full = join_path(&dir_path, &name);
         let inode = alloc.intern(&full);
         self.track_to_inode.insert(track_id, inode);
@@ -283,16 +303,16 @@ impl VirtualTree {
             inode,
             Node {
                 parent: dir,
-                name: name.clone(),
-                rendered_name: raw_name.to_string(),
+                name: Arc::clone(&name),
+                rendered_name: Arc::clone(&rendered),
                 kind: NodeKind::File { track_id },
             },
         );
         self.children
             .get_mut(&dir)
             .unwrap()
-            .insert(name.clone(), inode);
-        self.insert_rendered_child(dir, raw_name, &name, inode);
+            .insert(Arc::clone(&name), inode);
+        self.insert_rendered_child(dir, &rendered, &name, inode);
         self.insert_folded_child(dir, &name, inode);
     }
 
@@ -306,22 +326,18 @@ impl VirtualTree {
         let truncated = truncate_component(name, false);
         let name = truncated.as_ref();
         if let Some(existing) = self.dir_child_named(parent, name) {
-            let stored = self
-                .node(existing)
-                .expect("dir_child_named node")
-                .name
-                .clone();
-            return (existing, join_path(parent_path, &stored));
+            let stored = &self.node(existing).expect("dir_child_named node").name;
+            return (existing, join_path(parent_path, stored));
         }
-        let unique = self.disambiguate(parent, name);
+        let (unique, rendered) = self.intern_names(parent, name);
         let full = join_path(parent_path, &unique);
         let inode = alloc.intern(&full);
         self.nodes.insert(
             inode,
             Node {
                 parent,
-                name: unique.clone(),
-                rendered_name: name.to_string(),
+                name: Arc::clone(&unique),
+                rendered_name: Arc::clone(&rendered),
                 kind: NodeKind::Dir,
             },
         );
@@ -330,10 +346,25 @@ impl VirtualTree {
         self.children
             .get_mut(&parent)
             .unwrap()
-            .insert(unique.clone(), inode);
-        self.insert_rendered_child(parent, name, &unique, inode);
+            .insert(Arc::clone(&unique), inode);
+        self.insert_rendered_child(parent, &rendered, &unique, inode);
         self.insert_folded_child(parent, &unique, inode);
         (inode, full)
+    }
+
+    /// The `(disambiguated, rendered)` name pair for a new child of `dir`, as
+    /// shared handles. When disambiguation is a no-op — every name in a library
+    /// without collisions — both halves are the SAME allocation, and each map
+    /// keyed on either name stores a clone of one of these two handles rather
+    /// than its own copy of the bytes (#617).
+    fn intern_names(&self, dir: u64, rendered: &str) -> (Name, Name) {
+        let unique = self.disambiguate(dir, rendered);
+        if unique == rendered {
+            let shared = Name::from(unique);
+            (Arc::clone(&shared), shared)
+        } else {
+            (Name::from(unique), Name::from(rendered))
+        }
     }
 
     /// Return `name` if free in `dir`, else append ` (k)` before the extension.
@@ -352,14 +383,14 @@ impl VirtualTree {
     }
 
     /// Mirror a child insertion into the folded index (no-op unless folding).
-    fn insert_folded_child(&mut self, parent: u64, name: &str, inode: u64) {
+    fn insert_folded_child(&mut self, parent: u64, name: &Name, inode: u64) {
         if !self.case_insensitive {
             return;
         }
         self.folded_children
             .entry(parent)
             .or_default()
-            .insert(fold(name), inode);
+            .insert(fold_key(name), inode);
     }
 
     /// Mirror a child removal out of the folded index, dropping an emptied parent
@@ -369,7 +400,7 @@ impl VirtualTree {
             return;
         }
         if let Some(bucket) = self.folded_children.get_mut(&parent) {
-            bucket.remove(&fold(name));
+            bucket.remove(fold(name).as_str());
             if bucket.is_empty() {
                 self.folded_children.remove(&parent);
             }
@@ -381,7 +412,7 @@ impl VirtualTree {
         if self.case_insensitive {
             self.folded_children
                 .get(&dir)
-                .is_some_and(|b| b.contains_key(&fold(name)))
+                .is_some_and(|b| b.contains_key(fold(name).as_str()))
         } else {
             self.children
                 .get(&dir)
@@ -395,7 +426,7 @@ impl VirtualTree {
         let ino = if self.case_insensitive {
             self.folded_children
                 .get(&dir)
-                .and_then(|b| b.get(&fold(name)).copied())
+                .and_then(|b| b.get(fold(name).as_str()).copied())
         } else {
             self.children.get(&dir).and_then(|c| c.get(name).copied())
         }?;
@@ -423,13 +454,13 @@ impl VirtualTree {
         // generated candidate keys until the first free rank.
         for k in 2u32.. {
             let candidate = suffix_candidate(rendered, k);
-            match kids.get(&candidate) {
+            match kids.get(candidate.as_str()) {
                 None => return false,
                 Some(c) => {
                     if self
                         .nodes
                         .get(c)
-                        .is_some_and(|n| n.rendered_name == rendered)
+                        .is_some_and(|n| &*n.rendered_name == rendered)
                     {
                         return true;
                     }
@@ -481,13 +512,13 @@ impl VirtualTree {
         self.children_by_rendered_with_examined(dir, rendered).1
     }
 
-    fn insert_rendered_child(&mut self, parent: u64, rendered: &str, name: &str, inode: u64) {
+    fn insert_rendered_child(&mut self, parent: u64, rendered: &Name, name: &Name, inode: u64) {
         self.rendered_children
             .entry(parent)
             .or_default()
-            .entry(rendered.to_string())
+            .entry(Arc::clone(rendered))
             .or_default()
-            .insert(name.to_string(), inode);
+            .insert(Arc::clone(name), inode);
     }
 
     fn remove_rendered_child(&mut self, parent: u64, rendered: &str, name: &str) {
@@ -540,7 +571,7 @@ impl VirtualTree {
             let Some(n) = self.nodes.get(&cur) else {
                 break;
             };
-            parts.push(n.name.clone());
+            parts.push(&*n.name);
             cur = n.parent;
         }
         parts.reverse();
@@ -555,7 +586,7 @@ impl VirtualTree {
         &mut self,
         track_id: i64,
         _alloc: &mut InodeAllocator,
-    ) -> Option<(u64, Option<(String, String)>)> {
+    ) -> Option<(u64, Option<(Name, Name)>)> {
         let ino = self.track_to_inode.remove(&track_id)?;
         let parent = self.nodes.get(&ino)?.parent;
         let names = self
@@ -849,7 +880,7 @@ impl VirtualTree {
     /// Walk up from `dir`, removing empty directories; return the first non-empty
     /// (surviving) ancestor and the `(name, rendered_name)` of the last (topmost)
     /// dir removed, if any.
-    fn prune_empty_dirs_upward(&mut self, mut dir: u64) -> (u64, Option<(String, String)>) {
+    fn prune_empty_dirs_upward(&mut self, mut dir: u64) -> (u64, Option<(Name, Name)>) {
         let mut last_pruned = None;
         while dir != Self::ROOT && self.children.get(&dir).is_none_or(OrdMap::is_empty) {
             let Some(node) = self.nodes.get(&dir) else {
@@ -1005,6 +1036,90 @@ mod tests {
         assert_eq!(tree.node_count(), 5);
         // interned: "" (root) + the four component paths above
         assert_eq!(alloc.interned_path_count(), 5);
+    }
+
+    /// Every stored handle for the child `name` of `dir`: the `children` key,
+    /// the `rendered_children` outer key (keyed by `rendered`), and that
+    /// bucket's inner key. Interning means all of them are one allocation.
+    fn stored_handles<'a>(
+        tree: &'a VirtualTree,
+        dir: u64,
+        rendered: &str,
+        name: &str,
+    ) -> Vec<&'a Name> {
+        let (child_key, _) = tree
+            .children
+            .get(&dir)
+            .and_then(|kids| kids.get_key_value(name))
+            .expect("children key");
+        let (outer_key, bucket) = tree
+            .rendered_children
+            .get(&dir)
+            .and_then(|by_rendered| by_rendered.get_key_value(rendered))
+            .expect("rendered_children outer key");
+        let (inner_key, _) = bucket.get_key_value(name).expect("rendered_children key");
+        vec![child_key, outer_key, inner_key]
+    }
+
+    #[test]
+    fn undisambiguated_names_are_stored_as_one_shared_allocation() {
+        let tree = VirtualTree::build(&[(10, "Alice/Song.flac".into())]);
+        let alice = tree.lookup(VirtualTree::ROOT, "Alice").unwrap();
+        let song = tree.lookup(alice, "Song.flac").unwrap();
+        // Both a dir (ensure_dir) and a leaf (insert_file) intern their names.
+        for (parent, ino, name) in [
+            (VirtualTree::ROOT, alice, "Alice"),
+            (alice, song, "Song.flac"),
+        ] {
+            let node = tree.node(ino).expect("node");
+            assert!(
+                Arc::ptr_eq(&node.name, &node.rendered_name),
+                "{name}: an undisambiguated node holds one name, not two"
+            );
+            for handle in stored_handles(&tree, parent, name, name) {
+                assert!(
+                    Arc::ptr_eq(handle, &node.name),
+                    "{name}: every child-map key shares the node's allocation"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn disambiguated_name_shares_each_half_of_the_pair() {
+        let tree = VirtualTree::build(&[(10, "D/song.flac".into()), (20, "D/song.flac".into())]);
+        let d = tree.lookup(VirtualTree::ROOT, "D").unwrap();
+        let bumped = tree.lookup(d, "song (2).flac").unwrap();
+        let node = tree.node(bumped).expect("node");
+        assert_eq!(&*node.rendered_name, "song.flac");
+        assert!(
+            !Arc::ptr_eq(&node.name, &node.rendered_name),
+            "a collision genuinely needs two distinct names"
+        );
+        let handles = stored_handles(&tree, d, "song.flac", "song (2).flac");
+        assert!(Arc::ptr_eq(handles[0], &node.name), "children key");
+        assert!(Arc::ptr_eq(handles[2], &node.name), "rendered inner key");
+    }
+
+    #[test]
+    fn folded_index_shares_an_already_folded_name() {
+        let tree = VirtualTree::build_with_ci(
+            &[(10, "artist/song.flac".into())],
+            &mut InodeAllocator::new(true),
+            true,
+        );
+        let artist = tree.lookup(VirtualTree::ROOT, "artist").unwrap();
+        let song = tree.lookup(artist, "song.flac").unwrap();
+        let node = tree.node(song).expect("node");
+        let (folded_key, _) = tree
+            .folded_children
+            .get(&artist)
+            .and_then(|bucket| bucket.get_key_value("song.flac"))
+            .expect("folded key");
+        assert!(
+            Arc::ptr_eq(folded_key, &node.name),
+            "folding a lowercase name must not allocate a sixth copy"
+        );
     }
 
     #[test]

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -1128,6 +1128,18 @@ mod tests {
         );
         let handles = stored_handles(&tree, d, "song.flac", "song (2).flac");
         assert!(Arc::ptr_eq(handles[0], &node.name), "children key");
+        // The outer `rendered_children` key is NOT this node's `rendered_name`: it was
+        // interned by the first node to render "song.flac", and this one collided
+        // afterwards. Pin it against that first node, so a copied outer key still
+        // fails — the bumped node's own `rendered_name` stays a second allocation of
+        // the same value, which is one per collision and rare by construction.
+        let first = tree
+            .node(tree.lookup(d, "song.flac").unwrap())
+            .expect("first");
+        assert!(
+            Arc::ptr_eq(handles[1], &first.name),
+            "rendered outer key shares with the node that interned it"
+        );
         assert!(Arc::ptr_eq(handles[2], &node.name), "rendered inner key");
     }
 

--- a/musefs-core/src/tree.rs
+++ b/musefs-core/src/tree.rs
@@ -9,9 +9,11 @@ fn fold(name: &str) -> String {
     name.to_lowercase()
 }
 
-/// The folded-index key for an already-interned `name`: `name`'s own allocation
-/// when folding leaves it unchanged (an all-lowercase name), a fresh one
-/// otherwise — so a folded mount pays for a second copy only where it must.
+/// The folded index key for an already-interned string: its own allocation when
+/// folding leaves it unchanged (an all-lowercase value), a fresh one otherwise —
+/// so a folded mount pays for a second copy only where it must. Serves both the
+/// folded-children index (keyed on a node `Name`) and the inode allocator (keyed
+/// on a whole `RenderedPath`); the two aliases are the same type.
 fn fold_key(name: &Name) -> Name {
     let folded = fold(name);
     if folded == **name {
@@ -53,7 +55,7 @@ pub enum RebuildError {
 /// (#305).
 #[derive(Debug, Clone)]
 pub struct InodeAllocator {
-    paths: ImHashMap<String, u64>,
+    paths: ImHashMap<RenderedPath, u64>,
     next: u64,
     fold_keys: bool,
 }
@@ -61,7 +63,7 @@ pub struct InodeAllocator {
 impl InodeAllocator {
     pub fn new(case_insensitive: bool) -> InodeAllocator {
         let mut paths = ImHashMap::new();
-        paths.insert(String::new(), VirtualTree::ROOT); // root path "" -> inode 1
+        paths.insert(RenderedPath::from(""), VirtualTree::ROOT); // root path "" -> inode 1
         InodeAllocator {
             paths,
             next: 2,
@@ -72,42 +74,50 @@ impl InodeAllocator {
     /// Transform a path into its map key: case-folded when the mount is
     /// case-insensitive (so a survivor keeps its inode when an unrelated deletion
     /// flips a merged directory's display casing, #305), identity otherwise.
-    fn key<'a>(&self, path: &'a str) -> Cow<'a, str> {
+    /// Folding reuses `path`'s own allocation when it leaves the bytes unchanged
+    /// (`fold_key`), so a folded mount pays for a second copy only where it must.
+    fn key(&self, path: &RenderedPath) -> RenderedPath {
         if self.fold_keys {
-            Cow::Owned(fold(path))
+            fold_key(path)
         } else {
-            Cow::Borrowed(path)
+            Arc::clone(path)
         }
     }
 
     /// The inode for `path` (the disambiguated path from root), reused if seen
-    /// before, else freshly allocated.
-    fn intern(&mut self, path: &str) -> u64 {
+    /// before, else freshly allocated. Takes a shared handle rather than a `&str`
+    /// so a first-time insert stores the caller's allocation instead of copying
+    /// the same bytes a second time (#629); `Arc<str>` hashes and compares by
+    /// value, so the lookup goes through `Borrow<str>` unchanged.
+    fn intern(&mut self, path: &RenderedPath) -> u64 {
         let key = self.key(path);
-        if let Some(&ino) = self.paths.get(key.as_ref()) {
+        if let Some(&ino) = self.paths.get(&*key) {
             return ino;
         }
         let ino = self.next;
         self.next += 1;
-        self.paths.insert(key.into_owned(), ino);
+        self.paths.insert(key, ino);
         ino
     }
 
-    /// Rebuild `paths` from the live tree once retired entries outnumber live
-    /// ones (map > 2x live nodes), keeping each live path's existing inode.
-    /// `next` is untouched, so a retired inode is never reissued. A retired
-    /// path that reappears after a prune gets a fresh inode: a kernel dentry
-    /// cached for its old inode resolves ENOENT for at most one entry TTL,
-    /// the same degradation as any vanished path.
+    /// Drop retired entries once they outnumber live ones (map > 2x live nodes),
+    /// keeping each live path's existing inode. `next` is untouched, so a retired
+    /// inode is never reissued. A retired path that reappears after a prune gets a
+    /// fresh inode: a kernel dentry cached for its old inode resolves ENOENT for
+    /// at most one entry TTL, the same degradation as any vanished path.
+    ///
+    /// An entry is live exactly when its inode is still in the tree, so retaining
+    /// on that predicate keeps the same set as rebuilding the map from
+    /// `path_of`: `intern` allocates a fresh inode on every key miss, so key ->
+    /// inode is injective, and a node can only hold the inode its own current
+    /// path interned to. Retaining also leaves each survivor's key allocation in
+    /// place — the one the refresh snapshot shares — where a rebuild would hand
+    /// every live path a fresh copy and undo the sharing (#629).
     pub(crate) fn prune_retired(&mut self, tree: &VirtualTree) {
         if self.paths.len() <= 2 * tree.nodes.len() {
             return;
         }
-        let mut live = ImHashMap::new();
-        for &ino in tree.nodes.keys() {
-            live.insert(self.key(&tree.path_of(ino)).into_owned(), ino);
-        }
-        self.paths = live;
+        self.paths.retain(|_, ino| tree.nodes.contains_key(ino));
     }
 
     /// Number of interned paths (telemetry: inode-allocator footprint, #394).
@@ -128,6 +138,16 @@ pub enum NodeKind {
 /// cost of the mount (#617); `Arc<str>` compares, orders and hashes by value,
 /// so sharing is invisible to lookups and to the equivalence oracle.
 type Name = Arc<str>;
+
+/// A rendered path as the mount stores it: one refcounted allocation shared by
+/// the refresh snapshot's `TrackRenderState` and by the inode allocator's key for
+/// the same path. Unlike a leaf name a full path scales with tree depth and the
+/// `--template` shape, so the second copy the two used to keep independently was
+/// the leading per-track term left after #617. Sharing needs the two to agree
+/// byte for byte, which they do unless truncation, disambiguation, or an
+/// empty/`.`/`..` component made the materialized path differ from the rendered
+/// one; `insert_file` falls back to its own allocation there.
+type RenderedPath = Arc<str>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Node {
@@ -161,21 +181,21 @@ pub struct VirtualTree {
 impl VirtualTree {
     pub const ROOT: u64 = 1;
 
-    pub fn build(entries: &[(i64, String)]) -> VirtualTree {
+    pub fn build(entries: &[(i64, RenderedPath)]) -> VirtualTree {
         VirtualTree::build_with(entries, &mut InodeAllocator::new(false))
     }
 
     /// Case-sensitive build (the default everywhere except a folded mount).
     /// Inodes are assigned via `alloc` (keyed by rendered path), stable across
     /// rebuilds that reuse the same allocator.
-    pub fn build_with(entries: &[(i64, String)], alloc: &mut InodeAllocator) -> VirtualTree {
+    pub fn build_with(entries: &[(i64, RenderedPath)], alloc: &mut InodeAllocator) -> VirtualTree {
         VirtualTree::build_with_ci(entries, alloc, false)
     }
 
     /// Build with explicit case-folding. With `case_insensitive`, names fold:
     /// case-variant directories merge, case-variant files disambiguate.
     pub fn build_with_ci(
-        entries: &[(i64, String)],
+        entries: &[(i64, RenderedPath)],
         alloc: &mut InodeAllocator,
         case_insensitive: bool,
     ) -> VirtualTree {
@@ -280,7 +300,7 @@ impl VirtualTree {
         self.track_to_inode.get(&track_id).copied()
     }
 
-    fn insert_file(&mut self, track_id: i64, path: &str, alloc: &mut InodeAllocator) {
+    fn insert_file(&mut self, track_id: i64, path: &RenderedPath, alloc: &mut InodeAllocator) {
         let comps: Vec<&str> = path_components(path).collect();
         if comps.is_empty() {
             return;
@@ -297,6 +317,16 @@ impl VirtualTree {
         let raw_name = truncated.as_ref();
         let (name, rendered) = self.intern_names(dir, raw_name);
         let full = join_path(&dir_path, &name);
+        // Hand the allocator the caller's allocation whenever the materialized
+        // path is the rendered one byte for byte — the common case, since only
+        // truncation, disambiguation, or a dropped empty/`.`/`..` component can
+        // make them differ. The allocator's key is then the same `Arc` the
+        // refresh snapshot holds rather than a second copy of the path (#629).
+        let full = if full == **path {
+            Arc::clone(path)
+        } else {
+            RenderedPath::from(full)
+        };
         let inode = alloc.intern(&full);
         self.track_to_inode.insert(track_id, inode);
         self.nodes.insert(
@@ -331,7 +361,7 @@ impl VirtualTree {
         }
         let (unique, rendered) = self.intern_names(parent, name);
         let full = join_path(parent_path, &unique);
-        let inode = alloc.intern(&full);
+        let inode = alloc.intern(&RenderedPath::from(full.as_str()));
         self.nodes.insert(
             inode,
             Node {
@@ -637,7 +667,7 @@ impl VirtualTree {
         for id in ids {
             let path = new_paths
                 .get(&id)
-                .map(|s| s.path.as_str())
+                .map(|s| &s.path)
                 .ok_or(RebuildError::MissingRenderedPath(id))?;
             self.insert_file(id, path, alloc);
         }
@@ -732,7 +762,7 @@ impl VirtualTree {
         for &id in changed {
             let new_path = new_paths
                 .get(&id)
-                .map(|s| s.path.as_str())
+                .map(|s| &*s.path)
                 .ok_or(RebuildError::MissingRenderedPath(id))?;
             match self.inode_of_track(id) {
                 Some(ino) if self.path_of(ino) == new_path => { /* path stable: nothing */ }
@@ -759,7 +789,7 @@ impl VirtualTree {
         for &id in added.iter().chain(moved_in.iter()) {
             let rendered = new_paths
                 .get(&id)
-                .map(|s| s.path.as_str())
+                .map(|s| &*s.path)
                 .ok_or(RebuildError::MissingRenderedPath(id))?;
             let comps: Vec<&str> = path_components(rendered).collect();
             let (d, consumed) = self.deepest_existing_ancestor(rendered);
@@ -798,7 +828,7 @@ impl VirtualTree {
         for id in to_insert {
             let rendered = new_paths
                 .get(&id)
-                .map(|s| s.path.as_str())
+                .map(|s| &s.path)
                 .ok_or(RebuildError::MissingRenderedPath(id))?;
             self.insert_file(id, rendered, alloc);
         }
@@ -1102,6 +1132,43 @@ mod tests {
     }
 
     #[test]
+    fn rendered_path_is_shared_with_the_inode_allocator_key() {
+        // The whole point of #629: the caller's rendered path and the allocator's
+        // key for it are ONE allocation, not two. Only the file leaf can share —
+        // a directory's path is a prefix the caller never materialized.
+        let path = RenderedPath::from("Alice/Song.flac");
+        let mut alloc = InodeAllocator::new(false);
+        VirtualTree::build_with(&[(10, Arc::clone(&path))], &mut alloc);
+        let (key, _) = alloc
+            .paths
+            .get_key_value("Alice/Song.flac")
+            .expect("leaf path interned");
+        assert!(
+            Arc::ptr_eq(key, &path),
+            "the allocator must key on the caller's allocation, not a copy"
+        );
+    }
+
+    #[test]
+    fn colliding_leaf_interns_under_its_disambiguated_path() {
+        // Sharing is only sound while the materialized path IS the rendered one.
+        // A disambiguated leaf keyed on what it rendered from would collect the
+        // inode already issued to the sibling that kept the bare name, collapsing
+        // two live nodes onto one.
+        let mut alloc = InodeAllocator::new(false);
+        let t = VirtualTree::build_with(
+            &[(10, "D/song.flac".into()), (20, "D/song.flac".into())],
+            &mut alloc,
+        );
+        let bare = t.inode_of_track(10).expect("track 10 inode");
+        let bumped = t.inode_of_track(20).expect("track 20 inode");
+        assert_ne!(bare, bumped, "disambiguated siblings need distinct inodes");
+        // root + D + both leaves, each interned under its own path.
+        assert_eq!(t.node_count(), 4);
+        assert_eq!(alloc.interned_path_count(), 4);
+    }
+
+    #[test]
     fn folded_index_shares_an_already_folded_name() {
         let tree = VirtualTree::build_with_ci(
             &[(10, "artist/song.flac".into())],
@@ -1161,7 +1228,7 @@ mod tests {
     fn prune_retired_bounds_map_under_churn() {
         let mut alloc = InodeAllocator::new(false);
         for generation in 0..100 {
-            let entries = vec![(1, format!("Gen{generation}/a.flac"))];
+            let entries = vec![(1, format!("Gen{generation}/a.flac").into())];
             let tree = VirtualTree::build_with(&entries, &mut alloc);
             alloc.prune_retired(&tree);
             assert!(
@@ -1182,8 +1249,8 @@ mod tests {
         let mut last = tree;
         for generation in 0..10 {
             let entries = vec![
-                (1, "Keep/song.flac".to_string()),
-                (2, format!("Gen{generation}/x.flac")),
+                (1, "Keep/song.flac".into()),
+                (2, format!("Gen{generation}/x.flac").into()),
             ];
             last = VirtualTree::build_with(&entries, &mut alloc);
             alloc.prune_retired(&last);
@@ -1201,7 +1268,10 @@ mod tests {
         let gone_file = t1.lookup(gone_dir, "x.flac").unwrap();
         // Churn well past the threshold so a prune drops the retired entries.
         for generation in 0..10 {
-            let t = VirtualTree::build_with(&[(1, format!("Gen{generation}/x.flac"))], &mut alloc);
+            let t = VirtualTree::build_with(
+                &[(1, format!("Gen{generation}/x.flac").into())],
+                &mut alloc,
+            );
             alloc.prune_retired(&t);
         }
         assert!(
@@ -1286,7 +1356,7 @@ mod tests {
     fn case_insensitive_merges_directories() {
         // Two artist dirs differing only by case collapse into one; both titles
         // live under the first-seen casing.
-        let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+        let entries = vec![(1i64, "Foo/A".into()), (2i64, "foo/B".into())];
         let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(true), true);
         let foo = tree.lookup(VirtualTree::ROOT, "Foo").expect("Foo dir");
         // Case-insensitive lookup resolves any casing to the same inode.
@@ -1303,10 +1373,7 @@ mod tests {
     fn case_insensitive_disambiguates_leaf_files() {
         // Two files in the same dir whose names differ only by case must NOT
         // collide: the second is disambiguated.
-        let entries = vec![
-            (1i64, "Dir/Song".to_string()),
-            (2i64, "Dir/song".to_string()),
-        ];
+        let entries = vec![(1i64, "Dir/Song".into()), (2i64, "Dir/song".into())];
         let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(true), true);
         let dir = tree.lookup(VirtualTree::ROOT, "Dir").expect("Dir");
         let names: Vec<String> = tree
@@ -1324,7 +1391,7 @@ mod tests {
     fn case_sensitive_keeps_both_dirs_separate() {
         // Control: with folding OFF, "Foo" and "foo" are distinct dirs and a
         // differently-cased query misses.
-        let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+        let entries = vec![(1i64, "Foo/A".into()), (2i64, "foo/B".into())];
         let tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(false), false);
         assert_eq!(tree.children(VirtualTree::ROOT).unwrap().len(), 2);
         assert_ne!(
@@ -1338,10 +1405,7 @@ mod tests {
     fn case_insensitive_removal_keeps_folded_lookup_consistent() {
         // A folded tree mutated in place must not resolve a removed name via the
         // folded index (the index is maintained on removal, not just insert).
-        let entries = vec![
-            (1i64, "Dir/Song".to_string()),
-            (2i64, "Dir/Other".to_string()),
-        ];
+        let entries = vec![(1i64, "Dir/Song".into()), (2i64, "Dir/Other".into())];
         let mut tree = VirtualTree::build_with_ci(&entries, &mut InodeAllocator::new(true), true);
         let dir = tree.lookup(VirtualTree::ROOT, "dir").expect("dir");
         assert!(tree.lookup(dir, "song").is_some());
@@ -1361,11 +1425,11 @@ mod tests {
         // re-derive the casing from track 2 alone, rendering "foo". Track 2's
         // rendered path is unchanged, so its inode must be stable.
         let mut alloc = InodeAllocator::new(true);
-        let entries = vec![(1i64, "Foo/A".to_string()), (2i64, "foo/B".to_string())];
+        let entries = vec![(1i64, "Foo/A".into()), (2i64, "foo/B".into())];
         let tree = VirtualTree::build_with_ci(&entries, &mut alloc, true);
         let before = tree.inode_of_track(2).expect("track 2 inode");
 
-        let rebuilt = VirtualTree::build_with_ci(&[(2i64, "foo/B".to_string())], &mut alloc, true);
+        let rebuilt = VirtualTree::build_with_ci(&[(2i64, "foo/B".into())], &mut alloc, true);
         let after = rebuilt
             .inode_of_track(2)
             .expect("track 2 inode after rebuild");
@@ -1384,10 +1448,7 @@ mod tests {
         // pair: "Song" and "song" fold equal, so the second becomes "song (2)";
         // their fold-keys ("dir/song" vs "dir/song (2)") differ, so do their inodes.
         let mut alloc = InodeAllocator::new(true);
-        let entries = vec![
-            (1i64, "Dir/Song".to_string()),
-            (2i64, "Dir/song".to_string()),
-        ];
+        let entries = vec![(1i64, "Dir/Song".into()), (2i64, "Dir/song".into())];
         let tree = VirtualTree::build_with_ci(&entries, &mut alloc, true);
         let a = tree.inode_of_track(1).expect("track 1 inode");
         let b = tree.inode_of_track(2).expect("track 2 inode");
@@ -1464,11 +1525,11 @@ mod tests {
 
     #[test]
     fn deepest_existing_ancestor_rendered_miss_does_not_scan_root_fanout() {
-        let entries: Vec<(i64, String)> = (0..1024)
+        let entries: Vec<(i64, RenderedPath)> = (0..1024)
             .map(|i| {
                 (
                     i64::from(i),
-                    format!("Artist {i:04}/Album {i:04}/Track.flac"),
+                    RenderedPath::from(format!("Artist {i:04}/Album {i:04}/Track.flac")),
                 )
             })
             .collect();
@@ -1581,10 +1642,7 @@ mod tests {
     #[test]
     fn rebuild_subtree_matches_build_for_dir_vs_file() {
         // $album="X.flac" produces dir "X.flac"; a sibling file also "X.flac".
-        let entries = vec![
-            (1, "P/X.flac".to_string()),
-            (2, "P/X.flac/t.flac".to_string()),
-        ];
+        let entries = vec![(1, "P/X.flac".into()), (2, "P/X.flac/t.flac".into())];
         let reference = VirtualTree::build(&entries);
         let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
@@ -1603,9 +1661,9 @@ mod tests {
         // P has dir "X.flac" (from $album="X.flac", tracks 1 & 9) and file "X.flac"
         // (track 5). Ascending id: dir introduced by 1 claims "X.flac"; file 5 -> "X (2).flac".
         let entries = vec![
-            (1, "X.flac/a.flac".to_string()),
-            (9, "X.flac/b.flac".to_string()),
-            (5, "X.flac".to_string()), // a FILE rendered "X.flac" in root
+            (1, "X.flac/a.flac".into()),
+            (9, "X.flac/b.flac".into()),
+            (5, "X.flac".into()), // a FILE rendered "X.flac" in root
         ];
         let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
@@ -1617,7 +1675,7 @@ mod tests {
         // that same canonical order to be a meaningful oracle; the inner build
         // primitive deliberately does NOT sort (these tests feed it id-unordered
         // inputs).
-        let mut new_entries = vec![(9, "X.flac/b.flac".to_string()), (5, "X.flac".to_string())];
+        let mut new_entries = vec![(9, "X.flac/b.flac".into()), (5, "X.flac".into())];
         new_entries.sort_by_key(|(id, _)| *id);
         let reference = VirtualTree::build(&new_entries);
         let new_paths: std::collections::HashMap<i64, TrackRenderState> = new_entries
@@ -1637,15 +1695,15 @@ mod tests {
     fn apply_changes_handles_add_side_min_id_flip() {
         // Initial: file "X.flac" (id 2) claims the base name; dir "X.flac"
         // (introduced by id 5) is disambiguated to "X.flac (2)".
-        let entries = vec![(2, "X.flac".to_string()), (5, "X.flac/a.flac".to_string())];
+        let entries = vec![(2, "X.flac".into()), (5, "X.flac/a.flac".into())];
         let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         // ADD track 1 under the dir: its id (1) is now the dir's min (< file's 2), so a
         // full rebuild gives the DIR the base name and the file becomes "X.flac (2)".
         let mut new_entries = vec![
-            (1, "X.flac/b.flac".to_string()),
-            (2, "X.flac".to_string()),
-            (5, "X.flac/a.flac".to_string()),
+            (1, "X.flac/b.flac".into()),
+            (2, "X.flac".into()),
+            (5, "X.flac/a.flac".into()),
         ];
         new_entries.sort_by_key(|(id, _)| *id);
         let reference = VirtualTree::build(&new_entries);
@@ -1668,17 +1726,17 @@ mod tests {
         // path differs from its current placement): it must be removed from the old
         // leaf and inserted at the new one, matching a canonical full rebuild.
         let entries = vec![
-            (1, "Old/a.flac".to_string()),
-            (2, "Old/b.flac".to_string()),
-            (3, "New/c.flac".to_string()),
+            (1, "Old/a.flac".into()),
+            (2, "Old/b.flac".into()),
+            (3, "New/c.flac".into()),
         ];
         let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         // Track 2 moves Old -> New.
         let mut new_entries = vec![
-            (1, "Old/a.flac".to_string()),
-            (2, "New/b.flac".to_string()),
-            (3, "New/c.flac".to_string()),
+            (1, "Old/a.flac".into()),
+            (2, "New/b.flac".into()),
+            (3, "New/c.flac".into()),
         ];
         new_entries.sort_by_key(|(id, _)| *id);
         let reference = VirtualTree::build(&new_entries);
@@ -1699,7 +1757,7 @@ mod tests {
     fn apply_changes_unchanged_path_is_noop_for_changed_id() {
         // A `changed` id whose rendered path is identical (e.g. a tag edit that does
         // not affect the template) must leave structure untouched.
-        let entries = vec![(1, "A/x.flac".to_string()), (2, "A/y.flac".to_string())];
+        let entries = vec![(1, "A/x.flac".into()), (2, "A/y.flac".into())];
         let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
         let reference = VirtualTree::build(&entries);
@@ -1727,8 +1785,8 @@ mod tests {
     /// the canonical order production establishes in `render_entries` (#188). The
     /// `build_with` primitive itself does NOT sort, so the oracle must.
     fn assert_apply_matches_build(
-        before: &[(i64, String)],
-        after: &[(i64, String)],
+        before: &[(i64, RenderedPath)],
+        after: &[(i64, RenderedPath)],
         changed: &[i64],
         added: &[i64],
         removed: &[i64],
@@ -1763,16 +1821,16 @@ mod tests {
         // colliding with id 1 — so the dirty-set gate must strip it too and mark "A"
         // for rebuild. Before the unify, the gate reasoned over ["A", ".", "t.flac"]
         // and skipped the rebuild, diverging from a fresh build (#518).
-        let before = vec![(1, "A/t.flac".to_string())];
-        let after = vec![(1, "A/t.flac".to_string()), (2, "A/./t.flac".to_string())];
+        let before = vec![(1, "A/t.flac".into())];
+        let after = vec![(1, "A/t.flac".into()), (2, "A/./t.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 
     #[test]
     fn apply_changes_dotdot_component_collision_matches_build() {
         // Same as above for a literal ".." component.
-        let before = vec![(1, "A/t.flac".to_string())];
-        let after = vec![(1, "A/t.flac".to_string()), (2, "A/../t.flac".to_string())];
+        let before = vec![(1, "A/t.flac".into())];
+        let after = vec![(1, "A/t.flac".into()), (2, "A/../t.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 
@@ -1780,8 +1838,8 @@ mod tests {
     fn apply_changes_remove_base_of_collision_group_renames_survivor() {
         // ids 1,2 both render "A/t.flac": 1 -> "t.flac", 2 -> "t (2).flac".
         // Removing 1 must give 2 the base name back.
-        let before = vec![(1, "A/t.flac".to_string()), (2, "A/t.flac".to_string())];
-        let after = vec![(2, "A/t.flac".to_string())];
+        let before = vec![(1, "A/t.flac".into()), (2, "A/t.flac".into())];
+        let after = vec![(2, "A/t.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[], &[1], 1);
     }
 
@@ -1791,11 +1849,11 @@ mod tests {
         // rendered name), which pushed group-"t.flac" member id 3 to "t (3).flac".
         // Removing 2 frees the key: a fresh build puts 3 at "t (2).flac".
         let before = vec![
-            (1, "A/t.flac".to_string()),
-            (2, "A/t (2).flac".to_string()),
-            (3, "A/t.flac".to_string()),
+            (1, "A/t.flac".into()),
+            (2, "A/t (2).flac".into()),
+            (3, "A/t.flac".into()),
         ];
-        let after = vec![(1, "A/t.flac".to_string()), (3, "A/t.flac".to_string())];
+        let after = vec![(1, "A/t.flac".into()), (3, "A/t.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[], &[2], 1);
     }
 
@@ -1803,8 +1861,8 @@ mod tests {
     fn apply_changes_add_smaller_id_into_collision_group_shifts_member() {
         // id 5 holds base "t.flac"; adding id 2 with the same rendered name must
         // re-rank the group: 2 -> "t.flac", 5 -> "t (2).flac".
-        let before = vec![(5, "A/t.flac".to_string())];
-        let after = vec![(2, "A/t.flac".to_string()), (5, "A/t.flac".to_string())];
+        let before = vec![(5, "A/t.flac".into())];
+        let after = vec![(2, "A/t.flac".into()), (5, "A/t.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 
@@ -1816,8 +1874,11 @@ mod tests {
         // the collision goes undetected, and the re-rank (2 -> base, 5 -> "(2)")
         // never happens, diverging from a full rebuild (#535).
         let long = "d".repeat(NAME_MAX + 45);
-        let before = vec![(5, format!("{long}/t.flac"))];
-        let after = vec![(2, format!("{long}/t.flac")), (5, format!("{long}/t.flac"))];
+        let before = vec![(5, format!("{long}/t.flac").into())];
+        let after = vec![
+            (2, format!("{long}/t.flac").into()),
+            (5, format!("{long}/t.flac").into()),
+        ];
         assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 
@@ -1829,8 +1890,11 @@ mod tests {
         // collision goes undetected, and the re-rank (2 -> base, 5 -> "(2)") never
         // happens, diverging from a full rebuild (#535).
         let long = format!("{}.flac", "x".repeat(NAME_MAX + 45));
-        let before = vec![(5, format!("A/{long}"))];
-        let after = vec![(2, format!("A/{long}")), (5, format!("A/{long}"))];
+        let before = vec![(5, format!("A/{long}").into())];
+        let after = vec![
+            (2, format!("A/{long}").into()),
+            (5, format!("A/{long}").into()),
+        ];
         assert_apply_matches_build(&before, &after, &[], &[2], &[], 1);
     }
 
@@ -1838,8 +1902,8 @@ mod tests {
     fn apply_changes_dir_reclaims_base_name_when_colliding_file_removed() {
         // File id 1 rendered "X" owns the base; the dir for id 2's "X/a.flac" was
         // disambiguated to "X (2)". Removing the file must rename the dir to "X".
-        let before = vec![(1, "X".to_string()), (2, "X/a.flac".to_string())];
-        let after = vec![(2, "X/a.flac".to_string())];
+        let before = vec![(1, "X".into()), (2, "X/a.flac".into())];
+        let after = vec![(2, "X/a.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[], &[1], 1);
     }
 
@@ -1848,11 +1912,11 @@ mod tests {
         // The removed id is the introducing id of its whole ancestor chain but no
         // rendered names collide: equivalence must hold with no sibling churn.
         let before = vec![
-            (1, "A/B/t1.flac".to_string()),
-            (2, "A/B/t2.flac".to_string()),
-            (3, "C/u.flac".to_string()),
+            (1, "A/B/t1.flac".into()),
+            (2, "A/B/t2.flac".into()),
+            (3, "C/u.flac".into()),
         ];
-        let after = vec![(2, "A/B/t2.flac".to_string()), (3, "C/u.flac".to_string())];
+        let after = vec![(2, "A/B/t2.flac".into()), (3, "C/u.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[], &[1], 0);
     }
 
@@ -1860,11 +1924,11 @@ mod tests {
     fn apply_changes_add_new_top_level_dir_with_min_id_matches_build() {
         // The added id is smaller than every existing id (a root-wide min flip)
         // and lands under a brand-new top-level dir with no collisions.
-        let before = vec![(5, "A/t1.flac".to_string()), (6, "A/t2.flac".to_string())];
+        let before = vec![(5, "A/t1.flac".into()), (6, "A/t2.flac".into())];
         let after = vec![
-            (1, "B/u.flac".to_string()),
-            (5, "A/t1.flac".to_string()),
-            (6, "A/t2.flac".to_string()),
+            (1, "B/u.flac".into()),
+            (5, "A/t1.flac".into()),
+            (6, "A/t2.flac".into()),
         ];
         assert_apply_matches_build(&before, &after, &[], &[1], &[], 0);
     }
@@ -1875,14 +1939,11 @@ mod tests {
         // Neither collides with an EXISTING child, so no rebuild is triggered; the
         // insertions themselves must still rank by id (3 -> base, 7 -> " (2)"),
         // not by added-before-moved processing order.
-        let before = vec![
-            (3, "A/old.flac".to_string()),
-            (5, "A/keep.flac".to_string()),
-        ];
+        let before = vec![(3, "A/old.flac".into()), (5, "A/keep.flac".into())];
         let after = vec![
-            (3, "B/t.flac".to_string()),
-            (5, "A/keep.flac".to_string()),
-            (7, "B/t.flac".to_string()),
+            (3, "B/t.flac".into()),
+            (5, "A/keep.flac".into()),
+            (7, "B/t.flac".into()),
         ];
         assert_apply_matches_build(&before, &after, &[3], &[7], &[], 0);
     }
@@ -1894,14 +1955,14 @@ mod tests {
         // (it can't know the track lands back inside D), but exactly once — the
         // add-side equality (id == D's introducing id) must not double anything.
         let before = vec![
-            (1, "D/x.flac".to_string()),
-            (2, "D".to_string()),
-            (3, "D/z.flac".to_string()),
+            (1, "D/x.flac".into()),
+            (2, "D".into()),
+            (3, "D/z.flac".into()),
         ];
         let after = vec![
-            (1, "D/y.flac".to_string()),
-            (2, "D".to_string()),
-            (3, "D/z.flac".to_string()),
+            (1, "D/y.flac".into()),
+            (2, "D".into()),
+            (3, "D/z.flac".into()),
         ];
         assert_apply_matches_build(&before, &after, &[1], &[], &[], 1);
     }
@@ -1912,11 +1973,11 @@ mod tests {
         // "D/x.flac" was disambiguated to "D (2)". Adding id 1 under the dir
         // flips its introducing id below the file's — a fresh build now gives
         // the DIR the base name. The add-side min-flip walk must catch this.
-        let before = vec![(2, "D".to_string()), (5, "D/x.flac".to_string())];
+        let before = vec![(2, "D".into()), (5, "D/x.flac".into())];
         let after = vec![
-            (1, "D/y.flac".to_string()),
-            (2, "D".to_string()),
-            (5, "D/x.flac".to_string()),
+            (1, "D/y.flac".into()),
+            (2, "D".into()),
+            (5, "D/x.flac".into()),
         ];
         assert_apply_matches_build(&before, &after, &[], &[1], &[], 1);
     }
@@ -1926,12 +1987,12 @@ mod tests {
         // Two collision-gated removals dirty ROOT and "A". Shallow-first
         // reduction must rebuild ROOT once and skip "A" as covered.
         let before = vec![
-            (1, "t.flac".to_string()),
-            (2, "t.flac".to_string()),
-            (10, "A/u.flac".to_string()),
-            (11, "A/u.flac".to_string()),
+            (1, "t.flac".into()),
+            (2, "t.flac".into()),
+            (10, "A/u.flac".into()),
+            (11, "A/u.flac".into()),
         ];
-        let after = vec![(2, "t.flac".to_string()), (11, "A/u.flac".to_string())];
+        let after = vec![(2, "t.flac".into()), (11, "A/u.flac".into())];
         assert_apply_matches_build(&before, &after, &[], &[], &[1, 10], 1);
     }
 
@@ -1941,9 +2002,9 @@ mod tests {
         // through the intermediate `Sub` dir, and re-inserting only the survivor
         // must prune the now-empty intermediate dir.
         let entries = vec![
-            (1, "P/Sub/t.flac".to_string()),
-            (2, "P/Sub/u.flac".to_string()),
-            (3, "P/keep.flac".to_string()),
+            (1, "P/Sub/t.flac".into()),
+            (2, "P/Sub/u.flac".into()),
+            (3, "P/keep.flac".into()),
         ];
         let mut alloc = InodeAllocator::new(false);
         let mut t = VirtualTree::build_with(&entries, &mut alloc);
@@ -1951,7 +2012,7 @@ mod tests {
         // Drop both tracks under Sub; rebuild P from the survivors only.
         t.remove_track(1, &mut alloc);
         t.remove_track(2, &mut alloc);
-        let new_entries = vec![(3, "P/keep.flac".to_string())];
+        let new_entries = vec![(3, "P/keep.flac".into())];
         let reference = VirtualTree::build(&new_entries);
         let np: std::collections::HashMap<i64, TrackRenderState> = new_entries
             .iter()
@@ -2033,7 +2094,7 @@ mod tests {
 
     #[test]
     fn over_long_leaf_truncates_to_255_keeping_extension() {
-        let path = format!("{}.flac", "t".repeat(300));
+        let path = RenderedPath::from(format!("{}.flac", "t".repeat(300)));
         let t = VirtualTree::build(&[(10, path)]);
         let mut kids = t.children(VirtualTree::ROOT).unwrap();
         assert_eq!(kids.len(), 1);
@@ -2049,7 +2110,7 @@ mod tests {
 
     #[test]
     fn over_long_directory_component_truncates_to_255() {
-        let path = format!("{}/Song.flac", "d".repeat(300));
+        let path = RenderedPath::from(format!("{}/Song.flac", "d".repeat(300)));
         let t = VirtualTree::build(&[(10, path)]);
         let dir = t
             .children(VirtualTree::ROOT)
@@ -2063,7 +2124,7 @@ mod tests {
 
     #[test]
     fn over_long_component_truncates_on_utf8_boundary() {
-        let path = format!("{}.flac", "€".repeat(100));
+        let path = RenderedPath::from(format!("{}.flac", "€".repeat(100)));
         let t = VirtualTree::build(&[(10, path)]);
         let name = t
             .children(VirtualTree::ROOT)
@@ -2082,8 +2143,8 @@ mod tests {
 
     #[test]
     fn colliding_over_long_leaves_stay_distinct_and_within_255() {
-        let path = format!("{}.flac", "x".repeat(300));
-        let entries: Vec<(i64, String)> = (0..12).map(|i| (i, path.clone())).collect();
+        let path = RenderedPath::from(format!("{}.flac", "x".repeat(300)));
+        let entries: Vec<(i64, RenderedPath)> = (0..12).map(|i| (i, path.clone())).collect();
         let t = VirtualTree::build(&entries);
         let kids = t.children(VirtualTree::ROOT).unwrap();
         assert_eq!(kids.len(), 12, "all collisions disambiguated distinctly");
@@ -2102,7 +2163,7 @@ mod tests {
         // any stem, so the leaf falls back to a plain whole-name truncation rather
         // than emitting an empty-stem `.ext`. Guards truncate_component's
         // `budget > 0` filter.
-        let path = format!("{}.{}", "s".repeat(300), "e".repeat(254));
+        let path = RenderedPath::from(format!("{}.{}", "s".repeat(300), "e".repeat(254)));
         let t = VirtualTree::build(&[(10, path)]);
         let name = t
             .children(VirtualTree::ROOT)
@@ -2124,8 +2185,8 @@ mod tests {
 
     #[test]
     fn over_long_collisions_render_deterministically() {
-        let path = format!("{}.flac", "y".repeat(300));
-        let entries: Vec<(i64, String)> = (0..5).map(|i| (i, path.clone())).collect();
+        let path = RenderedPath::from(format!("{}.flac", "y".repeat(300)));
+        let entries: Vec<(i64, RenderedPath)> = (0..5).map(|i| (i, path.clone())).collect();
         let a = VirtualTree::build(&entries);
         let b = VirtualTree::build(&entries);
         let ak: Vec<_> = a
@@ -2161,12 +2222,12 @@ mod tests {
     /// would make the count scale with album count, tripping this gate. (This
     /// guards `apply_changes`'s O(changed) contract; it does NOT guard the
     /// facade's choice to call `apply_changes` vs a full `build_with`.)
-    fn library(albums: usize) -> Vec<(i64, String)> {
+    fn library(albums: usize) -> Vec<(i64, RenderedPath)> {
         let mut e = Vec::new();
         for a in 0..albums {
             for t in 0..3 {
                 let id = i64::try_from(a * 3 + t).unwrap();
-                e.push((id, format!("Album{a:04}/t{t}.flac")));
+                e.push((id, RenderedPath::from(format!("Album{a:04}/t{t}.flac"))));
             }
         }
         e
@@ -2181,7 +2242,7 @@ mod tests {
         let mut new_entries = entries.clone();
         for (id, path) in &mut new_entries {
             if *id == changed_id {
-                *path = "Album0000/renamed.flac".to_string();
+                *path = RenderedPath::from("Album0000/renamed.flac");
             }
         }
         let new_paths: std::collections::HashMap<i64, TrackRenderState> = new_entries

--- a/musefs-core/tests/concurrent_reads.rs
+++ b/musefs-core/tests/concurrent_reads.rs
@@ -3,6 +3,10 @@
 //! connection, exercising the quick_cache header cache and concurrent SQLite
 //! reads under contention. Deterministic (bounded, barrier-synchronized,
 //! asserts on bytes) so it can gate CI and run under AddressSanitizer.
+//!
+//! The second half of the file covers the read-ahead pool's shared byte budget
+//! under the same kind of load (#628) — the serve-path tests here run with
+//! read-ahead disabled, so they never reach it.
 mod common;
 
 use std::sync::{Arc, Barrier, Mutex};
@@ -178,4 +182,237 @@ fn sustained_mixed_load_does_not_deadlock_or_corrupt() {
 fn core_error_is_send() {
     fn assert_send<T: Send>() {}
     assert_send::<musefs_core::CoreError>();
+}
+
+// ---------------------------------------------------------------------------
+// Read-ahead budget accounting under concurrency (#628).
+//
+// The serve-path tests above run with `ReadAheadPool::new(0)` — read-ahead
+// disabled — so nothing they touch reaches the pool's shared `charged` counter.
+// The tests below drive that counter directly from many threads, so the ASan
+// and TSan legs (which run THIS binary) cover it too.
+//
+// The invariant under test is `charged == Σ(registered buffers' bytes.len())`,
+// maintained across three concurrent sites: `reconcile` on the read path,
+// `deregister` on handle drop, and `evict_one_coldest` under budget pressure.
+// #536 fixed a real race between the last two — an eviction clearing a buffer
+// while a `deregister` removed it either double-counted or leaked — by making
+// the buffer length the single coordination point. That property had no
+// concurrent regression test.
+// ---------------------------------------------------------------------------
+
+/// Backing bytes for the read-ahead stress. Small enough that 16 threads each
+/// holding a window stay cheap under a sanitizer, large enough that a 1 MiB
+/// per-stream window (the cap implied by `RA_BUDGET`) still leaves room to seek.
+const RA_BACKING_LEN: u64 = 4 * 1024 * 1024;
+/// Deliberately tiny: `per_stream_cap` is `budget / 4` == 1 MiB, so a handful of
+/// live streams exhaust it and every subsequent miss must evict a colder one.
+const RA_BUDGET: u64 = 4 * 1024 * 1024;
+const RA_THREADS: u64 = 16;
+/// Per round: this many seeks, each followed by a short sequential run — the
+/// mix that grows a window geometrically and then resets it to the floor.
+const RA_SEEKS_PER_ROUND: u32 = 3;
+const RA_SEQ_RUN: u32 = 4;
+const RA_CHUNK: u64 = 4096;
+
+/// Rounds of stream churn per thread. Deliberately modest: this binary is what
+/// the ASan and TSan CI legs run and a sanitized build is 10-50x slower, so the
+/// default keeps both new tests to ~2s under ThreadSanitizer (measured) instead
+/// of adding minutes to every run. `MUSEFS_READAHEAD_STRESS_ROUNDS` cranks it up
+/// for a local soak — 200, the scale of the report in #628, is ~9s under TSan.
+fn ra_rounds() -> u64 {
+    std::env::var("MUSEFS_READAHEAD_STRESS_ROUNDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(24)
+}
+
+/// A backing file of position-derived bytes plus its contents, so every read
+/// below can be checked against an oracle as well as counted.
+fn ra_backing(dir: &std::path::Path) -> (std::fs::File, Vec<u8>) {
+    use std::io::Write;
+    let path = dir.join("readahead.bin");
+    let len = usize::try_from(RA_BACKING_LEN).expect("64-bit target");
+    let data: Vec<u8> = (0..len)
+        .map(|i| u8::try_from(i % 251).expect("bounded by 251"))
+        .collect();
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(&data)
+        .unwrap();
+    (std::fs::File::open(&path).unwrap(), data)
+}
+
+/// Drive one registered stream through `RA_SEEKS_PER_ROUND` seeks, each followed
+/// by a sequential run — misses (which call `permitted_window`, evicting other
+/// streams) interleaved with hits, all charging the shared budget via
+/// `reconcile`. Asserts bytes as it goes so an accounting fix that corrupts the
+/// window ring cannot pass quietly.
+fn ra_drive(
+    file: &std::fs::File,
+    data: &[u8],
+    pool: &ReadAheadPool,
+    buf: &Arc<Mutex<ReadAhead>>,
+    key: usize,
+    seed: u64,
+) {
+    let chunk = usize::try_from(RA_CHUNK).expect("64-bit target");
+    let epoch = std::sync::atomic::AtomicU64::new(0);
+    let br = BackingReader::new(file, buf, pool, key, RA_BACKING_LEN, &epoch);
+    let mut got = vec![0u8; chunk];
+    let mut rng = seed | 1;
+    for _ in 0..RA_SEEKS_PER_ROUND {
+        rng = rng
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let mut off = rng % (RA_BACKING_LEN - RA_CHUNK);
+        for _ in 0..RA_SEQ_RUN {
+            br.read_exact_at(&mut got, off).unwrap();
+            let lo = usize::try_from(off).expect("64-bit target");
+            assert_eq!(
+                got,
+                data[lo..lo + chunk],
+                "read-ahead byte mismatch at {off}"
+            );
+            off += RA_CHUNK;
+            if off + RA_CHUNK > RA_BACKING_LEN {
+                break;
+            }
+        }
+    }
+}
+
+/// Sum of what the registered buffers actually hold — the right-hand side of
+/// the `charged == Σ bytes` invariant. Only safe to call once every reader has
+/// joined; a lock taken mid-read would just observe a torn moment.
+fn ra_buffered(streams: &[(usize, Arc<Mutex<ReadAhead>>)]) -> u64 {
+    streams.iter().map(|(_, b)| b.lock().unwrap().len()).sum()
+}
+
+/// Churn: many threads repeatedly register a stream, read through it, and
+/// deregister it, against a budget small enough that eviction fires constantly.
+/// Every stream is deregistered by the end, so the pool must be holding nothing:
+/// a leaked charge (an eviction and a `deregister` both declining to uncharge)
+/// leaves `charged` positive, a double uncharge underflows it to a huge value.
+#[test]
+fn readahead_churn_ends_with_nothing_charged() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file, data) = ra_backing(dir.path());
+    let pool = Arc::new(ReadAheadPool::new(RA_BUDGET));
+    let rounds = ra_rounds();
+
+    std::thread::scope(|s| {
+        for tid in 0..RA_THREADS {
+            let (file, data, pool) = (&file, &data, &pool);
+            s.spawn(move || {
+                for round in 0..rounds {
+                    // Slab keys are unique per live handle; re-using one while
+                    // another thread holds it registered would drop that
+                    // registration and strand its bytes by construction.
+                    let key = usize::try_from(tid * rounds + round).expect("64-bit target");
+                    let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+                    pool.register(key, Arc::clone(&buf));
+                    ra_drive(file, data, pool, &buf, key, tid * 7919 + round);
+                    // Reads for this handle are done (same thread), mirroring
+                    // release-after-last-read on the real serve path.
+                    pool.deregister(key);
+                }
+            });
+        }
+    });
+
+    assert_eq!(
+        pool.charged(),
+        0,
+        "every stream was deregistered; charged budget must return to 0"
+    );
+}
+
+/// The property #536 restored, asserted directly: with streams still registered
+/// and all readers joined, the pool's `charged` must equal the bytes those
+/// buffers really hold. Also pins that the overshoot the racy grant permits is
+/// transient — once reads serialize again, eviction pulls the pool back inside
+/// its budget.
+#[test]
+fn readahead_charged_matches_registered_buffers_at_quiescence() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file, data) = ra_backing(dir.path());
+    let pool = Arc::new(ReadAheadPool::new(RA_BUDGET));
+    let rounds = ra_rounds();
+
+    // One long-lived stream per thread, registered for the whole run.
+    let streams: Vec<(usize, Arc<Mutex<ReadAhead>>)> = (0..RA_THREADS)
+        .map(|tid| {
+            let key = usize::try_from(tid + 1).expect("64-bit target");
+            let buf = Arc::new(Mutex::new(ReadAhead::new(pool.per_stream_cap())));
+            pool.register(key, Arc::clone(&buf));
+            (key, buf)
+        })
+        .collect();
+
+    std::thread::scope(|s| {
+        for (tid, (key, buf)) in streams.iter().enumerate() {
+            let (file, data, pool) = (&file, &data, &pool);
+            let tid = u64::try_from(tid).expect("bounded by RA_THREADS");
+            s.spawn(move || {
+                for round in 0..rounds {
+                    ra_drive(file, data, pool, buf, *key, tid * 6151 + round);
+                }
+            });
+        }
+    });
+
+    // Quiesced: no reader holds a buffer lock, so the sum is exact.
+    let buffered = ra_buffered(&streams);
+    assert!(
+        buffered > 0,
+        "streams must still hold read-ahead bytes, else the invariant is 0 == 0"
+    );
+    assert_eq!(
+        pool.charged(),
+        buffered,
+        "charged budget diverged from the bytes the registered buffers hold"
+    );
+    // Per-stream containment is the half of the envelope that IS exact under
+    // concurrency: a grant is capped at `per_stream_cap` before any budget
+    // arithmetic, so no single stream can run away with the whole pool.
+    for (key, buf) in &streams {
+        let held = buf.lock().unwrap().len();
+        assert!(
+            held <= pool.per_stream_cap(),
+            "stream {key} holds {held} > per-stream cap {}",
+            pool.per_stream_cap()
+        );
+    }
+
+    // `permitted_window` loads `charged`, grants, and only charges after the
+    // fill completes, so concurrent misses can each grant against the same free
+    // room and overshoot the budget — racy by design (see `has_room_for`). What
+    // must hold is that the overshoot does not stick: one serialized pass evicts
+    // colder streams until the grant fits, so the pool settles back inside its
+    // envelope, still with the counter matching the buffers.
+    for (key, buf) in &streams {
+        let seed = u64::try_from(*key).expect("bounded by RA_THREADS");
+        ra_drive(&file, &data, &pool, buf, *key, seed);
+    }
+    assert!(
+        pool.charged() <= pool.budget(),
+        "serialized reads must settle the pool back inside its budget: charged {} > budget {}",
+        pool.charged(),
+        pool.budget()
+    );
+    assert_eq!(
+        pool.charged(),
+        ra_buffered(&streams),
+        "charged budget diverged from the buffers after the settling pass"
+    );
+
+    for (key, _) in &streams {
+        pool.deregister(*key);
+    }
+    assert_eq!(
+        pool.charged(),
+        0,
+        "release of every stream must uncharge all"
+    );
 }

--- a/musefs-core/tests/scan_abort_cleanup.rs
+++ b/musefs-core/tests/scan_abort_cleanup.rs
@@ -6,6 +6,14 @@
 //! would accumulate one leaked thread — plus its in-flight art bytes — per
 //! blocked worker, per failed scan (#618).
 
+// The stranding this guards against is platform-independent; the *observation* is
+// not. `live_threads` counts entries under `/proc/self/task`, which exists only on
+// Linux — and the macOS and FreeBSD legs both run `cargo test --workspace`, so
+// without this gate the helper's `expect` panics there rather than testing
+// anything. Linux carries the required gates (including both sanitizer legs), so
+// the regression stays covered where it is checked.
+#![cfg(target_os = "linux")]
+
 use musefs_core::{ScanOptions, scan_directory_with};
 use musefs_db::{Db, Format, NewTrack};
 use std::time::{Duration, Instant};

--- a/musefs-core/tests/scan_abort_cleanup.rs
+++ b/musefs-core/tests/scan_abort_cleanup.rs
@@ -1,0 +1,112 @@
+//! Regression guard for the scan pipeline's abort path: when a batch commit
+//! fails, `run_pipeline` propagates the error — but a worker parked in
+//! `ByteBudget::acquire` waits on a release only a successful flush performs, so
+//! nothing would ever wake it. `scan_directory_with` is public API and an
+//! embedder that catches the error and carries on (the Python plugin surface)
+//! would accumulate one leaked thread — plus its in-flight art bytes — per
+//! blocked worker, per failed scan (#618).
+
+use musefs_core::{ScanOptions, scan_directory_with};
+use musefs_db::{Db, Format, NewTrack};
+use std::time::{Duration, Instant};
+
+/// A minimal FLAC carrying a PICTURE block of `data_len` image bytes, so the
+/// probed track has a non-zero art weight for the budget (mirrors the fixture in
+/// `pipeline_backpressure.rs`). marker + STREAMINFO (not last) + PICTURE (last)
+/// + a little audio.
+fn flac_with_art(data_len: usize) -> Vec<u8> {
+    let mut v = b"fLaC".to_vec();
+    // STREAMINFO (type 0), not last, 34-byte body.
+    v.push(0x00);
+    v.extend_from_slice(&[0, 0, 34]);
+    v.extend(std::iter::repeat_n(0u8, 34));
+    // PICTURE (type 6), last block.
+    let mut body = Vec::new();
+    body.extend_from_slice(&3u32.to_be_bytes()); // picture type (front cover)
+    let mime = b"image/png";
+    body.extend_from_slice(&u32::try_from(mime.len()).unwrap().to_be_bytes());
+    body.extend_from_slice(mime);
+    body.extend_from_slice(&0u32.to_be_bytes()); // description length
+    body.extend_from_slice(&0u32.to_be_bytes()); // width
+    body.extend_from_slice(&0u32.to_be_bytes()); // height
+    body.extend_from_slice(&0u32.to_be_bytes()); // depth
+    body.extend_from_slice(&0u32.to_be_bytes()); // colors
+    body.extend_from_slice(&u32::try_from(data_len).unwrap().to_be_bytes());
+    body.extend(std::iter::repeat_n(0u8, data_len));
+    v.push(0x86); // last-block flag (0x80) | PICTURE (0x06)
+    let blen = body.len();
+    v.extend_from_slice(&[
+        u8::try_from((blen >> 16) & 0xFF).unwrap(),
+        u8::try_from((blen >> 8) & 0xFF).unwrap(),
+        u8::try_from(blen & 0xFF).unwrap(),
+    ]);
+    v.extend_from_slice(&body);
+    v.extend_from_slice(b"AUDIO");
+    v
+}
+
+/// Live threads in this process. This test binary holds no other test, so the
+/// count is a precise observation of the pipeline's own workers.
+fn live_threads() -> usize {
+    std::fs::read_dir("/proc/self/task")
+        .expect("/proc/self/task")
+        .count()
+}
+
+#[test]
+fn failed_flush_does_not_strand_budget_blocked_workers() {
+    let dir = tempfile::tempdir().unwrap();
+    let lib = dir.path().join("lib");
+    std::fs::create_dir(&lib).unwrap();
+    for i in 0..16 {
+        std::fs::write(lib.join(format!("a{i}.flac")), flac_with_art(6)).unwrap();
+    }
+
+    let db_path = dir.path().join("musefs.db");
+    let db = Db::open(&db_path).unwrap();
+    // Wedge the store: a second connection holds SQLite's single write lock in an
+    // uncommitted transaction, so the scan's first batch write fails (busy) just
+    // as a full disk or an I/O fault would.
+    let blocker = Db::open(&db_path).unwrap();
+    let mut hold = blocker.bulk_writer().unwrap();
+    hold.upsert_track(&NewTrack {
+        backing_path: "/blocker.flac".into(),
+        format: Format::Flac,
+        audio_offset: 0,
+        audio_length: 1,
+        backing_size: 1,
+        backing_mtime_ns: 0,
+        backing_ctime_ns: 0,
+    })
+    .unwrap();
+
+    let baseline = live_threads();
+    // Cap the in-flight budget below two files' cumulative art, so workers pile
+    // up in `acquire` behind the batch the failing flush never releases.
+    let err = scan_directory_with(
+        &db,
+        &lib,
+        &ScanOptions {
+            jobs: 4,
+            batch_bytes: 8,
+            ..Default::default()
+        },
+    )
+    .expect_err("a wedged store must fail the batch commit");
+    assert!(
+        db.list_tracks().unwrap().is_empty(),
+        "nothing may have been persisted through a wedged store"
+    );
+
+    // Workers are joined before the error propagates, so this is normally true on
+    // the first read; poll briefly so a thread still winding down cannot flake it.
+    let start = Instant::now();
+    while live_threads() > baseline && start.elapsed() < Duration::from_secs(10) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(
+        live_threads(),
+        baseline,
+        "aborted scan ({err}) left worker threads parked on the byte budget"
+    );
+}

--- a/musefs-core/tests/tree.rs
+++ b/musefs-core/tests/tree.rs
@@ -3,9 +3,9 @@ use musefs_core::{NodeKind, VirtualTree};
 #[test]
 fn builds_directories_and_files_with_lookup() {
     let tree = VirtualTree::build(&[
-        (10, "Pink Floyd/Animals/Pigs.flac".to_string()),
-        (11, "Pink Floyd/Animals/Dogs.flac".to_string()),
-        (12, "Pink Floyd/Meddle/Echoes.flac".to_string()),
+        (10, "Pink Floyd/Animals/Pigs.flac".into()),
+        (11, "Pink Floyd/Animals/Dogs.flac".into()),
+        (12, "Pink Floyd/Meddle/Echoes.flac".into()),
     ]);
 
     let artist = tree
@@ -26,9 +26,9 @@ fn builds_directories_and_files_with_lookup() {
 #[test]
 fn disambiguates_colliding_file_names() {
     let tree = VirtualTree::build(&[
-        (1, "A/song.flac".to_string()),
-        (2, "A/song.flac".to_string()),
-        (3, "A/song.flac".to_string()),
+        (1, "A/song.flac".into()),
+        (2, "A/song.flac".into()),
+        (3, "A/song.flac".into()),
     ]);
     let a = tree.lookup(VirtualTree::ROOT, "A").unwrap();
     assert_eq!(tree.children(a).unwrap().len(), 3);
@@ -50,7 +50,7 @@ fn root_node_is_a_directory() {
 
 #[test]
 fn parent_of_root_is_root_and_children_point_back() {
-    let tree = VirtualTree::build(&[(1, "Alice/Song.flac".to_string())]);
+    let tree = VirtualTree::build(&[(1, "Alice/Song.flac".into())]);
     assert_eq!(tree.parent(VirtualTree::ROOT), Some(VirtualTree::ROOT));
 
     let alice = tree.lookup(VirtualTree::ROOT, "Alice").unwrap();

--- a/musefs-core/tests/tree_footprint.rs
+++ b/musefs-core/tests/tree_footprint.rs
@@ -22,6 +22,8 @@
 //! The ceiling is deliberately loose. A gate that catches only a large regression
 //! is worth far more than one that reddens on a loaded runner.
 
+use std::sync::Arc;
+
 use musefs_core::convert::usize_from;
 use musefs_core::{InodeAllocator, VirtualTree};
 
@@ -63,8 +65,10 @@ fn rss_bytes() -> Option<usize> {
 }
 
 /// `$artist/$album/$title` paths for `tracks` tracks, in the ascending-id order a
-/// full rebuild uses.
-fn rendered_paths(tracks: usize) -> Vec<(i64, String)> {
+/// full rebuild uses. Each path is the single refcounted allocation the refresh
+/// snapshot would hold, so the build measured below pays only for whatever it
+/// cannot share with it.
+fn rendered_paths(tracks: usize) -> Vec<(i64, Arc<str>)> {
     let mut entries = Vec::with_capacity(tracks);
     for i in 0..tracks {
         let artist = i / (ALBUMS_PER_ARTIST * TRACKS_PER_ALBUM);
@@ -72,7 +76,9 @@ fn rendered_paths(tracks: usize) -> Vec<(i64, String)> {
         let track = i % TRACKS_PER_ALBUM;
         entries.push((
             i64::try_from(i).unwrap(),
-            format!("Artist {artist:05}/Album {album:02}/{track:02} Title {i:06}.flac"),
+            Arc::from(format!(
+                "Artist {artist:05}/Album {album:02}/{track:02} Title {i:06}.flac"
+            )),
         ));
     }
     entries

--- a/musefs-core/tests/tree_footprint.rs
+++ b/musefs-core/tests/tree_footprint.rs
@@ -1,0 +1,135 @@
+//! Resident-footprint gate for the virtual tree (#629).
+//!
+//! #617 cut the tree's per-track cost by interning node names, but the probe that
+//! measured it was a throwaway — nothing then kept the cost from creeping back.
+//! This turns that measurement into a committed gate.
+//!
+//! What is measured: the `VmRSS` delta across `VirtualTree::build_with` alone. The
+//! rendered paths are materialized — and their pages touched — BEFORE the baseline
+//! sample, so the delta is the marginal cost of the tree plus the inode
+//! allocator's path map, given paths the refresh snapshot already owns. That is
+//! the accounting a mount actually pays; it is NOT a mounted daemon's total RSS,
+//! for which `docs/src/guide/tuning.md` carries the number.
+//!
+//! Why a plain `#[test]` rather than a bench or an `#[ignore]`d harness: neither
+//! `cargo bench` nor `cargo test -- --ignored` runs for `musefs-core` in CI or in
+//! the pre-commit hook, so only a non-ignored test gates anything. Living in its
+//! own integration-test binary is what makes a process-wide `VmRSS` reading
+//! trustworthy — cargo runs test *binaries* concurrently, but this one holds a
+//! single test, so nothing else in this process allocates while the sample is
+//! taken.
+//!
+//! The ceiling is deliberately loose. A gate that catches only a large regression
+//! is worth far more than one that reddens on a loaded runner.
+
+use musefs_core::convert::usize_from;
+use musefs_core::{InodeAllocator, VirtualTree};
+
+/// Default corpus size: large enough that the delta (tens of MB) dwarfs
+/// page-granularity noise, small enough to keep the debug-profile workspace suite
+/// quick. Override with `MUSEFS_TREE_FOOTPRINT_TRACKS` to reproduce #617's
+/// 200,000-track figure.
+const DEFAULT_TRACKS: usize = 20_000;
+
+/// Corpus shape: three levels, as `$artist/$album/$title` renders — the shape
+/// #617 measured. Per-track cost depends on tree depth, so this must stay fixed
+/// for the ceiling below to mean anything.
+const ALBUMS_PER_ARTIST: usize = 10;
+const TRACKS_PER_ALBUM: usize = 10;
+
+/// Upper bound on bytes of RSS per track. The cost measured after #617 is
+/// ~1.3 KB/track and #629 takes it lower; 3 KB leaves better than 2x headroom, so
+/// runner noise, allocator arena rounding, or a different malloc cannot redden
+/// it — while a doubling of the per-node cost (reverting the name interning is a
+/// third of one) still trips it.
+const CEILING_BYTES_PER_TRACK: usize = 3072;
+
+/// Lower bound, so a broken measurement — a `VmRSS` that never moves — fails
+/// loudly instead of passing vacuously. No sharing scheme stores a node per track
+/// in less than this.
+const FLOOR_BYTES_PER_TRACK: usize = 128;
+
+/// Current resident set size in bytes, from `/proc/self/status` `VmRSS`. `None`
+/// off Linux or when unreadable; the test then reports and skips.
+fn rss_bytes() -> Option<usize> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let kib: usize = rest.trim().trim_end_matches(" kB").trim().parse().ok()?;
+            return Some(kib * 1024);
+        }
+    }
+    None
+}
+
+/// `$artist/$album/$title` paths for `tracks` tracks, in the ascending-id order a
+/// full rebuild uses.
+fn rendered_paths(tracks: usize) -> Vec<(i64, String)> {
+    let mut entries = Vec::with_capacity(tracks);
+    for i in 0..tracks {
+        let artist = i / (ALBUMS_PER_ARTIST * TRACKS_PER_ALBUM);
+        let album = (i / TRACKS_PER_ALBUM) % ALBUMS_PER_ARTIST;
+        let track = i % TRACKS_PER_ALBUM;
+        entries.push((
+            i64::try_from(i).unwrap(),
+            format!("Artist {artist:05}/Album {album:02}/{track:02} Title {i:06}.flac"),
+        ));
+    }
+    entries
+}
+
+#[test]
+fn virtual_tree_resident_cost_per_track_stays_under_ceiling() {
+    let tracks: usize = std::env::var("MUSEFS_TREE_FOOTPRINT_TRACKS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TRACKS);
+    assert!(tracks > 0, "corpus must hold at least one track");
+
+    // Materialize every rendered path first: the input belongs to the baseline, so
+    // what the delta measures is the tree's own marginal cost.
+    let entries = rendered_paths(tracks);
+
+    let Some(before) = rss_bytes() else {
+        println!("tree footprint: /proc/self/status unavailable, skipping");
+        return;
+    };
+    let mut alloc = InodeAllocator::new(false);
+    let tree = VirtualTree::build_with(&entries, &mut alloc);
+    let after = rss_bytes().expect("VmRSS stayed readable");
+
+    let (files, dirs) = tree.entry_counts();
+    let interned = alloc.interned_path_count();
+    let delta = after.saturating_sub(before);
+    let per_track = delta / tracks;
+    println!(
+        "tree footprint: {tracks} tracks -> {files} files + {dirs} dirs, \
+         {interned} interned paths, {} KiB resident, {per_track} B/track \
+         (ceiling {CEILING_BYTES_PER_TRACK})",
+        delta / 1024,
+    );
+
+    // Pin the corpus shape the per-track figure is normalized against, so an edit
+    // to `rendered_paths` cannot quietly make the budget easier to meet.
+    assert_eq!(
+        usize_from(files),
+        tracks,
+        "every entry must materialize a file"
+    );
+    assert_eq!(
+        interned,
+        tree.node_count(),
+        "a freshly built tree interns exactly one path per node"
+    );
+
+    assert!(
+        per_track >= FLOOR_BYTES_PER_TRACK,
+        "measured {per_track} B/track over {tracks} tracks: implausibly low — the \
+         RSS measurement is broken and this gate is vacuous"
+    );
+    assert!(
+        per_track <= CEILING_BYTES_PER_TRACK,
+        "virtual tree cost {per_track} B/track over {tracks} tracks, above the \
+         {CEILING_BYTES_PER_TRACK} B ceiling (#629)"
+    );
+}

--- a/musefs-core/tests/tree_footprint.rs
+++ b/musefs-core/tests/tree_footprint.rs
@@ -122,6 +122,14 @@ fn virtual_tree_resident_cost_per_track_stays_under_ceiling() {
         tracks,
         "every entry must materialize a file"
     );
+    // Directories are the other half of the corpus shape: without this, flattening
+    // `rendered_paths` would keep the file and intern counts true while lowering the
+    // measured per-track cost, quietly making the ceiling easier to meet.
+    assert_eq!(
+        usize_from(dirs),
+        tracks.div_ceil(ALBUMS_PER_ARTIST * TRACKS_PER_ALBUM) + tracks.div_ceil(TRACKS_PER_ALBUM),
+        "corpus must render one directory per artist and per album"
+    );
     assert_eq!(
         interned,
         tree.node_count(),

--- a/musefs-db/src/tracks.rs
+++ b/musefs-db/src/tracks.rs
@@ -188,6 +188,19 @@ impl<M> Db<M> {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    /// Just the `backing_path` column for every track: the projection a scan's
+    /// "already present" set needs, without materializing a `Track` (and its
+    /// `fingerprint`/`content_hash` strings) per row — ~40 MB of transient
+    /// allocation on a 200k-track store, on a path already holding a connection.
+    /// Unordered by design; the caller collects into a set.
+    pub fn list_backing_paths(&self) -> Result<Vec<String>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT backing_path FROM tracks")?;
+        let rows = stmt.query_map([], |r| r.get(0))?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
     pub fn track_content_version(&self, id: i64) -> Result<i64> {
         Ok(self.conn.query_row(
             "SELECT content_version FROM tracks WHERE id = ?1",
@@ -514,6 +527,18 @@ mod render_key_tests {
         assert_eq!(keys[1].1, 0, "b content_version untouched");
         assert_eq!(keys[0].2, Format::Flac);
         assert_eq!(keys[1].2, Format::Mp3);
+    }
+
+    #[test]
+    fn list_backing_paths_returns_every_stored_path() {
+        let db = open_mem();
+        db.upsert_track(&new_track("/a.flac", Format::Flac))
+            .unwrap();
+        db.upsert_track(&new_track("/b.mp3", Format::Mp3)).unwrap();
+
+        let mut paths = db.list_backing_paths().unwrap();
+        paths.sort();
+        assert_eq!(paths, vec!["/a.flac".to_string(), "/b.mp3".to_string()]);
     }
 
     #[test]

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -246,11 +246,31 @@ type DirListing = Vec<(u64, FileType, String)>;
 /// Cap on concurrently-open directory handles (#307). Each `opendir` snapshots a
 /// full `DirListing`, so an unreleased handle pins memory ~ (entries × name
 /// length); the cap bounds the *number* of snapshots, not their inherent size (a
-/// single `ls` of the widest directory already allocates one). 1024 sits well
-/// above a heavy parallel indexer's concurrent-dir-handle count (~hundreds), so
-/// legitimate clients never hit it, while an over-cap `opendir` returns `ENFILE`
-/// — the directory-side analogue of the file-handle `HandleTableFull → ENFILE`.
+/// single `ls` of the widest directory already allocates one).
+///
+/// The cap bounds memory, not correctness: an ordinary parallel walker (`bfs`,
+/// the default `find` on some distributions) blows past 1024 concurrent dir
+/// handles on a large mount, so over-cap opens must still *work* (#616). They
+/// are served statelessly via [`DIR_FH_STATELESS`] and counted, never refused.
 const MAX_DIR_HANDLES: usize = 1024;
+
+/// The `opendir` fh that stores no snapshot: `readdir` treats an unknown fh as a
+/// cache miss and rebuilds the listing, and `releasedir` on it removes nothing.
+/// Handed out for the synthetic `.musefs-metrics` directory and for any open
+/// over `MAX_DIR_HANDLES` (#616), so a saturated table costs a client a rebuild
+/// per `readdir` rather than the directory itself. `dir_fh` starts at 1, so no
+/// real handle can collide with it.
+const DIR_FH_STATELESS: u64 = 0;
+
+/// The fh an `opendir` reply carries, given the [`try_admit_dir_handle`]
+/// outcome: the admitted snapshot id, or the stateless sentinel when the table
+/// was full. Over-cap opens degrade instead of failing (#616) — replying
+/// `ENFILE` lost the directory from a parallel walk entirely, and surfaced to
+/// the operator as "Too many open files in system", pointing at their kernel
+/// rather than at the mount.
+fn dir_open_fh(admitted: Option<u64>) -> FileHandle {
+    FileHandle(admitted.unwrap_or(DIR_FH_STATELESS))
+}
 
 /// Cap on concurrently-open `.musefs-metrics/metrics` handles (#394). Each `open`
 /// pins one rendered snapshot until `release`; the cap bounds the map the same way
@@ -279,7 +299,8 @@ fn build_dir_listing(
 
 /// Admit a directory handle under the caller's `dir_handles` lock, enforcing
 /// `MAX_DIR_HANDLES` (#307). Returns the freshly allocated handle id on admit, or
-/// `None` when the table is at `cap` (the caller replies `ENFILE`). The id is
+/// `None` when the table is at `cap` (the caller falls back to the stateless
+/// fh; see [`dir_open_fh`]). The id is
 /// drawn from `counter` only on the admit path, and the whole check-then-insert
 /// runs under the single lock the caller holds, so concurrent `opendir` closures
 /// cannot race the count past the cap and a rejected open burns no id.
@@ -386,7 +407,7 @@ pub struct MusefsFs {
     /// poisoning panic can't tear a later `readdir`'s view; recovery is deliberate.
     #[allow(clippy::type_complexity)]
     dir_handles: Arc<Mutex<std::collections::HashMap<u64, Arc<Vec<(u64, FileType, String)>>>>>,
-    /// Monotonic dir-handle id (starts at 1; 0 stays the stateless sentinel).
+    /// Monotonic dir-handle id (starts at 1; 0 stays [`DIR_FH_STATELESS`]).
     ///
     /// Unlike the file slab's generation-encoded keys (`facade.rs`, ABA-safe by
     /// construction), this is a bare never-recycled counter — sufficient precisely
@@ -395,10 +416,13 @@ pub struct MusefsFs {
     /// handle, never evict a different open dir (#192). A 64-bit monotonic counter
     /// cannot wrap within any real process lifetime.
     dir_fh: Arc<AtomicU64>,
-    /// `opendir` calls that found `dir_handles` at `MAX_DIR_HANDLES`. Surfaced as
+    /// `opendir` calls that found `dir_handles` at `MAX_DIR_HANDLES` and fell back
+    /// to the stateless listing path. Surfaced as
     /// `musefs_dir_handle_rejections_total`: the `dir_handles` gauge alone cannot
     /// show saturation, because it is bursty enough to sit at 0 in every sample
-    /// while thousands of opens are turned away between them (#626).
+    /// while thousands of opens are turned away between them (#626). Since #616
+    /// this is also the only signal that directories are being re-listed on every
+    /// `readdir` — worth knowing before it shows up as CPU.
     dir_handle_rejections: Arc<AtomicU64>,
     /// In-flight foreground-read counter. `read` reserves a slot before enqueuing;
     /// over `MAX_INFLIGHT_READS` the read is rejected with `EAGAIN`, capping the
@@ -714,7 +738,7 @@ impl Filesystem for MusefsFs {
         if self.config.expose_metrics && ino.0 == metrics_dir::METRICS_DIR_INO {
             // Stateless: readdir(METRICS_DIR_INO) serves an inline listing and
             // never consults dir_handles, so this fh burns no MAX_DIR_HANDLES slot.
-            return reply.opened(FileHandle(0), FopenFlags::empty());
+            return reply.opened(FileHandle(DIR_FH_STATELESS), FopenFlags::empty());
         }
         let core = Arc::clone(&self.core);
         let handles = Arc::clone(&self.dir_handles);
@@ -732,15 +756,17 @@ impl Filesystem for MusefsFs {
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 try_admit_dir_handle(&mut guard, &counter, &rejections, MAX_DIR_HANDLES, listing)
             };
-            if let Some(fh) = admitted {
-                reply.opened(FileHandle(fh), FopenFlags::empty());
-            } else {
-                log::warn!(
-                    "opendir({ino}) rejected: ENFILE — dir-handle table full at {MAX_DIR_HANDLES}",
+            if admitted.is_none() {
+                // Debug, not warn: a parallel walk over a large mount produces
+                // thousands of these in seconds, and the walk still succeeds.
+                // `musefs_dir_handle_rejections_total` is the operator-facing
+                // signal that the degraded path is in use (#626).
+                log::debug!(
+                    "opendir({ino}) over the {MAX_DIR_HANDLES}-handle cap: serving it                      statelessly, listing rebuilt per readdir",
                     ino = ino.0
                 );
-                reply.error(fuser::Errno::ENFILE);
             }
+            reply.opened(dir_open_fh(admitted), FopenFlags::empty());
         });
     }
 
@@ -1290,6 +1316,24 @@ mod tests {
             rejections.load(Ordering::Relaxed),
             1,
             "the reject must be metered (#626)"
+        );
+    }
+
+    #[test]
+    fn over_cap_opendir_falls_back_to_the_stateless_fh() {
+        assert_eq!(
+            dir_open_fh(Some(7)),
+            FileHandle(7),
+            "an admitted handle keeps its snapshot id"
+        );
+        assert_eq!(
+            dir_open_fh(None),
+            FileHandle(DIR_FH_STATELESS),
+            "over cap must degrade to the stateless fh, not reply ENFILE (#616)"
+        );
+        assert_eq!(
+            DIR_FH_STATELESS, 0,
+            "readdir rebuilds for an unknown fh and releasedir(0) removes nothing"
         );
     }
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -314,17 +314,18 @@ fn reply_dir_page(mut reply: ReplyDirectory, listing: &[(u64, FileType, String)]
 
 /// Admit a directory handle under the caller's `dir_handles` lock, enforcing
 /// `MAX_DIR_HANDLES` (#307). Returns the freshly allocated handle id on admit, or
-/// `None` when the table is at `cap` (the caller falls back to the stateless
-/// fh; see [`dir_open_fh`]). The id is
-/// drawn from `counter` only on the admit path, and the whole check-then-insert
-/// runs under the single lock the caller holds, so concurrent `opendir` closures
-/// cannot race the count past the cap and a rejected open burns no id.
+/// `None` when the table is at `cap` and the caller falls back to the stateless
+/// fh (see [`dir_open_fh`]). The id is drawn from `counter` only on the admit
+/// path, and the whole check-then-insert runs under the single lock the caller
+/// holds, so concurrent `opendir` closures cannot race the count past the cap
+/// and a rejected open burns no id.
 ///
 /// The miss path bumps `rejections`, surfaced as
 /// `musefs_dir_handle_rejections_total`. Saturation is bursty — a parallel walk
 /// can rack up thousands of rejections between two samples of the
 /// `musefs_dir_handles` gauge, which reads healthy the whole time — so the
-/// monotonic counter is the only after-the-fact signal that the cap bit (#626).
+/// monotonic counter is the only after-the-fact signal that the cap was hit
+/// (#626).
 fn try_admit_dir_handle(
     handles: &mut std::collections::HashMap<u64, Arc<DirListing>>,
     counter: &AtomicU64,
@@ -773,11 +774,12 @@ impl Filesystem for MusefsFs {
             };
             if admitted.is_none() {
                 // Debug, not warn: a parallel walk over a large mount produces
-                // thousands of these in seconds, and the walk still succeeds.
+                // thousands of these in seconds, the walk still succeeds, and
+                // the listing is simply rebuilt per `readdir` from here on.
                 // `musefs_dir_handle_rejections_total` is the operator-facing
                 // signal that the degraded path is in use (#626).
                 log::debug!(
-                    "opendir({ino}) over the {MAX_DIR_HANDLES}-handle cap: serving it                      statelessly, listing rebuilt per readdir",
+                    "opendir({ino}) over the {MAX_DIR_HANDLES}-handle cap: serving it statelessly",
                     ino = ino.0
                 );
             }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -297,6 +297,20 @@ fn build_dir_listing(
     Ok(listing)
 }
 
+/// Answer a `readdir` with the page of `listing` starting at `offset`. Slicing
+/// from `offset` directly keeps a paginated enumeration O(n) rather than O(n^2):
+/// the skipped prefix is never re-walked (#442). The offset stored with each
+/// entry is the index of the *next* entry to return.
+fn reply_dir_page(mut reply: ReplyDirectory, listing: &[(u64, FileType, String)], offset: u64) {
+    let start = usize_from(offset).min(listing.len());
+    for (i, (child, kind, name)) in (start..).zip(&listing[start..]) {
+        if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
+            break;
+        }
+    }
+    reply.ok();
+}
+
 /// Admit a directory handle under the caller's `dir_handles` lock, enforcing
 /// `MAX_DIR_HANDLES` (#307). Returns the freshly allocated handle id on admit, or
 /// `None` when the table is at `cap` (the caller falls back to the stateless
@@ -957,18 +971,11 @@ impl Filesystem for MusefsFs {
         ino: INodeNo,
         fh: FileHandle,
         offset: u64,
-        mut reply: ReplyDirectory,
+        reply: ReplyDirectory,
     ) {
         self.fire_poll_refresh();
         if self.config.expose_metrics && ino.0 == metrics_dir::METRICS_DIR_INO {
-            let listing = metrics_dir::dir_listing();
-            let start = usize_from(offset).min(listing.len());
-            for (i, (child, kind, name)) in (start..).zip(&listing[start..]) {
-                if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
-                    break;
-                }
-            }
-            return reply.ok();
+            return reply_dir_page(reply, &metrics_dir::dir_listing(), offset);
         }
         let snapshot = self
             .dir_handles
@@ -976,25 +983,24 @@ impl Filesystem for MusefsFs {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(&fh.0)
             .map(Arc::clone);
-        // Lock released; the reply loop below runs without holding it.
-        let listing = match snapshot {
-            Some(l) => l,
-            // Unknown fh (e.g. fh 0): build once inline so we never regress.
-            None => match build_dir_listing(&self.core, ino.0, self.config.expose_metrics) {
-                Ok(l) => Arc::new(l),
-                Err(e) => return reply.error(reply_errno("readdir", ino.0, &e)),
-            },
+        // Lock released; the reply below runs without holding it.
+        let Some(listing) = snapshot else {
+            // Unknown fh — the stateless sentinel, from a synthetic directory or
+            // an over-cap `opendir` (#616). Rebuilding walks the virtual tree and
+            // resolves the parent, so it is offloaded like every other blocking
+            // op rather than run on the single dispatch thread: since #616 this
+            // is the normal path for exactly the wide directories that make it
+            // expensive (#623). `ReplyDirectory` is `Send`, so the worker answers.
+            let core = Arc::clone(&self.core);
+            let expose_metrics = self.config.expose_metrics;
+            return self.pool.execute(move || {
+                match build_dir_listing(&core, ino.0, expose_metrics) {
+                    Ok(listing) => reply_dir_page(reply, &listing, offset),
+                    Err(e) => reply.error(reply_errno("readdir", ino.0, &e)),
+                }
+            });
         };
-        // Slice from `offset` directly so paginated calls don't re-walk the
-        // skipped prefix; full enumeration stays O(n), not O(n^2) (#442).
-        let start = usize_from(offset).min(listing.len());
-        for (i, (child, kind, name)) in (start..).zip(&listing[start..]) {
-            // The stored offset is the index of the *next* entry to return.
-            if reply.add(INodeNo(*child), (i + 1) as u64, *kind, name) {
-                break;
-            }
-        }
-        reply.ok();
+        reply_dir_page(reply, &listing, offset);
     }
 }
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -283,13 +283,21 @@ fn build_dir_listing(
 /// drawn from `counter` only on the admit path, and the whole check-then-insert
 /// runs under the single lock the caller holds, so concurrent `opendir` closures
 /// cannot race the count past the cap and a rejected open burns no id.
+///
+/// The miss path bumps `rejections`, surfaced as
+/// `musefs_dir_handle_rejections_total`. Saturation is bursty — a parallel walk
+/// can rack up thousands of rejections between two samples of the
+/// `musefs_dir_handles` gauge, which reads healthy the whole time — so the
+/// monotonic counter is the only after-the-fact signal that the cap bit (#626).
 fn try_admit_dir_handle(
     handles: &mut std::collections::HashMap<u64, Arc<DirListing>>,
     counter: &AtomicU64,
+    rejections: &AtomicU64,
     cap: usize,
     listing: DirListing,
 ) -> Option<u64> {
     if handles.len() >= cap {
+        rejections.fetch_add(1, Ordering::Relaxed);
         return None;
     }
     let fh = counter.fetch_add(1, Ordering::Relaxed);
@@ -387,6 +395,11 @@ pub struct MusefsFs {
     /// handle, never evict a different open dir (#192). A 64-bit monotonic counter
     /// cannot wrap within any real process lifetime.
     dir_fh: Arc<AtomicU64>,
+    /// `opendir` calls that found `dir_handles` at `MAX_DIR_HANDLES`. Surfaced as
+    /// `musefs_dir_handle_rejections_total`: the `dir_handles` gauge alone cannot
+    /// show saturation, because it is bursty enough to sit at 0 in every sample
+    /// while thousands of opens are turned away between them (#626).
+    dir_handle_rejections: Arc<AtomicU64>,
     /// In-flight foreground-read counter. `read` reserves a slot before enqueuing;
     /// over `MAX_INFLIGHT_READS` the read is rejected with `EAGAIN`, capping the
     /// otherwise-unbounded pool queue (#308).
@@ -427,6 +440,7 @@ impl MusefsFs {
             passthrough: platform::passthrough::PassthroughState::new(structure_only),
             dir_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
             dir_fh: Arc::new(AtomicU64::new(1)),
+            dir_handle_rejections: Arc::new(AtomicU64::new(0)),
             inflight_reads: Arc::new(AtomicUsize::new(0)),
             read_errors: Arc::new(AtomicU64::new(0)),
             metrics_handles: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -501,6 +515,7 @@ impl MusefsFs {
             read_errors: self.read_errors.load(Ordering::Relaxed),
             dir_handles,
             dir_handles_max: MAX_DIR_HANDLES as u64,
+            dir_handle_rejections: self.dir_handle_rejections.load(Ordering::Relaxed),
             pool_workers: self.pool.max_count() as u64,
             pool_active: self.pool.active_count() as u64,
             pool_queued: self.pool.queued_count() as u64,
@@ -704,6 +719,7 @@ impl Filesystem for MusefsFs {
         let core = Arc::clone(&self.core);
         let handles = Arc::clone(&self.dir_handles);
         let counter = Arc::clone(&self.dir_fh);
+        let rejections = Arc::clone(&self.dir_handle_rejections);
         let expose_metrics = self.config.expose_metrics;
         self.pool.execute(move || {
             let listing = match build_dir_listing(&core, ino.0, expose_metrics) {
@@ -714,7 +730,7 @@ impl Filesystem for MusefsFs {
                 let mut guard = handles
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
-                try_admit_dir_handle(&mut guard, &counter, MAX_DIR_HANDLES, listing)
+                try_admit_dir_handle(&mut guard, &counter, &rejections, MAX_DIR_HANDLES, listing)
             };
             if let Some(fh) = admitted {
                 reply.opened(FileHandle(fh), FopenFlags::empty());
@@ -1238,7 +1254,8 @@ mod tests {
     fn try_admit_dir_handle_admits_and_allocates_id_below_cap() {
         let mut handles = empty_dir_handles();
         let counter = AtomicU64::new(1); // matches the live `dir_fh` start
-        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        let rejections = AtomicU64::new(0);
+        let fh = try_admit_dir_handle(&mut handles, &counter, &rejections, 2, Vec::new());
         assert_eq!(
             fh,
             Some(1),
@@ -1247,6 +1264,11 @@ mod tests {
         assert_eq!(handles.len(), 1);
         assert!(handles.contains_key(&1));
         assert_eq!(counter.load(Ordering::Relaxed), 2, "id allocated on admit");
+        assert_eq!(
+            rejections.load(Ordering::Relaxed),
+            0,
+            "an admit must not count as a rejection"
+        );
     }
 
     #[test]
@@ -1255,13 +1277,44 @@ mod tests {
         handles.insert(10, Arc::new(Vec::new()));
         handles.insert(11, Arc::new(Vec::new()));
         let counter = AtomicU64::new(12);
-        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        let rejections = AtomicU64::new(0);
+        let fh = try_admit_dir_handle(&mut handles, &counter, &rejections, 2, Vec::new());
         assert_eq!(fh, None, "at cap must reject");
         assert_eq!(handles.len(), 2, "must not insert on reject");
         assert_eq!(
             counter.load(Ordering::Relaxed),
             12,
             "must not burn a dir_fh id on reject"
+        );
+        assert_eq!(
+            rejections.load(Ordering::Relaxed),
+            1,
+            "the reject must be metered (#626)"
+        );
+    }
+
+    #[test]
+    fn try_admit_dir_handle_counts_every_rejection_once() {
+        // The gauge cannot substitute for this: occupancy sits pinned at the cap
+        // while the counter climbs, so only the counter records how many opens
+        // were turned away (#626).
+        let mut handles = empty_dir_handles();
+        let counter = AtomicU64::new(1);
+        let rejections = AtomicU64::new(0);
+        assert!(
+            try_admit_dir_handle(&mut handles, &counter, &rejections, 1, Vec::new()).is_some(),
+            "the first open fits cap 1"
+        );
+        for _ in 0..3 {
+            assert!(
+                try_admit_dir_handle(&mut handles, &counter, &rejections, 1, Vec::new()).is_none(),
+                "the table is full"
+            );
+        }
+        assert_eq!(
+            rejections.load(Ordering::Relaxed),
+            3,
+            "one increment per rejected opendir, not per burst"
         );
     }
 
@@ -1271,14 +1324,20 @@ mod tests {
         handles.insert(10, Arc::new(Vec::new()));
         handles.insert(11, Arc::new(Vec::new()));
         let counter = AtomicU64::new(12);
+        let rejections = AtomicU64::new(0);
         handles.remove(&10); // releasedir frees a slot
-        let fh = try_admit_dir_handle(&mut handles, &counter, 2, Vec::new());
+        let fh = try_admit_dir_handle(&mut handles, &counter, &rejections, 2, Vec::new());
         assert_eq!(fh, Some(12), "a freed slot admits again");
         assert_eq!(handles.len(), 2);
         assert!(!handles.contains_key(&10), "the freed handle stays gone");
         assert!(
             handles.contains_key(&12),
             "the new handle fills the freed slot"
+        );
+        assert_eq!(
+            rejections.load(Ordering::Relaxed),
+            0,
+            "re-admitting into a freed slot is not a rejection"
         );
     }
 

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -13,9 +13,10 @@ use threadpool::ThreadPool;
 
 use crate::convert::{assemble_dir_listing, to_file_attr};
 use fuser::{
-    BackgroundSession, Config, FileHandle, FileType, Filesystem, FopenFlags, Generation, INodeNo,
-    InitFlags, KernelConfig, LockOwner, Notifier, OpenAccMode, OpenFlags, ReplyAttr, ReplyData,
-    ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyXattr, Request, Session,
+    AccessFlags, BackgroundSession, Config, FileHandle, FileType, Filesystem, FopenFlags,
+    Generation, INodeNo, InitFlags, KernelConfig, LockOwner, Notifier, OpenAccMode, OpenFlags,
+    ReplyAttr, ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs,
+    ReplyXattr, Request, Session,
 };
 use musefs_core::CoreError;
 use musefs_core::Fh;
@@ -881,6 +882,18 @@ impl Filesystem for MusefsFs {
     fn removexattr(&self, _req: &Request, _ino: INodeNo, _name: &OsStr, reply: ReplyEmpty) {
         // Read-only: removing an xattr is unsupported. See `setxattr`.
         reply.error(fuser::Errno::ENOTSUP);
+    }
+
+    fn access(&self, _req: &Request, _ino: INodeNo, _mask: AccessFlags, reply: ReplyEmpty) {
+        // Every entry the daemon presents is accessible to whoever can reach the
+        // mount, so there is no per-inode check to make here. The mount carries
+        // `MountOption::RO`, so the kernel refuses write-intent access before it
+        // reaches us; with `allow_other` it also carries `default_permissions`
+        // and enforces the presented owner/mode bits itself (in which case this
+        // is never called at all). Replied explicitly rather than left to
+        // fuser's default, which logs a `[Not Implemented]` warn at the default
+        // log floor — the same stream the serve-failure lines use (#364, #624).
+        reply.ok();
     }
 
     fn read(

--- a/musefs-fuse/tests/dir_handles.rs
+++ b/musefs-fuse/tests/dir_handles.rs
@@ -1,0 +1,177 @@
+//! E2E: a saturated dir-handle table must not cost a client any directory (#616).
+//!
+//! The cap (#307) bounds how many `opendir` snapshots can be pinned at once. A
+//! parallel walker (`bfs` and friends) blows past it on a large mount, and when
+//! an over-cap `opendir` failed with `ENFILE` those directories simply vanished
+//! from the walk. This pins the whole table with held directory fds and then
+//! walks the tree through it: every listing must still be complete, served by
+//! `readdir`'s stateless fallback, and the rejections must show up in the
+//! telemetry counter (#626) rather than as lost files.
+//!
+//! Run with:
+//!   cargo test -p musefs-fuse --test dir_handles -- --ignored --nocapture
+
+use std::fs::File;
+use std::path::Path;
+
+use musefs_core::{Musefs, scan_directory};
+use musefs_fuse::FuseConfig;
+
+mod common;
+use common::{config, make_flac};
+
+/// `MAX_DIR_HANDLES` from `src/lib.rs`, which an integration test cannot name.
+/// The `musefs_dir_handles_max` assertion below fails loudly if the two drift.
+const CAP: usize = 1024;
+/// Directories to render: enough to pin the whole table and still have some left
+/// over to enumerate over-cap.
+const DIRS: usize = CAP + 16;
+/// File descriptors the test itself needs: one per pinned directory, plus room
+/// for the daemon's own backing files and the harness.
+const NEEDED_FDS: u64 = CAP as u64 + 256;
+
+fn artist(i: usize) -> String {
+    format!("Artist{i:04}")
+}
+
+/// Raise `RLIMIT_NOFILE` to `needed` if it is not already there. Returns false
+/// when the hard limit forbids it, in which case the test skips rather than
+/// failing on an environment it cannot control.
+fn raise_nofile(needed: u64) -> bool {
+    use rustix::process::{Resource, Rlimit, getrlimit, setrlimit};
+    let limit = getrlimit(Resource::Nofile);
+    if limit.current.is_none_or(|cur| cur >= needed) {
+        return true;
+    }
+    if limit.maximum.is_some_and(|max| max < needed) {
+        return false;
+    }
+    setrlimit(
+        Resource::Nofile,
+        Rlimit {
+            current: Some(needed),
+            maximum: limit.maximum,
+        },
+    )
+    .is_ok()
+}
+
+/// Every `.flac` under `dir`, recursively, propagating enumeration errors — an
+/// `ENFILE` from `opendir` must fail the test, not silently shrink the count.
+fn count_flacs(dir: &Path) -> usize {
+    let mut n = 0;
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("read_dir({}) failed: {e}", dir.display()));
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|e| panic!("dir entry in {}: {e}", dir.display()));
+        let path = entry.path();
+        if entry.file_type().unwrap().is_dir() {
+            n += count_flacs(&path);
+        } else if path.extension().is_some_and(|e| e == "flac") {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// The value of a single-sample Prometheus metric in `text`.
+fn metric(text: &str, name: &str) -> u64 {
+    let line = text
+        .lines()
+        .find(|l| l.starts_with(name) && l.as_bytes().get(name.len()) == Some(&b' '))
+        .unwrap_or_else(|| panic!("{name} missing from the metrics body"));
+    line[name.len() + 1..].trim().parse().unwrap()
+}
+
+fn read_metrics(mountpoint: &Path) -> String {
+    use std::io::Read;
+    // `/proc`-style: st_size is 0, so read to EOF rather than trusting it.
+    let mut f = File::open(mountpoint.join(".musefs-metrics").join("metrics")).unwrap();
+    let mut buf = Vec::new();
+    loop {
+        let prev = buf.len();
+        buf.resize(prev + 8192, 0);
+        let n = f.read(&mut buf[prev..]).unwrap();
+        buf.truncate(prev + n);
+        if n == 0 {
+            break;
+        }
+    }
+    String::from_utf8(buf).unwrap()
+}
+
+#[test]
+#[ignore = "requires /dev/fuse + libfuse; run with --ignored"]
+fn over_cap_opendir_still_lists_every_directory() {
+    if !raise_nofile(NEEDED_FDS) {
+        eprintln!("skipping: RLIMIT_NOFILE cannot reach {NEEDED_FDS}");
+        return;
+    }
+
+    // One track per artist, so the template renders one directory per artist.
+    let backing = tempfile::tempdir().unwrap();
+    for i in 0..DIRS {
+        let flac = make_flac(
+            &[&format!("ARTIST={}", artist(i)), "TITLE=Song"],
+            &[0xAAu8; 32],
+        );
+        std::fs::write(backing.path().join(format!("{i:04}.flac")), &flac).unwrap();
+    }
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, backing.path()).unwrap();
+    let core = Musefs::open(db, config()).unwrap();
+
+    let mountpoint = tempfile::tempdir().unwrap();
+    let session = musefs_fuse::spawn_with(
+        core,
+        mountpoint.path(),
+        "musefs-dir-handles-e2e",
+        FuseConfig {
+            expose_metrics: true,
+            ..FuseConfig::default()
+        },
+    )
+    .unwrap();
+    let root = mountpoint.path();
+
+    // Baseline: an unsaturated walk sees everything.
+    assert_eq!(count_flacs(root), DIRS, "baseline walk must be complete");
+
+    // Pin the whole table: each held directory fd is one live opendir snapshot.
+    let held: Vec<File> = (0..CAP)
+        .map(|i| {
+            File::open(root.join(artist(i)))
+                .unwrap_or_else(|e| panic!("opendir #{i} (at or under the cap) failed: {e}"))
+        })
+        .collect();
+
+    let saturated = read_metrics(root);
+    assert_eq!(
+        metric(&saturated, "musefs_dir_handles_max"),
+        CAP as u64,
+        "CAP here must track MAX_DIR_HANDLES in src/lib.rs"
+    );
+    assert_eq!(
+        metric(&saturated, "musefs_dir_handles"),
+        CAP as u64,
+        "the held fds must have pinned the whole table"
+    );
+    let before = metric(&saturated, "musefs_dir_handle_rejections_total");
+
+    // Every `opendir` from here on is over the cap. Pre-#616 each one replied
+    // ENFILE and the directory dropped out of the walk entirely.
+    assert_eq!(
+        count_flacs(root),
+        DIRS,
+        "a saturated dir-handle table must not lose directories"
+    );
+
+    let after = read_metrics(root);
+    assert!(
+        metric(&after, "musefs_dir_handle_rejections_total") > before,
+        "the degraded path must be visible in musefs_dir_handle_rejections_total (#626)"
+    );
+
+    drop(held);
+    drop(session);
+}


### PR DESCRIPTION
## What and why

The audit of v1.3.0 (`6eb0823`) surfaced 13 issues; this fixes all of them, plus
one follow-up (#629) opened while merging. The work was done on seven topic
branches and the merge commits are preserved, so each grouping can be reviewed
on its own.

Closes #616, closes #617, closes #618, closes #619, closes #620, closes #621,
closes #622, closes #623, closes #624, closes #625, closes #626, closes #627,
closes #628, closes #629.

### The one that actually bit users

**#616** — `MAX_DIR_HANDLES` capped concurrent directory snapshots at 1024 and
replied `ENFILE` past it, on the reasoning that 1024 sits well above any real
client. It does not: `bfs` — an ordinary parallel `find`, and the default `find`
in several distributions — blew through it immediately and lost ~9% of a
200,000-track mount (7,525 rejections, 17,910 files never enumerated). It
surfaced as "Too many open files in system", pointing operators at their kernel
rather than at the mount. Over-cap `opendir` now degrades to the existing
stateless fallback instead, keeping listings complete and #307's memory bound
intact. #623 (move that fallback off the dispatch thread) and #626 (count the
rejections) land with it, since the fix makes that path hot and it was
unmetered — which is why this went unnoticed.

### Grouped by branch

| Branch | Issues |
| --- | --- |
| `fix/fuse-dir-handles` | #616, #623, #624, #626 |
| `fix/scan-budget-and-projections` | #618, #621 |
| `fix/ogg-page-hardening` | #619, #625 |
| `perf/tree-name-interning` | #617 |
| `perf/shared-rendered-paths` | #629 |
| `test/readahead-budget-concurrency` | #628 |
| `chore/audit-housekeeping` | #620, #622, #627 |

### Worth a reviewer's attention

- **#620 is a privilege-escalation hardening.** Unmount helpers were spawned by
  bare name through `PATH`; the mounting guide recommends running as root for
  kernel passthrough, so a writable `PATH` entry meant attacker code as root on
  `SIGTERM`. `lazy_detach` had the identical exposure and is fixed too, though
  the issue only named `unmount_commands`.
- **#622 grew a mechanism.** A stale `RUSTSEC-2025-0167` ignore and an unmatched
  `ISC` license allowance both warned and exited 0, so neither ever surfaced on
  a PR. Both are dropped, and `advisory-not-detected` / `license-not-encountered`
  are now errors in the `deny` job — scoped to the root graph, which is what
  those lists are authored against, while `audit.yml`'s fuzz-lockfile scan allows
  the advisory diagnostic explicitly because off that graph it is noise, not rot.
  Verified by re-injecting a fake stale entry and confirming the gate fails.
- **#621 was half-done already.** `list_render_keys` existed with exactly the
  projection the issue proposed adding; `render_entries` simply was not wired to
  it. Only `list_backing_paths` was genuinely missing.
- **#628 does not assert what its issue asked for.** `charged <= budget` is not
  guaranteed at concurrent quiescence — `permitted_window` grants before
  charging, so N concurrent misses can grant against the same free room
  (measured 1.94-3.40 MiB against a 4 MiB budget). The test asserts it after a
  serialized settle pass, where it *is* guaranteed. No live bug was found; this
  closes a coverage gap where the sanitizer legs ran a test that builds
  `ReadAheadPool::new(0)`.
- **The memory numbers are smaller than the issues predicted.** #617 (-25%) and
  #629 (-7%) together take the tree from ~1713 to ~1078 bytes per track, about
  -37%. #629's saving removes exactly one path per track, so it tracks path
  length and template depth, not track count — a flat `--template` gains little.
  `musefs-core/tests/tree_footprint.rs` now gates the figure so it cannot creep
  back; the ceiling is deliberately loose (measured 1013-1033 B/track over 15
  runs against a 3072 ceiling).

## Checklist

- [x] The **pre-commit hook ran** on every commit (no `--no-verify`): `cargo
      fmt`, `cargo clippy --all-targets -- -D warnings`, the full workspace
      test suite, `shellcheck`/`yamllint`, and `ruff`.
- [x] If the **format-layer API changed**: `cargo +nightly fuzz build` passes.
      *(No `musefs-format` change here, but `fuzz_targets/ogg_page.rs` was
      rewritten — `cargo +nightly fuzz build` was run and passes; coverage
      against the committed seed went from 51 edges / 69 features to 129 / 267.)*
- [x] If the **`musefs-db` schema changed**: Python mirror regenerated and
      re-vendored. *(N/A — `list_backing_paths` is a new query, not a schema
      change, so no mirror regeneration was needed.)*
- [x] **Changelog entry** added under `## [Unreleased]` in `CHANGELOG.md` — the
      user-visible subset there, the full set with issue links in
      `docs/src/changelog.md` (which gained an `Internal` heading for the fuzz,
      sanitizer, CI and contributor-template work).
- [x] **Docs updated** under `docs/src/`: a "Memory footprint" section in the
      tuning guide, a "Directory listings" section in `architecture/serving.md`,
      sanitizer coverage in `contributing/testing.md`, and the
      `musefs_dir_handles_max` help string no longer claims `ENFILE`.
- [x] Commit subjects follow **conventional commits**.

## The invariant

- [x] This change does not copy or modify original audio bytes. Nothing here
      touches synthesis or the segment model: the FUSE changes are directory
      listing and telemetry, the Ogg change bounds how many candidate pages a
      seek CRC-validates before locating one, and the rest is tree memory, scan
      teardown, and DB projections.

## Verification

Run against the fully merged tree, not just per branch: `cargo fmt --check`,
`cargo clippy --all-targets -- -D warnings`, the full workspace suite, the FUSE
e2e `--ignored` tier, `yamllint` over all tracked YAML, and the mutant-anchor
drift guard (101 exclude_re entries against 3798 mutants — four branches
re-anchored `.cargo/mutants.toml`, and the auto-merge was re-validated against
real mutant coordinates rather than trusted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory listings remain complete when directory-handle capacity is reached, with stateless fallback.
  * Added `access` operation support and a Prometheus metric for fallback events.
  * Reduced memory usage during library refreshes and virtual-tree construction.

* **Bug Fixes**
  * Improved scan failure cleanup and worker shutdown.
  * Secured unmount-helper selection.
  * Limited Ogg validation work on malformed files.

* **Documentation**
  * Added tuning, architecture, testing, issue-report, feature-request, and pull-request guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->