### PR TITLE
chore(deps): batch the outstanding dependabot bumps + group future ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,42 @@
 version: 2
 updates:
+  # One grouped PR per ecosystem per week. `directories` lets a single update
+  # config span manifests, and a group spanning them collapses the lot into one
+  # PR instead of one per dependency per directory.
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
+      - "/fuzz"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/fuzz"
-    schedule:
-      interval: "weekly"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
   - package-ecosystem: "pip"
-    directory: "/contrib/beets"
+    directories:
+      - "/contrib/beets"
+      - "/contrib/lidarr"
+      - "/contrib/python-musefs"
+      - "/contrib/picard"
+      - "/tests/interop"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/contrib/lidarr"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/contrib/python-musefs"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/contrib/picard"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/tests/interop"
-    schedule:
-      interval: "weekly"
+    groups:
+      pip:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   # Tracks the FROM base images in docker/Dockerfile.{glibc,musl}. Numeric tags
   # (alpine:3.x) get version-bump PRs; the debian codename tag (trixie-slim) is
   # not version-comparable, so it stays manual unless digest-pinned.
@@ -39,3 +44,7 @@ updates:
     directory: "/docker"
     schedule:
       interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
       checks: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       lidarr: ${{ steps.filter.outputs.lidarr }}
       perf: ${{ steps.filter.outputs.perf }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           # Full history so the three-dot merge base is present (same reason as
@@ -94,7 +94,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install libfuse3
@@ -127,7 +127,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
@@ -158,7 +158,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -187,7 +187,7 @@ jobs:
     env:
       MUSEFS_REQUIRE_BIN: "1"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install FUSE + ffmpeg
@@ -235,7 +235,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -269,7 +269,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -293,7 +293,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -317,14 +317,14 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install Picard (system Python + PyQt5)
         run: ./scripts/apt-install.sh picard
       - name: Verify Picard module path
         run: test -d /usr/lib/picard/picard || { echo "::error::picard package not at /usr/lib/picard; PYTHONPATH is stale"; exit 1; }
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
       - name: Create venv on the system Python
         run: uv venv --system-site-packages --python "$(which python3)"
       - name: Install plugin test deps + ruff
@@ -344,7 +344,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install FUSE and ffmpeg
@@ -366,7 +366,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -389,7 +389,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -420,7 +420,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install libfuse3
@@ -458,10 +458,10 @@ jobs:
     # workflow default. A clean run is ~6 min (image download + in-VM build).
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-      - uses: vmactions/freebsd-vm@b84ab5559b5a1bb4b8ee2737d2506a16e1737636
+      - uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093
         with:
           usesh: true
           # Pass/fail e2e gate — we keep no build artifacts, so skip the rsync
@@ -487,7 +487,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install libfuse3
@@ -70,7 +70,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3
+        uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20
         with:
           tool: cargo-llvm-cov
       - name: Collect coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install mdbook + mdbook-linkcheck

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,7 +26,7 @@ jobs:
     # Per-PR: build all targets + a few seconds each to catch broken targets.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -77,7 +77,7 @@ jobs:
       matrix:
         target: [flac, mp3, mp4, ogg, wav, ogg_page, b64, vorbiscomment, serve]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/.github/workflows/lidarr-e2e.yml
+++ b/.github/workflows/lidarr-e2e.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/.github/workflows/lidarr-smoke.yml
+++ b/.github/workflows/lidarr-smoke.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       harness: ${{ steps.filter.outputs.harness }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           # Full history so the three-dot merge base is present (same reason as
@@ -73,7 +73,7 @@ jobs:
       has_mutants: ${{ steps.plan.outputs.has_mutants }}
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           # Full history so the merge base for the three-dot diff is present;
@@ -135,7 +135,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.in-diff-plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           # Full history so the merge base for the three-dot diff is present;
@@ -197,7 +197,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.harness == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -223,7 +223,7 @@ jobs:
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -269,7 +269,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.full-plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -16,7 +16,7 @@ jobs:
   version-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Verify tag matches every contrib package version
@@ -43,7 +43,7 @@ jobs:
     needs: version-gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -66,7 +66,7 @@ jobs:
     needs: version-gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -89,7 +89,7 @@ jobs:
     needs: version-gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -112,14 +112,14 @@ jobs:
     needs: version-gate
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install Picard (system Python + PyQt5)
         run: ./scripts/apt-install.sh picard
       - name: Verify Picard module path
         run: test -d /usr/lib/picard/picard || { echo "::error::picard package not at /usr/lib/picard; PYTHONPATH is stale"; exit 1; }
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
       - name: Create venv on the system Python
         run: uv venv --system-site-packages --python "$(which python3)"
       - name: Install plugin test deps + ruff
@@ -146,7 +146,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       checks: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -93,7 +93,7 @@ jobs:
     needs: smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install libfuse3
@@ -151,7 +151,7 @@ jobs:
           - triple: riscv64gc-unknown-linux-musl
             zig_target: riscv64gc-unknown-linux-musl
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
@@ -228,7 +228,7 @@ jobs:
     # which `needs: smoke`). The native host/alpine legs stay hard-gating.
     continue-on-error: ${{ matrix.mode == 'emulated' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Download artifact
@@ -296,7 +296,7 @@ jobs:
             riscv64_triple: riscv64gc-unknown-linux-musl
             ffmpeg_install: apk add --no-cache ffmpeg >/dev/null
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
@@ -352,7 +352,7 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
@@ -433,7 +433,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Install libfuse3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"

--- a/musefs-core/Cargo.toml
+++ b/musefs-core/Cargo.toml
@@ -38,7 +38,7 @@ rusqlite = { version = "0.40", features = ["bundled", "blob"] }
 musefs-format = { path = "../musefs-format", features = ["fuzzing"] }
 ogg = "0.9"
 crc = "3"
-base64 = "0.22"
+base64 = "0.23"
 
 [[bench]]
 name = "read_throughput"

--- a/musefs-format/Cargo.toml
+++ b/musefs-format/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 [dependencies]
 thiserror = "2"
 id3 = "1"
-base64 = "0.22"
+base64 = "0.23"
 
 [features]
 # Exposes pure check helpers + minimal-file fixtures for proptest, the fuzz

--- a/musefs-fuse/Cargo.toml
+++ b/musefs-fuse/Cargo.toml
@@ -31,7 +31,7 @@ musefs-format = { path = "../musefs-format", features = ["fuzzing"] }
 ogg = "0.9"
 sha2 = "0.11"
 memmap2 = "0.9"
-base64 = "0.22"
+base64 = "0.23"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Rolls the seven open dependabot PRs into one, and changes the dependabot
config so future weeks arrive grouped instead of one PR per dependency per
directory.

## Bumps

| Dependency | From | To | Supersedes |
| --- | --- | --- | --- |
| `base64` (workspace + `/fuzz`) | 0.22.1 | 0.23.1 | #634, #633 |
| `actions/checkout` | 7.0.0 | 7.0.1 | #635 |
| `astral-sh/setup-uv` | 8.2.0 | 10.0.1 | #638 |
| `docker/setup-buildx-action` | 4.1.0 | 4.3.0 | #632 |
| `taiki-e/install-action` | 2.82.3 | 2.86.2 | #636 |
| `vmactions/freebsd-vm` | 1.4.8 | 1.5.3 | #637 |

`base64` is the only semver-major of the set. Every call site names the
`general_purpose::STANDARD` engine explicitly (`musefs-format/src/ogg/b64.rs`
and friends) rather than leaning on a default, so the encoding is unchanged
and no code had to move — relevant because Ogg art rides on
`METADATA_BLOCK_PICTURE` base64, where a silent encoder change would be a
correctness bug rather than a build break.

The `/fuzz` lockfile is bumped in step, since that crate is outside the
workspace and the pre-commit gate does not cover it.

Also drops a stale `# v4` pin comment beside the checkout SHA in `docs.yml`
that had been wrong since the v7 bump.

## Grouping

`.github/dependabot.yml` now uses `directories` to span the two cargo
manifests and the five pip ones from a single update config, plus a
catch-all group per ecosystem. That caps a normal week at four PRs.

Ecosystems stay separate on purpose: cargo and github-actions bumps
exercise different CI legs, and the pre-commit gate runs the full workspace
suite, so mixing them makes a red run harder to attribute. The known
tradeoff is that one unmergeable dependency now blocks its whole group —
the fix, if it bites, is splitting the offender into its own named group.

## Verification

All local, on the merged branch:

- `cargo build --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — quiet
- `cargo test` — 1281 passed, 0 failed
- `cargo test --workspace -- --ignored` — the full e2e tier green, including
  the FUSE mount tests (`end_to_end_read_through_mount`, the Ogg page/audio
  validators, `randomized_reads_match_oracle_all_formats`,
  `mmap_whole_file_matches_pread`, the SIGTERM/unmount pair) and
  `all_supported_formats_decode_to_same_pcm_sha_as_source`, the ffmpeg PCM
  check that would catch a base64/art regression corrupting audio
- `scripts/contract-roundtrip.sh` — 2 passed (Python-written tags and art
  survive Rust synthesis)
- `MUSEFS_INTEROP_DIR=... pytest tests/interop` — 4 passed, mutagen reading
  back synthesized tags, binary frames, and M4A multi-cover art
- `cargo +nightly fuzz build` — builds
- `yamllint` over all tracked YAML — clean

The interop and contract suites ran against a venv built from
`tests/interop/requirements.txt` (mutagen 1.48.0), since mutagen is not in
the system Python here.

Closes #632
Closes #633
Closes #634
Closes #635
Closes #636
Closes #637
Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation components to newer pinned revisions.
  * Consolidated weekly dependency update notifications by ecosystem and directory.

* **Maintenance**
  * Updated Base64 support to version 0.23 across applicable components.
  * Improved consistency and security of automated checks, builds, releases, documentation, and coverage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
