### PR TITLE
Logging and messaging sweep: nine fixes across the CLI, scan, serve path, plugins, and docs

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-'musefs-core/src/scan\.rs:999:31:',
+'musefs-core/src/scan\.rs:1007:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:1006:30:',
+'musefs-core/src/scan\.rs:1014:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,7 +127,7 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:1017:21:',
+'musefs-core/src/scan\.rs:1025:21:',
     # `unparseable`'s diagnostic `file_len > MAX_PROBE_BYTES`: picks which of two
     # wordings the skip message carries (naming the probe ceiling, or not). It has
     # no effect on the returned verdict, its reason bucket, or any persisted state,
@@ -135,11 +135,11 @@ exclude_re = [
     # shim, like the metrics counters above. (Was in `probe_body` before #651 moved
     # the message out of the log call and into this helper.)
     # guard: op=">" fn="unparseable" rows=3
-'musefs-core/src/scan\.rs:1028:31:',
+'musefs-core/src/scan\.rs:1036:31:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1992:46:',
+'musefs-core/src/scan\.rs:2000:46:',
     # probe_body's tail-read predicate
     # `has_ext(mp3) || (has_ext(flac) && has_leading_id3(prefix))`, the inner `&&`
     # (col 66) -> `||`: widening it makes every .flac pay the 128-byte tail read,
@@ -152,7 +152,7 @@ exclude_re = [
     # behavioral (it decides whether an .mp3 gets its ID3v1 trailer trimmed) and
     # stays in scope, killed by scan.rs's mp3_id3v1_trailer_is_not_served_as_audio.
     # guard: op="&&" fn="probe_body" rows=1
-'musefs-core/src/scan\.rs:976:66:',
+'musefs-core/src/scan\.rs:984:66:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -165,30 +165,30 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:2118:22:',
+'musefs-core/src/scan\.rs:2139:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2164:33:',
+'musefs-core/src/scan\.rs:2205:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2164:48:',
+'musefs-core/src/scan\.rs:2205:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2164:63:',
+'musefs-core/src/scan\.rs:2205:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:2178:37:',
+'musefs-core/src/scan\.rs:2219:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2180:41:',
+'musefs-core/src/scan\.rs:2221:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2180:56:',
+'musefs-core/src/scan\.rs:2221:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2180:71:',
+'musefs-core/src/scan\.rs:2221:71:',
     # Same cadence class, one level up: each threshold flush is a let-chain
     # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
     # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
     # IS met — deferring the commit to the flush-on-empty / final flush, which
     # persist the identical track set and still surface a flush error (#618).
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2165:21:',
+'musefs-core/src/scan\.rs:2206:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2181:29:',
+'musefs-core/src/scan\.rs:2222:29:',
     # `ByteBudget::acquire`'s wait guard (`!st.closed && in_flight != 0 && ...`),
     # the FIRST `&&`->`||`. `&&` binds tighter than `||`, so the guard becomes
     # `!closed || (in_flight != 0 && over_cap)` and every reservation against an
@@ -209,11 +209,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2341:29:',
+'musefs-core/src/scan\.rs:2399:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2353:33:',
+'musefs-core/src/scan\.rs:2411:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:2410:29: replace \+ with -',
+'musefs-core/src/scan\.rs:2468:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -139,7 +139,7 @@ exclude_re = [
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:2000:46:',
+'musefs-core/src/scan\.rs:2013:46:',
     # probe_body's tail-read predicate
     # `has_ext(mp3) || (has_ext(flac) && has_leading_id3(prefix))`, the inner `&&`
     # (col 66) -> `||`: widening it makes every .flac pay the 128-byte tail read,
@@ -165,30 +165,30 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:2139:22:',
+'musefs-core/src/scan\.rs:2152:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2205:33:',
+'musefs-core/src/scan\.rs:2221:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2205:48:',
+'musefs-core/src/scan\.rs:2221:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2205:63:',
+'musefs-core/src/scan\.rs:2221:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:2219:37:',
+'musefs-core/src/scan\.rs:2235:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2221:41:',
+'musefs-core/src/scan\.rs:2237:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2221:56:',
+'musefs-core/src/scan\.rs:2237:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2221:71:',
+'musefs-core/src/scan\.rs:2237:71:',
     # Same cadence class, one level up: each threshold flush is a let-chain
     # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
     # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
     # IS met — deferring the commit to the flush-on-empty / final flush, which
     # persist the identical track set and still surface a flush error (#618).
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2206:21:',
+'musefs-core/src/scan\.rs:2222:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2222:29:',
+'musefs-core/src/scan\.rs:2238:29:',
     # `ByteBudget::acquire`'s wait guard (`!st.closed && in_flight != 0 && ...`),
     # the FIRST `&&`->`||`. `&&` binds tighter than `||`, so the guard becomes
     # `!closed || (in_flight != 0 && over_cap)` and every reservation against an
@@ -209,11 +209,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2399:29:',
+'musefs-core/src/scan\.rs:2415:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2411:33:',
+'musefs-core/src/scan\.rs:2427:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:2468:29: replace \+ with -',
+'musefs-core/src/scan\.rs:2484:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -167,28 +167,28 @@ exclude_re = [
     # guard: op="+=" fn="run_pipeline" rows=2
 'musefs-core/src/scan\.rs:2152:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2221:33:',
+'musefs-core/src/scan\.rs:2224:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2221:48:',
+'musefs-core/src/scan\.rs:2224:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2221:63:',
+'musefs-core/src/scan\.rs:2224:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:2235:37:',
+'musefs-core/src/scan\.rs:2238:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2237:41:',
+'musefs-core/src/scan\.rs:2240:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2237:56:',
+'musefs-core/src/scan\.rs:2240:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2237:71:',
+'musefs-core/src/scan\.rs:2240:71:',
     # Same cadence class, one level up: each threshold flush is a let-chain
     # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
     # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
     # IS met — deferring the commit to the flush-on-empty / final flush, which
     # persist the identical track set and still surface a flush error (#618).
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2222:21:',
+'musefs-core/src/scan\.rs:2225:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:2238:29:',
+'musefs-core/src/scan\.rs:2241:29:',
     # `ByteBudget::acquire`'s wait guard (`!st.closed && in_flight != 0 && ...`),
     # the FIRST `&&`->`||`. `&&` binds tighter than `||`, so the guard becomes
     # `!closed || (in_flight != 0 && over_cap)` and every reservation against an
@@ -209,11 +209,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2415:29:',
+'musefs-core/src/scan\.rs:2418:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2427:33:',
+'musefs-core/src/scan\.rs:2430:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:2484:29: replace \+ with -',
+'musefs-core/src/scan\.rs:2487:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,13 +113,13 @@ exclude_re = [
     # block end past the prefix), so `up_to.min(probe_cap)` always wins the max and
     # the `want + 1` term is never selected. `+`->`-`/`*` are equivalent.
     # guard: op="+" fn="probe_body" rows=2
-'musefs-core/src/scan\.rs:729:31:',
+'musefs-core/src/scan\.rs:999:31:',
     # probe_body post-loop fallback guard `(prefix.len() as u64) < probe_cap`: when
     # it differs, the only effect is a redundant re-read up to the probe cap that
     # feeds the same `probe_full` result. The >8-retry path that could diverge is
     # unreachable given the probers' exact (FLAC/MP3/WAV) / geometric (Ogg) NeedMore.
     # guard: op="<" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:736:30:',
+'musefs-core/src/scan\.rs:1006:30:',
     # probe_body WAV ceiling-fallback guard `file_len > MAX_PROBE_BYTES` (`>` at
     # :21): differs from `>=` only at file_len == MAX_PROBE_BYTES exactly, where the
     # whole file already fits within probe_cap — so `probe_full` parses it (valid)
@@ -127,18 +127,19 @@ exclude_re = [
     # (corrupt), giving the identical skip either way. The ceiling branch is never
     # the deciding path at the boundary, so the mutant is equivalent.
     # guard: op=">" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:747:21:',
-    # probe_body oversize-skip diagnostic `file_len > MAX_PROBE_BYTES` (`>` at :17):
-    # gates only a `log::warn!` (mirroring the M4A `MetadataTooLarge` warn). It has
-    # no effect on the returned `Probed`/skip decision or any persisted state, so
-    # every mutation of the condition is unobservable — a pure observability shim,
-    # like the metrics counters above.
-    # guard: op=">" fn="probe_body" rows=3
-'musefs-core/src/scan\.rs:752:17:',
+'musefs-core/src/scan\.rs:1017:21:',
+    # `unparseable`'s diagnostic `file_len > MAX_PROBE_BYTES`: picks which of two
+    # wordings the skip message carries (naming the probe ceiling, or not). It has
+    # no effect on the returned verdict, its reason bucket, or any persisted state,
+    # so every mutation of the condition is unobservable — a pure observability
+    # shim, like the metrics counters above. (Was in `probe_body` before #651 moved
+    # the message out of the log call and into this helper.)
+    # guard: op=">" fn="unparseable" rows=3
+'musefs-core/src/scan\.rs:1028:31:',
     # run_pipeline sync_channel capacity `jobs * 2`: pure throughput/blocking knob;
     # the persisted track set is identical for any positive capacity.
     # guard: op="*" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1688:46:',
+'musefs-core/src/scan\.rs:1992:46:',
     # probe_body's tail-read predicate
     # `has_ext(mp3) || (has_ext(flac) && has_leading_id3(prefix))`, the inner `&&`
     # (col 66) -> `||`: widening it makes every .flac pay the 128-byte tail read,
@@ -151,7 +152,7 @@ exclude_re = [
     # behavioral (it decides whether an .mp3 gets its ID3v1 trailer trimmed) and
     # stays in scope, killed by scan.rs's mp3_id3v1_trailer_is_not_served_as_audio.
     # guard: op="&&" fn="probe_body" rows=1
-'musefs-core/src/scan\.rs:708:66:',
+'musefs-core/src/scan\.rs:976:66:',
     # run_pipeline flush cadence (batch_bytes accounting + the
     # `len >= BATCH_FILES || batch_bytes >= cap` flush triggers, both the try_recv
     # and the recv branch): the mid-loop threshold flush is belt-and-suspenders on
@@ -164,30 +165,30 @@ exclude_re = [
     # safely description-anchored. Re-verify these coordinates (via
     # `cargo mutants --list`) after any change that reformats scan.rs.
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1799:22:',
+'musefs-core/src/scan\.rs:2118:22:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1845:33:',
+'musefs-core/src/scan\.rs:2164:33:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1845:48:',
+'musefs-core/src/scan\.rs:2164:48:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1845:63:',
+'musefs-core/src/scan\.rs:2164:63:',
     # guard: op="+=" fn="run_pipeline" rows=2
-'musefs-core/src/scan\.rs:1859:37:',
+'musefs-core/src/scan\.rs:2178:37:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1861:41:',
+'musefs-core/src/scan\.rs:2180:41:',
     # guard: op="||" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1861:56:',
+'musefs-core/src/scan\.rs:2180:56:',
     # guard: op=">=" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1861:71:',
+'musefs-core/src/scan\.rs:2180:71:',
     # Same cadence class, one level up: each threshold flush is a let-chain
     # (`(len >= BATCH_FILES || batch_bytes >= cap) && let Err(e) = flush(..)`), so
     # `&&`->`||` short-circuits past the mid-loop flush exactly when the threshold
     # IS met — deferring the commit to the flush-on-empty / final flush, which
     # persist the identical track set and still surface a flush error (#618).
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1846:21:',
+'musefs-core/src/scan\.rs:2165:21:',
     # guard: op="&&" fn="run_pipeline" rows=1
-'musefs-core/src/scan\.rs:1862:29:',
+'musefs-core/src/scan\.rs:2181:29:',
     # `ByteBudget::acquire`'s wait guard (`!st.closed && in_flight != 0 && ...`),
     # the FIRST `&&`->`||`. `&&` binds tighter than `||`, so the guard becomes
     # `!closed || (in_flight != 0 && over_cap)` and every reservation against an
@@ -208,11 +209,11 @@ exclude_re = [
     # scan.failed + skip_failed` sum is also insensitive to `+`->`-` (the `+`->`*`
     # variant IS caught, so only `-` is excluded here).
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2007:29:',
+'musefs-core/src/scan\.rs:2341:29:',
     # guard: op="+=" fn="revalidate_with" rows=2
-'musefs-core/src/scan\.rs:2016:33:',
+'musefs-core/src/scan\.rs:2353:33:',
     # guard: op="+" fn="revalidate_with" rows=1
-'musefs-core/src/scan\.rs:2072:29: replace \+ with -',
+'musefs-core/src/scan\.rs:2410:29: replace \+ with -',
     # Phase 2 ID3 binary tags: classify_binary_frame's POPM counter fold
     # `(a << 8) | b` -> `(a << 8) ^ b`. The accumulator is left-shifted by 8 before
     # each combine, so its low byte is always zero where `b` lands; `|` and `^` are

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,10 @@ build/
 
 # beets' pre-migration DB backups. Its test suite opens an in-memory library, so
 # beets names each backup after the literal `:memory:` and writes it to the CWD
-# — the repo root when the suite is run from there, where a broad `git add`
-# will happily stage a dozen binary blobs.
-/:memory:-*.bak
+# — where a broad `git add` will happily stage a dozen binary blobs. Left
+# unanchored: the CWD is the repo root when the suite is run from there, but
+# `contrib/beets/` when it is run from the package directory.
+:memory:-*.bak
 
 # cargo-mutants scratch + reports
 .mutants-tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Scan log records no longer shred the progress bar (and vice versa) on an
+  interactive terminal ([#648](https://github.com/Sohex/musefs/issues/648)).
+  The bar and the `log` sink both write to stderr with nothing between them, so
+  a warning landed mid-frame and the next tick erased part of it — which is the
+  common case, not an edge one: the end-of-scan skip tally warns about the
+  `cover.jpg`/`.cue`/`.log` sidecars essentially every library contains.
+  Records are now emitted with the bar lifted out of the way and redrawn
+  beneath them, as is the per-target summary line. Piped (non-interactive)
+  output is byte-for-byte unchanged.
 - A tag larger than the store's cap no longer aborts the entire scan
   ([#644](https://github.com/Sohex/musefs/issues/644)). The scanner had no
   length check on text tags, so an over-cap value reached the DB `CHECK` inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   common case, not an edge one: the end-of-scan skip tally warns about the
   `cover.jpg`/`.cue`/`.log` sidecars essentially every library contains.
   Records are now emitted with the bar lifted out of the way and redrawn
-  beneath them, as is the per-target summary line. Piped (non-interactive)
-  output is byte-for-byte unchanged.
+  beneath them, as is the per-target summary line. This change left piped
+  (non-interactive) output byte-for-byte alone.
+- The scan progress indicator now reaches 100% when files fail
+  ([#655](https://github.com/Sohex/musefs/issues/655)). The bar's length is the
+  walked file count, but its position advanced only on a committed file, so any
+  failure left it permanently short: 12 unparseable files out of 42 finished at
+  `30/42 (71%)` and were then cleared, which reads as an aborted scan rather
+  than a completed one about to report `failed 12`. Piped output never printed
+  its final `100%` milestone at all. A dispatched file that fails or races now
+  advances the same progress sequence as a committed one. **The piped milestone
+  line is renamed `ingested N/M (P%)` → `processed N/M (P%)`**, since it counts
+  every file the pipeline finished with rather than only the successes; scripts
+  matching the old prefix need updating.
 - A tag larger than the store's cap no longer aborts the entire scan
   ([#644](https://github.com/Sohex/musefs/issues/644)). The scanner had no
   length check on text tags, so an over-cap value reached the DB `CHECK` inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   window carries the suppressed count. A library walk over missing backing
   files previously warned once per file — 200,000 lines (tens of MB of log)
   for a single enumeration. The read load-shed (`EAGAIN`) warning shares the
-  same limiter, since a saturated client retries in a tight loop.
+  same limiter, since a saturated client retries in a tight loop. The limiter is
+  now process-wide rather than FUSE-local, so the warns emitted from inside
+  synthesis — a dropped Vorbis tag key, over-cap art, a failed art-blob read —
+  are bounded by the same budget instead of bypassing it (#650).
 - Worker read connections now cap their SQLite page cache at 512 KiB (the
   default is ~2 MiB). The serve path opens one connection per worker thread
   (2× CPUs), so the default multiplied into hundreds of MB of steady-state RSS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   same limiter, since a saturated client retries in a tight loop. The limiter is
   now process-wide rather than FUSE-local, so the warns emitted from inside
   synthesis — a dropped Vorbis tag key, over-cap art, a failed art-blob read —
-  are bounded by the same budget instead of bypassing it (#650).
+  are bounded by the same budget instead of bypassing it (#650). Log targets are
+  unchanged: each warning is still attributed to the module that raised it, so
+  per-crate `RUST_LOG` filters keep working.
 - Worker read connections now cap their SQLite page cache at 512 KiB (the
   default is ~2 MiB). The serve path opens one connection per worker thread
   (2× CPUs), so the default multiplied into hundreds of MB of steady-state RSS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   are bounded by the same budget instead of bypassing it (#650). Log targets are
   unchanged: each warning is still attributed to the module that raised it, so
   per-crate `RUST_LOG` filters keep working.
+- Scan failures are broken down by reason, and the per-file warnings capped
+  ([#651](https://github.com/Sohex/musefs/issues/651)). A scan ending `failed 37`
+  now also logs `failed 37: unparseable=30, io=5, oversize=2` — the four reasons
+  partition the count exactly — plus `walk errors N: unreadable=…, symlink=…`
+  for entries the walk never queued. Previously `failed N` had no explanation
+  and the only way to get one was to read N individual warnings out of the
+  scrollback. Per-file skip warnings are capped at ten per reason per scan;
+  past that, one line says the rest are going to `debug`, and they do.
+  **The per-extension skip breakdown moves from `warn` to `info`**, so it now
+  needs `-v` or `RUST_LOG=info`: cover art and `.cue`/`.log` sidecars are the
+  normal contents of a library, so that line fired on every healthy scan, and a
+  warning that always fires teaches operators to filter warnings out — which
+  would now also cost them the failure summary that matters. The `skipped N`
+  count itself is unchanged and still prints at any log level.
 - Worker read connections now cap their SQLite page cache at 512 KiB (the
   default is ~2 MiB). The serve path opens one connection per worker thread
   (2× CPUs), so the default multiplied into hundreds of MB of steady-state RSS
@@ -70,6 +84,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now documents the post-enumeration steady state as the number to size a host
   against, and the transparent-hugepage inflation some distros' `THP=always`
   default adds on top.
+- An in-place store schema upgrade now announces itself
+  ([#649](https://github.com/Sohex/musefs/issues/649)). `Db::open` migrates on
+  every open, so an older store was rewritten irreversibly on the first
+  `musefs scan` after a binary upgrade with nothing said about it — and the
+  first the user heard of it was `StoreTooNew` when they tried to run the older
+  build again. The announcement is at `warn` (once per store per schema bump,
+  so it is in the scrollback when it is needed) and names both versions;
+  completion is at `info`. Creating a fresh store stays at `info`, and opening
+  an already-current store stays silent.
 - The virtual tree stores each node name in one shared allocation instead of
   five copies, cutting about a quarter of its resident cost (~1.7 KB to ~1.3 KB
   per track, measured over 200,000 tracks). The tuning guide now documents the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `musefs_dir_handle_rejections_total` counts `opendir` calls that could not be
   given a cached directory snapshot, so directory-handle pressure stays visible
   after a burst rather than only as a gauge that reads healthy between samples.
+- `musefs_serve_warns_suppressed_total` counts the serve-path failure warnings
+  the rate limiter downgraded to `debug`, so log throttling is visible to
+  anything scraping metrics. Without it the count escaped only as prose inside
+  the next warning that was admitted, and an operator could not tell a quiet
+  serve path from one failing faster than it logs.
 - `--workers` (env `MUSEFS_WORKERS`) sizes the FUSE worker pool explicitly.
   The default stays auto (2× the CPU count, oversized for I/O-bound work), but
   each worker lazily opens its own read-only SQLite connection, so steady-state

--- a/contrib/CHANGELOG.md
+++ b/contrib/CHANGELOG.md
@@ -12,6 +12,10 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ### Added
 
+- **`musefs_common.ScanResult`** — what a completed `run_scan` did. Carries
+  `binary`, `target`, `verb`, `returncode`, `partial` and `stderr`, and renders
+  the shared non-fatal message via `.warning()` (`None` for a clean run). See
+  the `run_scan` change below.
 - **`musefs_common.MAX_TAG_VALUE_LEN`** — the store's byte cap on a
   `tags.value`, generated from the Rust constant into the schema mirror rather
   than hand-kept. A writer can now check a value against the contract instead of
@@ -21,6 +25,23 @@ and these packages adhere to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ### Changed
 
+- **`run_scan` no longer treats a partial scan as a failure** (musefs #647).
+  `musefs scan` exits `2` when the batch completed and committed but some file
+  could not be ingested; `run_scan` raised `ScanError` for any non-zero code, so
+  a single unparseable file took down the whole sync. Picard reported
+  `sync failed` and wrote **no tags at all**; the beets `cli_exit` hook skipped
+  its sync silently, surfacing only as a `WARNING` beets hides at default
+  verbosity; `beet musefs` and the Lidarr adapter aborted outright. `run_scan`
+  now reads the three-state contract — `0` success, `2` partial, anything else a
+  hard failure — and returns a `ScanResult` for the first two. All three
+  adapters warn and go on to sync. Hard failures still raise `ScanError`.
+  **Callers of `run_scan` that relied on it raising for exit `2` need updating.**
+- **`SchemaMismatch` now names the direction of the skew and the remedy**
+  (musefs #654). It reported both version numbers and said the versions "have
+  diverged", leaving the user to work out which side was behind and what to do.
+  It now says whether the store was written by a newer musefs (upgrade the
+  plugin) or predates the plugin (upgrade musefs and run `musefs scan`, which
+  migrates in place). This string is what Picard and beets surface verbatim.
 - The store schema is now at `user_version` 3 (musefs #644 widens the
   `tags.value` and `track_art.description` caps). `EXPECTED_USER_VERSION`
   tracks it automatically; no plugin change is needed, but a store must be

--- a/contrib/beets/beetsplug/musefs.py
+++ b/contrib/beets/beetsplug/musefs.py
@@ -205,10 +205,14 @@ class MusefsPlugin(BeetsPlugin):
 
         ``force`` re-seeds existing tracks from their backing files. ``revalidate``
         forwards to the new subcommand; ``prune`` deletes gone rows and GCs
-        orphaned art."""
+        orphaned art.
+
+        A partial scan (some file unparseable, the batch still committed) is not
+        an error: it is reported and the sync goes on, so one bad file can't cost
+        the whole library its tags (#647)."""
         binary = self._bin()
         try:
-            run_scan(
+            result = run_scan(
                 binary,
                 db_path,
                 targets,
@@ -219,6 +223,11 @@ class MusefsPlugin(BeetsPlugin):
             )
         except ScanError as exc:
             raise self._scan_user_error(exc)
+        if result is not None and result.partial:
+            # ui.print_ (not self._log): beets hides plugin WARNINGs at default
+            # verbosity, and files missing from the store is worth seeing.
+            ui.print_(f"musefs: {result.warning()}")
+        return result
 
     @staticmethod
     def _scan_user_error(exc):

--- a/contrib/beets/tests/test_reconcile.py
+++ b/contrib/beets/tests/test_reconcile.py
@@ -6,6 +6,7 @@ import pytest
 pytest.importorskip("beets")
 
 from conftest import insert_track  # noqa: E402,F401
+from musefs_common import ScanResult  # noqa: E402
 from musefs_common import connect as musefs_connect  # noqa: E402
 
 from beetsplug import musefs as musefs_mod  # noqa: E402
@@ -144,6 +145,59 @@ def test_run_scan_revalidate_passes_prune(monkeypatch):
     assert captured["force"] is False
     assert captured["prune"] is True
     assert captured["timeout"] == musefs_mod.SCAN_TIMEOUT_SECONDS == 120
+
+
+def _partial_result():
+    """What `run_scan` returns when the batch committed but a file didn't parse."""
+    return ScanResult(
+        binary="musefs",
+        target="/a.flac",
+        returncode=2,
+        partial=True,
+        stderr="skipping /b.flac: no parseable audio metadata",
+    )
+
+
+def test_run_scan_partial_warns_instead_of_raising(monkeypatch):
+    """Exit 2 is a partial success, not a failure: it must not abort, and it must
+    be visible — beets hides plugin warnings at default verbosity (#647)."""
+    result = _partial_result()
+    monkeypatch.setattr(musefs_mod, "run_scan", lambda *a, **kw: result)
+    prints = _capture_prints(monkeypatch)
+    plugin = MusefsPlugin.__new__(MusefsPlugin)
+    plugin._bin = lambda: "musefs"
+
+    assert plugin._run_scan("/db.sqlite", ["/a.flac"], force=True) is result
+    assert len(prints) == 1
+    assert "no parseable audio metadata" in prints[0][0]
+
+
+def test_run_scan_clean_scan_prints_nothing(monkeypatch):
+    monkeypatch.setattr(
+        musefs_mod, "run_scan", lambda *a, **kw: ScanResult(binary="musefs", target="/a.flac")
+    )
+    prints = _capture_prints(monkeypatch)
+    plugin = MusefsPlugin.__new__(MusefsPlugin)
+    plugin._bin = lambda: "musefs"
+    plugin._run_scan("/db.sqlite", ["/a.flac"], force=True)
+
+    assert prints == []
+
+
+def test_reconcile_pending_still_syncs_after_a_partial_scan(monkeypatch):
+    """The whole point of #647: one unparseable file must not silently skip the
+    sync of everything that did scan."""
+    monkeypatch.setattr(musefs_mod, "run_scan", lambda *a, **kw: _partial_result())
+    _capture_prints(monkeypatch)
+    synced = []
+    plugin = _plugin(monkeypatch)
+    plugin._autoscan = lambda: True
+    plugin._bin = lambda: "musefs"
+    plugin._sync = lambda db, items, **kwargs: synced.append(items)
+    plugin._reconcile_pending()
+
+    assert len(synced) == 1
+    assert plugin._log.warnings == []  # a partial scan is not an error
 
 
 def test_reconcile_pending_autoscan_forces_scan(monkeypatch):

--- a/contrib/lidarr/src/musefs_lidarr/sync.py
+++ b/contrib/lidarr/src/musefs_lidarr/sync.py
@@ -72,11 +72,20 @@ def config_from_env(environ: dict[str, str] | None = None) -> SyncConfig:
     )
 
 
-def scan_if_enabled(*, config: SyncConfig, paths: list[str], runner=run_scan) -> None:
-    """Run ``musefs scan`` over ``paths`` when autoscan is on and paths exist."""
+def scan_if_enabled(
+    *, config: SyncConfig, paths: list[str], runner=run_scan, warning_printer=print
+) -> None:
+    """Run ``musefs scan`` over ``paths`` when autoscan is on and paths exist.
+
+    A partial scan (exit 2: some file could not be ingested, the batch still
+    committed) is logged and tolerated — the import went through, so writing the
+    tags Lidarr has for the files that did land beats writing none (#647).
+    """
     if not config.autoscan or not paths:
         return
-    runner(config.musefs_bin, config.db_path, paths, timeout=SCAN_TIMEOUT_SECONDS)
+    result = runner(config.musefs_bin, config.db_path, paths, timeout=SCAN_TIMEOUT_SECONDS)
+    if result is not None and result.partial:
+        warning_printer(f"musefs-lidarr-sync: {result.warning()}", file=sys.stderr)
 
 
 def _log_skipped(skipped, *, warning_printer) -> None:

--- a/contrib/lidarr/tests/test_sync.py
+++ b/contrib/lidarr/tests/test_sync.py
@@ -2,6 +2,7 @@ from musefs_common import (
     MAX_TAG_VALUE_LEN,
     SCAN_TIMEOUT_SECONDS,
     ArtImage,
+    ScanResult,
     connect,
     realpath_key,
 )
@@ -128,6 +129,54 @@ def test_scan_if_enabled_passes_shared_timeout(tmp_path):
     scan_if_enabled(config=config, paths=["/music/a.flac"], runner=fake_runner)
 
     assert captured["timeout"] == SCAN_TIMEOUT_SECONDS == 120
+
+
+def test_scan_if_enabled_warns_and_continues_on_partial_scan(tmp_path):
+    """Exit 2 is a partial success: the batch committed, some file didn't parse.
+    It must not abort the sync (#647)."""
+    warnings = []
+    config = SyncConfig(
+        db_path=str(tmp_path / "m.db"),
+        link_mode=LinkMode.SYMLINK,
+        autoscan=True,
+    )
+    partial = ScanResult(
+        binary="musefs",
+        target="/music/a.flac",
+        returncode=2,
+        partial=True,
+        stderr="skipping /music/a.flac: no parseable audio metadata",
+    )
+
+    scan_if_enabled(
+        config=config,
+        paths=["/music/a.flac"],
+        runner=lambda *a, **kw: partial,
+        warning_printer=lambda message, **kw: warnings.append(message),
+    )
+
+    assert len(warnings) == 1
+    assert "musefs-lidarr-sync:" in warnings[0]
+    assert "no parseable audio metadata" in warnings[0]
+
+
+def test_scan_if_enabled_is_quiet_on_a_clean_scan(tmp_path):
+    warnings = []
+    config = SyncConfig(
+        db_path=str(tmp_path / "m.db"),
+        link_mode=LinkMode.SYMLINK,
+        autoscan=True,
+    )
+    clean = ScanResult(binary="musefs", target="/music/a.flac")
+
+    scan_if_enabled(
+        config=config,
+        paths=["/music/a.flac"],
+        runner=lambda *a, **kw: clean,
+        warning_printer=lambda message, **kw: warnings.append(message),
+    )
+
+    assert warnings == []
 
 
 def test_sync_records_writes_tags(

--- a/contrib/picard/musefs/__init__.py
+++ b/contrib/picard/musefs/__init__.py
@@ -113,12 +113,13 @@ if _PICARD:
 
     def _do_sync(opts, files):
         """Background-thread worker: autoscan each file, then write tags/art.
-        Returns SyncStats. Raises MusefsError / SchemaMismatch on hard failure."""
+        Returns SyncStats. Raises MusefsError / SchemaMismatch on hard failure;
+        a partial scan is logged, not raised."""
         if not opts.db:
             raise MusefsError("no musefs DB configured; set the DB path in Options → musefs sync")
         if opts.autoscan:
             try:
-                run_scan(
+                result = run_scan(
                     opts.bin,
                     opts.db,
                     [f.filename for f in files.values()],
@@ -126,6 +127,11 @@ if _PICARD:
                 )
             except ScanError as exc:
                 raise _scan_error(exc)
+            # A partial scan (exit 2) means some file could not be ingested while
+            # the batch still committed. Warn and sync the rest rather than
+            # dropping every file's tags and art over one bad file (#647).
+            if result is not None and result.partial:
+                log.warning("musefs: %s", result.warning())
         elif not os.path.exists(opts.db):
             raise MusefsError(
                 f"musefs DB not found at {opts.db}; enable autoscan or run `musefs scan` first"

--- a/contrib/picard/musefs/_common/__init__.py
+++ b/contrib/picard/musefs/_common/__init__.py
@@ -17,7 +17,7 @@ from .constants import (
 )
 from .errors import ScanError, SchemaMismatch
 from .paths import realpath_key
-from .scan import run_scan
+from .scan import ScanResult, run_scan
 from .store import (
     TagRow,
     check_schema_version,
@@ -45,6 +45,7 @@ __all__ = [
     "SCAN_TIMEOUT_SECONDS",
     "SchemaMismatch",
     "ScanError",
+    "ScanResult",
     "realpath_key",
     "run_scan",
     "connect",

--- a/contrib/picard/musefs/_common/errors.py
+++ b/contrib/picard/musefs/_common/errors.py
@@ -6,15 +6,29 @@ from .constants import EXPECTED_USER_VERSION
 
 class SchemaMismatch(Exception):  # noqa: N818
     """Raised when the musefs DB schema version differs from what this library
-    targets (``EXPECTED_USER_VERSION``)."""
+    targets (``EXPECTED_USER_VERSION``). Both hosts surface the message
+    verbatim, so it names which side is behind and the action that fixes it
+    (#654)."""
 
     def __init__(self, found):
         self.found = found
-        super().__init__(
-            f"musefs DB user_version is {found}, plugin targets "
-            f"{EXPECTED_USER_VERSION}; the musefs and plugin versions have "
-            f"diverged."
-        )
+        super().__init__(self._message(found))
+
+    @staticmethod
+    def _message(found):
+        head = f"musefs DB user_version is {found}, plugin targets {EXPECTED_USER_VERSION}"
+        if found > EXPECTED_USER_VERSION:
+            return (
+                f"{head}; the store was written by a newer musefs than this plugin "
+                f"knows — upgrade the plugin (beets: upgrade python-musefs; Picard: "
+                f"re-install the plugin folder) to write this store"
+            )
+        if found < EXPECTED_USER_VERSION:
+            return (
+                f"{head}; the store predates this plugin — upgrade musefs and run "
+                f"`musefs scan` against the library, which migrates the store in place"
+            )
+        return head
 
 
 class ScanError(Exception):  # noqa: N818

--- a/contrib/picard/musefs/_common/scan.py
+++ b/contrib/picard/musefs/_common/scan.py
@@ -3,8 +3,45 @@
 #
 import os
 import subprocess
+from dataclasses import dataclass
 
 from .errors import ScanError
+
+# `musefs scan` / `musefs revalidate` exit 2 when the batch itself completed and
+# committed but at least one file could not be ingested — the documented
+# partial-success signal (docs/src/guide/scanning.md), and the only
+# machine-detectable one: per-file failures otherwise appear on stderr alone.
+# It is deliberately not a hard failure: everything parseable is in the store,
+# so a host adapter warns and goes on to sync rather than aborting (#647).
+PARTIAL_EXIT_CODE = 2
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """What a completed ``run_scan`` invocation did.
+
+    ``partial`` is True for the exit-2 partial success: the batch committed, and
+    ``stderr`` names the file(s) that failed to ingest. A hard failure never
+    yields a ``ScanResult`` — it raises ``ScanError``."""
+
+    binary: str
+    target: str
+    verb: str = "scan"
+    returncode: int = 0
+    partial: bool = False
+    stderr: str = ""
+
+    def warning(self):
+        """A one-line, non-fatal message for a partial run, else ``None``. Host
+        adapters prefix it with their own tag and surface it without aborting."""
+        if not self.partial:
+            return None
+        detail = f":\n{self.stderr}" if self.stderr else ""
+        return (
+            f"`{self.binary} {self.verb}` could not ingest some file(s) of "
+            f"{self.target} (exit {self.returncode}); everything parseable was "
+            f"stored, continuing{detail}"
+        )
 
 
 def run_scan(binary, db_path, target, *, revalidate=False, force=False, prune=False, timeout=None):
@@ -17,9 +54,15 @@ def run_scan(binary, db_path, target, *, revalidate=False, force=False, prune=Fa
 
     All targets precede the ``--db`` flag and are scanned under one process
     (one DB open). Creates the DB if absent and fills the structural columns a
-    plugin can't compute. Raises ``ScanError`` (with ``kind`` in
-    ``"not_found" | "timeout" | "failed"``) on failure; the caller formats its
-    own user-facing message from the exception attributes."""
+    plugin can't compute.
+
+    Exit codes are three-state: ``0`` success, ``PARTIAL_EXIT_CODE`` (2) partial
+    success, anything else a hard failure. Returns a ``ScanResult`` for the first
+    two — ``result.partial`` distinguishes them, and ``result.warning()`` renders
+    the non-fatal message a caller should log before proceeding. Raises
+    ``ScanError`` (with ``kind`` in ``"not_found" | "timeout" | "failed"``) on a
+    hard failure; the caller formats its own user-facing message from the
+    exception attributes."""
     if isinstance(target, (str, os.PathLike)):
         targets = [target]
     else:
@@ -31,25 +74,32 @@ def run_scan(binary, db_path, target, *, revalidate=False, force=False, prune=Fa
     if prune and not revalidate:
         raise ValueError("run_scan: prune requires revalidate")
     display = str(targets[0]) if len(targets) == 1 else f"{len(targets)} target(s)"
-    if revalidate:
-        argv = [binary, "revalidate", *(str(t) for t in targets), "--db", str(db_path)]
-        if prune:
-            argv.append("--prune")
-    else:
-        argv = [binary, "scan", *(str(t) for t in targets), "--db", str(db_path)]
-        if force:
-            argv.append("--force")
+    verb = "revalidate" if revalidate else "scan"
+    argv = [binary, verb, *(str(t) for t in targets), "--db", str(db_path)]
+    if revalidate and prune:
+        argv.append("--prune")
+    if force:
+        argv.append("--force")
     try:
         result = subprocess.run(argv, capture_output=True, timeout=timeout)
     except FileNotFoundError as exc:
         raise ScanError("not_found", binary=binary, target=display) from exc
     except subprocess.TimeoutExpired as exc:
         raise ScanError("timeout", binary=binary, target=display, timeout=timeout) from exc
-    if result.returncode != 0:
+    stderr = result.stderr.decode(errors="replace").strip()
+    if result.returncode not in (0, PARTIAL_EXIT_CODE):
         raise ScanError(
             "failed",
             binary=binary,
             target=display,
             returncode=result.returncode,
-            stderr=result.stderr.decode(errors="replace").strip(),
+            stderr=stderr,
         )
+    return ScanResult(
+        binary=binary,
+        target=display,
+        verb=verb,
+        returncode=result.returncode,
+        partial=result.returncode == PARTIAL_EXIT_CODE,
+        stderr=stderr,
+    )

--- a/contrib/picard/tests/test_batch_scan.py
+++ b/contrib/picard/tests/test_batch_scan.py
@@ -32,6 +32,44 @@ def test_autoscan_batches_into_one_run_scan(monkeypatch, db_path):
     assert timeout == plugin_mod.SCAN_TIMEOUT_SECONDS == 120
 
 
+def test_partial_scan_warns_and_still_syncs(monkeypatch, db_path):
+    """`musefs scan` exits 2 when the batch committed but some file could not be
+    ingested. Syncing everything else beats dropping every file's tags (#647)."""
+    from musefs._common import ScanResult
+
+    warnings = []
+    synced = []
+    partial = ScanResult(
+        binary="musefs",
+        target="2 target(s)",
+        returncode=2,
+        partial=True,
+        stderr="skipping /music/b.flac: no parseable audio metadata",
+    )
+
+    def fake_sync_files(conn, records):
+        synced.append(records)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(plugin_mod, "run_scan", lambda *a, **kw: partial)
+    monkeypatch.setattr(plugin_mod, "log", SimpleNamespace(warning=lambda *a: warnings.append(a)))
+    monkeypatch.setattr(plugin_mod, "check_schema_version", lambda conn: None)
+    monkeypatch.setattr(plugin_mod, "sync_files", fake_sync_files)
+    monkeypatch.setattr(plugin_mod, "map_fields", lambda md, fields: [])
+    monkeypatch.setattr(plugin_mod, "images", lambda md: [])
+
+    opts = SimpleNamespace(db=db_path, bin="musefs", autoscan=True, fields={})
+    files = {
+        "/music/a.flac": SimpleNamespace(filename="/music/a.flac", metadata=object()),
+        "/music/b.flac": SimpleNamespace(filename="/music/b.flac", metadata=object()),
+    }
+    plugin_mod._do_sync(opts, files)  # must NOT raise
+
+    assert len(synced) == 1
+    assert len(warnings) == 1
+    assert "no parseable audio metadata" in warnings[0][1]
+
+
 def test_run_scan_force_appends_force(monkeypatch):
     import subprocess
 

--- a/contrib/python-musefs/src/musefs_common/__init__.py
+++ b/contrib/python-musefs/src/musefs_common/__init__.py
@@ -14,7 +14,7 @@ from .constants import (
 )
 from .errors import ScanError, SchemaMismatch
 from .paths import realpath_key
-from .scan import run_scan
+from .scan import ScanResult, run_scan
 from .store import (
     TagRow,
     check_schema_version,
@@ -42,6 +42,7 @@ __all__ = [
     "SCAN_TIMEOUT_SECONDS",
     "SchemaMismatch",
     "ScanError",
+    "ScanResult",
     "realpath_key",
     "run_scan",
     "connect",

--- a/contrib/python-musefs/src/musefs_common/errors.py
+++ b/contrib/python-musefs/src/musefs_common/errors.py
@@ -3,15 +3,29 @@ from .constants import EXPECTED_USER_VERSION
 
 class SchemaMismatch(Exception):  # noqa: N818
     """Raised when the musefs DB schema version differs from what this library
-    targets (``EXPECTED_USER_VERSION``)."""
+    targets (``EXPECTED_USER_VERSION``). Both hosts surface the message
+    verbatim, so it names which side is behind and the action that fixes it
+    (#654)."""
 
     def __init__(self, found):
         self.found = found
-        super().__init__(
-            f"musefs DB user_version is {found}, plugin targets "
-            f"{EXPECTED_USER_VERSION}; the musefs and plugin versions have "
-            f"diverged."
-        )
+        super().__init__(self._message(found))
+
+    @staticmethod
+    def _message(found):
+        head = f"musefs DB user_version is {found}, plugin targets {EXPECTED_USER_VERSION}"
+        if found > EXPECTED_USER_VERSION:
+            return (
+                f"{head}; the store was written by a newer musefs than this plugin "
+                f"knows — upgrade the plugin (beets: upgrade python-musefs; Picard: "
+                f"re-install the plugin folder) to write this store"
+            )
+        if found < EXPECTED_USER_VERSION:
+            return (
+                f"{head}; the store predates this plugin — upgrade musefs and run "
+                f"`musefs scan` against the library, which migrates the store in place"
+            )
+        return head
 
 
 class ScanError(Exception):  # noqa: N818

--- a/contrib/python-musefs/src/musefs_common/scan.py
+++ b/contrib/python-musefs/src/musefs_common/scan.py
@@ -1,7 +1,44 @@
 import os
 import subprocess
+from dataclasses import dataclass
 
 from .errors import ScanError
+
+# `musefs scan` / `musefs revalidate` exit 2 when the batch itself completed and
+# committed but at least one file could not be ingested — the documented
+# partial-success signal (docs/src/guide/scanning.md), and the only
+# machine-detectable one: per-file failures otherwise appear on stderr alone.
+# It is deliberately not a hard failure: everything parseable is in the store,
+# so a host adapter warns and goes on to sync rather than aborting (#647).
+PARTIAL_EXIT_CODE = 2
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """What a completed ``run_scan`` invocation did.
+
+    ``partial`` is True for the exit-2 partial success: the batch committed, and
+    ``stderr`` names the file(s) that failed to ingest. A hard failure never
+    yields a ``ScanResult`` — it raises ``ScanError``."""
+
+    binary: str
+    target: str
+    verb: str = "scan"
+    returncode: int = 0
+    partial: bool = False
+    stderr: str = ""
+
+    def warning(self):
+        """A one-line, non-fatal message for a partial run, else ``None``. Host
+        adapters prefix it with their own tag and surface it without aborting."""
+        if not self.partial:
+            return None
+        detail = f":\n{self.stderr}" if self.stderr else ""
+        return (
+            f"`{self.binary} {self.verb}` could not ingest some file(s) of "
+            f"{self.target} (exit {self.returncode}); everything parseable was "
+            f"stored, continuing{detail}"
+        )
 
 
 def run_scan(binary, db_path, target, *, revalidate=False, force=False, prune=False, timeout=None):
@@ -14,9 +51,15 @@ def run_scan(binary, db_path, target, *, revalidate=False, force=False, prune=Fa
 
     All targets precede the ``--db`` flag and are scanned under one process
     (one DB open). Creates the DB if absent and fills the structural columns a
-    plugin can't compute. Raises ``ScanError`` (with ``kind`` in
-    ``"not_found" | "timeout" | "failed"``) on failure; the caller formats its
-    own user-facing message from the exception attributes."""
+    plugin can't compute.
+
+    Exit codes are three-state: ``0`` success, ``PARTIAL_EXIT_CODE`` (2) partial
+    success, anything else a hard failure. Returns a ``ScanResult`` for the first
+    two — ``result.partial`` distinguishes them, and ``result.warning()`` renders
+    the non-fatal message a caller should log before proceeding. Raises
+    ``ScanError`` (with ``kind`` in ``"not_found" | "timeout" | "failed"``) on a
+    hard failure; the caller formats its own user-facing message from the
+    exception attributes."""
     if isinstance(target, (str, os.PathLike)):
         targets = [target]
     else:
@@ -28,25 +71,32 @@ def run_scan(binary, db_path, target, *, revalidate=False, force=False, prune=Fa
     if prune and not revalidate:
         raise ValueError("run_scan: prune requires revalidate")
     display = str(targets[0]) if len(targets) == 1 else f"{len(targets)} target(s)"
-    if revalidate:
-        argv = [binary, "revalidate", *(str(t) for t in targets), "--db", str(db_path)]
-        if prune:
-            argv.append("--prune")
-    else:
-        argv = [binary, "scan", *(str(t) for t in targets), "--db", str(db_path)]
-        if force:
-            argv.append("--force")
+    verb = "revalidate" if revalidate else "scan"
+    argv = [binary, verb, *(str(t) for t in targets), "--db", str(db_path)]
+    if revalidate and prune:
+        argv.append("--prune")
+    if force:
+        argv.append("--force")
     try:
         result = subprocess.run(argv, capture_output=True, timeout=timeout)
     except FileNotFoundError as exc:
         raise ScanError("not_found", binary=binary, target=display) from exc
     except subprocess.TimeoutExpired as exc:
         raise ScanError("timeout", binary=binary, target=display, timeout=timeout) from exc
-    if result.returncode != 0:
+    stderr = result.stderr.decode(errors="replace").strip()
+    if result.returncode not in (0, PARTIAL_EXIT_CODE):
         raise ScanError(
             "failed",
             binary=binary,
             target=display,
             returncode=result.returncode,
-            stderr=result.stderr.decode(errors="replace").strip(),
+            stderr=stderr,
         )
+    return ScanResult(
+        binary=binary,
+        target=display,
+        verb=verb,
+        returncode=result.returncode,
+        partial=result.returncode == PARTIAL_EXIT_CODE,
+        stderr=stderr,
+    )

--- a/contrib/python-musefs/tests/test_errors.py
+++ b/contrib/python-musefs/tests/test_errors.py
@@ -1,5 +1,6 @@
 import pytest
 
+from musefs_common.constants import EXPECTED_USER_VERSION
 from musefs_common.errors import ScanError, SchemaMismatch
 
 
@@ -7,7 +8,24 @@ def test_schema_mismatch_message_and_found():
     exc = SchemaMismatch(5)
     assert exc.found == 5
     assert "user_version is 5" in str(exc)
-    assert "diverged" in str(exc)
+    # Both versions stay in the text whichever way the skew runs.
+    assert str(EXPECTED_USER_VERSION) in str(exc)
+
+
+def test_schema_mismatch_newer_store_says_upgrade_the_plugin():
+    """A store ahead of the plugin: the plugin is the side that must move."""
+    message = str(SchemaMismatch(EXPECTED_USER_VERSION + 1))
+    assert f"user_version is {EXPECTED_USER_VERSION + 1}" in message
+    assert "newer musefs" in message
+    assert "upgrade the plugin" in message
+
+
+def test_schema_mismatch_older_store_says_rescan_to_migrate():
+    """A store behind the plugin: `musefs scan` migrates it in place."""
+    message = str(SchemaMismatch(EXPECTED_USER_VERSION - 1))
+    assert f"user_version is {EXPECTED_USER_VERSION - 1}" in message
+    assert "predates this plugin" in message
+    assert "`musefs scan`" in message
 
 
 def test_scan_error_not_found():

--- a/contrib/python-musefs/tests/test_public_api.py
+++ b/contrib/python-musefs/tests/test_public_api.py
@@ -13,6 +13,7 @@ def test_public_api_surface():
         "SCAN_TIMEOUT_SECONDS",
         "SchemaMismatch",
         "ScanError",
+        "ScanResult",
         "realpath_key",
         "run_scan",
         "connect",

--- a/contrib/python-musefs/tests/test_scan.py
+++ b/contrib/python-musefs/tests/test_scan.py
@@ -147,14 +147,14 @@ def test_run_scan_single_path_still_works(monkeypatch):
     assert seen["argv"] == ["musefs", "scan", "/only.flac", "--db", "/db.sqlite"]
 
 
-def test_run_scan_failed_batch_error_names_count(monkeypatch):
+def test_run_scan_hard_failure_error_names_count(monkeypatch):
     import subprocess
 
     import musefs_common.scan as scan
     from musefs_common import ScanError
 
     class FakeResult:
-        returncode = 2
+        returncode = 1
         stderr = b"boom"
 
     monkeypatch.setattr(subprocess, "run", lambda argv, **kw: FakeResult())
@@ -165,3 +165,63 @@ def test_run_scan_failed_batch_error_names_count(monkeypatch):
         assert "2" in str(exc.target)  # "2 target(s)"
     else:
         raise AssertionError("expected ScanError")
+
+
+# --- the three-state exit contract (#647) ---------------------------------
+#
+# 0 = success, 2 = partial success (the batch committed; some files failed to
+# ingest), anything else = hard failure.
+
+
+def _fake_exit(monkeypatch, code, stderr=b""):
+    """Make `subprocess.run` report ``code``/``stderr`` for a musefs invocation."""
+    import subprocess
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        subprocess, "run", lambda argv, **kw: SimpleNamespace(returncode=code, stderr=stderr)
+    )
+
+
+def test_run_scan_success_returns_non_partial_result(monkeypatch):
+    _fake_exit(monkeypatch, 0)
+    result = run_scan("musefs", "/db.sqlite", "/a.flac")
+    assert result.partial is False
+    assert result.returncode == 0
+    assert result.verb == "scan"
+    assert result.warning() is None
+
+
+def test_run_scan_partial_returns_result_instead_of_raising(monkeypatch):
+    _fake_exit(monkeypatch, 2, b"skipping /b.flac: no parseable audio metadata")
+    result = run_scan("musefs", "/db.sqlite", ["/a.flac", "/b.flac"])
+    assert result.partial is True
+    assert result.returncode == 2
+    assert result.target == "2 target(s)"
+    assert "no parseable audio metadata" in result.stderr
+
+
+def test_run_scan_partial_warning_names_binary_target_and_stderr(monkeypatch):
+    _fake_exit(monkeypatch, 2, b"skipping /b.flac: no parseable audio metadata")
+    warning = run_scan("musefs", "/db.sqlite", "/b.flac").warning()
+    assert "musefs scan" in warning
+    assert "/b.flac" in warning
+    assert "continuing" in warning
+    assert "no parseable audio metadata" in warning
+
+
+def test_run_scan_partial_revalidate_names_the_verb(monkeypatch):
+    _fake_exit(monkeypatch, 2)
+    result = run_scan("musefs", "/db.sqlite", "/a.flac", revalidate=True)
+    assert result.verb == "revalidate"
+    assert "musefs revalidate" in result.warning()
+
+
+def test_run_scan_other_nonzero_is_still_a_hard_failure(monkeypatch):
+    from musefs_common import ScanError
+
+    _fake_exit(monkeypatch, 1, b"opening database: permission denied")
+    with pytest.raises(ScanError) as ei:
+        run_scan("musefs", "/db.sqlite", "/a.flac")
+    assert ei.value.kind == "failed"
+    assert ei.value.returncode == 1

--- a/contrib/systemd/musefs.conf.example
+++ b/contrib/systemd/musefs.conf.example
@@ -85,6 +85,14 @@ MUSEFS_DB=/home/youruser/.local/share/musefs/library.db
 # `metrics` cargo feature, which adds backing-syscall counters. Default: false.
 #MUSEFS_EXPOSE_METRICS=true
 
+# Log verbosity. Default: warn (failures only). `info` adds the lines that
+# explain a mount's behaviour — the post-mount summary with its file/directory
+# counts, and whether kernel passthrough was available. Per-crate filtering
+# works too, e.g. `warn,musefs_fuse=debug`. See the Troubleshooting guide.
+# This is the systemd-friendly equivalent of the `-v` flag, which would mean
+# editing ExecStart.
+#RUST_LOG=info
+
 # --- Scan -------------------------------------------------------------------
 # (scan targets are set in musefs-scan.service, not here.)
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -12,6 +12,7 @@
 - [Tuning & metrics](guide/tuning.md)
 - [Maintenance](guide/maintenance.md)
 - [Ownership, permissions & config](guide/configuration.md)
+- [Logging & troubleshooting](guide/troubleshooting.md)
 - [FAQ](guide/faq.md)
 
 # Formats

--- a/docs/src/architecture/serving.md
+++ b/docs/src/architecture/serving.md
@@ -117,7 +117,8 @@ The metrics file is `/proc`-style: it advertises `st_size == 0` and is served
 via `FOPEN_DIRECT_IO`, so readers must read to EOF rather than trusting the
 stated size. Content is rendered at `open` time from a snapshot of
 `CoreTelemetry` (header/size caches, read-ahead budget/charge, virtual-tree
-footprint, refresh health), `FuseTelemetry` (uptime, read/dir-handle gates,
+footprint, refresh health, suppressed serve-path warnings), `FuseTelemetry`
+(uptime, read/dir-handle gates,
 worker pool, passthrough state), and optional jemalloc/syscall counters
 (including read-ahead hit/miss) — see
 [`musefs-core/src/telemetry.rs`](../../../musefs-core/src/telemetry.rs) for the full

--- a/docs/src/architecture/store.md
+++ b/docs/src/architecture/store.md
@@ -3,9 +3,10 @@
 ## The SQLite store
 
 `musefs-db/src/schema.rs` defines the schema as an ordered list of migrations
-(`MIGRATIONS`: the `MIGRATION_V1` baseline plus `MIGRATION_V2`, which adds the
-scanner-owned `fingerprint`/`content_hash` columns); `user_version` records the
-schema version (2).
+(`MIGRATIONS`: the `MIGRATION_V1` baseline, `MIGRATION_V2`, which adds the
+scanner-owned `fingerprint`/`content_hash` columns, and `MIGRATION_V3`, which
+widens the `tags.value` and `track_art.description` caps); `user_version`
+records the schema version (3).
 The store is the **interface external tools write to** — the beets and Picard
 plugins under `contrib/` write tags and art here out-of-band.
 

--- a/docs/src/architecture/store.md
+++ b/docs/src/architecture/store.md
@@ -90,6 +90,15 @@ third-party tool bumped the schema) is refused up front with a distinct
 "store is newer than this binary" error rather than silently treated as
 already-migrated — an older binary must not risk misreading a newer contract.
 
+**Migrations announce themselves.** The opposite direction — an open that finds
+an *older* store and upgrades it in place — is irreversible (the store stops
+opening with the previous musefs build), so it is logged at `warn`, the default
+filter level: the store path, the version found and the version reached,
+followed by a completion line at `info`. Creating a store from scratch is not a
+one-way step for existing data and logs at `info` only, and the common case — a
+store already at the latest version — stays silent, since that path runs on
+every open and every mount.
+
 **Art is immutable once written.** `art` rows are content-addressed by
 `sha256`; a trigger rejects any in-place `UPDATE` of an art row's
 content columns (`data`, `sha256`, `mime`, `byte_len`, `width`, `height`) with

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -67,6 +67,26 @@ see the [Release notes](release-notes.md).
 
 ### Fixed
 
+- Scan log records and the progress bar no longer clobber each other on an
+  interactive terminal ([#648](https://github.com/Sohex/musefs/issues/648)).
+  `ScanReporter` renders an `indicatif` bar on stderr and the `log` facade
+  writes to the same stderr, with nothing coordinating the two: a record was
+  emitted at whatever column the last bar frame left the cursor on, and the
+  next 120 ms tick issued a clear-line that ate part of it. Both the warning
+  and the bar came out mangled. This was reachable on essentially the first
+  interactive scan of any real library, because the end-of-walk skip tally
+  ([#341](https://github.com/Sohex/musefs/issues/341)) warns about `cover.jpg`
+  / `.cue` / `.log` / `.nfo` sidecars, and every unparseable file warns from
+  inside the pipeline. The CLI now owns a single process-wide stderr draw
+  target: the scan bar draws through it, and the binary's `env_logger` is
+  installed wrapped in a sink that emits each record while that target is
+  suspended — bar cleared, record written, bar redrawn below it. The per-target
+  summary line (`scanned N: …`, on stdout) is suspended the same way; it used
+  to be glued onto a bar frame whenever no log record happened to precede it.
+  Off a terminal the draw target is hidden and suspending is a no-op, so the
+  `--quiet` and piped `ingested N/M (P%)` paths are byte-for-byte unchanged, as
+  is the verbosity policy (`-v`/`-vv`/`-vvv`, `RUST_LOG` taking precedence),
+  which stays in the binary.
 - A tag larger than the store's cap no longer aborts the entire scan
   ([#644](https://github.com/Sohex/musefs/issues/644)). The scanner had no
   length check on text tags, so an over-cap value reached the DB `CHECK` inside

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -83,7 +83,11 @@ see the [Release notes](release-notes.md).
   fires per art *window*, so one bad blob produced many lines for one file. The
   limiter now lives in `musefs-core` next to `telemetry.rs` and both crates
   share one budget, which is the right unit: the operator's concern is total
-  serve-path log volume, not per-crate volume.
+  serve-path log volume, not per-crate volume. Only the budget is shared, not
+  the attribution: the emit side is the `musefs_core::serve_warn!` macro, so
+  each record still takes its target from the call site's own module and
+  per-crate `RUST_LOG` filtering (`RUST_LOG=warn,musefs_fuse=debug`) reaches
+  exactly what it did before.
 - `readdir`'s unknown-`fh` fallback runs on the worker pool instead of inline on
   the fuser dispatch thread ([#623](https://github.com/Sohex/musefs/issues/623)), matching the offload every other
   blocking operation already used. This matters more now that over-cap `opendir`

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -60,6 +60,17 @@ see the [Release notes](release-notes.md).
   of materializing a whole `Track` per row ([#621](https://github.com/Sohex/musefs/issues/621)) — roughly 40 MB of
   transient allocation on a 200,000-track store, on a path already holding a
   pool connection.
+- The serve-path warn rate limiter is process-wide instead of FUSE-local
+  ([#650](https://github.com/Sohex/musefs/issues/650)). It bounds failure warns
+  to a burst of 10 per 30-second window, but it lived in `musefs-fuse` and was
+  reachable only from the errno-reply path, so the warns synthesis itself emits
+  bypassed it: a dropped Vorbis tag key (once per header-cache miss, and that
+  cache is byte-budgeted, so an evicting library re-warns for the same track
+  indefinitely), art over the byte cap, and a failed art-blob read — the last
+  fires per art *window*, so one bad blob produced many lines for one file. The
+  limiter now lives in `musefs-core` next to `telemetry.rs` and both crates
+  share one budget, which is the right unit: the operator's concern is total
+  serve-path log volume, not per-crate volume.
 - `readdir`'s unknown-`fh` fallback runs on the worker pool instead of inline on
   the fuser dispatch thread ([#623](https://github.com/Sohex/musefs/issues/623)), matching the offload every other
   blocking operation already used. This matters more now that over-cap `opendir`

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -124,10 +124,24 @@ see the [Release notes](release-notes.md).
   suspended — bar cleared, record written, bar redrawn below it. The per-target
   summary line (`scanned N: …`, on stdout) is suspended the same way; it used
   to be glued onto a bar frame whenever no log record happened to precede it.
-  Off a terminal the draw target is hidden and suspending is a no-op, so the
-  `--quiet` and piped `ingested N/M (P%)` paths are byte-for-byte unchanged, as
-  is the verbosity policy (`-v`/`-vv`/`-vvv`, `RUST_LOG` taking precedence),
-  which stays in the binary.
+  Off a terminal the draw target is hidden and suspending is a no-op, so this
+  change left the `--quiet` and piped milestone paths byte-for-byte alone, as it
+  did the verbosity policy (`-v`/`-vv`/`-vvv`, `RUST_LOG` taking precedence),
+  which stays in the binary. (The milestone line is renamed by the progress-bar
+  convergence fix below, in this same release.)
+- The scan progress indicator now reaches 100% when files fail
+  ([#655](https://github.com/Sohex/musefs/issues/655)). The bar's length is the
+  walked file count, but its position only advanced on a committed file, so any
+  failure left it permanently short — a run with 12 unparseable files out of 42
+  finished at `30/42 (71%)` and was then cleared, which reads as an aborted scan
+  rather than a completed one about to report `failed 12`. On the piped path the
+  final `100%` milestone was simply never printed, so a log-scraping consumer
+  waited for a line that could not arrive. A dispatched file that fails or races
+  now advances the same progress sequence as a committed one; the two together
+  always account for the walked total, and a debug assertion pins that. The
+  piped milestone line is renamed `ingested N/M (P%)` → `processed N/M (P%)`,
+  because it now counts every file the pipeline finished with rather than only
+  the successes — scripts matching the old prefix need updating.
 - A tag larger than the store's cap no longer aborts the entire scan
   ([#644](https://github.com/Sohex/musefs/issues/644)). The scanner had no
   length check on text tags, so an over-cap value reached the DB `CHECK` inside

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,19 @@ see the [Release notes](release-notes.md).
   [#616](https://github.com/Sohex/musefs/issues/616) is in use and directories are being rebuilt on every
   `readdir`.
 
+- `musefs_serve_warns_suppressed_total`
+  ([#653](https://github.com/Sohex/musefs/issues/653)), a monotonic counter of
+  serve-path failure warnings the rate limiter downgraded to `debug`. The count
+  previously escaped only as a parenthetical inside the next admitted warning,
+  which is both unscrapeable and carried by the admitted lines alone. The
+  failure mode matches
+  [#626](https://github.com/Sohex/musefs/issues/626)'s: suppression is bursty by
+  construction — 10 admitted per 30-second window, the rest dropped — so a
+  scrape landing between bursts sees nothing, and "quiet" and "failing faster
+  than it can log" look identical. Since the limiter moved into `musefs-core`
+  ([#650](https://github.com/Sohex/musefs/issues/650)) the counter covers the
+  synthesis warns too, not just the FUSE errno path.
+
 ### Changed
 
 - The `tags.value` cap rises from 256 KiB to 16 MiB − 1, and

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -64,6 +64,19 @@ see the [Release notes](release-notes.md).
   the fuser dispatch thread ([#623](https://github.com/Sohex/musefs/issues/623)), matching the offload every other
   blocking operation already used. This matters more now that over-cap `opendir`
   makes that fallback the normal path for large directories.
+- Scan failures are now broken down by reason and their per-file warnings capped
+  ([#651](https://github.com/Sohex/musefs/issues/651)). A scan that ends
+  `failed 37` also logs `failed 37: unparseable=30, io=5, oversize=2` (and
+  `walk errors N: …` for directories the walk could not read), so the number
+  that drives the exit-2 partial-failure signal explains itself instead of
+  having to be reconstructed from N individual lines. The per-file messages
+  themselves are capped at ten per reason per scan, the rest dropping to
+  `debug` — an unreadable subtree or a share that went away mid-scan no longer
+  emits one warning per file. The existing per-extension skip breakdown moves
+  from `warn` to `info` (so it now needs `-v` / `RUST_LOG=info`): cover art and
+  `.cue` sidecars are the normal contents of a music library, and a warning on
+  every healthy scan only teaches operators to tune warnings out. The `skipped`
+  count itself is unchanged and still printed in the per-target summary.
 
 ### Fixed
 

--- a/docs/src/guide/mounting.md
+++ b/docs/src/guide/mounting.md
@@ -46,6 +46,22 @@ beets/Picard/Lidarr sync, raw SQL) and the view refreshes automatically.
 
 Run `musefs <command> --help` for the full flag list.
 
+### Raising log detail
+
+A mount logs at `warn` by default, which means it says nothing while it is
+working normally. The lines that explain what it *did* — the post-mount summary
+naming the store, mountpoint, and file/directory counts, and whether reads are
+being served by the kernel or by the daemon — are `info`, so add `-v` (or set
+`RUST_LOG=info`) when a mount is not behaving as expected:
+
+```bash
+musefs mount /path/to/mountpoint --db library.db -v
+```
+
+See [Logging & troubleshooting](troubleshooting.md) for the full level model,
+the serve-path warn limiter, and reading the log under systemd or in a
+container.
+
 ### Path templates
 
 Paths come from a beets-style template (matched case-insensitively;

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -58,7 +58,9 @@ like `musefs scan … && musefs mount …` stops on a partial or total ingest
 failure rather than mounting an incomplete library. A successful scan exits `0`;
 a hard error (a missing target, an unreadable DB) still exits `1`. The exit code
 is the only machine-detectable signal; per-file failures otherwise surface only
-on stderr.
+on stderr. The full exit-code contract, and how to raise log detail on those
+failures, are in
+[Logging & troubleshooting](troubleshooting.md#exit-codes).
 
 ### Content checksums and move re-identification
 

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -27,7 +27,9 @@ interactive terminal, a discovery spinner followed by a determinate bar
 (position, percent, ETA, current file); on a non-interactive stderr (piped or
 logged), throttled `ingested N/M (P%)` lines. `--quiet` (`-q`) suppresses the
 progress indicator and the per-target summary. Each summary line ends with the
-elapsed time.
+elapsed time. Anything logged during the scan (skip warnings, per-file
+failures) is printed above the bar, which is lifted out of the way and redrawn
+underneath, so warnings stay readable and scroll back intact.
 
 The per-target summary reads `scanned N: … already present Z, skipped X, failed Y`.
 `already present` counts files bare `scan` skipped because they were already

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -35,11 +35,21 @@ tracked. `skipped`
 counts every file that isn't a supported audio format — cover art, `.cue` /
 `.log` / `.nfo` sidecars, and anything else non-audio — so a large `skipped`
 number (hundreds or thousands on a big library) is expected, not an error.
-A per-extension breakdown of the skip count is logged at end of scan (e.g.
-`skipped 42: jpg=20, cue=10, log=8, <none>=4`), so you can tell expected
-sidecars from anything genuinely unexpected. `failed` is the one
-to watch: those are audio files musefs recognised by extension but could not
-parse. Format dispatch is by **extension only** —
+A per-extension breakdown of the skip count is logged at end of scan at
+`info` (e.g. `skipped 42: jpg=20, cue=10, log=8, <none>=4`, so it needs `-v` or
+`RUST_LOG=info`), letting you tell expected sidecars from anything genuinely
+unexpected. `failed` is the one to watch: those are audio files musefs
+recognised by extension but could not parse. Its own breakdown by reason is
+logged at end of scan too — `failed 37: unparseable=30, io=5, oversize=2` — at
+`warn`, so it is visible without `-v`; a further `walk errors N: unreadable=9,
+symlink=3` line accounts for directories and entries the walk itself could not
+read (those are counted in neither `skipped` nor `failed`, since no file was
+ever queued for them).
+
+Per-file skip messages are capped at ten per reason per scan; the rest drop to
+`debug` (`-vv` / `RUST_LOG=debug`) so an unreadable subtree or a share that
+vanished mid-scan cannot emit one line per file. The end-of-scan breakdowns
+carry the full counts either way. Format dispatch is by **extension only** —
 there is no content sniffing and no fallback to another parser, so a file
 whose contents don't match its extension (e.g. a FLAC named `.mp3`) is handed
 to the wrong parser, fails, and is counted here rather than retried. Renaming

--- a/docs/src/guide/scanning.md
+++ b/docs/src/guide/scanning.md
@@ -25,7 +25,7 @@ failures still surface on stderr (raise detail with `-v`/`-vv`, or
 `scan` (with or without `--force`) shows a live progress indicator: on an
 interactive terminal, a discovery spinner followed by a determinate bar
 (position, percent, ETA, current file); on a non-interactive stderr (piped or
-logged), throttled `ingested N/M (P%)` lines. `--quiet` (`-q`) suppresses the
+logged), throttled `processed N/M (P%)` lines. `--quiet` (`-q`) suppresses the
 progress indicator and the per-target summary. Each summary line ends with the
 elapsed time. Anything logged during the scan (skip warnings, per-file
 failures) is printed above the bar, which is lifted out of the way and redrawn

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -43,6 +43,11 @@ directly to stderr — `warning: mountpoint … is not empty`, the `--file-mode`
 `--dir-mode` write-bit warnings, and the final `musefs: <error>` on a hard
 failure.
 
+They share stderr with the log, but they do not collide with it: the progress
+bar is drawn through a target the log sink suspends around every record, so a
+warning emitted mid-scan clears the bar, prints, and the bar is redrawn beneath
+it. Raising verbosity during an interactive scan is safe.
+
 ## What each level buys
 
 ### `warn` — the default
@@ -51,12 +56,22 @@ failure.
   `lookup(…) failed: …`, and `read(…) rejected: EAGAIN` load-shedding. These
   go through the [warn limiter](#the-serve-path-warn-limiter).
 - Scan-time refusals: `skipping <path>: <reason>`, `skipping <path>: no
-  parseable audio metadata`, and the per-extension breakdown of the skip count
-  (`skipped 42: jpg=20, cue=10, …`).
+  parseable audio metadata`. These are capped per reason — see
+  [Scanning](scanning.md#scan).
+- The end-of-scan failure summaries: `failed 37: unparseable=30, io=5,
+  oversize=2` (these four reasons partition the `failed` count the CLI reports
+  and the exit-`2` signal keys on) and `walk errors 12: unreadable=9,
+  symlink=3` for entries the walk never queued. Neither fires on a healthy
+  library.
 - Degraded-but-correct fallbacks: `incremental tree mutation failed …; falling
   back to full rebuild`, `poll_refresh failed`, `inval_inode(…) failed`.
 - Tag keys dropped during Vorbis synthesis (`track N: dropping tag key … (not a
-  valid field name)`) — these are per-synthesis and are *not* rate-limited.
+  valid field name)`). Like the serve-path failures above, these go through the
+  [warn limiter](#the-serve-path-warn-limiter).
+- An in-place store schema upgrade: `upgrading store schema at … from version 1
+  to version 3; this is irreversible …`. Once per store per schema bump — it is
+  at `warn` precisely so it lands in your scrollback before you ever try to run
+  an older musefs against that store.
 - `scan --revalidate` deprecation.
 - `error` sits above it, reserved for a caught panic in a synthesis or scan
   worker, a scan aborted mid-ingest, and recovered lock poisoning.
@@ -93,6 +108,17 @@ behaviour are all `info`, so by default they are invisible:
   external edits than the changelog ring retains, so it rebuilt the tree
   wholesale instead of applying a diff. Correct, just more expensive.
 
+- The per-extension breakdown of a scan's skip count (`skipped 42: jpg=20,
+  cue=10, …`). This sits at `info` rather than `warn` because cover art and
+  `.cue`/`.log` sidecars are the normal contents of a music library, so it
+  fires on every healthy scan — and a warning that always fires teaches you to
+  filter warnings, which would cost you the failure summary that matters. The
+  `skipped N` total is in the CLI's per-target summary at any level; `-v` gates
+  only the breakdown.
+
+- `store schema at … is now at version 3 (took 0.4s)` — the completion half of
+  the upgrade announcement above.
+
 If a mount is behaving oddly and you only reach for one thing, reach for `-v`.
 
 ### `-vv` (`debug`)
@@ -106,6 +132,9 @@ If a mount is behaving oddly and you only reach for one thing, reach for `-v`.
   signal for this is the `musefs_dir_handle_rejections_total` counter in the
   [metrics surface](tuning.md#metrics); the log line is per-occurrence.
 - Scan-walk detail: duplicate backing targets, symlink handling.
+- Scan skips past their per-reason cap. After the first 10 of a given reason,
+  one line says `further "<reason>" skips are logged at debug …` and the rest
+  go here; the end-of-scan summary still has the totals.
 
 ## The serve-path warn limiter
 
@@ -125,12 +154,24 @@ multiplicity of that message.
 The limiter exists because the failure mode it guards is per-file: a library
 enumeration over a corpus whose backing files have moved would otherwise emit
 one warn per file — hundreds of thousands of lines, tens of MB of log, for a
-single walk. It covers the `reply_errno` warn arm (the failures behind
-`lookup`, `getattr`, `open`, `read`, `readdir`) and the read load-shedding
-`EAGAIN` line. It does not cover scan-time warns or synthesis warns.
+single walk. One budget is shared across the whole serve path: the
+`reply_errno` warn arm (the failures behind `lookup`, `getattr`, `open`,
+`read`, `readdir`), the read load-shedding `EAGAIN` line, and the synthesis
+warns — dropped Vorbis tag keys, over-cap art, art-blob read failures — which
+are emitted per cache miss and so scale the same way. Scan-time warns are
+capped separately and per reason; see [Scanning](scanning.md#scan).
+
+Sharing the budget does not merge the log targets: each message is still
+attributed to the module that raised it (`musefs_fuse`, `musefs_core::reader`,
+`musefs_core::mapping`), so per-crate `RUST_LOG` filtering works as described
+above.
 
 To see every suppressed failure, run at `-vv` (or `RUST_LOG=debug`): nothing is
-discarded, only downgraded.
+discarded, only downgraded. For the rate rather than the events, the
+`musefs_serve_warns_suppressed_total` counter on the
+[metrics surface](tuning.md#metrics) counts every downgraded warn since start —
+a scrape landing between bursts sees a quiet log either way, so the counter is
+what distinguishes a healthy serve path from a throttled one.
 
 ## Reading the logs under systemd
 

--- a/docs/src/guide/troubleshooting.md
+++ b/docs/src/guide/troubleshooting.md
@@ -1,0 +1,197 @@
+# Logging & troubleshooting
+
+Every musefs crate reports through the `log` facade; the `musefs` binary
+installs the sink and writes it to **stderr**. Nothing is logged to the mount
+or to the store, so the log is wherever that process's stderr goes — your
+terminal, the journal, or the container log.
+
+## Raising log detail
+
+The default floor is `warn`: enough that a failure is never silent, quiet
+enough to leave running. `-v` raises it, and repeats stack:
+
+| Flag | Level | What it adds |
+| ---- | ----- | ------------ |
+| *(none)* | `warn` | Failures only: serve-path errors, skipped/failed files, deprecations. |
+| `-v` | `info` | What the mount actually did — the mount summary and the passthrough decision. |
+| `-vv` | `debug` | Per-op detail, including everything the warn limiter suppressed. |
+| `-vvv` | `trace` | No musefs call site logs at trace today; it only opens up dependencies. |
+
+`-v` / `--verbose` is global — `musefs -v mount …` and `musefs mount … -v` are
+equivalent.
+
+**`RUST_LOG` wins.** The `-v` count only supplies the *default* filter, so an
+explicit `RUST_LOG` in the environment takes precedence and `-v` then has
+nothing to do. That is the lever to reach for when you cannot edit the command
+line (a systemd unit, a container `ExecStart`), and it is also the only way to
+filter per crate:
+
+```bash
+RUST_LOG=info musefs mount /mnt/music --db library.db
+RUST_LOG=warn,musefs_fuse=debug musefs mount /mnt/music --db library.db
+```
+
+Targets are crate names with underscores: `musefs`, `musefs_cli`,
+`musefs_core`, `musefs_db`, `musefs_fuse`, `musefs_format`. There is no
+`MUSEFS_*` variable for verbosity — unlike the mount and scan flags, this one
+is `RUST_LOG` or `-v` only.
+
+Two kinds of output ignore the log level entirely: `scan`/`revalidate` progress
+and per-target summaries (suppressed with `--quiet` / `-q`, see
+[Scanning](scanning.md#scan)), and a handful of CLI diagnostics printed
+directly to stderr — `warning: mountpoint … is not empty`, the `--file-mode` /
+`--dir-mode` write-bit warnings, and the final `musefs: <error>` on a hard
+failure.
+
+## What each level buys
+
+### `warn` — the default
+
+- Serve-path failures behind the mount: `read(…) failed: …`,
+  `lookup(…) failed: …`, and `read(…) rejected: EAGAIN` load-shedding. These
+  go through the [warn limiter](#the-serve-path-warn-limiter).
+- Scan-time refusals: `skipping <path>: <reason>`, `skipping <path>: no
+  parseable audio metadata`, and the per-extension breakdown of the skip count
+  (`skipped 42: jpg=20, cue=10, …`).
+- Degraded-but-correct fallbacks: `incremental tree mutation failed …; falling
+  back to full rebuild`, `poll_refresh failed`, `inval_inode(…) failed`.
+- Tag keys dropped during Vorbis synthesis (`track N: dropping tag key … (not a
+  valid field name)`) — these are per-synthesis and are *not* rate-limited.
+- `scan --revalidate` deprecation.
+- `error` sits above it, reserved for a caught panic in a synthesis or scan
+  worker, a scan aborted mid-ingest, and recovered lock poisoning.
+
+### `-v` (`info`) — "why is my mount doing this"
+
+This is the level worth knowing about. The lines that explain a mount's
+behaviour are all `info`, so by default they are invisible:
+
+- The pre-mount line naming the store, mountpoint, and template, then the
+  post-mount summary once the session is actually serving:
+
+  ```text
+  musefs mounted at /mnt/music: 41230 files in 3812 directories (Synthesis)
+  ```
+
+  An empty or wrong `--db` is otherwise indistinguishable from a correctly
+  serving one — the mount succeeds either way; the counts are the tell.
+
+- The passthrough decision. In `structure-only` mode on Linux 6.9+ musefs
+  registers the backing fd with the kernel so reads bypass the daemon; when
+  that is not available it says so once and serves reads itself:
+
+  ```text
+  FUSE passthrough unavailable; serving reads through the daemon: <error>
+  StructureOnly mount without CAP_SYS_ADMIN: kernel passthrough unavailable; reads will be served by the daemon
+  StructureOnly mount: kernel passthrough is Linux-only; reads will be served by the daemon
+  ```
+
+  This is the single best explanation for "why is my `structure-only` mount
+  slower than I expected".
+
+- `changelog gap; falling back to full refresh` — the mount slept past more
+  external edits than the changelog ring retains, so it rebuilt the tree
+  wholesale instead of applying a diff. Correct, just more expensive.
+
+If a mount is behaving oddly and you only reach for one thing, reach for `-v`.
+
+### `-vv` (`debug`)
+
+- Everything the warn limiter dropped, tagged `(over warn budget)`.
+- Routine tree-shape misses that never warn: `lookup(…) failed: no such inode:
+  …` and friends (`ENOENT` / `EISDIR` / `ENOTDIR`), which a kernel path probe
+  and a stale inode after a refresh generate constantly.
+- `opendir(…) over the 1024-handle cap: serving it statelessly` — the degraded
+  readdir path a parallel walk can push a mount onto. The operator-facing
+  signal for this is the `musefs_dir_handle_rejections_total` counter in the
+  [metrics surface](tuning.md#metrics); the log line is per-occurrence.
+- Scan-walk detail: duplicate backing targets, symlink handling.
+
+## The serve-path warn limiter
+
+Serve-path failure warns are rate-limited process-wide: **10 warns per 30 s
+window**. Over budget, a message is downgraded to `debug` with `(over warn
+budget)` appended and counted; the first warn of the next window carries the
+tally:
+
+```text
+read(1042) failed: backing file changed since scan: /music/a.flac (317 similar serve-path warnings suppressed in the last 30s)
+```
+
+Read that line carefully — the suppressed failures are *not* necessarily the
+same failure as the one printed. The count is a volume signal, not a
+multiplicity of that message.
+
+The limiter exists because the failure mode it guards is per-file: a library
+enumeration over a corpus whose backing files have moved would otherwise emit
+one warn per file — hundreds of thousands of lines, tens of MB of log, for a
+single walk. It covers the `reply_errno` warn arm (the failures behind
+`lookup`, `getattr`, `open`, `read`, `readdir`) and the read load-shedding
+`EAGAIN` line. It does not cover scan-time warns or synthesis warns.
+
+To see every suppressed failure, run at `-vv` (or `RUST_LOG=debug`): nothing is
+discarded, only downgraded.
+
+## Reading the logs under systemd
+
+The [user units](../integrations/systemd.md) send stderr to the journal:
+
+```bash
+journalctl --user -u musefs -f          # follow the mount
+journalctl --user -u musefs-scan -e     # the last of a scan run
+```
+
+`ExecStart` in the shipped unit is a bare `musefs mount` driven by `MUSEFS_*`
+environment variables, so the least invasive way to raise detail is the
+environment rather than the command line — add `RUST_LOG=info` to
+`~/.config/musefs/musefs.conf`, or set it in a drop-in
+(`systemctl --user edit musefs`):
+
+```ini
+[Service]
+Environment=RUST_LOG=info
+```
+
+Then `systemctl --user restart musefs`. Adding `-v` works too, but it means
+editing `ExecStart` itself.
+
+## Reading the logs in a container
+
+stderr is the container's log stream, so nothing special is needed to capture
+it:
+
+```bash
+docker logs -f musefs        # podman logs -f musefs
+```
+
+Raise detail with `-e RUST_LOG=info` on `docker run` / `podman run`, or by
+appending `-v` to the command after the image name. Note that the most common
+container failure — a missing `--device /dev/fuse` or `--cap-add SYS_ADMIN` —
+is not a log line at all: it is a hard error, `musefs: mounting at /mnt/musefs:
+…`, and the container exits 1. See
+[Running in containers](containers.md#required-flags).
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success. For `mount`, a clean unmount. |
+| `2` | `scan` / `revalidate` completed, but at least one file failed to ingest (`failed Y` with `Y > 0`). The parseable files *are* in the store. |
+| `1` | Hard error — a missing target, an unreadable or absent store, a mount that could not be established. The message is printed as `musefs: <error>`. |
+
+Exit `2` is what makes a partial ingest machine-detectable, so
+`musefs scan … && musefs mount …` stops instead of mounting an incomplete
+library — the per-file failures otherwise surface only on stderr. It overlaps
+clap's usage-error code, but a usage error fails before any work starts, so the
+two are never ambiguous in a pipeline that got as far as running. See
+[Scanning](scanning.md#scan) for what `failed` counts.
+
+## When the log is not the answer
+
+- A file that will not open or errors on read is usually a backing file that
+  changed since its last scan — see the [FAQ](faq.md) and run
+  `musefs revalidate`.
+- For steady-state behaviour (handle counts, cache hit rates, read errors,
+  degraded-readdir rejections) the counters in
+  [`.musefs-metrics/`](tuning.md#metrics) are the surface to watch; the log
+  reports events, not rates.

--- a/docs/src/guide/tuning.md
+++ b/docs/src/guide/tuning.md
@@ -117,6 +117,14 @@ musefs_handles_open 3
 musefs_cache_header_hits_total 100
 ```
 
+Serve-path failure warnings are rate-limited (a burst of 10 per 30-second
+window; the rest drop to `debug`), so a mount that is failing fast logs far less
+than it fails. `musefs_serve_warns_suppressed_total` counts what the limiter
+dropped, which is the signal that separates "the serve path is quiet" from "the
+serve path is failing faster than it can log". Suppression is bursty by
+construction, so watch the counter's rate rather than any single sample, and
+raise the log level to `debug` to see the individual failures behind it.
+
 `--expose-metrics` (default off) is a **runtime** flag that gates the virtual
 file; it is unrelated to the compile-time `metrics` cargo feature, which adds
 syscall counters (opens, preads, etc.) to the output. The jemalloc allocator

--- a/docs/src/integrations/python-musefs.md
+++ b/docs/src/integrations/python-musefs.md
@@ -248,6 +248,9 @@ for a custom write loop)
 **Exceptions**
 
 - `SchemaMismatch(found)` — schema-version skew; `.found` is the DB's version.
+  The message names which side is behind and the fix: a store newer than the
+  plugin means upgrading the plugin, an older one means rescanning with musefs
+  to migrate it.
 - `ScanError(kind, *, binary, target, …)` — a `musefs scan` failure; `.kind` ∈
   `{"not_found", "timeout", "failed"}`, with context attributes for messaging.
 

--- a/docs/src/integrations/python-musefs.md
+++ b/docs/src/integrations/python-musefs.md
@@ -44,7 +44,11 @@ def sync(db_path, files, *, musefs_bin="musefs"):
     # plugin cannot compute (format, audio offset/length, backing size/mtime).
     # On a brand-new store it must precede `connect`, which has nothing to open
     # until the scan has created the file.
-    run_scan(musefs_bin, db_path, files, timeout=SCAN_TIMEOUT_SECONDS)
+    result = run_scan(musefs_bin, db_path, files, timeout=SCAN_TIMEOUT_SECONDS)
+    if result.partial:
+        # Exit 2: the batch committed, but some file could not be ingested.
+        # Warn and sync the rest — don't abort over one unparseable file.
+        print(result.warning())
 
     conn = connect(db_path)
     try:
@@ -72,10 +76,17 @@ def sync(db_path, files, *, musefs_bin="musefs"):
 For a dry run, pass `dry_run=True` to `sync_files` and `conn.rollback()` instead
 of committing — `SyncStats` still reports what *would* change.
 
-`run_scan` raises `ScanError` (`kind` ∈ `{"not_found", "timeout", "failed"}`)
-and `check_schema_version` raises `SchemaMismatch`; a host adapter formats its
-own user-facing message from the exception attributes (see the beets plugin's
-`_scan_user_error`).
+`run_scan` reads the scanner's three-state exit code and returns a `ScanResult`:
+`0` is a clean run, and `2` is a **partial success** — the batch completed and
+committed, but at least one file could not be ingested (see
+[Scanning](../guide/scanning.md)). A partial run is not a failure, so it sets
+`result.partial` rather than raising; `result.warning()` renders the one-line,
+non-fatal message an adapter should surface before going on to sync the files
+that *did* land. Any other exit code is a hard failure and raises `ScanError`
+(`kind` ∈ `{"not_found", "timeout", "failed"}`), as do a missing binary and a
+timeout. `check_schema_version` raises `SchemaMismatch`; a host adapter formats
+its own user-facing message from the exception attributes (see the beets
+plugin's `_scan_user_error`).
 
 ### The `Record` shape
 
@@ -168,9 +179,12 @@ Everything in `__all__`, imported from the top-level `musefs_common` package.
 
 **Scanning**
 
-- `run_scan(binary, db_path, target, *, timeout=None)` — shell out to `musefs
-  scan`; `target` is one path or an iterable, all scanned under one process.
-  Creates the DB if absent. Raises `ScanError`.
+- `run_scan(binary, db_path, target, *, timeout=None)` → `ScanResult` — shell
+  out to `musefs scan`; `target` is one path or an iterable, all scanned under
+  one process. Creates the DB if absent. Raises `ScanError` on a hard failure.
+- `ScanResult(binary, target, verb, returncode, partial, stderr)` — a completed
+  run. `partial` marks the exit-2 partial success (the batch committed; some
+  file failed to ingest) and `warning()` renders its non-fatal message.
 
 **Building records**
 

--- a/docs/src/integrations/systemd.md
+++ b/docs/src/integrations/systemd.md
@@ -88,4 +88,7 @@ sandboxing is possible. The two units differ sharply:
 - **Headless servers.** A `--user` timer only fires while your user manager
   runs. For a daily scan when you are not logged in:
   `loginctl enable-linger <user>`.
-- **Logs.** `journalctl --user -u musefs -f`.
+- **Logs.** `journalctl --user -u musefs -f`. The units log at `warn` by
+  default; raise it with `Environment=RUST_LOG=info` in a drop-in or in
+  `musefs.conf` — see
+  [Logging & troubleshooting](../guide/troubleshooting.md#reading-the-logs-under-systemd).

--- a/musefs-cli/Cargo.toml
+++ b/musefs-cli/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["filesystem", "multimedia::audio", "command-line-utilities"]
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
-log = "0.4"
+# `std` for `set_boxed_logger`: the CLI installs the process-wide log sink
+# (wrapped so scan progress and log records do not clobber each other).
+log = { version = "0.4", features = ["std"] }
 musefs-db = { path = "../musefs-db", version = "1.3.0" }
 musefs-core = { path = "../musefs-core", version = "1.3.0" }
 musefs-fuse = { path = "../musefs-fuse", version = "1.3.0" }

--- a/musefs-cli/src/lib.rs
+++ b/musefs-cli/src/lib.rs
@@ -13,8 +13,11 @@ use musefs_db::Db;
 
 use crate::progress::ScanReporter;
 
+mod logging;
 mod progress;
 mod signal;
+
+pub use crate::logging::install_logger;
 
 /// Mount content mode (CLI surface for `musefs_core::Mode`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
@@ -335,15 +338,19 @@ pub fn run_scan(
             .with_context(|| format!("scanning {}", target.display()))?;
         total_failed += stats.failed;
         if !quiet {
-            println!(
-                "scanned {}: {} file(s), {} already present, skipped {}, failed {} in {}",
-                target.display(),
-                stats.scanned,
-                stats.already_present,
-                stats.skipped,
-                stats.failed,
-                HumanDuration(start.elapsed()),
-            );
+            // Suspended like a log record: the bar is still ticking between
+            // targets, and an un-lifted frame would swallow the summary line.
+            progress::suspend(|| {
+                println!(
+                    "scanned {}: {} file(s), {} already present, skipped {}, failed {} in {}",
+                    target.display(),
+                    stats.scanned,
+                    stats.already_present,
+                    stats.skipped,
+                    stats.failed,
+                    HumanDuration(start.elapsed()),
+                );
+            });
         }
     }
     reporter.finish();
@@ -380,15 +387,17 @@ pub fn run_revalidate(
             .with_context(|| format!("revalidating {}", target.display()))?;
         total_failed += stats.failed;
         if !quiet {
-            println!(
-                "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed in {}",
-                target.display(),
-                stats.updated,
-                stats.unchanged,
-                stats.pruned,
-                stats.failed,
-                HumanDuration(start.elapsed()),
-            );
+            progress::suspend(|| {
+                println!(
+                    "revalidated {}: {} updated, {} unchanged, {} pruned, {} failed in {}",
+                    target.display(),
+                    stats.updated,
+                    stats.unchanged,
+                    stats.pruned,
+                    stats.failed,
+                    HumanDuration(start.elapsed()),
+                );
+            });
         }
     }
     reporter.finish();

--- a/musefs-cli/src/logging.rs
+++ b/musefs-cli/src/logging.rs
@@ -1,0 +1,148 @@
+//! Global `log` sink installation.
+//!
+//! The scan progress bar (see [`crate::progress`]) and the `log` facade both
+//! write to stderr. Left uncoordinated, a record emitted while the bar is live
+//! lands mid-frame and the next tick overwrites it — the common case rather
+//! than an edge one, because the end-of-walk skip tally warns about the
+//! `cover.jpg`/`.cue`/`.log` files essentially every real library contains
+//! (#648).
+//!
+//! [`install_logger`] therefore wraps the caller's sink so every record is
+//! emitted while the shared progress draw target is suspended: the bar is
+//! cleared, the record is written, the bar is redrawn beneath it. The binary
+//! keeps ownership of *what* the sink is and of the verbosity mapping; this
+//! module only owns the interleaving.
+
+use log::{LevelFilter, Log, Metadata, Record};
+
+/// A `log::Log` that emits through the shared progress draw target, so records
+/// never interleave with a bar redraw.
+struct SuspendingLogger {
+    inner: Box<dyn Log>,
+}
+
+impl Log for SuspendingLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        // Cheap pre-filter: suspending takes the draw lock, which is wasted work
+        // for a record the sink will drop anyway. `enabled` is never stricter
+        // than the sink's own check, so this cannot suppress a record that would
+        // otherwise have printed.
+        if !self.inner.enabled(record.metadata()) {
+            return;
+        }
+        crate::progress::suspend(|| self.inner.log(record));
+    }
+
+    fn flush(&self) {
+        self.inner.flush();
+    }
+}
+
+/// Install `logger` as the global `log` sink, bridged to the scan progress bar.
+///
+/// `level` is the maximum level the sink can emit (for `env_logger`, that is
+/// `Logger::filter()`); it is forwarded verbatim to [`log::set_max_level`], so
+/// the caller's verbosity policy is preserved exactly.
+///
+/// # Panics
+///
+/// If a global logger is already installed, mirroring `env_logger::init`.
+pub fn install_logger(logger: Box<dyn Log>, level: LevelFilter) {
+    log::set_boxed_logger(Box::new(SuspendingLogger { inner: logger }))
+        .expect("a global logger is already installed");
+    log::set_max_level(level);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use log::Level;
+
+    use super::{Log, Metadata, Record, SuspendingLogger};
+
+    #[derive(Default)]
+    struct Seen {
+        lines: Mutex<Vec<String>>,
+        flushes: Mutex<usize>,
+    }
+
+    /// A sink that records what it was asked to emit, filtering the way
+    /// `env_logger` does: `enabled` on level, `log` re-checking it.
+    #[derive(Clone)]
+    struct Recorder {
+        max: Level,
+        seen: Arc<Seen>,
+    }
+
+    impl Log for Recorder {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.level() <= self.max
+        }
+
+        fn log(&self, record: &Record<'_>) {
+            if self.enabled(record.metadata()) {
+                self.seen
+                    .lines
+                    .lock()
+                    .unwrap()
+                    .push(record.args().to_string());
+            }
+        }
+
+        fn flush(&self) {
+            *self.seen.flushes.lock().unwrap() += 1;
+        }
+    }
+
+    fn wrapped(max: Level) -> (SuspendingLogger, Arc<Seen>) {
+        let rec = Recorder {
+            max,
+            seen: Arc::new(Seen::default()),
+        };
+        let seen = Arc::clone(&rec.seen);
+        (
+            SuspendingLogger {
+                inner: Box::new(rec),
+            },
+            seen,
+        )
+    }
+
+    #[test]
+    fn records_reach_the_wrapped_sink() {
+        let (wrapper, seen) = wrapped(Level::Warn);
+        wrapper.log(
+            &Record::builder()
+                .level(Level::Warn)
+                .args(format_args!("skipped 3 non-audio files"))
+                .build(),
+        );
+        assert_eq!(*seen.lines.lock().unwrap(), ["skipped 3 non-audio files"]);
+    }
+
+    #[test]
+    fn filtered_records_are_dropped() {
+        let (wrapper, seen) = wrapped(Level::Warn);
+        wrapper.log(
+            &Record::builder()
+                .level(Level::Debug)
+                .args(format_args!("chatter"))
+                .build(),
+        );
+        assert!(seen.lines.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn enabled_and_flush_delegate() {
+        let (wrapper, seen) = wrapped(Level::Info);
+        assert!(wrapper.enabled(&Metadata::builder().level(Level::Warn).build()));
+        assert!(!wrapper.enabled(&Metadata::builder().level(Level::Debug).build()));
+        wrapper.flush();
+        assert_eq!(*seen.flushes.lock().unwrap(), 1);
+    }
+}

--- a/musefs-cli/src/progress.rs
+++ b/musefs-cli/src/progress.rs
@@ -1,13 +1,38 @@
 use std::io::IsTerminal;
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use musefs_core::{ProgressSink, ScanProgress};
 
 const STEP: u64 = 5;
+
+/// The process-wide stderr draw target.
+///
+/// Both the scan bar and the global log sink write to stderr, so they have to
+/// share one target for [`suspend`] to be able to lift the bar out of the way
+/// of a log record (#648). The logger is installed once at startup while a bar
+/// lives only for the duration of a `run_scan`, so the target — not the bar —
+/// is what outlives both.
+///
+/// Off a terminal it is [`ProgressDrawTarget::hidden`], which makes [`suspend`]
+/// an unconditional no-op: the `Plain` and `Quiet` paths write nothing through
+/// it and are unaffected.
+static DRAW: LazyLock<MultiProgress> = LazyLock::new(|| {
+    if std::io::stderr().is_terminal() {
+        MultiProgress::new()
+    } else {
+        MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+    }
+});
+
+/// Run `f` with any live progress bar cleared from the terminal, redrawing it
+/// afterwards. Used by the log sink so records never land mid-frame.
+pub(crate) fn suspend<R>(f: impl FnOnce() -> R) -> R {
+    DRAW.suspend(f)
+}
 
 pub(crate) fn next_milestone(prev_done: u64, done: u64, total: u64) -> Option<u64> {
     if total == 0 || done <= prev_done {
@@ -84,7 +109,8 @@ impl ScanReporter {
         let mode = if quiet {
             Mode::Quiet
         } else if std::io::stderr().is_terminal() {
-            let bar = ProgressBar::new_spinner();
+            // Draw through the shared target so log records can suspend the bar.
+            let bar = DRAW.add(ProgressBar::new_spinner());
             bar.enable_steady_tick(Duration::from_millis(120));
             bar.set_message("discovering files…");
             Mode::Tty(bar)
@@ -119,6 +145,8 @@ impl ScanReporter {
     pub(crate) fn finish(&self) {
         if let Mode::Tty(bar) = &self.inner.mode {
             bar.finish_and_clear();
+            // Drop it from the shared target too; the target outlives the scan.
+            DRAW.remove(bar);
         }
     }
 }

--- a/musefs-cli/src/progress.rs
+++ b/musefs-cli/src/progress.rs
@@ -82,10 +82,25 @@ impl Renderer {
                 bar.set_position(done);
                 bar.set_message(basename(path));
             }
-            (Mode::Plain, ScanProgress::Ingested { done, total, .. }) => {
+            // A failed file advances the bar but leaves the message on the last
+            // file actually ingested: the failure is already named in a `warn`
+            // line, and blanking the message would make the bar flicker between
+            // a name and nothing on a run with many failures (#655).
+            (Mode::Tty(bar), ScanProgress::Failed { done, .. }) => {
+                bar.set_position(done);
+            }
+            (
+                Mode::Plain,
+                ScanProgress::Ingested { done, total, .. } | ScanProgress::Failed { done, total },
+            ) => {
                 let prev = self.prev_done.load(Ordering::Relaxed);
                 if let Some(pct) = next_milestone(prev, done, total) {
-                    eprintln!("ingested {done}/{total} ({pct}%)");
+                    // "processed", not "ingested": `done` counts every file the
+                    // pipeline finished with, failures included, because that is
+                    // what has to reach `total` (#655). Calling 12 failures
+                    // "ingested" to make the line hit 100% would trade one
+                    // inaccuracy for a worse one.
+                    eprintln!("processed {done}/{total} ({pct}%)");
                     self.prev_done.store(done, Ordering::Relaxed);
                 }
             }

--- a/musefs-cli/tests/logging.rs
+++ b/musefs-cli/tests/logging.rs
@@ -1,0 +1,49 @@
+//! `install_logger` wraps the caller's sink so scan progress and log records
+//! stop clobbering each other (#648) — but the wrapping must be transparent:
+//! every record the sink would have emitted still reaches it, and the caller's
+//! level ceiling is still what `log` filters on.
+//!
+//! Only one test may live here: installing a global logger is a once-per-process
+//! operation, and integration test binaries share a process.
+
+use std::sync::Mutex;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+static SEEN: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// A sink that filters the way `env_logger` does: `enabled` on level, `log`
+/// re-checking it.
+struct Sink;
+
+impl Log for Sink {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() <= Level::Debug
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if self.enabled(record.metadata()) {
+            SEEN.lock()
+                .unwrap()
+                .push(format!("{} {}", record.level(), record.args()));
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+#[test]
+fn installed_logger_forwards_records_and_honours_the_level_ceiling() {
+    musefs_cli::install_logger(Box::new(Sink), LevelFilter::Debug);
+    assert_eq!(
+        log::max_level(),
+        LevelFilter::Debug,
+        "the caller's ceiling must reach `log::set_max_level` verbatim"
+    );
+
+    log::warn!("warned");
+    log::debug!("debugged");
+    log::trace!("traced"); // above the ceiling: never even reaches the sink
+
+    assert_eq!(*SEEN.lock().unwrap(), ["WARN warned", "DEBUG debugged"]);
+}

--- a/musefs-core/src/facade.rs
+++ b/musefs-core/src/facade.rs
@@ -757,6 +757,7 @@ impl Musefs {
             refresh_generation: self.refresh_gen.load(Ordering::Acquire),
             refresh_gap_fallbacks: self.gap_fallbacks.load(Ordering::Relaxed),
             refresh_needs_rebuild: self.needs_rebuild.load(Ordering::Relaxed),
+            serve_warns_suppressed: crate::warn_limit::serve_warns_suppressed(),
         }
     }
 }

--- a/musefs-core/src/facade/tests.rs
+++ b/musefs-core/src/facade/tests.rs
@@ -1187,7 +1187,7 @@ fn telemetry_surfaces_serve_warns_suppressed() {
     let before = fs.telemetry().serve_warns_suppressed;
     // Well past the per-window burst budget, so warns are certainly dropped.
     for i in 0..64 {
-        crate::warn_limit::rate_limited_warn(format_args!("telemetry warn probe {i}"));
+        crate::serve_warn!("telemetry warn probe {i}");
     }
     assert!(
         fs.telemetry().serve_warns_suppressed > before,

--- a/musefs-core/src/facade/tests.rs
+++ b/musefs-core/src/facade/tests.rs
@@ -1176,3 +1176,21 @@ fn telemetry_counts_open_handles() {
     fs.release_handle(fh);
     assert_eq!(fs.telemetry().handles_open, base);
 }
+
+/// The suppressed-warn count reaches the metrics surface through `telemetry()`,
+/// so `musefs_serve_warns_suppressed_total` tracks the live limiter rather than
+/// a constant (#653). Delta-based and `>`: the limiter is a process-wide static
+/// shared with everything else in this test binary.
+#[test]
+fn telemetry_surfaces_serve_warns_suppressed() {
+    let (_dir, fs) = fs_with_poll_interval(std::time::Duration::ZERO);
+    let before = fs.telemetry().serve_warns_suppressed;
+    // Well past the per-window burst budget, so warns are certainly dropped.
+    for i in 0..64 {
+        crate::warn_limit::rate_limited_warn(format_args!("telemetry warn probe {i}"));
+    }
+    assert!(
+        fs.telemetry().serve_warns_suppressed > before,
+        "an over-budget burst must move the counter telemetry reports"
+    );
+}

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -14,7 +14,7 @@ mod scan;
 mod telemetry;
 mod template;
 mod tree;
-mod warn_limit;
+pub mod warn_limit;
 
 pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
@@ -33,7 +33,6 @@ pub use telemetry::{
 };
 pub use template::{Template, TemplateError};
 pub use tree::{InodeAllocator, Node, NodeKind, VirtualTree};
-pub use warn_limit::rate_limited_warn;
 
 #[cfg(test)]
 mod cross_layer_caps {

--- a/musefs-core/src/lib.rs
+++ b/musefs-core/src/lib.rs
@@ -14,6 +14,7 @@ mod scan;
 mod telemetry;
 mod template;
 mod tree;
+mod warn_limit;
 
 pub use db_pool::DbPool;
 pub use error::{CoreError, Result};
@@ -32,6 +33,7 @@ pub use telemetry::{
 };
 pub use template::{Template, TemplateError};
 pub use tree::{InodeAllocator, Node, NodeKind, VirtualTree};
+pub use warn_limit::rate_limited_warn;
 
 #[cfg(test)]
 mod cross_layer_caps {

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -55,12 +55,12 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
         // writer that disables check enforcement can still plant an oversize row,
         // and Component B would stream it with bounded memory, but we refuse it.
         if data_len.get() > crate::scan::MAX_ART_BYTES as u64 {
-            crate::warn_limit::rate_limited_warn(format_args!(
+            crate::serve_warn!(
                 "track {track_id} art {} is {} bytes, exceeds the {}-byte art cap; refusing to serve",
                 ta.art_id,
                 data_len.get(),
                 crate::scan::MAX_ART_BYTES,
-            ));
+            );
             return Err(crate::error::CoreError::ArtTooLarge {
                 track_id,
                 art_id: ta.art_id,
@@ -101,9 +101,9 @@ impl<M> musefs_format::ogg::ArtSource for DbArtSource<'_, M> {
         self.0
             .read_art_chunk_into(art_id, offset, buf)
             .map_err(|e| {
-                crate::warn_limit::rate_limited_warn(format_args!(
+                crate::serve_warn!(
                     "ogg synthesis: art {art_id} read failed at offset {offset}: {e}"
-                ));
+                );
                 musefs_format::FormatError::ArtRead { art_id }
             })
     }

--- a/musefs-core/src/mapping.rs
+++ b/musefs-core/src/mapping.rs
@@ -55,12 +55,12 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
         // writer that disables check enforcement can still plant an oversize row,
         // and Component B would stream it with bounded memory, but we refuse it.
         if data_len.get() > crate::scan::MAX_ART_BYTES as u64 {
-            log::warn!(
+            crate::warn_limit::rate_limited_warn(format_args!(
                 "track {track_id} art {} is {} bytes, exceeds the {}-byte art cap; refusing to serve",
                 ta.art_id,
                 data_len.get(),
                 crate::scan::MAX_ART_BYTES,
-            );
+            ));
             return Err(crate::error::CoreError::ArtTooLarge {
                 track_id,
                 art_id: ta.art_id,
@@ -91,7 +91,9 @@ pub(crate) fn track_art_to_inputs<M>(db: &Db<M>, track_id: i64) -> Result<Vec<Ar
 
 /// `ArtSource` over the SQLite blob store, used by Ogg synthesis to stream art
 /// bytes for page CRCs. Read failures (e.g. a deleted/short blob) are logged with
-/// the underlying DB error and surfaced as `FormatError::ArtRead`.
+/// the underlying DB error and surfaced as `FormatError::ArtRead`. The log goes
+/// through the shared serve-path warn limiter (#650): this fires per art
+/// *window*, so one failing blob would otherwise emit many lines for one file.
 pub(crate) struct DbArtSource<'a, M>(pub &'a Db<M>);
 
 impl<M> musefs_format::ogg::ArtSource for DbArtSource<'_, M> {
@@ -99,7 +101,9 @@ impl<M> musefs_format::ogg::ArtSource for DbArtSource<'_, M> {
         self.0
             .read_art_chunk_into(art_id, offset, buf)
             .map_err(|e| {
-                log::warn!("ogg synthesis: art {art_id} read failed at offset {offset}: {e}");
+                crate::warn_limit::rate_limited_warn(format_args!(
+                    "ogg synthesis: art {art_id} read failed at offset {offset}: {e}"
+                ));
                 musefs_format::FormatError::ArtRead { art_id }
             })
     }

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -214,11 +214,11 @@ impl HeaderCache {
                                 (structural, &binary_tag_inputs)
                             };
                         for key in invalid_vorbis_keys(&inputs) {
-                            log::warn!(
+                            crate::warn_limit::rate_limited_warn(format_args!(
                                 "track {}: dropping tag key {key:?} from Vorbis \
                                  synthesis (not a valid field name)",
                                 track.id
-                            );
+                            ));
                         }
                         flac::synthesize_layout(
                             &structural,
@@ -300,11 +300,11 @@ impl HeaderCache {
                             .collect();
                         let src = crate::mapping::DbArtSource(db);
                         for key in invalid_vorbis_keys(&inputs) {
-                            log::warn!(
+                            crate::warn_limit::rate_limited_warn(format_args!(
                                 "track {}: dropping tag key {key:?} from Vorbis \
                                  synthesis (not a valid field name)",
                                 track.id
-                            );
+                            ));
                         }
                         musefs_format::ogg::synthesize_layout(
                             &header,

--- a/musefs-core/src/reader.rs
+++ b/musefs-core/src/reader.rs
@@ -214,11 +214,11 @@ impl HeaderCache {
                                 (structural, &binary_tag_inputs)
                             };
                         for key in invalid_vorbis_keys(&inputs) {
-                            crate::warn_limit::rate_limited_warn(format_args!(
+                            crate::serve_warn!(
                                 "track {}: dropping tag key {key:?} from Vorbis \
                                  synthesis (not a valid field name)",
                                 track.id
-                            ));
+                            );
                         }
                         flac::synthesize_layout(
                             &structural,
@@ -300,11 +300,11 @@ impl HeaderCache {
                             .collect();
                         let src = crate::mapping::DbArtSource(db);
                         for key in invalid_vorbis_keys(&inputs) {
-                            crate::warn_limit::rate_limited_warn(format_args!(
+                            crate::serve_warn!(
                                 "track {}: dropping tag key {key:?} from Vorbis \
                                  synthesis (not a valid field name)",
                                 track.id
-                            ));
+                            );
                         }
                         musefs_format::ogg::synthesize_layout(
                             &header,
@@ -1972,5 +1972,32 @@ mod readahead_differential_tests {
             oracle_read(&resolved, &file, off, n, &mut direct).unwrap();
             assert_eq!(via, direct, "partial-seek mismatch at {off}+{n}");
         }
+    }
+}
+
+/// Emit one `serve_warn!` from this module's own scope so a test can pin the
+/// target the two Vorbis-key drops on the synthesis path log under. Deliberately
+/// at module scope rather than inside the test module: `module_path!()` — and so
+/// the record's target — is per module, and it is *this* module's name the
+/// production call sites carry.
+#[cfg(test)]
+fn serve_warn_target_probe(msg: &str) {
+    crate::serve_warn!("{msg}");
+}
+
+/// The Vorbis-key drops (#650) must stay attributed to `musefs_core::reader`:
+/// they are what an operator filters for with `RUST_LOG=musefs_core=debug`, and
+/// routing them through a shared limiter *function* would have relabelled every
+/// one of them `musefs_core::warn_limit`.
+#[cfg(test)]
+mod warn_target_tests {
+    use crate::warn_limit::log_capture::{install, target_of};
+
+    #[test]
+    fn serve_warns_from_the_reader_module_are_attributed_to_it() {
+        install();
+        let probe = format!("serve-warn target probe from {}", module_path!());
+        super::serve_warn_target_probe(&probe);
+        assert_eq!(target_of(&probe), "musefs_core::reader");
     }
 }

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -13,6 +13,7 @@ use musefs_db::limits::{
 };
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::sync_channel;
 
 const BATCH_FILES: usize = 256;
@@ -41,14 +42,17 @@ pub(crate) const MAX_ART_BYTES: usize = 16 * 1024 * 1024 - 64 * 1024;
 /// an oversize payload (e.g. a GEOB embedding a multi-MB file) fails.
 const MAX_BINARY_TAG_BYTES: usize = MAX_ART_BYTES;
 
-/// Outcome of probing one backing file. `Unparseable` is a supported-extension
-/// file whose bytes did not parse (counted as a scan `failed`). `Raced` means
-/// the file changed under us between the pre- and post-probe `fstat` — the probe
-/// may be torn, so nothing is committed for it (#276).
+/// Outcome of probing one backing file. `Failed` carries the reason and the
+/// line to log for a file that was supported and then lost — unparseable bytes,
+/// oversize metadata, a caught parser panic — and is counted as a scan `failed`;
+/// the caller tallies and logs it rather than the probe, so the warns can be
+/// capped per reason (#651). `Raced` means the file changed under us between the
+/// pre- and post-probe `fstat` — the probe may be torn, so nothing is committed
+/// for it (#276).
 #[derive(Debug)]
 enum ProbeOutcome {
     Probed(Probed, BackingStamp),
-    Unparseable,
+    Failed(Failure),
     Raced,
 }
 
@@ -169,6 +173,234 @@ impl SkipTally {
     }
 }
 
+/// Warn budget per skip reason, per scan. The first `SCAN_WARN_BURST` skips of
+/// a kind are logged individually at their natural level; the rest fall to
+/// `debug` and are carried by the end-of-scan breakdown instead. Without a cap,
+/// an unreadable subtree or a share that vanished mid-scan emits one line per
+/// file (#651). Mirrors the serve path's `rate_limited_warn` burst
+/// (`musefs-fuse`), but a scan is a bounded operation rather than a long-lived
+/// mount, so the budget is a plain per-reason count and not a sliding window.
+const SCAN_WARN_BURST: u64 = 10;
+
+/// Why one entry was passed over. Buckets the end-of-scan breakdowns and keys
+/// the per-reason warn budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkipReason {
+    /// Supported extension, but the bytes did not parse.
+    Unparseable,
+    /// Metadata over a storage cap — art, tag field, or binary frame (#644).
+    Oversize,
+    /// `open`/`stat`/`canonicalize` failed on a file the walk had accepted.
+    Io,
+    /// A parser panic caught by [`probe_file_caught`] (#425).
+    Panicked,
+    /// The file changed under the probe, so nothing was committed (#276).
+    Raced,
+    /// A directory or directory entry the walk could not read or classify.
+    WalkUnreadable,
+    /// A symlink the walk could not resolve, or one closing a cycle.
+    WalkSymlink,
+}
+
+impl SkipReason {
+    /// Every reason, in [`FailureTally`]'s array order (each reason indexes that
+    /// array by its discriminant).
+    const ALL: [SkipReason; 7] = [
+        SkipReason::Unparseable,
+        SkipReason::Oversize,
+        SkipReason::Io,
+        SkipReason::Panicked,
+        SkipReason::Raced,
+        SkipReason::WalkUnreadable,
+        SkipReason::WalkSymlink,
+    ];
+
+    /// The reasons that increment `ScanStats::failed`. They partition it
+    /// exactly, which is what makes the `failed N: ...` breakdown trustworthy.
+    const FAILED: [SkipReason; 4] = [
+        SkipReason::Unparseable,
+        SkipReason::Oversize,
+        SkipReason::Io,
+        SkipReason::Panicked,
+    ];
+
+    /// Walk-time entries, counted in no `ScanStats` field: no file was ever
+    /// queued for them, so they are neither `skipped` (the unsupported-extension
+    /// tally) nor `failed` (a probe or ingest that ran and lost).
+    const WALK: [SkipReason; 2] = [SkipReason::WalkUnreadable, SkipReason::WalkSymlink];
+
+    fn label(self) -> &'static str {
+        match self {
+            SkipReason::Unparseable => "unparseable",
+            SkipReason::Oversize => "oversize",
+            SkipReason::Io => "io",
+            SkipReason::Panicked => "panicked",
+            SkipReason::Raced => "changed-during-probe",
+            SkipReason::WalkUnreadable => "unreadable",
+            SkipReason::WalkSymlink => "symlink",
+        }
+    }
+
+    /// The level the in-budget lines for this reason are logged at. A caught
+    /// parser panic keeps `error`: it is a musefs bug, not a property of the
+    /// library being scanned.
+    fn level(self) -> log::Level {
+        match self {
+            SkipReason::Panicked => log::Level::Error,
+            _ => log::Level::Warn,
+        }
+    }
+}
+
+/// What the warn budget says about one skip. Split out of [`FailureTally::record`]
+/// so the policy is testable without a capturing logger, mirroring
+/// `WarnLimiter::decide` on the serve path.
+#[derive(Debug, PartialEq, Eq)]
+enum WarnBudget {
+    /// In budget: log the line at the reason's own level.
+    Spend(log::Level),
+    /// The first line over budget: say once that the rest are going to `debug`.
+    Exhausted,
+    /// Over budget: `debug` only.
+    Over,
+}
+
+/// Per-reason tally of everything a scan passed over, doing two jobs off one
+/// counter: it caps the per-file warns (the first [`SCAN_WARN_BURST`] of each
+/// reason at their natural level, the rest at `debug`) and it backs the
+/// end-of-scan breakdown that explains the otherwise bare `failed N` — the
+/// number the CLI reports and the one that drives the exit-2 partial-failure
+/// signal, so the one users most need explained (#651).
+///
+/// Distinct from [`SkipTally`], which buckets *unsupported-extension* files by
+/// extension: that breakdown is log-only and must never reach `ScanStats`
+/// (#341), whereas these failure counts partition `ScanStats::failed` exactly.
+///
+/// Shared across probe workers through `&self` — relaxed counters, no lock. The
+/// summaries are read after every worker has joined, and the warn budget only
+/// needs each caller to draw a distinct sequence number.
+#[derive(Debug, Default)]
+struct FailureTally {
+    counts: [AtomicU64; SkipReason::ALL.len()],
+}
+
+impl FailureTally {
+    /// Count one skip and decide its log level, spending this reason's warn
+    /// budget. Counting and deciding are the same atomic step: two callers can
+    /// never draw the same sequence number, so the "rest are at debug" notice is
+    /// emitted exactly once per reason however many workers race here.
+    fn decide(&self, reason: SkipReason) -> WarnBudget {
+        let prior = self.counts[reason as usize].fetch_add(1, Ordering::Relaxed);
+        // Fully qualified: the atomic `Ordering` is what this module imports.
+        match prior.cmp(&SCAN_WARN_BURST) {
+            std::cmp::Ordering::Less => WarnBudget::Spend(reason.level()),
+            std::cmp::Ordering::Equal => WarnBudget::Exhausted,
+            std::cmp::Ordering::Greater => WarnBudget::Over,
+        }
+    }
+
+    /// Record one skip and log `message` under this reason's warn budget: the
+    /// first [`SCAN_WARN_BURST`] go out at [`SkipReason::level`], then one line
+    /// says where the rest went, and the remainder are `debug`.
+    fn record(&self, reason: SkipReason, message: fmt::Arguments<'_>) {
+        match self.decide(reason) {
+            WarnBudget::Spend(level) => log::log!(level, "{message}"),
+            WarnBudget::Exhausted => {
+                log::warn!(
+                    "further \"{}\" skips are logged at debug ({SCAN_WARN_BURST} already reported); \
+                     the end-of-scan summary has the totals",
+                    reason.label()
+                );
+                log::debug!("{message}");
+            }
+            WarnBudget::Over => log::debug!("{message}"),
+        }
+    }
+
+    fn count(&self, reason: SkipReason) -> u64 {
+        self.counts[reason as usize].load(Ordering::Relaxed)
+    }
+
+    /// Everything counted toward `ScanStats::failed`.
+    fn failed_total(&self) -> u64 {
+        SkipReason::FAILED.iter().map(|r| self.count(*r)).sum()
+    }
+
+    /// `failed 37: unparseable=30, io=5, oversize=2` — the breakdown of
+    /// `ScanStats::failed`. `None` when nothing failed.
+    fn failed_summary(&self) -> Option<String> {
+        self.summary("failed", &SkipReason::FAILED)
+    }
+
+    /// `walk errors 12: unreadable=9, symlink=3` — entries the walk could not
+    /// read or classify, counted in no `ScanStats` field. `None` when the walk
+    /// was clean.
+    fn walk_summary(&self) -> Option<String> {
+        self.summary("walk errors", &SkipReason::WALK)
+    }
+
+    /// One summary line over `group`: `<label> <total>: reason=n, ...`, buckets
+    /// ordered by descending count with ties broken by reason name (matching
+    /// [`SkipTally::summary`]) and empty buckets omitted. `None` when the group
+    /// is empty, so there is no line to emit.
+    ///
+    /// [`SkipReason::Raced`] belongs to no group: it has exactly one cause, so a
+    /// breakdown would only repeat its own name, and its total is already
+    /// reported as `ScanStats::raced`.
+    fn summary(&self, label: &str, group: &[SkipReason]) -> Option<String> {
+        let mut buckets: Vec<(&'static str, u64)> = group
+            .iter()
+            .map(|r| (r.label(), self.count(*r)))
+            .filter(|(_, n)| *n > 0)
+            .collect();
+        let total: u64 = buckets.iter().map(|(_, n)| *n).sum();
+        if total == 0 {
+            return None;
+        }
+        buckets.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        let breakdown = buckets
+            .iter()
+            .map(|(reason, n)| format!("{reason}={n}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(format!("{label} {total}: {breakdown}"))
+    }
+}
+
+/// Outcome of [`probe_body`]'s per-format dispatch: a parse, or the [`Failure`]
+/// for the caller to tally and log.
+#[derive(Debug)]
+enum ProbeBody {
+    Parsed(Probed),
+    Failed(Failure),
+}
+
+/// One per-file failure on its way from the probe to the tally: the bucket it
+/// counts toward and the line to log for it. Carried out of the probe rather
+/// than logged where it happens so the tally — which lives with the worker
+/// pool — sees every failure and can cap the warns (#651).
+#[derive(Debug)]
+struct Failure {
+    reason: SkipReason,
+    message: String,
+}
+
+impl Failure {
+    fn new(reason: SkipReason, message: String) -> Failure {
+        Failure { reason, message }
+    }
+}
+
+/// The tallies threaded through the directory walk: the owned per-extension skip
+/// breakdown handed back to the caller, plus a borrow of the scan-wide
+/// [`FailureTally`] (shared with the probe workers) for entries the walk itself
+/// cannot read. Bundled into one parameter so the recursion's argument list
+/// stays inside clippy's limit.
+struct WalkTally<'a> {
+    skips: SkipTally,
+    failures: &'a FailureTally,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RevalidateStats {
     pub updated: u64,
@@ -196,12 +428,14 @@ fn is_supported_audio(path: &Path) -> bool {
         || has_ext(path, "wav")
 }
 
+/// Walk `root` with a throwaway failure tally — the callers that do not
+/// aggregate walk errors (the legacy oracle scan, unit tests).
 fn collect_audio(
     root: &Path,
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
 ) -> std::io::Result<SkipTally> {
-    collect_audio_with(root, out, follow_symlinks, None)
+    collect_audio_with(root, out, follow_symlinks, None, &FailureTally::default())
 }
 
 fn collect_audio_with(
@@ -209,10 +443,14 @@ fn collect_audio_with(
     out: &mut Vec<PathBuf>,
     follow_symlinks: bool,
     progress: Option<&ProgressSink>,
+    failures: &FailureTally,
 ) -> std::io::Result<SkipTally> {
     let mut visited = HashSet::new();
     let mut files_visited = HashSet::new();
-    let mut tally = SkipTally::default();
+    let mut tally = WalkTally {
+        skips: SkipTally::default(),
+        failures,
+    };
     if follow_symlinks && let Ok(meta) = std::fs::metadata(root) {
         visited.insert(dir_key(&meta));
     }
@@ -225,7 +463,7 @@ fn collect_audio_with(
         &mut tally,
         progress,
     )?;
-    Ok(tally)
+    Ok(tally.skips)
 }
 
 fn collect_audio_inner(
@@ -234,7 +472,7 @@ fn collect_audio_inner(
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
     files_visited: &mut HashSet<(u64, u64)>,
-    tally: &mut SkipTally,
+    tally: &mut WalkTally<'_>,
     progress: Option<&ProgressSink>,
 ) -> std::io::Result<()> {
     // A single unreadable subtree or vanished entry must drop only that entry,
@@ -245,7 +483,10 @@ fn collect_audio_inner(
     let entries = match std::fs::read_dir(root) {
         Ok(entries) => entries,
         Err(e) => {
-            log::warn!("skipping directory {}: {e}", root.display());
+            tally.failures.record(
+                SkipReason::WalkUnreadable,
+                format_args!("skipping directory {}: {e}", root.display()),
+            );
             return Ok(());
         }
     };
@@ -253,7 +494,10 @@ fn collect_audio_inner(
         let entry = match entry {
             Ok(entry) => entry,
             Err(e) => {
-                log::warn!("skipping unreadable entry in {}: {e}", root.display());
+                tally.failures.record(
+                    SkipReason::WalkUnreadable,
+                    format_args!("skipping unreadable entry in {}: {e}", root.display()),
+                );
                 continue;
             }
         };
@@ -261,7 +505,10 @@ fn collect_audio_inner(
         let ftype = match entry.file_type() {
             Ok(ftype) => ftype,
             Err(e) => {
-                log::warn!("skipping {}: {e}", path.display());
+                tally.failures.record(
+                    SkipReason::WalkUnreadable,
+                    format_args!("skipping {}: {e}", path.display()),
+                );
                 continue;
             }
         };
@@ -279,7 +526,7 @@ fn collect_audio_inner(
             if is_supported_audio(&path) {
                 push_file(&path, out, follow_symlinks, files_visited, None, progress);
             } else {
-                tally.record(&path);
+                tally.skips.record(&path);
             }
         } else if ftype.is_symlink() {
             if !follow_symlinks {
@@ -316,12 +563,15 @@ fn collect_audio_inner(
                             progress,
                         );
                     } else {
-                        tally.record(&path);
+                        tally.skips.record(&path);
                     }
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    log::warn!("skipping broken symlink {}: {e}", path.display());
+                    tally.failures.record(
+                        SkipReason::WalkSymlink,
+                        format_args!("skipping broken symlink {}: {e}", path.display()),
+                    );
                 }
             }
         } else {
@@ -330,7 +580,7 @@ fn collect_audio_inner(
             // never opened), but tally it so it surfaces in the skip breakdown
             // rather than vanishing without a trace, matching unsupported
             // regular files above (#544).
-            tally.record(&path);
+            tally.skips.record(&path);
         }
     }
     Ok(())
@@ -342,7 +592,7 @@ fn descend(
     follow_symlinks: bool,
     visited: &mut HashSet<(u64, u64)>,
     files_visited: &mut HashSet<(u64, u64)>,
-    tally: &mut SkipTally,
+    tally: &mut WalkTally<'_>,
     progress: Option<&ProgressSink>,
 ) -> std::io::Result<()> {
     if !follow_symlinks {
@@ -359,12 +609,20 @@ fn descend(
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
         Err(e) => {
-            log::warn!("skipping directory {}: {e}", path.display());
+            // `path` is a directory or a symlink to one; a failed `stat` cannot
+            // tell them apart, so it buckets with the walk's other unreadables.
+            tally.failures.record(
+                SkipReason::WalkUnreadable,
+                format_args!("skipping directory {}: {e}", path.display()),
+            );
             return Ok(());
         }
     };
     if !visited.insert(dir_key(&meta)) {
-        log::warn!("skipping symlink cycle at {}", path.display());
+        tally.failures.record(
+            SkipReason::WalkSymlink,
+            format_args!("skipping symlink cycle at {}", path.display()),
+        );
         return Ok(());
     }
     collect_audio_inner(
@@ -602,9 +860,10 @@ fn read_tail_128(file: &std::fs::File, file_len: u64) -> std::io::Result<Option<
 /// probe. Never reads the audio payload (M4A uses the seek reader;
 /// front-anchored formats read only the metadata extent).
 ///
-/// Returns `ProbeOutcome::Unparseable` for a supported-extension file that does
-/// not parse (counted as `failed`) and `ProbeOutcome::Raced` if the file
-/// changed under us.
+/// Returns `ProbeOutcome::Failed` for a supported-extension file that does not
+/// parse or cannot be stored (counted as `failed`) and `ProbeOutcome::Raced` if
+/// the file changed under us — a race outranks a failure, since a torn probe
+/// says nothing about whether the settled file would parse.
 fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     let file = std::fs::File::open(path)?;
     crate::metrics::on_scan_open();
@@ -616,12 +875,11 @@ fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
 
     let s2 = BackingStamp::from_metadata(&file.metadata()?);
     if s1 != s2 {
-        log::warn!("skipping {}: changed during probe", path.display());
         return Ok(ProbeOutcome::Raced);
     }
     Ok(match probed {
-        Some(p) => ProbeOutcome::Probed(p, s1),
-        None => ProbeOutcome::Unparseable,
+        ProbeBody::Parsed(p) => ProbeOutcome::Probed(p, s1),
+        ProbeBody::Failed(f) => ProbeOutcome::Failed(f),
     })
 }
 
@@ -630,9 +888,11 @@ fn probe_file(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
 /// drops just that file instead of unwinding the scan worker thread. An unwound
 /// worker would skip its `failed.fetch_add`, and a crafted directory could kill
 /// every worker, closing the channel so the writer reports success while
-/// silently truncating the rest of the library (#425). A caught panic is logged
-/// and folded into `ProbeOutcome::Unparseable`, which the worker already counts
-/// as `failed`. Mirrors the read path's `read_outcome` boundary (#359).
+/// silently truncating the rest of the library (#425). A caught panic is folded
+/// into a `Panicked` `ProbeOutcome::Failed`, which the worker already counts as
+/// `failed` — and which keeps its `error` level when the caller logs it, since a
+/// panic is a musefs bug rather than a property of the library being scanned.
+/// Mirrors the read path's `read_outcome` boundary (#359).
 fn probe_file_caught(path: &Path, window: usize) -> std::io::Result<ProbeOutcome> {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| probe_file(path, window))) {
         Ok(res) => res,
@@ -642,11 +902,13 @@ fn probe_file_caught(path: &Path, window: usize) -> std::io::Result<ProbeOutcome
                 .copied()
                 .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
                 .unwrap_or("<non-string panic>");
-            log::error!(
-                "scan worker panicked probing {}: {msg}; counting as failed",
-                path.display()
-            );
-            Ok(ProbeOutcome::Unparseable)
+            Ok(ProbeOutcome::Failed(Failure::new(
+                SkipReason::Panicked,
+                format!(
+                    "scan worker panicked probing {}: {msg}; counting as failed",
+                    path.display()
+                ),
+            )))
         }
     }
 }
@@ -654,22 +916,26 @@ fn probe_file_caught(path: &Path, window: usize) -> std::io::Result<ProbeOutcome
 /// The per-format metadata dispatch for one already-opened backing file, over
 /// its first `file_len` bytes. Split out of `probe_file` so the fstat-sandwich
 /// wrapper stays legible. Never reads the audio payload (M4A uses the seek
-/// reader; front-anchored formats read only the metadata extent). Returns
-/// `Ok(None)` for an unsupported/unparseable file.
+/// reader; front-anchored formats read only the metadata extent).
+/// `ProbeBody::Failed` is an unsupported/unparseable/oversize file — a verdict
+/// for the caller to tally and log, distinct from the outer `Err`, which is an
+/// I/O error on the already-open file.
 fn probe_body(
     path: &Path,
     file: &std::fs::File,
     file_len: u64,
     window: usize,
-) -> std::io::Result<Option<Probed>> {
+) -> std::io::Result<ProbeBody> {
     // M4A: seek reader, never touches mdat.
     if has_ext(path, "m4a") || has_ext(path, "m4b") {
         let mut f = file;
         let scan = match mp4::read_structure_from(&mut f, file_len) {
             Ok(s) => s,
             Err(e) => {
-                log::warn!("skipping {}: {e}", path.display());
-                return Ok(None);
+                return Ok(ProbeBody::Failed(Failure::new(
+                    SkipReason::Unparseable,
+                    format!("skipping {}: {e}", path.display()),
+                )));
             }
         };
         let (pictures, art_drops) = mp4::read_pictures_reporting(&scan.moov, MAX_ART_BYTES);
@@ -680,10 +946,12 @@ fn probe_body(
         // verdict `check_storable` produces for every other format, reached one
         // layer earlier because the payload is never materialized here.
         if let Some(e) = mp4_oversize_error(path, &art_drops, &bin_drops) {
-            log::warn!("skipping {e}");
-            return Ok(None);
+            return Ok(ProbeBody::Failed(Failure::new(
+                SkipReason::Oversize,
+                format!("skipping {e}"),
+            )));
         }
-        return Ok(Some(Probed {
+        return Ok(ProbeBody::Parsed(Probed {
             format: Format::M4a,
             audio_offset: scan.mdat_payload_offset,
             audio_length: scan.mdat_payload_len,
@@ -713,10 +981,12 @@ fn probe_body(
     };
     for _ in 0..MAX_WIDEN_RETRIES {
         match probe_prefix(path, &prefix, file_len, tail.as_ref()) {
-            Probe::Done(p) => return Ok(Some(p)),
+            Probe::Done(p) => return Ok(ProbeBody::Parsed(p)),
             Probe::Skip => {
-                log::warn!("skipping {}: no parseable audio metadata", path.display());
-                return Ok(None);
+                return Ok(ProbeBody::Failed(Failure::new(
+                    SkipReason::Unparseable,
+                    format!("skipping {}: no parseable audio metadata", path.display()),
+                )));
             }
             Probe::NeedMore(up_to) => {
                 // Read everything we're willing to probe? Widening can't help.
@@ -737,7 +1007,7 @@ fn probe_body(
         prefix = read_window(file, usize_from(probe_cap))?;
     }
     if let Some(p) = probe_full(path, &prefix) {
-        return Ok(Some(p));
+        return Ok(ProbeBody::Parsed(p));
     }
     // A WAV whose `data` payload runs past the probe ceiling fails the strict
     // full-buffer parse (the payload isn't present to bound), yet its `fmt `/`data`
@@ -747,17 +1017,23 @@ fn probe_body(
         && file_len > MAX_PROBE_BYTES
         && let Ok(bounds) = wav::locate_audio_at_ceiling(&prefix, file_len)
     {
-        return Ok(Some(wav_probed(&prefix, &bounds)));
+        return Ok(ProbeBody::Parsed(wav_probed(&prefix, &bounds)));
     }
-    if file_len > MAX_PROBE_BYTES {
-        log::warn!(
+    Ok(ProbeBody::Failed(unparseable(path, file_len)))
+}
+
+/// The "nothing parsed" verdict for one file, naming the probe ceiling when the
+/// file is large enough that the ceiling is the likely reason.
+fn unparseable(path: &Path, file_len: u64) -> Failure {
+    let message = if file_len > MAX_PROBE_BYTES {
+        format!(
             "skipping {}: no parseable metadata within first {MAX_PROBE_BYTES} bytes",
             path.display()
-        );
+        )
     } else {
-        log::warn!("skipping {}: no parseable audio metadata", path.display());
-    }
-    Ok(None)
+        format!("skipping {}: no parseable audio metadata", path.display())
+    };
+    Failure::new(SkipReason::Unparseable, message)
 }
 
 /// Outcome of a single bounded dispatch attempt against the current `prefix`.
@@ -1593,7 +1869,9 @@ fn ingest_bulk(
 /// increment `ScanStats::skipped` and are tallied by extension for the
 /// end-of-scan summary log line (#341); supported-extension files with a
 /// per-file I/O or parse error increment `ScanStats::failed` and do not abort
-/// the scan.
+/// the scan. Those failures are tallied by reason and summarized at the end too
+/// (#651), and their per-file warns are capped per reason so a whole unreadable
+/// subtree cannot scale the log with the library.
 pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<ScanStats> {
     // Canonicalize the root once. With symlinks unfollowed (the default) every
     // path the walk yields is then already absolute and symlink-free — i.e.
@@ -1602,6 +1880,7 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
     let root = canon.as_path();
     let mut files = Vec::new();
     let mut tally = SkipTally::default();
+    let failures = Arc::new(FailureTally::default());
     if root.is_file() {
         if is_supported_audio(root) {
             files.push(root.to_path_buf());
@@ -1614,6 +1893,7 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
             &mut files,
             opts.follow_symlinks,
             opts.progress.as_ref(),
+            &failures,
         )?;
     }
     let mut already_present = 0u64;
@@ -1641,16 +1921,36 @@ pub fn scan_directory_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<S
         });
     }
     db.apply_bulk_pragmas_self()?; // scan-scoped tuning on the caller's connection
-    let mut stats = run_pipeline(db, files, opts, WritePolicy::Full)?;
+    let mut stats = run_pipeline(db, files, opts, WritePolicy::Full, &failures)?;
     // skipped is tallied during the walk, not the pipeline
     stats.skipped = tally.total;
     stats.already_present = already_present;
     // Per-extension breakdown of the skip count, so a large `skipped` is
     // diagnosable (#341). Log-only: never folded into `stats`/the CLI summary.
+    //
+    // `info`, not `warn`: every ordinary library has cover art, `.cue` and
+    // `.log` sidecars, so a `warn` here fires on every healthy scan and teaches
+    // operators to tune warnings out. The count itself is never hidden — the CLI
+    // prints `skipped N` regardless of log level — so `-v` gates only the
+    // breakdown, which is a diagnostic you go looking for (#651).
     if let Some(summary) = tally.summary() {
+        log::info!("{summary}");
+    }
+    log_failure_summaries(&failures);
+    Ok(stats)
+}
+
+/// Emit the end-of-scan breakdowns of everything that went wrong, at `warn`:
+/// unlike the skip summary these do not fire on a healthy library, and `failed`
+/// is what drives the CLI's exit-2 partial-failure signal, so it must be legible
+/// at the default log floor (#651).
+fn log_failure_summaries(failures: &FailureTally) {
+    if let Some(summary) = failures.failed_summary() {
         log::warn!("{summary}");
     }
-    Ok(stats)
+    if let Some(summary) = failures.walk_summary() {
+        log::warn!("{summary}");
+    }
 }
 
 /// Back-compat shim used by the CLI and existing tests.
@@ -1660,14 +1960,17 @@ pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
 
 /// Probe `files` across `jobs` workers (no DB access) and write the results from a
 /// single writer (this thread) in batched transactions. Per-file errors are
-/// counted, not fatal.
+/// counted, not fatal: every one of them is recorded in `failures` (which also
+/// caps their warns) so the reason breakdown its caller logs partitions
+/// `ScanStats::failed` exactly.
 fn run_pipeline(
     db: &Db,
     files: Vec<PathBuf>,
     opts: &ScanOptions,
     policy: WritePolicy,
+    failures: &Arc<FailureTally>,
 ) -> Result<ScanStats> {
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::atomic::AtomicUsize;
 
     let jobs = effective_jobs(opts.jobs);
     let total = files.len() as u64;
@@ -1680,6 +1983,7 @@ fn run_pipeline(
     let budget = Arc::new(ByteBudget::new(cap));
     let failed = Arc::new(AtomicU64::new(0));
     let raced = Arc::new(AtomicU64::new(0));
+    let failed_before = failures.failed_total();
 
     // Work queue: a shared slice with an atomic cursor — each worker claims the
     // next index with a single relaxed `fetch_add`, no per-file lock contention.
@@ -1695,6 +1999,7 @@ fn run_pipeline(
         let budget = Arc::clone(&budget);
         let failed = Arc::clone(&failed);
         let raced = Arc::clone(&raced);
+        let failures = Arc::clone(failures);
         workers.push(std::thread::spawn(move || {
             loop {
                 let i = cursor.fetch_add(1, Ordering::Relaxed);
@@ -1708,7 +2013,10 @@ fn run_pipeline(
                             match std::fs::canonicalize(path) {
                                 Ok(abs) => abs.to_string_lossy().into_owned(),
                                 Err(e) => {
-                                    log::warn!("skipping {}: {e}", path.display());
+                                    failures.record(
+                                        SkipReason::Io,
+                                        format_args!("skipping {}: {e}", path.display()),
+                                    );
                                     failed.fetch_add(1, Ordering::Relaxed);
                                     continue;
                                 }
@@ -1726,7 +2034,7 @@ fn run_pipeline(
                         if policy == WritePolicy::Full
                             && let Err(e) = check_storable(&abs_path, &probed)
                         {
-                            log::warn!("skipping {e}");
+                            failures.record(SkipReason::Oversize, format_args!("skipping {e}"));
                             failed.fetch_add(1, Ordering::Relaxed);
                             continue;
                         }
@@ -1763,14 +2071,25 @@ fn run_pipeline(
                             break;
                         }
                     }
-                    Ok(ProbeOutcome::Unparseable) => {
+                    Ok(ProbeOutcome::Failed(f)) => {
+                        failures.record(f.reason, format_args!("{}", f.message));
                         failed.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(e) => {
-                        log::warn!("skipping {}: {e}", path.display());
+                        failures.record(
+                            SkipReason::Io,
+                            format_args!("skipping {}: {e}", path.display()),
+                        );
                         failed.fetch_add(1, Ordering::Relaxed);
                     }
                     Ok(ProbeOutcome::Raced) => {
+                        // Its own bucket, capped like the rest but left out of the
+                        // failure breakdown: a race has exactly one cause and is
+                        // already reported whole as `ScanStats::raced`.
+                        failures.record(
+                            SkipReason::Raced,
+                            format_args!("skipping {}: changed during probe", path.display()),
+                        );
                         raced.fetch_add(1, Ordering::Relaxed);
                     }
                 }
@@ -1893,13 +2212,23 @@ fn run_pipeline(
     }
     outcome?;
 
-    Ok(ScanStats {
+    let stats = ScanStats {
         scanned,
         skipped: 0, // counted at walk time; filled in by scan_directory_with
         already_present: 0,
         failed: failed.load(Ordering::Relaxed),
         raced: raced.load(Ordering::Relaxed),
-    })
+    };
+    // Every `failed` increment must be paired with a `failures.record`, or the
+    // breakdown would silently understate the number it exists to explain.
+    // Checked as a delta: the tally may already carry the walk's errors, or
+    // revalidate's pre-dispatch skip-pass failures.
+    debug_assert_eq!(
+        failures.failed_total() - failed_before,
+        stats.failed,
+        "every scan failure must be tallied by reason"
+    );
+    Ok(stats)
 }
 
 /// Test/oracle only: scan using the legacy whole-file probe (`probe_full`). The
@@ -1958,6 +2287,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
     let canon = std::fs::canonicalize(root)?;
     let root = canon.as_path();
     let mut files = Vec::new();
+    let failures = Arc::new(FailureTally::default());
     if root.is_file() {
         if is_supported_audio(root) {
             files.push(root.to_path_buf());
@@ -1968,6 +2298,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
             &mut files,
             opts.follow_symlinks,
             opts.progress.as_ref(),
+            &failures,
         )?;
     }
     db.apply_bulk_pragmas_self()?;
@@ -2003,7 +2334,10 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         let meta = match std::fs::metadata(&path) {
             Ok(meta) => meta,
             Err(e) => {
-                log::warn!("skipping {}: {e}", path.display());
+                failures.record(
+                    SkipReason::Io,
+                    format_args!("skipping {}: {e}", path.display()),
+                );
                 skip_failed += 1;
                 continue;
             }
@@ -2012,7 +2346,10 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
             match std::fs::canonicalize(&path) {
                 Ok(abs) => abs.to_string_lossy().into_owned(),
                 Err(e) => {
-                    log::warn!("skipping {}: {e}", path.display());
+                    failures.record(
+                        SkipReason::Io,
+                        format_args!("skipping {}: {e}", path.display()),
+                    );
                     skip_failed += 1;
                     continue;
                 }
@@ -2047,7 +2384,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
     }
 
     let mut pruned = 0u64;
-    let scan = run_pipeline(db, changed, opts, WritePolicy::StructuralOnly)?;
+    let scan = run_pipeline(db, changed, opts, WritePolicy::StructuralOnly, &failures)?;
 
     if opts.prune {
         let canon_root = root;
@@ -2065,6 +2402,7 @@ pub fn revalidate_with(db: &Db, root: &Path, opts: &ScanOptions) -> Result<Reval
         db.gc_orphan_art()?;
     }
 
+    log_failure_summaries(&failures);
     Ok(RevalidateStats {
         updated: scan.scanned,
         unchanged,

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -2188,8 +2188,10 @@ fn run_pipeline(
             failed.load(Ordering::Relaxed),
             raced.load(Ordering::Relaxed),
         );
-        while *failures_seen < tallied {
-            *failures_seen += 1;
+        // A bounded `for` rather than a `while` advancing its own cursor: the
+        // loop cannot outrun the tally, and it holds no increment whose failure
+        // to advance would spin forever.
+        for _ in *failures_seen..tallied {
             *finished += 1;
             if let Some(p) = progress {
                 p.emit(ScanProgress::Failed {
@@ -2198,6 +2200,7 @@ fn run_pipeline(
                 });
             }
         }
+        *failures_seen = tallied;
     };
 
     // Drain the channel, batching by file count and accumulated art bytes. The

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -1961,6 +1961,19 @@ fn log_failure_summaries(failures: &FailureTally) {
     }
 }
 
+/// Dispatched files that finished without being committed: probe failures plus
+/// races. Both leave the writer with nothing to persist, so both have to
+/// advance the progress sequence for it to reach the walked total (#655).
+///
+/// A free function rather than an inline sum so the arithmetic is reachable
+/// from a unit test: the pipeline cannot produce `raced > 0` under test at all,
+/// because the probe's mid-read race hook is a `thread_local!` and the probes
+/// run on worker threads the test never touches. Left inline, the sum would be
+/// indistinguishable from a difference in every test that can be written.
+fn uncommitted_total(failed: u64, raced: u64) -> u64 {
+    failed + raced
+}
+
 /// Back-compat shim used by the CLI and existing tests.
 pub fn scan_directory(db: &Db, root: &Path) -> Result<ScanStats> {
     scan_directory_with(db, root, &ScanOptions::default())
@@ -2171,7 +2184,10 @@ fn run_pipeline(
     // tracks failures as they happen) and once more after the final flush (so a
     // tail of failures with no commit behind them still lands).
     let catch_up = |finished: &mut u64, failures_seen: &mut u64| {
-        let tallied = failed.load(Ordering::Relaxed) + raced.load(Ordering::Relaxed);
+        let tallied = uncommitted_total(
+            failed.load(Ordering::Relaxed),
+            raced.load(Ordering::Relaxed),
+        );
         while *failures_seen < tallied {
             *failures_seen += 1;
             *finished += 1;

--- a/musefs-core/src/scan.rs
+++ b/musefs-core/src/scan.rs
@@ -96,6 +96,14 @@ pub enum ScanProgress<'a> {
         total: u64,
         path: &'a str,
     },
+    /// A dispatched file finished without being committed — it failed to probe
+    /// or raced. `done` shares the same 1..=total sequence as [`Self::Ingested`],
+    /// so the two together always reach `total` however many files fail (#655).
+    ///
+    /// There is no `path`: the failure was recorded on a probe worker, and only
+    /// the count crosses back to the writer thread a [`ProgressSink`] may be
+    /// invoked from. The `warn` line naming the file is the record of *which*.
+    Failed { done: u64, total: u64 },
 }
 
 /// UI-agnostic progress callback for [`ScanOptions`]. Invoked only from the
@@ -2100,9 +2108,22 @@ fn run_pipeline(
 
     // Writer: this thread. Batch by file count and accumulated art bytes.
     let mut scanned = 0u64;
+    // Files the pipeline is finished with, committed *or* failed. Both progress
+    // events report it, so the bar converges on `total` however many files fail
+    // (#655): a bar stalled at 93% reads as "this was aborted", which is the
+    // wrong story for a scan that completed and is about to report `failed N`.
+    let mut finished = 0u64;
+    // Failures already folded into `finished`. Workers tally on their own
+    // threads; only the counts cross back here, because a `ProgressSink` may be
+    // invoked from the writer and the walk but never from a probe worker.
+    let mut failures_seen = 0u64;
     let mut batch: Vec<Unit> = Vec::new();
     let mut batch_bytes = 0u64;
-    let flush = |batch: &mut Vec<Unit>, batch_bytes: &mut u64, scanned: &mut u64| -> Result<()> {
+    let flush = |batch: &mut Vec<Unit>,
+                 batch_bytes: &mut u64,
+                 scanned: &mut u64,
+                 finished: &mut u64|
+     -> Result<()> {
         if batch.is_empty() {
             return Ok(());
         }
@@ -2129,9 +2150,10 @@ fn run_pipeline(
         bw.commit()?;
         for abs_path in committed {
             *scanned += 1;
+            *finished += 1;
             if let Some(p) = progress {
                 p.emit(ScanProgress::Ingested {
-                    done: *scanned,
+                    done: *finished,
                     total,
                     path: &abs_path,
                 });
@@ -2142,6 +2164,24 @@ fn run_pipeline(
         budget.release(released);
         *batch_bytes = 0;
         Ok(())
+    };
+
+    // Fold any failures the workers have tallied since the last check into the
+    // progress sequence. Called at the top of each writer iteration (so the bar
+    // tracks failures as they happen) and once more after the final flush (so a
+    // tail of failures with no commit behind them still lands).
+    let catch_up = |finished: &mut u64, failures_seen: &mut u64| {
+        let tallied = failed.load(Ordering::Relaxed) + raced.load(Ordering::Relaxed);
+        while *failures_seen < tallied {
+            *failures_seen += 1;
+            *finished += 1;
+            if let Some(p) = progress {
+                p.emit(ScanProgress::Failed {
+                    done: *finished,
+                    total,
+                });
+            }
+        }
     };
 
     // Drain the channel, batching by file count and accumulated art bytes. The
@@ -2157,19 +2197,20 @@ fn run_pipeline(
     // pipeline must be torn down (below) before it propagates.
     let mut fatal: Option<crate::error::CoreError> = None;
     loop {
+        catch_up(&mut finished, &mut failures_seen);
         match rx.try_recv() {
             Ok(unit) => {
                 batch_bytes += unit.weight;
                 batch.push(unit);
                 if (batch.len() >= BATCH_FILES || batch_bytes >= cap)
-                    && let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned)
+                    && let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned, &mut finished)
                 {
                     fatal = Some(e);
                     break;
                 }
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
-                if let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned) {
+                if let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned, &mut finished) {
                     fatal = Some(e);
                     break;
                 }
@@ -2178,7 +2219,8 @@ fn run_pipeline(
                         batch_bytes += unit.weight;
                         batch.push(unit);
                         if (batch.len() >= BATCH_FILES || batch_bytes >= cap)
-                            && let Err(e) = flush(&mut batch, &mut batch_bytes, &mut scanned)
+                            && let Err(e) =
+                                flush(&mut batch, &mut batch_bytes, &mut scanned, &mut finished)
                         {
                             fatal = Some(e);
                             break;
@@ -2192,8 +2234,15 @@ fn run_pipeline(
     }
     let outcome = match fatal {
         Some(e) => Err(e),
-        None => flush(&mut batch, &mut batch_bytes, &mut scanned),
+        None => flush(&mut batch, &mut batch_bytes, &mut scanned, &mut finished),
     };
+    if outcome.is_ok() {
+        // Every worker has exited by now, so the tallies are final: this is the
+        // catch-up that matters when the tail of the run is failures with no
+        // commit behind them to drive the loop (the whole-target failure case,
+        // where nothing was ever sent and the loop ran once).
+        catch_up(&mut finished, &mut failures_seen);
+    }
     if outcome.is_err() {
         // A DB-write failure aborts the whole scan, but the workers must still be
         // wound down before the error propagates: `scan_directory_with` /
@@ -2227,6 +2276,15 @@ fn run_pipeline(
         failures.failed_total() - failed_before,
         stats.failed,
         "every scan failure must be tallied by reason"
+    );
+    // The companion invariant for the progress bar: every dispatched file is
+    // committed, failed, or raced, so the two progress events must together
+    // account for the walked total. If this ever trips, the bar has silently
+    // gone back to stalling short of 100% (#655).
+    debug_assert_eq!(
+        finished, total,
+        "progress must reach the walked total (scanned {} + failed {} + raced {})",
+        stats.scanned, stats.failed, stats.raced
     );
     Ok(stats)
 }

--- a/musefs-core/src/scan/bounded_probe_tests.rs
+++ b/musefs-core/src/scan/bounded_probe_tests.rs
@@ -174,7 +174,7 @@ fn oversize_unparseable_file_is_skipped_not_read_whole() {
 
     assert!(matches!(
         probe_file(&path, WINDOW).unwrap(),
-        ProbeOutcome::Unparseable
+        ProbeOutcome::Failed(_)
     ));
 }
 

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -1365,3 +1365,52 @@ fn ingest_bulk_assigns_sequential_structural_ordinals_per_kind() {
     assert_eq!(got[1].ordinal, 1);
     assert_eq!(got[1].body, vec![0xB2]);
 }
+
+// --- #655 / #651: mutation-gate survivors from PR #656 ---
+
+/// `uncommitted_total` sums the two ways a dispatched file can finish without a
+/// commit. A difference would pass every test that can drive the pipeline
+/// (`raced` is always 0 there — the probe race hook is thread-local and the
+/// probes run on worker threads), so the sum is pinned directly.
+#[test]
+fn uncommitted_total_sums_failures_and_races() {
+    assert_eq!(super::uncommitted_total(3, 2), 5, "failures plus races");
+    // The mutation this exists to kill: a difference agrees on every input
+    // where one side is zero, which is every case a pipeline test can build.
+    assert_ne!(super::uncommitted_total(3, 2), 3 - 2);
+    assert_eq!(super::uncommitted_total(0, 4), 4, "races alone still count");
+    assert_eq!(
+        super::uncommitted_total(4, 0),
+        4,
+        "failures alone still count"
+    );
+    assert_eq!(super::uncommitted_total(0, 0), 0);
+}
+
+/// The end-of-scan failure breakdown has to actually reach the log. The
+/// `failed_summary`/`walk_summary` formatters are unit-tested above, but
+/// nothing asserted that `run_pipeline` emits them — so stubbing the emission
+/// out entirely went unnoticed.
+#[test]
+fn scan_emits_the_failure_breakdown_to_the_log() {
+    crate::warn_limit::log_capture::install();
+    let dir = tempfile::tempdir().unwrap();
+    // Supported extension, unparseable content: counted `failed`, so the
+    // breakdown must name the `unparseable` bucket.
+    for i in 0..3 {
+        std::fs::write(dir.path().join(format!("broken{i}.flac")), b"not a flac").unwrap();
+    }
+    let db = Db::open_in_memory().unwrap();
+    let stats = scan_directory_with(&db, dir.path(), &ScanOptions::default()).unwrap();
+    assert_eq!(stats.failed, 3);
+
+    // Asserted by substring rather than by count: the capture buffer is shared
+    // across this binary's parallel tests. Presence is enough to kill the
+    // stub-the-emission mutant, which would leave the buffer without any
+    // breakdown line at all.
+    let breakdowns = crate::warn_limit::log_capture::messages_containing("unparseable=");
+    assert!(
+        breakdowns.iter().any(|m| m.starts_with("failed ")),
+        "expected a `failed N: unparseable=N` breakdown; captured: {breakdowns:?}"
+    );
+}

--- a/musefs-core/src/scan/hardening_tests.rs
+++ b/musefs-core/src/scan/hardening_tests.rs
@@ -416,7 +416,14 @@ fn probe_file_caught_isolates_parser_panic_as_failed() {
     set_after_s1_hook(|| panic!("parser exploded"));
     let out = probe_file_caught(&path, WINDOW);
     clear_after_s1_hook();
-    assert!(matches!(out, Ok(ProbeOutcome::Unparseable)), "got {out:?}");
+    match out {
+        Ok(ProbeOutcome::Failed(f)) => assert_eq!(
+            f.reason,
+            SkipReason::Panicked,
+            "a caught panic must have its own bucket, not merge into unparseable"
+        ),
+        other => panic!("got {other:?}"),
+    }
 }
 
 #[test]
@@ -461,6 +468,238 @@ fn skip_tally_ties_break_by_extension_name() {
 #[test]
 fn skip_tally_empty_has_no_summary() {
     assert!(super::SkipTally::default().summary().is_none());
+}
+
+/// `SkipReason` indexes `FailureTally`'s array by its discriminant, so `ALL`
+/// must list the variants in declaration order — a mismatch would silently
+/// credit one reason's skips to another.
+#[test]
+fn skip_reason_all_is_in_discriminant_order() {
+    for (i, reason) in SkipReason::ALL.iter().enumerate() {
+        assert_eq!(*reason as usize, i, "{reason:?} is out of order in ALL");
+    }
+}
+
+/// Every reason belongs to exactly one summary group, or (for `Raced`) to none
+/// deliberately: an accidentally ungrouped reason would be counted but never
+/// reported.
+#[test]
+fn skip_reason_groups_partition_all_reasons_except_raced() {
+    for reason in SkipReason::ALL {
+        let in_failed = SkipReason::FAILED.contains(&reason);
+        let in_walk = SkipReason::WALK.contains(&reason);
+        if reason == SkipReason::Raced {
+            assert!(
+                !in_failed && !in_walk,
+                "a race is reported whole as ScanStats::raced, not in a breakdown"
+            );
+        } else {
+            assert!(
+                in_failed ^ in_walk,
+                "{reason:?} must be in exactly one summary group"
+            );
+        }
+    }
+}
+
+/// The line the issue asked for: `failed N` explained by reason, ordered by
+/// descending count with ties broken by name (matching the extension tally).
+#[test]
+fn failure_tally_breaks_down_failed_by_reason() {
+    let tally = super::FailureTally::default();
+    for _ in 0..30 {
+        tally.record(SkipReason::Unparseable, format_args!("x"));
+    }
+    for _ in 0..5 {
+        tally.record(SkipReason::Io, format_args!("x"));
+    }
+    for _ in 0..2 {
+        tally.record(SkipReason::Oversize, format_args!("x"));
+    }
+    assert_eq!(
+        tally.failed_summary().unwrap(),
+        "failed 37: unparseable=30, io=5, oversize=2"
+    );
+    // Failure reasons are not walk errors, and neither breakdown may leak into
+    // the other.
+    assert!(tally.walk_summary().is_none());
+}
+
+#[test]
+fn failure_tally_omits_empty_buckets_and_breaks_ties_by_reason_name() {
+    let tally = super::FailureTally::default();
+    tally.record(SkipReason::Panicked, format_args!("x"));
+    tally.record(SkipReason::Io, format_args!("x"));
+    assert_eq!(
+        tally.failed_summary().unwrap(),
+        "failed 2: io=1, panicked=1"
+    );
+}
+
+/// A race is already reported whole as `ScanStats::raced`, and its breakdown
+/// would only repeat its own name — but it is still counted, because that is
+/// what caps its warns.
+#[test]
+fn failure_tally_counts_races_without_folding_them_into_failed() {
+    let tally = super::FailureTally::default();
+    for _ in 0..3 {
+        tally.record(SkipReason::Raced, format_args!("x"));
+    }
+    assert_eq!(tally.count(SkipReason::Raced), 3);
+    assert!(tally.failed_summary().is_none());
+    assert!(tally.walk_summary().is_none());
+}
+
+/// Walk-time errors get their own line: they are counted in no `ScanStats`
+/// field, so without it an unreadable subtree leaves no trace but its (capped)
+/// per-entry warns.
+#[test]
+fn failure_tally_summarizes_walk_errors_separately() {
+    let tally = super::FailureTally::default();
+    for _ in 0..9 {
+        tally.record(SkipReason::WalkUnreadable, format_args!("x"));
+    }
+    for _ in 0..3 {
+        tally.record(SkipReason::WalkSymlink, format_args!("x"));
+    }
+    assert_eq!(
+        tally.walk_summary().unwrap(),
+        "walk errors 12: unreadable=9, symlink=3"
+    );
+    assert!(tally.failed_summary().is_none());
+}
+
+#[test]
+fn failure_tally_empty_has_no_summaries() {
+    let tally = super::FailureTally::default();
+    assert!(tally.failed_summary().is_none());
+    assert!(tally.walk_summary().is_none());
+}
+
+/// The cap: the first `SCAN_WARN_BURST` of a reason are logged at their own
+/// level, one line announces the downgrade, and the rest are debug — so a
+/// vanished share cannot emit one warn per file (#651).
+#[test]
+fn warn_budget_caps_each_reason_after_the_burst() {
+    let tally = super::FailureTally::default();
+    for i in 0..SCAN_WARN_BURST {
+        assert_eq!(
+            tally.decide(SkipReason::Unparseable),
+            super::WarnBudget::Spend(log::Level::Warn),
+            "skip {i} is still within the burst"
+        );
+    }
+    assert_eq!(
+        tally.decide(SkipReason::Unparseable),
+        super::WarnBudget::Exhausted,
+        "the first over-budget skip must announce the downgrade"
+    );
+    for _ in 0..100 {
+        assert_eq!(
+            tally.decide(SkipReason::Unparseable),
+            super::WarnBudget::Over,
+            "the announcement must be made once, not per file"
+        );
+    }
+    assert_eq!(
+        tally.count(SkipReason::Unparseable),
+        SCAN_WARN_BURST + 101,
+        "capped warns must still be counted in full"
+    );
+}
+
+/// The budget is per reason: a flood of unparseable files must not hide the
+/// first I/O error behind it.
+#[test]
+fn warn_budget_is_spent_per_reason() {
+    let tally = super::FailureTally::default();
+    for _ in 0..SCAN_WARN_BURST * 2 {
+        tally.decide(SkipReason::Unparseable);
+    }
+    assert_eq!(
+        tally.decide(SkipReason::Io),
+        super::WarnBudget::Spend(log::Level::Warn)
+    );
+}
+
+/// A caught parser panic is a musefs bug, not a property of the library, so its
+/// in-budget lines keep `error` while everything else warns.
+#[test]
+fn warn_budget_keeps_caught_panics_at_error() {
+    let tally = super::FailureTally::default();
+    assert_eq!(
+        tally.decide(SkipReason::Panicked),
+        super::WarnBudget::Spend(log::Level::Error)
+    );
+    assert_eq!(
+        tally.decide(SkipReason::WalkUnreadable),
+        super::WarnBudget::Spend(log::Level::Warn)
+    );
+}
+
+/// The walk's failure tally must see entries it could not read, so an
+/// unreadable subtree is summarized rather than only warned about per entry.
+#[test]
+fn collect_audio_records_an_unreadable_subdir_in_the_failure_tally() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let locked = dir.path().join("locked");
+    std::fs::create_dir(&locked).unwrap();
+    std::fs::write(locked.join("a.flac"), b"x").unwrap();
+    let reachable = dir.path().join("b.flac");
+    std::fs::write(&reachable, b"x").unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+    if std::fs::read_dir(&locked).is_ok() {
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        eprintln!(
+            "skipping collect_audio_records_an_unreadable_subdir_in_the_failure_tally: directory permissions not enforced (running as root?)"
+        );
+        return;
+    }
+
+    let failures = super::FailureTally::default();
+    let mut out = Vec::new();
+    let skips = collect_audio_with(dir.path(), &mut out, false, None, &failures).unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert_eq!(
+        out,
+        vec![reachable],
+        "the readable file must still be found"
+    );
+    assert_eq!(
+        failures.walk_summary().unwrap(),
+        "walk errors 1: unreadable=1"
+    );
+    assert!(
+        failures.failed_summary().is_none(),
+        "a directory the walk could not read is not a file that failed to ingest"
+    );
+    assert_eq!(
+        skips.total, 0,
+        "walk errors must stay out of the extension tally that feeds ScanStats::skipped"
+    );
+}
+
+/// An unparseable backing file must arrive at the caller as a tallyable
+/// `Failure`, not as a warn the probe already spent.
+#[test]
+fn probe_reports_unparseable_with_its_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bad.flac");
+    std::fs::write(&path, b"not a real audio file").unwrap();
+    match probe_file(&path, WINDOW).unwrap() {
+        ProbeOutcome::Failed(f) => {
+            assert_eq!(f.reason, SkipReason::Unparseable);
+            assert!(
+                f.message.contains("no parseable audio metadata"),
+                "got {:?}",
+                f.message
+            );
+        }
+        other => panic!("got {other:?}"),
+    }
 }
 
 #[test]

--- a/musefs-core/src/scan/scan_unit_tests.rs
+++ b/musefs-core/src/scan/scan_unit_tests.rs
@@ -275,6 +275,7 @@ fn scan_emits_discovered_walked_ingested_events() {
             ScanProgress::Discovered { found } => format!("disc:{found}"),
             ScanProgress::Walked { total } => format!("walk:{total}"),
             ScanProgress::Ingested { done, total, .. } => format!("ing:{done}/{total}"),
+            ScanProgress::Failed { done, total } => format!("fail:{done}/{total}"),
         };
         recorder.lock().unwrap().push(line);
     });
@@ -299,6 +300,62 @@ fn scan_emits_discovered_walked_ingested_events() {
         ing,
         vec!["ing:1/5", "ing:2/5", "ing:3/5", "ing:4/5", "ing:5/5"],
     );
+}
+
+/// #655: a file that fails to probe still has to advance the progress sequence,
+/// or the bar stalls short of its length and a completed scan reads as aborted.
+/// Three good files and two unparseable ones must produce a 1..=5 run of events
+/// ending at 5/5, whatever order the two kinds interleave in.
+#[test]
+fn progress_reaches_the_total_when_files_fail() {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..3 {
+        let mut bytes = b"fLaC".to_vec();
+        bytes.push(0x80);
+        bytes.extend_from_slice(&[0, 0, 34]);
+        bytes.extend(std::iter::repeat_n(0u8, 34));
+        bytes.extend_from_slice(format!("AUDIO-{i}").as_bytes());
+        std::fs::write(dir.path().join(format!("good{i}.flac")), &bytes).unwrap();
+    }
+    // Supported extension, unparseable content: the walk queues these, and the
+    // probe worker fails them — the case that used to leave the bar short.
+    for i in 0..2 {
+        std::fs::write(dir.path().join(format!("bad{i}.flac")), b"not a flac").unwrap();
+    }
+
+    let events = Arc::new(Mutex::new(Vec::<(u64, u64)>::new()));
+    let recorder = Arc::clone(&events);
+    let sink = ProgressSink::new(move |ev| match ev {
+        ScanProgress::Ingested { done, total, .. } | ScanProgress::Failed { done, total } => {
+            recorder.lock().unwrap().push((done, total));
+        }
+        _ => {}
+    });
+
+    let db = Db::open_in_memory().unwrap();
+    let opts = ScanOptions {
+        jobs: 1,
+        progress: Some(sink),
+        ..Default::default()
+    };
+    let stats = scan_directory_with(&db, dir.path(), &opts).unwrap();
+    assert_eq!(stats.scanned, 3, "the three parseable files ingest");
+    assert_eq!(
+        stats.failed, 2,
+        "the two unparseable files are counted failed"
+    );
+
+    let ev = events.lock().unwrap();
+    // Every dispatched file reports exactly once, and `done` is a dense 1..=5
+    // sequence — so the bar lands on its length rather than stopping at 3/5.
+    assert_eq!(
+        ev.iter().map(|(d, _)| *d).collect::<Vec<_>>(),
+        vec![1, 2, 3, 4, 5],
+        "events: {ev:?}"
+    );
+    assert!(ev.iter().all(|(_, t)| *t == 5), "events: {ev:?}");
 }
 
 // --- fingerprint_of() / full_file_hash() / ChecksumTier / MatchStrictness ---

--- a/musefs-core/src/scan/scan_unit_tests.rs
+++ b/musefs-core/src/scan/scan_unit_tests.rs
@@ -210,7 +210,7 @@ fn probe_file_fails_file_with_oversized_mp4_covr() {
     let path = dir.path().join("oversized_art.m4a");
     std::fs::write(&path, &bytes).unwrap();
     assert!(
-        matches!(probe_file(&path, 0).unwrap(), ProbeOutcome::Unparseable),
+        matches!(probe_file(&path, 0).unwrap(), ProbeOutcome::Failed(_)),
         "an oversized covr must fail the file, not yield a track without its art"
     );
 }
@@ -223,7 +223,7 @@ fn probe_file_fails_file_with_oversized_mp4_binary_freeform() {
     let path = dir.path().join("oversized_bin.m4a");
     std::fs::write(&path, &bytes).unwrap();
     assert!(
-        matches!(probe_file(&path, 0).unwrap(), ProbeOutcome::Unparseable),
+        matches!(probe_file(&path, 0).unwrap(), ProbeOutcome::Failed(_)),
         "an oversized `----` value must fail the file"
     );
 }

--- a/musefs-core/src/telemetry.rs
+++ b/musefs-core/src/telemetry.rs
@@ -7,7 +7,8 @@
 use std::fmt::Write;
 
 /// Core-owned telemetry: the file-handle slab count, header/size caches, the
-/// virtual-tree footprint, and refresh health. Produced by `Musefs::telemetry`.
+/// virtual-tree footprint, refresh health, and the shared serve-path warn
+/// limiter's suppressed count. Produced by `Musefs::telemetry`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct CoreTelemetry {
     pub handles_open: u64,
@@ -24,6 +25,7 @@ pub struct CoreTelemetry {
     pub refresh_generation: u64,
     pub refresh_gap_fallbacks: u64,
     pub refresh_needs_rebuild: bool,
+    pub serve_warns_suppressed: u64,
 }
 
 /// Passthrough sub-telemetry; `None` (in [`FuseTelemetry`]) off Linux.
@@ -176,6 +178,12 @@ pub fn render_prometheus(
         "musefs_dir_handle_rejections_total",
         "opendir calls that found the dir-handle table full and were served statelessly.",
         fuse.dir_handle_rejections,
+    );
+    counter(
+        &mut out,
+        "musefs_serve_warns_suppressed_total",
+        "Serve-path failure warnings downgraded to debug by the warn rate limiter.",
+        core.serve_warns_suppressed,
     );
 
     gauge(
@@ -429,6 +437,7 @@ mod tests {
             refresh_generation: 2,
             refresh_gap_fallbacks: 1,
             refresh_needs_rebuild: false,
+            serve_warns_suppressed: 13,
         }
     }
 
@@ -512,6 +521,9 @@ mod tests {
         );
         assert!(out.contains(
             "# TYPE musefs_dir_handle_rejections_total counter\nmusefs_dir_handle_rejections_total 11\n"
+        ));
+        assert!(out.contains(
+            "# TYPE musefs_serve_warns_suppressed_total counter\nmusefs_serve_warns_suppressed_total 13\n"
         ));
         assert!(out.contains("musefs_pool_queued 0\n"));
         assert!(out.contains("musefs_readahead_budget_bytes 67108864\n"));

--- a/musefs-core/src/warn_limit.rs
+++ b/musefs-core/src/warn_limit.rs
@@ -1,0 +1,139 @@
+//! Process-wide rate limit for serve-path failure warns (#650).
+//!
+//! Both the FUSE errno-reply path and the synthesis paths inside this crate
+//! log per-file failures, and both scale with library size: one warn per file
+//! over a 200,000-track walk is tens of MB of log for a single enumeration
+//! (#631). One budget covers all of them — the operator's concern is total
+//! serve-path log volume, not per-crate volume — so `musefs-fuse` routes
+//! `reply_errno` through [`rate_limited_warn`] rather than owning a limiter of
+//! its own.
+//!
+//! Lives in `musefs-core` (the integration layer) next to [`crate::telemetry`],
+//! since both crates above it feed the same budget.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Burst of serve-path failure warns allowed per [`WARN_WINDOW_SECS`] window;
+/// the rest of the window is downgraded to debug and counted.
+const WARN_BURST: u64 = 10;
+/// Length of one warn rate-limit window, in seconds.
+const WARN_WINDOW_SECS: u64 = 30;
+
+/// What [`WarnLimiter::decide`] told the caller to do with one warn.
+#[derive(Debug, PartialEq, Eq)]
+enum WarnDecision {
+    /// Emit the warn. `suppressed` is the count dropped since the last window
+    /// opened (nonzero only on the first warn of a new window) so the log
+    /// still reflects the true failure volume.
+    Log { suppressed: u64 },
+    /// Over budget for this window: downgrade to debug.
+    Suppress,
+}
+
+/// Rate limit for serve-path failure warns. Without it, a library enumeration
+/// over a corpus whose backing files are missing emits one warn per file —
+/// 200,000 lines (tens of MB of log) for a single walk (#631). Failures stay
+/// visible — a burst per window plus a suppressed-count on each new window —
+/// without the log scaling with library size. Lock-free; a lost race under
+/// concurrent windows-rollover merely logs one extra line.
+struct WarnLimiter {
+    /// Unix seconds when the current window opened.
+    window_start: AtomicU64,
+    /// Warns emitted in the current window (the burst budget).
+    in_window: AtomicU64,
+    /// Warns downgraded in the current window, reported when the next opens.
+    suppressed: AtomicU64,
+}
+
+impl WarnLimiter {
+    const fn new() -> WarnLimiter {
+        WarnLimiter {
+            window_start: AtomicU64::new(0),
+            in_window: AtomicU64::new(0),
+            suppressed: AtomicU64::new(0),
+        }
+    }
+
+    /// Decide one warn's fate at `now_secs` (Unix seconds; injected so tests
+    /// don't sleep).
+    fn decide(&self, now_secs: u64) -> WarnDecision {
+        let start = self.window_start.load(Ordering::Relaxed);
+        if now_secs >= start.saturating_add(WARN_WINDOW_SECS)
+            && self
+                .window_start
+                .compare_exchange(start, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            self.in_window.store(1, Ordering::Relaxed);
+            return WarnDecision::Log {
+                suppressed: self.suppressed.swap(0, Ordering::Relaxed),
+            };
+        }
+        if self.in_window.fetch_add(1, Ordering::Relaxed) < WARN_BURST {
+            WarnDecision::Log { suppressed: 0 }
+        } else {
+            self.suppressed.fetch_add(1, Ordering::Relaxed);
+            WarnDecision::Suppress
+        }
+    }
+}
+
+/// The one process-wide limiter for serve-path failure warns.
+static SERVE_WARN_LIMITER: WarnLimiter = WarnLimiter::new();
+
+/// Emit a serve-path failure warn through [`SERVE_WARN_LIMITER`]. Over-budget
+/// messages drop to debug so `RUST_LOG=debug` still sees every failure. Callers
+/// pass `format_args!(...)`, so the message is formatted once, at whichever
+/// level it ends up on.
+pub fn rate_limited_warn(message: std::fmt::Arguments<'_>) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    match SERVE_WARN_LIMITER.decide(now) {
+        WarnDecision::Log { suppressed: 0 } => log::warn!("{message}"),
+        WarnDecision::Log { suppressed } => log::warn!(
+            "{message} ({suppressed} similar serve-path warnings suppressed in the last {WARN_WINDOW_SECS}s)"
+        ),
+        WarnDecision::Suppress => log::debug!("{message} (over warn budget)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warn_limiter_allows_a_burst_then_suppresses() {
+        let l = WarnLimiter::new();
+        // First call opens the window; the burst budget covers WARN_BURST warns.
+        for i in 0..WARN_BURST {
+            assert_eq!(
+                l.decide(100),
+                WarnDecision::Log { suppressed: 0 },
+                "warn {i} is within the burst"
+            );
+        }
+        assert_eq!(l.decide(100), WarnDecision::Suppress);
+        assert_eq!(l.decide(100), WarnDecision::Suppress);
+    }
+
+    #[test]
+    fn warn_limiter_new_window_reports_suppressed_count() {
+        let l = WarnLimiter::new();
+        for _ in 0..WARN_BURST {
+            l.decide(100);
+        }
+        for _ in 0..5 {
+            assert_eq!(l.decide(100), WarnDecision::Suppress);
+        }
+        // Window rolls over: log again, carrying the dropped count once.
+        assert_eq!(
+            l.decide(100 + WARN_WINDOW_SECS),
+            WarnDecision::Log { suppressed: 5 }
+        );
+        assert_eq!(
+            l.decide(100 + WARN_WINDOW_SECS),
+            WarnDecision::Log { suppressed: 0 }
+        );
+    }
+}

--- a/musefs-core/src/warn_limit.rs
+++ b/musefs-core/src/warn_limit.rs
@@ -9,7 +9,9 @@
 //! its own.
 //!
 //! Lives in `musefs-core` (the integration layer) next to [`crate::telemetry`],
-//! since both crates above it feed the same budget.
+//! since both crates above it feed the same budget — which is also what makes
+//! [`serve_warns_suppressed`] a local read for
+//! `musefs_serve_warns_suppressed_total` (#653).
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -43,6 +45,10 @@ struct WarnLimiter {
     in_window: AtomicU64,
     /// Warns downgraded in the current window, reported when the next opens.
     suppressed: AtomicU64,
+    /// Every warn ever downgraded, never reset: the monotonic source for
+    /// `musefs_serve_warns_suppressed_total` (#653). Distinct from
+    /// `suppressed`, which each new window drains into its first log line.
+    suppressed_total: AtomicU64,
 }
 
 impl WarnLimiter {
@@ -51,6 +57,7 @@ impl WarnLimiter {
             window_start: AtomicU64::new(0),
             in_window: AtomicU64::new(0),
             suppressed: AtomicU64::new(0),
+            suppressed_total: AtomicU64::new(0),
         }
     }
 
@@ -73,8 +80,14 @@ impl WarnLimiter {
             WarnDecision::Log { suppressed: 0 }
         } else {
             self.suppressed.fetch_add(1, Ordering::Relaxed);
+            self.suppressed_total.fetch_add(1, Ordering::Relaxed);
             WarnDecision::Suppress
         }
+    }
+
+    /// Warns downgraded to debug over the limiter's whole lifetime.
+    fn suppressed_total(&self) -> u64 {
+        self.suppressed_total.load(Ordering::Relaxed)
     }
 }
 
@@ -96,6 +109,15 @@ pub fn rate_limited_warn(message: std::fmt::Arguments<'_>) {
         ),
         WarnDecision::Suppress => log::debug!("{message} (over warn budget)"),
     }
+}
+
+/// Serve-path warns downgraded to debug since process start, rendered as
+/// `musefs_serve_warns_suppressed_total` (#653). Neither a gauge nor the
+/// parenthetical on an admitted log line can stand in for it: suppression is
+/// bursty by construction, so a scrape landing between bursts sees nothing and
+/// the operator cannot tell a quiet serve path from a throttled one.
+pub(crate) fn serve_warns_suppressed() -> u64 {
+    SERVE_WARN_LIMITER.suppressed_total()
 }
 
 #[cfg(test)]
@@ -134,6 +156,53 @@ mod tests {
         assert_eq!(
             l.decide(100 + WARN_WINDOW_SECS),
             WarnDecision::Log { suppressed: 0 }
+        );
+    }
+
+    #[test]
+    fn suppressed_total_is_monotonic_across_windows() {
+        // The per-window count is drained into the next window's first log
+        // line; the total is not, so the metric survives a rollover (#653).
+        let l = WarnLimiter::new();
+        for _ in 0..WARN_BURST + 5 {
+            l.decide(100);
+        }
+        assert_eq!(l.suppressed_total(), 5);
+        assert_eq!(
+            l.decide(100 + WARN_WINDOW_SECS),
+            WarnDecision::Log { suppressed: 5 }
+        );
+        assert_eq!(l.suppressed_total(), 5, "rollover must not reset the total");
+        // That rollover call spent one of the new window's budget, so these
+        // WARN_BURST + 3 leave 4 over budget: 5 + 4.
+        for _ in 0..WARN_BURST + 3 {
+            l.decide(100 + WARN_WINDOW_SECS);
+        }
+        assert_eq!(l.suppressed_total(), 9);
+    }
+
+    #[test]
+    fn admitted_warns_never_count_as_suppressed() {
+        let l = WarnLimiter::new();
+        for _ in 0..WARN_BURST {
+            assert_eq!(l.decide(100), WarnDecision::Log { suppressed: 0 });
+        }
+        assert_eq!(l.suppressed_total(), 0);
+    }
+
+    #[test]
+    fn process_wide_counter_advances_through_rate_limited_warn() {
+        // End-to-end over the real static: a burst past the budget must move
+        // the counter the metric reads, whichever crate emitted the warns.
+        // Delta-based and `>=`, since the static is shared with the rest of
+        // the suite and the window may already be part-spent.
+        let before = serve_warns_suppressed();
+        for i in 0..=WARN_BURST * 2 {
+            rate_limited_warn(format_args!("warn-limit self-test {i}"));
+        }
+        assert!(
+            serve_warns_suppressed() > before,
+            "an over-budget burst must be counted"
         );
     }
 }

--- a/musefs-core/src/warn_limit.rs
+++ b/musefs-core/src/warn_limit.rs
@@ -5,25 +5,43 @@
 //! over a 200,000-track walk is tens of MB of log for a single enumeration
 //! (#631). One budget covers all of them — the operator's concern is total
 //! serve-path log volume, not per-crate volume — so `musefs-fuse` routes
-//! `reply_errno` through [`rate_limited_warn`] rather than owning a limiter of
-//! its own.
+//! `reply_errno` through [`serve_warn!`](crate::serve_warn) rather than owning
+//! a limiter of its own.
 //!
 //! Lives in `musefs-core` (the integration layer) next to [`crate::telemetry`],
 //! since both crates above it feed the same budget — which is also what makes
 //! [`serve_warns_suppressed`] a local read for
 //! `musefs_serve_warns_suppressed_total` (#653).
+//!
+//! The emit side is a **macro**, not a function, and deliberately so: a `log`
+//! record takes its target from `module_path!()` at the expansion site, so a
+//! shared helper function would stamp every serve-path warn with this module's
+//! path. That would collapse provenance — a synthesis warn and an errno reply
+//! would be indistinguishable by target — and break the per-crate `RUST_LOG`
+//! filtering the troubleshooting guide documents
+//! (`RUST_LOG=warn,musefs_fuse=debug`). Sharing the *decision* while expanding
+//! the *emit* at the call site keeps one budget and one honest target per site.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+
+/// `log` re-export so [`serve_warn!`](crate::serve_warn) expands in crates that
+/// do not name `log` themselves. Implementation detail of the macro.
+#[doc(hidden)]
+pub use log as __log;
 
 /// Burst of serve-path failure warns allowed per [`WARN_WINDOW_SECS`] window;
 /// the rest of the window is downgraded to debug and counted.
 const WARN_BURST: u64 = 10;
-/// Length of one warn rate-limit window, in seconds.
-const WARN_WINDOW_SECS: u64 = 30;
+/// Length of one warn rate-limit window, in seconds. Public because
+/// [`serve_warn!`](crate::serve_warn) names it in the suppressed-count
+/// parenthetical it formats at the call site.
+pub const WARN_WINDOW_SECS: u64 = 30;
 
-/// What [`WarnLimiter::decide`] told the caller to do with one warn.
+/// What [`decide`] told the caller to do with one warn. Public as the macro's
+/// expansion target; call [`serve_warn!`](crate::serve_warn) rather than
+/// matching on this by hand.
 #[derive(Debug, PartialEq, Eq)]
-enum WarnDecision {
+pub enum WarnDecision {
     /// Emit the warn. `suppressed` is the count dropped since the last window
     /// opened (nonzero only on the first warn of a new window) so the log
     /// still reflects the true failure volume.
@@ -94,21 +112,50 @@ impl WarnLimiter {
 /// The one process-wide limiter for serve-path failure warns.
 static SERVE_WARN_LIMITER: WarnLimiter = WarnLimiter::new();
 
-/// Emit a serve-path failure warn through [`SERVE_WARN_LIMITER`]. Over-budget
-/// messages drop to debug so `RUST_LOG=debug` still sees every failure. Callers
-/// pass `format_args!(...)`, so the message is formatted once, at whichever
-/// level it ends up on.
-pub fn rate_limited_warn(message: std::fmt::Arguments<'_>) {
+/// Ask [`SERVE_WARN_LIMITER`] what to do with one serve-path warn, now.
+/// Public as the decision half of [`serve_warn!`](crate::serve_warn), which
+/// owns the emit half; nothing else should need it.
+pub fn decide() -> WarnDecision {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
-    match SERVE_WARN_LIMITER.decide(now) {
-        WarnDecision::Log { suppressed: 0 } => log::warn!("{message}"),
-        WarnDecision::Log { suppressed } => log::warn!(
-            "{message} ({suppressed} similar serve-path warnings suppressed in the last {WARN_WINDOW_SECS}s)"
-        ),
-        WarnDecision::Suppress => log::debug!("{message} (over warn budget)"),
-    }
+    SERVE_WARN_LIMITER.decide(now)
+}
+
+/// Emit a serve-path failure warn through the process-wide limiter, at the
+/// caller's own log target. Takes the same arguments as [`log::warn!`].
+/// Over-budget messages drop to debug so `RUST_LOG=debug` still sees every
+/// failure.
+///
+/// A macro rather than a function so `module_path!()` — and therefore the log
+/// record's target — resolves to the *call site*: `reply_errno` still logs
+/// under `musefs_fuse`, synthesis still logs under `musefs_core::reader` /
+/// `musefs_core::mapping`, and `RUST_LOG=warn,musefs_fuse=debug` still reaches
+/// exactly what it did before the limiter was shared. Only the budget is
+/// global; the attribution is not.
+#[macro_export]
+macro_rules! serve_warn {
+    ($($arg:tt)+) => {
+        match $crate::warn_limit::decide() {
+            $crate::warn_limit::WarnDecision::Log { suppressed: 0 } => {
+                $crate::warn_limit::__log::warn!($($arg)+);
+            }
+            $crate::warn_limit::WarnDecision::Log { suppressed } => {
+                $crate::warn_limit::__log::warn!(
+                    "{} ({} similar serve-path warnings suppressed in the last {}s)",
+                    ::core::format_args!($($arg)+),
+                    suppressed,
+                    $crate::warn_limit::WARN_WINDOW_SECS,
+                );
+            }
+            $crate::warn_limit::WarnDecision::Suppress => {
+                $crate::warn_limit::__log::debug!(
+                    "{} (over warn budget)",
+                    ::core::format_args!($($arg)+),
+                );
+            }
+        }
+    };
 }
 
 /// Serve-path warns downgraded to debug since process start, rendered as
@@ -120,9 +167,76 @@ pub(crate) fn serve_warns_suppressed() -> u64 {
     SERVE_WARN_LIMITER.suppressed_total()
 }
 
+/// Log-capture harness shared by the target-attribution tests. Any module that
+/// hosts a `serve_warn!` call site can pin the target it logs under from its
+/// own test module; `log` permits one global logger per test binary, so the
+/// installer is `Once`-guarded and lookups filter the shared buffer by message.
+#[cfg(test)]
+pub(crate) mod log_capture {
+    use std::sync::Mutex;
+
+    static CAPTURED: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+    static CAPTURE_LOGGER: CaptureLogger = CaptureLogger;
+
+    /// Global logger keeping every record's target and rendered message.
+    struct CaptureLogger;
+
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record<'_>) {
+            CAPTURED
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push((record.target().to_string(), record.args().to_string()));
+        }
+        fn flush(&self) {}
+    }
+
+    /// Install the capture logger for this test binary (idempotent).
+    pub(crate) fn install() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            log::set_logger(&CAPTURE_LOGGER)
+                .expect("no other logger may be installed in this test binary");
+            // Over-budget warns drop to debug; the target must be pinned on
+            // those too, so the capture has to see them.
+            log::set_max_level(log::LevelFilter::Debug);
+        });
+    }
+
+    /// Every captured message containing `needle`, in emission order.
+    pub(crate) fn messages_containing(needle: &str) -> Vec<String> {
+        CAPTURED
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .filter(|(_, m)| m.contains(needle))
+            .map(|(_, m)| m.clone())
+            .collect()
+    }
+
+    /// The target of the one captured record whose message contains `needle`.
+    pub(crate) fn target_of(needle: &str) -> String {
+        let captured = CAPTURED
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let hits: Vec<&(String, String)> = captured
+            .iter()
+            .filter(|(_, m)| m.contains(needle))
+            .collect();
+        assert_eq!(hits.len(), 1, "expected exactly one record for {needle:?}");
+        hits[0].0.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::warn_limit::log_capture::{
+        install as install_capture_logger, messages_containing, target_of,
+    };
 
     #[test]
     fn warn_limiter_allows_a_burst_then_suppresses() {
@@ -191,18 +305,86 @@ mod tests {
     }
 
     #[test]
-    fn process_wide_counter_advances_through_rate_limited_warn() {
+    fn process_wide_counter_advances_through_serve_warn() {
         // End-to-end over the real static: a burst past the budget must move
         // the counter the metric reads, whichever crate emitted the warns.
         // Delta-based and `>=`, since the static is shared with the rest of
         // the suite and the window may already be part-spent.
         let before = serve_warns_suppressed();
         for i in 0..=WARN_BURST * 2 {
-            rate_limited_warn(format_args!("warn-limit self-test {i}"));
+            crate::serve_warn!("warn-limit self-test {i}");
         }
         assert!(
             serve_warns_suppressed() > before,
             "an over-budget burst must be counted"
+        );
+    }
+
+    /// A second module so the assertion is "the record follows the call site",
+    /// not "every record carries one fixed string".
+    mod elsewhere {
+        /// Returns `(this module's path, the message it logged)`.
+        pub fn emit(tag: &str) -> (&'static str, String) {
+            let msg = format!("serve-warn target probe from elsewhere {tag}");
+            crate::serve_warn!("{msg}");
+            (module_path!(), msg)
+        }
+    }
+
+    #[test]
+    fn serve_warn_is_attributed_to_the_call_site_not_the_limiter() {
+        // The whole reason `serve_warn!` is a macro: a helper *function* would
+        // stamp every serve-path record with `musefs_core::warn_limit`,
+        // silently breaking per-crate `RUST_LOG` filtering and collapsing
+        // synthesis warns together with errno-path warns.
+        install_capture_logger();
+        let here = format!("serve-warn target probe from {}", module_path!());
+        crate::serve_warn!("{here}");
+        let (there_module, there) = elsewhere::emit("a");
+
+        assert_eq!(target_of(&here), module_path!());
+        assert_eq!(target_of(&there), there_module);
+        assert_ne!(
+            target_of(&here),
+            target_of(&there),
+            "two call sites in different modules must not share a target"
+        );
+        assert!(
+            !target_of(&here).ends_with("warn_limit"),
+            "no record may be attributed to the limiter's own module"
+        );
+    }
+
+    #[test]
+    fn over_budget_records_keep_the_debug_suffix() {
+        // The macro must render the downgraded form exactly as the function it
+        // replaced did: the caller's message, then " (over warn budget)".
+        install_capture_logger();
+        let tag = "over-budget suffix probe";
+        for _ in 0..WARN_BURST * 3 {
+            crate::serve_warn!("{tag} payload");
+        }
+        let msgs = messages_containing(tag);
+        assert!(
+            msgs.iter()
+                .any(|m| m == "over-budget suffix probe payload (over warn budget)"),
+            "expected a downgraded record with the exact suffix, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn art_read_failure_is_attributed_to_the_mapping_module() {
+        // The real production site (`DbArtSource::read_window`, #650), not a
+        // synthetic call: an art id that does not exist fails the blob read.
+        install_capture_logger();
+        let db = musefs_db::Db::open_in_memory().unwrap();
+        let src = crate::mapping::DbArtSource(&db);
+        let mut buf = [0u8; 4];
+        let err = musefs_format::ogg::ArtSource::read_window(&src, 424_242, 0, &mut buf);
+        assert!(err.is_err(), "a missing art blob must fail the read");
+        assert_eq!(
+            target_of("ogg synthesis: art 424242 read failed"),
+            "musefs_core::mapping"
         );
     }
 }

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -402,6 +402,34 @@ pub fn migrate(conn: &mut Connection) -> Result<()> {
     // sees the updated version and skips re-applying the migration.
     let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
     let current: i64 = tx.pragma_query_value(None, "user_version", |r| r.get(0))?;
+    // Announce only an upgrade this call actually performs: another process may
+    // have migrated the store while we waited for the write lock, in which case
+    // the version read under the lock is already the latest and the loop below
+    // applies nothing.
+    let mut work = None;
+    if current < latest {
+        // `Connection::path` is `Some("")` for an in-memory or temporary store.
+        let at = match tx.path().filter(|p| !p.is_empty()) {
+            Some(path) => format!(" at {path}"),
+            None => String::new(),
+        };
+        if current == 0 {
+            // A store this binary is creating from scratch — nothing is being
+            // taken anywhere it cannot come back from, so this stays quiet at
+            // the default filter.
+            log::info!("creating store schema{at} at version {latest}");
+        } else {
+            // A pre-existing store is about to be rewritten in place, one way.
+            // The user gets this once per store, and wants it in their
+            // scrollback if they ever try to roll musefs back.
+            log::warn!(
+                "upgrading store schema{at} from version {current} to version {latest}; \
+                 this is irreversible and the store will no longer open with musefs \
+                 builds older than this one"
+            );
+        }
+        work = Some((at, std::time::Instant::now()));
+    }
     for (target, sql) in (1i64..).zip(MIGRATIONS) {
         if current < target {
             tx.execute_batch(sql)?;
@@ -409,7 +437,186 @@ pub fn migrate(conn: &mut Connection) -> Result<()> {
         }
     }
     tx.commit()?;
+    if let Some((at, started)) = work {
+        let secs = started.elapsed().as_secs_f64();
+        log::info!("store schema{at} is now at version {latest} (took {secs:.1}s)");
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod migration_logging_tests {
+    use log::{Level, LevelFilter, Log, Metadata, Record};
+    use rusqlite::Connection;
+    use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+    use std::thread::ThreadId;
+
+    /// Records emitted on the capturing thread, newest last.
+    static RECORDS: Mutex<Vec<(Level, String)>> = Mutex::new(Vec::new());
+    /// Serializes the capturing tests: `log::set_logger` installs one logger per
+    /// process, so they share a single buffer.
+    static SERIAL: Mutex<()> = Mutex::new(());
+    /// The thread whose records are being captured. Everything the rest of the
+    /// (parallel) test binary logs is dropped, so a capture only ever sees what
+    /// the test itself provoked.
+    static CAPTURING: Mutex<Option<ThreadId>> = Mutex::new(None);
+
+    struct Capture;
+    static CAPTURE: Capture = Capture;
+
+    impl Log for Capture {
+        fn enabled(&self, _: &Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &Record) {
+            if *CAPTURING.lock().unwrap() == Some(std::thread::current().id()) {
+                RECORDS
+                    .lock()
+                    .unwrap()
+                    .push((record.level(), record.args().to_string()));
+            }
+        }
+        fn flush(&self) {}
+    }
+
+    /// Holds the capture open; the buffer is reachable only through the guard,
+    /// so no test can read records it does not own.
+    struct Captured {
+        records: &'static Mutex<Vec<(Level, String)>>,
+        _serial: MutexGuard<'static, ()>,
+    }
+
+    impl Captured {
+        fn records(&self) -> Vec<(Level, String)> {
+            self.records.lock().unwrap().clone()
+        }
+        /// Drop everything logged so far, so the next assertion sees only what
+        /// follows this call.
+        fn clear(&self) {
+            self.records.lock().unwrap().clear();
+        }
+    }
+
+    impl Drop for Captured {
+        fn drop(&mut self) {
+            *CAPTURING.lock().unwrap() = None;
+            RECORDS.lock().unwrap().clear();
+        }
+    }
+
+    /// Start capturing this thread's log records until the returned guard drops.
+    fn capture() -> Captured {
+        let serial = SERIAL.lock().unwrap_or_else(PoisonError::into_inner);
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            log::set_logger(&CAPTURE).expect("no other logger is installed in this test binary");
+            log::set_max_level(LevelFilter::Trace);
+        });
+        RECORDS.lock().unwrap().clear();
+        *CAPTURING.lock().unwrap() = Some(std::thread::current().id());
+        Captured {
+            records: &RECORDS,
+            _serial: serial,
+        }
+    }
+
+    /// A store stamped at v1 with only MIGRATION_V1 applied — what an older
+    /// musefs build left behind.
+    fn store_at_v1(conn: &Connection) {
+        conn.execute_batch(super::MIGRATION_V1).unwrap();
+        conn.pragma_update(None, "user_version", 1i64).unwrap();
+    }
+
+    #[test]
+    fn upgrading_an_existing_store_warns_with_both_versions() {
+        let captured = capture();
+        let mut conn = Connection::open_in_memory().unwrap();
+        store_at_v1(&conn);
+        captured.clear();
+
+        super::migrate(&mut conn).unwrap();
+
+        let records = captured.records();
+        let warnings: Vec<&String> = records
+            .iter()
+            .filter(|(level, _)| *level == Level::Warn)
+            .map(|(_, msg)| msg)
+            .collect();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "an in-place upgrade must announce itself exactly once at warn, \
+             which is the default filter level; got {records:?}"
+        );
+        let warning = warnings[0];
+        assert!(
+            warning.contains("from version 1")
+                && warning.contains(&format!("to version {}", super::LATEST_VERSION)),
+            "the warning must name the version found and the version reached: {warning}"
+        );
+        assert!(
+            records.iter().any(|(level, msg)| *level == Level::Info
+                && msg.contains(&format!("version {}", super::LATEST_VERSION))),
+            "a completion line must follow the upgrade: {records:?}"
+        );
+    }
+
+    #[test]
+    fn the_warning_names_the_store_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("library.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            store_at_v1(&conn);
+        }
+        let captured = capture();
+        let mut conn = Connection::open(&path).unwrap();
+        super::migrate(&mut conn).unwrap();
+
+        let records = captured.records();
+        let path = path.to_str().unwrap();
+        assert!(
+            records
+                .iter()
+                .any(|(level, msg)| *level == Level::Warn && msg.contains(path)),
+            "the upgrade warning must identify which store was upgraded: {records:?}"
+        );
+    }
+
+    #[test]
+    fn opening_an_already_current_store_logs_nothing() {
+        let captured = capture();
+        let mut conn = Connection::open_in_memory().unwrap();
+        super::migrate(&mut conn).unwrap();
+        captured.clear();
+
+        // The fast path, taken on every open and every mount.
+        super::migrate(&mut conn).unwrap();
+
+        assert!(
+            captured.records().is_empty(),
+            "a store already at the latest version must stay silent: {:?}",
+            captured.records()
+        );
+    }
+
+    #[test]
+    fn creating_a_fresh_store_does_not_warn() {
+        let captured = capture();
+        let mut conn = Connection::open_in_memory().unwrap();
+        super::migrate(&mut conn).unwrap();
+
+        let records = captured.records();
+        assert!(
+            records.iter().all(|(level, _)| *level != Level::Warn),
+            "creating a store is not an irreversible upgrade of the user's data, \
+             so nothing may reach the default filter: {records:?}"
+        );
+        assert!(
+            records.iter().any(|(level, _)| *level == Level::Info),
+            "creating a store should still be visible under -v: {records:?}"
+        );
+    }
 }
 
 fn reference_objects() -> &'static std::collections::BTreeMap<(String, String), String> {

--- a/musefs-db/src/schema.rs
+++ b/musefs-db/src/schema.rs
@@ -379,6 +379,30 @@ const _: () = assert!(
     "LATEST_VERSION must match MIGRATIONS"
 );
 
+#[cfg(test)]
+thread_local! {
+    static BEFORE_LOCK_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+#[cfg(test)]
+fn fire_before_lock() {
+    // Take the hook out before running it: it opens a second connection and
+    // migrates, which re-enters `migrate` on this same thread and would
+    // otherwise recurse until the stack gives out.
+    let hook = BEFORE_LOCK_HOOK.with(|h| h.borrow_mut().take());
+    if let Some(mut f) = hook {
+        f();
+    }
+}
+#[cfg(test)]
+fn set_before_lock_hook(f: impl FnMut() + 'static) {
+    BEFORE_LOCK_HOOK.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+}
+#[cfg(test)]
+fn clear_before_lock_hook() {
+    BEFORE_LOCK_HOOK.with(|h| *h.borrow_mut() = None);
+}
+
 pub fn migrate(conn: &mut Connection) -> Result<()> {
     let latest = LATEST_VERSION;
     let current = conn.pragma_query_value::<i64, _>(None, "user_version", |r| r.get(0))?;
@@ -396,6 +420,12 @@ pub fn migrate(conn: &mut Connection) -> Result<()> {
     if current >= latest {
         return Ok(());
     }
+    // Test seam: the window between the read above and the write lock below is
+    // exactly where a competing writer can migrate the store out from under us.
+    // Nothing in a single-process test can land there on its own, so the race
+    // arm of the announcement guard below is only reachable through this hook.
+    #[cfg(test)]
+    fire_before_lock();
     // Use an IMMEDIATE transaction so the write lock is acquired up front. The
     // user_version read below is then authoritative: a second process opening
     // the same database concurrently blocks here until the first commits, then
@@ -525,6 +555,61 @@ mod migration_logging_tests {
     fn store_at_v1(conn: &Connection) {
         conn.execute_batch(super::MIGRATION_V1).unwrap();
         conn.pragma_update(None, "user_version", 1i64).unwrap();
+    }
+
+    /// The announcement fires only for an upgrade this call actually performs.
+    /// Another writer can migrate the store while we wait for the write lock, in
+    /// which case the version read *under* the lock is already the latest and
+    /// the loop applies nothing — announcing there would report an irreversible
+    /// upgrade that this process did not do, on a store it did not change.
+    ///
+    /// Only reachable through the before-lock seam: the pre-lock read has to see
+    /// an old version and the post-lock read a current one, which no
+    /// single-threaded test can arrange otherwise.
+    #[test]
+    fn a_migration_lost_to_a_competing_writer_says_nothing() {
+        struct HookGuard;
+        impl Drop for HookGuard {
+            fn drop(&mut self) {
+                super::clear_before_lock_hook();
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("library.db");
+        let mut conn = Connection::open(&path).unwrap();
+        store_at_v1(&conn);
+
+        // Stand in for the competing process: migrate the store to the latest
+        // version on a second connection, after our pre-lock read but before we
+        // take the write lock.
+        let racer_path = path.clone();
+        let captured = capture();
+        super::set_before_lock_hook(move || {
+            let mut racer = Connection::open(&racer_path).unwrap();
+            super::migrate(&mut racer).unwrap();
+            // The racer re-enters `migrate` on this thread, so its own — entirely
+            // correct — announcement lands in the same capture buffer. Drop it,
+            // leaving only whatever the call that lost the race goes on to say.
+            RECORDS
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clear();
+        });
+        let _guard = HookGuard;
+
+        super::migrate(&mut conn).unwrap();
+        let records = captured.records();
+
+        assert!(
+            records.is_empty(),
+            "a call that migrated nothing must say nothing; got {records:?}"
+        );
+        // The store is still correctly migrated — by the racer, not by us.
+        let version: i64 = conn
+            .pragma_query_value(None, "user_version", |r| r.get(0))
+            .unwrap();
+        assert_eq!(version, super::LATEST_VERSION);
     }
 
     #[test]

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -22,6 +22,7 @@ use musefs_core::CoreError;
 use musefs_core::Fh;
 use musefs_core::Musefs;
 use musefs_core::convert::usize_from;
+use musefs_core::rate_limited_warn;
 use std::num::NonZeroU64;
 
 mod convert;
@@ -206,95 +207,14 @@ pub fn errno(err: &CoreError) -> fuser::Errno {
     }
 }
 
-/// Burst of serve-path failure warns allowed per [`WARN_WINDOW_SECS`] window;
-/// the rest of the window is downgraded to debug and counted.
-const WARN_BURST: u64 = 10;
-/// Length of one warn rate-limit window, in seconds.
-const WARN_WINDOW_SECS: u64 = 30;
-
-/// What [`WarnLimiter::decide`] told the caller to do with one warn.
-#[derive(Debug, PartialEq, Eq)]
-enum WarnDecision {
-    /// Emit the warn. `suppressed` is the count dropped since the last window
-    /// opened (nonzero only on the first warn of a new window) so the log
-    /// still reflects the true failure volume.
-    Log { suppressed: u64 },
-    /// Over budget for this window: downgrade to debug.
-    Suppress,
-}
-
-/// Rate limit for serve-path failure warns. Without it, a library enumeration
-/// over a corpus whose backing files are missing emits one warn per file —
-/// 200,000 lines (tens of MB of log) for a single walk (#631). Failures stay
-/// visible — a burst per window plus a suppressed-count on each new window —
-/// without the log scaling with library size. Lock-free; a lost race under
-/// concurrent windows-rollover merely logs one extra line.
-struct WarnLimiter {
-    /// Unix seconds when the current window opened.
-    window_start: AtomicU64,
-    /// Warns emitted in the current window (the burst budget).
-    in_window: AtomicU64,
-    /// Warns downgraded in the current window, reported when the next opens.
-    suppressed: AtomicU64,
-}
-
-impl WarnLimiter {
-    const fn new() -> WarnLimiter {
-        WarnLimiter {
-            window_start: AtomicU64::new(0),
-            in_window: AtomicU64::new(0),
-            suppressed: AtomicU64::new(0),
-        }
-    }
-
-    /// Decide one warn's fate at `now_secs` (Unix seconds; injected so tests
-    /// don't sleep).
-    fn decide(&self, now_secs: u64) -> WarnDecision {
-        let start = self.window_start.load(Ordering::Relaxed);
-        if now_secs >= start.saturating_add(WARN_WINDOW_SECS)
-            && self
-                .window_start
-                .compare_exchange(start, now_secs, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-        {
-            self.in_window.store(1, Ordering::Relaxed);
-            return WarnDecision::Log {
-                suppressed: self.suppressed.swap(0, Ordering::Relaxed),
-            };
-        }
-        if self.in_window.fetch_add(1, Ordering::Relaxed) < WARN_BURST {
-            WarnDecision::Log { suppressed: 0 }
-        } else {
-            self.suppressed.fetch_add(1, Ordering::Relaxed);
-            WarnDecision::Suppress
-        }
-    }
-}
-
-/// The one process-wide limiter for serve-path failure warns.
-static SERVE_WARN_LIMITER: WarnLimiter = WarnLimiter::new();
-
-/// Emit a serve-path failure warn through [`SERVE_WARN_LIMITER`]. Over-budget
-/// messages drop to debug so `RUST_LOG=debug` still sees every failure.
-fn rate_limited_warn(message: std::fmt::Arguments<'_>) {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
-    match SERVE_WARN_LIMITER.decide(now) {
-        WarnDecision::Log { suppressed: 0 } => log::warn!("{message}"),
-        WarnDecision::Log { suppressed } => log::warn!(
-            "{message} ({suppressed} similar serve-path warnings suppressed in the last {WARN_WINDOW_SECS}s)"
-        ),
-        WarnDecision::Suppress => log::debug!("{message} (over warn budget)"),
-    }
-}
-
 /// Log a serve-path failure before it collapses to an errno reply, so the
 /// cause (e.g. the offending path in `BackingChanged`, or an `Io` error with
 /// no raw OS errno) is not lost. Routine tree-shape misses — a stale inode
 /// after a refresh, kernel path probing — stay at debug to avoid noise, and
-/// the warn arm is rate-limited so per-file failures (a walk over missing
-/// backing files) can't scale the log with library size.
+/// the warn arm goes through the process-wide limiter in `musefs-core` so
+/// per-file failures (a walk over missing backing files) can't scale the log
+/// with library size. The limiter is shared with core's own synthesis warns
+/// (#650): one serve path, one budget.
 fn reply_errno(op: &str, ino: u64, err: &CoreError) -> fuser::Errno {
     match err {
         CoreError::NoEntry(_)
@@ -1345,41 +1265,6 @@ mod tests {
         let core =
             Musefs::open(musefs_db::Db::open(dir.path().join("m.db")).unwrap(), cfg).unwrap();
         (dir, MusefsFs::new(core, FuseConfig::default()))
-    }
-
-    #[test]
-    fn warn_limiter_allows_a_burst_then_suppresses() {
-        let l = WarnLimiter::new();
-        // First call opens the window; the burst budget covers WARN_BURST warns.
-        for i in 0..WARN_BURST {
-            assert_eq!(
-                l.decide(100),
-                WarnDecision::Log { suppressed: 0 },
-                "warn {i} is within the burst"
-            );
-        }
-        assert_eq!(l.decide(100), WarnDecision::Suppress);
-        assert_eq!(l.decide(100), WarnDecision::Suppress);
-    }
-
-    #[test]
-    fn warn_limiter_new_window_reports_suppressed_count() {
-        let l = WarnLimiter::new();
-        for _ in 0..WARN_BURST {
-            l.decide(100);
-        }
-        for _ in 0..5 {
-            assert_eq!(l.decide(100), WarnDecision::Suppress);
-        }
-        // Window rolls over: log again, carrying the dropped count once.
-        assert_eq!(
-            l.decide(100 + WARN_WINDOW_SECS),
-            WarnDecision::Log { suppressed: 5 }
-        );
-        assert_eq!(
-            l.decide(100 + WARN_WINDOW_SECS),
-            WarnDecision::Log { suppressed: 0 }
-        );
     }
 
     #[test]

--- a/musefs-fuse/src/lib.rs
+++ b/musefs-fuse/src/lib.rs
@@ -22,7 +22,7 @@ use musefs_core::CoreError;
 use musefs_core::Fh;
 use musefs_core::Musefs;
 use musefs_core::convert::usize_from;
-use musefs_core::rate_limited_warn;
+use musefs_core::serve_warn;
 use std::num::NonZeroU64;
 
 mod convert;
@@ -221,7 +221,7 @@ fn reply_errno(op: &str, ino: u64, err: &CoreError) -> fuser::Errno {
         | CoreError::TrackNotFound(_)
         | CoreError::IsDir(_)
         | CoreError::NotADir(_) => log::debug!("{op}({ino}) failed: {err}"),
-        _ => rate_limited_warn(format_args!("{op}({ino}) failed: {err}")),
+        _ => serve_warn!("{op}({ino}) failed: {err}"),
     }
     errno(err)
 }
@@ -959,10 +959,10 @@ impl Filesystem for MusefsFs {
             self.read_errors.fetch_add(1, Ordering::Relaxed);
             // Rate-limited: a saturated client retries rejected reads in a tight
             // loop, so this otherwise warns once per shed read for the whole storm.
-            rate_limited_warn(format_args!(
+            serve_warn!(
                 "read({}) rejected: EAGAIN — {MAX_INFLIGHT_READS} reads already in flight (load-shedding)",
                 ino.0
-            ));
+            );
             return reply.error(fuser::Errno::EAGAIN);
         };
         let core = Arc::clone(&self.core);
@@ -1526,5 +1526,60 @@ mod errno_tests {
     #[test]
     fn handle_table_full_maps_to_enfile() {
         assert_eq!(errno(&CoreError::HandleTableFull).code(), libc::ENFILE);
+    }
+}
+
+/// The serve-path warn limiter lives in `musefs-core`, but `reply_errno`'s warn
+/// must still be *attributed* to this crate: the troubleshooting guide documents
+/// per-crate filtering (`RUST_LOG=warn,musefs_fuse=debug`), and that only works
+/// while the record's target follows the call site. This is what makes
+/// `musefs_core::serve_warn!` a macro rather than a shared function (#650).
+#[cfg(test)]
+mod warn_target_tests {
+    use std::sync::Mutex;
+
+    use super::reply_errno;
+    use musefs_core::CoreError;
+
+    static CAPTURED: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+    static CAPTURE_LOGGER: CaptureLogger = CaptureLogger;
+
+    /// Global logger keeping each record's target and rendered message.
+    struct CaptureLogger;
+
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record<'_>) {
+            CAPTURED
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push((record.target().to_string(), record.args().to_string()));
+        }
+        fn flush(&self) {}
+    }
+
+    #[test]
+    fn reply_errno_warn_is_attributed_to_musefs_fuse() {
+        log::set_logger(&CAPTURE_LOGGER).expect("only this test installs a logger");
+        // Over-budget warns drop to debug and must carry the same target.
+        log::set_max_level(log::LevelFilter::Debug);
+
+        let err = CoreError::BackingChanged("warn-target-probe.flac".into());
+        reply_errno("read", 4242, &err);
+
+        let captured = CAPTURED
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let hits: Vec<&(String, String)> = captured
+            .iter()
+            .filter(|(_, m)| m.contains("warn-target-probe.flac"))
+            .collect();
+        assert_eq!(hits.len(), 1, "expected exactly one record, got {hits:?}");
+        assert_eq!(
+            hits[0].0, "musefs_fuse",
+            "reply_errno must log under this crate, not the limiter's module"
+        );
     }
 }

--- a/musefs/src/main.rs
+++ b/musefs/src/main.rs
@@ -44,8 +44,14 @@ fn main() -> std::process::ExitCode {
         2 => "debug",
         _ => "trace",
     };
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default_level))
-        .init();
+    // Built rather than `.init()`ed: `musefs_cli` installs it wrapped so records
+    // are emitted with the scan progress bar suspended instead of shredding it
+    // (#648). The verbosity policy above still belongs to the binary.
+    let logger =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default_level))
+            .build();
+    let level = logger.filter();
+    musefs_cli::install_logger(Box::new(logger), level);
     #[cfg(feature = "jemalloc")]
     {
         enable_jemalloc_background_thread();


### PR DESCRIPTION
## What and why

A sweep of logging and user-facing messaging across the workspace, and the nine issues it turned up. Closes #647, #648, #649, #650, #651, #652, #653, #654, #655.

The messaging in musefs was already in good shape — the CLI error paths in particular. The gaps clustered in three places: the boundary where `contrib/` reads the scanner's exit code, the interaction between the progress bar and the log sink, and the absence of any operator-facing documentation for either.

### The user-visible bugs

- **`scan`'s exit `2` was read as a hard failure by every plugin** (#647). Exit `2` is the documented *partial success* signal — the batch completed and committed, but some file could not be ingested. `run_scan` treated any non-zero code as fatal, so one unparseable file made Picard report `sync failed` and write **no tags at all**, silently skipped the beets `cli_exit` sync (surfacing only as a `WARNING` beets hides by default), and aborted `beet musefs` and the Lidarr adapter. `run_scan` now reads the three-state contract and returns a `ScanResult`; each adapter warns and proceeds.
- **Scan logs and the progress bar shredded each other** (#648). Both write to stderr with nothing between them, so a warning landed mid-frame and the next tick erased part of it — the common case, since the skip tally warns about the `cover.jpg`/`.cue` sidecars nearly every library has. Records are now emitted with the bar suspended, via a process-wide draw target. No new dependency.
- **The progress bar could never reach 100% when files failed** (#655). Its length is the walked count but its position only advanced on a *committed* file, so 12 failures out of 42 finished at `30/42 (71%)` and were then cleared — which reads as an aborted scan. The piped path never printed its final `100%` milestone at all.

### The silent paths

- **Schema migrations logged nothing** (#649). `Db::open` migrates in place on every open, so an old store was upgraded irreversibly on the first `musefs scan` after a binary upgrade with no indication. The refusing path (`StoreTooNew`) was loud; the path that actually made the store unreadable to the older build was mute. Now `warn` on the announcement, `info` on completion.
- **Serve-path warns from `musefs-core` bypassed the rate limiter** (#650). The limiter lived in `musefs-fuse` and only wrapped `reply_errno`, so the synthesis warns — dropped Vorbis keys, over-cap art, art-blob read failures — were unbounded, and the Vorbis one re-fires on every `HeaderCache` eviction. The limiter moved to `musefs-core` and both crates share one budget via a call-site macro that preserves each site's log target.
- **Scan skip/failure warns had no cap and no breakdown** (#651). An unreadable subtree emitted one line per file; `failed N` had no per-reason explanation. Now two summaries (`failed 37: unparseable=30, io=5, oversize=2` and `walk errors 12: unreadable=9, symlink=3`) with per-reason warn caps.
- **No metric counted suppressed warns** (#653). `musefs_serve_warns_suppressed_total` closes the gap, matching the #626/#523 pattern.

### Documentation

- **A troubleshooting page** (#652): the log-level model, what each level buys, the warn limiter, reading logs under systemd and Docker, and the exit-code contract — which was previously documented only inside `guide/scanning.md`. `RUST_LOG` had appeared exactly once in the entire user guide.
- **`SchemaMismatch` names the remedy** (#654), matching what the Rust errors already do.

### Behavioural notes for review

- **The piped milestone line is renamed `ingested N/M (P%)` → `processed N/M (P%)`.** It now counts every file the pipeline finished with, not only successes, so keeping the old word to make it reach 100% would have traded one inaccuracy for a worse one. Scripts matching the old prefix need updating.
- The `--quiet` path and the verbosity policy (`-v`/`-vv`/`-vvv`, `RUST_LOG` taking precedence) are unchanged.
- The skip-tally summary moved `warn` → `info`, on the reasoning that a warning firing on every healthy scan teaches operators to filter warnings — which would then also cost them the failure summary that matters. `skipped N` still prints in the CLI summary at any level; `-v` gates only the breakdown.
- Two `debug_assert`s pin invariants that would otherwise regress silently: every scan failure is tallied by reason, and the progress events together reach the walked total.

### Verification

Full workspace suite **1339 passed / 0 failed**, plus the FUSE e2e tier (19) and the metrics tier (13), run on the *merged* state rather than only per-branch. `clippy --all-targets -- -D warnings` and `cargo fmt` clean; mutant-anchor guard reports 101 entries validated; `mdbook build` with linkcheck passes.

End-to-end on a 42-file fixture (30 parseable, 12 unparseable, 2 sidecars): exit `2`, `processed 42/42 (100%)`, `failed 12: unparseable=12`. Under a pty the bar reaches `42/42` and all 12 warn records are preceded by a bar-clear. The Python suites ran against real beets 2.13.1 and Picard 2.13.3 in a venv — not skipped — for 320 passing tests.

## Checklist

- [x] The **pre-commit hook ran** on every commit (no `--no-verify`). Note that the six merge commits invoke `pre-merge-commit`, not `pre-commit`, so the full gate was additionally run by hand against the merged tree — results above.
- [ ] If the **format-layer API changed**: `cargo +nightly fuzz build` passes. — **n/a**, `musefs-format` is untouched by this branch.
- [ ] If the **`musefs-db` schema changed**: Python mirror regenerated and re-vendored. — **n/a**, #649 adds logging to `migrate()` and changes no schema SQL. (`contrib/` *was* re-vendored, for the unrelated #647/#654 library changes.)
- [x] **Changelog entry** added under `## [Unreleased]` in `CHANGELOG.md`.
- [x] **Docs updated** under `docs/src/`.
- [x] Commit subjects follow **conventional commits**.

## The invariant

- [x] This change does not copy or modify original audio bytes. Nothing here touches synthesis or the segment model: `musefs-format` is untouched, and the `musefs-core/src/reader.rs` diff is confined to two log statements and their tests.

---

### Review order

The branch is six merged topic branches plus two commits of my own, so reviewing by merge commit keeps each issue self-contained. #647 is the one with real user impact and is worth reading first. #650's third commit (`42ebf05`) exists because the first version wrapped `log::warn!` in a function, which collapsed all six call sites onto one log target and broke the per-crate `RUST_LOG` filtering documented in #652 — the macro form fixes that, with tests pinning each site's target.

Two follow-ups were deliberately left out of scope and are noted in the issues rather than fixed here: `scan.rs`'s `probe_full` mp4-oversize warn (unreachable from the production bounded probe) and the uncapped `content hash failed for …` warn (it does not fail the file, so tallying it would break the partition invariant).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial scans now warn while continuing to synchronize successfully processed files.
  * Scan progress completes even when files fail, with clearer failure summaries and reason breakdowns.
  * Serve-path warnings are rate-limited across the application, with suppressed-warning metrics available.
  * Schema migrations provide clearer version-specific guidance and progress logging.
* **Bug Fixes**
  * Improved terminal output coordination prevents logs from disrupting progress displays.
* **Documentation**
  * Added logging, troubleshooting, scanning, tuning, and system service guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->