### PR TITLE
fix(id3): step over a leading tag whose version we cannot parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A leading ID3v2 tag on an MP3 (or a FLAC) is stepped over by its declared size
+  even when its major version is not one musefs can parse the frames of, instead
+  of the whole file being rejected. The ID3v2 header has the same shape in every
+  version, so its size is enough to step over the tag, and the spec's rule for a
+  version a reader does not understand is to ignore it. Such a tag's frames are
+  still not read.
 - A parallel directory walk over a large mount no longer loses entries. Once
   1024 directory handles were open, further `opendir` calls were rejected with
   `ENFILE` — `bfs` over a 200,000-track mount silently lost about 9% of the

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -52,6 +52,12 @@ see the [Release notes](release-notes.md).
 
 ### Fixed
 
+- A leading ID3v2 tag on an MP3 (or a FLAC) is stepped over by its declared size
+  even when its major version is not one musefs can parse the frames of, instead
+  of the whole file being rejected. The ID3v2 header has the same shape in every
+  version, so its size is enough to step over the tag, and the spec's rule for a
+  version a reader does not understand is to ignore it. Such a tag's frames are
+  still not read.
 - Over-cap `opendir` degrades to a stateless directory handle instead of
   replying `ENFILE` ([#616](https://github.com/Sohex/musefs/issues/616)). The 1024-handle cap was assumed to sit
   well above any real client, but `bfs` — an ordinary parallel `find`, and the

--- a/docs/src/formats/flac.md
+++ b/docs/src/formats/flac.md
@@ -34,7 +34,15 @@ a converter. musefs scans them rather than skipping them:
 
 - The tag run is stepped over to find the `fLaC` marker, and the recorded audio
   offset counts it, so the audio segment still reads the right range out of the
-  backing file.
+  backing file. A tag is stepped over by its **declared size**, whatever its
+  version: the ID3v2 header has the same shape in every version, and the spec's
+  own rule for a version a reader does not understand is to ignore the tag. A
+  header musefs cannot parse the *frames* of is therefore still skipped
+  correctly — only its contents go unread. What is required is that the header
+  matches the spec's detection pattern (`$49 44 33 yy yy xx zz zz zz zz`, both
+  version bytes below `$FF`, every size byte below `$80`) and that its declared
+  length lands on the marker. A header that fails either test contradicts the
+  file it is in, and the file is skipped rather than guessed at.
 - The tag's **text frames and `APIC` pictures are ingested as a fallback**: the
   FLAC's own `VORBIS_COMMENT` / `PICTURE` blocks win, and the ID3 tag only
   supplies keys the FLAC does not define. The rule is all-or-nothing per key, so

--- a/docs/src/formats/flac.md
+++ b/docs/src/formats/flac.md
@@ -41,8 +41,10 @@ a converter. musefs scans them rather than skipping them:
   correctly — only its contents go unread. What is required is that the header
   matches the spec's detection pattern (`$49 44 33 yy yy xx zz zz zz zz`, both
   version bytes below `$FF`, every size byte below `$80`) and that its declared
-  length lands on the marker. A header that fails either test contradicts the
-  file it is in, and the file is skipped rather than guessed at.
+  length lands where the next thing in the file starts — the following ID3v2
+  header, or the `fLaC` marker for the last tag in the run. A header that fails
+  either test contradicts the file it is in, and the file is skipped rather than
+  guessed at.
 - The tag's **text frames and `APIC` pictures are ingested as a fallback**: the
   FLAC's own `VORBIS_COMMENT` / `PICTURE` blocks win, and the ID3 tag only
   supplies keys the FLAC does not define. The rule is all-or-nothing per key, so

--- a/musefs-core/tests/flac_id3_prefix.rs
+++ b/musefs-core/tests/flac_id3_prefix.rs
@@ -240,3 +240,64 @@ fn bounded_widening_matches_the_full_probe_over_a_large_tag() {
     assert_eq!(oracle.1, 512, "the oracle located the audio");
     assert_eq!(oracle, rows(&bounded_db));
 }
