### PR TITLE
fix(scan): fail the file, not the scan, when metadata exceeds a cap

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-'musefs-core/src/scan\.rs:712:31:',
+'musefs-core/src/scan\.rs:729:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:719:30:',
+'musefs-core/src/scan\.rs:736:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,27 +127,18 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:730:21:',
+'musefs-core/src/scan\.rs:747:21:',
     # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
     # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
     # no effect on the returned `Probed`/skip decision or any persisted state, so
     # every mutation of the condition is unobservable — a pure observability shim,
     # like the metrics counters above.
     # guard: op=">" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:735:17:',
-    # log_mp4_oversize_drops is a pure observability shim: it emits a `log::warn!`
-    # per oversized mp4 `covr` / `----` payload the format layer skipped before
-    # materialization (#343) and returns nothing. With no log-capture harness in the
-    # suite its emission is unobservable to any test, so `replace ... with ()` is
-    # MISSED-yet-unkillable — the same class as the probe_body oversize-diag warn
-    # above and the metrics counters. The drop DECISIONS it reports are pinned in
-    # musefs-format (read_pictures_reporting / read_binary_tags_reporting tests).
-    # guard: count=1
-    'replace log_mp4_oversize_drops with \(\)',
+'musefs-core/src/scan\.rs:752:17:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1530:46:',
+'musefs-core/src/scan\.rs:1688:46:',
     # probe_body's tail-read predicate
     # `has_ext(mp3) || (has_ext(flac) && has_leading_id3(prefix))`, the inner `&&`
     # (col 66) -> `||`: widening it makes every .flac pay the 128-byte tail read,
@@ -160,7 +151,7 @@ exclude_re = [
     # behavioral (it decides whether an .mp3 gets its ID3v1 trailer trimmed) and
     # stays in scope, killed by scan.rs's mp3_id3v1_trailer_is_not_served_as_audio.
     # guard: op="&&" fn="probe_body" rows=1
-'musefs-core/src/scan\.rs:691:66:',
+'musefs-core/src/scan\.rs:708:66:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -173,30 +164,30 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1627:22:',
+'musefs-core/src/scan\.rs:1799:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1666:33:',
+'musefs-core/src/scan\.rs:1845:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1666:48:',
+'musefs-core/src/scan\.rs:1845:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1666:63:',
+'musefs-core/src/scan\.rs:1845:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1680:37:',
+'musefs-core/src/scan\.rs:1859:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1682:41:',
+'musefs-core/src/scan\.rs:1861:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1682:56:',
+'musefs-core/src/scan\.rs:1861:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1682:71:',
+'musefs-core/src/scan\.rs:1861:71:',
     # Same cadence class, one level up: each threshold flush is a let-chain
     # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
     # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
     # IS met — deferring the commit to the flush-on-empty / final flush, which
     # persist the identical track set and still surface a flush error (#618).
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1667:21:',
+'musefs-core/src/scan\.rs:1846:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1683:29:',
+'musefs-core/src/scan\.rs:1862:29:',
     # `ByteBudget::acquire`'s wait guard (`!st.closed && in_flight != 0 && ...`),
     # the FIRST `&&`->`||`. `&&` binds tighter than `||`, so the guard becomes
     # `!closed || (in_flight != 0 && over_cap)` and every reservation against an
@@ -217,11 +208,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:1828:29:',
+'musefs-core/src/scan\.rs:2007:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:1837:33:',
+'musefs-core/src/scan\.rs:2016:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:1893:29: replace \+ with -',
+'musefs-core/src/scan\.rs:2072:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ __pycache__/
 dist/
 build/
 
+# beets' pre-migration DB backups. Its test suite opens an in-memory library, so
+# beets names each backup after the literal `:memory:` and writes it to the CWD
+# — the repo root when the suite is run from there, where a broad `git add`
+# will happily stage a dozen binary blobs.
+/:memory:-*.bak
+
 # cargo-mutants scratch + reports
 .mutants-tmp/
 mutants-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The `tags.value` cap rises from 256 KiB to 16 MiB − 1, and
+  `track_art.description` from 1 KiB to 8 KiB (schema `MIGRATION_V3`). The new
+  tag cap is FLAC's 24-bit metadata-block ceiling — the largest tag synthesis
+  could ever serve — so the store no longer refuses a tag the format itself can
+  carry. Existing stores upgrade in place, and automatically, on the next
+  `musefs scan` or `musefs mount`: both open the store read-write and run the
+  migration, which only widens the constraints and so carries every existing row
+  across. No rescan of audio is needed and nothing has to be regenerated.
+- A backing file whose metadata exceeds a store limit now fails **that file**
+  instead of being stored with the offending part quietly dropped. Oversize
+  embedded art and binary tags were previously omitted from an otherwise-stored
+  track with only a `warn` to show for it, which is easy to lose in a scan of
+  ten thousand files and leaves a mount silently missing data. Such a file is
+  now logged with its path, what was too big, its size and the limit, counted
+  `failed`, and skipped; the rest of the directory scans normally.
 - Serve-path failure warnings are rate-limited: a burst of 10 per 30-second
   window logs at warn, the rest drop to debug, and the first warn of each new
   window carries the suppressed count. A library walk over missing backing
@@ -58,6 +73,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A tag larger than the store's cap no longer aborts the entire scan
+  ([#644](https://github.com/Sohex/musefs/issues/644)). The scanner had no
+  length check on text tags, so an over-cap value reached the DB `CHECK` inside
+  a batch commit and failed the whole run with
+  `CHECK constraint failed: length(CAST(value AS BLOB)) <= 262144` — naming
+  neither the offending file nor what the number meant. Every cap the scanner
+  can trip is now checked in one place before anything is written, and a
+  violation fails only that file, with a message naming it. The same applies to
+  the `tags.key`, `art.mime` and `track_art.description` caps, which had the
+  identical unattributed-abort failure mode. Should a store write still fail
+  fatally, the error now names the file it died on.
+- A FLAC whose tags outgrow what a `VORBIS_COMMENT` block can hold is rejected
+  at scan time rather than stored and then served `EIO` on every read. This is
+  reachable by merging a leading ID3v2 tag's fields into a FLAC's own comments
+  ([#602](https://github.com/Sohex/musefs/issues/602)): ID3v2's tag size is
+  synchsafe 28-bit (256 MiB) while a FLAC metadata block is 24-bit.
 - A leading ID3v2 tag on an MP3 (or a FLAC) is stepped over by its declared size
   even when its major version is not one musefs can parse the frames of, instead
   of the whole file being rejected. The ID3v2 header has the same shape in every

--- a/contrib/CHANGELOG.md
+++ b/contrib/CHANGELOG.md
@@ -10,6 +10,23 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+### Added
+
+- **`musefs_common.MAX_TAG_VALUE_LEN`** — the store's byte cap on a
+  `tags.value`, generated from the Rust constant into the schema mirror rather
+  than hand-kept. A writer can now check a value against the contract instead of
+  discovering the limit as an `IntegrityError` from the `CHECK`. The cap moved
+  in the same change (musefs #644), which is exactly why it should not be a
+  literal in anyone's source.
+
+### Changed
+
+- The store schema is now at `user_version` 3 (musefs #644 widens the
+  `tags.value` and `track_art.description` caps). `EXPECTED_USER_VERSION`
+  tracks it automatically; no plugin change is needed, but a store must be
+  migrated by `musefs scan`/`musefs mount` from a build carrying that migration
+  before these packages will open it.
+
 ## [1.1.0] - 2026-06-17
 
 ### Changed

--- a/contrib/lidarr/tests/test_sync.py
+++ b/contrib/lidarr/tests/test_sync.py
@@ -1,4 +1,10 @@
-from musefs_common import SCAN_TIMEOUT_SECONDS, ArtImage, connect, realpath_key
+from musefs_common import (
+    MAX_TAG_VALUE_LEN,
+    SCAN_TIMEOUT_SECONDS,
+    ArtImage,
+    connect,
+    realpath_key,
+)
 
 from musefs_lidarr.errors import LidarrApiError
 from musefs_lidarr.events import EventType, LidarrEvent
@@ -217,7 +223,10 @@ def test_sync_records_logs_invalid_record(
 ):
     key = realpath_key(sample_track_file["path"])
     make_track(key)
-    bad_track = {**sample_track, "title": "x" * 262145}  # over the value-length CHECK
+    # One byte over the store's tags.value cap, taken from the contract rather
+    # than written out: the cap moved once already (#644) and a literal here
+    # silently stops testing anything the moment it moves again.
+    bad_track = {**sample_track, "title": "x" * (MAX_TAG_VALUE_LEN + 1)}
     event = LidarrEvent(
         event_type=EventType.ALBUM_DOWNLOAD,
         raw_type="AlbumDownload",

--- a/contrib/picard/musefs/_common/__init__.py
+++ b/contrib/picard/musefs/_common/__init__.py
@@ -9,7 +9,12 @@ shell-out, and the per-file sync write-loop. Consumed by the beets plugin (as a
 pip dependency) and by the Picard plugin (vendored into ``musefs/_common``).
 """
 
-from .constants import EXPECTED_USER_VERSION, MAX_ART_BYTES, SCAN_TIMEOUT_SECONDS
+from .constants import (
+    EXPECTED_USER_VERSION,
+    MAX_ART_BYTES,
+    MAX_TAG_VALUE_LEN,
+    SCAN_TIMEOUT_SECONDS,
+)
 from .errors import ScanError, SchemaMismatch
 from .paths import realpath_key
 from .scan import run_scan
@@ -36,6 +41,7 @@ __version__ = "1.2.0"
 __all__ = [
     "EXPECTED_USER_VERSION",
     "MAX_ART_BYTES",
+    "MAX_TAG_VALUE_LEN",
     "SCAN_TIMEOUT_SECONDS",
     "SchemaMismatch",
     "ScanError",

--- a/contrib/picard/musefs/_common/constants.py
+++ b/contrib/picard/musefs/_common/constants.py
@@ -1,9 +1,16 @@
 # GENERATED from python-musefs/src/musefs_common/constants.py — do not edit.
 # Run contrib/python-musefs/vendor_to_picard.py after changing the library.
 #
+from .schema import MAX_TAG_VALUE_LEN as _MAX_TAG_VALUE_LEN
 from .schema import USER_VERSION
 
 EXPECTED_USER_VERSION = USER_VERSION
+
+# Byte cap on a `tags.value`, re-exported from the generated schema mirror so a
+# writer can reject an oversize value itself instead of taking an IntegrityError
+# from the store's CHECK. Bytes, not characters: the CHECK counts
+# `length(CAST(value AS BLOB))`.
+MAX_TAG_VALUE_LEN = _MAX_TAG_VALUE_LEN
 
 MAX_ART_BYTES = 16 * 1024 * 1024 - 64 * 1024
 

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -370,3 +370,8 @@ PRAGMA user_version = 3;
 """
 
 USER_VERSION = 3
+
+# Byte cap on `tags.value`, mirrored so an external writer can check a
+# value before the `CHECK` does. Generated from the Rust constant: it
+# moved once already (#644) and a hand-kept copy would silently rot.
+MAX_TAG_VALUE_LEN = 16777215

--- a/contrib/picard/musefs/_common/schema.py
+++ b/contrib/picard/musefs/_common/schema.py
@@ -268,6 +268,105 @@ CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
     WHERE id = OLD.track_id;
 END;
 PRAGMA user_version = 2;
+
+-- ── MIGRATION_V3 ──
+-- Widen the two caps musefs invented rather than inherited (#644).
+--
+-- `tags.value` moves 256 KiB -> 16 MiB - 1 (FLAC's 24-bit metadata-block
+-- ceiling, the largest tag synthesis could ever serve) and
+-- `track_art.description` moves 1 KiB -> 8 KiB. Both are *widenings*, so the
+-- refills need no WHERE filter and drop no rows -- unlike V2's narrowing, which
+-- had to shed over-cap rows to avoid aborting on its own new CHECK.
+--
+-- SQLite cannot alter a CHECK in place, so both tables are recreated. V1/V2
+-- text is left untouched: they must stay replayable for a V1 -> V2 -> V3
+-- upgrade, and their literals are frozen history, not the current caps.
+
+-- `art_ad`'s body reads `track_art`. ALTER TABLE ... RENAME reparses the whole
+-- schema and would fail with 'error in trigger art_ad: no such table' while
+-- track_art is momentarily absent, so drop it up front and recreate it verbatim
+-- below. (V2's `tags` rebuild needed no such dance: nothing referenced `tags`.)
+DROP TRIGGER art_ad;
+
+CREATE TABLE tags_v3 (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(CAST(value AS BLOB)) <= 16777215),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+INSERT INTO tags_v3 (track_id, key, value, ordinal, value_blob)
+    SELECT track_id, key, value, ordinal, value_blob FROM tags;
+DROP TABLE tags;
+ALTER TABLE tags_v3 RENAME TO tags;
+
+CREATE TABLE track_art_v3 (
+    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    art_id       INTEGER NOT NULL REFERENCES art(id),
+    picture_type INTEGER NOT NULL DEFAULT 3,
+    description  TEXT NOT NULL DEFAULT '',
+    ordinal      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (track_id, ordinal),
+    CHECK (picture_type BETWEEN 0 AND 20),
+    CHECK (ordinal >= 0),
+    CHECK (length(description) <= 8192)
+);
+INSERT INTO track_art_v3 (track_id, art_id, picture_type, description, ordinal)
+    SELECT track_id, art_id, picture_type, description, ordinal FROM track_art;
+DROP TABLE track_art;
+ALTER TABLE track_art_v3 RENAME TO track_art;
+
+-- DROP TABLE took each table's triggers (and track_art's index) with it;
+-- recreate them verbatim so the content_version/updated_at bump contract and
+-- the reverse art -> track_art edge are unchanged.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+PRAGMA user_version = 3;
 """
 
-USER_VERSION = 2
+USER_VERSION = 3

--- a/contrib/picard/tests/test_conftest_sanity.py
+++ b/contrib/picard/tests/test_conftest_sanity.py
@@ -1,11 +1,13 @@
-from musefs._common import connect, track_id_for_path
+from musefs._common import EXPECTED_USER_VERSION, connect, track_id_for_path
 
 
 def test_db_path_has_schema(db_path):
     conn = connect(db_path)
     try:
-        # user_version applied from the fixture SQL.
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        # user_version applied from the fixture SQL. Compared against the
+        # vendored mirror rather than a literal, so a schema migration does not
+        # break a test that is really only asserting "the fixture ran".
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == EXPECTED_USER_VERSION
     finally:
         conn.close()
 

--- a/contrib/python-musefs/src/musefs_common/__init__.py
+++ b/contrib/python-musefs/src/musefs_common/__init__.py
@@ -6,7 +6,12 @@ shell-out, and the per-file sync write-loop. Consumed by the beets plugin (as a
 pip dependency) and by the Picard plugin (vendored into ``musefs/_common``).
 """
 
-from .constants import EXPECTED_USER_VERSION, MAX_ART_BYTES, SCAN_TIMEOUT_SECONDS
+from .constants import (
+    EXPECTED_USER_VERSION,
+    MAX_ART_BYTES,
+    MAX_TAG_VALUE_LEN,
+    SCAN_TIMEOUT_SECONDS,
+)
 from .errors import ScanError, SchemaMismatch
 from .paths import realpath_key
 from .scan import run_scan
@@ -33,6 +38,7 @@ __version__ = "1.2.0"
 __all__ = [
     "EXPECTED_USER_VERSION",
     "MAX_ART_BYTES",
+    "MAX_TAG_VALUE_LEN",
     "SCAN_TIMEOUT_SECONDS",
     "SchemaMismatch",
     "ScanError",

--- a/contrib/python-musefs/src/musefs_common/constants.py
+++ b/contrib/python-musefs/src/musefs_common/constants.py
@@ -1,6 +1,13 @@
+from .schema import MAX_TAG_VALUE_LEN as _MAX_TAG_VALUE_LEN
 from .schema import USER_VERSION
 
 EXPECTED_USER_VERSION = USER_VERSION
+
+# Byte cap on a `tags.value`, re-exported from the generated schema mirror so a
+# writer can reject an oversize value itself instead of taking an IntegrityError
+# from the store's CHECK. Bytes, not characters: the CHECK counts
+# `length(CAST(value AS BLOB))`.
+MAX_TAG_VALUE_LEN = _MAX_TAG_VALUE_LEN
 
 MAX_ART_BYTES = 16 * 1024 * 1024 - 64 * 1024
 

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -367,3 +367,8 @@ PRAGMA user_version = 3;
 """
 
 USER_VERSION = 3
+
+# Byte cap on `tags.value`, mirrored so an external writer can check a
+# value before the `CHECK` does. Generated from the Rust constant: it
+# moved once already (#644) and a hand-kept copy would silently rot.
+MAX_TAG_VALUE_LEN = 16777215

--- a/contrib/python-musefs/src/musefs_common/schema.py
+++ b/contrib/python-musefs/src/musefs_common/schema.py
@@ -265,6 +265,105 @@ CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
     WHERE id = OLD.track_id;
 END;
 PRAGMA user_version = 2;
+
+-- ── MIGRATION_V3 ──
+-- Widen the two caps musefs invented rather than inherited (#644).
+--
+-- `tags.value` moves 256 KiB -> 16 MiB - 1 (FLAC's 24-bit metadata-block
+-- ceiling, the largest tag synthesis could ever serve) and
+-- `track_art.description` moves 1 KiB -> 8 KiB. Both are *widenings*, so the
+-- refills need no WHERE filter and drop no rows -- unlike V2's narrowing, which
+-- had to shed over-cap rows to avoid aborting on its own new CHECK.
+--
+-- SQLite cannot alter a CHECK in place, so both tables are recreated. V1/V2
+-- text is left untouched: they must stay replayable for a V1 -> V2 -> V3
+-- upgrade, and their literals are frozen history, not the current caps.
+
+-- `art_ad`'s body reads `track_art`. ALTER TABLE ... RENAME reparses the whole
+-- schema and would fail with 'error in trigger art_ad: no such table' while
+-- track_art is momentarily absent, so drop it up front and recreate it verbatim
+-- below. (V2's `tags` rebuild needed no such dance: nothing referenced `tags`.)
+DROP TRIGGER art_ad;
+
+CREATE TABLE tags_v3 (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(CAST(value AS BLOB)) <= 16777215),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+INSERT INTO tags_v3 (track_id, key, value, ordinal, value_blob)
+    SELECT track_id, key, value, ordinal, value_blob FROM tags;
+DROP TABLE tags;
+ALTER TABLE tags_v3 RENAME TO tags;
+
+CREATE TABLE track_art_v3 (
+    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    art_id       INTEGER NOT NULL REFERENCES art(id),
+    picture_type INTEGER NOT NULL DEFAULT 3,
+    description  TEXT NOT NULL DEFAULT '',
+    ordinal      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (track_id, ordinal),
+    CHECK (picture_type BETWEEN 0 AND 20),
+    CHECK (ordinal >= 0),
+    CHECK (length(description) <= 8192)
+);
+INSERT INTO track_art_v3 (track_id, art_id, picture_type, description, ordinal)
+    SELECT track_id, art_id, picture_type, description, ordinal FROM track_art;
+DROP TABLE track_art;
+ALTER TABLE track_art_v3 RENAME TO track_art;
+
+-- DROP TABLE took each table's triggers (and track_art's index) with it;
+-- recreate them verbatim so the content_version/updated_at bump contract and
+-- the reverse art -> track_art edge are unchanged.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+PRAGMA user_version = 3;
 """
 
-USER_VERSION = 2
+USER_VERSION = 3

--- a/contrib/python-musefs/tests/test_constants.py
+++ b/contrib/python-musefs/tests/test_constants.py
@@ -1,8 +1,25 @@
-from musefs_common import constants
+import re
+
+from musefs_common import constants, schema
 
 
 def test_expected_user_version_matches_rust_migrations():
-    assert constants.EXPECTED_USER_VERSION == 2
+    # Checks what the name says instead of pinning a literal: the mirror stamps
+    # `PRAGMA user_version = n` once per Rust migration, so the count and the
+    # last stamp must both agree with the constant. A hardcoded number here just
+    # breaks on every migration without ever verifying the correspondence.
+    stamps = [int(n) for n in re.findall(r"PRAGMA user_version = (\d+);", schema.SCHEMA_SQL)]
+    assert stamps, "the mirrored schema must stamp a user_version per migration"
+    assert stamps == list(range(1, len(stamps) + 1)), stamps
+    assert constants.EXPECTED_USER_VERSION == stamps[-1]
+
+
+def test_max_tag_value_len_matches_the_mirrored_check():
+    # The cap the store actually enforces is the one in the LAST migration to
+    # rebuild `tags`; earlier migrations carry their own frozen literals.
+    caps = re.findall(r"length\(CAST\(value AS BLOB\)\) <= (\d+)", schema.SCHEMA_SQL)
+    assert caps, "the mirrored schema must carry a byte-counting tags.value CHECK"
+    assert constants.MAX_TAG_VALUE_LEN == int(caps[-1])
 
 
 def test_max_art_bytes_is_16mib_minus_64kib():

--- a/docs/src/architecture/store.md
+++ b/docs/src/architecture/store.md
@@ -64,7 +64,9 @@ malformed *shapes* at commit, so an external writer cannot persist them:
 - an `art.byte_len` that disagrees with its blob, or a `sha256` of the wrong
   length;
 - a `picture_type` outside `0..=20`;
-- a `tags.key` over 256 chars or `tags.value` over 256 KiB;
+- a `tags.key` over 256 chars or `tags.value` over 16 MiB − 1 bytes (FLAC's
+  24-bit metadata-block ceiling — the largest tag synthesis could serve, so the
+  store never refuses a tag the format could carry);
 - `tags.key` must be non-empty and contain no ASCII control characters (a DB
   `CHECK` enforces this, rejecting violating writes — with one blind spot: an
   embedded NUL terminates SQLite's `length()`/`GLOB`, so a key like `a\0b` slips
@@ -75,7 +77,7 @@ malformed *shapes* at commit, so an external writer cannot persist them:
   wider set (e.g. `=`, `:`, spaces, non-ASCII).
 - a `value_blob` over `MAX_BINARY_TAG_BYTES`;
 - an `art.mime` over 255 chars or `byte_len` over `MAX_ART_BYTES`;
-- a `track_art.description` over 1 KiB;
+- a `track_art.description` over 8 KiB;
 - a `structural_blocks` row with an unknown `kind`, negative `ordinal`, or `body`
   over the FLAC 24-bit block limit.
 
@@ -108,8 +110,8 @@ degrading to a controlled
 `BackingChanged`/layout error, never undefined behavior. The store's
 `CHECK` rejects art over `MAX_ART_BYTES` (16 MiB − 64 KiB) at write time;
 resolve also re-checks it (`ArtTooLarge`, all formats) to backstop a writer
-that disables check enforcement, and the scanner's ingest-time drop is
-tracked in #284.
+that disables check enforcement, and the scanner refuses to ingest a file
+carrying such art at all (#644).
 Referential gaps are treated the same way: a `track_art` row whose `art_id`
 has no matching `art` row (an orphan an external writer can produce with FK
 enforcement disabled) fails the serve with `EIO` rather than silently dropping

--- a/docs/src/architecture/tree-scanning.md
+++ b/docs/src/architecture/tree-scanning.md
@@ -85,12 +85,28 @@ collect supported audio files, probe each (format detection → audio
 offset/length, tags, pictures, structural blocks) on a parallel probe
 pipeline feeding a single DB writer, committing in batches. Probing reads
 are bounded — the scanner never slurps whole files — and ingestion caps
-per-item sizes (`MAX_ART_BYTES`, `MAX_BINARY_TAG_BYTES`) so a crafted file
-cannot balloon the store. An over-cap picture or binary tag is dropped and
-logged (`RUST_LOG=warn`) rather than vanishing silently, so a track that
-appears to have lost its cover art has an explanation in the logs; a
-supported-extension file that fails to parse, or errors mid-probe, is
-likewise logged with the reason and counted `failed`.
+per-item sizes (`MAX_ART_BYTES`, `MAX_BINARY_TAG_BYTES`, and the store's
+`tags.key`/`tags.value`/`art.mime`/`track_art.description` limits) so a crafted
+file cannot balloon the store.
+
+`check_storable` applies every one of those caps in a single place, before
+anything is written. **A file that exceeds any of them fails — that file, not
+the scan.** It is logged with its path, what was too big, its size, and the
+limit (`RUST_LOG=warn`), and counted `failed`; the rest of the directory scans
+normally. Nothing partial is stored for it, so the mount never contains a track
+that is quietly missing a tag or its cover art. FLAC gets one extra check: tags
+merged from a leading ID3v2 tag (#602) can push the total past what a
+`VORBIS_COMMENT` block can hold, which would scan clean and then serve `EIO` on
+every read, so that total is checked at scan time too. A supported-extension
+file that fails to parse, or errors mid-probe, is likewise logged with the
+reason and counted `failed`.
+
+Before v1.4 an over-cap picture or binary tag was instead dropped with a warning
+and the rest of the track stored. That left users with a mount quietly missing
+data behind a `warn` that is easy to lose in a scan of ten thousand files, and
+it did not cover text tags at all — an over-cap `tags.value` reached the DB
+`CHECK` and aborted the entire scan with an error naming neither the file nor
+the limit (#644).
 
 Symlinks are **not followed by default**: a symlinked file or directory is
 logged (`RUST_LOG=info`/`warn`) and skipped, which keeps the walk immune to

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -24,6 +24,21 @@ see the [Release notes](release-notes.md).
 
 ### Changed
 
+- The `tags.value` cap rises from 256 KiB to 16 MiB − 1, and
+  `track_art.description` from 1 KiB to 8 KiB (schema `MIGRATION_V3`). The new
+  tag cap is FLAC's 24-bit metadata-block ceiling — the largest tag synthesis
+  could ever serve — so the store no longer refuses a tag the format itself can
+  carry. Existing stores upgrade in place, and automatically, on the next
+  `musefs scan` or `musefs mount`: both open the store read-write and run the
+  migration, which only widens the constraints and so carries every existing row
+  across. No rescan of audio is needed and nothing has to be regenerated.
+- A backing file whose metadata exceeds a store limit now fails **that file**
+  instead of being stored with the offending part quietly dropped. Oversize
+  embedded art and binary tags were previously omitted from an otherwise-stored
+  track with only a `warn` to show for it, which is easy to lose in a scan of
+  ten thousand files and leaves a mount silently missing data. Such a file is
+  now logged with its path, what was too big, its size and the limit, counted
+  `failed`, and skipped; the rest of the directory scans normally.
 - The virtual tree interns each node name into one shared `Arc<str>` rather than
   storing it separately in `Node.name`, `Node.rendered_name`, the `children` key
   and both `rendered_children` keys ([#617](https://github.com/Sohex/musefs/issues/617)). Measured over 200,000
@@ -52,6 +67,22 @@ see the [Release notes](release-notes.md).
 
 ### Fixed
 
+- A tag larger than the store's cap no longer aborts the entire scan
+  ([#644](https://github.com/Sohex/musefs/issues/644)). The scanner had no
+  length check on text tags, so an over-cap value reached the DB `CHECK` inside
+  a batch commit and failed the whole run with
+  `CHECK constraint failed: length(CAST(value AS BLOB)) <= 262144` — naming
+  neither the offending file nor what the number meant. Every cap the scanner
+  can trip is now checked in one place before anything is written, and a
+  violation fails only that file, with a message naming it. The same applies to
+  the `tags.key`, `art.mime` and `track_art.description` caps, which had the
+  identical unattributed-abort failure mode. Should a store write still fail
+  fatally, the error now names the file it died on.
+- A FLAC whose tags outgrow what a `VORBIS_COMMENT` block can hold is rejected
+  at scan time rather than stored and then served `EIO` on every read. This is
+  reachable by merging a leading ID3v2 tag's fields into a FLAC's own comments
+  ([#602](https://github.com/Sohex/musefs/issues/602)): ID3v2's tag size is
+  synchsafe 28-bit (256 MiB) while a FLAC metadata block is 24-bit.
 - A leading ID3v2 tag on an MP3 (or a FLAC) is stepped over by its declared size
   even when its major version is not one musefs can parse the frames of, instead
   of the whole file being rejected. The ID3v2 header has the same shape in every

--- a/musefs-core/src/error.rs
+++ b/musefs-core/src/error.rs
@@ -30,6 +30,29 @@ pub enum CoreError {
     },
     #[error("backing file changed since scan: {0}")]
     BackingChanged(String),
+    #[error("{path}: {item} is {len} {unit}, over musefs's limit of {cap} {unit}")]
+    TrackFieldTooLarge {
+        path: String,
+        /// What was too big, in the user's terms — `tag "LYRICS"`,
+        /// `binary tag "GEOB"`, `embedded image/jpeg art`, `art description`.
+        item: String,
+        len: u64,
+        cap: u64,
+        /// `bytes` or `characters` — the schema `CHECK`s count TEXT columns in
+        /// characters and blobs/`CAST(... AS BLOB)` in bytes, and a message that
+        /// quotes the wrong unit sends the user measuring the wrong thing.
+        unit: &'static str,
+    },
+    #[error(
+        "{path}: its {format} tag block would be {len} bytes, over the {cap}-byte \
+         {format} metadata limit — musefs could not serve this file"
+    )]
+    TrackMetadataTooLarge {
+        path: String,
+        format: &'static str,
+        len: u64,
+        cap: u64,
+    },
     #[error(
         "track {track_id} references art {art_id}, which has no metadata row (orphaned track_art — DB contract violation)"
     )]

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -43,4 +43,20 @@ mod cross_layer_caps {
             "db structural body cap must equal FLAC's 24-bit block limit",
         );
     }
+
+    /// #644 put the `tags.value` cap *at* FLAC's block ceiling rather than below
+    /// it, and that equality is load-bearing twice over. It is why the cap can
+    /// be described as inherited from the format rather than invented, and it is
+    /// what makes an over-cap tag structurally unreachable through a legal FLAC:
+    /// the whole `VORBIS_COMMENT` body is length-prefixed with 24 bits, so no
+    /// comment inside it can exceed the cap. Drop the cap below this and the
+    /// crash class #644 reported becomes reachable again for stock FLAC files.
+    #[test]
+    fn tag_value_cap_is_not_below_the_flac_block_limit() {
+        assert!(
+            u64::try_from(musefs_db::limits::MAX_TAG_VALUE_LEN).unwrap()
+                >= musefs_format::flac::MAX_BLOCK_BODY,
+            "a legal FLAC comment must never be too large for the store to hold",
+        );
+    }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -8,6 +8,9 @@ use musefs_format::{EmbeddedBinaryTag, EmbeddedPicture, Extent, flac, mp3, mp4, 
 use crate::byte_budget::ByteBudget;
 use crate::error::Result;
 use crate::freshness::BackingStamp;
+use musefs_db::limits::{
+    MAX_ART_DESCRIPTION_LEN, MAX_ART_MIME_LEN, MAX_TAG_KEY_LEN, MAX_TAG_VALUE_LEN,
+};
 use std::fmt;
 use std::sync::Arc;
 use std::sync::mpsc::sync_channel;
@@ -27,14 +30,15 @@ const MAX_WIDEN_RETRIES: usize = 8;
 /// giant `NeedMore` widen.
 pub(crate) const MAX_PROBE_BYTES: u64 = 64 << 20; // 64 MiB
 
-/// The artwork-size ceiling. Enforced here at ingest (oversize scanned art is
-/// dropped) and at resolve in `mapping::track_art_to_inputs` (oversize art from
-/// any writer is rejected). Sized to clear FLAC's 24-bit block length with
-/// headroom for the picture-block framing.
+/// The artwork-size ceiling. Enforced here at ingest (a file carrying oversize
+/// art fails, see [`check_storable`]) and at resolve in
+/// `mapping::track_art_to_inputs` (oversize art from any writer is rejected).
+/// Sized to clear FLAC's 24-bit block length with headroom for the
+/// picture-block framing.
 pub(crate) const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
 
-/// Per-frame cap for opaque binary tags, mirroring `MAX_ART_BYTES`. Oversize
-/// payloads (e.g. a GEOB embedding a multi-MB file) are logged-and-skipped.
+/// Per-frame cap for opaque binary tags, mirroring `MAX_ART_BYTES`. A file with
+/// an oversize payload (e.g. a GEOB embedding a multi-MB file) fails.
 const MAX_BINARY_TAG_BYTES: usize = MAX_ART_BYTES;
 
 /// Outcome of probing one backing file. `Unparseable` is a supported-extension
@@ -528,7 +532,13 @@ pub(crate) fn probe_full(path: &Path, bytes: &[u8]) -> Option<Probed> {
         let bounds = mp4::locate_audio(bytes).ok()?;
         let (pictures, art_drops) = mp4::read_pictures_reporting(bytes, MAX_ART_BYTES);
         let (binary_tags, bin_drops) = mp4::read_binary_tags_reporting(bytes, MAX_BINARY_TAG_BYTES);
-        log_mp4_oversize_drops(path, &art_drops, &bin_drops);
+        // Oversize `covr`/`----` payloads fail the file (#644). This oracle path
+        // has no error channel, so it reports the same verdict as `None` — which
+        // its caller already counts as `failed`, matching the bounded probe.
+        if let Some(e) = mp4_oversize_error(path, &art_drops, &bin_drops) {
+            log::warn!("skipping {e}");
+            return None;
+        }
         Some(Probed {
             format: Format::M4a,
             audio_offset: bounds.audio_offset,
@@ -665,7 +675,14 @@ fn probe_body(
         let (pictures, art_drops) = mp4::read_pictures_reporting(&scan.moov, MAX_ART_BYTES);
         let (binary_tags, bin_drops) =
             mp4::read_binary_tags_reporting(&scan.moov, MAX_BINARY_TAG_BYTES);
-        log_mp4_oversize_drops(path, &art_drops, &bin_drops);
+        // Oversize `covr`/`----` payloads fail the file (#644). Reported as
+        // "no probe result", which the caller counts as `failed` — the same
+        // verdict `check_storable` produces for every other format, reached one
+        // layer earlier because the payload is never materialized here.
+        if let Some(e) = mp4_oversize_error(path, &art_drops, &bin_drops) {
+            log::warn!("skipping {e}");
+            return Ok(None);
+        }
         return Ok(Some(Probed {
             format: Format::M4a,
             audio_offset: scan.mdat_payload_offset,
@@ -928,44 +945,170 @@ fn key_passes_floor(key: &str) -> bool {
     !key.is_empty() && key.bytes().all(|b| b >= 0x20)
 }
 
-/// Drops embedded pictures over [`MAX_ART_BYTES`], logging each so a cover that
-/// vanishes from the synthesized view is explained rather than silent (#284).
-/// Filtering here, before the caller enumerates, keeps stored art ordinals
-/// gap-free. Note: the mp4 `covr` path caps oversize art earlier, inside
-/// `mp4::read_pictures`, so those drops never reach this filter.
-fn accept_pictures(abs_path: &str, pictures: Vec<EmbeddedPicture>) -> Vec<EmbeddedPicture> {
-    pictures
-        .into_iter()
-        .filter(|p| {
-            if p.data.len() > MAX_ART_BYTES {
-                log::warn!(
-                    "{abs_path}: dropping embedded {} art ({} bytes), over the {MAX_ART_BYTES}-byte cap",
-                    p.mime,
-                    p.data.len(),
-                );
-                return false;
-            }
-            true
-        })
-        .collect()
+/// Every store cap the scanner can trip on an honest read of a legal file,
+/// checked in one place before anything is written (#644).
+///
+/// A violation fails **that file**, not the scan. The caps are DB `CHECK`
+/// constraints, so before this existed an over-cap tag surfaced as
+/// `CHECK constraint failed: ...` from inside a batch commit — fatal, and with
+/// the per-file context already gone. Checking here instead means the caller
+/// counts one `failed` file, names it, and keeps going.
+///
+/// It also replaces the older drop-and-warn treatment of oversize art and
+/// binary tags (#284): silently omitting a payload from the store leaves the
+/// user with a mount that is quietly missing data, and a `warn` buried in a
+/// scan of ten thousand files is easy to miss. Refusing the file is louder and
+/// leaves no state nobody asked for.
+///
+/// Units are not uniform and the messages say which applies: SQLite's `length()`
+/// counts **characters** on a TEXT column but **bytes** on a blob, and the
+/// schema deliberately uses `length(CAST(value AS BLOB))` for `tags.value` so
+/// its cap is a real memory bound (#505).
+fn check_storable(abs_path: &str, probed: &Probed) -> Result<()> {
+    // The two scanner-owned caps are `usize` consts; the DB's are `i64` because
+    // they are compared against SQLite `length()`. Convert once here so the
+    // per-field checks below all read the same way.
+    let art_cap = i64::try_from(MAX_ART_BYTES).expect("art cap fits i64");
+    let binary_cap = i64::try_from(MAX_BINARY_TAG_BYTES).expect("binary tag cap fits i64");
+    let too_large = |item: String, len: usize, cap: i64, unit: &'static str| {
+        crate::error::CoreError::TrackFieldTooLarge {
+            path: abs_path.to_string(),
+            item,
+            len: len as u64,
+            cap: cap.unsigned_abs(),
+            unit,
+        }
+    };
+
+    for (key, value) in &probed.tags {
+        // Skipped keys are not stored, so they cannot violate anything.
+        if !key_passes_floor(key) {
+            continue;
+        }
+        let key_chars = key.chars().count();
+        if i64::try_from(key_chars).unwrap_or(i64::MAX) > MAX_TAG_KEY_LEN {
+            return Err(too_large(
+                format!("tag key {key:?}"),
+                key_chars,
+                MAX_TAG_KEY_LEN,
+                "characters",
+            ));
+        }
+        if i64::try_from(value.len()).unwrap_or(i64::MAX) > MAX_TAG_VALUE_LEN {
+            return Err(too_large(
+                format!("tag {key:?}"),
+                value.len(),
+                MAX_TAG_VALUE_LEN,
+                "bytes",
+            ));
+        }
+    }
+
+    for b in &probed.binary_tags {
+        if b.payload.len() > MAX_BINARY_TAG_BYTES {
+            return Err(too_large(
+                format!("binary tag {:?}", b.key),
+                b.payload.len(),
+                binary_cap,
+                "bytes",
+            ));
+        }
+    }
+
+    for p in &probed.pictures {
+        if p.data.len() > MAX_ART_BYTES {
+            return Err(too_large(
+                format!("embedded {} art", p.mime),
+                p.data.len(),
+                art_cap,
+                "bytes",
+            ));
+        }
+        let mime_chars = p.mime.chars().count();
+        if i64::try_from(mime_chars).unwrap_or(i64::MAX) > MAX_ART_MIME_LEN {
+            return Err(too_large(
+                "art MIME type".to_string(),
+                mime_chars,
+                MAX_ART_MIME_LEN,
+                "characters",
+            ));
+        }
+        let desc_chars = p.description.chars().count();
+        if i64::try_from(desc_chars).unwrap_or(i64::MAX) > MAX_ART_DESCRIPTION_LEN {
+            return Err(too_large(
+                format!("description of the embedded {} art", p.mime),
+                desc_chars,
+                MAX_ART_DESCRIPTION_LEN,
+                "characters",
+            ));
+        }
+    }
+
+    check_metadata_fits_format(abs_path, probed)
 }
 
-/// Filters embedded binary tags to those worth storing, logging oversize drops
-/// (#284). Empty payloads carry nothing to serve, so they are dropped silently;
-/// payloads over [`MAX_BINARY_TAG_BYTES`] are a lossy drop and get a warning.
-fn accept_binary_tags(abs_path: &str, tags: Vec<EmbeddedBinaryTag>) -> Vec<musefs_db::BinaryTag> {
+/// Reject a file whose tags, taken together, cannot fit the metadata container
+/// its format synthesizes into.
+///
+/// Only the FLAC family needs this, and the reachable case is narrower than it
+/// looks. A stock FLAC cannot trip it: its whole `VORBIS_COMMENT` body is
+/// length-prefixed with 24 bits, so the comments inside can never sum past the
+/// ceiling they were read from. What breaks that arithmetic is a **second tag
+/// source merged into the first** — a FLAC carrying a leading ID3v2 tag (#602),
+/// whose absent keys `fill_absent_keys` appends. ID3v2's synchsafe tag size is
+/// 256 MiB, so the merged set can exceed what a FLAC comment block can hold.
+///
+/// Left unchecked, such a file scans clean and then fails synthesis with
+/// `FormatError::TooLarge`, serving `EIO` on every read — a file that is
+/// present in the mount and unreadable, with nothing in the scan log to explain
+/// it. That is precisely the unanticipated state the fail-the-file policy
+/// exists to prevent, so the arithmetic runs here, where it can still name the
+/// file.
+///
+/// Conservative by construction: this is the *lower bound* on the synthesized
+/// body (real synthesis maps and may add comments, never shrinks below the raw
+/// pairs), so a file over the ceiling here provably cannot be served. Under it,
+/// nothing is claimed.
+///
+/// The remaining formats need no equivalent. Ogg Opus/Vorbis comment packets
+/// carry 32-bit lengths and span pages, so they have no ceiling worth checking;
+/// MP4 and WAV use 32-bit box/chunk lengths; and MP3 synthesizes back into the
+/// same 256 MiB ID3v2 container it was read from.
+fn check_metadata_fits_format(abs_path: &str, probed: &Probed) -> Result<()> {
+    let (format_name, cap) = match probed.format {
+        Format::Flac => ("FLAC", musefs_format::flac::MAX_BLOCK_BODY),
+        Format::OggFlac => ("Ogg FLAC", musefs_format::flac::MAX_BLOCK_BODY),
+        _ => return Ok(()),
+    };
+    // VORBIS_COMMENT body: 4-byte vendor length + vendor string + 4-byte comment
+    // count + per comment (4-byte length + "KEY=VALUE"). The vendor string is
+    // synthesis's own and unknown here; omitting it only makes the bound more
+    // conservative, which is the safe direction.
+    let mut total: u64 = 8;
+    for (key, value) in &probed.tags {
+        if !key_passes_floor(key) {
+            continue;
+        }
+        total = total.saturating_add(4 + key.len() as u64 + 1 + value.len() as u64);
+    }
+    if total > cap {
+        return Err(crate::error::CoreError::TrackMetadataTooLarge {
+            path: abs_path.to_string(),
+            format: format_name,
+            len: total,
+            cap,
+        });
+    }
+    Ok(())
+}
+
+/// Assign storage ordinals to the binary tags worth keeping. Empty payloads are
+/// dropped silently: they carry nothing to serve, so unlike an oversize payload
+/// their absence costs the user nothing. Size is not decided here — that is
+/// [`check_storable`]'s job, and by the time this runs the file has passed it.
+fn storable_binary_tags(tags: Vec<EmbeddedBinaryTag>) -> Vec<musefs_db::BinaryTag> {
     tags.into_iter()
-        .filter(|b| {
-            if b.payload.len() > MAX_BINARY_TAG_BYTES {
-                log::warn!(
-                    "{abs_path}: dropping binary tag {} ({} bytes), over the {MAX_BINARY_TAG_BYTES}-byte cap",
-                    b.key,
-                    b.payload.len(),
-                );
-                return false;
-            }
-            !b.payload.is_empty()
-        })
+        .filter(|b| !b.payload.is_empty())
         .enumerate()
         .map(|(ordinal, b)| musefs_db::BinaryTag {
             key: b.key,
@@ -975,29 +1118,41 @@ fn accept_binary_tags(abs_path: &str, tags: Vec<EmbeddedBinaryTag>) -> Vec<musef
         .collect()
 }
 
-/// Logs each oversized mp4 `covr` image / binary `----` value that the format
-/// layer skipped before materialization (#343). These drops happen inside
-/// `mp4::read_pictures` / `mp4::read_binary_tags` — earlier than the `accept_*`
-/// ingest filters that log the lossy drops for the other formats (#284), and
-/// deliberately so, to avoid building a large image out of a large `moov` — so
-/// they are surfaced here at probe time, mirroring the `accept_*` message shape.
-fn log_mp4_oversize_drops(path: &Path, art: &[mp4::OversizeDrop], binary: &[mp4::OversizeDrop]) {
-    for d in art {
-        log::warn!(
-            "{}: dropping embedded {} art ({} bytes), over the {MAX_ART_BYTES}-byte cap",
-            path.display(),
-            d.descriptor,
+/// Build the [`CoreError`](crate::error::CoreError) for an mp4 payload the
+/// format layer skipped before materialization (#343).
+///
+/// These drops happen inside `mp4::read_pictures_reporting` /
+/// `mp4::read_binary_tags_reporting` — deliberately earlier than
+/// [`check_storable`], to avoid building a large image out of a large `moov`
+/// just to reject it. Only the *report* reaches here, never the payload, so the
+/// decision is made at the probe site instead; routing the message through this
+/// one helper keeps it identical to the ingest-time refusals.
+fn mp4_oversize_error(
+    path: &Path,
+    art: &[mp4::OversizeDrop],
+    binary: &[mp4::OversizeDrop],
+) -> Option<crate::error::CoreError> {
+    let (item, bytes, cap) = if let Some(d) = art.first() {
+        (
+            format!("embedded {} art", d.descriptor),
             d.bytes,
-        );
-    }
-    for d in binary {
-        log::warn!(
-            "{}: dropping binary tag {} ({} bytes), over the {MAX_BINARY_TAG_BYTES}-byte cap",
-            path.display(),
-            d.descriptor,
+            MAX_ART_BYTES,
+        )
+    } else {
+        let d = binary.first()?;
+        (
+            format!("binary tag {:?}", d.descriptor),
             d.bytes,
-        );
-    }
+            MAX_BINARY_TAG_BYTES,
+        )
+    };
+    Some(crate::error::CoreError::TrackFieldTooLarge {
+        path: path.display().to_string(),
+        item,
+        len: bytes as u64,
+        cap: cap as u64,
+        unit: "bytes",
+    })
 }
 
 fn structural_blocks_from(blocks: Vec<(String, Vec<u8>)>) -> Vec<musefs_db::StructuralBlock> {
@@ -1204,6 +1359,12 @@ fn ingest_into(
     fingerprint: Option<&str>,
     content_hash: Option<&str>,
 ) -> Result<()> {
+    // The pipeline already rejected an over-cap file in the worker, before the
+    // payload was ever buffered. Re-checking here is what makes the direct
+    // `ingest` / `ingest_bulk` entry points honour the same contract instead of
+    // writing a row the `CHECK` will reject mid-transaction.
+    check_storable(abs_path, &probed)?;
+
     let track_id = w.upsert_track(&NewTrack {
         backing_path: abs_path.to_string(),
         format: probed.format,
@@ -1227,17 +1388,14 @@ fn ingest_into(
     }
     w.replace_tags(track_id, &tags)?;
 
-    let binary_tags = accept_binary_tags(abs_path, probed.binary_tags);
+    let binary_tags = storable_binary_tags(probed.binary_tags);
     w.set_binary_tags(track_id, &binary_tags)?;
 
     let structural_blocks = structural_blocks_from(probed.structural_blocks);
     w.set_structural_blocks(track_id, &structural_blocks)?;
 
     let mut track_arts = Vec::new();
-    for (ordinal, pic) in accept_pictures(abs_path, probed.pictures)
-        .into_iter()
-        .enumerate()
-    {
+    for (ordinal, pic) in probed.pictures.into_iter().enumerate() {
         let art_id = w.upsert_art(&NewArt {
             mime: pic.mime,
             width: (pic.width != 0).then_some(pic.width),
@@ -1558,6 +1716,20 @@ fn run_pipeline(
                         } else {
                             path.to_string_lossy().into_owned()
                         };
+                        // Reject an over-cap file here, before its payload is
+                        // charged to the budget and buffered into a batch: a
+                        // `CHECK` violation discovered at commit time is fatal
+                        // to the whole scan and has lost the path by then
+                        // (#644). Full-write policy only — `StructuralOnly`
+                        // (revalidate) writes neither tags nor art, so failing
+                        // a stored track for them would be inventing a failure.
+                        if policy == WritePolicy::Full
+                            && let Err(e) = check_storable(&abs_path, &probed)
+                        {
+                            log::warn!("skipping {e}");
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            continue;
+                        }
                         let weight = payload_weight(&probed);
                         budget.acquire(weight); // backpressure on in-flight art bytes
                         let fingerprint = match tier {
@@ -1626,7 +1798,14 @@ fn run_pipeline(
         for unit in batch.drain(..) {
             released += unit.weight;
             committed.push(unit.abs_path.clone());
-            ingest_unit(&mut bw, unit, strictness, policy)?;
+            // A write failure here is still fatal (the store, not the file, is
+            // the problem), but it must say which file it died on — issue #644
+            // was reported as an unattributed `CHECK constraint failed`.
+            let abs_path = unit.abs_path.clone();
+            ingest_unit(&mut bw, unit, strictness, policy).map_err(|e| {
+                log::error!("aborting scan while ingesting {abs_path}: {e}");
+                e
+            })?;
         }
         bw.commit()?;
         for abs_path in committed {

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -583,10 +583,11 @@ fn scan_ingests_binary_tags_and_promotes() {
     );
 }
 
-/// Probed carrying a valid, an empty, and an oversize binary tag. Only the
-/// valid one is stored: the filter drops empty (`EmptySegment` would fail
-/// layout validation) and oversize (`> MAX_BINARY_TAG_BYTES`) payloads, with
-/// gap-free ordinals.
+/// Probed carrying a valid and an empty binary tag. Only the valid one is
+/// stored: an empty payload carries nothing to serve (and `EmptySegment` would
+/// fail layout validation), so dropping it costs the user nothing. Oversize
+/// payloads are a different matter and no longer appear here — they fail the
+/// whole file (#644), asserted separately below.
 fn probed_with_mixed_binary_tags() -> Probed {
     Probed {
         format: musefs_db::Format::Mp3,
@@ -603,17 +604,23 @@ fn probed_with_mixed_binary_tags() -> Probed {
                 key: "GEOB".into(),
                 payload: Vec::new(),
             },
-            EmbeddedBinaryTag {
-                key: "SYLT".into(),
-                payload: vec![0u8; MAX_BINARY_TAG_BYTES + 1],
-            },
         ],
         structural_blocks: Vec::new(),
     }
 }
 
+/// `probed_with_mixed_binary_tags` plus one payload a single byte over the cap.
+fn probed_with_oversize_binary_tag() -> Probed {
+    let mut p = probed_with_mixed_binary_tags();
+    p.binary_tags.push(EmbeddedBinaryTag {
+        key: "SYLT".into(),
+        payload: vec![0u8; MAX_BINARY_TAG_BYTES + 1],
+    });
+    p
+}
+
 #[test]
-fn ingest_filters_empty_and_oversize_binary_tags() {
+fn ingest_filters_empty_binary_tags() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("a.mp3");
     std::fs::write(&path, b"x").unwrap();
@@ -639,8 +646,40 @@ fn ingest_filters_empty_and_oversize_binary_tags() {
     assert_eq!(rows[0].byte_len, 3);
 }
 
+/// #644: an oversize payload is not quietly omitted from an otherwise-stored
+/// track. The direct `ingest` entry point rejects the whole file, so a caller
+/// cannot end up with a track that is silently missing data.
 #[test]
-fn ingest_bulk_filters_empty_and_oversize_binary_tags() {
+fn ingest_rejects_a_file_with_an_oversize_binary_tag() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("a.mp3");
+    std::fs::write(&path, b"x").unwrap();
+    let meta = std::fs::metadata(&path).unwrap();
+    let db = Db::open_in_memory().unwrap();
+
+    let err = ingest(
+        &db,
+        &path.to_string_lossy(),
+        &meta,
+        probed_with_oversize_binary_tag(),
+    )
+    .expect_err("an oversize binary tag must fail the file");
+
+    let msg = err.to_string();
+    assert!(msg.contains("SYLT"), "names the offending tag: {msg}");
+    assert!(
+        msg.contains(&MAX_BINARY_TAG_BYTES.to_string()),
+        "quotes the limit: {msg}"
+    );
+    // Nothing partial was written.
+    assert!(
+        db.list_tracks().unwrap().is_empty(),
+        "no track row survives"
+    );
+}
+
+#[test]
+fn ingest_bulk_filters_empty_binary_tags() {
     let db = Db::open_in_memory().unwrap();
     {
         let mut bw = db.bulk_writer().unwrap();
@@ -669,34 +708,218 @@ fn ingest_bulk_filters_empty_and_oversize_binary_tags() {
 }
 
 #[test]
-fn accept_pictures_keeps_at_cap_and_drops_over_cap() {
-    let mk = |len: usize| EmbeddedPicture {
+fn ingest_bulk_rejects_a_file_with_an_oversize_binary_tag() {
+    let db = Db::open_in_memory().unwrap();
+    let mut bw = db.bulk_writer().unwrap();
+    let err = ingest_bulk(
+        &mut bw,
+        "/a.mp3",
+        BackingStamp {
+            size: 1,
+            mtime_ns: 0,
+            ctime_ns: 0,
+        },
+        probed_with_oversize_binary_tag(),
+    )
+    .expect_err("an oversize binary tag must fail the file");
+    assert!(err.to_string().contains("SYLT"), "{err}");
+}
+
+fn picture_of_len(len: usize) -> EmbeddedPicture {
+    EmbeddedPicture {
         mime: "image/jpeg".to_string(),
         picture_type: musefs_format::PictureType::new(3).unwrap(),
         description: String::new(),
         width: 0,
         height: 0,
         data: vec![0u8; len],
-    };
-    // A picture exactly at the cap is kept; one byte over is dropped. The
-    // boundary pins `>` against `>=` (an at-cap drop would be silent loss).
-    let kept = accept_pictures("/x.flac", vec![mk(MAX_ART_BYTES), mk(MAX_ART_BYTES + 1)]);
-    assert_eq!(kept.len(), 1, "exactly the at-cap picture survives");
-    assert_eq!(kept[0].data.len(), MAX_ART_BYTES);
+    }
+}
+
+fn probed_with_pictures(pictures: Vec<EmbeddedPicture>) -> Probed {
+    Probed {
+        format: musefs_db::Format::Mp3,
+        audio_offset: 0,
+        audio_length: 0,
+        tags: Vec::new(),
+        pictures,
+        binary_tags: Vec::new(),
+        structural_blocks: Vec::new(),
+    }
+}
+
+/// The cap boundary is inclusive on both sides of every field, pinning each
+/// `>` against a `>=`/`==` mutant. An at-cap rejection would fail a file that
+/// stores fine; an over-cap acceptance is the #644 crash.
+#[test]
+fn check_storable_accepts_art_at_cap_and_rejects_one_over() {
+    assert!(
+        check_storable(
+            "/x.flac",
+            &probed_with_pictures(vec![picture_of_len(MAX_ART_BYTES)])
+        )
+        .is_ok()
+    );
+    let err = check_storable(
+        "/x.flac",
+        &probed_with_pictures(vec![picture_of_len(MAX_ART_BYTES + 1)]),
+    )
+    .expect_err("one byte over the art cap fails the file");
+    assert!(err.to_string().contains("/x.flac"), "names the file: {err}");
 }
 
 #[test]
-fn accept_binary_tags_keeps_at_cap_and_drops_over_cap() {
-    let mk = |len: usize| EmbeddedBinaryTag {
-        key: "PRIV".to_string(),
-        payload: vec![0u8; len],
+fn check_storable_accepts_binary_tag_at_cap_and_rejects_one_over() {
+    let mk = |len: usize| {
+        let mut p = probed_with_pictures(Vec::new());
+        p.binary_tags = vec![EmbeddedBinaryTag {
+            key: "PRIV".to_string(),
+            payload: vec![0u8; len],
+        }];
+        p
     };
-    let kept = accept_binary_tags(
-        "/x.mp3",
-        vec![mk(MAX_BINARY_TAG_BYTES), mk(MAX_BINARY_TAG_BYTES + 1)],
+    assert!(check_storable("/x.mp3", &mk(MAX_BINARY_TAG_BYTES)).is_ok());
+    assert!(check_storable("/x.mp3", &mk(MAX_BINARY_TAG_BYTES + 1)).is_err());
+}
+
+#[test]
+fn check_storable_accepts_tag_value_at_cap_and_rejects_one_over() {
+    let cap = usize::try_from(musefs_db::limits::MAX_TAG_VALUE_LEN).unwrap();
+    // MP3, so the FLAC block-total check does not confound the per-value one.
+    let mk = |len: usize| probed_with_text_tags(&[("LYRICS", &"v".repeat(len))]);
+    assert!(check_storable("/x.mp3", &mk(cap)).is_ok());
+    let err = check_storable("/x.mp3", &mk(cap + 1))
+        .expect_err("one byte over the tag-value cap fails the file");
+    let msg = err.to_string();
+    assert!(msg.contains("LYRICS"), "names the tag: {msg}");
+    assert!(msg.contains(&cap.to_string()), "quotes the limit: {msg}");
+}
+
+#[test]
+fn check_storable_accepts_tag_key_at_cap_and_rejects_one_over() {
+    let cap = usize::try_from(musefs_db::limits::MAX_TAG_KEY_LEN).unwrap();
+    let at = "k".repeat(cap);
+    let over = "k".repeat(cap + 1);
+    assert!(check_storable("/x.mp3", &probed_with_text_tags(&[(&at, "v")])).is_ok());
+    assert!(check_storable("/x.mp3", &probed_with_text_tags(&[(&over, "v")])).is_err());
+}
+
+#[test]
+fn check_storable_accepts_art_description_at_cap_and_rejects_one_over() {
+    let cap = usize::try_from(musefs_db::limits::MAX_ART_DESCRIPTION_LEN).unwrap();
+    let mk = |len: usize| {
+        let mut pic = picture_of_len(1);
+        pic.description = "d".repeat(len);
+        probed_with_pictures(vec![pic])
+    };
+    assert!(check_storable("/x.flac", &mk(cap)).is_ok());
+    assert!(check_storable("/x.flac", &mk(cap + 1)).is_err());
+}
+
+/// The TEXT caps are compared against SQLite `length()`, which counts
+/// characters, not bytes. Counting bytes here would reject a legal multibyte
+/// key/description the `CHECK` would have accepted — failing a file for a limit
+/// it does not exceed, the mirror image of the bug #644 reported.
+#[test]
+fn check_storable_counts_characters_not_bytes_for_text_caps() {
+    let cap = usize::try_from(musefs_db::limits::MAX_TAG_KEY_LEN).unwrap();
+    let key = "é".repeat(cap); // `cap` chars, 2 * cap bytes
+    assert!(key.len() > cap, "fixture must be multibyte");
+    assert!(
+        check_storable("/x.mp3", &probed_with_text_tags(&[(&key, "v")])).is_ok(),
+        "a key at the character cap must pass even when its byte length exceeds it"
     );
-    assert_eq!(kept.len(), 1, "exactly the at-cap binary tag survives");
-    assert_eq!(kept[0].payload.len(), MAX_BINARY_TAG_BYTES);
+}
+
+#[test]
+fn check_storable_accepts_art_mime_at_cap_and_rejects_one_over() {
+    let cap = usize::try_from(musefs_db::limits::MAX_ART_MIME_LEN).unwrap();
+    let mk = |len: usize| {
+        let mut pic = picture_of_len(1);
+        pic.mime = "m".repeat(len);
+        probed_with_pictures(vec![pic])
+    };
+    assert!(check_storable("/x.flac", &mk(cap)).is_ok());
+    let err = check_storable("/x.flac", &mk(cap + 1))
+        .expect_err("one character over the MIME cap fails the file");
+    assert!(err.to_string().contains("MIME"), "{err}");
+}
+
+/// One tag whose `VORBIS_COMMENT` framing lands the running total on *exactly*
+/// the block ceiling, and the same tag one byte longer.
+///
+/// The pair pins the whole size computation, not just its verdict: the framing
+/// is `4-byte comment length + KEY + '=' + VALUE` on top of an 8-byte header,
+/// so getting any of those terms wrong shifts the total off the boundary and
+/// flips one of these two assertions. A test using values far over the ceiling
+/// (as the FLAC case below does) cannot see that — it is over either way.
+fn probed_with_comment_block_total(format: musefs_db::Format, total: usize) -> Probed {
+    // total = 8 (vendor len + comment count) + 4 (comment len) + "A" + '=' + value
+    let value = "v".repeat(total - 14);
+    let mut p = probed_with_text_tags(&[("A", &value)]);
+    p.format = format;
+    p
+}
+
+#[test]
+fn check_storable_comment_block_boundary_is_inclusive_and_exactly_framed() {
+    let cap = usize::try_from(musefs_format::flac::MAX_BLOCK_BODY).unwrap();
+    assert!(
+        check_storable(
+            "/x.flac",
+            &probed_with_comment_block_total(musefs_db::Format::Flac, cap)
+        )
+        .is_ok(),
+        "a comment block landing exactly on the ceiling still fits"
+    );
+    assert!(
+        check_storable(
+            "/x.flac",
+            &probed_with_comment_block_total(musefs_db::Format::Flac, cap + 1)
+        )
+        .is_err(),
+        "one byte past the ceiling cannot be synthesized"
+    );
+}
+
+/// Ogg FLAC carries the same FLAC metadata blocks as native FLAC, so it is
+/// bound by the same 24-bit ceiling and must not be waved through.
+#[test]
+fn check_storable_applies_the_comment_block_ceiling_to_ogg_flac() {
+    let cap = usize::try_from(musefs_format::flac::MAX_BLOCK_BODY).unwrap();
+    assert!(
+        check_storable(
+            "/x.oga",
+            &probed_with_comment_block_total(musefs_db::Format::OggFlac, cap)
+        )
+        .is_ok()
+    );
+    let err = check_storable(
+        "/x.oga",
+        &probed_with_comment_block_total(musefs_db::Format::OggFlac, cap + 1),
+    )
+    .expect_err("Ogg FLAC is bound by FLAC's block ceiling too");
+    assert!(err.to_string().contains("Ogg FLAC"), "{err}");
+}
+
+/// A tag value is capped at exactly FLAC's block ceiling, so one always fits
+/// alone — but two need not. Without this check the file would scan clean and
+/// then `EIO` on every read, which is the state #644's fail-the-file policy
+/// exists to prevent.
+#[test]
+fn check_storable_rejects_flac_tags_that_cannot_fit_a_comment_block() {
+    let cap = usize::try_from(musefs_db::limits::MAX_TAG_VALUE_LEN).unwrap();
+    let big = "v".repeat(cap * 2 / 3);
+    let mut probed = probed_with_text_tags(&[("A", &big), ("B", &big)]);
+    probed.format = musefs_db::Format::Flac;
+    let err = check_storable("/x.flac", &probed)
+        .expect_err("two two-thirds-cap tags overflow the comment block");
+    assert!(err.to_string().contains("FLAC"), "{err}");
+
+    // The same tags in an MP3 are fine: ID3v2's ceiling is 256 MiB.
+    let mut mp3 = probed_with_text_tags(&[("A", &big), ("B", &big)]);
+    mp3.format = musefs_db::Format::Mp3;
+    assert!(check_storable("/x.mp3", &mp3).is_ok());
 }
 
 fn probed_with_text_tags(tags: &[(&str, &str)]) -> Probed {

--- a/musefs-core/src/scan/scan_unit_tests.rs
+++ b/musefs-core/src/scan/scan_unit_tests.rs
@@ -198,42 +198,52 @@ fn mp4_with_covr(type_code: u32, value: &[u8]) -> Vec<u8> {
     [bx(b"ftyp", b"M4A "), moov, bx(b"mdat", b"AUDIODATA")].concat()
 }
 
+/// #644: an oversize `covr` fails the whole file rather than being dropped from
+/// an otherwise-stored track. The size check still happens before any copy, so
+/// the image is described and refused, never materialized — that property is
+/// what forces the verdict here at the probe rather than in `check_storable`.
 #[test]
-fn probe_file_skips_oversized_mp4_covr() {
+fn probe_file_fails_file_with_oversized_mp4_covr() {
     let oversized = vec![0xFFu8; MAX_ART_BYTES + 1];
     let bytes = mp4_with_covr(13, &oversized);
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("oversized_art.m4a");
     std::fs::write(&path, &bytes).unwrap();
-    let probed = match probe_file(&path, 0).unwrap() {
-        ProbeOutcome::Probed(p, _) => p,
-        other => panic!("expected Probed, got {other:?}"),
-    };
-    assert_eq!(probed.format, Format::M4a);
     assert!(
-        probed.pictures.is_empty(),
-        "oversized covr must be skipped at extraction, not materialized"
+        matches!(probe_file(&path, 0).unwrap(), ProbeOutcome::Unparseable),
+        "an oversized covr must fail the file, not yield a track without its art"
     );
 }
 
 #[test]
-fn probe_file_skips_oversized_mp4_binary_freeform() {
-    // A `----` value larger than MAX_BINARY_TAG_BYTES must be skipped at
-    // extraction by the real seek-path scanner, so it is absent from Probed.
+fn probe_file_fails_file_with_oversized_mp4_binary_freeform() {
     let oversized = vec![0xABu8; MAX_BINARY_TAG_BYTES + 1];
     let bytes = mp4_with_binary_freeform("com.serato.dj", "analysis", &oversized);
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("oversized_bin.m4a");
+    std::fs::write(&path, &bytes).unwrap();
+    assert!(
+        matches!(probe_file(&path, 0).unwrap(), ProbeOutcome::Unparseable),
+        "an oversized `----` value must fail the file"
+    );
+}
+
+/// An at-cap `covr` is still stored: the boundary is inclusive, and a drop here
+/// would be exactly the silent art loss #644 set out to remove.
+#[test]
+fn probe_file_keeps_mp4_covr_at_cap() {
+    let at_cap = vec![0xFFu8; MAX_ART_BYTES];
+    let bytes = mp4_with_covr(13, &at_cap);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("at_cap_art.m4a");
     std::fs::write(&path, &bytes).unwrap();
     let probed = match probe_file(&path, 0).unwrap() {
         ProbeOutcome::Probed(p, _) => p,
         other => panic!("expected Probed, got {other:?}"),
     };
     assert_eq!(probed.format, Format::M4a);
-    assert!(
-        probed.binary_tags.is_empty(),
-        "oversized binary freeform must be skipped at extraction, not materialized"
-    );
+    assert_eq!(probed.pictures.len(), 1);
+    assert_eq!(probed.pictures[0].data.len(), MAX_ART_BYTES);
 }
 
 #[test]

--- a/musefs-core/tests/flac_id3_prefix.rs
+++ b/musefs-core/tests/flac_id3_prefix.rs
@@ -301,3 +301,58 @@ fn serves_untouched_audio_from_behind_an_unparseable_tag() {
     let start = usize::try_from(scan.audio_offset).unwrap();
     assert_eq!(&served[start..], &audio[..]);
 }
+
+/// #644: merging an ID3 prefix into a FLAC's own comments is the one route by
+/// which a scanned FLAC's tags can outgrow what a `VORBIS_COMMENT` block can
+/// hold — ID3v2's synchsafe tag size is 256 MiB, FLAC's block length is 24 bits.
+/// Without a scan-time check such a file lands in the store and then serves
+/// `EIO` on every read, present in the mount and unreadable with nothing in the
+/// log to explain it. It must fail at scan instead, naming the file, and must
+/// not take the rest of the directory down with it.
+#[test]
+fn a_flac_whose_id3_prefix_overflows_the_comment_block_fails_only_itself() {
+    let dir = tempfile::tempdir().unwrap();
+    let audio = vec![0xCD; 4096];
+
+    // Two ID3 text frames, each comfortably *under* the per-tag cap but together
+    // past FLAC's 24-bit block ceiling, under keys the FLAC itself does not
+    // carry so `fill_absent_keys` appends both. Splitting them is deliberate: a
+    // single over-ceiling frame would trip the per-value cap instead, and this
+    // test is about the total.
+    let ceiling = usize::try_from(musefs_format::flac::MAX_BLOCK_BODY).unwrap();
+    let half = "z".repeat(ceiling * 6 / 10);
+    let mut bytes = id3_tag(&[("TIT2", &half), ("TALB", &half)]);
+    bytes.extend(make_flac(
+        &[
+            (0, streaminfo_body()),
+            (4, vorbis_comment_body("v", &["ARTIST=Alice"])),
+        ],
+        &audio,
+    ));
+    std::fs::write(dir.path().join("big.flac"), &bytes).unwrap();
+
+    std::fs::write(
+        dir.path().join("ok.flac"),
+        make_flac(
+            &[
+                (0, streaminfo_body()),
+                (4, vorbis_comment_body("v", &["ARTIST=Bob", "TITLE=Fine"])),
+            ],
+            &audio,
+        ),
+    )
+    .unwrap();
+
+    let db = musefs_db::Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).expect("one bad file must not abort the scan");
+
+    assert_eq!(stats.failed, 1, "the overflowing file is counted as failed");
+    assert_eq!(stats.scanned, 1, "its neighbour still lands");
+    let tracks = db.list_tracks().unwrap();
+    assert_eq!(tracks.len(), 1);
+    assert!(
+        tracks[0].backing_path.ends_with("ok.flac"),
+        "got {}",
+        tracks[0].backing_path
+    );
+}

--- a/musefs-core/tests/scan.rs
+++ b/musefs-core/tests/scan.rs
@@ -440,6 +440,32 @@ fn scan_ingests_and_dedups_embedded_art() {
     assert_eq!(db.get_art_meta(only).unwrap().unwrap().byte_len, 100);
 }
 
+/// The raise itself (#644): 300 KB of lyrics is over the old 256 KiB cap and
+/// well under the new one, so the file that prompted the report now scans and
+/// round-trips its tag.
+#[test]
+fn scan_stores_a_tag_value_the_old_cap_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let lyrics_body = "z".repeat(300_000);
+    std::fs::write(
+        dir.path().join("a.flac"),
+        flac_with_pictures(&["TITLE=A", &format!("LYRICS={lyrics_body}")], &[]),
+    )
+    .unwrap();
+
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
+    assert_eq!((stats.scanned, stats.failed), (1, 0));
+
+    let t = &db.list_tracks().unwrap()[0];
+    let tags = db.get_tags(t.id).unwrap();
+    let lyrics = tags
+        .iter()
+        .find(|t| t.key.eq_ignore_ascii_case("LYRICS"))
+        .expect("the 300 KB lyrics tag is stored");
+    assert_eq!(lyrics.value, lyrics_body);
+}
+
 fn flac_with_pictures(comments: &[&str], pics: &[(u32, &[u8])]) -> Vec<u8> {
     use common::{flac_block, streaminfo_body, vorbis_comment_body};
     fn picture_body(pic_type: u32, mime: &str, data: &[u8]) -> Vec<u8> {
@@ -494,10 +520,13 @@ fn scan_clamps_out_of_range_picture_type() {
     assert_eq!(ta[0].ordinal, 0);
 }
 
+/// #644: a file carrying oversize art fails outright rather than being stored
+/// with that art quietly missing. Its neighbours in the same directory are
+/// unaffected — the whole point of failing the file instead of the scan.
 #[test]
-fn scan_filters_oversized_art_without_ordinal_gaps() {
+fn scan_fails_only_the_file_with_oversized_art() {
     let dir = tempfile::tempdir().unwrap();
-    // Over MAX_ART_BYTES (16 MiB - 1 KiB) but still within FLAC's 24-bit block limit.
+    // Over MAX_ART_BYTES (16 MiB - 64 KiB) but still within FLAC's 24-bit block limit.
     let big = vec![0u8; 16_776_500];
     let small = vec![0x22u8; 50];
     std::fs::write(
@@ -505,15 +534,26 @@ fn scan_filters_oversized_art_without_ordinal_gaps() {
         flac_with_pictures(&["TITLE=A"], &[(3, &big), (4, &small)]),
     )
     .unwrap();
+    std::fs::write(
+        dir.path().join("b.flac"),
+        flac_with_pictures(&["TITLE=B"], &[(3, &small)]),
+    )
+    .unwrap();
 
     let db = Db::open_in_memory().unwrap();
-    scan_directory(&db, dir.path()).unwrap();
+    let stats = scan_directory(&db, dir.path()).unwrap();
 
-    let t = &db.list_tracks().unwrap()[0];
-    let ta = db.get_track_art(t.id).unwrap();
-    // The oversized first picture is skipped; the survivor keeps a gapless ordinal 0.
+    assert_eq!(stats.failed, 1, "the oversize file is counted as failed");
+    assert_eq!(stats.scanned, 1, "its neighbour still lands");
+    let tracks = db.list_tracks().unwrap();
+    assert_eq!(tracks.len(), 1);
+    assert!(
+        tracks[0].backing_path.ends_with("b.flac"),
+        "only the clean file is stored, got {}",
+        tracks[0].backing_path
+    );
+    // No partial row for the failed file, and no orphan art from it either.
+    let ta = db.get_track_art(tracks[0].id).unwrap();
     assert_eq!(ta.len(), 1);
-    assert_eq!(ta[0].ordinal, 0);
-    assert_eq!(ta[0].picture_type, 4);
     assert_eq!(db.get_art_meta(ta[0].art_id).unwrap().unwrap().byte_len, 50);
 }

--- a/musefs-db/src/art.rs
+++ b/musefs-db/src/art.rs
@@ -220,6 +220,7 @@ impl Db<ReadWrite> {
 #[cfg(test)]
 mod guard_tests {
     use crate::error::DbError;
+    use crate::limits::MAX_ART_DESCRIPTION_LEN;
     use crate::models::{NewArt, TrackArt};
     use crate::{Db, Format, NewTrack};
 
@@ -286,7 +287,7 @@ mod guard_tests {
         db.conn
             .execute_batch("PRAGMA ignore_check_constraints=ON")
             .unwrap();
-        let desc = "d".repeat(1025);
+        let desc = "d".repeat(usize::try_from(MAX_ART_DESCRIPTION_LEN).unwrap() + 1);
         db.set_track_art(
             track,
             &[TrackArt {

--- a/musefs-db/src/lib.rs
+++ b/musefs-db/src/lib.rs
@@ -6,6 +6,7 @@ pub mod limits;
 mod maintenance;
 mod models;
 mod schema;
+pub use schema::LATEST_VERSION;
 mod structural;
 mod tags;
 mod tracks;

--- a/musefs-db/src/limits.rs
+++ b/musefs-db/src/limits.rs
@@ -10,16 +10,36 @@
 
 /// Max `tags.key` length. Compared against SQLite `length()` (i64).
 pub const MAX_TAG_KEY_LEN: i64 = 256;
-/// Max `tags.value` length in bytes — 256 KiB. Both the schema `CHECK`
-/// (`length(CAST(value AS BLOB)) <= 262144`) and the read-time guard in
+/// Max `tags.value` length in bytes — 16 MiB − 1. Both the schema `CHECK`
+/// (`length(CAST(value AS BLOB)) <= 16777215`) and the read-time guard in
 /// [`crate::tags`] count bytes, not UTF-8 characters, so the
 /// materialized-memory bound is exact rather than ~4x looser for multibyte
 /// text (#505).
-pub const MAX_TAG_VALUE_LEN: i64 = 262_144;
+///
+/// The value is FLAC's 24-bit metadata-block ceiling
+/// (`musefs_format::flac::MAX_BLOCK_BODY`, equal to [`MAX_STRUCTURAL_BODY_LEN`]),
+/// i.e. the largest tag synthesis could ever serve. It was 256 KiB until #644,
+/// which was a number musefs invented: a lyrics/cuesheet/review tag past it
+/// aborted the whole scan on the `CHECK`. Capping below what the format can
+/// carry is enumerating badness against people who do unusual-but-legal things
+/// to their files, so the cap now sits exactly at the format ceiling and
+/// anything past it fails that one file with a legible message.
+///
+/// Materialization bound, stated plainly rather than papered over: a crafted DB
+/// can pair this with [`MAX_TAGS_PER_TRACK`] for ~64 GiB of text on one track.
+/// That is a wider DoS surface than the old 256 KiB gave (~1 GiB), accepted as
+/// low-severity — it needs a hand-crafted store the reader already distrusts,
+/// and the payoff is that no honest file can be rejected for a limit musefs
+/// made up.
+pub const MAX_TAG_VALUE_LEN: i64 = 0x00FF_FFFF;
 /// Max `art.mime` length.
 pub const MAX_ART_MIME_LEN: i64 = 255;
-/// Max `track_art.description` length — 1 KiB.
-pub const MAX_ART_DESCRIPTION_LEN: i64 = 1024;
+/// Max `track_art.description` length — 8 KiB. Raised from 1 KiB in #644: a
+/// picture description is free-form UTF-8 with a 32-bit length in both FLAC
+/// `PICTURE` and ID3 `APIC`, and a tagger pasting a paragraph of provenance
+/// into it is odd but legal. The row cost is negligible next to the art blob it
+/// annotates, so the tight cap bought nothing and only risked failing a file.
+pub const MAX_ART_DESCRIPTION_LEN: i64 = 8192;
 /// Max `structural_blocks.body` length in bytes. Mirrors
 /// `musefs_format::flac::MAX_BLOCK_BODY` (FLAC's 24-bit block limit); the db
 /// layer cannot depend on the format layer, so the equality is asserted by a
@@ -51,8 +71,12 @@ mod tests {
 
     #[test]
     fn cap_values_are_pinned() {
-        assert_eq!(MAX_TAG_VALUE_LEN, 256 * 1024);
-        assert_eq!(MAX_ART_DESCRIPTION_LEN, 1024);
+        assert_eq!(MAX_TAG_VALUE_LEN, 16 * 1024 * 1024 - 1);
+        // The tag cap is the format ceiling, not an independent number: it must
+        // track FLAC's 24-bit block limit, which `MAX_STRUCTURAL_BODY_LEN`
+        // already mirrors (and a musefs-core test ties to the format constant).
+        assert_eq!(MAX_TAG_VALUE_LEN, MAX_STRUCTURAL_BODY_LEN);
+        assert_eq!(MAX_ART_DESCRIPTION_LEN, 8 * 1024);
         assert_eq!(MAX_STRUCTURAL_BODY_LEN, 0x00FF_FFFF);
         assert_eq!(MAX_BINARY_TAG_BYTES, 16 * 1024 * 1024 - 64 * 1024);
         assert_eq!(MAX_ART_BYTES, 16 * 1024 * 1024 - 64 * 1024);

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -264,15 +264,123 @@ CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
 END;
 ";
 
+const MIGRATION_V3: &str = r"
+-- Widen the two caps musefs invented rather than inherited (#644).
+--
+-- `tags.value` moves 256 KiB -> 16 MiB - 1 (FLAC's 24-bit metadata-block
+-- ceiling, the largest tag synthesis could ever serve) and
+-- `track_art.description` moves 1 KiB -> 8 KiB. Both are *widenings*, so the
+-- refills need no WHERE filter and drop no rows -- unlike V2's narrowing, which
+-- had to shed over-cap rows to avoid aborting on its own new CHECK.
+--
+-- SQLite cannot alter a CHECK in place, so both tables are recreated. V1/V2
+-- text is left untouched: they must stay replayable for a V1 -> V2 -> V3
+-- upgrade, and their literals are frozen history, not the current caps.
+
+-- `art_ad`'s body reads `track_art`. ALTER TABLE ... RENAME reparses the whole
+-- schema and would fail with 'error in trigger art_ad: no such table' while
+-- track_art is momentarily absent, so drop it up front and recreate it verbatim
+-- below. (V2's `tags` rebuild needed no such dance: nothing referenced `tags`.)
+DROP TRIGGER art_ad;
+
+CREATE TABLE tags_v3 (
+    track_id   INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    ordinal    INTEGER NOT NULL DEFAULT 0,
+    value_blob BLOB,
+    PRIMARY KEY (track_id, key, ordinal),
+    CHECK (ordinal >= 0),
+    CHECK (value_blob IS NULL OR value = ''),
+    CHECK (length(key) <= 256),
+    CHECK (length(key) >= 1
+           AND key NOT GLOB '*[' || char(1) || '-' || char(31) || ']*'),
+    CHECK (length(CAST(value AS BLOB)) <= 16777215),
+    CHECK (value_blob IS NULL OR length(value_blob) <= 16711680)
+);
+INSERT INTO tags_v3 (track_id, key, value, ordinal, value_blob)
+    SELECT track_id, key, value, ordinal, value_blob FROM tags;
+DROP TABLE tags;
+ALTER TABLE tags_v3 RENAME TO tags;
+
+CREATE TABLE track_art_v3 (
+    track_id     INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    art_id       INTEGER NOT NULL REFERENCES art(id),
+    picture_type INTEGER NOT NULL DEFAULT 3,
+    description  TEXT NOT NULL DEFAULT '',
+    ordinal      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (track_id, ordinal),
+    CHECK (picture_type BETWEEN 0 AND 20),
+    CHECK (ordinal >= 0),
+    CHECK (length(description) <= 8192)
+);
+INSERT INTO track_art_v3 (track_id, art_id, picture_type, description, ordinal)
+    SELECT track_id, art_id, picture_type, description, ordinal FROM track_art;
+DROP TABLE track_art;
+ALTER TABLE track_art_v3 RENAME TO track_art;
+
+-- DROP TABLE took each table's triggers (and track_art's index) with it;
+-- recreate them verbatim so the content_version/updated_at bump contract and
+-- the reverse art -> track_art edge are unchanged.
+CREATE INDEX track_art_art_id_idx ON track_art(art_id);
+
+CREATE TRIGGER tags_ai AFTER INSERT ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_au AFTER UPDATE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER tags_ad AFTER DELETE ON tags BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER track_art_ai AFTER INSERT ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_au AFTER UPDATE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = NEW.track_id;
+END;
+CREATE TRIGGER track_art_ad AFTER DELETE ON track_art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id = OLD.track_id;
+END;
+
+CREATE TRIGGER art_ad AFTER DELETE ON art BEGIN
+    UPDATE tracks SET content_version = content_version + 1,
+                      updated_at = CAST(strftime('%s','now') AS INTEGER)
+    WHERE id IN (SELECT track_id FROM track_art WHERE art_id = OLD.id);
+END;
+";
+
 /// Ring capacity of the `track_changes` changelog. Must match the literal in
 /// MIGRATION_V1 (guarded by `changelog_cap_constant_matches_migration_sql`).
 #[allow(dead_code)]
 pub const CHANGELOG_CAP: i64 = 8192;
 
-const MIGRATIONS: &[&str] = &[MIGRATION_V1, MIGRATION_V2];
+const MIGRATIONS: &[&str] = &[MIGRATION_V1, MIGRATION_V2, MIGRATION_V3];
+
+/// The `user_version` a fully-migrated store carries. Exported so callers and
+/// tests assert "the latest schema" rather than a literal that has to be chased
+/// through every test file each time a migration is appended.
+pub const LATEST_VERSION: i64 = 3;
+const _: () = assert!(
+    MIGRATIONS.len() == 3,
+    "LATEST_VERSION must match MIGRATIONS"
+);
 
 pub fn migrate(conn: &mut Connection) -> Result<()> {
-    let latest = i64::try_from(MIGRATIONS.len()).expect("MIGRATIONS count must fit i64");
+    let latest = LATEST_VERSION;
     let current = conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))?;
     // A store at a user_version past anything this binary knows about was written
     // by a newer (or third-party) tool that bumped the schema. Refuse it loudly
@@ -380,7 +488,11 @@ mod baseline_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 2);
+        assert_eq!(
+            uv,
+            super::LATEST_VERSION,
+            "migrate() must reach the latest migration"
+        );
 
         // value_blob exists on tags and defaults to NULL.
         conn.execute(
@@ -417,7 +529,7 @@ mod baseline_tests {
         let uv2: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv2, 2);
+        assert_eq!(uv2, super::LATEST_VERSION);
     }
 
     #[test]
@@ -427,8 +539,8 @@ mod baseline_tests {
         assert_eq!(
             conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))
                 .unwrap(),
-            2,
-            "V2 migration must bump user_version to 2"
+            super::LATEST_VERSION,
+            "migrate() must stamp user_version with the latest migration index"
         );
         // Both columns exist, are nullable, and default to NULL.
         conn.execute(
@@ -456,27 +568,48 @@ mod baseline_tests {
         assert!(super::MIGRATION_V1.contains(&format!("NEW.seq - {}", super::CHANGELOG_CAP)));
     }
 
+    /// The caps a later migration has since widened live in V1/V2 as *frozen
+    /// history* — those steps must stay replayable byte-for-byte for the
+    /// V1 -> V2 -> V3 upgrade path, so their literals are pinned to the values
+    /// they shipped with and deliberately NOT to `crate::limits`. Binding them
+    /// to the live constants (as this test once did) makes any future cap
+    /// change look like it must be back-edited into released migration text.
+    #[test]
+    fn superseded_migration_literals_are_frozen() {
+        assert!(super::MIGRATION_V1.contains("length(value) <= 262144"));
+        assert!(super::MIGRATION_V1.contains("length(description) <= 1024"));
+        assert!(
+            super::MIGRATION_V2.contains("length(CAST(value AS BLOB)) <= 262144"),
+            "V2's byte-accurate rebuild (#505) shipped at the 256 KiB cap"
+        );
+    }
+
+    /// The literals in the *latest* definition of each table are what a fresh
+    /// `migrate()` leaves behind, so those are the ones that must track
+    /// `crate::limits`. V3 owns `tags` and `track_art`; V1 still owns `art` and
+    /// `structural_blocks`.
     #[test]
     fn check_literals_match_limits_constants() {
         use crate::limits::*;
-        let sql = super::MIGRATION_V1;
-        assert!(sql.contains(&format!("length(key) <= {MAX_TAG_KEY_LEN}")));
-        assert!(sql.contains(&format!("length(value) <= {MAX_TAG_VALUE_LEN}")));
-        // V2 rebuilds `tags` with a byte-accurate value cap (#505).
-        assert!(super::MIGRATION_V2.contains(&format!(
+        let v1 = super::MIGRATION_V1;
+        let v3 = super::MIGRATION_V3;
+        // V3 rebuilds `tags` at FLAC's block ceiling and `track_art` at 8 KiB (#644).
+        assert!(v3.contains(&format!("length(key) <= {MAX_TAG_KEY_LEN}")));
+        assert!(v3.contains(&format!(
             "length(CAST(value AS BLOB)) <= {MAX_TAG_VALUE_LEN}"
         )));
-        assert!(sql.contains(&format!("length(value_blob) <= {MAX_BINARY_TAG_BYTES}")));
-        assert!(sql.contains(&format!("length(mime) <= {MAX_ART_MIME_LEN}")));
-        assert!(sql.contains(&format!("byte_len <= {MAX_ART_BYTES}")));
-        assert!(sql.contains(&format!("length(description) <= {MAX_ART_DESCRIPTION_LEN}")));
-        assert!(sql.contains(&format!("length(body) <= {MAX_STRUCTURAL_BODY_LEN}")));
+        assert!(v3.contains(&format!("length(value_blob) <= {MAX_BINARY_TAG_BYTES}")));
+        assert!(v3.contains(&format!("length(description) <= {MAX_ART_DESCRIPTION_LEN}")));
+        // Still V1-owned: no later migration recreates `art` or `structural_blocks`.
+        assert!(v1.contains(&format!("length(mime) <= {MAX_ART_MIME_LEN}")));
+        assert!(v1.contains(&format!("byte_len <= {MAX_ART_BYTES}")));
+        assert!(v1.contains(&format!("length(body) <= {MAX_STRUCTURAL_BODY_LEN}")));
         let kinds = STRUCTURAL_KINDS
             .iter()
             .map(|k| format!("'{k}'"))
             .collect::<Vec<_>>()
             .join(",");
-        assert!(sql.contains(&format!("kind IN ({kinds})")));
+        assert!(v1.contains(&format!("kind IN ({kinds})")));
     }
 }
 
@@ -506,7 +639,7 @@ mod changelog_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 2);
+        assert_eq!(uv, super::LATEST_VERSION);
 
         insert_track(&conn, "/a.flac"); // tracks AI -> 1 row
         assert_eq!(count_changes(&conn), 1);
@@ -690,10 +823,7 @@ mod schema_py_tests {
 
         assert_eq!(dump_master(&rendered), dump_master(&migrated));
         assert_eq!(user_version(&rendered), user_version(&migrated));
-        assert_eq!(
-            user_version(&rendered),
-            i64::try_from(MIGRATIONS.len()).unwrap()
-        );
+        assert_eq!(user_version(&rendered), super::LATEST_VERSION);
     }
 
     #[test]
@@ -708,10 +838,7 @@ mod schema_py_tests {
         conn.execute_batch(MIGRATIONS[0]).unwrap(); // apply V1 only
         conn.pragma_update(None, "user_version", 1i64).unwrap();
         super::migrate(&mut conn).expect("upgrading from v1 must apply only the remaining steps");
-        assert_eq!(
-            user_version(&conn),
-            i64::try_from(MIGRATIONS.len()).unwrap()
-        );
+        assert_eq!(user_version(&conn), super::LATEST_VERSION);
     }
 
     #[test]
@@ -719,7 +846,7 @@ mod schema_py_tests {
         // #505: V2 rebuilds `tags` with a byte-accurate value cap. Simulate a v1
         // store, plant an over-cap multibyte value (legal under V1's char-counting
         // CHECK: 150_000 chars / 300_000 bytes) plus a normal one, then upgrade.
-        let mut conn = Connection::open_in_memory().unwrap();
+        let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(MIGRATIONS[0]).unwrap(); // V1 only
         conn.pragma_update(None, "user_version", 1i64).unwrap();
         conn.execute(
@@ -741,7 +868,11 @@ mod schema_py_tests {
         )
         .unwrap();
 
-        super::migrate(&mut conn).expect("upgrade to v2");
+        // V2 only, applied directly. `migrate()` would run on through V3, whose
+        // widened cap (#644) accepts this value — that is the later step's
+        // business, asserted separately below. This test is about what V2 did.
+        conn.execute_batch(MIGRATIONS[1]).unwrap();
+        conn.pragma_update(None, "user_version", 2i64).unwrap();
 
         // The over-cap row is dropped; the valid row survives.
         let keys: Vec<String> = {
@@ -751,7 +882,7 @@ mod schema_py_tests {
         };
         assert_eq!(keys, vec!["ok".to_string()]);
 
-        // The rebuilt CHECK now rejects an over-cap multibyte value at write.
+        // The rebuilt CHECK rejects an over-cap multibyte value at write.
         assert!(
             conn.execute(
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'big2',?1,0)",
@@ -778,6 +909,122 @@ mod schema_py_tests {
             cv(&conn) > before,
             "tags_ai trigger must survive the rebuild"
         );
+    }
+
+    /// #644: V3 widens `tags.value` to FLAC's block ceiling and
+    /// `track_art.description` to 8 KiB. Both are widenings, so unlike V2's
+    /// narrowing the rebuild must carry every existing row across — losing user
+    /// tags to a migration that only relaxes a limit would be gratuitous.
+    #[test]
+    fn v3_rebuild_widens_caps_and_preserves_rows() {
+        use crate::limits::{MAX_ART_DESCRIPTION_LEN, MAX_TAG_VALUE_LEN};
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(MIGRATIONS[0]).unwrap();
+        conn.execute_batch(MIGRATIONS[1]).unwrap();
+        conn.pragma_update(None, "user_version", 2i64).unwrap();
+        conn.execute(
+            "INSERT INTO tracks (backing_path, format, audio_offset, audio_length, \
+             backing_size, backing_mtime_ns, backing_ctime_ns, updated_at) \
+             VALUES ('/a.flac','flac',0,0,0,0,0,0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO art (sha256, mime, width, height, byte_len, data) \
+             VALUES (?1,'image/png',1,1,1,X'00')",
+            [&"a".repeat(64)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'artist','A',0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal) \
+             VALUES (1,1,3,'cover',0)",
+            [],
+        )
+        .unwrap();
+
+        super::migrate(&mut conn).expect("upgrade to v3");
+
+        assert_eq!(
+            conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))
+                .unwrap(),
+            super::LATEST_VERSION
+        );
+        // Rows survive: a widening must never drop data.
+        let (key, value): (String, String) = conn
+            .query_row("SELECT key, value FROM tags", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!((key.as_str(), value.as_str()), ("artist", "A"));
+        let desc: String = conn
+            .query_row("SELECT description FROM track_art", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(desc, "cover");
+
+        // A value the V2 cap rejected now writes cleanly — the point of #644.
+        let over_v2 = "é".repeat(150_000);
+        assert!(
+            over_v2.len() > 262_144 && i64::try_from(over_v2.len()).unwrap() < MAX_TAG_VALUE_LEN
+        );
+        conn.execute(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1,'lyrics',?1,0)",
+            rusqlite::params![over_v2],
+        )
+        .expect("V3 accepts a value the 256 KiB cap rejected");
+        conn.execute(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal) \
+             VALUES (1,1,3,?1,1)",
+            rusqlite::params!["d".repeat(2048)],
+        )
+        .expect("V3 accepts a description the 1 KiB cap rejected");
+
+        // The triggers and the reverse-edge index came back with the rebuild.
+        let objects: Vec<String> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name FROM sqlite_master \
+                     WHERE name IN ('tags_ai','tags_au','tags_ad','track_art_ai', \
+                                    'track_art_au','track_art_ad','art_ad', \
+                                    'track_art_art_id_idx') ORDER BY name",
+                )
+                .unwrap();
+            let rows = stmt.query_map([], |r| r.get(0)).unwrap();
+            rows.collect::<rusqlite::Result<_>>().unwrap()
+        };
+        assert_eq!(
+            objects,
+            vec![
+                "art_ad",
+                "tags_ad",
+                "tags_ai",
+                "tags_au",
+                "track_art_ad",
+                "track_art_ai",
+                "track_art_art_id_idx",
+                "track_art_au",
+            ],
+            "V3 must restore every object its two DROP TABLEs took with them"
+        );
+        // `art_ad` reads `track_art`; a rebuild that renamed the table out from
+        // under that trigger leaves a body that errors at *fire* time, not at
+        // migration time, so the object-name check above would not catch it.
+        // Fire it, in the exact shape it was written for: an art row deleted
+        // while track_art still references it (only reachable with FKs off).
+        conn.pragma_update(None, "foreign_keys", false).unwrap();
+        conn.execute("DELETE FROM art WHERE id = 1", [])
+            .expect("art_ad must still resolve track_art after the V3 rebuild");
+        let bumped: i64 = conn
+            .query_row("SELECT content_version FROM tracks WHERE id=1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert!(bumped > 0, "art_ad must bump the referencing track");
+        assert_eq!(MAX_ART_DESCRIPTION_LEN, 8192);
     }
 
     /// NOT #[ignore]d on purpose: the compare path must run under plain
@@ -834,7 +1081,7 @@ mod constraint_tests {
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 2);
+        assert_eq!(uv, super::LATEST_VERSION);
 
         insert_track(&conn, "/a.flac");
         conn.execute(
@@ -871,6 +1118,15 @@ mod constraint_tests {
             )
             .unwrap();
         assert_eq!(pic, 3);
+    }
+
+    /// SQL expression yielding `n` copies of `c`, for cap-boundary inserts.
+    /// `hex(zeroblob(k))` is `2k` ASCII '0's, so one `replace` plus a `substr`
+    /// builds any length without materializing a multi-MiB Rust string just to
+    /// interpolate it into a statement.
+    fn repeated_char_sql(c: char, n: i64) -> String {
+        let half = n / 2 + n % 2;
+        format!("substr(replace(hex(zeroblob({half})), '0', '{c}'), 1, {n})")
     }
 
     fn rejected(conn: &Connection, sql: &str) {
@@ -1212,16 +1468,39 @@ mod constraint_tests {
 
     #[test]
     fn v4_tags_rejects_oversize_value() {
+        use crate::limits::MAX_TAG_VALUE_LEN;
         let mut conn = Connection::open_in_memory().unwrap();
         fresh(&mut conn);
         insert_track(&conn, "/a.flac");
-        let big = "v".repeat(262_145);
+        // Built in SQL rather than Rust: at the post-#644 cap the string is
+        // 16 MiB, and interpolating one into a statement costs twice that for a
+        // test whose whole point is the `<=` boundary.
+        let over = repeated_char_sql('v', MAX_TAG_VALUE_LEN + 1);
         rejected(
             &conn,
-            &format!(
-                "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1, 'k', '{big}', 0)"
-            ),
+            &format!("INSERT INTO tags (track_id, key, value, ordinal) VALUES (1, 'k', {over}, 0)"),
         );
+    }
+
+    /// The widened cap (#644) accepts exactly at the boundary, so the pair pins
+    /// the `CHECK`'s `<=` against an off-by-one in either direction.
+    #[test]
+    fn v4_tags_accepts_value_at_cap() {
+        use crate::limits::MAX_TAG_VALUE_LEN;
+        let mut conn = Connection::open_in_memory().unwrap();
+        fresh(&mut conn);
+        insert_track(&conn, "/a.flac");
+        let at = repeated_char_sql('v', MAX_TAG_VALUE_LEN);
+        conn.execute_batch(&format!(
+            "INSERT INTO tags (track_id, key, value, ordinal) VALUES (1, 'k', {at}, 0)"
+        ))
+        .unwrap();
+        let len: i64 = conn
+            .query_row("SELECT length(CAST(value AS BLOB)) FROM tags", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(len, MAX_TAG_VALUE_LEN);
     }
 
     #[test]
@@ -1280,16 +1559,36 @@ mod constraint_tests {
 
     #[test]
     fn v4_track_art_rejects_oversize_description() {
+        use crate::limits::MAX_ART_DESCRIPTION_LEN;
         let mut conn = Connection::open_in_memory().unwrap();
         fresh(&mut conn);
         seed_track_and_art(&conn);
-        let desc = "d".repeat(1025);
+        let over = repeated_char_sql('d', MAX_ART_DESCRIPTION_LEN + 1);
         rejected(
             &conn,
             &format!(
-                "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal) VALUES (1, 1, 3, '{desc}', 0)"
+                "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal) VALUES (1, 1, 3, {over}, 0)"
             ),
         );
+    }
+
+    #[test]
+    fn v4_track_art_accepts_description_at_cap() {
+        use crate::limits::MAX_ART_DESCRIPTION_LEN;
+        let mut conn = Connection::open_in_memory().unwrap();
+        fresh(&mut conn);
+        seed_track_and_art(&conn);
+        let at = repeated_char_sql('d', MAX_ART_DESCRIPTION_LEN);
+        conn.execute_batch(&format!(
+            "INSERT INTO track_art (track_id, art_id, picture_type, description, ordinal) VALUES (1, 1, 3, {at}, 0)"
+        ))
+        .unwrap();
+        let len: i64 = conn
+            .query_row("SELECT length(description) FROM track_art", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(len, MAX_ART_DESCRIPTION_LEN);
     }
 
     #[test]
@@ -1568,12 +1867,12 @@ mod art_immutability_tests {
     }
 
     #[test]
-    fn migration_reaches_user_version_1() {
+    fn migration_reaches_latest_user_version() {
         let conn = migrated();
         let uv: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(uv, 2);
+        assert_eq!(uv, super::LATEST_VERSION);
     }
 
     #[test]

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -790,9 +790,15 @@ mod schema_py_tests {
              SCHEMA_SQL = \"\"\"\\\n\
              {sql}\"\"\"\n\
              \n\
-             USER_VERSION = {version}\n",
+             USER_VERSION = {version}\n\
+             \n\
+             # Byte cap on `tags.value`, mirrored so an external writer can check a\n\
+             # value before the `CHECK` does. Generated from the Rust constant: it\n\
+             # moved once already (#644) and a hand-kept copy would silently rot.\n\
+             MAX_TAG_VALUE_LEN = {max_tag_value_len}\n",
             sql = render_schema_sql(),
-            version = MIGRATIONS.len()
+            version = MIGRATIONS.len(),
+            max_tag_value_len = crate::limits::MAX_TAG_VALUE_LEN
         )
     }
 

--- a/musefs-db/src/tags.rs
+++ b/musefs-db/src/tags.rs
@@ -241,6 +241,19 @@ mod tags_for_tracks_tests {
     fn open_mem() -> Db {
         Db::open_in_memory().unwrap()
     }
+    /// The `tags.value` cap in bytes. Derived, never spelled out: these
+    /// boundary tests exist to pin the guard's `>` comparison, not the cap's
+    /// current value, and hardcoding it means every cap change (#644) breaks
+    /// tests that were never about the number.
+    fn cap() -> usize {
+        usize::try_from(MAX_TAG_VALUE_LEN).unwrap()
+    }
+    fn at_cap_value() -> String {
+        "v".repeat(cap())
+    }
+    fn over_cap_value() -> String {
+        "v".repeat(cap() + 1)
+    }
     fn new_track(path: &str) -> NewTrack {
         NewTrack {
             backing_path: path.into(),
@@ -401,7 +414,7 @@ mod tags_for_tracks_tests {
         db.conn
             .execute_batch("PRAGMA ignore_check_constraints=ON")
             .unwrap();
-        let big = "v".repeat(262_145);
+        let big = over_cap_value();
         db.conn
             .execute(
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, 'k', ?2, 0)",
@@ -419,26 +432,27 @@ mod tags_for_tracks_tests {
     fn get_tags_accepts_value_at_cap() {
         let db = open_mem();
         let a = db.upsert_track(&new_track("/a.flac")).unwrap();
-        let at = "v".repeat(262_144);
+        let at = at_cap_value();
         db.conn
             .execute(
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, 'k', ?2, 0)",
                 rusqlite::params![a, at],
             )
             .unwrap();
-        assert_eq!(db.get_tags(a).unwrap()[0].value.len(), 262_144);
+        assert_eq!(db.get_tags(a).unwrap()[0].value.len(), cap());
     }
 
     #[test]
     fn multibyte_value_over_byte_cap_is_rejected_at_write_and_read() {
-        // Regression for #505: the cap counts bytes, not characters. 150_000
-        // two-byte chars is 150_000 chars (under the old char-counting CHECK)
-        // but 300_000 bytes (over the 256 KiB materialized-memory bound).
+        // Regression for #505: the cap counts bytes, not characters. Half the
+        // cap's worth of two-byte chars is under the cap by character count but
+        // one byte over it by byte count — the exact gap the old char-counting
+        // CHECK left open.
         let db = open_mem();
         let a = db.upsert_track(&new_track("/a.flac")).unwrap();
-        let multibyte = "é".repeat(150_000);
-        assert!(multibyte.chars().count() < 262_144, "under the char count");
-        assert!(multibyte.len() > 262_144, "over the byte cap");
+        let multibyte = "é".repeat(cap() / 2 + 1);
+        assert!(multibyte.chars().count() < cap(), "under the char count");
+        assert!(multibyte.len() > cap(), "over the byte cap");
 
         // Write path: the byte-accurate schema CHECK rejects the honest insert.
         let write_err = db.conn.execute(
@@ -530,7 +544,7 @@ mod tags_for_tracks_tests {
         db.conn
             .execute_batch("PRAGMA ignore_check_constraints=ON")
             .unwrap();
-        let big = "v".repeat(262_145);
+        let big = over_cap_value();
         db.conn
             .execute(
                 "INSERT INTO tags (track_id, key, value, ordinal) VALUES (?1, 'k', ?2, 0)",

--- a/musefs-db/tests/schema.rs
+++ b/musefs-db/tests/schema.rs
@@ -1,9 +1,9 @@
-use musefs_db::Db;
+use musefs_db::{Db, LATEST_VERSION};
 
 #[test]
 fn open_in_memory_runs_migration_to_latest() {
     let db = Db::open_in_memory().expect("open");
-    assert_eq!(db.user_version().expect("user_version"), 2);
+    assert_eq!(db.user_version().expect("user_version"), LATEST_VERSION);
 }
 
 #[test]
@@ -12,12 +12,12 @@ fn migration_is_idempotent_across_reopen() {
     let path = dir.path().join("musefs.db");
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 2);
+    assert_eq!(db.user_version().unwrap(), LATEST_VERSION);
     drop(db);
 
     // Reopening must not error and must not advance the version.
     let db2 = Db::open(&path).unwrap();
-    assert_eq!(db2.user_version().unwrap(), 2);
+    assert_eq!(db2.user_version().unwrap(), LATEST_VERSION);
 }
 
 #[test]
@@ -28,9 +28,10 @@ fn opening_a_store_newer_than_the_binary_fails_loudly() {
     // Create a normal store, then simulate a future/third-party tool bumping the
     // schema past what this binary knows about.
     Db::open(&path).unwrap();
+    let future = LATEST_VERSION + 1;
     {
         let conn = rusqlite::Connection::open(&path).unwrap();
-        conn.pragma_update(None, "user_version", 3).unwrap();
+        conn.pragma_update(None, "user_version", future).unwrap();
     }
 
     // Reopening must refuse the store instead of silently treating it as
@@ -39,12 +40,10 @@ fn opening_a_store_newer_than_the_binary_fails_loudly() {
     assert!(
         matches!(
             err,
-            musefs_db::DbError::StoreTooNew {
-                found: 3,
-                supported: 2
-            }
+            musefs_db::DbError::StoreTooNew { found, supported }
+                if found == future && supported == LATEST_VERSION
         ),
-        "expected StoreTooNew {{ found: 3, supported: 2 }}, got {err:?}"
+        "expected StoreTooNew {{ found: {future}, supported: {LATEST_VERSION} }}, got {err:?}"
     );
 }
 
@@ -52,7 +51,9 @@ fn opening_a_store_newer_than_the_binary_fails_loudly() {
 #[test]
 fn default_db_is_unmigrated_version_zero() {
     // Kills `Db::user_version -> Ok(1)`: Default opens an UNMIGRATED in-memory
-    // connection, so user_version is 0, distinct from the always-migrated 2.
+    // connection, so user_version is 0, distinct from the always-migrated
+    // LATEST_VERSION.
     let db = Db::default();
     assert_eq!(db.user_version().unwrap(), 0);
+    assert_ne!(0, LATEST_VERSION);
 }

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -196,6 +196,11 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
         | CoreError::ArtTooLarge { .. }
         | CoreError::InvalidPictureType { .. }
         | CoreError::HeaderTooLarge { .. }
+        // Scan-time refusals (#644). They cannot reach a FUSE reply — nothing
+        // over-cap is ever written — but EIO is the right collapse if the
+        // scanner's validation is ever reused on a serve path.
+        | CoreError::TrackFieldTooLarge { .. }
+        | CoreError::TrackMetadataTooLarge { .. }
         | CoreError::Format(_)
         | CoreError::InvalidTemplate(_) => fuser::Errno::EIO,
     }


### PR DESCRIPTION
## What and why

Closes #644.

Scanning a FLAC with a tag over 256 KiB aborted the **entire** run with

```
CHECK constraint failed: length(CAST(value AS BLOB)) <= 262144
```

naming neither the offending file nor what the number meant. Two separate
defects sat behind it, and the reporter was right about both: the limit was too
low, and the reporting was opaque.

**The scanner had no length check on text tags at all.** `ingest_into` handed
every probed tag straight to `replace_tags`, so the cap was enforced by the DB
`CHECK` inside a batch commit — where `flush` treats any write error as fatal
and the per-file context is already gone. Three sibling caps (`tags.key`,
`art.mime`, `track_art.description`) had the identical failure mode; nobody had
happened to trip them yet.

**The caps that were enforced went the other way.** Oversize art and binary tags
were dropped with a warning and the rest of the track stored (#284). A `warn`
buried in a scan of ten thousand files is easy to miss, and it leaves a mount
quietly missing data the user never agreed to lose.

### Fail the file, not the scan

Both halves are now one policy. `check_storable` applies every cap in one place
before anything is written — called from the pipeline worker (before the payload
is charged to the byte budget) and again from `ingest_into`, so `ingest` /
`ingest_bulk` honour the same contract. The file is counted `failed` and the
scan carries on:

```
skipping /music/a.flac: embedded image/png art is 16740000 bytes, over musefs's limit of 16711680 bytes
scanned /music: 1 file(s), 0 already present, skipped 0, failed 1
```

MP4 keeps refusing oversize `covr`/`----` payloads at the probe, one layer
earlier, because the size check there deliberately runs before any copy — a huge
image is described and rejected, never materialized. Only the verdict changed.
A still-fatal store write now names the file it died on.

### The cap moves to the format ceiling

`tags.value` goes to 16 MiB − 1, FLAC's 24-bit metadata-block ceiling and so the
largest tag synthesis could ever serve; `track_art.description` goes 1 KiB → 8
KiB in the same migration. 256 KiB was a number musefs invented, and capping
below what the format can carry is enumerating badness against people who do
unusual but legal things to their files.

`tags.key` (256) and `art.mime` (255) stay: both have real de-facto ceilings and
are map keys rather than payloads, and exceeding them now costs one
clearly-logged file rather than the scan.

**Upgrade path.** Both caps only widen, so `MIGRATION_V3` carries every existing
row across. Stores upgrade in place and automatically on the next `musefs scan`
*or* `musefs mount` (both open read-write and migrate) — no rescan, nothing to
regenerate. Verified end to end against a real V2 store built from the shipped
`schema.py`: rows preserved, all six triggers, `art_ad`, and the reverse-edge
index restored.

### One consequence, closed

Putting the cap *at* the ceiling means one tag can fill an entire comment block,
so two need not fit. That is reachable — a FLAC with a leading ID3v2 tag (#602)
merges fields from a 256 MiB container into a 16 MiB one — and unchecked it
produces a file that scans clean and then serves `EIO` on every read, present in
the mount and unreadable with nothing in the log to explain it. Exactly the
state this change exists to remove, so `check_metadata_fits_format` computes the
comment-block total at scan time (a conservative lower bound: synthesis may add
comments, never shrink below the raw pairs).

Note that a **stock** FLAC can no longer trip the per-value cap at all, since the
comment block it was read from is itself 24-bit length-prefixed. That equality is
pinned by a cross-layer test — drop the cap below the block limit and this crash
class becomes reachable again.

### Testing

`cargo test` (88 targets), `cargo clippy --all-targets`, `cargo fmt --check`,
`ruff`, `cargo +nightly fuzz build`, and the in-diff mutation gate: **47 mutants,
41 caught, 6 unviable, 0 missed**.

The first mutation run had 8 missed, all mine — no `art.mime` boundary test, and
an aggregate test using values so far over the ceiling that the
`VORBIS_COMMENT` framing arithmetic and the `>` boundary didn't matter. Fixed by
a test that lands the running total on *exactly* the ceiling, so any wrong term
in `4 + key + '=' + value` shifts it off and flips an assertion.

`.cargo/mutants.toml`'s scan.rs anchors are re-pinned to the shifted
coordinates. The `log_mp4_oversize_drops` exclusion is dropped rather than
transplanted: it was excluded as an unobservable logging shim, and its successor
`mp4_oversize_error` decides whether the file is ingested.

## Checklist

- [x] The **pre-commit hook ran** on every commit (no `--no-verify`)
- [x] If the **format-layer API changed**: `cargo +nightly fuzz build` passes.
- [x] If the **`musefs-db` schema changed**: the Python mirror was regenerated
      with `MUSEFS_REGEN_SCHEMA_PY=1 cargo test -p musefs-db schema_py` and
      re-vendored to the plugins.
- [x] **Changelog entry** added under `## [Unreleased]` in `CHANGELOG.md`
- [x] **Docs updated** under `docs/src/` (`architecture/store.md`,
      `architecture/tree-scanning.md`)
- [x] Commit subjects follow **conventional commits**

## The invariant

- [x] This change does not copy or modify original audio bytes. It only decides
      which files are admitted to the store; the read path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased supported tag-value limits to nearly 16 MiB and artwork-description limits to 8 KiB.
  * Databases automatically upgrade to the latest schema while preserving existing data.
  * Added clearer file-specific reporting for oversized metadata.

* **Bug Fixes**
  * Files with oversized metadata now fail individually instead of being partially stored or silently filtered.
  * Added validation for FLAC comment-block limits and other format-specific metadata caps.
  * Improved handling of oversized MP4 artwork and binary metadata.

* **Documentation**
  * Updated storage limits, scanning behavior, and changelog documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->