+
+#[test]
+fn scans_a_flac_behind_a_tag_whose_version_we_cannot_parse() {
+    // `ID3` and nothing but zeros: the spec's detection pattern accepts it and
+    // its declared size lands exactly on `fLaC`, so it is stepped over like any
+    // other tag. Only its frames go unread — version 0 has no layout we know.
+    let dir = tempfile::tempdir().unwrap();
+    let audio = vec![0xCD; 4096];
+    let mut bytes = vec![b'I', b'D', b'3', 0, 0, 0, 0, 0, 0, 0];
+    bytes.extend(make_flac(
+        &[
+            (0, streaminfo_body()),
+            (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
+        ],
+        &audio,
+    ));
+    std::fs::write(dir.path().join("a.flac"), &bytes).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+
+    assert_eq!(stats.scanned, 1, "the file is no longer skipped");
+    assert_eq!(stats.failed, 0);
+    let track = &db.list_tracks().unwrap()[0];
+    assert_eq!(track.bounds.audio_length(), audio.len() as u64);
+    assert_eq!(
+        track.bounds.audio_offset(),
+        (bytes.len() - audio.len()) as u64
+    );
+    let tags = db.get_tags(track.id).unwrap();
+    assert!(tags.iter().any(|t| t.key == "title" && t.value == "Song"));
+}
+
+#[test]
+fn serves_untouched_audio_from_behind_an_unparseable_tag() {
+    let dir = tempfile::tempdir().unwrap();
+    let audio = vec![0xCD; 4096];
+    let mut bytes = vec![b'I', b'D', b'3', 0, 0, 0, 0, 0, 0, 0];
+    bytes.extend(make_flac(
+        &[
+            (0, streaminfo_body()),
+            (4, vorbis_comment_body("v", &["ARTIST=Alice", "TITLE=Song"])),
+        ],
+        &audio,
+    ));
+    std::fs::write(dir.path().join("a.flac"), &bytes).unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    scan_directory(&db, dir.path()).unwrap();
+    let fs = Musefs::open(db, config()).unwrap();
+
+    let artist = fs.lookup(VirtualTree::ROOT, "Alice").unwrap();
+    let (_, inode, _) = fs.readdir(artist).unwrap().into_iter().next().unwrap();
+    let served = read_whole(&fs, inode);
+
+    assert_eq!(&served[0..4], b"fLaC", "no ID3 prefix on the served file");
+    metaflac::Tag::read_from(&mut std::io::Cursor::new(&served)).expect("valid FLAC");
+    let scan = musefs_format::flac::locate_audio(&served).unwrap();
+    let start = usize::try_from(scan.audio_offset).unwrap();
+    assert_eq!(&served[start..], &audio[..]);
+}

--- a/musefs-format/src/id3v2.rs
+++ b/musefs-format/src/id3v2.rs
@@ -50,7 +50,11 @@ pub(crate) fn body_end(data: &[u8]) -> Result<Option<usize>> {
     if data.len() < HEADER_LEN || &data[0..3] != b"ID3" {
         return Ok(None);
     }
-    if !matches!(data[3], 2..=4) {
+    // The spec's own detection pattern is `$49 44 33 yy yy xx zz zz zz zz`,
+    // where neither version byte is $FF and every size byte is below $80. Bytes
+    // that fail it are not an ID3v2 tag of *any* version, so there is no
+    // declared length here worth trusting.
+    if data[3] == 0xFF || data[4] == 0xFF {
         return Err(FormatError::Malformed);
     }
     // A well-formed synchsafe size has the high bit clear in every byte; reject
@@ -58,9 +62,23 @@ pub(crate) fn body_end(data: &[u8]) -> Result<Option<usize>> {
     if data[6..HEADER_LEN].iter().any(|&b| b & 0x80 != 0) {
         return Err(FormatError::Malformed);
     }
+    // Deliberately no check that the version is one we can parse: the header is
+    // laid out the same way in every version, so its size is enough to step
+    // *over* the tag. Stepping *into* it needs the frame layout, which is what
+    // [`frames_are_parseable`] gates.
     Ok(Some(
         HEADER_LEN + synchsafe_decode(&data[6..HEADER_LEN]) as usize,
     ))
+}
+
+/// Is this tag's major version one whose frame layout the crate knows? Callers
+/// that parse frame contents must gate on this; callers that only need to know
+/// where the tag ends must not, or they reject a tag the spec says to skip.
+///
+/// The ID3v2 rule for a version you do not understand is to ignore the tag —
+/// which means stepping over it by its declared size, not refusing the file.
+pub(crate) fn frames_are_parseable(data: &[u8]) -> bool {
+    data.len() >= HEADER_LEN && matches!(data[3], 2..=4)
 }
 
 /// Total on-disk length of the ID3v2 tag at the front of `data`: header, body,
@@ -70,7 +88,9 @@ pub(crate) fn total_len(data: &[u8]) -> Result<Option<usize>> {
     let Some(end) = body_end(data)? else {
         return Ok(None);
     };
-    let has_footer = data[5] & 0x10 != 0;
+    // Only ID3v2.4 defines a footer, so only there does that flag bit mean one
+    // is present. In an unknown version the flags are not ours to interpret.
+    let has_footer = data[3] == 4 && data[5] & 0x10 != 0;
     Ok(Some(if has_footer { end + FOOTER_LEN } else { end }))
 }
 
@@ -192,14 +212,43 @@ mod tests {
     }
 
     #[test]
-    fn bad_version_and_size_are_malformed() {
-        let mut bad_version = header(4, 0);
-        bad_version[3] = 9;
-        assert!(leading_tags_len(&bad_version).is_err());
+    fn a_version_we_cannot_parse_is_still_stepped_over() {
+        // The header layout does not vary by version, so an unknown one still
+        // says how long it is. The spec's rule for a version you do not
+        // understand is to ignore the tag, and ignoring it means skipping it.
+        let mut unknown = tag(20, 0);
+        unknown[3] = 9;
+        assert_eq!(
+            leading_tags_len(&unknown).unwrap(),
+            Extent::Complete(HEADER_LEN + 20)
+        );
+        assert!(!frames_are_parseable(&unknown), "but not parsed");
+    }
+
+    #[test]
+    fn bytes_outside_the_detection_pattern_are_malformed() {
+        // `$49 44 33 yy yy xx zz zz zz zz`, yy < $FF and zz < $80. Fail that and
+        // this is not an ID3v2 tag of any version, so its "size" means nothing.
+        let mut bad_major = header(4, 0);
+        bad_major[3] = 0xFF;
+        assert!(leading_tags_len(&bad_major).is_err());
+
+        let mut bad_revision = header(4, 0);
+        bad_revision[4] = 0xFF;
+        assert!(leading_tags_len(&bad_revision).is_err());
 
         let mut bad_size = header(4, 0);
         bad_size[7] = 0x80; // high bit set in a synchsafe byte
         assert!(leading_tags_len(&bad_size).is_err());
+    }
+
+    #[test]
+    fn only_v2_4_has_a_footer() {
+        // Bit 4 of the flags means "footer present" in ID3v2.4 and nothing at
+        // all elsewhere, so it must not add ten bytes to a v2.3 tag's length.
+        let mut v23 = header(20, 0x10);
+        v23[3] = 3;
+        assert_eq!(total_len(&v23).unwrap(), Some(HEADER_LEN + 20));
     }
 
     #[test]

--- a/musefs-format/src/mp3.rs
+++ b/musefs-format/src/mp3.rs
@@ -510,6 +510,13 @@ fn id3v2_alloc_safe(data: &[u8]) -> bool {
         // Not an ID3v2 tag at offset 0, or a malformed header: skip parsing.
         return false;
     };
+    // `body_end` admits any version the spec's detection pattern allows, since
+    // stepping over a tag needs only its size. Walking its frames does not: an
+    // unrecognised major version has no frame layout we can validate, so the
+    // bounds below would be guesses and the allocation guard meaningless.
+    if !id3v2::frames_are_parseable(data) {
+        return false;
+    }
     let flags = data[5];
     // Extended header (0x40) and unsynchronisation (0x80) complicate frame
     // bounds; skip rather than risk mis-validating.
@@ -2413,10 +2420,28 @@ mod tests {
     }
 
     #[test]
-    fn locate_audio_rejects_unsupported_major_version() {
+    fn locate_audio_steps_over_an_unsupported_major_version() {
+        // A version we cannot parse still declares its own length, and the spec
+        // says to ignore such a tag — so the audio behind it is located rather
+        // than the file rejected. Its frames stay unparsed (`id3v2_alloc_safe`).
         let mut data = Vec::new();
         data.extend_from_slice(b"ID3");
         data.extend_from_slice(&[0x05, 0x00, 0x00]); // major 5 (unsupported)
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+        let bounds = locate_audio(&data).expect("the tag is skippable");
+        assert_eq!(bounds.audio_offset, 10);
+        assert!(!id3v2_alloc_safe(&data), "frames are not walked");
+        assert!(read_tags(&data).is_empty());
+    }
+
+    #[test]
+    fn locate_audio_rejects_a_version_byte_of_ff() {
+        // $FF is excluded by the spec's own detection pattern: these bytes are
+        // not an ID3v2 header, so there is no length here to step over.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ID3");
+        data.extend_from_slice(&[0xFF, 0x00, 0x00]);
         data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
         data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
         assert_eq!(locate_audio(&data), Err(FormatError::Malformed));

--- a/musefs-format/tests/flac_id3_prefix.rs
+++ b/musefs-format/tests/flac_id3_prefix.rs
@@ -248,3 +248,67 @@ fn bounded_accepts_metadata_that_fills_the_whole_file() {
     assert_eq!(scan.audio_offset, file.len() as u64);
     assert_eq!(scan.audio_length, 0);
 }
+
+#[test]
+fn steps_over_a_tag_whose_version_we_cannot_parse() {
+    // `ID3` followed by nothing but zeros — "blank header" read literally. It
+    // satisfies the spec's detection pattern (neither version byte is $FF, every
+    // size byte is below $80) and declares a zero-length body, so the `fLaC`
+    // marker is exactly ten bytes in. There is nothing to guess at here: musefs
+    // used to reject it only because version 0 is not a version it can parse,
+    // which is a question about frames, not about where the tag ends.
+    let audio = vec![0xAB; 128];
+    let prefix = vec![b'I', b'D', b'3', 0, 0, 0, 0, 0, 0, 0];
+    let file = id3_then_flac(&prefix, &["TITLE=Blank"], &audio);
+
+    let scan = locate_audio(&file).unwrap();
+    assert_eq!(scan.audio_offset, (file.len() - audio.len()) as u64);
+    assert_eq!(scan.audio_length, audio.len() as u64);
+    let comments = read_vorbis_comments(&file).unwrap();
+    assert!(comments.contains(&("title".to_string(), "Blank".to_string())));
+}
+
+#[test]
+fn an_unparseable_version_still_bounds_a_non_empty_tag() {
+    // The declared size is what does the work, so it has to be honoured for an
+    // unknown version too — not treated as an empty tag.
+    let audio = vec![0xAB; 128];
+    let mut prefix = vec![b'I', b'D', b'3', 9, 0, 0, 0, 0, 0, 64];
+    prefix.extend(std::iter::repeat_n(0u8, 64));
+    let file = id3_then_flac(&prefix, &[], &audio);
+
+    let scan = locate_audio(&file).unwrap();
+    assert_eq!(scan.audio_offset, (file.len() - audio.len()) as u64);
+}
+
+#[test]
+fn still_rejects_a_version_byte_of_ff() {
+    // $FF is the one version byte the spec's detection pattern excludes, so
+    // these bytes are not a tag header and the file is not FLAC.
+    let file = id3_then_flac(
+        &[b'I', b'D', b'3', 0xFF, 0, 0, 0, 0, 0, 0],
+        &[],
+        &[0xAB; 128],
+    );
+    assert_eq!(locate_audio(&file).unwrap_err(), FormatError::Malformed);
+}
+
+#[test]
+fn still_rejects_a_tag_whose_declared_length_misses_the_marker() {
+    // Slack between the tag's declared end and `fLaC`. The header contradicts
+    // the file, and recovering would mean searching for the marker — guessing.
+    let mut prefix = blank_id3(16);
+    prefix.extend(std::iter::repeat_n(0u8, 1024));
+    let file = id3_then_flac(&prefix, &[], &[0xAB; 128]);
+    assert_eq!(locate_audio(&file).unwrap_err(), FormatError::NotFlac);
+}
+
+#[test]
+fn still_rejects_a_non_synchsafe_size() {
+    // A size written as a plain big-endian integer sets a high bit the spec's
+    // detection pattern forbids, so the declared length cannot be trusted.
+    let mut prefix = vec![b'I', b'D', b'3', 3, 0, 0, 0, 0, 0, 200];
+    prefix.extend(std::iter::repeat_n(0u8, 200));
+    let file = id3_then_flac(&prefix, &[], &[0xAB; 128]);
+    assert_eq!(locate_audio(&file).unwrap_err(), FormatError::Malformed);
+}


### PR DESCRIPTION
The ID3v2 header is laid out the same way in every version — ten bytes with a
synchsafe size at a fixed offset — and the spec's rule for a version a reader
does not understand is to ignore the tag. musefs instead rejected any major
version outside `2..=4` outright, conflating two separate questions: *where the
tag ends*, which is version independent, and *what is inside it*, which is not.

## What changes

- `body_end`/`total_len` now admit any header matching the spec's own detection
  pattern (`$49 44 33 yy yy xx zz zz zz zz`, neither version byte `$FF`, every
  size byte below `$80`) and step over it by its declared size.
- Reading the tag's *frames* still needs a layout we know, which is what the new
  `frames_are_parseable` gates. `mp3::id3v2_alloc_safe` checks it explicitly, so
  the allocation guard stays exactly as strict as it was and such a tag's
  contents simply go unread.
- `total_len` honours the footer flag only for v2.4, the one version that defines
  a footer. Bit 4 is undefined in v2.2/v2.3, and reading the flag bits of a
  version we cannot parse would be guessing.

The MP3 half is the concrete improvement: a file fronted by a tag whose version
we cannot parse now locates its audio instead of being rejected, because the tag
still declares its length and the MPEG frames begin where it says they do. The
FLAC half falls out of the same change.

## Deliberately still skipped

Each pinned by a test: slack between the tag's declared end and the `fLaC`
marker, a size written big-endian rather than synchsafe, and a `$FF` version
byte. Those headers contradict the file they sit in, so recovering them would
mean searching for the marker instead of being told where it is.

## Relationship to #602

No reported file needs this. It came out of a matrix of ID3-prefixed FLACs built
while investigating #602, whose reporter's file turned out to be handled
correctly as of #615 — this is the one shape in that matrix well-formed enough
to be worth supporting. **It does not close #602.**

## Tests

New `flac_id3_prefix` suites at both the format and core layers cover the
accepted shape and each rejected one. Full workspace suite green via the
pre-commit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MP3 and FLAC files with unsupported but valid leading ID3v2 tags are now accepted.
  * Audio processing skips these tags using their declared size while preserving the underlying audio and metadata.
  * Unsupported tag contents are left unread, while malformed or inconsistent tag headers continue to be rejected safely.

* **Documentation**
  * Updated format documentation and changelogs to describe supported leading ID3v2 tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->